### PR TITLE
fix(huggingface): initialize existing dataset options

### DIFF
--- a/frontend/src/sections/huggingface/HuggingFaceDetailDrawer.jsx
+++ b/frontend/src/sections/huggingface/HuggingFaceDetailDrawer.jsx
@@ -6,7 +6,8 @@ import HuggingDetailForm from "./HuggingDetailForm";
 
 const HuggingFaceDetailDrawer = ({
   show,
-  reset,
+  getValues,
+  setValue,
   control,
   huggingFaceDetail,
   watch,
@@ -20,22 +21,41 @@ const HuggingFaceDetailDrawer = ({
 }) => {
   useEffect(() => {
     if (!show) return;
-    if (show && showNameField && huggingFaceDetail?.name) {
-      const defaultValues = { name: huggingFaceDetail.name };
-      if (subsetOptions?.length > 0) {
-        defaultValues.huggingface_dataset_config = subsetOptions[0].value;
-      }
-      if (splitOptions?.length > 0) {
-        defaultValues.huggingface_dataset_split = splitOptions[0].value;
-      }
-      defaultValues.num_rows = 1;
-      reset(defaultValues);
+
+    if (showNameField && huggingFaceDetail?.name && !getValues("name")) {
+      setValue("name", huggingFaceDetail.name);
+    }
+
+    const currentSubset = getValues("huggingface_dataset_config");
+    if (
+      subsetOptions?.length > 0 &&
+      !subsetOptions.some(({ value }) => value === currentSubset)
+    ) {
+      setValue("huggingface_dataset_config", subsetOptions[0].value);
+    }
+
+    const currentSplit = getValues("huggingface_dataset_split");
+    if (
+      splitOptions?.length > 0 &&
+      !splitOptions.some(({ value }) => value === currentSplit)
+    ) {
+      setValue("huggingface_dataset_split", splitOptions[0].value);
+    }
+
+    const currentRowCount = getValues("num_rows");
+    if (
+      currentRowCount === undefined ||
+      currentRowCount === null ||
+      currentRowCount === ""
+    ) {
+      setValue("num_rows", 1);
     }
   }, [
     show,
     showNameField,
     huggingFaceDetail?.name,
-    reset,
+    getValues,
+    setValue,
     subsetOptions,
     splitOptions,
   ]);
@@ -76,7 +96,8 @@ const HuggingFaceDetailDrawer = ({
 HuggingFaceDetailDrawer.propTypes = {
   show: PropTypes.bool.isRequired,
   setShow: PropTypes.func.isRequired,
-  reset: PropTypes.func.isRequired,
+  getValues: PropTypes.func.isRequired,
+  setValue: PropTypes.func.isRequired,
   control: PropTypes.object.isRequired,
   huggingFaceDetail: PropTypes.object,
   watch: PropTypes.func.isRequired,

--- a/frontend/src/sections/huggingface/HuggingFaceView.jsx
+++ b/frontend/src/sections/huggingface/HuggingFaceView.jsx
@@ -92,7 +92,7 @@ const HuggingFaceView = () => {
     ? HuggingFaceDatasetValidationSchema2
     : HuggingFaceDatasetValidationSchema1;
 
-  const { control, handleSubmit, watch, reset } = useForm({
+  const { control, handleSubmit, watch, reset, getValues, setValue } = useForm({
     defaultValues: getDefaultValue(),
     resolver: zodResolver(validationSchema),
   });
@@ -1203,7 +1203,8 @@ const HuggingFaceView = () => {
         <HuggingFaceDetailDrawer
           show={show}
           setShow={setShow}
-          reset={reset}
+          getValues={getValues}
+          setValue={setValue}
           control={control}
           huggingFaceDetail={huggingFaceDetail?.data?.result?.dataset}
           watch={watch}

--- a/frontend/src/sections/huggingface/__tests__/hugging_face_detail_drawer.test.jsx
+++ b/frontend/src/sections/huggingface/__tests__/hugging_face_detail_drawer.test.jsx
@@ -1,0 +1,210 @@
+import { useForm } from "react-hook-form";
+import { describe, expect, it, vi } from "vitest";
+import { act, render, renderHook, waitFor } from "src/utils/test-utils";
+import HuggingFaceDetailDrawer from "../HuggingFaceDetailDrawer";
+
+vi.mock("../HuggingDetailForm", () => ({
+  default: () => <div>Hugging Face detail form</div>,
+}));
+
+const createProps = (overrides = {}) => ({
+  show: true,
+  setShow: vi.fn(),
+  huggingFaceDetail: { name: "future-agi/example-dataset" },
+  subsetOptions: [],
+  splitOptions: [],
+  onSubmit: vi.fn(),
+  onClose: vi.fn(),
+  isLoadingCreateDataset: false,
+  showNameField: false,
+  ...overrides,
+});
+
+const renderDrawer = (overrides = {}, initialValues = {}) => {
+  const { result } = renderHook(() =>
+    useForm({
+      defaultValues: {
+        name: "",
+        huggingface_dataset_config: "",
+        huggingface_dataset_split: "",
+        num_rows: "",
+        ...initialValues,
+      },
+    }),
+  );
+  const props = createProps({
+    control: result.current.control,
+    getValues: result.current.getValues,
+    setValue: result.current.setValue,
+    watch: result.current.watch,
+    ...overrides,
+  });
+
+  return {
+    form: result.current,
+    props,
+    ...render(<HuggingFaceDetailDrawer {...props} />),
+  };
+};
+
+describe("HuggingFaceDetailDrawer", () => {
+  it("initializes subset and split after options load for an existing dataset", async () => {
+    const { form, props, rerender } = renderDrawer();
+
+    rerender(
+      <HuggingFaceDetailDrawer
+        {...props}
+        subsetOptions={[{ label: "default", value: "default" }]}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(form.getValues("huggingface_dataset_config")).toBe("default");
+      expect(form.getValues("num_rows")).toBe(1);
+    });
+
+    rerender(
+      <HuggingFaceDetailDrawer
+        {...props}
+        subsetOptions={[{ label: "default", value: "default" }]}
+        splitOptions={[{ label: "train", value: "train" }]}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(form.getValues()).toEqual({
+        name: "",
+        huggingface_dataset_config: "default",
+        huggingface_dataset_split: "train",
+        num_rows: 1,
+      });
+    });
+  });
+
+  it("also initializes the dataset name when creating a new dataset", async () => {
+    const { form } = renderDrawer({
+      showNameField: true,
+      subsetOptions: [{ label: "default", value: "default" }],
+      splitOptions: [{ label: "validation", value: "validation" }],
+    });
+
+    await waitFor(() => {
+      expect(form.getValues()).toEqual({
+        name: "future-agi/example-dataset",
+        huggingface_dataset_config: "default",
+        huggingface_dataset_split: "validation",
+        num_rows: 1,
+      });
+    });
+  });
+
+  it("initializes available options before a new dataset name loads", async () => {
+    const { form, props, rerender } = renderDrawer({
+      showNameField: true,
+      huggingFaceDetail: {},
+      subsetOptions: [{ label: "default", value: "default" }],
+      splitOptions: [{ label: "test", value: "test" }],
+    });
+
+    await waitFor(() => {
+      expect(form.getValues()).toEqual({
+        name: "",
+        huggingface_dataset_config: "default",
+        huggingface_dataset_split: "test",
+        num_rows: 1,
+      });
+    });
+
+    rerender(
+      <HuggingFaceDetailDrawer
+        {...props}
+        huggingFaceDetail={{ name: "future-agi/delayed-dataset" }}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(form.getValues("name")).toBe("future-agi/delayed-dataset");
+    });
+  });
+
+  it("preserves valid manual selections and row count when options recompute", async () => {
+    const subsetOptions = [
+      { label: "default", value: "default" },
+      { label: "english", value: "english" },
+    ];
+    const splitOptions = [
+      { label: "train", value: "train" },
+      { label: "test", value: "test" },
+    ];
+    const { form, props, rerender } = renderDrawer({
+      subsetOptions,
+      splitOptions,
+    });
+
+    await waitFor(() => {
+      expect(form.getValues("huggingface_dataset_config")).toBe("default");
+      expect(form.getValues("huggingface_dataset_split")).toBe("train");
+    });
+
+    act(() => {
+      form.setValue("huggingface_dataset_config", "english");
+      form.setValue("huggingface_dataset_split", "test");
+      form.setValue("num_rows", 25);
+    });
+
+    rerender(
+      <HuggingFaceDetailDrawer
+        {...props}
+        subsetOptions={subsetOptions.map((option) => ({ ...option }))}
+        splitOptions={splitOptions.map((option) => ({ ...option }))}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(form.getValues()).toEqual({
+        name: "",
+        huggingface_dataset_config: "english",
+        huggingface_dataset_split: "test",
+        num_rows: 25,
+      });
+    });
+  });
+
+  it("replaces selections that are no longer available", async () => {
+    const { form } = renderDrawer(
+      {
+        subsetOptions: [{ label: "default", value: "default" }],
+        splitOptions: [{ label: "train", value: "train" }],
+      },
+      {
+        huggingface_dataset_config: "removed-subset",
+        huggingface_dataset_split: "removed-split",
+        num_rows: 50,
+      },
+    );
+
+    await waitFor(() => {
+      expect(form.getValues()).toEqual({
+        name: "",
+        huggingface_dataset_config: "default",
+        huggingface_dataset_split: "train",
+        num_rows: 50,
+      });
+    });
+  });
+
+  it("does not initialize form values while the drawer is closed", () => {
+    const { form } = renderDrawer({
+      show: false,
+      subsetOptions: [{ label: "default", value: "default" }],
+      splitOptions: [{ label: "test", value: "test" }],
+    });
+
+    expect(form.getValues()).toEqual({
+      name: "",
+      huggingface_dataset_config: "",
+      huggingface_dataset_split: "",
+      num_rows: "",
+    });
+  });
+});


### PR DESCRIPTION
## Summary

The Hugging Face drawer only initialized form defaults when the dataset name field was visible. As a result, the add-rows flow for an existing dataset never received its available subset, split, or row-count defaults. This PR initializes each field independently as asynchronous options arrive while preserving valid user selections.

## Linked issues

Closes #1500
Linear: N/A

## AI use

AI use: OpenAI Codex implemented the field-level initialization and regression tests under my direction; I reviewed the form behavior, API path, tests, and final diff.

## Type of change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that causes existing functionality to change)
- [ ] 📖 Documentation only
- [ ] 🧹 Chore / refactor (no user-visible change)
- [ ] 🚀 Performance improvement
- [ ] 🧪 Test-only change

## E2E coverage

E2E: exempt (harness-gap deterministic Hugging Face metadata fixture)

---

## 1) What changes were done

**A. Existing-dataset parameter initialization**

- Initialize `huggingface_dataset_config`, `huggingface_dataset_split`, and `num_rows` independently whenever their options are available and the drawer is open.
- Keep `name` initialization scoped to the create-new-dataset flow through `showNameField`.
- Preserve valid manual subset/split selections and row-count input when option arrays recompute.
- Fall back to the first option only when the current selection is empty or no longer available.
- Preserve the existing React Hook Form submission and backend API paths.

**B. Behavioral regression coverage**

- Exercise the drawer with a real React Hook Form instance.
- Cover asynchronous options, create-new-dataset defaults, delayed names, preserved manual selections, invalid-option fallback, and the closed-drawer no-op.

## 2) Why the changes were done

- **Product/UX:** Users adding rows to an existing Hugging Face dataset should see valid subset and split selections instead of empty required fields.
- **Technical:** The previous `showNameField && huggingFaceDetail?.name` guard incorrectly gated all form defaults, even though only the name field is specific to dataset creation.
- **Architecture:** Field-level `getValues`/`setValue` updates avoid resetting unrelated form state; no API, serializer, storage, or routing changes are needed.

## 3) Tests written + scenarios each covers

**`frontend/src/sections/huggingface/__tests__/hugging_face_detail_drawer.test.jsx`** — exercises the drawer's real props-to-effect-to-React-Hook-Form path.

- `initializes subset and split after options load for an existing dataset` — reproduces the reported add-rows bug and verifies asynchronous option arrival.
- `also initializes the dataset name when creating a new dataset` — protects the existing create flow.
- `initializes available options before a new dataset name loads` — verifies options are not blocked by a delayed name response.
- `preserves valid manual selections and row count when options recompute` — prevents option-array identity changes from overwriting user input.
- `replaces selections that are no longer available` — verifies stale selections fall back to valid options.
- `does not initialize form values while the drawer is closed` — protects the existing closed-state behavior.

```text
✓ src/sections/huggingface/__tests__/hugging_face_detail_drawer.test.jsx (6 tests) 281ms

Test Files  1 passed (1)
Tests  6 passed (6)
Duration  52.88s
```

Focused ESLint completed with no findings. Prettier and `git diff --check` pass for all changed files.

## 4) How to run / test

### Frontend tests

```bash
cd frontend
./node_modules/.bin/vitest run src/sections/huggingface/__tests__/hugging_face_detail_drawer.test.jsx
./node_modules/.bin/eslint \
  src/sections/huggingface/HuggingFaceDetailDrawer.jsx \
  src/sections/huggingface/HuggingFaceView.jsx \
  src/sections/huggingface/__tests__/hugging_face_detail_drawer.test.jsx
```

### UI steps

1. Open a dataset and start the add-rows-from-Hugging-Face flow.
2. Select a Hugging Face dataset whose subset and split metadata loads successfully.
3. Verify the first available subset and split are selected and the row count defaults to `1`.
4. Manually select a non-first subset/split and verify the selections remain unchanged after the available options recompute.
5. Open the create-new-dataset flow and verify the dataset name still initializes there.

## 5) Screenshots / recordings

Not applicable; this changes form initialization without changing the rendered layout.

## 6) Edge cases & considerations

- Options may arrive in stages: the effect reruns when subset or split options change, so the final form state includes both.
- Valid user-selected subset/split values survive effect reruns.
- Selections removed from the current option list fall back to the first valid option.
- Existing `num_rows` and name input are not overwritten.
- A delayed or missing dataset name does not block subset, split, or row-count initialization.
- Closing the drawer does not reset values through this effect.
- No API contract changed, so contract generation is not required.

## 8) Architectural / important decisions

- **Use field-level initialization:** `getValues` and `setValue` fill only empty or invalid fields, avoiding the unrelated-value loss caused by whole-form `reset`.
- **Test behavior rather than an extracted helper:** The regression test renders `HuggingFaceDetailDrawer` with a real React Hook Form instance instead of testing a duplicate pure function.

## Checklist

- [x] My code follows the [style guide](../CONTRIBUTING.md#code-style)
- [x] I've added tests that prove my fix is effective
- [ ] `bin/test` passes locally (backend not changed)
- [x] Frontend focused tests pass locally
- [x] No API surface changed; contract verification is not required
- [x] Documentation is not required for this scoped bug fix
- [x] No hardcoded secrets, URLs, or PII
- [ ] I've signed the [CLA](../CONTRIBUTING.md#contributor-license-agreement-cla)
- [x] PR title follows Conventional Commits
- [ ] Linear issue is linked and updated with status (no Linear issue provided)

