### PR TITLE
feat(workbench): persist eval version pins on PromptEvalConfig (TH-6979)

### DIFF
--- a/frontend/src/sections/common/EvalPicker/EvalPickerConfigFull.jsx
+++ b/frontend/src/sections/common/EvalPicker/EvalPickerConfigFull.jsx
@@ -197,17 +197,15 @@ const EvalPickerConfigFull = ({ evalData, onBack, onSave, isSaving }) => {
   const [dataReady, setDataReady] = useState(false);
   const [isDirty, setIsDirty] = useState(false);
   useEffect(() => {
-    const pinned =
-      evalData?.pinned_version_id ?? evalData?.pinnedVersionId ?? null;
-    if (pinned && !selectedVersionId && !isDirty) {
+    if (selectedVersionId || isDirty) return;
+    const pinned = evalData?.pinned_version_id ?? null;
+    if (pinned) {
       setSelectedVersionId(pinned);
+    } else if (versions.length) {
+      const def = versions.find((v) => v.is_default);
+      if (def) setSelectedVersionId(def.id);
     }
-  }, [
-    evalData?.pinned_version_id,
-    evalData?.pinnedVersionId,
-    selectedVersionId,
-    isDirty,
-  ]);
+  }, [evalData?.pinned_version_id, selectedVersionId, isDirty, versions]);
   const [isTesting, setIsTesting] = useState(false);
   const [testPassed, setTestPassed] = useState(false);
   const [testError, setTestError] = useState(null);
@@ -267,6 +265,14 @@ const EvalPickerConfigFull = ({ evalData, onBack, onSave, isSaving }) => {
     compositeDetail?.children || [],
   );
   const [compositeChildWeights, setCompositeChildWeights] = useState({});
+  const hydrateCompositeWeights = useCallback((children) => {
+    if (!Array.isArray(children)) return;
+    const weights = {};
+    children.forEach((c) => {
+      if (c?.child_id != null) weights[c.child_id] = c.weight ?? 1;
+    });
+    setCompositeChildWeights(weights);
+  }, []);
   const compositePopulatedRef = useRef(false);
   useEffect(() => {
     if (!isComposite) return;
@@ -481,6 +487,8 @@ const EvalPickerConfigFull = ({ evalData, onBack, onSave, isSaving }) => {
     if (config.error_localizer_enabled != null) {
       setErrorLocalizerEnabled(!!config.error_localizer_enabled);
     }
+
+    hydrateCompositeWeights(config.children);
 
     if (isEditMode) setEvalName(evalData?.name || fullEval?.name || "");
     setIsDirty(false);
@@ -825,6 +833,7 @@ const EvalPickerConfigFull = ({ evalData, onBack, onSave, isSaving }) => {
             : ["variables_only"],
         );
         setUseInternet(config.check_internet ?? false);
+        hydrateCompositeWeights(config.children);
         setIsDirty(false);
       }
     },
@@ -1069,6 +1078,7 @@ const EvalPickerConfigFull = ({ evalData, onBack, onSave, isSaving }) => {
         templateType,
         config: fullEval?.config || evalData?.config,
         versionId: selectedVersionId,
+        isDirty,
         data_injection: dataInjection,
         error_localizer_enabled: errorLocalizerActive,
         composite_weight_overrides: compositeChildWeights,
@@ -1089,6 +1099,7 @@ const EvalPickerConfigFull = ({ evalData, onBack, onSave, isSaving }) => {
       outputType,
       config: resolvedConfig,
       versionId: selectedVersionId,
+      isDirty,
       instructions,
       messages,
       pass_threshold: passThreshold,
@@ -1149,6 +1160,7 @@ const EvalPickerConfigFull = ({ evalData, onBack, onSave, isSaving }) => {
     source,
     onFiltersChange,
     localFilterForm,
+    isDirty,
   ]);
 
   if (isLoading) {
@@ -1273,14 +1285,10 @@ const EvalPickerConfigFull = ({ evalData, onBack, onSave, isSaving }) => {
           {versions.length > 0 && (
             <Select
               size="small"
-              value={selectedVersionId || ""}
+              value={selectedVersionId || (versions.find((v) => v.is_default)?.id ?? versions[0]?.id ?? "")}
               onChange={handleVersionChange}
-              displayEmpty
               sx={{ fontSize: "12px", minWidth: 130, height: 30 }}
             >
-              <MenuItem value="" sx={{ fontSize: "12px" }}>
-                Default version
-              </MenuItem>
               {versions.map((v) => (
                 <MenuItem key={v.id} value={v.id} sx={{ fontSize: "12px" }}>
                   V{v.version_number}

--- a/frontend/src/sections/common/EvaluationDrawer/EvaluationDrawer.jsx
+++ b/frontend/src/sections/common/EvaluationDrawer/EvaluationDrawer.jsx
@@ -648,6 +648,65 @@ const EvaluationDrawerChild = ({
           // shape than the dataset/task/experiment endpoints.
           let payload;
           if ((module || "dataset") === "workbench") {
+            // Version creation — same as experiment wizard.
+            let resolvedVersionId = evalConfig.versionId || null;
+            if (evalConfig.isDirty && evalConfig.templateId) {
+              try {
+                if (isComposite) {
+                  const patchPayload = {};
+                  if (evalConfig.composite_weight_overrides) {
+                    const weights = {};
+                    for (const [childId, w] of Object.entries(evalConfig.composite_weight_overrides)) {
+                      if (w != null) weights[childId] = w;
+                    }
+                    if (Object.keys(weights).length) patchPayload.child_weights = weights;
+                  }
+                  await axios.patch(
+                    endpoints.develop.eval.getCompositeDetail(evalConfig.templateId),
+                    patchPayload,
+                  );
+                  const { data: versionsData } = await axios.get(
+                    endpoints.develop.eval.getEvalVersions(evalConfig.templateId),
+                  );
+                  const latest = versionsData?.result?.versions?.[0];
+                  if (latest?.id) resolvedVersionId = latest.id;
+                } else {
+                  const isCodeEval = evalConfig.evalType === "code";
+                  const updatePayload = Object.fromEntries(
+                    Object.entries({
+                      instructions: isCodeEval ? undefined : evalConfig.instructions,
+                      code: isCodeEval ? evalConfig.instructions : undefined,
+                      code_language: isCodeEval ? (evalConfig.codeLanguage || "python") : undefined,
+                      model: evalConfig.model,
+                      pass_threshold: evalConfig.pass_threshold,
+                      choice_scores: evalConfig.choice_scores,
+                      multi_choice: evalConfig.multi_choice,
+                      messages: evalConfig.messages,
+                      mode: evalConfig.agent_mode,
+                      check_internet: evalConfig.check_internet,
+                      summary: evalConfig.summary,
+                      tools: evalConfig.tools,
+                      knowledge_bases: evalConfig.knowledge_bases,
+                      data_injection: evalConfig.data_injection,
+                      error_localizer_enabled: evalConfig.error_localizer_enabled,
+                    }).filter(([, v]) => v !== undefined),
+                  );
+                  await axios.put(
+                    endpoints.develop.eval.updateEvalTemplate(evalConfig.templateId),
+                    updatePayload,
+                  );
+                  const { data: versionData } = await axios.post(
+                    endpoints.develop.eval.createEvalVersion(evalConfig.templateId),
+                    {},
+                  );
+                  if (versionData?.result?.id) resolvedVersionId = versionData.result.id;
+                }
+                queryClient.invalidateQueries({ queryKey: ["evals", "versions", evalConfig.templateId] });
+                queryClient.invalidateQueries({ queryKey: ["evals", "composite", evalConfig.templateId] });
+              } catch {
+                // Fall back to the version the user selected in the picker.
+              }
+            }
             payload = {
               id: evalConfig.templateId,
               name: evalConfig.name,
@@ -662,6 +721,7 @@ const EvaluationDrawerChild = ({
               error_localizer: runConfig.error_localizer_enabled || false,
               is_run: true,
               version_to_run: workbenchVersions || [],
+              ...(resolvedVersionId ? { pinned_version_id: resolvedVersionId } : {}),
             };
           } else {
             payload = {
@@ -770,6 +830,11 @@ const EvaluationDrawerChild = ({
           // await so errors propagate to EvalPickerDrawer's handleSaveEval
           // catch block — keeps the drawer open on failure.
           await handleRun(payload, () => {
+            if (evalConfig.templateId) {
+              queryClient.invalidateQueries({
+                queryKey: ["evals", "versions", evalConfig.templateId],
+              });
+            }
             setEvalPickerOpen(false);
             setVisibleSection("list");
           });

--- a/futureagi/model_hub/migrations/0123_promptevalconfig_pinned_version.py
+++ b/futureagi/model_hub/migrations/0123_promptevalconfig_pinned_version.py
@@ -1,0 +1,23 @@
+import django.db.models.deletion
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("model_hub", "0122_backfill_queueitem_source_preview"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="promptevalconfig",
+            name="pinned_version",
+            field=models.ForeignKey(
+                blank=True,
+                null=True,
+                on_delete=django.db.models.deletion.SET_NULL,
+                related_name="pinned_prompt_eval_configs",
+                to="model_hub.evaltemplateversion",
+            ),
+        ),
+    ]

--- a/futureagi/model_hub/models/run_prompt.py
+++ b/futureagi/model_hub/models/run_prompt.py
@@ -389,3 +389,10 @@ class PromptEvalConfig(BaseModel):
         blank=True,
         default=None,
     )
+    pinned_version = models.ForeignKey(
+        "model_hub.EvalTemplateVersion",
+        on_delete=models.SET_NULL,
+        null=True,
+        blank=True,
+        related_name="pinned_prompt_eval_configs",
+    )

--- a/futureagi/model_hub/serializers/prompt_template.py
+++ b/futureagi/model_hub/serializers/prompt_template.py
@@ -661,6 +661,9 @@ class SingleEvaluationConfigSerializer(serializers.Serializer):
     kb_id = serializers.CharField(
         required=False, allow_null=True, allow_blank=True, default=None
     )
+    pinned_version_id = serializers.UUIDField(
+        required=False, allow_null=True, default=None
+    )
 
     def validate(self, data):
         """Validate the evaluation configuration"""

--- a/futureagi/model_hub/views/prompt_template.py
+++ b/futureagi/model_hub/views/prompt_template.py
@@ -2152,6 +2152,7 @@ class PromptTemplateViewSet(BaseModelViewSetMixin, viewsets.ModelViewSet):
                         "eval_group": (
                             config.eval_group.name if config.eval_group else None
                         ),
+                        "pinned_version_id": str(config.pinned_version_id) if config.pinned_version_id else None,
                     }
                 )
 
@@ -2263,6 +2264,9 @@ class PromptTemplateViewSet(BaseModelViewSetMixin, viewsets.ModelViewSet):
                 prompt_eval.error_localizer = new_config.get(
                     "error_localizer", False
                 )
+                prompt_eval.pinned_version_id = new_config.get(
+                    "pinned_version_id"
+                )
                 prompt_eval.save(
                     update_fields=[
                         "name",
@@ -2271,6 +2275,7 @@ class PromptTemplateViewSet(BaseModelViewSetMixin, viewsets.ModelViewSet):
                         "config",
                         "kb",
                         "error_localizer",
+                        "pinned_version",
                         "updated_at",
                     ]
                 )
@@ -2284,6 +2289,7 @@ class PromptTemplateViewSet(BaseModelViewSetMixin, viewsets.ModelViewSet):
                     user=request.user,
                     kb=kb,
                     error_localizer=new_config.get("error_localizer", False),
+                    pinned_version_id=new_config.get("pinned_version_id"),
                 )
 
             # If is_run is true, run evaluations on specified versions
@@ -2391,6 +2397,7 @@ class PromptTemplateViewSet(BaseModelViewSetMixin, viewsets.ModelViewSet):
                 {
                     "message": "Evaluation configuration updated successfully",
                     "prompt_eval_config_id": str(prompt_eval.id),
+                    "pinned_version_id": str(prompt_eval.pinned_version_id) if prompt_eval.pinned_version_id else None,
                 }
             )
 


### PR DESCRIPTION
Workbench counterpart of #2062. Adds `pinned_version_id` to `PromptEvalConfig` so eval version picks in the prompt workbench survive save/reopen. Supersedes #1843 with a simpler approach — uses the same template update + version create endpoints as the eval workbench instead of modifying `maybe_pin_new_version`.

When the user edits an eval config in the workbench picker (`isDirty`), the frontend calls `PUT /eval-templates/{id}/update/` + `POST .../versions/create/` (normal evals) or `PATCH /eval-templates/{id}/composite/` (composite evals) to create a version. A pure version-dropdown switch just passes the selected ID. The resolved `pinned_version_id` flows into the `update-evaluation-configs` POST where the backend writes it to the `PromptEvalConfig.pinned_version` FK. The GET `evaluation-configs` response now returns it for picker pre-selection on reopen.

Also fixes: version dropdown now shows the actual default version instead of blank text, initial version selection sets state so `onSave` sends it, composite weight hydration extracted into a shared helper with null guards, code eval fields (`code`, `code_language`) included in the template update payload, composite detail cache invalidated after PATCH.

Closes TH-6979 (workbench portion).

## File-by-file changes

**Backend**

- `futureagi/model_hub/models/run_prompt.py` (+7) — `pinned_version` FK on `PromptEvalConfig` → `EvalTemplateVersion`, nullable, SET_NULL on delete.
- `futureagi/model_hub/migrations/0123_promptevalconfig_pinned_version.py` (+23) — adds the FK column.
- `futureagi/model_hub/serializers/prompt_template.py` (+3) — `pinned_version_id` field on `SingleEvaluationConfigSerializer`.
- `futureagi/model_hub/views/prompt_template.py` (+7) — `update_evaluation_configs`: writes `pinned_version_id` on both create and update branches, returns it in response. `get_evaluation_configs`: returns `pinned_version_id` per config.

**Frontend**

- `frontend/src/sections/common/EvalPicker/EvalPickerConfigFull.jsx` (+36 -14) — emits `isDirty` in both onSave payloads. Extracted `hydrateCompositeWeights` helper with null guards (used by initial load effect + handleVersionChange). Version dropdown resolves to actual default version, sets `selectedVersionId` in state so onSave sends it. Dropped camelCase fallbacks on `pinned_version_id`, `version_number`, `is_default`.
- `frontend/src/sections/common/EvaluationDrawer/EvaluationDrawer.jsx` (+65) — workbench payload builder: when `isDirty`, calls `PUT /update/` + `POST /versions/create/` (normal) or `PATCH /composite/` (composite) before the save POST. Includes `pinned_version_id` in the workbench payload. Invalidates version + composite detail caches after save. Handles code evals by sending `code`/`code_language` instead of `instructions`.

## Test checklist
- [ ] Workbench: add eval → edit config → verify version created, pinned_version_id saved
- [ ] Workbench: add eval → switch version only → verify no version created, selected ID persisted
- [ ] Workbench: reopen eval → verify picker shows pinned version with correct weights
- [ ] Workbench: composite eval → edit weights → verify version created with correct snapshot
- [ ] Workbench: composite eval → switch version → verify weights hydrate

## Type of Change
- [x] New feature

## Checklist
- [x] Self-review done
- [x] All PR #1843 review comments addressed
- [x] No changes to `maybe_pin_new_version` — version creation uses existing template endpoints
- [x] `EvalPickerConfigFull` changes shared with #2062 (identical merge on whichever lands second)