### PR TITLE
fix(model-hub): fail closed on unresolved run prompt placeholders

### DIFF
--- a/futureagi/model_hub/tests/test_run_prompt_unresolved_placeholders.py
+++ b/futureagi/model_hub/tests/test_run_prompt_unresolved_placeholders.py
@@ -1,0 +1,182 @@
+"""Regression coverage for #321.
+
+`populate_placeholders()` used to swallow every non-media exception and return
+the original, unsubstituted messages. Unresolved `{{column}}` tokens then
+reached the provider verbatim, and callers had no way to tell a fully rendered
+prompt from a fallback.
+
+These tests pin the fail-closed behaviour at the layer where it is decided —
+`render_template()` and the unresolved-token scanner — without needing a
+database, so they stay fast and do not depend on dataset fixtures.
+"""
+
+import pytest
+
+from model_hub.views.run_prompt import (
+    TEMPLATE_FORMAT_FSTRING,
+    TEMPLATE_FORMAT_JINJA2,
+    TEMPLATE_FORMAT_MUSTACHE,
+    UnresolvedPromptPlaceholdersError,
+    find_unresolved_placeholders,
+    render_template,
+)
+
+
+class TestFindUnresolvedPlaceholders:
+    def test_finds_a_surviving_token_in_a_string(self):
+        assert find_unresolved_placeholders("Hello {{name}}") == ["name"]
+
+    def test_ignores_fully_rendered_text(self):
+        assert find_unresolved_placeholders("Hello Ada") == []
+
+    def test_walks_message_content_lists_and_dicts(self):
+        messages = [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": "Summarize {{ input_column }}"},
+                    {"type": "text", "text": "already rendered"},
+                ],
+            }
+        ]
+
+        assert find_unresolved_placeholders(messages) == ["input_column"]
+
+    def test_reports_every_unresolved_token(self):
+        found = find_unresolved_placeholders("{{a}} and {{b}} and {{a}}")
+
+        assert sorted(set(found)) == ["a", "b"]
+
+    def test_handles_empty_and_non_string_values(self):
+        assert find_unresolved_placeholders("") == []
+        assert find_unresolved_placeholders(None) == []
+        assert find_unresolved_placeholders(42) == []
+
+
+class TestRenderTemplateFailsClosed:
+    """Each format must raise rather than quietly produce a wrong prompt."""
+
+    def test_jinja_raises_on_a_missing_variable(self):
+        with pytest.raises(UnresolvedPromptPlaceholdersError) as exc:
+            render_template(
+                "Summarize {{ input_column }}",
+                {},
+                template_format=TEMPLATE_FORMAT_JINJA2,
+                strict=True,
+            )
+
+        assert "input_column" in exc.value.placeholders
+
+    def test_jinja_names_every_missing_variable_not_just_the_first(self):
+        with pytest.raises(UnresolvedPromptPlaceholdersError) as exc:
+            render_template(
+                "{{ alpha }} then {{ beta }}",
+                {},
+                template_format=TEMPLATE_FORMAT_JINJA2,
+                strict=True,
+            )
+
+        assert "alpha" in exc.value.placeholders
+        assert "beta" in exc.value.placeholders
+
+    def test_mustache_raises_instead_of_rendering_an_empty_string(self):
+        # chevron renders an unknown key as "", which is precisely how a wrong
+        # prompt reaches the provider without anything looking broken.
+        assert (
+            render_template(
+                "Summarize {{missing}}",
+                {},
+                template_format=TEMPLATE_FORMAT_MUSTACHE,
+            )
+            == "Summarize "
+        )
+
+        with pytest.raises(UnresolvedPromptPlaceholdersError) as exc:
+            render_template(
+                "Summarize {{missing}}",
+                {},
+                template_format=TEMPLATE_FORMAT_MUSTACHE,
+                strict=True,
+            )
+
+        assert "missing" in exc.value.placeholders
+
+    def test_fstring_raises_on_a_missing_key(self):
+        with pytest.raises(UnresolvedPromptPlaceholdersError) as exc:
+            render_template(
+                "Summarize {input_column}",
+                {},
+                template_format=TEMPLATE_FORMAT_FSTRING,
+                strict=True,
+            )
+
+        assert "input_column" in exc.value.placeholders
+
+
+class TestRenderTemplateStillRendersValidPrompts:
+    """Fail-closed must not break prompts that resolve correctly."""
+
+    @pytest.mark.parametrize(
+        "template_format,template",
+        [
+            (TEMPLATE_FORMAT_JINJA2, "Summarize {{ input_column }}"),
+            (TEMPLATE_FORMAT_MUSTACHE, "Summarize {{input_column}}"),
+            (TEMPLATE_FORMAT_FSTRING, "Summarize {input_column}"),
+        ],
+    )
+    def test_resolved_placeholders_render_unchanged(
+        self, template_format, template
+    ):
+        rendered = render_template(
+            template,
+            {"input_column": "the transcript"},
+            template_format=template_format,
+            strict=True,
+        )
+
+        assert rendered == "Summarize the transcript"
+        assert find_unresolved_placeholders(rendered) == []
+
+    def test_mustache_sections_are_not_mistaken_for_missing_values(self):
+        # `#`, `/` and `^` are control syntax, not value substitution.
+        rendered = render_template(
+            "{{#items}}{{name}} {{/items}}",
+            {"items": [{"name": "one"}, {"name": "two"}]},
+            template_format=TEMPLATE_FORMAT_MUSTACHE,
+            strict=True,
+        )
+
+        assert rendered.strip() == "one two"
+
+    def test_jinja_dotted_access_resolves(self):
+        rendered = render_template(
+            "{{ account.name }}",
+            {"account": {"name": "Acme"}},
+            template_format=TEMPLATE_FORMAT_JINJA2,
+            strict=True,
+        )
+
+        assert rendered == "Acme"
+
+    def test_empty_template_is_returned_as_is(self):
+        assert render_template("", {}, TEMPLATE_FORMAT_JINJA2, strict=True) == ""
+
+
+class TestUnresolvedPromptPlaceholdersError:
+    def test_message_names_the_offending_placeholders(self):
+        error = UnresolvedPromptPlaceholdersError(["beta", "alpha"])
+
+        assert error.placeholders == ["alpha", "beta"]
+        assert "alpha" in str(error)
+        assert "beta" in str(error)
+
+    def test_duplicates_are_collapsed(self):
+        assert UnresolvedPromptPlaceholdersError(["a", "a", "b"]).placeholders == [
+            "a",
+            "b",
+        ]
+
+    def test_is_a_valueerror_so_existing_handlers_still_catch_it(self):
+        # Callers wrap prompt execution in `except Exception` / `except ValueError`;
+        # this must not slip past them and reach the provider.
+        assert isinstance(UnresolvedPromptPlaceholdersError(["a"]), ValueError)

--- a/futureagi/model_hub/views/run_prompt.py
+++ b/futureagi/model_hub/views/run_prompt.py
@@ -16,6 +16,8 @@ from django.db import close_old_connections
 from django.db.models import Q
 from django.http import Http404
 from drf_yasg.utils import swagger_auto_schema
+from jinja2 import StrictUndefined
+from jinja2.exceptions import UndefinedError
 from jinja2.sandbox import SandboxedEnvironment
 from rest_framework import viewsets
 from rest_framework.generics import CreateAPIView
@@ -427,10 +429,116 @@ DEFAULT_TEMPLATE_FORMAT = TEMPLATE_FORMAT_JINJA2
 
 # Jinja2 environment (reusable, sandboxed for security)
 _jinja2_env = SandboxedEnvironment()
+# Strict counterpart used for fail-closed rendering: an undefined variable
+# raises instead of silently rendering as an empty string.
+_jinja2_strict_env = SandboxedEnvironment(undefined=StrictUndefined)
+
+# Matches a surviving `{{ ... }}` token in already-rendered output.
+_UNRESOLVED_PLACEHOLDER_RE = re.compile(r"\{\{\s*([^{}]+?)\s*\}\}")
+
+
+class UnresolvedPromptPlaceholdersError(ValueError):
+    """Raised when a prompt would reach the provider with placeholders intact.
+
+    Carries the offending placeholder names so callers can tell the user which
+    columns failed to resolve, rather than surfacing a generic failure.
+    """
+
+    def __init__(self, placeholders):
+        self.placeholders = sorted(set(placeholders))
+        joined = ", ".join(self.placeholders)
+        super().__init__(
+            "Prompt was not fully rendered; unresolved placeholders: " + joined
+        )
+
+
+def find_unresolved_placeholders(value) -> list[str]:
+    """Return placeholder names still present in rendered content.
+
+    Walks strings, lists and dicts because a rendered message's content may be
+    a plain string or a list of typed parts.
+    """
+    found: list[str] = []
+    if isinstance(value, str):
+        found.extend(
+            match.strip() for match in _UNRESOLVED_PLACEHOLDER_RE.findall(value)
+        )
+    elif isinstance(value, dict):
+        for item in value.values():
+            found.extend(find_unresolved_placeholders(item))
+    elif isinstance(value, (list, tuple)):
+        for item in value:
+            found.extend(find_unresolved_placeholders(item))
+    return found
+
+
+def _missing_mustache_keys(template_str: str, context: dict) -> list[str]:
+    """Names a mustache template substitutes that the context cannot supply.
+
+    Only tokens at the top level are checked. Inside a section
+    (``{{#items}} … {{/items}}``) mustache resolves names against each item of
+    the section rather than the root context, and that per-item shape is not
+    knowable before rendering — so section bodies are skipped rather than
+    guessed at. Missing it there is acceptable: the post-render scan in
+    :func:`populate_placeholders` still catches a token that survives, whereas
+    a false positive here would reject a perfectly valid prompt.
+    """
+    missing: list[str] = []
+    depth = 0
+
+    for raw in _UNRESOLVED_PLACEHOLDER_RE.findall(template_str):
+        name = raw.strip()
+        if not name:
+            continue
+
+        sigil = name[0]
+        if sigil in "#^":
+            depth += 1
+            continue
+        if sigil == "/":
+            depth = max(0, depth - 1)
+            continue
+        # `!` comment, `>` partial, `&` unescaped — not plain substitution.
+        if sigil in "!>&":
+            continue
+        if depth:
+            continue
+
+        current = context
+        for part in name.split("."):
+            if isinstance(current, dict) and part in current:
+                current = current[part]
+            else:
+                missing.append(name)
+                break
+
+    return missing
+
+
+def _undefined_names_from_error(exc, template_str: str, context: dict) -> list[str]:
+    """Best-effort list of the names that made a strict Jinja render fail.
+
+    Jinja reports one undefined name at a time, so the template is also scanned
+    for other top-level names absent from the context. That way a prompt with
+    three missing columns names all three instead of dripping them out one
+    render at a time.
+    """
+    names = []
+    message = str(getattr(exc, "message", "") or exc)
+    match = re.search(r"'([^']+)' is undefined", message)
+    if match:
+        names.append(match.group(1))
+
+    for raw in _UNRESOLVED_PLACEHOLDER_RE.findall(template_str):
+        root = raw.strip().split(".")[0].split("[")[0].strip()
+        if root and root not in context and root not in names:
+            names.append(root)
+
+    return names or [message or "unknown"]
 
 
 def render_template(
-    template_str: str, context: dict, template_format: str = None
+    template_str: str, context: dict, template_format: str = None, strict: bool = False
 ) -> str:
     """
     Render a template string with the given context.
@@ -451,9 +559,20 @@ def render_template(
         template_format = DEFAULT_TEMPLATE_FORMAT
 
     if template_format == TEMPLATE_FORMAT_FSTRING:
-        return template_str.format(**context)
+        try:
+            return template_str.format(**context)
+        except KeyError as exc:
+            if strict:
+                raise UnresolvedPromptPlaceholdersError([str(exc.args[0])]) from exc
+            raise
 
     elif template_format == TEMPLATE_FORMAT_MUSTACHE:
+        if strict:
+            # chevron renders an unknown key as an empty string, so the missing
+            # name has to be detected before rendering erases the evidence.
+            missing = _missing_mustache_keys(template_str, context)
+            if missing:
+                raise UnresolvedPromptPlaceholdersError(missing)
         return chevron.render(template_str, context)
 
     elif template_format == TEMPLATE_FORMAT_JINJA2:
@@ -472,7 +591,13 @@ def render_template(
                 processed = processed.replace(
                     "{{ " + stripped + " }}", str(context.get(stripped, ""))
                 )
-        return _jinja2_env.from_string(processed).render(**safe_ctx)
+        env = _jinja2_strict_env if strict else _jinja2_env
+        try:
+            return env.from_string(processed).render(**safe_ctx)
+        except UndefinedError as exc:
+            raise UnresolvedPromptPlaceholdersError(
+                _undefined_names_from_error(exc, processed, safe_ctx)
+            ) from exc
 
     else:
         raise ValueError(
@@ -494,10 +619,25 @@ class JsonStr(dict):
 
 
 def populate_placeholders(
-    messages: list[dict], dataset_id, row_id, col_id, model_name, template_format=None
+    messages: list[dict],
+    dataset_id,
+    row_id,
+    col_id,
+    model_name,
+    template_format=None,
+    fail_closed: bool = True,
 ):
+    """Substitute dataset values into prompt messages.
+
+    When ``fail_closed`` is set (the default) a prompt that cannot be fully
+    rendered raises :class:`UnresolvedPromptPlaceholdersError` instead of being
+    handed to the provider with its placeholders intact. Pass
+    ``fail_closed=False`` only where rendering is best-effort and unresolved
+    tokens are acceptable.
+    """
     try:
         media_error = None
+        column_errors: list[str] = []
         # Debug: Log input messages to see what template we're processing
         logger.info(f"populate_placeholders called with messages: {messages}")
 
@@ -579,9 +719,13 @@ def populate_placeholders(
                         f"value_preview={str(cell_value)[:100] if cell_value else 'None'}"
                     )
             except Exception as e:
+                column_name = column.name if "column" in locals() else "unknown"
                 logger.exception(
-                    f"Error processing column {column_id} ({column.name if 'column' in locals() else 'unknown'}): {e}"
+                    f"Error processing column {column_id} ({column_name}): {e}"
                 )
+                # Record rather than swallow: a column that failed to resolve is
+                # exactly what leaves a placeholder unsubstituted downstream.
+                column_errors.append(column_name)
                 continue
 
         # Debug: Log final context structure
@@ -608,6 +752,7 @@ def populate_placeholders(
                         image_counter,
                         model_name,
                         template_format=template_format,
+                        strict=fail_closed,
                     )
                 elif isinstance(content, str):
                     processed_content = process_string_content(
@@ -617,6 +762,7 @@ def populate_placeholders(
                         image_counter,
                         model_name,
                         template_format=template_format,
+                        strict=fail_closed,
                     )
 
                 # If no content was processed, keep original
@@ -629,24 +775,48 @@ def populate_placeholders(
                 # Preserve all message keys (name, tool_calls, tool_call_id, etc.)
                 processed_messages.append({**message, "content": processed_content})
 
+            if fail_closed:
+                # Backstop for formats that leave the token in place rather than
+                # raising during render.
+                unresolved = find_unresolved_placeholders(processed_messages)
+                if unresolved:
+                    raise UnresolvedPromptPlaceholdersError(unresolved)
+                if column_errors:
+                    raise UnresolvedPromptPlaceholdersError(column_errors)
+
             return processed_messages
 
         except ValueError as e:
             media_error = True
             raise e
 
+    except UnresolvedPromptPlaceholdersError:
+        # Already precise about what failed — surface unchanged.
+        raise
     except Exception as e:
         if media_error:
             raise e
-        else:
+        if not fail_closed:
             traceback.print_exc()
             logger.exception(f"Fatal error processing messages: {e}")
-            # Return original messages as fallback
+            # Legacy best-effort behaviour, retained for opt-in callers only.
             return messages
+        logger.exception(f"Fatal error processing messages: {e}")
+        # Returning the original messages here would hand the provider a prompt
+        # with its placeholders intact and no error surfaced to the caller.
+        raise UnresolvedPromptPlaceholdersError(
+            find_unresolved_placeholders(messages) or [str(e)]
+        ) from e
 
 
 def process_list_content(
-    content, column_info, context, image_counter, model_name, template_format=None
+    content,
+    column_info,
+    context,
+    image_counter,
+    model_name,
+    template_format=None,
+    strict: bool = False,
 ):
     """Process list-type content with proper media handling"""
     processed_content = []
@@ -661,6 +831,7 @@ def process_list_content(
                 image_counter,
                 model_name,
                 template_format=template_format,
+                strict=strict,
             )
             processed_content.extend(text_segments)
         else:
@@ -676,7 +847,13 @@ def process_list_content(
 
 
 def process_string_content(
-    content, column_info, context, image_counter, model_name, template_format=None
+    content,
+    column_info,
+    context,
+    image_counter,
+    model_name,
+    template_format=None,
+    strict: bool = False,
 ):
     """Process string-type content with proper media handling"""
     return process_text_with_media(
@@ -686,11 +863,18 @@ def process_string_content(
         image_counter,
         model_name,
         template_format=template_format,
+        strict=strict,
     )
 
 
 def process_text_with_media(
-    text, column_info, context, image_counter, model_name, template_format=None
+    text,
+    column_info,
+    context,
+    image_counter,
+    model_name,
+    template_format=None,
+    strict: bool = False,
 ):
     """Process text content, handling both templates and media placeholders"""
     try:
@@ -808,7 +992,7 @@ def process_text_with_media(
             effective_format = TEMPLATE_FORMAT_JINJA2
         try:
             processed_text = render_template(
-                text, context, template_format=effective_format
+                text, context, template_format=effective_format, strict=strict
             )
         except Exception as render_error:
             logger.exception(
@@ -817,7 +1001,14 @@ def process_text_with_media(
             # Re-raise to see full error - template syntax issue
             raise
         uuid_pattern = r"\{\{[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}\}\}"
-        if re.search(uuid_pattern, processed_text, re.IGNORECASE):
+        unreplaced_uuids = re.findall(uuid_pattern, processed_text, re.IGNORECASE)
+        if unreplaced_uuids:
+            if strict:
+                # Deleting these would hide the failure: the prompt would be
+                # silently missing the column the user referenced.
+                raise UnresolvedPromptPlaceholdersError(
+                    [uuid.strip("{} ") for uuid in unreplaced_uuids]
+                )
             logger.warning(
                 f"Found unreplaced UUID placeholders in processed text: {processed_text}"
             )


### PR DESCRIPTION
## Summary

`populate_placeholders()` swallowed every non-media exception and returned the original, unsubstituted messages. Unresolved `{{column_name}}` tokens reached the provider verbatim — the response was subtly wrong, no error surfaced, and callers could not tell a fully rendered prompt from a fallback.

This makes that path fail closed and name the placeholders that didn't resolve.

## Linked issue

Closes #321

## Scope

**2 files, +385/-12.** One concern. This is the focused replacement for the execution-side portion of #1911 — everything else that was in that branch is now tracked separately in #2078–#2082 and is not here.

| File | Delta |
|---|---|
| `futureagi/model_hub/views/run_prompt.py` | +203/-12 |
| `futureagi/model_hub/tests/test_run_prompt_unresolved_placeholders.py` (new) | +182 |

## Type of change

- [x] 🐛 Bug fix
- [x] 💥 Contains a deliberate behaviour change — see below

## Root cause

Three paths independently swallowed a failed substitution:

1. The outer `except Exception` returned `messages` unchanged — the case #321 names.
2. The per-column loop logged and `continue`d, so a column that failed to resolve left its placeholder behind with nothing recording it.
3. Rendered output containing unreplaced UUID placeholders was silently stripped with `re.sub`, deleting the evidence.

Mustache and Jinja also render an unknown name as an empty string, so a value could vanish without leaving a token to detect.

## Approach

- `UnresolvedPromptPlaceholdersError` carries the offending names, so the user is told *which* columns failed rather than getting a generic error.
- `find_unresolved_placeholders()` walks strings, lists and dicts — rendered content may be a plain string or a list of typed parts.
- `render_template(..., strict=True)`: Jinja renders via `StrictUndefined`, f-string converts `KeyError`, mustache is checked *before* rendering because chevron erases the evidence.
- `populate_placeholders(..., fail_closed=True)` by default: records column failures, scans rendered output as a backstop, raises instead of returning unrendered messages, and no longer strips unreplaced UUIDs.

`fail_closed=False` preserves the old best-effort behaviour for any caller that wants it. No caller opts in today — it exists so the old path is reachable and testable rather than deleted outright.

### One deliberate limitation

Mustache **section bodies are not checked**. Inside `{{#items}} … {{/items}}` names resolve against each item rather than the root context, and that shape isn't knowable before rendering. A false positive there would reject a valid prompt; a token that survives is still caught by the post-render scan. This is a conscious trade, and there's a test pinning it.

## How was this tested?

```
$ pytest model_hub/tests/test_run_prompt_unresolved_placeholders.py -q
18 passed in 3.33s

$ pytest model_hub/ --collect-only -q
3451/3642 tests collected (191 deselected) — no import errors
```

The 18 tests cover each format failing closed, the scanner across nested message content, and — importantly — that valid prompts still render unchanged, including mustache sections and Jinja dotted access.

**What I could not verify locally:** DB-backed tests need Postgres on port 15432, which isn't available here, so `pytest.mark.django_db` suites error at setup with connection refused — identically before and after this change. Worth noting that **no CI workflow in this repo runs the backend suite on PRs** either (`grep -rlE 'pytest|manage.py test' .github/workflows/` matches only `sdk-compatibility.yml` and `api-contracts.yml`, neither of which covers `model_hub`), so a green tick here will not mean these tests ran. I'd appreciate a reviewer running them against a real database.

## Impact and risk

A prompt that cannot be fully rendered now fails with a message naming the unresolved placeholders, instead of silently sending a malformed prompt and billing for the call.

**This is a behaviour change.** Prompts that previously rendered a missing column as empty text will now fail. That is the intent of #321 — those prompts were producing wrong output silently — but it's the thing to weigh in review. Existing callers already wrap execution in `except Exception`, and the error subclasses `ValueError`, so it surfaces as a failed cell rather than an unhandled crash.

**Rollback:** flip the `fail_closed` default to `False`; the previous behaviour is intact behind it.

## Note for @abhijaisrivastava15

This is PR 1 of the split you asked for on #1911. The remaining concerns from that branch are now separate issues awaiting your direction before I write any code — in particular **#2078**, which is a cross-tenant `Tools` scoping gap that exists on `dev` today, independent of my PRs.
