### PR TITLE
fix(share): clarify direct-link close action

### DIFF
--- a/frontend/src/components/Share/Share.jsx
+++ b/frontend/src/components/Share/Share.jsx
@@ -78,6 +78,9 @@ const Share = ({ open, title = "Share as link", body, onClose }) => {
         >
           {body}
         </Typography>
+        <Typography variant="caption" color="text.secondary">
+          Note: This creates a direct link without access control.
+        </Typography>
 
         <Box display="flex" alignItems="center" gap={theme.spacing(1)} mt={2}>
           <Box flex={8}>
@@ -152,9 +155,9 @@ const Share = ({ open, title = "Share as link", body, onClose }) => {
             Cancel
           </Button>
           <Button
-            aria-label="finish-share-project"
-            variant="contained"
-            color="primary"
+            aria-label="close-share-project"
+            variant="outlined"
+            color="inherit"
             onClick={onClose}
             sx={{
               flex: 1,
@@ -162,7 +165,7 @@ const Share = ({ open, title = "Share as link", body, onClose }) => {
               fontSize: "13px",
             }}
           >
-            Done
+            Close
           </Button>
         </Box>
       </DialogActions>

--- a/frontend/src/components/Share/__tests__/share.test.jsx
+++ b/frontend/src/components/Share/__tests__/share.test.jsx
@@ -1,0 +1,64 @@
+import { describe, expect, it, vi } from "vitest";
+import { render, screen, userEvent } from "src/utils/test-utils";
+import Share from "../Share";
+
+const renderShare = (overrides = {}) => {
+  const props = {
+    open: true,
+    title: "Share project",
+    body: "Anyone with the link can view the selected runs.",
+    onClose: vi.fn(),
+    ...overrides,
+  };
+
+  render(<Share {...props} />);
+  return props;
+};
+
+describe("Share", () => {
+  it("presents the terminal action as a neutral Close button", () => {
+    renderShare();
+
+    const closeButton = screen.getByRole("button", {
+      name: "close-share-project",
+    });
+
+    expect(closeButton).toHaveTextContent("Close");
+    expect(closeButton).toHaveClass("MuiButton-outlined");
+    expect(closeButton).toHaveClass("MuiButton-colorInherit");
+    expect(
+      screen.queryByRole("button", { name: "finish-share-project" }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("explains that the direct link has no access control", () => {
+    renderShare();
+
+    expect(
+      screen.getByText(
+        "Note: This creates a direct link without access control.",
+      ),
+    ).toBeInTheDocument();
+  });
+
+  it("keeps caller-provided body text and the Cancel action", () => {
+    renderShare();
+
+    expect(
+      screen.getByText("Anyone with the link can view the selected runs."),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Cancel-share-project" }),
+    ).toBeInTheDocument();
+  });
+
+  it("closes the dialog from the terminal action", async () => {
+    const props = renderShare();
+
+    await userEvent.click(
+      screen.getByRole("button", { name: "close-share-project" }),
+    );
+
+    expect(props.onClose).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## Summary

The legacy Share dialog presents a primary “Done” action even though that action only closes the dialog and saves no access-control setting. This PR makes the action an honest neutral “Close” button and adds a visible note explaining that the generated direct link has no access control, while preserving caller content, copy behavior, and existing close paths.

## Linked issues

Closes #1501
Linear: N/A

## Type of change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📖 Documentation only
- [ ] 🧹 Chore / refactor
- [ ] 🚀 Performance improvement
- [ ] 🧪 Test-only change

## 1) What changes were done

**A. Honest terminal action**

- Rename the terminal action from `Done` to `Close`.
- Change its aria label to `close-share-project`.
- Use neutral outlined/inherit styling instead of a primary contained style.

**B. Access-control clarification**

- Keep the caller-provided `body` text unchanged.
- Add a static note that the link is direct and has no access control.

**C. Behavioral regression coverage**

- Verify the terminal action’s label, accessibility name, and neutral styling.
- Verify the no-access-control note and caller body both render.
- Verify Cancel remains available and Close still invokes `onClose`.

## 2) Why the changes were done

- **Product/UX:** A primary “Done” action implies that a setting is being saved, but this component has no save operation.
- **Technical:** The existing component should accurately communicate its current behavior without introducing a new backend access-control contract.
- **Scope:** The separate `ShareDialog` component that supports persisted access modes is unchanged.

## 3) Tests written + scenarios each covers

**`frontend/src/components/Share/__tests__/share.test.jsx`**

- `presents the terminal action as a neutral Close button`
- `explains that the direct link has no access control`
- `keeps caller-provided body text and the Cancel action`
- `closes the dialog from the terminal action`

> Focused result: **4 passed**. Full Vitest result: **302 test files and 2560 tests passed**. Focused ESLint, Prettier, and `git diff --check` are clean.

## 4) How to run / test

```bash
cd frontend
yarn test:run src/components/Share/__tests__/share.test.jsx
```

### UI steps

1. Open the legacy Share dialog from a project detail or dataset row.
2. Verify the direct-link limitation note is visible.
3. Verify the terminal action reads “Close” with neutral styling.
4. Verify Cancel, copy, the caller body, and dialog closing still work.

## 5) Screenshots / recordings

Not included; the change is limited to button semantics and one explanatory caption.

## 6) Edge cases & considerations

- Caller-provided body text remains rendered.
- The Cancel action remains unchanged.
- Copy-to-clipboard behavior remains unchanged.
- No API or generated contract changed.

## 8) Architectural / important decisions

- **No fake persistence:** This PR does not add frontend-only access-control state that the backend cannot save.
- **Behavioral test path:** Tests render the actual `Share` component rather than an extracted helper.

## Checklist

- [x] My code follows the style guide
- [x] I've added tests that prove the fix is effective
- [x] Frontend focused and full Vitest suites pass locally
- [x] No API surface changed; contract verification is not required
- [x] Documentation is not required for this scoped UI correction
- [x] No hardcoded secrets, URLs, or PII
- [ ] I've signed the CLA
- [x] PR title follows Conventional Commits
- [ ] Linear issue is linked (none provided)
