### PR TITLE
fix(frontend): darken the yellow eval-score cell for dark theme [TH-7330]

### DIFF
--- a/frontend/src/global.css
+++ b/frontend/src/global.css
@@ -229,7 +229,7 @@
   --score-green-light: rgba(0, 162, 81, 0.14);
   --score-green-strong: rgba(0, 162, 81, 0.25);
 
-  --eval-score-yellow-bg: #4b3901;
+  --eval-score-yellow-bg: rgba(75, 57, 1, 0.5);
   --eval-score-yellow-text: #edbe00;
 
   /* Monaco editor */

--- a/frontend/src/global.css
+++ b/frontend/src/global.css
@@ -116,6 +116,9 @@
   --score-green-light: #00a2511a;
   --score-green-strong: #00a25133;
 
+  --eval-score-yellow-bg: #fff9e6;
+  --eval-score-yellow-text: #997a00;
+
   /* Monaco editor */
   --monaco-bg: rgba(243, 243, 243, 1);
   --monaco-gutter-bg: rgba(231, 231, 231, 1);
@@ -225,6 +228,9 @@
   --score-yellow: rgba(230, 184, 0, 0.14);
   --score-green-light: rgba(0, 162, 81, 0.14);
   --score-green-strong: rgba(0, 162, 81, 0.25);
+
+  --eval-score-yellow-bg: #4b3901;
+  --eval-score-yellow-text: #edbe00;
 
   /* Monaco editor */
   --monaco-bg: #111111;

--- a/frontend/src/utils/__tests__/interpolateColorTokenBasedOnScore.test.js
+++ b/frontend/src/utils/__tests__/interpolateColorTokenBasedOnScore.test.js
@@ -1,0 +1,50 @@
+import { describe, it, expect } from "vitest";
+import { interpolateColorTokenBasedOnScore } from "../utils";
+
+describe("interpolateColorTokenBasedOnScore", () => {
+  const yellowBand = [60, 65.25, 75.5, 79.99];
+  const otherBands = [0, 19, 25, 45, 55, 85, 98, 100];
+
+  it("resolves the yellow band through theme-aware tokens", () => {
+    yellowBand.forEach((score) => {
+      const { bgcolor, color } = interpolateColorTokenBasedOnScore(score, 100);
+      expect(bgcolor).toBe("var(--eval-score-yellow-bg)");
+      expect(color).toBe("var(--eval-score-yellow-text)");
+    });
+  });
+
+  it("leaves the other bands on their existing tokens", () => {
+    // Designer signed off on green and red in dark theme, so they stay put.
+    otherBands.forEach((score) => {
+      const { bgcolor } = interpolateColorTokenBasedOnScore(score, 100);
+      expect(bgcolor).not.toBe("var(--eval-score-yellow-bg)");
+      expect(bgcolor).toBeTruthy();
+    });
+  });
+
+  it("keeps the band boundaries where they were", () => {
+    // 60 opens the yellow band and 80 closes it.
+    expect(interpolateColorTokenBasedOnScore(59.99, 100).bgcolor).not.toBe(
+      "var(--eval-score-yellow-bg)",
+    );
+    expect(interpolateColorTokenBasedOnScore(60, 100).bgcolor).toBe(
+      "var(--eval-score-yellow-bg)",
+    );
+    expect(interpolateColorTokenBasedOnScore(80, 100).bgcolor).not.toBe(
+      "var(--eval-score-yellow-bg)",
+    );
+  });
+
+  it("still honours reverse and clamping", () => {
+    // reverse flips the score, so a low raw score lands in the yellow band.
+    expect(interpolateColorTokenBasedOnScore(35, 100, true).bgcolor).toBe(
+      "var(--eval-score-yellow-bg)",
+    );
+    expect(interpolateColorTokenBasedOnScore(-10, 100).bgcolor).toBe(
+      interpolateColorTokenBasedOnScore(0, 100).bgcolor,
+    );
+    expect(interpolateColorTokenBasedOnScore(150, 100).bgcolor).toBe(
+      interpolateColorTokenBasedOnScore(100, 100).bgcolor,
+    );
+  });
+});

--- a/frontend/src/utils/utils.js
+++ b/frontend/src/utils/utils.js
@@ -1052,8 +1052,8 @@ export function interpolateColorTokenBasedOnScore(
     };
   } else if (factor < 80) {
     return {
-      bgcolor: palette("light").yellow[50],
-      color: palette("light").yellow[800],
+      bgcolor: "var(--eval-score-yellow-bg)",
+      color: "var(--eval-score-yellow-text)",
     };
   } else if (factor < 99) {
     return {


### PR DESCRIPTION
## 🐛 Bug

In Observe, eval-score cells scoring **60–80%** painted a near-white block on the dark grid.

`interpolateColorTokenBasedOnScore` (`src/utils/utils.js`) resolves every band from `palette("light")`. That mostly goes unnoticed because the other bands return **alpha** tokens — `red.o5`, `orange.o5`, `green.o5`, `green.o10` — which composite acceptably over either background. The yellow band was the sole **opaque** swatch, so `yellow[50]` (`#FFF9E6`) rendered at full strength against the `#0A0A0A` table.

That's why the designer's note says green and red already look fine — structurally, only yellow could break.

## 🔧 What changed

- Yellow band now resolves through `--eval-score-yellow-bg` / `--eval-score-yellow-text` rather than a baked light hex.
- Both variables declared per theme in `global.css`, next to the existing `--score-*` tokens:
  - light — `#FFF9E6` / `#997A00` (unchanged from today)
  - dark — `rgba(75, 57, 1, 0.5)` / `#EDBE00`
- No other band touched.

## 🤔 Why

Vel's decision on the ticket: *"use #4B3901 for the background and #EDBE00 for the text. This is only for the cells that are in yellow, i think the green and red looks already fine in dark theme."* There's no dark-theme colour system in Figma yet, so this is a point fix rather than a token-system change.

CSS variables were chosen over threading the theme mode into the function: the helper is pure and called from three render paths, and `global.css` already establishes exactly this light/dark override pattern for `--score-*`.

cc @cdileep23

## 🧪 Tests

New `src/utils/__tests__/interpolateColorTokenBasedOnScore.test.js` — the helper had no coverage at all before:

- yellow band (60, 65.25, 75.5, 79.99) resolves to both CSS variables
- other bands (0, 19, 25, 45, 55, 85, 98, 100) stay on their existing tokens
- band boundaries hold: 59.99 is not yellow, 60 is, 80 is not
- `reverse` and clamping still behave (a reversed 35 lands in yellow; −10 and 150 clamp)

## ▶️ How to verify

1. Observe → Tracing → any project with eval columns → switch to **dark** theme
2. Find an eval cell scoring 60–80% and confirm it is dark amber, not white
3. Switch to **light** theme and confirm that cell is unchanged

Verified by reading computed styles rather than by eye:

```
dark   65.25%  bg=rgba(75, 57, 1, 0.5)  renders #2A2206   text=rgb(237, 190, 0)  #EDBE00
light  65.25%  bg=rgb(255, 249, 230) #FFF9E6   text=rgb(153, 122, 0)  #997A00
```

## 💻 Commands

```bash
cd frontend
npx vitest run src/utils/__tests__/interpolateColorTokenBasedOnScore.test.js
yarn test    # full suite
```

## ⚠️ Worth a reviewer's eye

The hue is the `#4B3901` Vel gave on the ticket, applied at **50% opacity** so the band sits at a comparable weight to its neighbours — the other bands are 5–14% alpha washes (the 55% orange cell beside it renders `#150F0A`), and an opaque fill made yellow read far heavier than red or green. Vel reviewed 100/75/50/35/25% side by side over Slack and approved 50%.

Also note `data-theme` is set on `<body>`, not `<html>`. The dark values therefore reach cells by inheritance, and reading these variables at `document.documentElement` returns the light value even in dark mode. That applies to every `--score-*` token already; mentioning it only because it makes DevTools inspection at `<html>` misleading.

## 📹 Videos & Screenshots

![1-before-dark](https://github.com/user-attachments/assets/a58523f5-ee38-4896-bfba-10fb422adf37)

![2-after-dark](https://github.com/user-attachments/assets/2ee08050-987e-4226-a038-c2e05fb0426e)

![3-after-light](https://github.com/user-attachments/assets/000d984a-b2d6-4e2e-801f-0a7be7643501)
