### PR TITLE
fix(annotations): allow clearing numeric label min and max [TH-6991]

### DIFF
--- a/frontend/src/sections/annotations/labels/__tests__/numeric-settings.test.jsx
+++ b/frontend/src/sections/annotations/labels/__tests__/numeric-settings.test.jsx
@@ -2,8 +2,13 @@
 import { describe, expect, it, vi } from "vitest";
 import { Button } from "@mui/material";
 import { useForm } from "react-hook-form";
+import { enqueueSnackbar } from "notistack";
 import { render, screen, userEvent } from "src/utils/test-utils";
 import NumericSettings from "../settings/numeric-settings";
+
+vi.mock("notistack", () => ({
+  enqueueSnackbar: vi.fn(),
+}));
 
 function NumericSettingsHarness({ defaultValues, onSubmit }) {
   const methods = useForm({ defaultValues });
@@ -45,5 +50,47 @@ describe("NumericSettings", () => {
     expect(screen.getByText("Maximum cannot be negative")).toBeInTheDocument();
     expect(screen.getByText("Step size must be positive")).toBeInTheDocument();
     expect(onSubmit).not.toHaveBeenCalled();
+  });
+
+  it("does not keep a leading zero when typing over the default value", async () => {
+    const user = userEvent.setup();
+
+    render(
+      <NumericSettingsHarness
+        defaultValues={{
+          settings: { min: 0, max: 10, step_size: 1, display_type: "slider" },
+        }}
+        onSubmit={vi.fn()}
+      />,
+    );
+
+    const minInput = screen.getByLabelText(/minimum/i);
+    await user.type(minInput, "5");
+
+    expect(minInput).toHaveValue(5);
+  });
+
+  it("blocks values above the cap on maximum and warns instead", async () => {
+    const user = userEvent.setup();
+    const onSubmit = vi.fn();
+
+    render(
+      <NumericSettingsHarness
+        defaultValues={{
+          settings: { min: 0, max: 1, step_size: 1, display_type: "slider" },
+        }}
+        onSubmit={onSubmit}
+      />,
+    );
+
+    const maxInput = screen.getByLabelText(/maximum/i);
+    await user.clear(maxInput);
+    await user.type(maxInput, "11");
+
+    expect(maxInput).toHaveValue(1);
+    expect(enqueueSnackbar).toHaveBeenCalledWith(
+      "Maximum value is 10",
+      expect.objectContaining({ variant: "warning" }),
+    );
   });
 });

--- a/frontend/src/sections/annotations/labels/settings/numeric-settings.jsx
+++ b/frontend/src/sections/annotations/labels/settings/numeric-settings.jsx
@@ -9,10 +9,31 @@ import {
   Typography,
 } from "@mui/material";
 import { Controller } from "react-hook-form";
+import { enqueueSnackbar } from "notistack";
+
+const MAX_VALUE = 10;
 
 NumericSettings.propTypes = {
   control: PropTypes.object.isRequired,
 };
+
+const handleNumberChange =
+  (field, max = Infinity) =>
+  (e) => {
+    const raw = e.target.value;
+    const cleaned = raw.replace(/^(-?)0+(?=\d)/, "$1");
+    if (cleaned !== raw) e.target.value = cleaned;
+    if (cleaned === "") {
+      field.onChange("");
+      return;
+    }
+    const num = Number(cleaned);
+    if (num > max) {
+      enqueueSnackbar(`Maximum value is ${max}`, { variant: "warning" });
+      return;
+    }
+    field.onChange(num);
+  };
 
 export default function NumericSettings({ control }) {
   return (
@@ -36,7 +57,7 @@ export default function NumericSettings({ control }) {
               fullWidth
               error={!!fieldState.error}
               helperText={fieldState.error?.message}
-              onChange={(e) => field.onChange(Number(e.target.value))}
+              onChange={handleNumberChange(field)}
               inputProps={{ min: 0 }}
             />
           )}
@@ -46,6 +67,7 @@ export default function NumericSettings({ control }) {
           control={control}
           rules={{
             required: "Required",
+            max: { value: MAX_VALUE, message: `Maximum is ${MAX_VALUE}` },
             validate: (value, formValues) => {
               if (Number(value) < 0) return "Maximum cannot be negative";
               return (
@@ -64,8 +86,8 @@ export default function NumericSettings({ control }) {
               fullWidth
               error={!!fieldState.error}
               helperText={fieldState.error?.message}
-              onChange={(e) => field.onChange(Number(e.target.value))}
-              inputProps={{ min: 0 }}
+              onChange={handleNumberChange(field, MAX_VALUE)}
+              inputProps={{ min: 0, max: MAX_VALUE }}
             />
           )}
         />
@@ -89,7 +111,7 @@ export default function NumericSettings({ control }) {
             fullWidth
             error={!!fieldState.error}
             helperText={fieldState.error?.message}
-            onChange={(e) => field.onChange(Number(e.target.value))}
+            onChange={handleNumberChange(field)}
             inputProps={{ min: 0.000001, step: "any" }}
           />
         )}


### PR DESCRIPTION
Closes TH-6991

### Problem

On the create-label drawer, the numeric settings' **Minimum** / **Maximum** / **Step Size** fields could not be cleared, and typing over the default produced a leading zero (`0` + `2222` → `02222`).

Two causes:

1. `onChange` stored `Number(e.target.value)`, so clearing the field wrote `0` back — the field could never be empty, and the cursor was left sitting after a `0`.
2. React skips DOM updates on a `type="number"` input when the raw string and the stored number compare loosely equal. `"02222" == 2222` is true, so even once the number was normalised the visible text kept its leading zero.

### Fix

All three inputs now share a `handleNumberChange` helper that:

- strips leading zeros from the raw string (`"02222"` → `"2222"`, decimals like `"0.5"` untouched) and writes the cleaned value back onto the input so React's loose comparison can't keep the stale text;
- stores `""` for an empty field instead of `0`, making the fields clearable — the existing `required: "Required"` rules still catch a blank on submit.

### Maximum capped at 10

Per the follow-up on the ticket, **Maximum** is now capped at 10, matching the existing behaviour of `star-settings.jsx`. A keystroke that would exceed the cap is rejected and shows a `warning` snackbar ("Maximum value is 10") instead. A react-hook-form `max` rule plus `inputProps={{ max: 10 }}` back this up so a value arriving from elsewhere (e.g. an existing label being edited) still surfaces the helper text and blocks submit.

Minimum is deliberately left uncapped — it's still guarded by the existing "Max must be greater than min" rule.

### Testing

`numeric-settings.test.jsx` gains two cases — one asserting no leading zero survives typing over the default, one asserting the cap blocks the value and fires the snackbar. All 3 tests pass; eslint clean on both files.
