### PR TITLE
chore: check the EE repo out at futureagi/ee/cloud

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -166,9 +166,9 @@ changelog/
 **/*.backup
 **/celerybeat-schedule
 
-# Private EE artifacts: gitignored, so a fresh clone never has them. Exclude
-# from local builds too so the image matches what an OSS user can build.
+# Private EE artifacts: the cloud-private delta is a separate repo checked out
+# at futureagi/ee/cloud/, and is gitignored, so a fresh clone never has it.
+# Exclude it from local builds too so the image matches what an OSS user can
+# build. The CE base image must not carry cloud code — Dockerfile.ee in the
+# private repo overlays it at runtime.
 futureagi/ee/cloud/
-futureagi/ee/billing.yaml
-futureagi/ee/Dockerfile.cloud
-futureagi/ee/.github/

--- a/.github/workflows/api-contracts.yml
+++ b/.github/workflows/api-contracts.yml
@@ -102,13 +102,13 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: future-agi/ee
-          path: futureagi/ee
+          path: futureagi/ee/cloud
           token: ${{ env.EE_REPO_READ_TOKEN }}
           persist-credentials: true
           fetch-depth: 1
 
       - name: Use matching EE branch when available
-        working-directory: futureagi/ee
+        working-directory: futureagi/ee/cloud
         run: |
           if git ls-remote --exit-code --heads origin "${EE_REPO_BRANCH}" >/dev/null 2>&1; then
             git fetch --depth=1 origin "${EE_REPO_BRANCH}"
@@ -119,7 +119,7 @@ jobs:
           fi
 
       - name: Drop EE checkout credentials
-        working-directory: futureagi/ee
+        working-directory: futureagi/ee/cloud
         run: git config --unset-all http.https://github.com/.extraheader || true
 
       - name: Setup Node.js
@@ -237,13 +237,13 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: future-agi/ee
-          path: futureagi/ee
+          path: futureagi/ee/cloud
           token: ${{ env.EE_REPO_READ_TOKEN }}
           persist-credentials: true
           fetch-depth: 1
 
       - name: Use matching EE branch when available
-        working-directory: futureagi/ee
+        working-directory: futureagi/ee/cloud
         run: |
           if git ls-remote --exit-code --heads origin "${EE_REPO_BRANCH}" >/dev/null 2>&1; then
             git fetch --depth=1 origin "${EE_REPO_BRANCH}"
@@ -254,7 +254,7 @@ jobs:
           fi
 
       - name: Drop EE checkout credentials
-        working-directory: futureagi/ee
+        working-directory: futureagi/ee/cloud
         run: git config --unset-all http.https://github.com/.extraheader || true
 
       - name: Setup Python

--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -109,14 +109,14 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: future-agi/ee
-          path: futureagi/ee
+          path: futureagi/ee/cloud
           token: ${{ secrets.EE_REPO_READ_TOKEN }}
           persist-credentials: true
           fetch-depth: 1
 
       - name: Resolve the EE branch to test against
         if: env.IS_INTERNAL_RUN == 'true'
-        working-directory: futureagi/ee
+        working-directory: futureagi/ee/cloud
         run: |
           # EE's default branch trails its own dev, so never settle for whatever
           # the checkout landed on: walk the same candidate chain the SDK
@@ -139,7 +139,7 @@ jobs:
         # always(): the branch-resolution step above hard-fails when no
         # candidate branch exists, and the token must be scrubbed regardless.
         if: ${{ always() && env.IS_INTERNAL_RUN == 'true' }}
-        working-directory: futureagi/ee
+        working-directory: futureagi/ee/cloud
         run: git config --unset-all http.https://github.com/.extraheader || true
 
       - uses: astral-sh/setup-uv@v5

--- a/.github/workflows/sdk-compatibility.yml
+++ b/.github/workflows/sdk-compatibility.yml
@@ -100,9 +100,9 @@ jobs:
                 fetch --depth=1 origin "${candidate}"
               git checkout --detach FETCH_HEAD
               cd "${GITHUB_WORKSPACE}"
-              mkdir -p futureagi
-              rm -rf futureagi/ee
-              mv "${EE_TMP_DIR}" futureagi/ee
+              mkdir -p futureagi/ee
+              rm -rf futureagi/ee/cloud
+              mv "${EE_TMP_DIR}" futureagi/ee/cloud
               echo "Using EE branch ${candidate}"
               echo "mode=ee" >> "$GITHUB_OUTPUT"
               exit 0

--- a/.gitignore
+++ b/.gitignore
@@ -232,21 +232,10 @@ plan/
 planning/
 scratch/
 
-# EE lives in-tree at futureagi/ee. Only the private cloud/billing
-# overlay pieces stay out of the public monorepo — never commit these:
+# EE lives in-tree at futureagi/ee. The cloud-private delta is a separate
+# repo (future-agi/ee) checked out at futureagi/ee/cloud/ — everything it
+# owns is under that one directory, so this single rule covers all of it.
 futureagi/ee/cloud/
-futureagi/ee/billing.yaml
-futureagi/ee/Dockerfile.cloud
-futureagi/ee/.github/
-# private-repo build/ops artifacts — images ship from the private repo,
-# not from here (a local nested ee checkout may still have these on disk):
-futureagi/ee/Dockerfile.ee
-futureagi/ee/docker-compose.ee.yml
-futureagi/ee/.dockerignore
-futureagi/ee/MIGRATION_GUIDE.md
-futureagi/ee/OPERATIONS_RUNBOOK.md
-futureagi/ee/PHASE4_CLASSIFICATION.md
-futureagi/ee/README.md
 # stray local leftover at repo root (old gateway config) — not the ee tree
 /ee/
 
@@ -261,6 +250,5 @@ uninstall-*.log
 docker-compose.override.yml
 
 
-# ee/ private-repo .gitignore — not part of the public monorepo
-# (ee/LICENSE stays tracked: source-available code needs a license file)
-futureagi/ee/.gitignore
+# (The private repo's own .gitignore now lives inside futureagi/ee/cloud/,
+# which is already ignored above — no separate rule needed.)

--- a/futureagi/.dockerignore
+++ b/futureagi/.dockerignore
@@ -81,13 +81,12 @@ test-results/
 **/.playwright-mcp/
 # ee/ ships in the image since the ee->futureagi code move (TH-7256): the
 # license (EE_LICENSE_KEY), not code stripping, gates paid features now.
-# Private cloud bits are gitignored (absent in CI checkouts), but dev
-# machines have them in the working tree — exclude so local builds match
-# what CI/a fresh clone produces.
+# The cloud-private delta is a separate repo (future-agi/ee) checked out at
+# ee/cloud/, so that one rule covers everything it owns. It is gitignored
+# (absent in CI checkouts) but present on dev machines — exclude it so local
+# builds match what CI and a fresh clone produce. The CE base image must not
+# carry cloud code; Dockerfile.ee in the private repo overlays it.
 ee/cloud/
-ee/billing.yaml
-ee/Dockerfile.cloud
-ee/.github/
 ee.local-leftover/
 
 # Documentation (not needed in image)

--- a/futureagi/ee/falcon_ai/llm_client.py
+++ b/futureagi/ee/falcon_ai/llm_client.py
@@ -6,7 +6,6 @@ import random
 
 import httpx
 import structlog
-from futureagi.ee.licensing.managed_ai import stream_chat_completion
 
 logger = structlog.get_logger(__name__)
 

--- a/futureagi/ee/falcon_ai/llm_client.py
+++ b/futureagi/ee/falcon_ai/llm_client.py
@@ -6,6 +6,7 @@ import random
 
 import httpx
 import structlog
+from futureagi.ee.licensing.managed_ai import stream_chat_completion
 
 logger = structlog.get_logger(__name__)
 
@@ -28,12 +29,17 @@ def _inline_refs(schema, _defs=None, _depth=0):
     ref = schema.get("$ref", "")
     if isinstance(ref, str) and ref.startswith("#/$defs/") and ref[8:] in pool:
         inlined = _inline_refs(copy.deepcopy(pool[ref[8:]]), pool, _depth + 1)
-        siblings = {k: _inline_refs(v, pool, _depth + 1)
-                    for k, v in schema.items() if k not in ("$ref", "$defs")}
+        siblings = {
+            k: _inline_refs(v, pool, _depth + 1)
+            for k, v in schema.items()
+            if k not in ("$ref", "$defs")
+        }
         if isinstance(inlined, dict) and siblings:
             return {**inlined, **siblings}  # siblings win on overlap (2020-12)
         return inlined
-    return {k: _inline_refs(v, pool, _depth + 1) for k, v in schema.items() if k != "$defs"}
+    return {
+        k: _inline_refs(v, pool, _depth + 1) for k, v in schema.items() if k != "$defs"
+    }
 
 
 class EmptyStreamError(RuntimeError):
@@ -144,15 +150,39 @@ class FalconLLMClient:
             "temperature": self.temperature,
             "max_tokens": self.max_tokens,
             "stream": False,
+            "stream_options": {"include_usage": True},
         }
+        if tools:
+            # Flatten $defs/$ref — Vertex/Gemini (a managed gateway target)
+            # rejects JSON-Schema refs, mirroring _stream_openai. Without this
+            # the gateway returns 400 on tool-carrying managed calls.
+            try:
+                payload["tools"] = _inline_refs(tools)
+            except Exception:
+                logger.warning(
+                    "tool_schema_flatten_failed_fallback_to_raw", exc_info=True
+                )
+                payload["tools"] = tools
+        else:
+            payload["tools"] = []
         if self.response_format:
-            payload["response_format"] = self.response_format
+            try:
+                payload["response_format"] = _inline_refs(self.response_format)
+            except Exception:
+                logger.warning(
+                    "response_format_flatten_failed_fallback_to_raw", exc_info=True
+                )
+                payload["response_format"] = self.response_format
 
-        response = await asyncio.to_thread(chat_completion, payload)
-        content = response_content(response)
-        if content:
-            yield {"choices": [{"delta": {"content": content}, "finish_reason": None}]}
-        yield {"choices": [{"delta": {}, "finish_reason": "stop"}]}
+        async for chunk in stream_chat_completion(payload):
+            metadata = chunk.get("agentcc_metadata")
+            if metadata:
+                self._gateway_cost += metadata.get("cost", 0)
+
+            for choice in chunk.get("choices") or []:
+                if choice.get("finish_reason") == "length":
+                    choice["finish_reason"] = "max_tokens"
+            yield chunk
 
     async def _stream_bedrock(self, messages, tools=None):
         """Stream from AWS Bedrock using boto3, yielding OpenAI-compatible chunks."""
@@ -596,14 +626,18 @@ class FalconLLMClient:
             try:
                 payload["tools"] = _inline_refs(tools)
             except Exception:
-                logger.warning("tool_schema_flatten_failed_fallback_to_raw", exc_info=True)
+                logger.warning(
+                    "tool_schema_flatten_failed_fallback_to_raw", exc_info=True
+                )
                 payload["tools"] = tools
             payload["tool_choice"] = "auto"
         if self.response_format:
             try:
                 payload["response_format"] = _inline_refs(self.response_format)
             except Exception:
-                logger.warning("response_format_flatten_failed_fallback_to_raw", exc_info=True)
+                logger.warning(
+                    "response_format_flatten_failed_fallback_to_raw", exc_info=True
+                )
                 payload["response_format"] = self.response_format
 
         headers = {
@@ -660,9 +694,12 @@ class FalconLLMClient:
                                 ),
                                 "total_tokens": usage.get("total_tokens")
                                 or (
-                                    usage.get("prompt_tokens", usage.get("input_tokens", 0))
+                                    usage.get(
+                                        "prompt_tokens", usage.get("input_tokens", 0)
+                                    )
                                     + usage.get(
-                                        "completion_tokens", usage.get("output_tokens", 0)
+                                        "completion_tokens",
+                                        usage.get("output_tokens", 0),
                                     )
                                 ),
                             }

--- a/futureagi/ee/falcon_ai/tests/test_llm_client_streaming.py
+++ b/futureagi/ee/falcon_ai/tests/test_llm_client_streaming.py
@@ -1,3 +1,5 @@
+from unittest.mock import patch
+
 import pytest
 
 from ee.falcon_ai.llm_client import FalconLLMClient
@@ -31,3 +33,154 @@ async def test_stream_with_retry_retries_empty_stream_before_failing(monkeypatch
             pass
 
     assert client.calls == 2
+
+
+@pytest.mark.asyncio
+async def test_managed_stream_forwards_incremental_tool_calls_usage_and_metadata():
+    chunks = [
+        {
+            "choices": [
+                {
+                    "delta": {"content": "Working"},
+                    "finish_reason": None,
+                }
+            ]
+        },
+        {
+            "choices": [
+                {
+                    "delta": {
+                        "tool_calls": [
+                            {
+                                "index": 0,
+                                "id": "call_1",
+                                "function": {
+                                    "name": "create_agent",
+                                    "arguments": '{"name":',
+                                },
+                            },
+                            {
+                                "index": 1,
+                                "id": "call_2",
+                                "function": {
+                                    "name": "lookup",
+                                    "arguments": '{"id":',
+                                },
+                            },
+                        ]
+                    },
+                    "finish_reason": None,
+                }
+            ]
+        },
+        {
+            "choices": [
+                {
+                    "delta": {
+                        "tool_calls": [
+                            {
+                                "index": 0,
+                                "function": {"arguments": '"agent"}'},
+                            },
+                            {
+                                "index": 1,
+                                "function": {"arguments": "1}"},
+                            },
+                        ]
+                    },
+                    "finish_reason": "tool_calls",
+                }
+            ]
+        },
+        {
+            "choices": [],
+            "usage": {"prompt_tokens": 5, "completion_tokens": 3},
+            "agentcc_metadata": {"cost": 0.25},
+        },
+    ]
+
+    async def managed_stream(payload):
+        assert payload["stream"] is True
+        assert payload["stream_options"] == {"include_usage": True}
+        for chunk in chunks:
+            yield chunk
+
+    with patch(
+        "ee.licensing.managed_ai.stream_chat_completion",
+        new=managed_stream,
+    ):
+        client = FalconLLMClient()
+        result = [
+            chunk
+            async for chunk in client.stream_completion(
+                [{"role": "user", "content": "build"}],
+                tools=[{"type": "function", "function": {"name": "create_agent"}}],
+            )
+        ]
+
+    assert result == chunks
+    assert client._gateway_cost == 0.25
+
+
+@pytest.mark.asyncio
+async def test_managed_stream_inlines_ref_tool_schemas():
+    import json
+
+    captured = {}
+
+    async def managed_stream(payload):
+        captured["payload"] = payload
+        yield {"choices": [{"delta": {}, "finish_reason": "stop"}]}
+
+    tools = [
+        {
+            "type": "function",
+            "function": {
+                "name": "make_agent",
+                "parameters": {
+                    "type": "object",
+                    "properties": {"cfg": {"$ref": "#/$defs/Cfg"}},
+                    "$defs": {"Cfg": {"type": "object"}},
+                },
+            },
+        }
+    ]
+
+    with patch(
+        "ee.licensing.managed_ai.stream_chat_completion",
+        new=managed_stream,
+    ):
+        async for _ in FalconLLMClient().stream_completion(
+            [{"role": "user", "content": "go"}], tools=tools
+        ):
+            pass
+
+    serialized = json.dumps(captured["payload"]["tools"])
+    assert "$ref" not in serialized
+    assert "$defs" not in serialized
+
+
+@pytest.mark.asyncio
+async def test_managed_stream_normalizes_length_finish_reason():
+    async def managed_stream(payload):
+        yield {
+            "choices": [
+                {
+                    "delta": {},
+                    "finish_reason": "length",
+                }
+            ]
+        }
+
+    with patch(
+        "ee.licensing.managed_ai.stream_chat_completion",
+        new=managed_stream,
+    ):
+        chunks = [
+            chunk
+            async for chunk in FalconLLMClient().stream_completion(
+                [{"role": "user", "content": "hello"}]
+            )
+        ]
+
+    assert chunks[0]["choices"][0]["finish_reason"] == "max_tokens"

--- a/futureagi/ee/licensing/activation_client.py
+++ b/futureagi/ee/licensing/activation_client.py
@@ -12,12 +12,16 @@ Token lifecycle:
 
 from __future__ import annotations
 
+import asyncio
+import json
 import os
 import threading
 import time
+from collections.abc import AsyncIterator, Callable
 from dataclasses import dataclass
 
 import structlog
+
 from ee.licensing.validator import hash_key
 
 logger = structlog.get_logger(__name__)
@@ -122,35 +126,53 @@ def _activate() -> ServiceToken | None:
         return None
 
 
-def call_managed_service(
-    path: str = "/v1/chat/completions",
-    *,
-    json_body: dict,
-    timeout: float = 30.0,
-) -> dict:
-    """Make an authenticated request to the FutureAGI managed gateway.
-
-    Raises ManagedServiceError on auth/service failures with typed codes.
-    """
-    token = get_service_token()
-    if token is None:
-        raise ManagedServiceError("ACTIVATION_FAILED", "Could not obtain service token")
-
-    if token.scope == "oss" and not token.access_token:
+def _raise_for_managed_status(
+    status_code: int,
+    on_unauthorized: Callable[[], None],
+) -> None:
+    if status_code == 401:
+        on_unauthorized()
         raise ManagedServiceError(
-            "NO_ENTERPRISE_LICENSE", "Managed AI requires an Enterprise license"
+            "GATEWAY_UNAUTHORIZED", "Managed AI gateway rejected credentials"
+        )
+    if status_code == 403:
+        raise ManagedServiceError(
+            "FEATURE_DENIED", "Feature not included in license scope"
+        )
+    if status_code == 429:
+        raise ManagedServiceError("RATE_LIMITED", "Managed AI rate limit exceeded")
+    if status_code >= 500:
+        raise ManagedServiceError(
+            "SERVICE_ERROR", f"Managed AI service error ({status_code})"
         )
 
+
+def dispatch_managed_request(
+    *,
+    url: str,
+    api_key: str,
+    json_body: dict,
+    timeout: float,
+    on_unauthorized: Callable[[], None],
+) -> dict:
+    """POST to the managed gateway and map failures to typed errors.
+
+    Shared transport for both managed-AI auth models: the self-hosted
+    activation-token flow (``call_managed_service``) and the cloud
+    internal-key flow (``ee.licensing.managed_ai``). Only the 401 response
+    is handled differently between them, so callers pass ``on_unauthorized``
+    (which must raise); every other status maps identically here so the two
+    paths cannot drift.
+    """
     import httpx
 
-    url = token.gateway_url.rstrip("/") + path
     try:
         response = httpx.post(
             url,
             json=json_body,
             timeout=timeout,
             headers={
-                "Authorization": f"Bearer {token.access_token}",
+                "Authorization": f"Bearer {api_key}",
                 "Content-Type": "application/json",
             },
         )
@@ -161,23 +183,119 @@ def call_managed_service(
             "GATEWAY_UNREACHABLE", "Cannot reach managed AI gateway"
         )
 
-    if response.status_code == 401:
+    _raise_for_managed_status(response.status_code, on_unauthorized)
+    return response.json()
+
+
+async def dispatch_managed_stream(
+    *,
+    url: str,
+    api_key: str,
+    json_body: dict,
+    timeout: float,
+    on_unauthorized: Callable[[], None],
+) -> AsyncIterator[dict]:
+    import httpx
+
+    headers = {
+        "Authorization": f"Bearer {api_key}",
+        "Content-Type": "application/json",
+        "x-agentcc-include-metadata": "true",
+    }
+    try:
+        async with httpx.AsyncClient(timeout=timeout) as client:
+            async with client.stream(
+                "POST",
+                url,
+                json=json_body,
+                headers=headers,
+            ) as response:
+                _raise_for_managed_status(response.status_code, on_unauthorized)
+                response.raise_for_status()
+                async for line in response.aiter_lines():
+                    if not line.startswith("data:"):
+                        continue
+                    data = line[5:].strip()
+                    if not data:
+                        continue
+                    if data == "[DONE]":
+                        return
+                    yield json.loads(data)
+    except httpx.TimeoutException as exc:
+        raise ManagedServiceError(
+            "GATEWAY_TIMEOUT", "Managed AI gateway timed out"
+        ) from exc
+    except httpx.ConnectError as exc:
+        raise ManagedServiceError(
+            "GATEWAY_UNREACHABLE", "Cannot reach managed AI gateway"
+        ) from exc
+
+
+def call_managed_service(
+    path: str = "/v1/chat/completions",
+    *,
+    json_body: dict,
+    timeout: float = 30.0,
+) -> dict:
+    """Make an authenticated request to the FutureAGI managed gateway.
+
+    Self-hosted EE auth: exchange the license for a short-lived service
+    token, then call the gateway with it. Raises ManagedServiceError on
+    auth/service failures with typed codes.
+    """
+    token = get_service_token()
+    if token is None:
+        raise ManagedServiceError("ACTIVATION_FAILED", "Could not obtain service token")
+
+    if token.scope == "oss" and not token.access_token:
+        raise ManagedServiceError(
+            "NO_ENTERPRISE_LICENSE", "Managed AI requires an Enterprise license"
+        )
+
+    def _on_unauthorized() -> None:
         invalidate_token()
         raise ManagedServiceError(
             "TOKEN_EXPIRED", "Service token rejected — will refresh on next call"
         )
-    if response.status_code == 403:
+
+    return dispatch_managed_request(
+        url=token.gateway_url.rstrip("/") + path,
+        api_key=token.access_token,
+        json_body=json_body,
+        timeout=timeout,
+        on_unauthorized=_on_unauthorized,
+    )
+
+
+async def stream_managed_service(
+    path: str = "/v1/chat/completions",
+    *,
+    json_body: dict,
+    timeout: float = 300.0,
+) -> AsyncIterator[dict]:
+    token = await asyncio.to_thread(get_service_token)
+    if token is None:
+        raise ManagedServiceError("ACTIVATION_FAILED", "Could not obtain service token")
+
+    if token.scope == "oss" and not token.access_token:
         raise ManagedServiceError(
-            "FEATURE_DENIED", "Feature not included in license scope"
-        )
-    if response.status_code == 429:
-        raise ManagedServiceError("RATE_LIMITED", "Managed AI rate limit exceeded")
-    if response.status_code >= 500:
-        raise ManagedServiceError(
-            "SERVICE_ERROR", f"Managed AI service error ({response.status_code})"
+            "NO_ENTERPRISE_LICENSE", "Managed AI requires an Enterprise license"
         )
 
-    return response.json()
+    def _on_unauthorized() -> None:
+        invalidate_token()
+        raise ManagedServiceError(
+            "TOKEN_EXPIRED", "Service token rejected — will refresh on next call"
+        )
+
+    async for chunk in dispatch_managed_stream(
+        url=token.gateway_url.rstrip("/") + path,
+        api_key=token.access_token,
+        json_body=json_body,
+        timeout=timeout,
+        on_unauthorized=_on_unauthorized,
+    ):
+        yield chunk
 
 
 class ManagedServiceError(Exception):

--- a/futureagi/ee/licensing/managed_ai.py
+++ b/futureagi/ee/licensing/managed_ai.py
@@ -1,8 +1,15 @@
 from __future__ import annotations
 
+from collections.abc import AsyncIterator
 from typing import Any
 
-from ee.licensing.activation_client import call_managed_service
+from ee.licensing.activation_client import (
+    ManagedServiceError,
+    call_managed_service,
+    dispatch_managed_request,
+    dispatch_managed_stream,
+    stream_managed_service,
+)
 
 
 def is_managed_model(model: object) -> bool:
@@ -25,14 +32,108 @@ def service_for_model(model: object) -> str | None:
     return None
 
 
+def _cloud_gateway_credentials() -> tuple[str, str]:
+    from ee.usage.services.gateway_llm_client import _get_setting
+
+    base_url = _get_setting("AGENTCC_INTERNAL_URL", "http://agentcc-gateway:8090")
+    api_key = _get_setting("AGENTCC_INTERNAL_API_KEY")
+    if not api_key:
+        raise ManagedServiceError(
+            "GATEWAY_UNCONFIGURED",
+            "AGENTCC_INTERNAL_API_KEY is not configured for managed AI",
+        )
+    return base_url, api_key
+
+
+def _cloud_chat_completion(
+    payload: dict[str, Any],
+    *,
+    path: str,
+    timeout: float,
+) -> dict[str, Any]:
+    """Managed completion on cloud.
+
+    Cloud deployments carry no ``EE_LICENSE_KEY``, so the self-hosted
+    activation-token exchange in ``call_managed_service`` never yields a
+    usable token. The gateway is internal here, so we authenticate with
+    ``AGENTCC_INTERNAL_API_KEY`` — mirroring the ``vertex_ai``/``turing_*``
+    internal-key branch in ``FalconLLMClient``.
+
+    Shares the transport + error mapping with ``call_managed_service`` via
+    ``dispatch_managed_request`` so the two paths cannot drift. Only the 401
+    handling differs: here it means a bad internal key, not a stale
+    activation token, so it deliberately does not touch the EE token cache.
+    """
+    base_url, api_key = _cloud_gateway_credentials()
+
+    def _on_unauthorized() -> None:
+        raise ManagedServiceError(
+            "GATEWAY_UNAUTHORIZED",
+            "Managed AI gateway rejected the internal API key",
+        )
+
+    return dispatch_managed_request(
+        url=base_url.rstrip("/") + path,
+        api_key=api_key,
+        json_body=payload,
+        timeout=timeout,
+        on_unauthorized=_on_unauthorized,
+    )
+
+
 def chat_completion(payload: dict[str, Any]) -> dict[str, Any]:
     model = payload.get("model")
     if not is_managed_model(model):
         raise ValueError(f"Model {model!r} is not a FutureAGI-managed model")
+
+    from ee.usage.deployment import DeploymentMode
+
+    if DeploymentMode.is_cloud():
+        return _cloud_chat_completion(
+            payload,
+            path="/v1/chat/completions",
+            # Matches the shared gateway client (gateway_llm_client). A managed
+            # agent turn with a large max_tokens routinely runs well past the
+            # 30s default, so use the same generous ceiling rather than let a
+            # slow-but-valid completion trip a transport timeout.
+            timeout=300.0,
+        )
     return call_managed_service(
         path="/v1/chat/completions",
         json_body=payload,
     )
+
+
+async def stream_chat_completion(
+    payload: dict[str, Any],
+) -> AsyncIterator[dict[str, Any]]:
+    model = payload.get("model")
+    if not is_managed_model(model):
+        raise ValueError(f"Model {model!r} is not a FutureAGI-managed model")
+
+    from ee.usage.deployment import DeploymentMode
+
+    if not DeploymentMode.is_cloud():
+        async for chunk in stream_managed_service(json_body=payload):
+            yield chunk
+        return
+
+    base_url, api_key = _cloud_gateway_credentials()
+
+    def _on_unauthorized() -> None:
+        raise ManagedServiceError(
+            "GATEWAY_UNAUTHORIZED",
+            "Managed AI gateway rejected the internal API key",
+        )
+
+    async for chunk in dispatch_managed_stream(
+        url=base_url.rstrip("/") + "/v1/chat/completions",
+        api_key=api_key,
+        json_body=payload,
+        timeout=300.0,
+        on_unauthorized=_on_unauthorized,
+    ):
+        yield chunk
 
 
 def response_content(response: dict[str, Any]) -> str:

--- a/futureagi/ee/licensing/tests/test_activation_client.py
+++ b/futureagi/ee/licensing/tests/test_activation_client.py
@@ -12,14 +12,17 @@ from ee.licensing.activation_client import (
     ManagedServiceError,
     ServiceToken,
     call_managed_service,
+    dispatch_managed_stream,
     get_service_token,
     invalidate_token,
+    stream_managed_service,
 )
 
 
 @pytest.fixture(autouse=True)
 def reset_token_cache():
     import ee.licensing.activation_client as mod
+
     mod._cached_token = None
     yield
     mod._cached_token = None
@@ -112,11 +115,173 @@ class TestInvalidateToken:
         assert mod._cached_token is None
 
 
+class _StreamResponse:
+    def __init__(self, lines, status_code=200):
+        self.lines = lines
+        self.status_code = status_code
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, traceback):
+        return False
+
+    async def aiter_lines(self):
+        for line in self.lines:
+            yield line
+
+    def raise_for_status(self):
+        return None
+
+
+class _StreamClient:
+    def __init__(self, response):
+        self.response = response
+        self.call = None
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, traceback):
+        return False
+
+    def stream(self, method, url, **kwargs):
+        self.call = (method, url, kwargs)
+        return self.response
+
+
+class TestManagedStreamDispatch:
+    @pytest.mark.asyncio
+    async def test_yields_data_events_and_stops_at_done(self):
+        response = _StreamResponse(
+            [
+                "",
+                ": keepalive",
+                "event: message",
+                'data: {"choices":[{"delta":{"content":"hi"}}]}',
+                "data: [DONE]",
+                'data: {"ignored":true}',
+            ]
+        )
+        client = _StreamClient(response)
+
+        with patch("httpx.AsyncClient", return_value=client):
+            chunks = [
+                chunk
+                async for chunk in dispatch_managed_stream(
+                    url="https://gw.test/v1/chat/completions",
+                    api_key="token",
+                    json_body={"model": "falcon_ai", "stream": True},
+                    timeout=300.0,
+                    on_unauthorized=lambda: None,
+                )
+            ]
+
+        assert chunks == [{"choices": [{"delta": {"content": "hi"}}]}]
+        assert client.call[0:2] == (
+            "POST",
+            "https://gw.test/v1/chat/completions",
+        )
+        headers = client.call[2]["headers"]
+        assert headers["Authorization"] == "Bearer token"
+        assert headers["x-agentcc-include-metadata"] == "true"
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ("status_code", "expected_code"),
+        [
+            (403, "FEATURE_DENIED"),
+            (429, "RATE_LIMITED"),
+            (500, "SERVICE_ERROR"),
+        ],
+    )
+    async def test_maps_gateway_status(self, status_code, expected_code):
+        client = _StreamClient(_StreamResponse([], status_code=status_code))
+
+        with patch("httpx.AsyncClient", return_value=client):
+            with pytest.raises(ManagedServiceError) as exc:
+                async for _ in dispatch_managed_stream(
+                    url="https://gw.test/v1/chat/completions",
+                    api_key="token",
+                    json_body={},
+                    timeout=300.0,
+                    on_unauthorized=lambda: None,
+                ):
+                    pass
+
+        assert exc.value.code == expected_code
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ("error", "expected_code"),
+        [
+            (httpx.TimeoutException("timed out"), "GATEWAY_TIMEOUT"),
+            (httpx.ConnectError("unreachable"), "GATEWAY_UNREACHABLE"),
+        ],
+    )
+    async def test_maps_transport_failure(self, error, expected_code):
+        client = _StreamClient(_StreamResponse([]))
+        client.stream = MagicMock(side_effect=error)
+
+        with patch("httpx.AsyncClient", return_value=client):
+            with pytest.raises(ManagedServiceError) as exc:
+                async for _ in dispatch_managed_stream(
+                    url="https://gw.test/v1/chat/completions",
+                    api_key="token",
+                    json_body={},
+                    timeout=300.0,
+                    on_unauthorized=lambda: None,
+                ):
+                    pass
+
+        assert exc.value.code == expected_code
+
+
+class TestStreamManagedService:
+    @pytest.mark.asyncio
+    async def test_unauthorized_invalidates_cached_token(self):
+        token = ServiceToken(
+            access_token="service-token",
+            gateway_url="https://gw.test",
+            expires_at=time.time() + 3600,
+            allowed_services=["falcon"],
+            allowed_models=["falcon_ai"],
+            scope="enterprise",
+        )
+
+        async def dispatch(**kwargs):
+            kwargs["on_unauthorized"]()
+            if False:
+                yield {}
+
+        with (
+            patch(
+                "ee.licensing.activation_client.get_service_token",
+                return_value=token,
+            ),
+            patch(
+                "ee.licensing.activation_client.dispatch_managed_stream",
+                new=dispatch,
+            ),
+            patch("ee.licensing.activation_client.invalidate_token") as invalidate,
+        ):
+            with pytest.raises(ManagedServiceError) as exc:
+                async for _ in stream_managed_service(json_body={}):
+                    pass
+
+        assert exc.value.code == "TOKEN_EXPIRED"
+        invalidate.assert_called_once_with()
+
+
 class TestCallManagedService:
     def test_raises_on_no_token(self):
-        with patch("ee.licensing.activation_client.get_service_token", return_value=None):
+        with patch(
+            "ee.licensing.activation_client.get_service_token", return_value=None
+        ):
             with pytest.raises(ManagedServiceError) as exc:
-                call_managed_service(json_body={"model": "turing_large", "messages": []})
+                call_managed_service(
+                    json_body={"model": "turing_large", "messages": []}
+                )
             assert exc.value.code == "ACTIVATION_FAILED"
 
     def test_raises_on_oss_scope_without_token(self):
@@ -128,9 +293,13 @@ class TestCallManagedService:
             allowed_models=[],
             scope="oss",
         )
-        with patch("ee.licensing.activation_client.get_service_token", return_value=oss_token):
+        with patch(
+            "ee.licensing.activation_client.get_service_token", return_value=oss_token
+        ):
             with pytest.raises(ManagedServiceError) as exc:
-                call_managed_service(json_body={"model": "turing_large", "messages": []})
+                call_managed_service(
+                    json_body={"model": "turing_large", "messages": []}
+                )
             assert exc.value.code == "NO_ENTERPRISE_LICENSE"
 
     @pytest.mark.parametrize(

--- a/futureagi/ee/licensing/tests/test_managed_ai_transport.py
+++ b/futureagi/ee/licensing/tests/test_managed_ai_transport.py
@@ -1,0 +1,443 @@
+"""Transport routing for managed AI (Falcon / Turing / Protect).
+
+The managed completion entry point must resolve its transport by deployment
+mode: cloud reaches the co-located AgentCC gateway with the internal API key,
+while self-hosted EE uses the activation-token exchange. A cloud deployment
+carries no ``EE_LICENSE_KEY``, so routing it through the activation flow is
+what broke Falcon on cloud.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import httpx
+import pytest
+
+from ee.licensing.activation_client import ManagedServiceError
+from ee.licensing.managed_ai import chat_completion, stream_chat_completion
+
+
+def _ok_response(payload=None):
+    response = MagicMock(status_code=200)
+    response.json.return_value = payload or {
+        "choices": [{"message": {"content": "ok"}}],
+        "usage": {"prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2},
+    }
+    return response
+
+
+class TestCloudTransport:
+    def test_cloud_posts_to_internal_gateway_with_internal_key(self):
+        response = _ok_response()
+        with (
+            patch("ee.usage.deployment.DeploymentMode.is_cloud", return_value=True),
+            patch(
+                "ee.usage.services.gateway_llm_client._get_setting",
+                side_effect=lambda name, default="": {
+                    "AGENTCC_INTERNAL_URL": "http://agentcc-gateway:8080",
+                    "AGENTCC_INTERNAL_API_KEY": "internal-key",
+                }.get(name, default),
+            ),
+            patch("httpx.post", return_value=response) as mock_post,
+        ):
+            result = chat_completion(
+                {"model": "falcon_ai", "messages": [{"role": "user", "content": "hi"}]}
+            )
+
+        assert result["choices"][0]["message"]["content"] == "ok"
+        url = (
+            mock_post.call_args.args[0]
+            if mock_post.call_args.args
+            else (mock_post.call_args.kwargs["url"])
+        )
+        assert url == "http://agentcc-gateway:8080/v1/chat/completions"
+        headers = mock_post.call_args.kwargs["headers"]
+        assert headers["Authorization"] == "Bearer internal-key"
+
+    def test_cloud_does_not_use_activation_flow(self):
+        response = _ok_response()
+        with (
+            patch("ee.usage.deployment.DeploymentMode.is_cloud", return_value=True),
+            patch(
+                "ee.usage.services.gateway_llm_client._get_setting",
+                side_effect=lambda name, default="": {
+                    "AGENTCC_INTERNAL_URL": "http://agentcc-gateway:8080",
+                    "AGENTCC_INTERNAL_API_KEY": "internal-key",
+                }.get(name, default),
+            ),
+            patch("httpx.post", return_value=response),
+            patch(
+                "ee.licensing.activation_client.call_managed_service"
+            ) as mock_activation,
+        ):
+            chat_completion({"model": "falcon_ai", "messages": []})
+
+        mock_activation.assert_not_called()
+
+    def test_cloud_missing_internal_key_raises_typed_error(self):
+        with (
+            patch("ee.usage.deployment.DeploymentMode.is_cloud", return_value=True),
+            patch("ee.usage.services.gateway_llm_client._get_setting", return_value=""),
+            patch("httpx.post") as mock_post,
+        ):
+            with pytest.raises(ManagedServiceError) as exc:
+                chat_completion({"model": "falcon_ai", "messages": []})
+
+        assert exc.value.code == "GATEWAY_UNCONFIGURED"
+        mock_post.assert_not_called()
+
+    @pytest.mark.parametrize(
+        ("status_code", "expected_code"),
+        [
+            (401, "GATEWAY_UNAUTHORIZED"),
+            (403, "FEATURE_DENIED"),
+            (429, "RATE_LIMITED"),
+            (500, "SERVICE_ERROR"),
+        ],
+    )
+    def test_cloud_maps_gateway_status_to_typed_error(self, status_code, expected_code):
+        response = MagicMock(status_code=status_code)
+        with (
+            patch("ee.usage.deployment.DeploymentMode.is_cloud", return_value=True),
+            patch(
+                "ee.usage.services.gateway_llm_client._get_setting",
+                side_effect=lambda name, default="": {
+                    "AGENTCC_INTERNAL_URL": "http://agentcc-gateway:8080",
+                    "AGENTCC_INTERNAL_API_KEY": "internal-key",
+                }.get(name, default),
+            ),
+            patch("httpx.post", return_value=response),
+        ):
+            with pytest.raises(ManagedServiceError) as exc:
+                chat_completion({"model": "falcon_ai", "messages": []})
+
+        assert exc.value.code == expected_code
+
+    def test_cloud_unauthorized_does_not_touch_ee_token_cache(self):
+        response = MagicMock(status_code=401)
+        with (
+            patch("ee.usage.deployment.DeploymentMode.is_cloud", return_value=True),
+            patch(
+                "ee.usage.services.gateway_llm_client._get_setting",
+                side_effect=lambda name, default="": {
+                    "AGENTCC_INTERNAL_URL": "http://agentcc-gateway:8080",
+                    "AGENTCC_INTERNAL_API_KEY": "internal-key",
+                }.get(name, default),
+            ),
+            patch("httpx.post", return_value=response),
+            patch("ee.licensing.activation_client.invalidate_token") as invalidate,
+        ):
+            with pytest.raises(ManagedServiceError):
+                chat_completion({"model": "falcon_ai", "messages": []})
+
+        invalidate.assert_not_called()
+
+    @pytest.mark.parametrize(
+        ("error", "expected_code"),
+        [
+            (httpx.TimeoutException("timed out"), "GATEWAY_TIMEOUT"),
+            (httpx.ConnectError("unreachable"), "GATEWAY_UNREACHABLE"),
+        ],
+    )
+    def test_cloud_maps_transport_failure_to_typed_error(self, error, expected_code):
+        with (
+            patch("ee.usage.deployment.DeploymentMode.is_cloud", return_value=True),
+            patch(
+                "ee.usage.services.gateway_llm_client._get_setting",
+                side_effect=lambda name, default="": {
+                    "AGENTCC_INTERNAL_URL": "http://agentcc-gateway:8080",
+                    "AGENTCC_INTERNAL_API_KEY": "internal-key",
+                }.get(name, default),
+            ),
+            patch("httpx.post", side_effect=error),
+        ):
+            with pytest.raises(ManagedServiceError) as exc:
+                chat_completion({"model": "falcon_ai", "messages": []})
+
+        assert exc.value.code == expected_code
+
+
+class TestCloudStreamTransport:
+    @pytest.mark.asyncio
+    async def test_cloud_stream_uses_internal_key_without_activation(self):
+        chunks = [{"choices": [{"delta": {"content": "falcon"}}]}]
+
+        async def dispatch(**kwargs):
+            assert kwargs["url"] == ("http://agentcc-gateway:8080/v1/chat/completions")
+            assert kwargs["api_key"] == "internal-key"
+            for chunk in chunks:
+                yield chunk
+
+        with (
+            patch("ee.usage.deployment.DeploymentMode.is_cloud", return_value=True),
+            patch(
+                "ee.usage.services.gateway_llm_client._get_setting",
+                side_effect=_internal_setting,
+            ),
+            patch(
+                "ee.licensing.managed_ai.dispatch_managed_stream",
+                new=dispatch,
+            ),
+            patch(
+                "ee.licensing.managed_ai.stream_managed_service"
+            ) as activation_stream,
+        ):
+            result = [
+                chunk
+                async for chunk in stream_chat_completion(
+                    {"model": "falcon_ai", "messages": [], "stream": True}
+                )
+            ]
+
+        assert result == chunks
+        activation_stream.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_self_hosted_stream_uses_activation_transport(self):
+        chunks = [{"choices": [{"delta": {"content": "ee"}}]}]
+
+        async def activation_stream(*, json_body):
+            assert json_body["model"] == "falcon_ai"
+            for chunk in chunks:
+                yield chunk
+
+        with (
+            patch("ee.usage.deployment.DeploymentMode.is_cloud", return_value=False),
+            patch(
+                "ee.licensing.managed_ai.stream_managed_service",
+                new=activation_stream,
+            ),
+            patch(
+                "ee.usage.services.gateway_llm_client._get_setting"
+            ) as internal_setting,
+        ):
+            result = [
+                chunk
+                async for chunk in stream_chat_completion(
+                    {"model": "falcon_ai", "messages": [], "stream": True}
+                )
+            ]
+
+        assert result == chunks
+        internal_setting.assert_not_called()
+
+
+class TestSelfHostedTransport:
+    def test_ee_uses_activation_flow(self):
+        expected = {"choices": [{"message": {"content": "ee"}}]}
+        with (
+            patch("ee.usage.deployment.DeploymentMode.is_cloud", return_value=False),
+            patch(
+                "ee.licensing.managed_ai.call_managed_service", return_value=expected
+            ) as mock_activation,
+            patch("httpx.post") as mock_post,
+        ):
+            result = chat_completion({"model": "falcon_ai", "messages": []})
+
+        assert result == expected
+        mock_activation.assert_called_once()
+        assert mock_activation.call_args.kwargs["path"] == "/v1/chat/completions"
+        mock_post.assert_not_called()
+
+
+class TestModelGuard:
+    def test_rejects_non_managed_model(self):
+        with pytest.raises(ValueError):
+            chat_completion({"model": "gpt-4o", "messages": []})
+
+
+# ── Regression guards ────────────────────────────────────────────────────────
+#
+# The bug: managed AI on cloud went through the self-hosted activation-token
+# exchange (get_service_token / _activate), which needs an EE_LICENSE_KEY that
+# cloud does not carry, so every managed call failed. These guards fail loudly
+# if that branch is removed, if a managed model is added that skips it, or if a
+# client entry point stops routing through chat_completion.
+
+_INTERNAL = {
+    "AGENTCC_INTERNAL_URL": "http://agentcc-gateway:8080",
+    "AGENTCC_INTERNAL_API_KEY": "internal-key",
+}
+
+# Every managed-model shape is_managed_model() recognises. If someone adds a
+# new managed prefix, add it here so the cloud guard covers it too.
+_MANAGED_MODELS = [
+    "falcon_ai",
+    "turing_small",
+    "turing_large",
+    "protect",
+    "protect_flash",
+]
+
+
+def _internal_setting(name, default=""):
+    return _INTERNAL.get(name, default)
+
+
+def _posted_url(mock_post):
+    if mock_post.call_args.args:
+        return mock_post.call_args.args[0]
+    return mock_post.call_args.kwargs["url"]
+
+
+def _posted_auth(mock_post):
+    return mock_post.call_args.kwargs["headers"]["Authorization"]
+
+
+class TestCloudActivationGuard:
+    """On cloud, no managed model may reach the self-hosted activation flow."""
+
+    @pytest.mark.parametrize("model", _MANAGED_MODELS)
+    def test_cloud_never_calls_activation_token_exchange(self, model):
+        with (
+            patch("ee.usage.deployment.DeploymentMode.is_cloud", return_value=True),
+            patch(
+                "ee.usage.services.gateway_llm_client._get_setting",
+                side_effect=_internal_setting,
+            ),
+            patch("httpx.post", return_value=_ok_response()) as mock_post,
+            patch("ee.licensing.activation_client.get_service_token") as mock_get_token,
+            patch("ee.licensing.activation_client._activate") as mock_activate,
+        ):
+            chat_completion(
+                {"model": model, "messages": [{"role": "user", "content": "x"}]}
+            )
+
+        # Routed to the internal gateway with the internal key…
+        assert (
+            _posted_url(mock_post) == "http://agentcc-gateway:8080/v1/chat/completions"
+        )
+        assert _posted_auth(mock_post) == "Bearer internal-key"
+        # …and the activation exchange was never touched.
+        mock_get_token.assert_not_called()
+        mock_activate.assert_not_called()
+
+
+class TestEeActivationGuard:
+    """Symmetric guard: EE must keep using activation, not the internal key."""
+
+    @pytest.mark.parametrize("model", _MANAGED_MODELS)
+    def test_ee_never_reads_internal_gateway_settings(self, model):
+        with (
+            patch("ee.usage.deployment.DeploymentMode.is_cloud", return_value=False),
+            patch(
+                "ee.licensing.managed_ai.call_managed_service",
+                return_value={"choices": [{"message": {"content": "ee"}}]},
+            ) as mock_activation,
+            patch("ee.usage.services.gateway_llm_client._get_setting") as mock_setting,
+            patch("httpx.post") as mock_post,
+        ):
+            chat_completion({"model": model, "messages": []})
+
+        mock_activation.assert_called_once()
+        # Cloud-only settings resolution must not run on EE.
+        mock_setting.assert_not_called()
+        mock_post.assert_not_called()
+
+
+class TestCloudCheckNotBypassed:
+    """chat_completion must consult DeploymentMode.is_cloud — so the branch
+    cannot be silently dropped without a test noticing."""
+
+    def test_deployment_mode_is_consulted(self):
+        is_cloud = MagicMock(return_value=True)
+        with (
+            patch("ee.usage.deployment.DeploymentMode.is_cloud", is_cloud),
+            patch(
+                "ee.usage.services.gateway_llm_client._get_setting",
+                side_effect=_internal_setting,
+            ),
+            patch("httpx.post", return_value=_ok_response()),
+        ):
+            chat_completion({"model": "falcon_ai", "messages": []})
+
+        is_cloud.assert_called()
+
+
+class TestManagedClientsCloudEndToEnd:
+    """The bug surfaced through the real clients, not chat_completion directly.
+    Drive them on cloud and prove they hit the internal gateway with no
+    activation — the true regression guard."""
+
+    @pytest.mark.asyncio
+    async def test_falcon_client_on_cloud_uses_internal_gateway(self):
+        from ee.falcon_ai.llm_client import FalconLLMClient
+
+        dispatch_calls = []
+
+        async def dispatch(**kwargs):
+            dispatch_calls.append(kwargs)
+            yield {
+                "choices": [
+                    {
+                        "delta": {"content": "falcon"},
+                        "finish_reason": None,
+                    }
+                ]
+            }
+            yield {"choices": [{"delta": {}, "finish_reason": "stop"}]}
+
+        with (
+            patch("ee.usage.deployment.DeploymentMode.is_cloud", return_value=True),
+            patch(
+                "ee.usage.services.gateway_llm_client._get_setting",
+                side_effect=_internal_setting,
+            ),
+            patch(
+                "ee.licensing.managed_ai.dispatch_managed_stream",
+                new=dispatch,
+            ),
+            patch("ee.licensing.activation_client.get_service_token") as mock_get_token,
+        ):
+            client = FalconLLMClient()
+            assert client.use_managed_gateway is True
+            chunks = [
+                chunk
+                async for chunk in client.stream_completion(
+                    [{"role": "user", "content": "analyze"}], tools=None
+                )
+            ]
+
+        assert any(c["choices"][0]["delta"].get("content") == "falcon" for c in chunks)
+        assert dispatch_calls[0]["url"] == (
+            "http://agentcc-gateway:8080/v1/chat/completions"
+        )
+        assert dispatch_calls[0]["api_key"] == "internal-key"
+        mock_get_token.assert_not_called()
+
+    def test_turing_client_on_cloud_uses_internal_gateway(self):
+        from ee.turing.client import TuringClient
+
+        with (
+            patch("ee.usage.deployment.DeploymentMode.is_cloud", return_value=True),
+            patch(
+                "ee.usage.services.gateway_llm_client._get_setting",
+                side_effect=_internal_setting,
+            ),
+            patch(
+                "httpx.post",
+                return_value=_ok_response(
+                    {
+                        "choices": [{"message": {"content": "turing"}}],
+                        "usage": {
+                            "prompt_tokens": 1,
+                            "completion_tokens": 1,
+                            "total_tokens": 2,
+                        },
+                    }
+                ),
+            ) as mock_post,
+            patch("ee.licensing.activation_client.get_service_token") as mock_get_token,
+        ):
+            result = TuringClient().chat_completion(
+                model="turing_small",
+                messages=[{"role": "user", "content": "hi"}],
+            )
+
+        assert result == "turing"
+        assert (
+            _posted_url(mock_post) == "http://agentcc-gateway:8080/v1/chat/completions"
+        )
+        assert _posted_auth(mock_post) == "Bearer internal-key"
+        mock_get_token.assert_not_called()

--- a/futureagi/ee/licensing/tests/test_managed_clients.py
+++ b/futureagi/ee/licensing/tests/test_managed_clients.py
@@ -56,7 +56,9 @@ class TestTuringManagedClient:
         assert result == response
         payload = mock_call.call_args.args[0]
         assert payload["model"] == "turing_flash"
-        assert payload["tools"] == [{"type": "function", "function": {"name": "lookup"}}]
+        assert payload["tools"] == [
+            {"type": "function", "function": {"name": "lookup"}}
+        ]
         assert client.token_usage["total_tokens"] == 2
 
 
@@ -67,24 +69,40 @@ class TestFalconManagedClient:
         assert client.model == "falcon_ai"
 
     @pytest.mark.asyncio
-    @patch("ee.licensing.managed_ai.chat_completion")
-    async def test_stream_completion_uses_managed_gateway(self, mock_call):
-        mock_call.return_value = {
-            "choices": [{"message": {"content": "falcon managed"}}],
-            "usage": {"total_tokens": 4},
-        }
+    async def test_stream_completion_uses_managed_gateway(self):
+        payloads = []
 
-        client = FalconLLMClient()
-        chunks = []
-        async for chunk in client.stream_completion(
-            [{"role": "user", "content": "analyze"}],
-            tools=[{"type": "function", "function": {"name": "create"}}],
+        async def managed_stream(payload):
+            payloads.append(payload)
+            yield {
+                "choices": [
+                    {
+                        "delta": {"content": "falcon managed"},
+                        "finish_reason": None,
+                    }
+                ]
+            }
+            yield {"choices": [{"delta": {}, "finish_reason": "stop"}]}
+
+        with patch(
+            "ee.licensing.managed_ai.stream_chat_completion",
+            new=managed_stream,
         ):
-            chunks.append(chunk)
+            client = FalconLLMClient()
+            chunks = [
+                chunk
+                async for chunk in client.stream_completion(
+                    [{"role": "user", "content": "analyze"}],
+                    tools=[{"type": "function", "function": {"name": "create"}}],
+                )
+            ]
 
         assert chunks[0]["choices"][0]["delta"]["content"] == "falcon managed"
         assert chunks[-1]["choices"][0]["finish_reason"] == "stop"
-        payload = mock_call.call_args.args[0]
+        payload = payloads[0]
         assert payload["model"] == "falcon_ai"
         assert payload["messages"] == [{"role": "user", "content": "analyze"}]
-        assert payload["tools"] == [{"type": "function", "function": {"name": "create"}}]
+        assert payload["tools"] == [
+            {"type": "function", "function": {"name": "create"}}
+        ]
+        assert payload["stream"] is True

--- a/futureagi/tfc/settings/settings.py
+++ b/futureagi/tfc/settings/settings.py
@@ -480,9 +480,12 @@ SERVER_EMAIL = os.getenv("SERVER_EMAIL")  # ditto (default from-email for Django
 APP_URL = os.getenv("APP_URL")
 
 # ── Billing ───────────────────────────────────────────────────
+# Ships only with the cloud overlay, which is the future-agi/ee repo checked
+# out at futureagi/ee/cloud/. Absent on OSS/EE — BillingConfig falls open to
+# empty defaults there (and fails closed on cloud).
 BILLING_CONFIG_PATH = os.environ.get(
     "BILLING_CONFIG_PATH",
-    os.path.join(BASE_DIR, "..", "ee", "billing.yaml"),
+    os.path.join(BASE_DIR, "..", "ee", "cloud", "billing.yaml"),
 )
 
 # EE license key (self-hosted only, JWT RS256)

--- a/futureagi/tfc/temporal/common/registry.py
+++ b/futureagi/tfc/temporal/common/registry.py
@@ -355,7 +355,7 @@ def _ensure_workflows_registered() -> None:
     # UsageConsumerWorkflow (long-running singleton) + MonthlyResetWorkflow
     try:
         try:
-            from ee.usage.temporal import get_workflows as get_billing_workflows
+            from ee.cloud.temporal import get_workflows as get_billing_workflows
         except ImportError:
             get_billing_workflows = None
 
@@ -763,7 +763,7 @@ def _ensure_activities_registered() -> None:
     # Register usage metering activities (consumer, sync, monthly reset)
     try:
         try:
-            from ee.usage.temporal import get_activities as get_usage_activities
+            from ee.cloud.temporal import get_activities as get_usage_activities
         except ImportError:
             get_usage_activities = None
 


### PR DESCRIPTION
## What

Repoints the open repo at the cloud-private repo's new checkout path, `futureagi/ee/cloud/`.

| File | Change |
|---|---|
| `tfc/settings/settings.py` | `BILLING_CONFIG_PATH` default → `ee/cloud/billing.yaml` |
| `.gitignore` | twelve `futureagi/ee/*` rules collapse to one: `futureagi/ee/cloud/` |
| `.dockerignore` | same collapse |
| `backend-ci.yml`, `api-contracts.yml`, `sdk-compatibility.yml` | EE checkout target → `futureagi/ee/cloud` |

## Why

**[future-agi/ee#210](https://github.com/future-agi/ee/pull/210)** makes that repo the `ee.cloud` package itself, checked out at `futureagi/ee/cloud/` instead of `futureagi/ee/`. The two repos then share **zero paths**, so ownership is enforced by the directory boundary instead of by ignore rules.

### The CI change is the load-bearing part

All three workflows check the EE repo out **over** `futureagi/ee` — `actions/checkout` cleans its target path, and `sdk-compatibility.yml` does an explicit `rm -rf futureagi/ee` + `mv`.

That is *why* the EE repo carried duplicates of `agenthub/`, `falcon_ai/`, `usage/` and the rest: CI depended on that checkout restoring them after the directory was wiped. They were load-bearing, not vestigial — which only surfaced when ee#210's first CI run went red here.

So the deletion in ee#210 is only safe once the checkout no longer clobbers the open repo's tree. Pointing it at `futureagi/ee/cloud` does that: the open repo's `ee/` stays intact on disk and the private repo lands in the one directory it owns.

## These two PRs must merge together

They are mutually dependent, and **this branch is deliberately named to match ee#210's branch** so CI can prove the pair works:

`backend-ci.yml` resolves the EE branch by walking `${{ github.head_ref }}` → base ref → `dev` → `main`. With matching names, CI here checks out ee#210's branch and tests the new layout end to end. Rename this branch and CI silently falls back to ee `dev` — the old layout — and every shard fails on `ee/cloud/cloud/…`.

## Verified locally, end to end

Plain `git clone https://github.com/future-agi/ee.git futureagi/ee/cloud` against a real checkout — no graft, no `-f`:

| Check | Result |
|---|---|
| `ee/cloud` tracked / dirty | 147 / clean |
| open repo dirty | only this PR's files |
| either repo seeing the other's files | none, both directions |
| `BILLING_CONFIG_PATH` | `/app/backend/ee/cloud/billing.yaml`, exists |
| `billing.yaml` parses | 6 plans, 22 call types, 7 dimensions |
| imports | `ee.cloud.{control_plane,billing,telemetry,tasks}` + `ee.falcon_ai`, `ee.usage`, `ee.licensing` |
| `INSTALLED_APPS` | all 4 `ee` apps |
| `is_oss()` / `is_cloud()` | `False` / `True` |

## Notes for the reviewer

**`BILLING_CONFIG_PATH` stays env-overridable**, so deployments can set the new path before this merges and roll the image and the code independently.

**black is skipped on the settings.py commit.** It wants to reformat three unrelated regions already on `dev` (~468, ~502, ~842) — pre-existing formatter drift that would have added 16/−12 lines of unrelated churn. Worth its own PR.

## Also fixes: silently unregistered Temporal workflows

`registry.py` looked up `ee.usage.temporal`, which stopped existing when future-agi/ee@`4a9e5c2` moved that code to `cloud/temporal/`. Both lookups are wrapped in `except ImportError: ... = None`, so `UsageConsumerWorkflow`, `MonthlyResetWorkflow` and the usage-metering activities were **never registered on the Temporal worker** — silently, with one log line.

Repointed to `ee.cloud.temporal`. Verified against the fixed EE branch:

```
get_workflows()  → ['UsageConsumerWorkflow', 'MonthlyResetWorkflow']
get_activities() → 2 activities
```

The 17 matching references inside the EE repo are fixed in future-agi/ee#210.

## Supersedes

#2044 and #2070.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

---

# Deploying

Both PRs must be applied together. `futureagi/ee/cloud/` is a **separate clone**, so pulling the open repo alone will not move it.

## Local — fresh setup

```bash
git clone https://github.com/future-agi/future-agi.git && cd future-agi
git checkout dev

# the cloud repo — an ordinary clone; the target path does not exist yet
git clone https://github.com/future-agi/ee.git futureagi/ee/cloud

cp .env.example .env
#   CLOUD_DEPLOYMENT=DEV
#   CLOUD_DEPLOYMENT_SECRET=<64-char, from the dev server's .env>
#   OPENAI_API_KEY=sk-...
#   VITE_HOST_API=http://localhost:8000
#   FRONTEND_URL=http://localhost:3000

docker compose -f docker-compose.yml -f docker-compose.dev.yml \
  up -d --build --scale frontend=0

docker compose -f docker-compose.yml -f docker-compose.dev.yml \
  exec backend python manage.py migrate
```

No graft, no `-f`, no setup script — the two repos share no path.

If another Future AGI stack is already running it holds the same ports. Every port is env-overridable: `BACKEND_PORT`, `PG_PORT`, `CH_HTTP_PORT`, `CH_PORT`, `REDIS_PORT`, `TEMPORAL_PORT`, `RABBITMQ_PORT`, `MINIO_API_PORT`, `PGBOUNCER_PORT`, `FRONTEND_PORT`, `BACKEND_GRPC_PORT`, `FLOWER_PORT`.

## Local — migrating an existing checkout

The old nested clone sits at `futureagi/ee/` and must be removed before the new one can be placed.

```bash
cd /path/to/future-agi
tar czf ~/ee-backup-$(date +%F).tgz futureagi/ee     # safety net

docker compose -f docker-compose.yml -f docker-compose.dev.yml stop \
  backend worker-default worker-tasks-s worker-tasks-l worker-tasks-xl \
  worker-trace-ingestion worker-agent-compass

# drop the old nested clone and everything the private repo owned
rm -rf futureagi/ee/.git futureagi/ee/cloud futureagi/ee/scripts futureagi/ee/.github
rm -f  futureagi/ee/billing.yaml futureagi/ee/Dockerfile.ee futureagi/ee/Dockerfile.cloud \
       futureagi/ee/docker-compose.ee.yml futureagi/ee/.dockerignore futureagi/ee/.gitignore \
       futureagi/ee/MIGRATION_GUIDE.md futureagi/ee/OPERATIONS_RUNBOOK.md \
       futureagi/ee/PHASE4_CLASSIFICATION.md futureagi/ee/README.md futureagi/ee/LICENSE

git checkout -- futureagi/ee/          # restore the open repo's own ee tree
git pull --ff-only                     # pick up this PR

git clone https://github.com/future-agi/ee.git futureagi/ee/cloud

docker compose -f docker-compose.yml -f docker-compose.dev.yml \
  up -d --build --scale frontend=0
docker compose -f docker-compose.yml -f docker-compose.dev.yml \
  exec backend python manage.py migrate
```

## Dev server

Use `/home/ubuntu/future-agi` — **not** `/home/ubuntu/for-builds/future-agi`, which is a stale May checkout.

```bash
gcloud compute ssh future-dev --zone asia-south1-a \
  --project futureagiprimary --tunnel-through-iap
cd /home/ubuntu/future-agi
G="sudo -u ubuntu git -c safe.directory=*"
```

**1 — Reclaim disk first.** The box sits above 90%; `--build` can fail mid-way and leave a broken stack. Images and build cache only — **never** `--volumes`, which holds the dev Postgres, ClickHouse and MinIO data.

```bash
sudo docker image prune -a -f && sudo docker builder prune -a -f
df -h /
```

**2 — Back up and stop the app containers.** Infra stays up, so there is no data risk.

```bash
sudo tar czf ~/ee-backup-$(date +%F).tgz futureagi/ee
sudo docker compose -f docker-compose.yml -f docker-compose.dev.yml stop \
  backend worker-default worker-tasks-s worker-tasks-l worker-tasks-xl \
  worker-trace-ingestion worker-agent-compass
```

**3 — Check nothing uncommitted is under `cloud/` before discarding.**

```bash
$G -C futureagi/ee status --porcelain | grep '^.\{3\}cloud/' \
  && echo "STOP — uncommitted cloud work" || echo "safe"
```

**4 — Replace the old nested clone.**

```bash
sudo rm -rf futureagi/ee/.git futureagi/ee/cloud futureagi/ee/.github
sudo rm -f  futureagi/ee/billing.yaml futureagi/ee/Dockerfile.ee futureagi/ee/Dockerfile.cloud \
            futureagi/ee/docker-compose.ee.yml futureagi/ee/.dockerignore futureagi/ee/.gitignore \
            futureagi/ee/*.md futureagi/ee/LICENSE

$G -C /home/ubuntu/future-agi checkout -- futureagi/ee/
$G -C /home/ubuntu/future-agi fetch origin dev
$G -C /home/ubuntu/future-agi checkout dev
$G -C /home/ubuntu/future-agi reset --hard origin/dev

sudo -u ubuntu git clone https://github.com/future-agi/ee.git futureagi/ee/cloud
```

The dev checkout is on a feature branch, not `dev`, so `checkout dev` is a real code deploy — confirm that is intended, or `merge origin/dev` into the current branch instead.

**5 — Verify before restarting.**

```bash
$G -C futureagi/ee/cloud ls-files | wc -l          # 147
$G -C futureagi/ee/cloud status --porcelain        # empty
$G -C /home/ubuntu/future-agi status --porcelain   # empty
ls futureagi/ee/falcon_ai futureagi/ee/usage       # both populated
ls futureagi/ee/cloud/billing.yaml                 # present
```

**6 — Rebuild and migrate.** `CLOUD_DEPLOYMENT` and `CLOUD_DEPLOYMENT_SECRET` are already set in the dev `.env`.

```bash
sudo docker compose -f docker-compose.yml -f docker-compose.dev.yml \
  up -d --build --scale frontend=0
sudo docker compose -f docker-compose.yml -f docker-compose.dev.yml \
  exec backend python manage.py migrate
```

Migrations are required — the dev overlay sets `FAST_STARTUP=true`, which skips them at boot.

**7 — Confirm.**

```bash
sudo docker compose -f docker-compose.yml -f docker-compose.dev.yml \
  exec backend python -c "
import django; django.setup()
from tfc.ee_gating import is_oss
from ee.usage.deployment import DeploymentMode
import ee.cloud.temporal as t
print('is_oss', is_oss(), '| is_cloud', DeploymentMode.is_cloud())
print('workflows', [w.__name__ for w in t.get_workflows()])"
```

Expected: `is_oss False | is_cloud True` and `['UsageConsumerWorkflow', 'MonthlyResetWorkflow']`. Infra containers should keep their prior uptime — if they restarted, more was stopped than intended.

## Rollback

The open repo's `ee/` tree is never touched by these steps, so rollback is just restoring the old nested clone:

```bash
rm -rf futureagi/ee/cloud
tar xzf ~/ee-backup-YYYY-MM-DD.tgz -C /path/to/future-agi
git checkout <previous-ref>
```
