### PR TITLE
fix(tracer): materialize eval_score from structured eval outputs (TH-7492)

### DIFF
--- a/futureagi/tracer/management/commands/backfill_eval_score.py
+++ b/futureagi/tracer/management/commands/backfill_eval_score.py
@@ -1,49 +1,12 @@
-"""
-Backfill the ``usage_apicalllog.eval_score`` materialized column.
+"""Re-materialize ``usage_apicalllog.eval_score`` on rows already on disk.
 
-``eval_score`` is MATERIALIZED, so its value is computed once at INSERT and
-stored in the part. Changing the expression (schema.py's ``CH_EVAL_SCORE_EXPR``)
-therefore only affects rows written after the change — every row already on
-disk keeps whatever the old expression produced. ``ALTER TABLE ... MODIFY
-COLUMN`` in ``POST_DDL_ALTERS`` updates the metadata but does NOT rewrite
-existing parts; only ``MATERIALIZE COLUMN`` does, and that is a mutation, so it
-must not run on every app boot.
+Sequence: DROP INDEX, MODIFY, ADD INDEX, MATERIALIZE COLUMN, MATERIALIZE INDEX.
 
-Hence this command: run it once per environment after deploying the structured-
-eval-output fix, and the already-ingested rows start reporting their real score
-instead of 0.
-
-The ``idx_eval_score`` minmax skip index has to be rebuilt in the same pass.
-Re-materializing the column leaves the index holding the OLD min/max, and
-``MATERIALIZE INDEX`` on its own does not repair it — verified against
-ClickHouse 25.3, where a row backfilled to 1.0 stayed invisible to
-``WHERE eval_score >= 1.0`` until the index was dropped and re-added. A stale
-skip index prunes whole granules, so eval_score filters and breakdowns come
-back empty rather than wrong-looking, which is why the sequence below is
-DROP INDEX -> MODIFY -> ADD INDEX -> MATERIALIZE COLUMN -> MATERIALIZE INDEX.
-
-Usage on prod:
-
-    # 1. See how many rows are actually wrong before touching anything:
-    python manage.py backfill_eval_score --dry-run
-
-    # 2. Run it. Chunked by partition (toYYYYMM(created_at)) so each mutation
-    #    rewrites one month of parts at a time instead of the whole table:
-    python manage.py backfill_eval_score --no-confirm
-
-    # 3. Re-run the dry-run to confirm the affected count is now 0.
-
-Notes:
-  * Idempotent — a second run finds nothing to fix and exits without
-    submitting a mutation.
-  * ``--force`` rebuilds and re-materializes even when no row disagrees with
-    the expression. The stored values and the ``idx_eval_score`` skip index go
-    stale independently, and a current column with a stale index reports
-    "already up to date" while filters keep pruning real rows away.
-  * Refuses to start when an eval_score MATERIALIZE mutation is already
-    in flight, so overlapping deploys cannot stack mutations on one table.
-  * Only rewrites the eval_score column and its index; no other column is
-    touched and no row is deleted.
+* ``MODIFY COLUMN`` is metadata-only and does not rewrite stored parts.
+* ``MATERIALIZE COLUMN`` does, but it is a mutation, so it cannot run on boot.
+* ``idx_eval_score`` keeps its pre-backfill bounds unless dropped and re-added
+  (``MATERIALIZE INDEX`` alone does not repair it), and a stale skip index
+  prunes granules, so eval_score filters return nothing at all.
 """
 
 from __future__ import annotations
@@ -55,8 +18,7 @@ COLUMN = "eval_score"
 INDEX = "idx_eval_score"
 INDEX_DEF = f"{INDEX} {COLUMN} TYPE minmax GRANULARITY 1"
 
-# Rows whose stored eval_score disagrees with what the current expression
-# would produce. Structured outputs stored under the old expression are 0.
+# Structured-output rows whose stored eval_score disagrees with the expression.
 _AFFECTED_COUNT = """
 SELECT count()
 FROM {table}
@@ -73,8 +35,8 @@ WHERE table = '{table}' AND database = currentDatabase() AND active
 ORDER BY partition DESC
 """
 
-# position() rather than LIKE '%…%': the driver runs printf-style substitution
-# over every query, so a literal % here is read as a format spec and raises.
+# position() rather than LIKE: the driver runs printf substitution over every
+# query, so a literal % here is read as a format spec and raises.
 _IN_FLIGHT = """
 SELECT count()
 FROM system.mutations
@@ -83,12 +45,7 @@ WHERE table = '{table}' AND NOT is_done AND position(command, '{column}') > 0
 
 
 def rebuild_statements(table: str = TABLE) -> list[str]:
-    """The DDL that carries a new eval_score expression onto an existing table.
-
-    The index is dropped around the MODIFY and re-added after it; leaving it in
-    place keeps it pruning granules on the pre-backfill min/max, and
-    MATERIALIZE INDEX alone does not repair that.
-    """
+    """DDL carrying a new eval_score expression onto an existing table."""
     from tracer.services.clickhouse.schema import CH_EVAL_SCORE_EXPR
 
     return [
@@ -129,7 +86,11 @@ class Command(BaseCommand):
         parser.add_argument(
             "--force",
             action="store_true",
-            help="Rebuild even when no row is stale, to repair a stale skip index.",
+            help=(
+                "Rebuild and re-materialize unconditionally. The stale count "
+                "only looks at structured outputs, so use this to repair a "
+                "stale skip index or drift on any other output shape."
+            ),
         )
 
     def handle(self, *args, **opts):
@@ -154,7 +115,12 @@ class Command(BaseCommand):
         self.stdout.write(f"rows with a stale {COLUMN}: {affected}")
 
         if affected == 0 and not opts["force"]:
-            self.stdout.write(self.style.SUCCESS(f"✓ {COLUMN} is already up to date — nothing to do."))
+            self.stdout.write(
+                self.style.SUCCESS(
+                    f"{COLUMN} is already up to date, nothing to do. "
+                    "Re-run with --force to rebuild anyway."
+                )
+            )
             return
 
         if opts["dry_run"]:
@@ -164,8 +130,8 @@ class Command(BaseCommand):
         in_flight = self._scalar(ch, _IN_FLIGHT.format(table=TABLE, column=COLUMN))
         if in_flight:
             raise CommandError(
-                f"{in_flight} {COLUMN} mutation(s) already running on {TABLE} — "
-                "wait for them to finish (see system.mutations) before re-running."
+                f"{in_flight} {COLUMN} mutation(s) already running on {TABLE}. "
+                "Wait for them to finish (see system.mutations) before re-running."
             )
 
         if not opts["no_confirm"]:
@@ -192,7 +158,7 @@ class Command(BaseCommand):
 
         self.stdout.write(
             self.style.SUCCESS(
-                "✓ mutation(s) submitted. They run asynchronously — poll "
+                "mutation(s) submitted. They run asynchronously, so poll "
                 f"system.mutations for table='{TABLE}', then re-run with "
                 "--dry-run to confirm the affected count is 0."
             )

--- a/futureagi/tracer/management/commands/backfill_eval_score.py
+++ b/futureagi/tracer/management/commands/backfill_eval_score.py
@@ -1,0 +1,207 @@
+"""
+Backfill the ``usage_apicalllog.eval_score`` materialized column.
+
+``eval_score`` is MATERIALIZED, so its value is computed once at INSERT and
+stored in the part. Changing the expression (schema.py's ``CH_EVAL_SCORE_EXPR``)
+therefore only affects rows written after the change — every row already on
+disk keeps whatever the old expression produced. ``ALTER TABLE ... MODIFY
+COLUMN`` in ``POST_DDL_ALTERS`` updates the metadata but does NOT rewrite
+existing parts; only ``MATERIALIZE COLUMN`` does, and that is a mutation, so it
+must not run on every app boot.
+
+Hence this command: run it once per environment after deploying the structured-
+eval-output fix, and the already-ingested rows start reporting their real score
+instead of 0.
+
+The ``idx_eval_score`` minmax skip index has to be rebuilt in the same pass.
+Re-materializing the column leaves the index holding the OLD min/max, and
+``MATERIALIZE INDEX`` on its own does not repair it — verified against
+ClickHouse 25.3, where a row backfilled to 1.0 stayed invisible to
+``WHERE eval_score >= 1.0`` until the index was dropped and re-added. A stale
+skip index prunes whole granules, so eval_score filters and breakdowns come
+back empty rather than wrong-looking, which is why the sequence below is
+DROP INDEX -> MODIFY -> ADD INDEX -> MATERIALIZE COLUMN -> MATERIALIZE INDEX.
+
+Usage on prod:
+
+    # 1. See how many rows are actually wrong before touching anything:
+    python manage.py backfill_eval_score --dry-run
+
+    # 2. Run it. Chunked by partition (toYYYYMM(created_at)) so each mutation
+    #    rewrites one month of parts at a time instead of the whole table:
+    python manage.py backfill_eval_score --no-confirm
+
+    # 3. Re-run the dry-run to confirm the affected count is now 0.
+
+Notes:
+  * Idempotent — a second run finds nothing to fix and exits without
+    submitting a mutation.
+  * ``--force`` rebuilds and re-materializes even when no row disagrees with
+    the expression. The stored values and the ``idx_eval_score`` skip index go
+    stale independently, and a current column with a stale index reports
+    "already up to date" while filters keep pruning real rows away.
+  * Refuses to start when an eval_score MATERIALIZE mutation is already
+    in flight, so overlapping deploys cannot stack mutations on one table.
+  * Only rewrites the eval_score column and its index; no other column is
+    touched and no row is deleted.
+"""
+
+from __future__ import annotations
+
+from django.core.management.base import BaseCommand, CommandError
+
+TABLE = "usage_apicalllog"
+COLUMN = "eval_score"
+INDEX = "idx_eval_score"
+INDEX_DEF = f"{INDEX} {COLUMN} TYPE minmax GRANULARITY 1"
+
+# Rows whose stored eval_score disagrees with what the current expression
+# would produce. Structured outputs stored under the old expression are 0.
+_AFFECTED_COUNT = """
+SELECT count()
+FROM {table}
+WHERE _peerdb_is_deleted = 0
+  AND {predicate}
+  AND {column} != {expr}
+"""
+
+# system.parts spans every database on the server, so scope it to this one.
+_PARTITIONS = """
+SELECT DISTINCT partition
+FROM system.parts
+WHERE table = '{table}' AND database = currentDatabase() AND active
+ORDER BY partition DESC
+"""
+
+# position() rather than LIKE '%…%': the driver runs printf-style substitution
+# over every query, so a literal % here is read as a format spec and raises.
+_IN_FLIGHT = """
+SELECT count()
+FROM system.mutations
+WHERE table = '{table}' AND NOT is_done AND position(command, '{column}') > 0
+"""
+
+
+def rebuild_statements(table: str = TABLE) -> list[str]:
+    """The DDL that carries a new eval_score expression onto an existing table.
+
+    The index is dropped around the MODIFY and re-added after it; leaving it in
+    place keeps it pruning granules on the pre-backfill min/max, and
+    MATERIALIZE INDEX alone does not repair that.
+    """
+    from tracer.services.clickhouse.schema import CH_EVAL_SCORE_EXPR
+
+    return [
+        f"ALTER TABLE {table} DROP INDEX IF EXISTS {INDEX}",
+        f"ALTER TABLE {table} MODIFY COLUMN {COLUMN} Float64 MATERIALIZED {CH_EVAL_SCORE_EXPR}",
+        f"ALTER TABLE {table} ADD INDEX IF NOT EXISTS {INDEX_DEF}",
+    ]
+
+
+def materialize_statements(table: str = TABLE, partition: str | None = None) -> list[str]:
+    """Mutations that rewrite the stored column and rebuild its index."""
+    scope = f" IN PARTITION {partition}" if partition is not None else ""
+    return [
+        f"ALTER TABLE {table} MATERIALIZE COLUMN {COLUMN}{scope}",
+        f"ALTER TABLE {table} MATERIALIZE INDEX {INDEX}{scope}",
+    ]
+
+
+class Command(BaseCommand):
+    help = "Re-materialize usage_apicalllog.eval_score so existing rows pick up the current extraction."
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--dry-run",
+            action="store_true",
+            help="Report the affected row count without submitting a mutation.",
+        )
+        parser.add_argument(
+            "--no-confirm",
+            action="store_true",
+            help="Skip the interactive prompt (for CI/CD and deploy automation).",
+        )
+        parser.add_argument(
+            "--whole-table",
+            action="store_true",
+            help="Materialize the whole table in one mutation instead of per partition.",
+        )
+        parser.add_argument(
+            "--force",
+            action="store_true",
+            help="Rebuild even when no row is stale, to repair a stale skip index.",
+        )
+
+    def handle(self, *args, **opts):
+        from tracer.services.clickhouse.client import get_clickhouse_client
+        from tracer.services.clickhouse.eval_expressions import (
+            eval_has_structured_score,
+        )
+        from tracer.services.clickhouse.schema import (
+            CH_EVAL_SCORE_EXPR,
+            EVAL_OUTPUT_JSON_ARGS,
+        )
+
+        ch = get_clickhouse_client()
+
+        predicate = eval_has_structured_score(EVAL_OUTPUT_JSON_ARGS)
+        affected = self._scalar(
+            ch,
+            _AFFECTED_COUNT.format(
+                table=TABLE, column=COLUMN, expr=CH_EVAL_SCORE_EXPR, predicate=predicate
+            ),
+        )
+        self.stdout.write(f"rows with a stale {COLUMN}: {affected}")
+
+        if affected == 0 and not opts["force"]:
+            self.stdout.write(self.style.SUCCESS(f"✓ {COLUMN} is already up to date — nothing to do."))
+            return
+
+        if opts["dry_run"]:
+            self.stdout.write("--dry-run: no mutation submitted.")
+            return
+
+        in_flight = self._scalar(ch, _IN_FLIGHT.format(table=TABLE, column=COLUMN))
+        if in_flight:
+            raise CommandError(
+                f"{in_flight} {COLUMN} mutation(s) already running on {TABLE} — "
+                "wait for them to finish (see system.mutations) before re-running."
+            )
+
+        if not opts["no_confirm"]:
+            scope = f"{affected} rows" if affected else "every row (forced)"
+            answer = input(f"Re-materialize {COLUMN} for {scope}? [y/N] ")
+            if answer.strip().lower() not in ("y", "yes"):
+                self.stdout.write("aborted.")
+                return
+
+        for sql in rebuild_statements():
+            ch.execute(sql)
+            self.stdout.write(f"  {sql}")
+
+        if opts["whole_table"]:
+            targets = [None]
+        else:
+            targets = [row[0] for row in ch.execute(_PARTITIONS.format(table=TABLE))]
+            self.stdout.write(f"materializing across {len(targets)} partition(s)")
+
+        for target in targets:
+            for sql in materialize_statements(partition=target):
+                ch.execute(sql)
+                self.stdout.write(f"  submitted: {sql}")
+
+        self.stdout.write(
+            self.style.SUCCESS(
+                "✓ mutation(s) submitted. They run asynchronously — poll "
+                f"system.mutations for table='{TABLE}', then re-run with "
+                "--dry-run to confirm the affected count is 0."
+            )
+        )
+
+    @staticmethod
+    def _scalar(ch, sql) -> int:
+        rows = ch.execute(sql)
+        if not rows:
+            return 0
+        first = rows[0]
+        return int(first[0] if isinstance(first, (list, tuple)) else first)

--- a/futureagi/tracer/management/commands/backfill_eval_score.py
+++ b/futureagi/tracer/management/commands/backfill_eval_score.py
@@ -1,12 +1,6 @@
 """Re-materialize ``usage_apicalllog.eval_score`` on rows already on disk.
 
 Sequence: DROP INDEX, MODIFY, ADD INDEX, MATERIALIZE COLUMN, MATERIALIZE INDEX.
-
-* ``MODIFY COLUMN`` is metadata-only and does not rewrite stored parts.
-* ``MATERIALIZE COLUMN`` does, but it is a mutation, so it cannot run on boot.
-* ``idx_eval_score`` keeps its pre-backfill bounds unless dropped and re-added
-  (``MATERIALIZE INDEX`` alone does not repair it), and a stale skip index
-  prunes granules, so eval_score filters return nothing at all.
 """
 
 from __future__ import annotations

--- a/futureagi/tracer/services/clickhouse/eval_expressions.py
+++ b/futureagi/tracer/services/clickhouse/eval_expressions.py
@@ -1,15 +1,13 @@
-"""Shared eval-output SQL expressions.
-
-A leaf module: ``schema.py`` and the query builders both read these, and
-``query_builders/__init__`` imports all 15 builder modules, so putting them
-there would pull that whole tree into ``schema.py`` at import time.
-"""
+"""Shared eval-output SQL, kept leaf-level so ``schema.py`` can import it."""
 
 # Structured evals nest their number here: {"score": 0.5, "choice": "Partial"}.
 EVAL_STRUCTURED_SCORE_KEY = "score"
 
 EVAL_TRUTHY_OUTPUTS = ("passed", "pass", "true", "1")
 EVAL_FALSY_OUTPUTS = ("failed", "fail", "false", "0")
+
+# JSONType names for a real number. A null or a string score is not scorable.
+EVAL_NUMERIC_JSON_TYPES = ("Double", "Int64", "UInt64")
 
 # A bare number rendered as text, e.g. "0.8".
 EVAL_NUMERIC_OUTPUT_PATTERN = "^-?[0-9]+\\.?[0-9]*$"
@@ -21,9 +19,12 @@ def sql_str_set(values: tuple[str, ...]) -> str:
 
 
 def eval_has_structured_score(json_args: str) -> str:
-    """SQL predicate: does this row's eval output carry a nested score?
+    """SQL predicate: does this row's eval output nest a NUMERIC score?
 
-    ``json_args`` is spliced into ``JSONHas(...)``: a column holding the
-    serialized output, or a comma-joined argument fragment.
+    Typed, not ``JSONHas``: the extractor beside it scores null/string as 0.
+    ``json_args`` is a column, or a comma-joined JSON argument fragment.
     """
-    return f"JSONHas({json_args}, '{EVAL_STRUCTURED_SCORE_KEY}')"
+    return (
+        f"(JSONType({json_args}, '{EVAL_STRUCTURED_SCORE_KEY}') "
+        f"IN {sql_str_set(EVAL_NUMERIC_JSON_TYPES)})"
+    )

--- a/futureagi/tracer/services/clickhouse/eval_expressions.py
+++ b/futureagi/tracer/services/clickhouse/eval_expressions.py
@@ -1,0 +1,35 @@
+"""Shared eval-output SQL expressions.
+
+A leaf module on purpose: both ``schema.py`` (which renders the DDL) and the
+query builders read these, and ``query_builders/__init__`` eagerly imports
+every builder, so ``schema.py`` must not reach into that package.
+"""
+
+# Structured (choice-based) evals nest their number under this key —
+# {"score": 0.5, "choice": "Partial"} — while score evals emit a bare scalar.
+EVAL_STRUCTURED_SCORE_KEY = "score"
+
+# Eval outputs that are pass/fail strings rather than numbers.
+EVAL_TRUTHY_OUTPUTS = ("passed", "pass", "true", "1")
+EVAL_FALSY_OUTPUTS = ("failed", "fail", "false", "0")
+
+# A bare number rendered as text, e.g. "0.8" — the scalar-output eval shape.
+EVAL_NUMERIC_OUTPUT_PATTERN = "^-?[0-9]+\\.?[0-9]*$"
+
+
+def sql_str_set(values: tuple[str, ...]) -> str:
+    """Render a tuple of strings as a SQL ``IN`` list, e.g. ``('pass', '1')``."""
+    return "(" + ", ".join(f"'{v}'" for v in values) + ")"
+
+
+def eval_has_structured_score(json_args: str) -> str:
+    """SQL predicate: does this row's eval output carry a nested numeric score?
+
+    ``json_args`` is spliced straight into ``JSONHas(...)``, so it is
+    deliberately called two ways: with a bare column that already holds the
+    serialized output (``e.eval_output_str``), and with the comma-joined
+    argument fragment that digs the output out of ``config``
+    (``EVAL_OUTPUT_JSON_ARGS``). Callers that read ``eval_score`` need this to
+    tell a genuine 0.0 from "no number here".
+    """
+    return f"JSONHas({json_args}, '{EVAL_STRUCTURED_SCORE_KEY}')"

--- a/futureagi/tracer/services/clickhouse/eval_expressions.py
+++ b/futureagi/tracer/services/clickhouse/eval_expressions.py
@@ -1,19 +1,17 @@
 """Shared eval-output SQL expressions.
 
-A leaf module on purpose: both ``schema.py`` (which renders the DDL) and the
-query builders read these, and ``query_builders/__init__`` eagerly imports
-every builder, so ``schema.py`` must not reach into that package.
+A leaf module: ``schema.py`` and the query builders both read these, and
+``query_builders/__init__`` imports all 15 builder modules, so putting them
+there would pull that whole tree into ``schema.py`` at import time.
 """
 
-# Structured (choice-based) evals nest their number under this key —
-# {"score": 0.5, "choice": "Partial"} — while score evals emit a bare scalar.
+# Structured evals nest their number here: {"score": 0.5, "choice": "Partial"}.
 EVAL_STRUCTURED_SCORE_KEY = "score"
 
-# Eval outputs that are pass/fail strings rather than numbers.
 EVAL_TRUTHY_OUTPUTS = ("passed", "pass", "true", "1")
 EVAL_FALSY_OUTPUTS = ("failed", "fail", "false", "0")
 
-# A bare number rendered as text, e.g. "0.8" — the scalar-output eval shape.
+# A bare number rendered as text, e.g. "0.8".
 EVAL_NUMERIC_OUTPUT_PATTERN = "^-?[0-9]+\\.?[0-9]*$"
 
 
@@ -23,13 +21,9 @@ def sql_str_set(values: tuple[str, ...]) -> str:
 
 
 def eval_has_structured_score(json_args: str) -> str:
-    """SQL predicate: does this row's eval output carry a nested numeric score?
+    """SQL predicate: does this row's eval output carry a nested score?
 
-    ``json_args`` is spliced straight into ``JSONHas(...)``, so it is
-    deliberately called two ways: with a bare column that already holds the
-    serialized output (``e.eval_output_str``), and with the comma-joined
-    argument fragment that digs the output out of ``config``
-    (``EVAL_OUTPUT_JSON_ARGS``). Callers that read ``eval_score`` need this to
-    tell a genuine 0.0 from "no number here".
+    ``json_args`` is spliced into ``JSONHas(...)``: a column holding the
+    serialized output, or a comma-joined argument fragment.
     """
     return f"JSONHas({json_args}, '{EVAL_STRUCTURED_SCORE_KEY}')"

--- a/futureagi/tracer/services/clickhouse/query_builders/dashboard.py
+++ b/futureagi/tracer/services/clickhouse/query_builders/dashboard.py
@@ -210,6 +210,22 @@ def _eval_source_bucket_expr(exclude: str) -> str:
     return "".join(parts)
 
 
+def eval_pass_expr(score_col: str, output_str_col: str) -> str:
+    """SQL predicate: this eval row reads as a pass, by score or by output text."""
+    return (
+        f"({score_col} >= 1.0 OR lower({output_str_col}) IN "
+        f"{sql_str_set(EVAL_TRUTHY_OUTPUTS)})"
+    )
+
+
+def eval_fail_expr(score_col: str, output_str_col: str) -> str:
+    """SQL predicate: this eval row reads as a fail."""
+    return (
+        f"({score_col} < 1.0 AND lower({output_str_col}) NOT IN "
+        f"{sql_str_set(EVAL_TRUTHY_OUTPUTS)})"
+    )
+
+
 def rescale_rate_to_percent(agg_expr: str, aggregation: str) -> str:
     """Wrap *agg_expr* in ``(... ) * 100`` for averaging aggregations.
 
@@ -718,8 +734,8 @@ class DashboardQueryBuilder:
         _output_str_lower = "lower(e.eval_output_str)"
         _truthy = sql_str_set(EVAL_TRUTHY_OUTPUTS)
         _falsy = sql_str_set(EVAL_FALSY_OUTPUTS)
-        _is_pass = f"(e.eval_score >= 1.0 OR {_output_str_lower} IN {_truthy})"
-        _is_fail = f"(e.eval_score < 1.0 AND {_output_str_lower} NOT IN {_truthy})"
+        _is_pass = eval_pass_expr("e.eval_score", "e.eval_output_str")
+        _is_fail = eval_fail_expr("e.eval_score", "e.eval_output_str")
         _unified_score = f"if({_is_pass}, 1.0, e.eval_score)"
 
         _EVAL_AGGREGATIONS: dict[str, str] = {
@@ -1482,9 +1498,12 @@ class DashboardQueryBuilder:
 
                 # Use materialized columns for fast extraction
                 if output_type == "PASS_FAIL":
+                    _passed = eval_pass_expr(
+                        f"{alias}.eval_score", f"{alias}.eval_output_str"
+                    )
                     val_expr = (
                         f"if({alias}.id IS NULL, '(not set)', "
-                        f"if({alias}.eval_output_str = 'Passed', 'Pass', 'Fail'))"
+                        f"if({_passed}, 'Pass', 'Fail'))"
                     )
                 elif output_type in ("CHOICE", "CHOICES"):
                     val_expr = (
@@ -1695,7 +1714,8 @@ class DashboardQueryBuilder:
                 output_type = (f.get("output_type") or "SCORE").upper()
                 # config is double-encoded
                 if output_type == "PASS_FAIL":
-                    eval_col = "if(eval_output_str = 'Passed', 1.0, 0.0)"
+                    _passed = eval_pass_expr("eval_score", "eval_output_str")
+                    eval_col = f"if({_passed}, 1.0, 0.0)"
                 else:
                     eval_col = "eval_score"
 

--- a/futureagi/tracer/services/clickhouse/query_builders/dashboard.py
+++ b/futureagi/tracer/services/clickhouse/query_builders/dashboard.py
@@ -18,6 +18,13 @@ import re
 from datetime import UTC, date, datetime, timedelta
 from typing import Any
 
+from tracer.services.clickhouse.eval_expressions import (
+    EVAL_FALSY_OUTPUTS,
+    EVAL_NUMERIC_OUTPUT_PATTERN,
+    EVAL_TRUTHY_OUTPUTS,
+    eval_has_structured_score,
+    sql_str_set,
+)
 from tracer.services.clickhouse.query_builders.expressions import (
     annotation_numeric_value_expr,
 )
@@ -709,14 +716,10 @@ class DashboardQueryBuilder:
         params["workspace_id"] = self.workspace_id
 
         _output_str_lower = "lower(e.eval_output_str)"
-        _is_pass = (
-            f"(e.eval_score >= 1.0 OR {_output_str_lower} IN "
-            "('passed', 'pass', 'true', '1'))"
-        )
-        _is_fail = (
-            f"(e.eval_score < 1.0 AND {_output_str_lower} NOT IN "
-            "('passed', 'pass', 'true', '1'))"
-        )
+        _truthy = sql_str_set(EVAL_TRUTHY_OUTPUTS)
+        _falsy = sql_str_set(EVAL_FALSY_OUTPUTS)
+        _is_pass = f"(e.eval_score >= 1.0 OR {_output_str_lower} IN {_truthy})"
+        _is_fail = f"(e.eval_score < 1.0 AND {_output_str_lower} NOT IN {_truthy})"
         _unified_score = f"if({_is_pass}, 1.0, e.eval_score)"
 
         _EVAL_AGGREGATIONS: dict[str, str] = {
@@ -735,13 +738,17 @@ class DashboardQueryBuilder:
             if output_type == "PASS_FAIL":
                 col_expr = _unified_score
             else:
-                # Some templates with missing output_type still emit pass/fail strings.
+                # Some templates with missing output_type still emit pass/fail
+                # strings; structured evals emit {"score": …, "choice": …}.
+                _has_number = (
+                    f"match(e.eval_output_str, '{EVAL_NUMERIC_OUTPUT_PATTERN}') "
+                    f"OR {eval_has_structured_score('e.eval_output_str')}"
+                )
                 col_expr = (
                     "if(e.eval_output_str = '', NULL, "
-                    f"if({_output_str_lower} IN ('passed', 'pass', 'true', '1'), 1.0, "
-                    f"if({_output_str_lower} IN ('failed', 'fail', 'false', '0'), 0.0, "
-                    "if(match(e.eval_output_str, '^-?[0-9]+\\.?[0-9]*$'), "
-                    "e.eval_score, NULL))))"
+                    f"if({_output_str_lower} IN {_truthy}, 1.0, "
+                    f"if({_output_str_lower} IN {_falsy}, 0.0, "
+                    f"if({_has_number}, e.eval_score, NULL))))"
                 )
             agg_expr = AGGREGATIONS.get(aggregation, "avg({col})").format(col=col_expr)
 

--- a/futureagi/tracer/services/clickhouse/query_builders/dashboard.py
+++ b/futureagi/tracer/services/clickhouse/query_builders/dashboard.py
@@ -738,8 +738,8 @@ class DashboardQueryBuilder:
             if output_type == "PASS_FAIL":
                 col_expr = _unified_score
             else:
-                # Some templates with missing output_type still emit pass/fail
-                # strings; structured evals emit {"score": …, "choice": …}.
+                # Templates with no output_type still emit pass/fail strings,
+                # bare numbers, or a structured object carrying a score.
                 _has_number = (
                     f"match(e.eval_output_str, '{EVAL_NUMERIC_OUTPUT_PATTERN}') "
                     f"OR {eval_has_structured_score('e.eval_output_str')}"

--- a/futureagi/tracer/services/clickhouse/schema.py
+++ b/futureagi/tracer/services/clickhouse/schema.py
@@ -34,6 +34,11 @@ from __future__ import annotations
 import os
 import re
 
+from tracer.services.clickhouse.eval_expressions import (
+    EVAL_STRUCTURED_SCORE_KEY,
+    eval_has_structured_score,
+)
+
 # Resolve the configured CH database name for use in DDL templates.
 # Falls back to "futureagi" which is the production default.
 _CH_DATABASE = os.getenv("CH_DATABASE", "futureagi")
@@ -1726,6 +1731,17 @@ WHERE c._peerdb_is_deleted = 0;
 #   simulation, SDK, playground) writes here with source_id = eval_template_id.
 # ---------------------------------------------------------------------------
 
+# Comma-joined JSON arguments, not a path: spliced into JSONExtract*(...) calls.
+EVAL_OUTPUT_JSON_ARGS = "JSONExtractString(config), 'output', 'output'"
+
+CH_EVAL_SCORE_EXPR = (
+    f"if({eval_has_structured_score(EVAL_OUTPUT_JSON_ARGS)}, "
+    f"JSONExtractFloat({EVAL_OUTPUT_JSON_ARGS}, '{EVAL_STRUCTURED_SCORE_KEY}'), "
+    f"JSONExtractFloat({EVAL_OUTPUT_JSON_ARGS}))"
+)
+
+CH_EVAL_OUTPUT_STR_EXPR = f"JSONExtractString({EVAL_OUTPUT_JSON_ARGS})"
+
 CDC_USAGE_APICALLLOG = """
 CREATE TABLE IF NOT EXISTS usage_apicalllog (
     id Int64,
@@ -1749,8 +1765,9 @@ CREATE TABLE IF NOT EXISTS usage_apicalllog (
 
     -- Materialized columns: pre-extracted from config JSON at insert time.
     -- Config is double-encoded (JSONB string), so JSONExtractString unwraps first.
-    eval_score Float64 MATERIALIZED JSONExtractFloat(JSONExtractString(config), 'output', 'output'),
-    eval_output_str String MATERIALIZED JSONExtractString(JSONExtractString(config), 'output', 'output'),
+    -- The two placeholders below are substituted from the CH_EVAL_* constants.
+    eval_score Float64 MATERIALIZED __CH_EVAL_SCORE_EXPR__,
+    eval_output_str String MATERIALIZED __CH_EVAL_OUTPUT_STR_EXPR__,
     eval_trace_id String MATERIALIZED JSONExtractString(JSONExtractString(config), 'trace_id'),
     eval_dataset_id String MATERIALIZED JSONExtractString(JSONExtractString(config), 'dataset_id'),
 
@@ -1785,7 +1802,9 @@ ENGINE = ReplicatedReplacingMergeTree('/clickhouse/tables/{shard}/usage_apicalll
 PARTITION BY toYYYYMM(created_at)
 ORDER BY (organization_id, source_id, created_at, id)
 SETTINGS index_granularity = 8192;
-"""
+""".replace("__CH_EVAL_SCORE_EXPR__", CH_EVAL_SCORE_EXPR).replace(
+    "__CH_EVAL_OUTPUT_STR_EXPR__", CH_EVAL_OUTPUT_STR_EXPR
+)
 
 # ============================================================================
 # Ordered list of all DDL statements
@@ -1896,11 +1915,14 @@ SCHEMA_DDL_STATEMENTS: list[tuple[str, str]] = [
 # that PeerDB may recreate without them during RESYNC operations.
 POST_DDL_ALTERS: list[str] = [
     "ALTER TABLE usage_apicalllog ADD COLUMN IF NOT EXISTS "
-    "eval_score Float64 MATERIALIZED "
-    "JSONExtractFloat(JSONExtractString(config), 'output', 'output')",
+    f"eval_score Float64 MATERIALIZED {CH_EVAL_SCORE_EXPR}",
+    # ADD COLUMN IF NOT EXISTS no-ops once the column exists, so an already-
+    # deployed table keeps its old expression until MODIFYed. Metadata-only;
+    # existing rows are backfilled by the backfill_eval_score command.
+    "ALTER TABLE usage_apicalllog MODIFY COLUMN "
+    f"eval_score Float64 MATERIALIZED {CH_EVAL_SCORE_EXPR}",
     "ALTER TABLE usage_apicalllog ADD COLUMN IF NOT EXISTS "
-    "eval_output_str String MATERIALIZED "
-    "JSONExtractString(JSONExtractString(config), 'output', 'output')",
+    f"eval_output_str String MATERIALIZED {CH_EVAL_OUTPUT_STR_EXPR}",
     "ALTER TABLE usage_apicalllog ADD COLUMN IF NOT EXISTS "
     "eval_trace_id String MATERIALIZED "
     "JSONExtractString(JSONExtractString(config), 'trace_id')",

--- a/futureagi/tracer/services/clickhouse/schema.py
+++ b/futureagi/tracer/services/clickhouse/schema.py
@@ -1917,9 +1917,7 @@ POST_DDL_ALTERS: list[str] = [
     "ALTER TABLE usage_apicalllog ADD COLUMN IF NOT EXISTS "
     f"eval_score Float64 MATERIALIZED {CH_EVAL_SCORE_EXPR}",
     # ADD COLUMN IF NOT EXISTS no-ops once the column exists, so a deployed
-    # table keeps its old expression until MODIFYed. No DROP/ADD index
-    # sandwich here: Code 524 fires on a TYPE change, and the type is restated
-    # unchanged. Existing rows are backfilled by backfill_eval_score.
+    # table keeps its old expression until MODIFYed.
     "ALTER TABLE usage_apicalllog MODIFY COLUMN "
     f"eval_score Float64 MATERIALIZED {CH_EVAL_SCORE_EXPR}",
     # Restores idx_eval_score if a backfill run died between its DROP and ADD.

--- a/futureagi/tracer/services/clickhouse/schema.py
+++ b/futureagi/tracer/services/clickhouse/schema.py
@@ -1916,11 +1916,15 @@ SCHEMA_DDL_STATEMENTS: list[tuple[str, str]] = [
 POST_DDL_ALTERS: list[str] = [
     "ALTER TABLE usage_apicalllog ADD COLUMN IF NOT EXISTS "
     f"eval_score Float64 MATERIALIZED {CH_EVAL_SCORE_EXPR}",
-    # ADD COLUMN IF NOT EXISTS no-ops once the column exists, so an already-
-    # deployed table keeps its old expression until MODIFYed. Metadata-only;
-    # existing rows are backfilled by the backfill_eval_score command.
+    # ADD COLUMN IF NOT EXISTS no-ops once the column exists, so a deployed
+    # table keeps its old expression until MODIFYed. No DROP/ADD index
+    # sandwich here: Code 524 fires on a TYPE change, and the type is restated
+    # unchanged. Existing rows are backfilled by backfill_eval_score.
     "ALTER TABLE usage_apicalllog MODIFY COLUMN "
     f"eval_score Float64 MATERIALIZED {CH_EVAL_SCORE_EXPR}",
+    # Restores idx_eval_score if a backfill run died between its DROP and ADD.
+    "ALTER TABLE usage_apicalllog ADD INDEX IF NOT EXISTS "
+    "idx_eval_score eval_score TYPE minmax GRANULARITY 1",
     "ALTER TABLE usage_apicalllog ADD COLUMN IF NOT EXISTS "
     f"eval_output_str String MATERIALIZED {CH_EVAL_OUTPUT_STR_EXPR}",
     "ALTER TABLE usage_apicalllog ADD COLUMN IF NOT EXISTS "

--- a/futureagi/tracer/tests/test_clickhouse.py
+++ b/futureagi/tracer/tests/test_clickhouse.py
@@ -242,11 +242,7 @@ class TestClickHouseSchema:
         )
 
     def test_eval_score_expression_reads_structured_and_scalar_outputs(self):
-        """One expression covers ``{"score": …}`` objects and bare numbers.
-
-        Choice-based evals nest their number under ``score``; score evals emit
-        a bare scalar. Dropping either branch blanks one family of widgets.
-        """
+        """Dropping either branch blanks one family of eval widgets."""
         from tracer.services.clickhouse.schema import (
             CDC_USAGE_APICALLLOG,
             CH_EVAL_SCORE_EXPR,
@@ -255,10 +251,7 @@ class TestClickHouseSchema:
         assert (
             "JSONHas(JSONExtractString(config), 'output', 'output', 'score')"
             in CH_EVAL_SCORE_EXPR
-        ), (
-            "eval_score must branch on the nested score key; without it a "
-            "structured output extracts as 0."
-        )
+        ), "without the nested-score branch a structured output extracts as 0."
         assert (
             "JSONExtractFloat(JSONExtractString(config), 'output', 'output'))"
             in CH_EVAL_SCORE_EXPR
@@ -280,10 +273,7 @@ class TestClickHouseSchema:
         assert (
             "usage_apicalllog MODIFY COLUMN eval_score Float64 "
             f"MATERIALIZED {CH_EVAL_SCORE_EXPR}" in joined
-        ), (
-            "POST_DDL_ALTERS must MODIFY eval_score; ADD COLUMN IF NOT EXISTS "
-            "no-ops on a deployed table and leaves the old expression in place."
-        )
+        ), "ADD COLUMN IF NOT EXISTS no-ops on a deployed table; MODIFY does not."
         assert (
             "usage_apicalllog ADD COLUMN IF NOT EXISTS eval_score Float64 "
             f"MATERIALIZED {CH_EVAL_SCORE_EXPR}" in joined
@@ -292,11 +282,13 @@ class TestClickHouseSchema:
             "usage_apicalllog ADD COLUMN IF NOT EXISTS eval_output_str String "
             f"MATERIALIZED {CH_EVAL_OUTPUT_STR_EXPR}" in joined
         )
+        assert (
+            "usage_apicalllog ADD INDEX IF NOT EXISTS idx_eval_score "
+            "eval_score TYPE minmax GRANULARITY 1" in joined
+        ), "a backfill dying between its DROP and ADD otherwise loses the index."
 
     def test_backfill_queries_survive_driver_parameter_substitution(self):
-        """The driver runs ``query % params`` on everything it executes, so a
-        literal ``%`` in one of these templates raises before it reaches CH.
-        """
+        """A literal ``%`` in a template raises before it reaches CH."""
         from tracer.management.commands import backfill_eval_score as cmd
         from tracer.services.clickhouse.eval_expressions import (
             eval_has_structured_score,
@@ -325,9 +317,7 @@ class TestClickHouseSchema:
                 pytest.fail(f"{name} is not substitution-safe: {exc}")
 
     def test_backfill_partition_scan_is_scoped_to_this_database(self):
-        """system.parts spans every database; an unscoped scan would pick up
-        the same table name in test_futureagi and materialize the wrong parts.
-        """
+        """An unscoped system.parts scan materializes another database's parts."""
         from tracer.management.commands import backfill_eval_score as cmd
 
         assert "database = currentDatabase()" in cmd._PARTITIONS
@@ -365,9 +355,7 @@ class TestClickHouseSchema:
         assert not any("ALTER TABLE" in q for q in ch.executed)
 
     def test_backfill_force_rebuilds_when_no_row_is_stale(self):
-        """A current column can still carry a stale index, so --force has to
-        run the rebuild that the "nothing to do" early return would skip.
-        """
+        """--force runs the rebuild the "nothing to do" early return skips."""
         from io import StringIO
 
         from django.core.management import call_command

--- a/futureagi/tracer/tests/test_clickhouse.py
+++ b/futureagi/tracer/tests/test_clickhouse.py
@@ -58,6 +58,26 @@ class TestNonTerminalEvalMarker:
 # ============================================================================
 
 
+def _fake_backfill_client(affected=0, in_flight=0, partitions=("202601", "202602")):
+    """A CH client stub that answers backfill_eval_score's three read queries."""
+    client = mock.MagicMock()
+    client.executed = []
+
+    def execute(query, *args, **kwargs):
+        client.executed.append(query)
+        collapsed = " ".join(query.split())
+        if collapsed.startswith("SELECT count() FROM system.mutations"):
+            return [(in_flight,)]
+        if collapsed.startswith("SELECT count() FROM usage_apicalllog"):
+            return [(affected,)]
+        if collapsed.startswith("SELECT DISTINCT partition"):
+            return [(p,) for p in partitions]
+        return []
+
+    client.execute = execute
+    return client
+
+
 @pytest.mark.unit
 class TestClickHouseSchema:
     """Test schema DDL generation."""
@@ -220,6 +240,157 @@ class TestClickHouseSchema:
             "POST_DDL_ALTERS must order DROP INDEX → MODIFY COLUMN → ADD INDEX "
             "for idx_trace_id; ClickHouse refuses to alter an indexed column."
         )
+
+    def test_eval_score_expression_reads_structured_and_scalar_outputs(self):
+        """One expression covers ``{"score": …}`` objects and bare numbers.
+
+        Choice-based evals nest their number under ``score``; score evals emit
+        a bare scalar. Dropping either branch blanks one family of widgets.
+        """
+        from tracer.services.clickhouse.schema import (
+            CDC_USAGE_APICALLLOG,
+            CH_EVAL_SCORE_EXPR,
+        )
+
+        assert (
+            "JSONHas(JSONExtractString(config), 'output', 'output', 'score')"
+            in CH_EVAL_SCORE_EXPR
+        ), (
+            "eval_score must branch on the nested score key; without it a "
+            "structured output extracts as 0."
+        )
+        assert (
+            "JSONExtractFloat(JSONExtractString(config), 'output', 'output'))"
+            in CH_EVAL_SCORE_EXPR
+        ), "eval_score must keep the bare-scalar fallback for score evals."
+        assert (
+            f"eval_score Float64 MATERIALIZED {CH_EVAL_SCORE_EXPR}"
+            in CDC_USAGE_APICALLLOG
+        )
+
+    def test_post_ddl_alters_modifies_eval_score_on_existing_tables(self):
+        """ALTER statements bring an already-created usage_apicalllog forward."""
+        from tracer.services.clickhouse.schema import (
+            CH_EVAL_OUTPUT_STR_EXPR,
+            CH_EVAL_SCORE_EXPR,
+            POST_DDL_ALTERS,
+        )
+
+        joined = "\n".join(POST_DDL_ALTERS)
+        assert (
+            "usage_apicalllog MODIFY COLUMN eval_score Float64 "
+            f"MATERIALIZED {CH_EVAL_SCORE_EXPR}" in joined
+        ), (
+            "POST_DDL_ALTERS must MODIFY eval_score; ADD COLUMN IF NOT EXISTS "
+            "no-ops on a deployed table and leaves the old expression in place."
+        )
+        assert (
+            "usage_apicalllog ADD COLUMN IF NOT EXISTS eval_score Float64 "
+            f"MATERIALIZED {CH_EVAL_SCORE_EXPR}" in joined
+        )
+        assert (
+            "usage_apicalllog ADD COLUMN IF NOT EXISTS eval_output_str String "
+            f"MATERIALIZED {CH_EVAL_OUTPUT_STR_EXPR}" in joined
+        )
+
+    def test_backfill_queries_survive_driver_parameter_substitution(self):
+        """The driver runs ``query % params`` on everything it executes, so a
+        literal ``%`` in one of these templates raises before it reaches CH.
+        """
+        from tracer.management.commands import backfill_eval_score as cmd
+        from tracer.services.clickhouse.eval_expressions import (
+            eval_has_structured_score,
+        )
+        from tracer.services.clickhouse.schema import (
+            CH_EVAL_SCORE_EXPR,
+            EVAL_OUTPUT_JSON_ARGS,
+        )
+
+        templates = {
+            "_PARTITIONS": cmd._PARTITIONS.format(table=cmd.TABLE),
+            "_IN_FLIGHT": cmd._IN_FLIGHT.format(table=cmd.TABLE, column=cmd.COLUMN),
+            "_AFFECTED_COUNT": cmd._AFFECTED_COUNT.format(
+                table=cmd.TABLE,
+                column=cmd.COLUMN,
+                expr=CH_EVAL_SCORE_EXPR,
+                predicate=eval_has_structured_score(EVAL_OUTPUT_JSON_ARGS),
+            ),
+            # Travels through ch.execute() from rebuild_statements/POST_DDL_ALTERS.
+            "CH_EVAL_SCORE_EXPR": CH_EVAL_SCORE_EXPR,
+        }
+        for name, sql in templates.items():
+            try:
+                sql % {}
+            except (TypeError, ValueError) as exc:
+                pytest.fail(f"{name} is not substitution-safe: {exc}")
+
+    def test_backfill_partition_scan_is_scoped_to_this_database(self):
+        """system.parts spans every database; an unscoped scan would pick up
+        the same table name in test_futureagi and materialize the wrong parts.
+        """
+        from tracer.management.commands import backfill_eval_score as cmd
+
+        assert "database = currentDatabase()" in cmd._PARTITIONS
+
+    def test_backfill_dry_run_counts_without_mutating(self):
+        """--dry-run reports the stale rows and stops before any ALTER."""
+        from io import StringIO
+
+        from django.core.management import call_command
+
+        from tracer.services.clickhouse import client as ch_client
+
+        ch = _fake_backfill_client(affected=7)
+        out = StringIO()
+        with mock.patch.object(ch_client, "get_clickhouse_client", lambda: ch):
+            call_command("backfill_eval_score", "--dry-run", stdout=out)
+
+        assert "rows with a stale eval_score: 7" in out.getvalue()
+        assert "--dry-run: no mutation submitted." in out.getvalue()
+        assert not any("ALTER TABLE" in q for q in ch.executed)
+
+    def test_backfill_refuses_to_stack_on_an_in_flight_mutation(self):
+        """Overlapping deploys must not queue a second eval_score mutation."""
+        from io import StringIO
+
+        from django.core.management import CommandError, call_command
+
+        from tracer.services.clickhouse import client as ch_client
+
+        ch = _fake_backfill_client(affected=7, in_flight=1)
+        with mock.patch.object(ch_client, "get_clickhouse_client", lambda: ch):
+            with pytest.raises(CommandError, match="already running"):
+                call_command("backfill_eval_score", "--no-confirm", stdout=StringIO())
+
+        assert not any("ALTER TABLE" in q for q in ch.executed)
+
+    def test_backfill_force_rebuilds_when_no_row_is_stale(self):
+        """A current column can still carry a stale index, so --force has to
+        run the rebuild that the "nothing to do" early return would skip.
+        """
+        from io import StringIO
+
+        from django.core.management import call_command
+
+        from tracer.services.clickhouse import client as ch_client
+
+        ch = _fake_backfill_client(affected=0)
+        out = StringIO()
+        with mock.patch.object(ch_client, "get_clickhouse_client", lambda: ch):
+            call_command("backfill_eval_score", "--force", "--no-confirm", stdout=out)
+
+        altered = [q for q in ch.executed if q.startswith("ALTER TABLE")]
+        assert any("DROP INDEX IF EXISTS idx_eval_score" in q for q in altered)
+        assert any("ADD INDEX IF NOT EXISTS idx_eval_score" in q for q in altered)
+        # One MATERIALIZE COLUMN + one MATERIALIZE INDEX per partition.
+        assert sum("MATERIALIZE COLUMN" in q for q in altered) == 2
+        assert sum("MATERIALIZE INDEX" in q for q in altered) == 2
+        assert "materializing across 2 partition(s)" in out.getvalue()
+
+        unforced = _fake_backfill_client(affected=0)
+        with mock.patch.object(ch_client, "get_clickhouse_client", lambda: unforced):
+            call_command("backfill_eval_score", "--no-confirm", stdout=StringIO())
+        assert not any("ALTER TABLE" in q for q in unforced.executed)
 
     def test_mv_recreate_manifest_consistency(self):
         """Every MV_RECREATE_MANIFEST entry must resolve to a real DDL constant."""

--- a/futureagi/tracer/tests/test_clickhouse.py
+++ b/futureagi/tracer/tests/test_clickhouse.py
@@ -249,9 +249,12 @@ class TestClickHouseSchema:
         )
 
         assert (
-            "JSONHas(JSONExtractString(config), 'output', 'output', 'score')"
-            in CH_EVAL_SCORE_EXPR
-        ), "without the nested-score branch a structured output extracts as 0."
+            "JSONType(JSONExtractString(config), 'output', 'output', 'score') "
+            "IN ('Double', 'Int64', 'UInt64')" in CH_EVAL_SCORE_EXPR
+        ), (
+            "the nested-score branch must gate on the value's type: JSONHas is "
+            "true for a null or string score that JSONExtractFloat reads as 0."
+        )
         assert (
             "JSONExtractFloat(JSONExtractString(config), 'output', 'output'))"
             in CH_EVAL_SCORE_EXPR

--- a/futureagi/tracer/tests/test_clickhouse_integration.py
+++ b/futureagi/tracer/tests/test_clickhouse_integration.py
@@ -17,10 +17,12 @@ Covered:
 - SimulationQueryBuilder integration (system metrics, breakdowns, filters)
 - DatasetQueryBuilder integration (system metrics, breakdowns)
 - usage_apicalllog eval-score materialization per eval-output shape
+- an opt-in eval-score backfill benchmark, see TestEvalScoreBackfillAtScale
 """
 
 import json
 import os
+import time
 import uuid
 from datetime import datetime, timezone
 
@@ -60,6 +62,211 @@ EVAL_OUTPUT_SHAPES: tuple[tuple[str, dict, float, bool], ...] = (
 
 EVAL_SCORED_SHAPES = tuple(s for s in EVAL_OUTPUT_SHAPES if s[3])
 EVAL_SCORED_AVERAGE = 0.625
+
+EVAL_SHAPE_PAYLOADS = {label: payload for label, payload, _s, _h in EVAL_OUTPUT_SHAPES}
+EVAL_SHAPE_SCORES = {label: score for label, _p, score, _h in EVAL_OUTPUT_SHAPES}
+
+# ---------------------------------------------------------------------------
+# Backfill benchmark seeding (opt-in, see TestEvalScoreBackfillAtScale)
+# ---------------------------------------------------------------------------
+
+# Unqualified: the benchmark client sets _TEST_DATABASE as its default, so the
+# command's own currentDatabase()-scoped partition query works verbatim.
+_BENCH_TABLE = "usage_apicalllog_bench"
+
+# Upper bounds per 100k rows, so the production mix is expressible exactly:
+# structured outputs are a 1.56% slice, split 76 / 18 / 6 inside that slice.
+BENCH_BUCKET_SCALE = 100_000
+BENCH_MIX: tuple[tuple[int, str], ...] = (
+    (1_186, "structured_complete"),
+    (1_467, "structured_incomplete"),
+    (1_560, "structured_partial"),
+    (41_560, "scalar_score"),
+    (81_560, "text_output"),
+    (BENCH_BUCKET_SCALE, "no_output"),
+)
+
+# Repeated prose plus a random tail, so a seeded row weighs about what a
+# production row weighs on disk rather than compressing away to nothing.
+BENCH_REASON_REPEATS = 20
+BENCH_REASON_RANDOM_BYTES = 600
+BENCH_REASON_SENTENCES: tuple[str, ...] = (
+    "The response addresses every requirement stated in the user prompt.",
+    "Key steps in the reasoning chain are present and ordered correctly.",
+    "The assistant restated the constraint before applying it to the answer.",
+    "No unsupported factual claims were introduced beyond the given context.",
+    "The final paragraph summarises the outcome without adding new content.",
+    "Tone stays consistent with the system instruction throughout the turn.",
+    "One requested field is missing from the structured portion of the reply.",
+    "The answer stops short of covering the third sub question that was asked.",
+    "Formatting follows the requested schema and parses without modification.",
+    "Citations map to passages that actually appear in the retrieved context.",
+    "The model hedged where the context was genuinely ambiguous, which is fine.",
+    "A minor arithmetic slip appears in the intermediate calculation step.",
+    "Latency stayed inside the budget configured for this evaluation template.",
+    "The refusal was appropriate given the policy category that was triggered.",
+    "Coverage of the source document is partial but the omissions are minor.",
+    "The reply repeats the question back before answering, which is redundant.",
+    "Instructions about output length were respected within a small margin.",
+    "The completion resolves the ambiguity by asking a clarifying question.",
+    "Nothing in the transcript indicates the tool call result was ignored.",
+    "The grader found the response complete against all listed criteria.",
+)
+
+# Small blocks: a seeded row carries kilobytes of config, so the default block
+# size builds multi-GB buffers and a modest box runs out of memory mid-seed.
+BENCH_SEED_SETTINGS = (
+    "max_insert_threads = 1, max_threads = 1, max_memory_usage = 1400000000, "
+    "max_block_size = 1024, max_insert_block_size = 32768, "
+    "min_insert_block_size_rows = 32768, min_insert_block_size_bytes = 0"
+)
+BENCH_READ_SETTINGS = "max_memory_usage = 1400000000, max_threads = 3"
+BENCH_SETTLED_PARTS = 16
+
+
+def _bench_sql_literal(value: str) -> str:
+    return "'" + value.replace("\\", "\\\\").replace("'", "\\'") + "'"
+
+
+def _bench_multi_if(column: str, value_for_label) -> str:
+    """Render BENCH_MIX as a multiIf over a per-row bucket column."""
+    branches = [
+        f"{column} < {upper}, {_bench_sql_literal(value_for_label(label))}"
+        for upper, label in BENCH_MIX[:-1]
+    ]
+    branches.append(_bench_sql_literal(value_for_label(BENCH_MIX[-1][1])))
+    return "multiIf(" + ", ".join(branches) + ")"
+
+
+def _bench_output_fragment(label: str) -> str:
+    """The opening of one row's config, carrying that shape's eval output."""
+    output = EVAL_SHAPE_PAYLOADS[label]["output"]
+    if "output" not in output:
+        return '"output":{'
+    return '"output":{"output":' + json.dumps(output["output"]) + ","
+
+
+def _bench_reason_sql() -> str:
+    pool = "multiIf(" + ", ".join(
+        f"modulo(number, {len(BENCH_REASON_SENTENCES)}) = {i}, "
+        f"{_bench_sql_literal(sentence)}"
+        for i, sentence in enumerate(BENCH_REASON_SENTENCES[:-1])
+    ) + f", {_bench_sql_literal(BENCH_REASON_SENTENCES[-1])})"
+    return (
+        f"concat(repeat(concat({pool}, ' '), {BENCH_REASON_REPEATS}), "
+        f"hex(randomString({BENCH_REASON_RANDOM_BYTES})))"
+    )
+
+
+def _bench_ddl(table: str, shape: str) -> str:
+    """Canonical DDL, optionally wound to the shape PeerDB built in production."""
+    from tracer.services.clickhouse.schema import (
+        CDC_USAGE_APICALLLOG,
+        _to_single_node_engine,
+    )
+
+    ddl = _to_single_node_engine(CDC_USAGE_APICALLLOG).replace(
+        "CREATE TABLE IF NOT EXISTS usage_apicalllog",
+        f"CREATE TABLE IF NOT EXISTS {table}",
+    )
+    if shape != "prod":
+        return ddl
+
+    ddl = ddl.replace("PARTITION BY toYYYYMM(created_at)\n", "").replace(
+        "ORDER BY (organization_id, source_id, created_at, id)", "ORDER BY id"
+    )
+    assert "PARTITION BY" not in ddl and "ORDER BY id" in ddl, (
+        "the production table shape could not be derived from the canonical DDL"
+    )
+    return ddl
+
+
+def _bench_seed(client, table: str, rows: int, shape: str) -> None:
+    from tracer.services.clickhouse.schema import EVAL_OUTPUT_JSON_ARGS
+
+    client.command(f"DROP TABLE IF EXISTS {table}")
+    client.command(_bench_ddl(table, shape))
+    # Wind the expression back to the one a deployed cluster still carries, so
+    # every seeded row lands genuinely stale.
+    client.command(
+        f"ALTER TABLE {table} MODIFY COLUMN eval_score Float64 "
+        f"MATERIALIZED JSONExtractFloat({EVAL_OUTPUT_JSON_ARGS})"
+    )
+
+    label_expr = _bench_multi_if("bucket", lambda label: label)
+    output_expr = _bench_multi_if("bucket", _bench_output_fragment)
+    if shape == "prod":
+        created_expr = "now64(6) - toIntervalSecond(modulo(number, 15552000))"
+    else:
+        created_expr = (
+            "toDateTime64('2026-01-01 00:00:00', 6) + "
+            f"toIntervalSecond(intDiv(number * 15552000, {rows}))"
+        )
+
+    # One tenant, as a single customer's table looks, and merges held off until
+    # the seed is in so they do not compete with it for memory.
+    org = "toUUID('11111111-1111-1111-1111-111111111111')"
+    client.command(f"SYSTEM STOP MERGES {table}")
+
+    written = 0
+    while written < rows:
+        take = min(500_000, rows - written)
+        client.command(
+            f"""
+            INSERT INTO {table}
+                (id, log_id, organization_id, workspace_id, status, reference_id,
+                 config, source, source_id, created_at, updated_at,
+                 _peerdb_synced_at, _peerdb_is_deleted, _peerdb_version)
+            SELECT toInt64(number), generateUUIDv4(), {org}, {org}, 'success', label,
+                   toJSONString(concat('{{', output, '"reason":"', reason,
+                       '"}},"trace_id":"', toString(generateUUIDv4()),
+                       '","model":"gpt-4o-mini","latency_ms":',
+                       toString(modulo(number, 5000) + 120), '}}')),
+                   'tracer', 'bench-template', created, created, created, 0, 1
+            FROM (
+                SELECT number, modulo(number, {BENCH_BUCKET_SCALE}) AS bucket,
+                       {label_expr} AS label,
+                       {output_expr} AS output,
+                       {_bench_reason_sql()} AS reason,
+                       {created_expr} AS created
+                FROM numbers({written}, {take})
+            )
+            SETTINGS {BENCH_SEED_SETTINGS}
+            """
+        )
+        written += take
+
+    client.command(f"SYSTEM START MERGES {table}")
+    _bench_settle(client, table)
+
+
+def _bench_settle(client, table: str, timeout: int = 600) -> None:
+    """Let merges consolidate the seed so timings are not merge noise.
+
+    Bounded: a fully merged table takes far longer than the timings are worth,
+    and a part count in the low tens already matches a real table's layout.
+    """
+    deadline = time.time() + timeout
+    last, stable = None, 0
+    while time.time() < deadline:
+        merging = client.query(
+            "SELECT count() FROM system.merges "
+            f"WHERE database = '{_TEST_DATABASE}' AND table = '{table}'"
+        ).result_rows[0][0]
+        parts = client.query(
+            "SELECT count() FROM system.parts WHERE active "
+            f"AND database = '{_TEST_DATABASE}' AND table = '{table}'"
+        ).result_rows[0][0]
+        if parts <= BENCH_SETTLED_PARTS:
+            return
+        if merging == 0 and parts == last:
+            stable += 1
+            if stable >= 3:
+                return
+        else:
+            stable = 0
+        last = parts
+        time.sleep(5)
 
 
 @pytest.fixture(scope="session")
@@ -651,3 +858,189 @@ class TestEvalScoreMaterialization:
             "the eval_score minmax index disagrees with the stored rows after "
             f"the backfill, so filters prune real rows away: {counts}"
         )
+
+
+# ===========================================================================
+# F. TestEvalScoreBackfillAtScale
+# ===========================================================================
+
+
+@pytest.fixture
+def ch_backfill_bench_table(ch_schema):
+    """Seed a large usage_apicalllog copy, or skip when the run is not opted in."""
+    rows = int(os.environ.get("EVAL_SCORE_BENCH_ROWS", "0"))
+    if rows <= 0:
+        pytest.skip(
+            "set EVAL_SCORE_BENCH_ROWS to run the eval_score backfill benchmark"
+        )
+
+    import clickhouse_connect
+
+    shape = os.environ.get("EVAL_SCORE_BENCH_SHAPE", "prod")
+    client = clickhouse_connect.get_client(
+        host=os.environ.get("CH_TEST_HOST", "localhost"),
+        port=int(os.environ.get("CH_TEST_PORT", "18123")),
+        database=_TEST_DATABASE,
+        send_receive_timeout=14400,
+        settings={"max_execution_time": 14400},
+    )
+
+    started = time.perf_counter()
+    _bench_seed(client, _BENCH_TABLE, rows, shape)
+
+    yield {
+        "client": client,
+        "table": _BENCH_TABLE,
+        "rows": rows,
+        "shape": shape,
+        "seed_seconds": time.perf_counter() - started,
+    }
+
+    client.command(f"DROP TABLE IF EXISTS {_BENCH_TABLE}")
+    client.close()
+
+
+@pytest.mark.benchmark
+@pytest.mark.skipif(
+    not os.environ.get("EVAL_SCORE_BENCH_ROWS"),
+    reason="set EVAL_SCORE_BENCH_ROWS to run the eval_score backfill benchmark",
+)
+class TestEvalScoreBackfillAtScale:
+    """Time the eval_score backfill on a large table and prove it stays correct.
+
+    Opt-in twice over: the ``benchmark`` marker is deselected by the default
+    addopts, and the fixture skips unless ``EVAL_SCORE_BENCH_ROWS`` is set. A
+    ten million row seed must never run in an ordinary suite invocation.
+
+        EVAL_SCORE_BENCH_ROWS=10000000 pytest
+            tracer/tests/test_clickhouse_integration.py -m benchmark -k AtScale -s
+
+    ``EVAL_SCORE_BENCH_SHAPE`` picks the table shape: ``prod`` (default,
+    unpartitioned and ordered by id, which is what PeerDB built) or
+    ``canonical`` (the schema.py DDL, partitioned by month).
+    """
+
+    @staticmethod
+    def _timed(call):
+        started = time.perf_counter()
+        result = call()
+        return time.perf_counter() - started, result
+
+    def _stale_count(self, client, table):
+        from tracer.management.commands.backfill_eval_score import _AFFECTED_COUNT
+        from tracer.services.clickhouse.eval_expressions import (
+            eval_has_structured_score,
+        )
+        from tracer.services.clickhouse.schema import (
+            CH_EVAL_SCORE_EXPR,
+            EVAL_OUTPUT_JSON_ARGS,
+        )
+
+        sql = _AFFECTED_COUNT.format(
+            table=table,
+            column="eval_score",
+            expr=CH_EVAL_SCORE_EXPR,
+            predicate=eval_has_structured_score(EVAL_OUTPUT_JSON_ARGS),
+        )
+        seconds, result = self._timed(
+            lambda: client.query(f"{sql}\nSETTINGS {BENCH_READ_SETTINGS}")
+        )
+        return seconds, int(result.result_rows[0][0])
+
+    def test_backfill_scales_and_leaves_every_shape_correct(
+        self, ch_backfill_bench_table
+    ):
+        """The real backfill statements, timed, against a table of real size."""
+        from tracer.management.commands.backfill_eval_score import (
+            _PARTITIONS,
+            materialize_statements,
+            rebuild_statements,
+        )
+
+        client = ch_backfill_bench_table["client"]
+        table = ch_backfill_bench_table["table"]
+        rows = ch_backfill_bench_table["rows"]
+
+        size = client.query(
+            "SELECT sum(rows), sum(bytes_on_disk), count() FROM system.parts "
+            f"WHERE database = '{_TEST_DATABASE}' AND table = '{table}' AND active"
+        ).result_rows[0]
+
+        dry_run_cold, stale_before = self._stale_count(client, table)
+        assert stale_before > 0, (
+            "the seed is not stale, so this run would time a no-op backfill"
+        )
+
+        rebuild_seconds = 0.0
+        for statement in rebuild_statements(table):
+            seconds, _ = self._timed(lambda s=statement: client.command(s))
+            rebuild_seconds += seconds
+
+        partitions = [
+            row[0] for row in client.query(_PARTITIONS.format(table=table)).result_rows
+        ]
+        assert partitions, "the backfill found no partitions to materialize"
+
+        column_seconds = index_seconds = 0.0
+        for partition in partitions:
+            column_sql, index_sql = materialize_statements(table, partition)
+            # mutations_sync = 2 so the wall time is completion, not submission.
+            seconds, _ = self._timed(
+                lambda s=column_sql: client.command(f"{s} SETTINGS mutations_sync = 2")
+            )
+            column_seconds += seconds
+            seconds, _ = self._timed(
+                lambda s=index_sql: client.command(f"{s} SETTINGS mutations_sync = 2")
+            )
+            index_seconds += seconds
+
+        dry_run_after, stale_after = self._stale_count(client, table)
+
+        parity = {
+            use_skip_indexes: int(
+                client.query(
+                    f"SELECT count() FROM {table} WHERE eval_score >= 1.0 "
+                    f"SETTINGS use_skip_indexes = {use_skip_indexes}, "
+                    f"{BENCH_READ_SETTINGS}"
+                ).result_rows[0][0]
+            )
+            for use_skip_indexes in (0, 1)
+        }
+        scores = dict(
+            client.query(
+                f"SELECT reference_id, eval_score FROM {table} "
+                f"GROUP BY reference_id, eval_score SETTINGS {BENCH_READ_SETTINGS}"
+            ).result_rows
+        )
+
+        print(
+            "\n".join(
+                [
+                    "",
+                    f"eval_score backfill, {rows:,} rows, "
+                    f"{ch_backfill_bench_table['shape']} table shape",
+                    f"  rows on disk           {size[0]:,} in {size[2]} active parts",
+                    f"  bytes on disk          {size[1]:,} "
+                    f"({size[1] / max(size[0], 1):.0f} per row)",
+                    f"  seed                   {ch_backfill_bench_table['seed_seconds']:8.2f}s",
+                    f"  dry-run scan           {dry_run_cold:8.2f}s  ({stale_before:,} stale)",
+                    f"  rebuild DDL, 3 stmts   {rebuild_seconds:8.2f}s",
+                    f"  MATERIALIZE COLUMN     {column_seconds:8.2f}s  "
+                    f"over {len(partitions)} partition(s)",
+                    f"  MATERIALIZE INDEX      {index_seconds:8.2f}s",
+                    f"  dry-run scan after     {dry_run_after:8.2f}s  ({stale_after:,} stale)",
+                    "",
+                ]
+            )
+        )
+
+        assert stale_after == 0, (
+            f"{stale_after} rows are still stale after the backfill"
+        )
+        assert parity[1] == parity[0], (
+            "the eval_score minmax index disagrees with the stored rows after "
+            f"the backfill, so filters prune real rows away: {parity}"
+        )
+        assert scores == {
+            label: EVAL_SHAPE_SCORES[label] for _bound, label in BENCH_MIX
+        }, f"a seeded output shape resolved to the wrong score: {scores}"

--- a/futureagi/tracer/tests/test_clickhouse_integration.py
+++ b/futureagi/tracer/tests/test_clickhouse_integration.py
@@ -58,7 +58,6 @@ EVAL_OUTPUT_SHAPES: tuple[tuple[str, dict, float, bool], ...] = (
     ("no_output", {"output": {}}, 0.0, False),
 )
 
-# The number-carrying shapes and the mean a dashboard average returns over them.
 EVAL_SCORED_SHAPES = tuple(s for s in EVAL_OUTPUT_SHAPES if s[3])
 EVAL_SCORED_AVERAGE = 0.625
 
@@ -226,13 +225,8 @@ def ch_dataset_data(ch_schema):
 def ch_eval_output_rows(ch_schema):
     """Recreate usage_apicalllog from the canonical DDL and seed every shape.
 
-    The table is dropped first because ``CREATE TABLE IF NOT EXISTS`` keeps a
-    stale MATERIALIZED expression from an earlier run — the exact drift the
-    POST_DDL_ALTERS ``MODIFY COLUMN`` exists to repair on deployed clusters.
-
-    Rows land twice: once under ``all_shapes_source_id`` (one per shape) and
-    once under ``scored_shapes_source_id`` (number-carrying shapes only), so a
-    dashboard average can be read back without the pass/fail row skewing it.
+    Dropped first because ``CREATE TABLE IF NOT EXISTS`` would keep a stale
+    MATERIALIZED expression from an earlier run.
     """
     from tracer.services.clickhouse.schema import (
         CDC_USAGE_APICALLLOG,
@@ -546,9 +540,7 @@ class TestEvalScoreMaterialization:
     """Eval scores read back out of a real ClickHouse instance."""
 
     def test_every_eval_output_shape_materializes_its_score(self, ch_eval_output_rows):
-        """Structured outputs resolve to their nested score; scalar and text
-        outputs keep the value they always had.
-        """
+        """Structured outputs resolve to their nested score; the rest hold."""
         result = ch_eval_output_rows["client"].query(
             f"SELECT reference_id, eval_score FROM {_EVAL_TABLE} "
             f"WHERE source_id = '{ch_eval_output_rows['all_shapes_source_id']}'"
@@ -561,9 +553,7 @@ class TestEvalScoreMaterialization:
     def test_structured_eval_output_str_holds_the_nested_object(
         self, ch_eval_output_rows
     ):
-        """Readers branch on eval_output_str, so a structured row must carry
-        the serialized object there rather than an empty string.
-        """
+        """Readers branch on eval_output_str, so it must not be empty here."""
         label, payload, _score, _has_number = EVAL_OUTPUT_SHAPES[0]
         result = ch_eval_output_rows["client"].query(
             f"SELECT eval_output_str FROM {_EVAL_TABLE} "
@@ -574,9 +564,7 @@ class TestEvalScoreMaterialization:
         assert json.loads(result.result_rows[0][0]) == payload["output"]["output"]
 
     def test_dashboard_average_counts_structured_eval_scores(self, ch_eval_output_rows):
-        """The widget SQL, executed for real, averages structured outputs
-        alongside scalar ones instead of dropping the structured rows.
-        """
+        """The real widget SQL averages structured rows instead of dropping them."""
         from tracer.services.clickhouse.query_builders.dashboard import (
             DashboardQueryBuilder,
         )
@@ -608,12 +596,7 @@ class TestEvalScoreMaterialization:
     def test_backfill_leaves_the_score_index_agreeing_with_the_rows(
         self, ch_eval_output_rows
     ):
-        """A backfilled row has to stay visible to a filter on eval_score.
-
-        The minmax index keeps the pre-backfill bounds unless it is dropped and
-        re-added, and a stale one prunes whole granules — the filter then
-        returns nothing at all rather than something obviously wrong.
-        """
+        """A backfilled row has to stay visible to a filter on eval_score."""
         from tracer.management.commands.backfill_eval_score import (
             materialize_statements,
             rebuild_statements,
@@ -633,8 +616,7 @@ class TestEvalScoreMaterialization:
                 f"CREATE TABLE IF NOT EXISTS {table}",
             )
         )
-        # Wind the table back to the expression a deployed cluster still has,
-        # so the rows below store the values it would have produced.
+        # Wind the table back to the expression a deployed cluster still has.
         client.command(
             f"ALTER TABLE {table} MODIFY COLUMN eval_score Float64 "
             f"MATERIALIZED JSONExtractFloat({EVAL_OUTPUT_JSON_ARGS})"
@@ -667,5 +649,5 @@ class TestEvalScoreMaterialization:
         client.command(f"DROP TABLE IF EXISTS {table}")
         assert counts[1] == counts[0] == expected, (
             "the eval_score minmax index disagrees with the stored rows after "
-            f"the backfill — filters prune real rows away: {counts}"
+            f"the backfill, so filters prune real rows away: {counts}"
         )

--- a/futureagi/tracer/tests/test_clickhouse_integration.py
+++ b/futureagi/tracer/tests/test_clickhouse_integration.py
@@ -35,7 +35,7 @@ import pytest
 _TEST_DATABASE = "test_futureagi"
 _EVAL_TABLE = f"{_TEST_DATABASE}.usage_apicalllog"
 
-# (label, config payload, the eval_score it must materialize, carries a number)
+# (label, config payload, the eval_score it must materialize, holds a real number)
 EVAL_OUTPUT_SHAPES: tuple[tuple[str, dict, float, bool], ...] = (
     (
         "structured_complete",
@@ -55,6 +55,18 @@ EVAL_OUTPUT_SHAPES: tuple[tuple[str, dict, float, bool], ...] = (
         0.2,
         True,
     ),
+    (
+        "structured_null_score",
+        {"output": {"output": {"score": None, "choice": "Unknown"}}},
+        0.0,
+        False,
+    ),
+    (
+        "structured_text_score",
+        {"output": {"output": {"score": "high"}}},
+        0.0,
+        False,
+    ),
     ("scalar_score", {"output": {"output": 0.8}}, 0.8, True),
     ("text_output", {"output": {"output": "Passed"}}, 0.0, False),
     ("no_output", {"output": {}}, 0.0, False),
@@ -62,6 +74,13 @@ EVAL_OUTPUT_SHAPES: tuple[tuple[str, dict, float, bool], ...] = (
 
 EVAL_SCORED_SHAPES = tuple(s for s in EVAL_OUTPUT_SHAPES if s[3])
 EVAL_SCORED_AVERAGE = 0.625
+
+# Over every shape: the four numbers above plus "Passed" read as 1.0. The empty,
+# null-score and text-score rows are excluded rather than averaged in as 0.
+EVAL_ALL_SHAPES_AVERAGE = 0.7
+
+# Every path that answers "did this eval pass?" has to name this same set.
+EVAL_PASSING_SHAPES = frozenset({"structured_complete", "text_output"})
 
 EVAL_SHAPE_PAYLOADS = {label: payload for label, payload, _s, _h in EVAL_OUTPUT_SHAPES}
 EVAL_SHAPE_SCORES = {label: score for label, _p, score, _h in EVAL_OUTPUT_SHAPES}
@@ -458,8 +477,10 @@ def ch_eval_output_rows(ch_schema):
 
     def _seed(source_id, shapes, first_id):
         for offset, (label, payload, _score, _has_number) in enumerate(shapes):
+            # trace_id: eval filters select on eval_trace_id, so it names the row.
             # config is double-encoded (a JSON string holding JSON) in CH.
-            literal = json.dumps(payload).replace("\\", "\\\\").replace("'", "\\'")
+            config = dict(payload, trace_id=label)
+            literal = json.dumps(config).replace("\\", "\\\\").replace("'", "\\'")
             client.command(
                 f"""
                 INSERT INTO {_EVAL_TABLE}
@@ -770,8 +791,17 @@ class TestEvalScoreMaterialization:
 
         assert json.loads(result.result_rows[0][0]) == payload["output"]["output"]
 
-    def test_dashboard_average_counts_structured_eval_scores(self, ch_eval_output_rows):
-        """The real widget SQL averages structured rows instead of dropping them."""
+    @pytest.mark.parametrize(
+        ("source_key", "expected"),
+        [
+            ("scored_shapes_source_id", EVAL_SCORED_AVERAGE),
+            ("all_shapes_source_id", EVAL_ALL_SHAPES_AVERAGE),
+        ],
+    )
+    def test_dashboard_average_counts_only_the_shapes_it_can_score(
+        self, ch_eval_output_rows, source_key, expected
+    ):
+        """Structured rows are averaged in; a null or text score stays excluded."""
         from tracer.services.clickhouse.query_builders.dashboard import (
             DashboardQueryBuilder,
         )
@@ -786,7 +816,7 @@ class TestEvalScoreMaterialization:
                     "id": "structured_eval",
                     "name": "structured_eval",
                     "type": "eval_metric",
-                    "config_id": ch_eval_output_rows["scored_shapes_source_id"],
+                    "config_id": ch_eval_output_rows[source_key],
                     "aggregation": "avg",
                 }
             ],
@@ -796,9 +826,80 @@ class TestEvalScoreMaterialization:
 
         result = ch_eval_output_rows["client"].query(sql_test, parameters=params)
 
-        assert [row[1] for row in result.result_rows] == [
-            pytest.approx(EVAL_SCORED_AVERAGE)
-        ]
+        assert [row[1] for row in result.result_rows] == [pytest.approx(expected)]
+
+    def test_pass_fail_paths_classify_every_row_the_same_way(self, ch_eval_output_rows):
+        """One eval, three widgets: the time series, the breakdown label and the
+        filter have to reach the same verdict on the same row.
+        """
+        from tracer.services.clickhouse.query_builders.dashboard import (
+            DashboardQueryBuilder,
+        )
+
+        client = ch_eval_output_rows["client"]
+        source_id = ch_eval_output_rows["all_shapes_source_id"]
+        metric = {
+            "id": "pass_fail_eval",
+            "name": "pass_fail_eval",
+            "type": "eval_metric",
+            "config_id": source_id,
+            "output_type": "PASS_FAIL",
+            "aggregation": "pass_count",
+        }
+        config = {
+            "organization_id": ch_eval_output_rows["organization_id"],
+            "workspace_id": ch_eval_output_rows["workspace_id"],
+            "granularity": "day",
+            "time_range": {"preset": "7D"},
+            "metrics": [metric],
+            "breakdowns": [metric],
+        }
+
+        def _run(sql, params=None):
+            return client.query(
+                sql.replace("usage_apicalllog", _EVAL_TABLE), parameters=params
+            ).result_rows
+
+        builder = DashboardQueryBuilder(config)
+
+        sql, params, _ = builder.build_all_queries()[0]
+        time_series_passes = sum(row[1] for row in _run(sql, params))
+
+        label_expr = builder._resolve_all_breakdowns({})[0]["expr"]
+        breakdown_passes = {
+            label
+            for label, verdict in _run(
+                f"SELECT reference_id, {label_expr} FROM usage_apicalllog AS ev0 "
+                f"WHERE source_id = '{source_id}'"
+            )
+            if verdict == "Pass"
+        }
+
+        clauses, filter_params = builder._build_subquery_filters(
+            [
+                {
+                    "metric_type": "eval_metric",
+                    "metric_name": source_id,
+                    "output_type": "PASS_FAIL",
+                    "operator": "equal_to",
+                    "value": 1.0,
+                }
+            ],
+            {},
+            "f_",
+        )
+        subquery = clauses[0][clauses[0].index("(") + 1 : clauses[0].rindex(")")]
+        filter_passes = {row[0] for row in _run(subquery, filter_params)}
+
+        assert breakdown_passes == filter_passes == set(EVAL_PASSING_SHAPES), (
+            "the breakdown label and the eval filter disagree on which rows "
+            f"passed: breakdown {sorted(breakdown_passes)}, "
+            f"filter {sorted(filter_passes)}"
+        )
+        assert time_series_passes == len(EVAL_PASSING_SHAPES), (
+            "the time series counts a different number of passes than the "
+            f"breakdown and the filter do: {time_series_passes}"
+        )
 
     def test_backfill_leaves_the_score_index_agreeing_with_the_rows(
         self, ch_eval_output_rows

--- a/futureagi/tracer/tests/test_clickhouse_integration.py
+++ b/futureagi/tracer/tests/test_clickhouse_integration.py
@@ -16,8 +16,10 @@ Covered:
 - Connection and schema lifecycle
 - SimulationQueryBuilder integration (system metrics, breakdowns, filters)
 - DatasetQueryBuilder integration (system metrics, breakdowns)
+- usage_apicalllog eval-score materialization per eval-output shape
 """
 
+import json
 import os
 import uuid
 from datetime import datetime, timezone
@@ -29,6 +31,36 @@ import pytest
 # ---------------------------------------------------------------------------
 
 _TEST_DATABASE = "test_futureagi"
+_EVAL_TABLE = f"{_TEST_DATABASE}.usage_apicalllog"
+
+# (label, config payload, the eval_score it must materialize, carries a number)
+EVAL_OUTPUT_SHAPES: tuple[tuple[str, dict, float, bool], ...] = (
+    (
+        "structured_complete",
+        {"output": {"output": {"score": 1, "choice": "Complete"}}},
+        1.0,
+        True,
+    ),
+    (
+        "structured_partial",
+        {"output": {"output": {"score": 0.5, "choice": "Partial"}}},
+        0.5,
+        True,
+    ),
+    (
+        "structured_incomplete",
+        {"output": {"output": {"score": 0.2, "choice": "Incomplete"}}},
+        0.2,
+        True,
+    ),
+    ("scalar_score", {"output": {"output": 0.8}}, 0.8, True),
+    ("text_output", {"output": {"output": "Passed"}}, 0.0, False),
+    ("no_output", {"output": {}}, 0.0, False),
+)
+
+# The number-carrying shapes and the mean a dashboard average returns over them.
+EVAL_SCORED_SHAPES = tuple(s for s in EVAL_OUTPUT_SHAPES if s[3])
+EVAL_SCORED_AVERAGE = 0.625
 
 
 @pytest.fixture(scope="session")
@@ -186,6 +218,75 @@ def ch_dataset_data(ch_schema):
 
     try:
         client.command(f"TRUNCATE TABLE {_TEST_DATABASE}.model_hub_cell")
+    except Exception:
+        pass
+
+
+@pytest.fixture
+def ch_eval_output_rows(ch_schema):
+    """Recreate usage_apicalllog from the canonical DDL and seed every shape.
+
+    The table is dropped first because ``CREATE TABLE IF NOT EXISTS`` keeps a
+    stale MATERIALIZED expression from an earlier run — the exact drift the
+    POST_DDL_ALTERS ``MODIFY COLUMN`` exists to repair on deployed clusters.
+
+    Rows land twice: once under ``all_shapes_source_id`` (one per shape) and
+    once under ``scored_shapes_source_id`` (number-carrying shapes only), so a
+    dashboard average can be read back without the pass/fail row skewing it.
+    """
+    from tracer.services.clickhouse.schema import (
+        CDC_USAGE_APICALLLOG,
+        _to_single_node_engine,
+    )
+
+    client = ch_schema
+    organization_id = str(uuid.uuid4())
+    workspace_id = str(uuid.uuid4())
+    all_shapes_source_id = str(uuid.uuid4())
+    scored_shapes_source_id = str(uuid.uuid4())
+
+    ddl = _to_single_node_engine(CDC_USAGE_APICALLLOG).replace(
+        "CREATE TABLE IF NOT EXISTS usage_apicalllog",
+        f"CREATE TABLE IF NOT EXISTS {_EVAL_TABLE}",
+    )
+    client.command(f"DROP TABLE IF EXISTS {_EVAL_TABLE}")
+    client.command(ddl)
+
+    # Backdated so clock skew against the CH container can't push rows past "now".
+    seeded_at = "now64(6) - toIntervalHour(1)"
+
+    def _seed(source_id, shapes, first_id):
+        for offset, (label, payload, _score, _has_number) in enumerate(shapes):
+            # config is double-encoded (a JSON string holding JSON) in CH.
+            literal = json.dumps(payload).replace("\\", "\\\\").replace("'", "\\'")
+            client.command(
+                f"""
+                INSERT INTO {_EVAL_TABLE}
+                    (id, log_id, organization_id, workspace_id, status,
+                     reference_id, config, source, source_id,
+                     created_at, updated_at,
+                     _peerdb_synced_at, _peerdb_is_deleted, _peerdb_version)
+                SELECT {first_id + offset}, generateUUIDv4(),
+                       toUUID('{organization_id}'), toUUID('{workspace_id}'),
+                       'success', '{label}', toJSONString('{literal}'),
+                       'tracer', '{source_id}',
+                       {seeded_at}, {seeded_at}, {seeded_at}, 0, 1
+                """
+            )
+
+    _seed(all_shapes_source_id, EVAL_OUTPUT_SHAPES, 1)
+    _seed(scored_shapes_source_id, EVAL_SCORED_SHAPES, 101)
+
+    yield {
+        "client": client,
+        "organization_id": organization_id,
+        "workspace_id": workspace_id,
+        "all_shapes_source_id": all_shapes_source_id,
+        "scored_shapes_source_id": scored_shapes_source_id,
+    }
+
+    try:
+        client.command(f"TRUNCATE TABLE {_EVAL_TABLE}")
     except Exception:
         pass
 
@@ -433,3 +534,138 @@ class TestDatasetQueryBuilderIntegration:
         queries = builder.build_all_queries()
         sql, _, _ = queries[0]
         assert "breakdown_value" in sql
+
+
+# ===========================================================================
+# F. TestEvalScoreMaterialization
+# ===========================================================================
+
+
+@pytest.mark.integration
+class TestEvalScoreMaterialization:
+    """Eval scores read back out of a real ClickHouse instance."""
+
+    def test_every_eval_output_shape_materializes_its_score(self, ch_eval_output_rows):
+        """Structured outputs resolve to their nested score; scalar and text
+        outputs keep the value they always had.
+        """
+        result = ch_eval_output_rows["client"].query(
+            f"SELECT reference_id, eval_score FROM {_EVAL_TABLE} "
+            f"WHERE source_id = '{ch_eval_output_rows['all_shapes_source_id']}'"
+        )
+
+        assert dict(result.result_rows) == {
+            label: score for label, _payload, score, _has_number in EVAL_OUTPUT_SHAPES
+        }
+
+    def test_structured_eval_output_str_holds_the_nested_object(
+        self, ch_eval_output_rows
+    ):
+        """Readers branch on eval_output_str, so a structured row must carry
+        the serialized object there rather than an empty string.
+        """
+        label, payload, _score, _has_number = EVAL_OUTPUT_SHAPES[0]
+        result = ch_eval_output_rows["client"].query(
+            f"SELECT eval_output_str FROM {_EVAL_TABLE} "
+            f"WHERE source_id = '{ch_eval_output_rows['all_shapes_source_id']}' "
+            f"AND reference_id = '{label}'"
+        )
+
+        assert json.loads(result.result_rows[0][0]) == payload["output"]["output"]
+
+    def test_dashboard_average_counts_structured_eval_scores(self, ch_eval_output_rows):
+        """The widget SQL, executed for real, averages structured outputs
+        alongside scalar ones instead of dropping the structured rows.
+        """
+        from tracer.services.clickhouse.query_builders.dashboard import (
+            DashboardQueryBuilder,
+        )
+
+        config = {
+            "organization_id": ch_eval_output_rows["organization_id"],
+            "workspace_id": ch_eval_output_rows["workspace_id"],
+            "granularity": "day",
+            "time_range": {"preset": "7D"},
+            "metrics": [
+                {
+                    "id": "structured_eval",
+                    "name": "structured_eval",
+                    "type": "eval_metric",
+                    "config_id": ch_eval_output_rows["scored_shapes_source_id"],
+                    "aggregation": "avg",
+                }
+            ],
+        }
+        sql, params, _ = DashboardQueryBuilder(config).build_all_queries()[0]
+        sql_test = sql.replace("usage_apicalllog", _EVAL_TABLE)
+
+        result = ch_eval_output_rows["client"].query(sql_test, parameters=params)
+
+        assert [row[1] for row in result.result_rows] == [
+            pytest.approx(EVAL_SCORED_AVERAGE)
+        ]
+
+    def test_backfill_leaves_the_score_index_agreeing_with_the_rows(
+        self, ch_eval_output_rows
+    ):
+        """A backfilled row has to stay visible to a filter on eval_score.
+
+        The minmax index keeps the pre-backfill bounds unless it is dropped and
+        re-added, and a stale one prunes whole granules — the filter then
+        returns nothing at all rather than something obviously wrong.
+        """
+        from tracer.management.commands.backfill_eval_score import (
+            materialize_statements,
+            rebuild_statements,
+        )
+        from tracer.services.clickhouse.schema import (
+            CDC_USAGE_APICALLLOG,
+            EVAL_OUTPUT_JSON_ARGS,
+            _to_single_node_engine,
+        )
+
+        client = ch_eval_output_rows["client"]
+        table = f"{_EVAL_TABLE}_deployed"
+        client.command(f"DROP TABLE IF EXISTS {table}")
+        client.command(
+            _to_single_node_engine(CDC_USAGE_APICALLLOG).replace(
+                "CREATE TABLE IF NOT EXISTS usage_apicalllog",
+                f"CREATE TABLE IF NOT EXISTS {table}",
+            )
+        )
+        # Wind the table back to the expression a deployed cluster still has,
+        # so the rows below store the values it would have produced.
+        client.command(
+            f"ALTER TABLE {table} MODIFY COLUMN eval_score Float64 "
+            f"MATERIALIZED JSONExtractFloat({EVAL_OUTPUT_JSON_ARGS})"
+        )
+        for offset, (_label, payload, _score, _has_number) in enumerate(
+            EVAL_SCORED_SHAPES
+        ):
+            literal = json.dumps(payload).replace("\\", "\\\\").replace("'", "\\'")
+            client.command(
+                f"INSERT INTO {table} (id, log_id, organization_id, status, config, "
+                "source, source_id, created_at, updated_at, _peerdb_synced_at, "
+                "_peerdb_is_deleted, _peerdb_version) SELECT "
+                f"{201 + offset}, generateUUIDv4(), generateUUIDv4(), 'success', "
+                f"toJSONString('{literal}'), 'tracer', 'deployed', "
+                "now64(6), now64(6), now64(6), 0, 1"
+            )
+
+        for statement in rebuild_statements(table) + materialize_statements(table):
+            client.command(f"{statement} SETTINGS mutations_sync = 2")
+
+        expected = sum(1 for _l, _p, score, _h in EVAL_SCORED_SHAPES if score >= 1.0)
+        counts = {
+            skip_indexes: client.query(
+                f"SELECT count() FROM {table} WHERE eval_score >= 1.0 "
+                f"SETTINGS use_skip_indexes = {skip_indexes}"
+            ).result_rows[0][0]
+            for skip_indexes in (0, 1)
+        }
+
+        client.command(f"DROP TABLE IF EXISTS {table}")
+        assert counts[1] == counts[0] == expected, (
+            "the eval_score minmax index disagrees with the stored rows after "
+            f"the backfill — filters prune real rows away: {counts}"
+        )

--- a/futureagi/tracer/tests/test_dashboard.py
+++ b/futureagi/tracer/tests/test_dashboard.py
@@ -1604,9 +1604,8 @@ class TestDashboardQueryBuilder:
         assert "sum(e.eval_score)" not in sql
 
     def test_eval_metric_avg_keeps_structured_score_rows(self):
-        """A ``{"score": …, "choice": …}`` output is not numeric text, so the
-        numeric-detection branch must also accept the nested score — otherwise
-        every structured row is NULLed out of the aggregate.
+        """A structured output is not numeric text, so the numeric-detection
+        branch must accept the nested score or every such row is NULLed out.
         """
         config = {
             "project_ids": ["proj1"],

--- a/futureagi/tracer/tests/test_dashboard.py
+++ b/futureagi/tracer/tests/test_dashboard.py
@@ -1603,6 +1603,30 @@ class TestDashboardQueryBuilder:
         assert "lower(e.eval_output_str) IN ('passed', 'pass', 'true', '1')" in sql
         assert "sum(e.eval_score)" not in sql
 
+    def test_eval_metric_avg_keeps_structured_score_rows(self):
+        """A ``{"score": …, "choice": …}`` output is not numeric text, so the
+        numeric-detection branch must also accept the nested score — otherwise
+        every structured row is NULLed out of the aggregate.
+        """
+        config = {
+            "project_ids": ["proj1"],
+            "granularity": "day",
+            "time_range": {"preset": "7D"},
+            "metrics": [
+                {
+                    "id": "e2",
+                    "name": "conversation_hallucination",
+                    "type": "eval_metric",
+                    "config_id": str(uuid.uuid4()),
+                    "aggregation": "avg",
+                }
+            ],
+        }
+        builder = DashboardQueryBuilder(config)
+        queries = builder.build_all_queries()
+        sql, _, _ = queries[0]
+        assert "JSONHas(e.eval_output_str, 'score')" in sql
+
     def test_eval_metric_combines_project_and_dataset_breakdowns(self):
         config = {
             "project_ids": ["proj1"],

--- a/futureagi/tracer/tests/test_dashboard.py
+++ b/futureagi/tracer/tests/test_dashboard.py
@@ -1624,7 +1624,63 @@ class TestDashboardQueryBuilder:
         builder = DashboardQueryBuilder(config)
         queries = builder.build_all_queries()
         sql, _, _ = queries[0]
-        assert "JSONHas(e.eval_output_str, 'score')" in sql
+        assert (
+            "JSONType(e.eval_output_str, 'score') IN ('Double', 'Int64', 'UInt64')"
+            in sql
+        )
+
+    def test_pass_fail_paths_render_one_shared_predicate(self):
+        """The time-series predicate is unchanged to the byte, and the breakdown
+        label and the eval filter now render it instead of a 'Passed' literal.
+        """
+        eval_id = str(uuid.uuid4())
+        metric = {
+            "id": "e_pf",
+            "name": "pass_fail_eval",
+            "type": "eval_metric",
+            "config_id": eval_id,
+            "output_type": "PASS_FAIL",
+            "aggregation": "pass_rate",
+        }
+        builder = DashboardQueryBuilder(
+            {
+                "project_ids": ["proj1"],
+                "organization_id": str(uuid.uuid4()),
+                "granularity": "day",
+                "time_range": {"preset": "7D"},
+                "metrics": [metric],
+                "breakdowns": [metric],
+            }
+        )
+
+        sql, _, _ = builder.build_all_queries()[0]
+        breakdown_expr = builder._resolve_all_breakdowns({})[0]["expr"]
+        filter_clauses, _ = builder._build_subquery_filters(
+            [
+                {
+                    "metric_type": "eval_metric",
+                    "metric_name": eval_id,
+                    "output_type": "PASS_FAIL",
+                    "operator": "equal_to",
+                    "value": 1.0,
+                }
+            ],
+            {},
+            "f_",
+        )
+
+        assert (
+            "(e.eval_score >= 1.0 OR lower(e.eval_output_str) IN "
+            "('passed', 'pass', 'true', '1'))" in sql
+        ), "the time-series pass predicate must render exactly as it did before"
+        assert (
+            "(ev0.eval_score >= 1.0 OR lower(ev0.eval_output_str) IN "
+            "('passed', 'pass', 'true', '1'))" in breakdown_expr
+        ), "the PASS_FAIL breakdown label must not read a structured row as Fail"
+        assert (
+            "(eval_score >= 1.0 OR lower(eval_output_str) IN "
+            "('passed', 'pass', 'true', '1'))" in filter_clauses[0]
+        ), "the PASS_FAIL eval filter must select what the widget labels Pass"
 
     def test_eval_metric_combines_project_and_dataset_breakdowns(self):
         config = {


### PR DESCRIPTION
## Summary

Dashboard eval widgets rendered blank for evals whose output is a structured object such as `{"score": 1, "choice": "Complete"}`.

The `usage_apicalllog.eval_score` MATERIALIZED column extracted `config.output.output` with `JSONExtractFloat`, which returns `0` for an object. This branches the extraction on a numeric nested `score` while keeping the bare-scalar fallback, puts every dashboard path that answers "did this eval pass?" on one shared predicate, carries the new expression onto already-deployed tables, and ships an ops command to re-materialize existing rows.

## Why / where it breaks

A customer's completeness eval scores their agent's responses and the scores are visible in Evals to Usage. They wanted the same score as a Dashboard time-series. Average came back blank, True Rate `0.00`, Count a meaningless `9.20` (`count` maps to `count()`, so the per-day values are integers: 9, 9, 10, 9, 9. The `9.20` is the widget summary row averaging those buckets, not a fractional count).

### Where it breaks (BE)

`tracer/services/clickhouse/schema.py` (old expression):

```sql
eval_score Float64 MATERIALIZED JSONExtractFloat(JSONExtractString(config), 'output', 'output')
```

For `{"output": {"output": {"score": 1, "choice": "Complete"}}}` that path is an **object**, so `JSONExtractFloat` yields `0`. Every structured row stored `eval_score = 0`.

`tracer/services/clickhouse/query_builders/dashboard.py` is the second head. `eval_output_str` for a structured row is the serialized object `{"score":1,"choice":"Complete"}`, which is neither empty nor pass/fail nor numeric-matching, so the `col_expr` chain NULLed the row before `eval_score` was ever read. That is why Average returned blank rather than `0`.

Verified against ClickHouse 25.3.14.14:

| stored output | old `eval_score` | new `eval_score` | dashboard `avg` reads it as |
|---|---|---|---|
| `{"score": 1, "choice": "Complete"}` | 0 | 1.0 | 1.0 |
| `{"score": 0.5, "choice": "Partial"}` | 0 | 0.5 | 0.5 |
| `{"score": 0.2, "choice": "Incomplete"}` | 0 | 0.2 | 0.2 |
| `{"score": null, "choice": "Unknown"}` | 0 | 0 | NULL, excluded |
| `{"score": "high"}` | 0 | 0 | NULL, excluded |
| `0.8` (scalar eval) | 0.8 | 0.8 | 0.8 |
| `"Passed"` | 0 | 0 | 1.0 |
| absent | 0 | 0 | NULL, excluded |

The last column is the point of the type gate. `JSONHas(x, 'score')` is true whenever the key merely exists, and `JSONExtractFloat` returns `0` for a null or a string, so gating on key presence would drag `{"score": null}` into the average as a hard `0.0`, which is worse than the blank it produces today. `JSONType(x, 'score') IN ('Double', 'Int64', 'UInt64')` is `1` only for a real number, so those rows stay excluded.

## What changed

### `tracer/services/clickhouse/eval_expressions.py` (new)

A leaf module holding the eval-output SQL that both the DDL and the query builders need: `EVAL_STRUCTURED_SCORE_KEY`, `EVAL_NUMERIC_JSON_TYPES`, `eval_has_structured_score()`, the truthy/falsy output sets and `sql_str_set()`.

`eval_has_structured_score()` gates on the value's JSON **type**, not on key presence, so the detector accepts exactly the set its extractor can score. `JSONHas` and `JSONExtractFloat` disagree on `{"score": null}` and `{"score": "high"}`: the first says yes, the second returns `0`. One change here covers all three call sites: the DDL expression in `schema.py`, the dashboard numeric-detection branch, and the backfill's stale-row predicate, including the one that passes the comma-joined `EVAL_OUTPUT_JSON_ARGS` fragment.

It is a leaf on purpose. `query_builders/__init__.py` imports all 15 builder modules, so putting these in `query_builders/expressions.py` would make `schema.py` pull that whole tree in at import time just to render DDL. There is no import cycle today, and none is claimed: no builder imports `schema`. The reason is weight, not a cycle.

### `tracer/services/clickhouse/schema.py`

`CH_EVAL_SCORE_EXPR` branches on `JSONType(..., 'score') IN ('Double', 'Int64', 'UInt64')` and keeps `JSONExtractFloat(...)` as the fallback, so both output shapes resolve to the same float. One constant now feeds both the `CREATE TABLE` DDL and `POST_DDL_ALTERS`; before this they were duplicated verbatim and could drift.

`POST_DDL_ALTERS` gains a `MODIFY COLUMN` alongside the existing `ADD COLUMN IF NOT EXISTS`. `ADD COLUMN IF NOT EXISTS` is a no-op on a table that already has the column, so without the `MODIFY` this fix would reach fresh installs and no deployed environment. No `DROP INDEX` / `ADD INDEX` sandwich is needed around it, unlike the `tracer_eval_logger.trace_id` block in the same file: Code 524 fires on a type change, and the type is restated unchanged.

It also gains `ADD INDEX IF NOT EXISTS idx_eval_score`, matching the three `tracer_eval_logger` index statements already there. A backfill run that dies between its `DROP INDEX` and `ADD INDEX` otherwise leaves the table with no skip index and nothing to restore it.

Named `CH_` because `tracer/queries/feed.py` already defines an `EVAL_SCORE_EXPR` (a Django ORM `Case`) used in the same domain.

### `tracer/services/clickhouse/query_builders/dashboard.py`

**The only semantic change inside `_build_eval_metric_query` is the added `OR <structured-score predicate>` in the numeric-detection branch (`dashboard.py:759-761`).** `_is_pass`, `_is_fail` and `_unified_score` render byte-identical SQL to before. They were rewritten to call `eval_pass_expr()` / `eval_fail_expr()`, which emit the same strings character for character, and that is asserted below. Nothing else in that block moved.

The pass/fail literal sets are read from named constants instead of being inlined.

**Three heads of the same contract now agree.** `_is_pass` reads a row as a pass when `eval_score >= 1.0` **or** the output text is truthy. Two sibling paths classified the same row by comparing `eval_output_str` to the exact, case-sensitive string `'Passed'`:

| path | before | after |
|---|---|---|
| `_is_pass` / `_unified_score`, time series | `eval_score >= 1.0 OR lower(output) IN (truthy)` | unchanged |
| `dashboard.py:1500`, PASS_FAIL breakdown label | `eval_output_str = 'Passed'` | `eval_pass_expr(...)` |
| `dashboard.py:1717`, PASS_FAIL eval filter | `eval_output_str = 'Passed'` | `eval_pass_expr(...)` |

Those two lines are pre-existing, but the **disagreement** is new and is caused by this PR. Before it, `eval_score` was `0` for every structured row, so `_is_pass` also read one as a fail and all three agreed. After it, `_is_pass` reads `{"score": 1, ...}` as a pass while the other two still render `Fail` / `0.0`: the same eval, the same widget, contradictory answers. All three now build their predicate from one function.

The widening is deliberate: `'Passed'` was an exact case-sensitive match, and the shared predicate is `eval_score >= 1.0 OR lower(output) IN ('passed', 'pass', 'true', '1')`. It is monotone: every row that read as a pass before still does, since `lower('Passed')` is in the set. What is added is (a) case and spelling variants a template may legitimately emit, and (b) structured rows whose nested score is `1`, which is the whole point of this PR. No test pinned the narrow behaviour; the only two that referenced these lines are the new ones added here.

Two other `eval_output_str` sites in this file are deliberately untouched and are **not** a fourth head: `dashboard.py:894` and `909` render the raw `eval_output_str` as a PASS_FAIL/CHOICE breakdown label, and `dashboard.py:967` and `980` filter that same raw string against the value the UI sends. Label and filter are consistent with each other, and neither hardcodes a literal.

### `tracer/management/commands/backfill_eval_score.py` (new)

`MODIFY COLUMN` is metadata only and does not rewrite stored parts, so existing rows keep whatever the old expression produced. Only `MATERIALIZE COLUMN` rewrites them, and that is a mutation, so it must not run on every app boot. Hence a one-shot ops command.

It drops and re-adds `idx_eval_score` around the change. This is the non-obvious part, measured on two identical tables of 50 structured rows:

| sequence | `WHERE eval_score >= 1.0`, index ON | index OFF |
|---|---|---|
| MODIFY, MATERIALIZE COLUMN, MATERIALIZE INDEX | **0** | 50 |
| DROP INDEX, MODIFY, ADD INDEX, MATERIALIZE COLUMN, MATERIALIZE INDEX | **50** | 50 |

Re-materializing the column leaves the minmax index on its pre-backfill bounds, and `MATERIALIZE INDEX` alone does not repair it. A stale skip index prunes whole granules, so filters return nothing at all rather than something visibly wrong. The second sequence is the pattern this repo already uses for `tracer_eval_logger.trace_id`.

The in-flight guard uses `position(command, 'eval_score') > 0` rather than `LIKE '%eval_score%'`: the driver runs printf substitution over every query it executes, so a literal `%` raises `TypeError: must be real number, not dict` before the query reaches ClickHouse.

## Tests

| # | Test | Setup | Action | What it pins |
|---|---|---|---|---|
| 1 | `test_every_eval_output_shape_materializes_its_score` | canonical DDL on a real CH instance, eight payload shapes inserted | read `eval_score` per row | exact score per shape; scalar and text outputs unchanged |
| 2 | `test_structured_eval_output_str_holds_the_nested_object` | same | read `eval_output_str` | it is the serialized object, not `''`; the dashboard branch depends on this |
| 3 | `test_dashboard_average_counts_only_the_shapes_it_can_score` | seeded rows, real `DashboardQueryBuilder` SQL, parametrized over two sources | execute it against CH | scored shapes average `0.625`; over every shape it is `0.7`, so a null or text score is excluded rather than averaged in as `0` |
| 4 | `test_pass_fail_paths_classify_every_row_the_same_way` | the same seeded rows, one PASS_FAIL eval | execute the real time-series SQL, the real breakdown label expression and the real filter subquery | all three name the same rows as passes; red if either sibling goes back to `= 'Passed'` |
| 5 | `test_backfill_leaves_the_score_index_agreeing_with_the_rows` | table wound back to the deployed expression, then the real backfill statements | count with and without `use_skip_indexes` | the counts agree; catches the stale-index regression |
| 6 | `test_eval_score_expression_reads_structured_and_scalar_outputs` | - | inspect the rendered expression | the type gate and the scalar fallback are both present |
| 7 | `test_post_ddl_alters_modifies_eval_score_on_existing_tables` | - | inspect `POST_DDL_ALTERS` | `MODIFY COLUMN` present, not only `ADD COLUMN`, and `idx_eval_score` is re-added |
| 8 | `test_backfill_queries_survive_driver_parameter_substitution` | - | run each template through `% {}` | no literal `%` can come back |
| 9 | `test_eval_metric_avg_keeps_structured_score_rows` | eval metric config | build the SQL | the type-gated structured-score branch is in the generated SQL |
| 10 | `test_pass_fail_paths_render_one_shared_predicate` | one PASS_FAIL eval | build the time-series SQL, the breakdown expression and the filter clause | the time-series predicate is byte-identical to the pre-PR one, and the other two render it too |
| 11-13 | `backfill_eval_score` dry-run, in-flight guard, force path | mocked CH client, real `call_command` | run the command | early return, guard, and partition loop behave |
| 14 | scalar-output compatibility, covered by #1 | - | - | a future simplification that drops the fallback fails loudly |

Tests 1-5 are `@pytest.mark.integration` and require the test ClickHouse container.

## Commands

`bin/test` uses `.venv/bin/python` when one is present and otherwise falls back to whatever `python` resolves to, which in a fresh worktree has no Django. Point it at a real environment:

```bash
cd futureagi
PYTHON_BIN=/path/to/futureagi/.venv/bin/python \
  bash bin/test tracer/tests/test_clickhouse.py tracer/tests/test_dashboard.py \
  tracer/tests/test_clickhouse_integration.py -m "integration or not integration"
```

## Local verification

```
tracer/tests/test_clickhouse.py ........................................ [ 40%]
tracer/tests/test_dashboard.py .......................................... [ 81%]
tracer/tests/test_clickhouse_integration.py ...s.ss.......s              [100%]

======================== 825 passed, 4 skipped in 9.22s ========================
```

The four skips: three pre-existing integration cases whose tables (`simulate_call_execution`, `model_hub_cell`) are not in the test schema, plus the opt-in backfill benchmark, which skips unless `EVAL_SCORE_BENCH_ROWS` is set.

Red-green was proven by reverting each change in turn, not asserted:

| reverted | result |
|---|---|
| `CH_EVAL_SCORE_EXPR` to the bare `JSONExtractFloat` | 4 fail. `{'structured_complete': 0.0} != 1.0`, and the dashboard average returns `[0.2]` instead of `[0.625]` |
| `eval_has_structured_score` to `JSONHas` | 3 fail. The all-shapes average returns `0.5` instead of `0.7`, because `{"score": null}` and `{"score": "high"}` are averaged in as `0` |
| `dashboard.py:1500` to `= 'Passed'` | 1 fail. The breakdown drops `structured_complete` from the pass set the time series and the filter both name |
| `dashboard.py:1717` to `= 'Passed'` | 1 fail. The filter and the breakdown disagree on `structured_complete` |
| `DROP INDEX` / `ADD INDEX` out of the backfill | 1 fail. Index parity `{0: 1, 1: 0}` |

All restored and verified byte-identical.

## Backwards compatibility

| Caller | Pre-PR | Post-PR |
|---|---|---|
| Dashboard eval widget, `avg`/`median`/`min`/`max`/percentile | blank for structured evals | the real score |
| Dashboard eval widget on scalar-output evals | correct | unchanged |
| `pass_rate` / `fail_rate` / `true_rate` | `0` for structured evals, since `eval_score` never reached 1.0 | uses the real score |
| SCORE-type breakdown labels | `(not set)` for structured evals | `100` / `50` / `20` |
| CHOICE-type breakdown labels | the serialized object | unchanged, see Out of scope |
| PASS_FAIL breakdown labels | `Fail` unless the output was exactly `Passed` | `Pass` when the score is `>= 1.0` or the text is truthy, matching the widget |
| PASS_FAIL eval filters | matched only rows whose output was exactly `Passed` | the same predicate the breakdown and the time series use |
| Evals whose nested score is `null` or a string | blank | blank, and still excluded from the average rather than counted as `0` |
| `eval_score` filters | never matched structured rows | match, and the index agrees after the backfill |
| `dashboard_metrics_catalog.py` | reads `source_id` only | unaffected |
| Evals to Usage page | reads Postgres, not ClickHouse | unaffected |
| `tracer/queries/feed.py` `_avg_eval_score` | reads PG `EvalLogger` | unaffected |

The consumer set of the changed column is closed, and enumerated rather than assumed:

```bash
for f in $(git grep -ln eval_score -- 'futureagi/**/*.py' ':!*test*'); do
  grep -q apicalllog "$f" && echo "$f"
done
```

Three files, all three in this diff: `schema.py` defines the column, `query_builders/dashboard.py` reads it, `management/commands/backfill_eval_score.py` re-materializes it. Everything else named `eval_score` reads `tracer_eval_logger` (`query_service.get_trace_eval_scores_ch`, `v2/query_builders/trace_detail.py`, both via `output_float` / `output_bool`) or Postgres, so no sibling path is left on the old extraction.

**Client-visible changes wider than the ticket.** Three, stated deliberately:

1. SCORE breakdowns flip from `(not set)` to a real percentage. Correct, and previously the column was `0` for every structured row.
2. PASS_FAIL widgets on structured evals flip from all-fail to real pass/fail, for the same reason.
3. PASS_FAIL breakdown labels and eval filters widen from an exact `= 'Passed'` match to the shared pass predicate. Monotone, since nothing that read as a pass stops doing so, and it exists to stop this PR from making those two paths contradict the time series.

CHOICE breakdown labels are not a third. `eval_output_str` is byte-identical before and after this PR (`JSONExtractString(JSONExtractString(config), 'output', 'output')`), so a CHOICE breakdown labelled its groups with the serialized object before this change and still does. What changes is that a metric grouped by one of those labels now returns a value instead of blank. Rendering `Complete` instead of the object is a separate change, see Out of scope.

## Out of scope

Real, verified, and deliberately left out of this diff:

- The `count` aggregation on an eval metric maps to `count()`, so it counts rows and never reads the eval value. Unchanged by this PR, and not the number a `Count` widget looks like it should show.
- CHOICE label extraction (`dashboard.py:1489-1492`). The label is the whole serialized object. Rendering the choice means changing what `eval_output_str` means, which changes eval filter behaviour and needs its own materialized column and its own backfill.
- The `label` vs `choice` key. This PR reads the nested `score` only; templates that name their text field `label` rather than `choice` are untouched, because nothing here reads the text field at all.
- Five more copies of the truthy/falsy literal sets, all pre-existing. This PR routes only the dashboard eval path through `eval_expressions.py`. Deferred individually, not as a block. Each is a different table, a different backend, or a different language:

  | copy | why it is genuinely a different path |
  |---|---|
  | `query_builders/filters.py:1519` | Python membership test, not SQL. Maps the UI's `Passed`/`Failed` tokens onto `tracer_eval_logger.output_bool`, a boolean column on a different table with no `eval_score` beside it, so the shared pass predicate does not apply. Could adopt the tuple constants; would still need its own tests. |
  | `utils/filters.py:1564` | Django ORM `Q()` over Postgres JSON, not ClickHouse at all. Same Python membership test, different backend entirely. |
  | `query_builders/dataset_dashboard.py:125` | Classifies `model_hub_cell.value`, a raw dataset cell with no companion score column, so it can only ever be a string test. Changing it moves dataset widget numbers. |
  | `query_builders/simulation_dashboard.py:607` | The same expression over simulation eval columns, same reasoning, and it moves simulation widget numbers. |
  | `schema.py:1260` | `value_bool` on the `model_hub_cell` denormalized view, a genuinely different table, and it is DDL. Changing it needs a view recreate plus its own backfill, which is the same size of job as the `eval_score` change in this PR. |

- Non-structured drift. The stale count only looks at rows whose output carries a nested `score`, so a scalar-output row whose stored `eval_score` has drifted for some other reason reports "already up to date". `MATERIALIZE COLUMN` rewrites every row regardless, so `--force` repairs it; the `--force` help text says so.

## Manual verification

1. Seed `usage_apicalllog` with the customer's real distribution: 42 rows `{"score":1,"choice":"Complete"}`, 10 `{"score":0.2,"choice":"Incomplete"}`, 3 `{"score":0.5,"choice":"Partial"}`, spread over six days, plus a scalar-output eval as a control.
2. Build a Dashboard widget: the eval metric, aggregation Average, granularity Day, over that range. It renders blank; the API returns `value: null` for every bucket.
3. Deploy this change and restart the backend. `POST_DDL_ALTERS` carries the new expression onto the existing table.
4. `python manage.py backfill_eval_score --dry-run` reports 55 stale rows. `--no-confirm` runs the rebuild and the mutations. A second `--dry-run` reports 0.
5. The same widget, unchanged, now reads `0.83` with per-day values `0.77 / 0.82 / 0.87 / 0.82 / 0.86`. The scalar control eval still reads `0.75`.
6. `SELECT count() FROM usage_apicalllog WHERE eval_score >= 1.0` returns the same number with and without `SETTINGS use_skip_indexes = 0`.

## Video

Before and after on the dashboard, same widget and same controls.

https://github.com/user-attachments/assets/d2527333-d363-42a4-8cca-91bfa0bb1290

## Before / After

Average returns blank; the API returns `value: null` for every bucket.

![before](https://github.com/user-attachments/assets/afbe5883-3536-4a84-afeb-afa4d5f70360)

Same widget, same controls, after the fix and the backfill: 0.83.

![after](https://github.com/user-attachments/assets/6d1bd0eb-6c65-4f49-ada5-ab307a7b97d9)

## Test suite run

![test suite run](https://github.com/user-attachments/assets/a9221b0f-09c6-4588-966e-67cdeb2d6b6d)

## Benchmark

The reviewer asked for this on at least a million rows, so it was measured at 1M, at the current production row count, and at 10M.

### The table this is measured against

Production `usage_apicalllog` today is **2,084,283 rows, 2.48 GiB across 8 active parts**, and only **32,586 rows (1.56%)** carry a structured output, which is what this fix corrects.

Two details of the production table matter and are reproduced here rather than assumed:

- It has **no `PARTITION BY`**. `SELECT DISTINCT partition FROM system.parts` returns the single value `tuple()`. PeerDB created the table with its own shape, not the canonical DDL in `schema.py`.
- Its sorting key is **`id`** alone, not `(organization_id, source_id, created_at, id)`.

So the benchmark's primary shape is the unpartitioned, `ORDER BY id` table. `MATERIALIZE COLUMN eval_score IN PARTITION tuple()` is accepted and does backfill correctly, confirmed at every scale below.

### Hardware

| | |
|---|---|
| Docker runtime | colima, 6 CPU, 8 GiB RAM, 100 GiB disk |
| ClickHouse | 25.3.14.14, `clickhouse/clickhouse-server:25.3-alpine`, single node |
| Engine | `ReplacingMergeTree(_peerdb_version)`, the single-node form of production's `Replicated` engine |

### Seeded data

Rows are seeded from the canonical `CDC_USAGE_APICALLLOG` DDL, then the column is wound back to the expression a deployed cluster still carries, so every row lands genuinely stale. The mix reproduces production: structured outputs are 1.56% of the table, split 76 / 18 / 6 across `Complete` / `Incomplete` / `Partial`, with the rest scalar-output, text-output and absent-output rows.

Seeded rows weigh **1382 bytes on disk**, against production's **1278 bytes**, so the scan below is timed on a table at least as heavy per row as the real one.

### Timings, production table shape

| rows | on disk | `--dry-run` scan | rebuild DDL | MATERIALIZE COLUMN | MATERIALIZE INDEX | scan after |
|---|---|---|---|---|---|---|
| 1,000,000 | 1.29 GiB | **1.62s** | 21ms | 2.65s | 0.01s | 1.12s |
| 2,084,283 (production count) | 2.68 GiB | **4.34s** | 93ms | 5.20s | 0.05s | 3.83s |
| 10,000,000 | 12.88 GiB | **26.98s** | 484ms | 27.22s | 0.97s | 22.71s |

`MATERIALIZE COLUMN` and `MATERIALIZE INDEX` run with `mutations_sync = 2`, so those are completion times, not submission times.

The scan column is a **cold** read: the server is restarted and the host page cache dropped between seeding and measuring, so nothing is served from cache. Running the test straight through instead reports a warm number roughly three times faster, which is the less conservative figure and not the one quoted here.

### Correctness at scale

| rows | stale before | stale after | index parity | every shape correct |
|---|---|---|---|---|
| 1,000,000 | 15,600 | 0 | 11,860 with the index, 11,860 without | yes |
| 2,084,283 (production count) | 32,760 | 0 | 24,906 with the index, 24,906 without | yes |
| 10,000,000 | 156,000 | 0 | 118,600 with the index, 118,600 without | yes |

Index parity is `count(... eval_score >= 1.0)` with and without `SETTINGS use_skip_indexes = 0`. Equal counts mean the minmax index agrees with the stored rows, which is the regression the backfill's `DROP INDEX` / `ADD INDEX` sandwich exists to prevent.

### Secondary: the canonical partitioned shape

Not what production looks like, but it is what `schema.py` creates on a fresh install, and it is the only shape where the per-partition loop does more than one iteration.

| rows | partitions | `--dry-run` scan | MATERIALIZE COLUMN, total | MATERIALIZE INDEX, total |
|---|---|---|---|---|
| 1,000,000 | 6 | 2.27s | 3.24s | 0.09s |

### Reproducing this

The benchmark is a test in the repo. It is opt-in twice over: it carries the `benchmark` marker, which the default `addopts` deselects, and it skips unless `EVAL_SCORE_BENCH_ROWS` is set, so a ten million row seed can never run in a normal suite invocation.

```bash
cd futureagi
EVAL_SCORE_BENCH_ROWS=10000000 PYTHON_BIN=/path/to/futureagi/.venv/bin/python \
  bash bin/test tracer/tests/test_clickhouse_integration.py \
  -m benchmark -k AtScale -s
```

`EVAL_SCORE_BENCH_SHAPE=canonical` switches it to the partitioned shape. It asserts correctness as well as printing timings: stale count reaches 0, index parity holds, and every output shape resolves to its expected score.

## Deploy note

This does not backfill itself. After merge, run per environment:

```bash
python manage.py backfill_eval_score --dry-run     # how many rows are stale
python manage.py backfill_eval_score --no-confirm  # rebuild + materialize
python manage.py backfill_eval_score --dry-run     # confirm 0
```

`POST_DDL_ALTERS` runs on boot and is metadata only, so new rows are correct immediately. Rows already ingested stay stale until the command runs.

The verification query is shard-local. On a multi-shard deployment run it per shard, or the dry-run will report a green 0 while other shards are still stale.

**The writes are shard-local too, and that is the part worth reading twice.** Neither `POST_DDL_ALTERS` nor `rebuild_statements()` carries `ON CLUSTER`: `model_hub/apps.py:122` and `backfill_eval_score.py:139` both hand the raw statement to `ch.execute()`, and the `ON CLUSTER` rewriter in `clickhouse/v2/apply_schema_rewriter.py` is on a different code path that these do not go through. The engine is `ReplicatedReplacingMergeTree('/clickhouse/tables/{shard}/usage_apicalllog', '{replica}', _peerdb_version)`, so a `MODIFY COLUMN` or a `MATERIALIZE COLUMN` fans out to the replicas of the shard it was issued against and no further. On a multi-shard deployment the whole sequence, the ALTERs and the mutations and not just the verification query, has to run once per shard.

`--dry-run` is an unbounded scan, and it has now been measured rather than guessed at. It reads every non-deleted row in **4.3s at the production row count** and **27.0s at 10,000,000 rows**, 5 times production size, on a 6 CPU laptop VM, against the client's 300s `CH_SEND_TIMEOUT` / `CH_RECEIVE_TIMEOUT`. That leaves 11x of headroom at the largest size measured, so the timeout is not a real risk on a table this shape. It stays worth running off-peak because it is CPU-bound JSON parsing over the whole `config` column (26.57 GiB read at 10,000,000 rows), not because it is close to timing out. The scan is deliberately unbounded: a bounded count would under-report, and a dry-run that prints a green `0` while rows outside the bound are still stale is a worse failure than a slow one.

The mutation side is the part worth planning, not the scan. The production table has no `PARTITION BY`, so `_PARTITIONS` returns the single value `tuple()` and the per-partition loop runs exactly once: one mutation over the whole table, not one per month. `--whole-table` therefore changes nothing on production, and only helps on a deployment created from the canonical partitioned DDL.

`MATERIALIZE COLUMN` also rewrites `eval_score` for **every** row regardless of how few are wrong. On production that means rewriting 2,084,283 rows to correct 32,586 of them (1.56%). That is the real operational trade here, and it is why the command is one-shot ops tooling rather than something that runs on boot. Measured cost at the production row count is 5.2s for the column and 0.05s for the index.

`POST_DDL_ALTERS` runs its `MODIFY COLUMN` on every boot. It is metadata-only and wrapped in try/except, so the downside is bounded, but on a multi-replica cluster each boot still writes a ZooKeeper log entry for the ALTER. Worth knowing if many replicas restart at once during a rollout.

## Type of change

Bug fix.

## Checklist

- [x] Root-cause fix, not a workaround
- [x] Tests added, and they fail if the fix is reverted
- [x] Full sibling suites green locally
- [x] Rebased on latest `dev`

## Backout

Reverting restores the old expression for newly written rows. Rows already backfilled keep their corrected values, so a revert is not a full restore, though it loses no data.

The new command and the new module remove cleanly.

Closes TH-7492






