### PR TITLE
fix(frontend): move axis assignment above the axis config [TH-6575]

### DIFF
--- a/frontend/src/sections/dashboards/WidgetEditorView.jsx
+++ b/frontend/src/sections/dashboards/WidgetEditorView.jsx
@@ -5968,6 +5968,91 @@ export default function WidgetEditorView() {
                       AXIS
                     </Typography>
 
+                    {/* Axis Assignment */}
+                    <Box>
+                      <Typography
+                        variant="subtitle2"
+                        fontWeight={700}
+                        sx={{ mb: 1.5 }}
+                      >
+                        Axis Assignment
+                      </Typography>
+                      {previewSeries.map((s, si) => {
+                        const seriesColor = getSeriesColor(
+                          s.name,
+                          seriesColorMap,
+                        );
+                        return (
+                          <Stack
+                            key={si}
+                            direction="row"
+                            alignItems="center"
+                            justifyContent="space-between"
+                            sx={{ mb: 1 }}
+                          >
+                            <Stack
+                              direction="row"
+                              alignItems="center"
+                              gap={1}
+                              sx={{ flex: 1, minWidth: 0 }}
+                            >
+                              <Box
+                                sx={{
+                                  width: 22,
+                                  height: 22,
+                                  borderRadius: 0.5,
+                                  display: "flex",
+                                  alignItems: "center",
+                                  justifyContent: "center",
+                                  bgcolor: seriesColor + "22",
+                                  color: seriesColor,
+                                  fontSize: "11px",
+                                  fontWeight: 700,
+                                }}
+                              >
+                                {LETTER_LABELS[si] || si}
+                              </Box>
+                              <Iconify
+                                icon="mdi:chart-line"
+                                width={16}
+                                sx={{
+                                  color: seriesColor,
+                                  flexShrink: 0,
+                                }}
+                              />
+                              <Typography
+                                variant="body2"
+                                noWrap
+                                sx={{ fontWeight: 500 }}
+                              >
+                                {s.name?.split(" (")[0] || s.name}
+                              </Typography>
+                            </Stack>
+                            <ToggleButtons
+                              options={[
+                                { label: "L", value: "left" },
+                                { label: "R", value: "right" },
+                              ]}
+                              value={axisConfig.seriesAxis[si] || "left"}
+                              onChange={(v) => setSeriesAxis(si, v)}
+                              theme={theme}
+                            />
+                          </Stack>
+                        );
+                      })}
+                      {previewSeries.length === 0 && (
+                        <Typography
+                          variant="body2"
+                          color="text.secondary"
+                          sx={{ fontStyle: "italic" }}
+                        >
+                          Add metrics to see axis assignments
+                        </Typography>
+                      )}
+                    </Box>
+
+                    <Divider sx={{ my: 2 }} />
+
                     {/* Left Y-Axis */}
                     <AxisSection
                       title="Left Y-Axis"
@@ -6074,91 +6159,6 @@ export default function WidgetEditorView() {
                           }}
                         />
                       </Stack>
-                    </Box>
-
-                    <Divider sx={{ my: 2 }} />
-
-                    {/* Axis Assignment */}
-                    <Box>
-                      <Typography
-                        variant="subtitle2"
-                        fontWeight={700}
-                        sx={{ mb: 1.5 }}
-                      >
-                        Axis Assignment
-                      </Typography>
-                      {previewSeries.map((s, si) => {
-                        const seriesColor = getSeriesColor(
-                          s.name,
-                          seriesColorMap,
-                        );
-                        return (
-                          <Stack
-                            key={si}
-                            direction="row"
-                            alignItems="center"
-                            justifyContent="space-between"
-                            sx={{ mb: 1 }}
-                          >
-                            <Stack
-                              direction="row"
-                              alignItems="center"
-                              gap={1}
-                              sx={{ flex: 1, minWidth: 0 }}
-                            >
-                              <Box
-                                sx={{
-                                  width: 22,
-                                  height: 22,
-                                  borderRadius: 0.5,
-                                  display: "flex",
-                                  alignItems: "center",
-                                  justifyContent: "center",
-                                  bgcolor: seriesColor + "22",
-                                  color: seriesColor,
-                                  fontSize: "11px",
-                                  fontWeight: 700,
-                                }}
-                              >
-                                {LETTER_LABELS[si] || si}
-                              </Box>
-                              <Iconify
-                                icon="mdi:chart-line"
-                                width={16}
-                                sx={{
-                                  color: seriesColor,
-                                  flexShrink: 0,
-                                }}
-                              />
-                              <Typography
-                                variant="body2"
-                                noWrap
-                                sx={{ fontWeight: 500 }}
-                              >
-                                {s.name?.split(" (")[0] || s.name}
-                              </Typography>
-                            </Stack>
-                            <ToggleButtons
-                              options={[
-                                { label: "L", value: "left" },
-                                { label: "R", value: "right" },
-                              ]}
-                              value={axisConfig.seriesAxis[si] || "left"}
-                              onChange={(v) => setSeriesAxis(si, v)}
-                              theme={theme}
-                            />
-                          </Stack>
-                        );
-                      })}
-                      {previewSeries.length === 0 && (
-                        <Typography
-                          variant="body2"
-                          color="text.secondary"
-                          sx={{ fontStyle: "italic" }}
-                        >
-                          Add metrics to see axis assignments
-                        </Typography>
-                      )}
                     </Box>
                   </>
                 )}


### PR DESCRIPTION
## 🧹 Chore (UI placement)

**Axis Assignment** sat last in the widget editor's **Chart** tab — below Left Y-Axis, Right Y-Axis and X-Axis.

Measured on the repro widget: the panel is 904px tall and the section started at **y=1312**, so it was roughly **400px below the fold**. You configure the Right Y-Axis (label, unit, decimals, thresholds) *before* being offered the control that decides whether any series is on that axis at all.

## 🔧 What changed

Moved the `Axis Assignment` block to the top of the `AXIS` panel — directly under the heading, above Left Y-Axis, with a divider between.

| Section | before | after |
|---|---|---|
| **Axis Assignment** | 1312 (below fold) | **146** |
| Left Y-Axis | 146 | 318 |
| Right Y-Axis | 650 | 822 |
| X-Axis | 1155 | 1326 |

## 🤔 Why above Left Y-Axis, not between Left and Right

The ticket says *"move axis assignment to the top here (after scale - linear/log scale)"*, which reads as between Left and Right Y-Axis. I tried that first, but there is no divider between the Left Y-Axis rows and Axis Assignment, so it visually grouped with Left Y-Axis and looked like one of its fields.

It governs **both** axes, so it belongs above both. Same intent — "to the top" — just placed so the grouping is unambiguous. @cdileep23 worth confirming with @vel / Chintan if you disagree.

## ✅ This is a pure relocation — no logic change

Verified mechanically, not by eye:

- The moved block is **byte-identical**: 82 lines, extracted by brace-matching from both versions, `old == new` exactly (same lines, same order — not just the same set)
- **Everything else in the file is byte-identical**: 6251 lines compared after removing the block and normalising blanks/dividers
- **Divider count unchanged**: 3 in the AXIS panel and 3 in the file, before and after
- Only the order changed: `LeftY ── RightY ── XAxis ── AxisAssignment` → `AxisAssignment ── LeftY ── RightY ── XAxis`

Nothing else was touched — no prop, handler, condition or state. `previewSeries.map()`, `axisConfig.seriesAxis[si]`, `setSeriesAxis`, `getSeriesColor` and `LETTER_LABELS` all sit inside the moved block and were already in scope at the new position.

The diff shows 85 added / 85 removed, so **please don't read it as a rewrite** — it's one block relocated.

## 🧪 Tests / verification

No unit tests exist for `WidgetEditorView`, so this was verified in the running app:

- Section positions measured in the DOM before and after (table above)
- **Functional check**: assigning a metric to `R` still takes the chart from 1 y-axis to 2, with no page errors — the `seriesAxis` wiring survived the move
- `npx vitest run src/sections/dashboards` — 67 passed
- eslint 0 errors, prettier clean

## ▶️ How to verify

1. Open any widget with 2+ metrics → right panel → **Chart** tab
2. Axis Assignment is now the first thing under `AXIS`, visible without scrolling
3. Toggle a metric to `R` and confirm the right axis still appears

## ⚠️ Notes for the reviewer

**The ticket's premise is slightly off, and I did not act on it.** The title says *"in case of more than one metrics"*, but the section is **not** gated on metric count — `previewSeries.map()` renders a row per **series**. Verified:

| Config | rows |
|---|---|
| 0 metrics | *"Add metrics to see axis assignments"* |
| 1 metric, no breakdown | 1 |
| 2 metrics, no breakdown | 2 |
| **1 metric + Project breakdown** | **3** (one per project) |

So a single-metric widget can still have several rows, and the placement fix is correct unconditionally. No `metrics.length > 1` condition was added.

**Separate pre-existing bug found while testing — not fixed here.** With the *first* metric assigned to `R` and a later one to `L`, the left axis never renders. The dual-axis `show` condition assumes series 0 is on the left:

```js
show: i === 0 || (side === "right" && !earlierSeriesOnRight)
```

`A=L, B=R` works; `A=R, B=L` leaves the left edge blank. Reproduces identically on unmodified `dev`, so it is unrelated to this change. Filing separately.

## 📹 Videos & Screenshots

**Before** — Chart tab, no scrolling. Axis Assignment is nowhere in sight; it starts ~400px below the fold, under X-Axis.

![Before — Axis Assignment below the fold](https://github.com/user-attachments/assets/ebca2e81-9661-408c-b4b5-8a2490eced97)

**After** — same widget, same scroll position. Axis Assignment is the first thing under `AXIS`, with a divider separating it from Left Y-Axis.

![After — Axis Assignment at the top of the panel](https://github.com/user-attachments/assets/dc8b5ad1-60dd-4ab6-84c7-0161139dcaee)

