### PR TITLE
fix: register the usage-consumer Temporal workflow (TH-7256)

### DIFF
--- a/futureagi/tfc/temporal/common/registry.py
+++ b/futureagi/tfc/temporal/common/registry.py
@@ -77,7 +77,7 @@ TEMPORAL_ACTIVITY_MODULES = [
     # Self-hosted deployment registration and usage heartbeat
     "tfc.temporal.schedules.deployment_telemetry",
     # Deployment telemetry receiver-side integrations (PostHog, HubSpot, Slack)
-    "ee.usage.services.deployment_telemetry_integrations",
+    "ee.cloud.telemetry.deployment_telemetry_integrations",
 ]
 
 
@@ -355,7 +355,7 @@ def _ensure_workflows_registered() -> None:
     # UsageConsumerWorkflow (long-running singleton) + MonthlyResetWorkflow
     try:
         try:
-            from ee.usage.temporal import get_workflows as get_billing_workflows
+            from ee.cloud.temporal import get_workflows as get_billing_workflows
         except ImportError:
             get_billing_workflows = None
 
@@ -763,7 +763,7 @@ def _ensure_activities_registered() -> None:
     # Register usage metering activities (consumer, sync, monthly reset)
     try:
         try:
-            from ee.usage.temporal import get_activities as get_usage_activities
+            from ee.cloud.temporal import get_activities as get_usage_activities
         except ImportError:
             get_usage_activities = None
 


### PR DESCRIPTION
## Description

`UsageConsumerWorkflow` has not been running, so usage events accumulate undrained in the Redis stream and metering/pricing go stale.

The usage/billing Temporal package moved from `ee/usage/temporal` to `ee/cloud/temporal`, but the registry still looked it up at the old path. Both lookups sit inside `except ImportError: ... = None`, so the failure was silent — the workflow, `MonthlyResetWorkflow` and the usage-metering activities were simply never registered on the `default` worker.

The emitter still starts the workflow, which is where the visible error came from:

```
Workflow class UsageConsumerWorkflow is not registered on this worker,
available workflows: ContinuousEvalTaskWorkflow, HistoricalEvalTaskWorkflow,
RunEvaluationBatchWorkflow, RunEvaluationWorkflow, TaskRunnerWorkflow
```

That list is the `default` queue minus the two billing workflows.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Changes

Three lines in `futureagi/tfc/temporal/common/registry.py`:

- `:358`, `:766` — billing workflow/activity lookups repointed to `ee.cloud.temporal`
- `:80` — `deployment_telemetry_integrations` repointed to `ee.cloud.telemetry`. Stranded by the same move and failing the same silent way: the module is only imported later via `get_activities()`, after the drop-in sweep has already read `_ACTIVITY_REGISTRY`, so `deployment_telemetry_registration_integrations` and `deployment_telemetry_heartbeat_integrations` never reached a worker

No restructure, no checkout-path changes — those belong to the `ee/cloud` migration and are deliberately excluded so this can ship on its own.

## Testing

Verified in the running `worker-default` container, not just under test settings:

```
DEFAULT: ContinuousEvalTaskWorkflow, HistoricalEvalTaskWorkflow, MonthlyResetWorkflow,
         RunEvaluationBatchWorkflow, RunEvaluationWorkflow, TaskRunnerWorkflow,
         UsageConsumerWorkflow
USAGE:     process_consumer_batch_activity, monthly_reset_activity
TELEMETRY: deployment_telemetry_registration_integrations, ..._heartbeat_integrations
```

Reproduced the pre-fix state by reverting `:80` alone — the two telemetry activities disappear from the queue, confirming that line is a distinct defect and not cosmetic.

Not covered: that the existing Redis backlog drains correctly. That needs a worker running against Redis and Postgres, and should be checked after deploy via `XINFO GROUPS usage:events`.

## Related Issues

Refs: TH-7256

Pairs with future-agi/ee#218 — **merge together**. Neither works alone: this repo points at `ee.cloud.temporal`, which cannot import its own `types` until the ee side lands.

Companion PR into `dev`: #2095 (merge this one first).