### PR TITLE
fix(evals): scope session-eval ClickHouse lookup by the task's project

### DIFF
--- a/futureagi/tracer/tests/test_eval_session_observe_cross_project_scoping.py
+++ b/futureagi/tracer/tests/test_eval_session_observe_cross_project_scoping.py
@@ -1,0 +1,121 @@
+"""``evaluate_trace_session_observe`` scopes its ClickHouse session lookup by
+the attached eval CONFIG's project, not by the eval TASK's. A task may run
+configs authored in a sibling project (the M2M has no same-project
+constraint — see ``fix(eval-tasks): scope runtime target loads by the task's
+project``, which fixed the identical bug in ``run_entry``'s CH-direct span /
+trace / session loads) while its sessions live in the task's own project:
+scoping the CH-direct read by the config's project instead finds nothing and
+raises "TraceSession ... does not exist" even though the session is sitting
+in ClickHouse the whole time, under the task's project.
+
+This does not touch the separate, intentional org-scope/billing anchor
+(``custom_eval_config.project``, still used for the returned vehicle's
+``.project`` and downstream cost-deduction) — only the CH lookup scope needs
+to follow the data.
+"""
+
+import pytest
+
+from model_hub.models.ai_model import AIModel
+from tracer.models.custom_eval_config import CustomEvalConfig
+from tracer.models.eval_task import EvalTask, EvalTaskStatus, RunType
+from tracer.models.observation_span import EvalLogger
+from tracer.models.project import Project
+from tracer.models.trace_session import TraceSession
+from tracer.tests._ch_seed import seed_ch_trace_sessions
+from tracer.utils.eval import evaluate_trace_session_observe
+
+
+@pytest.fixture
+def config_project(db, organization, workspace):
+    """The sibling project the borrowed config is authored in — it never
+    holds the evaluated session."""
+    return Project.objects.create(
+        name="Config Author Project",
+        organization=organization,
+        workspace=workspace,
+        model_type=AIModel.ModelTypes.GENERATIVE_LLM,
+        trace_type="observe",
+    )
+
+
+def _borrowed_config(config_project, eval_template, mapping):
+    return CustomEvalConfig.objects.create(
+        name="Borrowed Eval",
+        project=config_project,
+        eval_template=eval_template,
+        config={"threshold": 0.8},
+        mapping=mapping,
+        filters={},
+    )
+
+
+def _task_with(project, config):
+    task = EvalTask.objects.create(
+        project=project,
+        name="Cross-project Session Eval Task",
+        filters={},
+        sampling_rate=1.0,
+        run_type=RunType.CONTINUOUS,
+        status=EvalTaskStatus.PENDING,
+        spans_limit=100,
+    )
+    task.evals.add(config)
+    return task
+
+
+@pytest.mark.integration
+@pytest.mark.django_db
+class TestEvaluateTraceSessionObserveCrossProjectScoping:
+    def test_completes_when_config_lives_in_sibling_project(
+        self,
+        observe_project,
+        config_project,
+        eval_template,
+        stub_run_eval,
+        stub_cost_log,
+    ):
+        # "name" is a session field; "input" is not — same mapping shape the
+        # sibling run_entry test uses for its session case.
+        config = _borrowed_config(config_project, eval_template, {"input": "name"})
+        task = _task_with(observe_project, config)
+        session = TraceSession.objects.create(project=observe_project, name="sess")
+        seed_ch_trace_sessions([session])
+
+        result = evaluate_trace_session_observe(
+            session_id=str(session.id),
+            custom_eval_config_id=str(config.id),
+            eval_task_id=str(task.id),
+        )
+
+        assert result is True
+        entry = EvalLogger.objects.get(
+            trace_session_id=str(session.id),
+            custom_eval_config_id=str(config.id),
+            eval_task_id=str(task.id),
+        )
+        assert not entry.error
+
+    def test_still_works_when_config_and_task_share_a_project(
+        self, observe_project, eval_template, stub_run_eval, stub_cost_log
+    ):
+        """Regression guard: the common case (config and task in the same
+        project) must keep working unchanged."""
+        config = _borrowed_config(observe_project, eval_template, {"input": "name"})
+        task = _task_with(observe_project, config)
+        session = TraceSession.objects.create(project=observe_project, name="sess")
+        seed_ch_trace_sessions([session])
+
+        result = evaluate_trace_session_observe(
+            session_id=str(session.id),
+            custom_eval_config_id=str(config.id),
+            eval_task_id=str(task.id),
+        )
+
+        assert result is True
+        entry = EvalLogger.objects.get(
+            trace_session_id=str(session.id),
+            custom_eval_config_id=str(config.id),
+            eval_task_id=str(task.id),
+        )
+        assert not entry.error

--- a/futureagi/tracer/utils/eval.py
+++ b/futureagi/tracer/utils/eval.py
@@ -3898,6 +3898,25 @@ def evaluate_trace_session_observe(
             f"CustomEvalConfig with id {custom_eval_config_id} does not exist."
         ) from None
 
+    # Resolve the eval TASK's project to scope the CH read below. A task may
+    # run configs authored in a sibling project (see fix(eval-tasks): scope
+    # runtime target loads by the task's project), so the session data lives
+    # under the TASK's project, not necessarily the config's. This is
+    # intentionally separate from the org-scope/billing anchor above
+    # (``custom_eval_config.project``, used on the vehicle below) — that one
+    # stays the config's project per the comment there; only the CH lookup
+    # scope needs to follow the data.
+    ch_scope_project_id = str(custom_eval_config.project_id)
+    if eval_task_id:
+        try:
+            ch_scope_project_id = str(
+                EvalTask.objects.values_list("project_id", flat=True).get(
+                    id=eval_task_id
+                )
+            )
+        except EvalTask.DoesNotExist:
+            pass
+
     # Resolve the eval TARGET's identity from CH (DESIGN §5 / Slice C), NOT the
     # PG ``TraceSession`` table: a net-new session (first seen post-flip) has no
     # PG row, and a straddler queried by its NEW deterministic id would 404 the
@@ -3910,9 +3929,9 @@ def evaluate_trace_session_observe(
         resolve_session_fields,
     )
 
-    _fields = resolve_session_fields(
-        [session_id], project_id=str(custom_eval_config.project_id)
-    ).get(str(session_id))
+    _fields = resolve_session_fields([session_id], project_id=ch_scope_project_id).get(
+        str(session_id)
+    )
     if not _fields:
         # Parity with the old ``.get`` raising DoesNotExist: no live curated
         # session names this id (unknown / tombstoned / wrong project's id that


### PR DESCRIPTION
## What

`evaluate_trace_session_observe()` scopes its ClickHouse session lookup by `custom_eval_config.project_id` (the eval config's project), not the eval task's project.

## Why

A task can run configs authored in a sibling project — this is the exact scenario `fix(eval-tasks): scope runtime target loads by the task's project` (#2069) just fixed for `run_entry`'s span/trace/session loads. That fix didn't touch this sibling dispatch path (`evaluate_trace_session_observe`, dispatched by `process_eval_task` for `row_type=sessions`), which has the identical bug: a cross-project session eval scopes `resolve_session_fields()`'s ClickHouse read by the config's project, finds nothing, and raises `TraceSession ... does not exist` even though the session is sitting in ClickHouse under the task's project the whole time.

`eval_task_id` is already a parameter on this function and is already used a few lines down for the idempotency check — it just wasn't being used to resolve the correct project for the CH lookup.

This intentionally does **not** touch `custom_eval_config.project` used later as the org-scope/billing anchor on the constructed `TraceSession` vehicle. Per the existing comment there, that's a deliberate, separate decision (the session's own PG project FK isn't reliably available post-flip, so the billing anchor stays on the config's project). Only the CH lookup scope needs to follow the data — same distinction #2069 draws between data-location scoping and other project usages.

## Testing

Added `test_eval_session_observe_cross_project_scoping.py`, mirroring the pattern from #2069's own `test_run_entry_cross_project_scoping.py` (session-target case): a config in a sibling project, a session seeded in ClickHouse under the task's project, asserting the eval completes instead of raising. Included a same-project case as a regression guard for the common path.

**Honesty note on verification**: I don't have `docker-compose.test.yml`'s services (Postgres/ClickHouse/Redis/MinIO) available in my environment, so I wasn't able to run the live integration suite. I validated via:
- Close reading against the exact fixed sibling path (`run_entry.py` / `eval_loader.py`) and `resolve_session_fields()`'s own docstring, which confirms `project_id` is a hard WHERE-scope for this exact "eval-path caller" use case
- `black` (pinned `25.11.0` from `.pre-commit-config.yaml`) and `isort` — both clean
- Python syntax/AST validation

Happy to iterate based on CI results or review feedback — please let me know if I've mis-modeled anything about the CH25 session-read path.

## Related

- Found while exploring the codebase after Nikhil's outreach — this is a sibling gap in the pattern #2069 just fixed, in the same file's other two eval-target dispatchers (`evaluate_observation_span_observe`, `evaluate_trace_observe`) I checked but found not affected the same way: `evaluate_observation_span_observe` omits `project_id` entirely (an unscoped/unpruned CH read rather than a wrong-project filter — a minor perf gap, not a correctness bug, happy to file separately if useful), and `evaluate_trace_observe` reads straight from Postgres by primary key so it isn't in the CH-scoping code path at all.