### PR TITLE
fix(falcon): stream managed AI over native gateway SSE

### DIFF
--- a/futureagi/ee/falcon_ai/llm_client.py
+++ b/futureagi/ee/falcon_ai/llm_client.py
@@ -140,14 +140,32 @@ class FalconLLMClient:
         payload = {
             "model": self.model,
             "messages": messages,
-            "tools": tools or [],
             "temperature": self.temperature,
             "max_tokens": self.max_tokens,
             "stream": True,
             "stream_options": {"include_usage": True},
         }
+        if tools:
+            # Flatten $defs/$ref — Vertex/Gemini (a managed gateway target)
+            # rejects JSON-Schema refs, mirroring _stream_openai. Without this
+            # the gateway returns 400 on tool-carrying managed calls.
+            try:
+                payload["tools"] = _inline_refs(tools)
+            except Exception:
+                logger.warning(
+                    "tool_schema_flatten_failed_fallback_to_raw", exc_info=True
+                )
+                payload["tools"] = tools
+        else:
+            payload["tools"] = []
         if self.response_format:
-            payload["response_format"] = self.response_format
+            try:
+                payload["response_format"] = _inline_refs(self.response_format)
+            except Exception:
+                logger.warning(
+                    "response_format_flatten_failed_fallback_to_raw", exc_info=True
+                )
+                payload["response_format"] = self.response_format
 
         async for chunk in stream_chat_completion(payload):
             metadata = chunk.get("agentcc_metadata")

--- a/futureagi/ee/falcon_ai/llm_client.py
+++ b/futureagi/ee/falcon_ai/llm_client.py
@@ -135,7 +135,7 @@ class FalconLLMClient:
                 yield chunk
 
     async def _stream_managed(self, messages, tools=None):
-        from ee.licensing.managed_ai import chat_completion, response_content
+        from ee.licensing.managed_ai import stream_chat_completion
 
         payload = {
             "model": self.model,
@@ -143,16 +143,21 @@ class FalconLLMClient:
             "tools": tools or [],
             "temperature": self.temperature,
             "max_tokens": self.max_tokens,
-            "stream": False,
+            "stream": True,
+            "stream_options": {"include_usage": True},
         }
         if self.response_format:
             payload["response_format"] = self.response_format
 
-        response = await asyncio.to_thread(chat_completion, payload)
-        content = response_content(response)
-        if content:
-            yield {"choices": [{"delta": {"content": content}, "finish_reason": None}]}
-        yield {"choices": [{"delta": {}, "finish_reason": "stop"}]}
+        async for chunk in stream_chat_completion(payload):
+            metadata = chunk.get("agentcc_metadata")
+            if metadata:
+                self._gateway_cost += metadata.get("cost", 0)
+
+            for choice in chunk.get("choices") or []:
+                if choice.get("finish_reason") == "length":
+                    choice["finish_reason"] = "max_tokens"
+            yield chunk
 
     async def _stream_bedrock(self, messages, tools=None):
         """Stream from AWS Bedrock using boto3, yielding OpenAI-compatible chunks."""

--- a/futureagi/ee/falcon_ai/tests/test_llm_client_streaming.py
+++ b/futureagi/ee/falcon_ai/tests/test_llm_client_streaming.py
@@ -120,6 +120,44 @@ async def test_managed_stream_forwards_incremental_tool_calls_usage_and_metadata
 
 
 @pytest.mark.asyncio
+async def test_managed_stream_inlines_ref_tool_schemas():
+    import json
+
+    captured = {}
+
+    async def managed_stream(payload):
+        captured["payload"] = payload
+        yield {"choices": [{"delta": {}, "finish_reason": "stop"}]}
+
+    tools = [
+        {
+            "type": "function",
+            "function": {
+                "name": "make_agent",
+                "parameters": {
+                    "type": "object",
+                    "properties": {"cfg": {"$ref": "#/$defs/Cfg"}},
+                    "$defs": {"Cfg": {"type": "object"}},
+                },
+            },
+        }
+    ]
+
+    with patch(
+        "ee.licensing.managed_ai.stream_chat_completion",
+        new=managed_stream,
+    ):
+        async for _ in FalconLLMClient().stream_completion(
+            [{"role": "user", "content": "go"}], tools=tools
+        ):
+            pass
+
+    serialized = json.dumps(captured["payload"]["tools"])
+    assert "$ref" not in serialized
+    assert "$defs" not in serialized
+
+
+@pytest.mark.asyncio
 async def test_managed_stream_normalizes_length_finish_reason():
     async def managed_stream(payload):
         yield {"choices": [{"delta": {}, "finish_reason": "length"}]}

--- a/futureagi/ee/falcon_ai/tests/test_llm_client_streaming.py
+++ b/futureagi/ee/falcon_ai/tests/test_llm_client_streaming.py
@@ -1,3 +1,5 @@
+from unittest.mock import patch
+
 import pytest
 
 from ee.falcon_ai.llm_client import FalconLLMClient
@@ -31,3 +33,106 @@ async def test_stream_with_retry_retries_empty_stream_before_failing(monkeypatch
             pass
 
     assert client.calls == 2
+
+
+@pytest.mark.asyncio
+async def test_managed_stream_forwards_incremental_tool_calls_usage_and_metadata():
+    chunks = [
+        {
+            "choices": [
+                {"delta": {"content": "Working"}, "finish_reason": None}
+            ]
+        },
+        {
+            "choices": [
+                {
+                    "delta": {
+                        "tool_calls": [
+                            {
+                                "index": 0,
+                                "id": "call_1",
+                                "function": {
+                                    "name": "create_agent",
+                                    "arguments": '{"name":',
+                                },
+                            },
+                            {
+                                "index": 1,
+                                "id": "call_2",
+                                "function": {
+                                    "name": "lookup",
+                                    "arguments": '{"id":',
+                                },
+                            },
+                        ]
+                    },
+                    "finish_reason": None,
+                }
+            ]
+        },
+        {
+            "choices": [
+                {
+                    "delta": {
+                        "tool_calls": [
+                            {
+                                "index": 0,
+                                "function": {"arguments": '"agent"}'},
+                            },
+                            {
+                                "index": 1,
+                                "function": {"arguments": '1}'},
+                            },
+                        ]
+                    },
+                    "finish_reason": "tool_calls",
+                }
+            ]
+        },
+        {
+            "choices": [],
+            "usage": {"prompt_tokens": 5, "completion_tokens": 3},
+            "agentcc_metadata": {"cost": 0.25},
+        },
+    ]
+
+    async def managed_stream(payload):
+        assert payload["stream"] is True
+        assert payload["stream_options"] == {"include_usage": True}
+        for chunk in chunks:
+            yield chunk
+
+    with patch(
+        "ee.licensing.managed_ai.stream_chat_completion",
+        new=managed_stream,
+    ):
+        client = FalconLLMClient()
+        result = [
+            chunk
+            async for chunk in client.stream_completion(
+                [{"role": "user", "content": "build"}],
+                tools=[{"type": "function", "function": {"name": "create_agent"}}],
+            )
+        ]
+
+    assert result == chunks
+    assert client._gateway_cost == 0.25
+
+
+@pytest.mark.asyncio
+async def test_managed_stream_normalizes_length_finish_reason():
+    async def managed_stream(payload):
+        yield {"choices": [{"delta": {}, "finish_reason": "length"}]}
+
+    with patch(
+        "ee.licensing.managed_ai.stream_chat_completion",
+        new=managed_stream,
+    ):
+        chunks = [
+            chunk
+            async for chunk in FalconLLMClient().stream_completion(
+                [{"role": "user", "content": "hello"}]
+            )
+        ]
+
+    assert chunks[0]["choices"][0]["finish_reason"] == "max_tokens"

--- a/futureagi/ee/licensing/activation_client.py
+++ b/futureagi/ee/licensing/activation_client.py
@@ -12,14 +12,15 @@ Token lifecycle:
 
 from __future__ import annotations
 
+import asyncio
+import json
 import os
 import threading
 import time
+from collections.abc import AsyncIterator, Callable
 from dataclasses import dataclass
-from typing import Callable
 
 import structlog
-
 from ee.licensing.validator import hash_key
 
 logger = structlog.get_logger(__name__)
@@ -46,10 +47,13 @@ _cached_token: ServiceToken | None = None
 
 
 def get_activation_url() -> str:
-    return os.getenv(
-        "FUTURE_AGI_LICENSE_URL",
-        "https://api.futureagi.com",
-    ).rstrip("/") + "/v1/self-hosted/activations"
+    return (
+        os.getenv(
+            "FUTURE_AGI_LICENSE_URL",
+            "https://api.futureagi.com",
+        ).rstrip("/")
+        + "/v1/self-hosted/activations"
+    )
 
 
 def get_service_token() -> ServiceToken | None:
@@ -121,6 +125,27 @@ def _activate() -> ServiceToken | None:
         return None
 
 
+def _raise_for_managed_status(
+    status_code: int,
+    on_unauthorized: Callable[[], None],
+) -> None:
+    if status_code == 401:
+        on_unauthorized()
+        raise ManagedServiceError(
+            "GATEWAY_UNAUTHORIZED", "Managed AI gateway rejected credentials"
+        )
+    if status_code == 403:
+        raise ManagedServiceError(
+            "FEATURE_DENIED", "Feature not included in license scope"
+        )
+    if status_code == 429:
+        raise ManagedServiceError("RATE_LIMITED", "Managed AI rate limit exceeded")
+    if status_code >= 500:
+        raise ManagedServiceError(
+            "SERVICE_ERROR", f"Managed AI service error ({status_code})"
+        )
+
+
 def dispatch_managed_request(
     *,
     url: str,
@@ -129,15 +154,6 @@ def dispatch_managed_request(
     timeout: float,
     on_unauthorized: Callable[[], None],
 ) -> dict:
-    """POST to the managed gateway and map failures to typed errors.
-
-    Shared transport for both managed-AI auth models: the self-hosted
-    activation-token flow (``call_managed_service``) and the cloud
-    internal-key flow (``ee.licensing.managed_ai``). Only the 401 response
-    is handled differently between them, so callers pass ``on_unauthorized``
-    (which must raise); every other status maps identically here so the two
-    paths cannot drift.
-    """
     import httpx
 
     try:
@@ -153,22 +169,53 @@ def dispatch_managed_request(
     except httpx.TimeoutException:
         raise ManagedServiceError("GATEWAY_TIMEOUT", "Managed AI gateway timed out")
     except httpx.ConnectError:
-        raise ManagedServiceError("GATEWAY_UNREACHABLE", "Cannot reach managed AI gateway")
-
-    if response.status_code == 401:
-        on_unauthorized()
-        # Callers must raise in on_unauthorized; guard in case one does not.
         raise ManagedServiceError(
-            "GATEWAY_UNAUTHORIZED", "Managed AI gateway rejected credentials"
+            "GATEWAY_UNREACHABLE", "Cannot reach managed AI gateway"
         )
-    if response.status_code == 403:
-        raise ManagedServiceError("FEATURE_DENIED", "Feature not included in license scope")
-    if response.status_code == 429:
-        raise ManagedServiceError("RATE_LIMITED", "Managed AI rate limit exceeded")
-    if response.status_code >= 500:
-        raise ManagedServiceError("SERVICE_ERROR", f"Managed AI service error ({response.status_code})")
 
+    _raise_for_managed_status(response.status_code, on_unauthorized)
     return response.json()
+
+
+async def dispatch_managed_stream(
+    *,
+    url: str,
+    api_key: str,
+    json_body: dict,
+    timeout: float,
+    on_unauthorized: Callable[[], None],
+) -> AsyncIterator[dict]:
+    import httpx
+
+    headers = {
+        "Authorization": f"Bearer {api_key}",
+        "Content-Type": "application/json",
+        "x-agentcc-include-metadata": "true",
+    }
+    try:
+        async with httpx.AsyncClient(timeout=timeout) as client:
+            async with client.stream(
+                "POST", url, json=json_body, headers=headers
+            ) as response:
+                _raise_for_managed_status(response.status_code, on_unauthorized)
+                response.raise_for_status()
+                async for line in response.aiter_lines():
+                    if not line.startswith("data:"):
+                        continue
+                    data = line[5:].strip()
+                    if not data:
+                        continue
+                    if data == "[DONE]":
+                        return
+                    yield json.loads(data)
+    except httpx.TimeoutException as exc:
+        raise ManagedServiceError(
+            "GATEWAY_TIMEOUT", "Managed AI gateway timed out"
+        ) from exc
+    except httpx.ConnectError as exc:
+        raise ManagedServiceError(
+            "GATEWAY_UNREACHABLE", "Cannot reach managed AI gateway"
+        ) from exc
 
 
 def call_managed_service(
@@ -177,18 +224,14 @@ def call_managed_service(
     json_body: dict,
     timeout: float = 30.0,
 ) -> dict:
-    """Make an authenticated request to the FutureAGI managed gateway.
-
-    Self-hosted EE auth: exchange the license for a short-lived service
-    token, then call the gateway with it. Raises ManagedServiceError on
-    auth/service failures with typed codes.
-    """
     token = get_service_token()
     if token is None:
         raise ManagedServiceError("ACTIVATION_FAILED", "Could not obtain service token")
 
     if token.scope == "oss" and not token.access_token:
-        raise ManagedServiceError("NO_ENTERPRISE_LICENSE", "Managed AI requires an Enterprise license")
+        raise ManagedServiceError(
+            "NO_ENTERPRISE_LICENSE", "Managed AI requires an Enterprise license"
+        )
 
     def _on_unauthorized() -> None:
         invalidate_token()
@@ -203,6 +246,37 @@ def call_managed_service(
         timeout=timeout,
         on_unauthorized=_on_unauthorized,
     )
+
+
+async def stream_managed_service(
+    path: str = "/v1/chat/completions",
+    *,
+    json_body: dict,
+    timeout: float = 300.0,
+) -> AsyncIterator[dict]:
+    token = await asyncio.to_thread(get_service_token)
+    if token is None:
+        raise ManagedServiceError("ACTIVATION_FAILED", "Could not obtain service token")
+
+    if token.scope == "oss" and not token.access_token:
+        raise ManagedServiceError(
+            "NO_ENTERPRISE_LICENSE", "Managed AI requires an Enterprise license"
+        )
+
+    def _on_unauthorized() -> None:
+        invalidate_token()
+        raise ManagedServiceError(
+            "TOKEN_EXPIRED", "Service token rejected — will refresh on next call"
+        )
+
+    async for chunk in dispatch_managed_stream(
+        url=token.gateway_url.rstrip("/") + path,
+        api_key=token.access_token,
+        json_body=json_body,
+        timeout=timeout,
+        on_unauthorized=_on_unauthorized,
+    ):
+        yield chunk
 
 
 class ManagedServiceError(Exception):

--- a/futureagi/ee/licensing/managed_ai.py
+++ b/futureagi/ee/licensing/managed_ai.py
@@ -1,11 +1,14 @@
 from __future__ import annotations
 
+from collections.abc import AsyncIterator
 from typing import Any
 
 from ee.licensing.activation_client import (
     ManagedServiceError,
     call_managed_service,
     dispatch_managed_request,
+    dispatch_managed_stream,
+    stream_managed_service,
 )
 
 
@@ -29,25 +32,7 @@ def service_for_model(model: object) -> str | None:
     return None
 
 
-def _cloud_chat_completion(
-    payload: dict[str, Any],
-    *,
-    path: str,
-    timeout: float,
-) -> dict[str, Any]:
-    """Managed completion on cloud.
-
-    Cloud deployments carry no ``EE_LICENSE_KEY``, so the self-hosted
-    activation-token exchange in ``call_managed_service`` never yields a
-    usable token. The gateway is internal here, so we authenticate with
-    ``AGENTCC_INTERNAL_API_KEY`` — mirroring the ``vertex_ai``/``turing_*``
-    internal-key branch in ``FalconLLMClient``.
-
-    Shares the transport + error mapping with ``call_managed_service`` via
-    ``dispatch_managed_request`` so the two paths cannot drift. Only the 401
-    handling differs: here it means a bad internal key, not a stale
-    activation token, so it deliberately does not touch the EE token cache.
-    """
+def _cloud_gateway_credentials() -> tuple[str, str]:
     from ee.usage.services.gateway_llm_client import _get_setting
 
     base_url = _get_setting("AGENTCC_INTERNAL_URL", "http://agentcc-gateway:8090")
@@ -57,6 +42,16 @@ def _cloud_chat_completion(
             "GATEWAY_UNCONFIGURED",
             "AGENTCC_INTERNAL_API_KEY is not configured for managed AI",
         )
+    return base_url, api_key
+
+
+def _cloud_chat_completion(
+    payload: dict[str, Any],
+    *,
+    path: str,
+    timeout: float,
+) -> dict[str, Any]:
+    base_url, api_key = _cloud_gateway_credentials()
 
     def _on_unauthorized() -> None:
         raise ManagedServiceError(
@@ -84,16 +79,44 @@ def chat_completion(payload: dict[str, Any]) -> dict[str, Any]:
         return _cloud_chat_completion(
             payload,
             path="/v1/chat/completions",
-            # Matches the shared gateway client (gateway_llm_client). A managed
-            # agent turn with a large max_tokens routinely runs well past the
-            # 30s default, so use the same generous ceiling rather than let a
-            # slow-but-valid completion trip a transport timeout.
             timeout=300.0,
         )
     return call_managed_service(
         path="/v1/chat/completions",
         json_body=payload,
     )
+
+
+async def stream_chat_completion(
+    payload: dict[str, Any],
+) -> AsyncIterator[dict[str, Any]]:
+    model = payload.get("model")
+    if not is_managed_model(model):
+        raise ValueError(f"Model {model!r} is not a FutureAGI-managed model")
+
+    from ee.usage.deployment import DeploymentMode
+
+    if not DeploymentMode.is_cloud():
+        async for chunk in stream_managed_service(json_body=payload):
+            yield chunk
+        return
+
+    base_url, api_key = _cloud_gateway_credentials()
+
+    def _on_unauthorized() -> None:
+        raise ManagedServiceError(
+            "GATEWAY_UNAUTHORIZED",
+            "Managed AI gateway rejected the internal API key",
+        )
+
+    async for chunk in dispatch_managed_stream(
+        url=base_url.rstrip("/") + "/v1/chat/completions",
+        api_key=api_key,
+        json_body=payload,
+        timeout=300.0,
+        on_unauthorized=_on_unauthorized,
+    ):
+        yield chunk
 
 
 def response_content(response: dict[str, Any]) -> str:

--- a/futureagi/ee/licensing/tests/test_activation_client.py
+++ b/futureagi/ee/licensing/tests/test_activation_client.py
@@ -12,8 +12,10 @@ from ee.licensing.activation_client import (
     ManagedServiceError,
     ServiceToken,
     call_managed_service,
+    dispatch_managed_stream,
     get_service_token,
     invalidate_token,
+    stream_managed_service,
 )
 
 
@@ -110,6 +112,164 @@ class TestInvalidateToken:
         )
         invalidate_token()
         assert mod._cached_token is None
+
+
+class _StreamResponse:
+    def __init__(self, lines, status_code=200):
+        self.lines = lines
+        self.status_code = status_code
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, traceback):
+        return False
+
+    async def aiter_lines(self):
+        for line in self.lines:
+            yield line
+
+    def raise_for_status(self):
+        return None
+
+
+class _StreamClient:
+    def __init__(self, response):
+        self.response = response
+        self.call = None
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, traceback):
+        return False
+
+    def stream(self, method, url, **kwargs):
+        self.call = (method, url, kwargs)
+        return self.response
+
+
+class TestManagedStreamDispatch:
+    @pytest.mark.asyncio
+    async def test_yields_data_events_and_stops_at_done(self):
+        response = _StreamResponse(
+            [
+                "",
+                ": keepalive",
+                "event: message",
+                'data: {"choices":[{"delta":{"content":"hi"}}]}',
+                "data: [DONE]",
+                'data: {"ignored":true}',
+            ]
+        )
+        client = _StreamClient(response)
+
+        with patch("httpx.AsyncClient", return_value=client):
+            chunks = [
+                chunk
+                async for chunk in dispatch_managed_stream(
+                    url="https://gw.test/v1/chat/completions",
+                    api_key="token",
+                    json_body={"model": "falcon_ai", "stream": True},
+                    timeout=300.0,
+                    on_unauthorized=lambda: None,
+                )
+            ]
+
+        assert chunks == [{"choices": [{"delta": {"content": "hi"}}]}]
+        assert client.call[0:2] == (
+            "POST",
+            "https://gw.test/v1/chat/completions",
+        )
+        headers = client.call[2]["headers"]
+        assert headers["Authorization"] == "Bearer token"
+        assert headers["x-agentcc-include-metadata"] == "true"
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ("status_code", "expected_code"),
+        [
+            (403, "FEATURE_DENIED"),
+            (429, "RATE_LIMITED"),
+            (500, "SERVICE_ERROR"),
+        ],
+    )
+    async def test_maps_gateway_status(self, status_code, expected_code):
+        client = _StreamClient(_StreamResponse([], status_code=status_code))
+
+        with patch("httpx.AsyncClient", return_value=client):
+            with pytest.raises(ManagedServiceError) as exc:
+                async for _ in dispatch_managed_stream(
+                    url="https://gw.test/v1/chat/completions",
+                    api_key="token",
+                    json_body={},
+                    timeout=300.0,
+                    on_unauthorized=lambda: None,
+                ):
+                    pass
+
+        assert exc.value.code == expected_code
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ("error", "expected_code"),
+        [
+            (httpx.TimeoutException("timed out"), "GATEWAY_TIMEOUT"),
+            (httpx.ConnectError("unreachable"), "GATEWAY_UNREACHABLE"),
+        ],
+    )
+    async def test_maps_transport_failure(self, error, expected_code):
+        client = _StreamClient(_StreamResponse([]))
+        client.stream = MagicMock(side_effect=error)
+
+        with patch("httpx.AsyncClient", return_value=client):
+            with pytest.raises(ManagedServiceError) as exc:
+                async for _ in dispatch_managed_stream(
+                    url="https://gw.test/v1/chat/completions",
+                    api_key="token",
+                    json_body={},
+                    timeout=300.0,
+                    on_unauthorized=lambda: None,
+                ):
+                    pass
+
+        assert exc.value.code == expected_code
+
+
+class TestStreamManagedService:
+    @pytest.mark.asyncio
+    async def test_unauthorized_invalidates_cached_token(self):
+        token = ServiceToken(
+            access_token="service-token",
+            gateway_url="https://gw.test",
+            expires_at=time.time() + 3600,
+            allowed_services=["falcon"],
+            allowed_models=["falcon_ai"],
+            scope="enterprise",
+        )
+
+        async def dispatch(**kwargs):
+            kwargs["on_unauthorized"]()
+            if False:
+                yield {}
+
+        with (
+            patch(
+                "ee.licensing.activation_client.get_service_token",
+                return_value=token,
+            ),
+            patch(
+                "ee.licensing.activation_client.dispatch_managed_stream",
+                new=dispatch,
+            ),
+            patch("ee.licensing.activation_client.invalidate_token") as invalidate,
+        ):
+            with pytest.raises(ManagedServiceError) as exc:
+                async for _ in stream_managed_service(json_body={}):
+                    pass
+
+        assert exc.value.code == "TOKEN_EXPIRED"
+        invalidate.assert_called_once_with()
 
 
 class TestCallManagedService:

--- a/futureagi/ee/licensing/tests/test_managed_clients.py
+++ b/futureagi/ee/licensing/tests/test_managed_clients.py
@@ -67,24 +67,40 @@ class TestFalconManagedClient:
         assert client.model == "falcon_ai"
 
     @pytest.mark.asyncio
-    @patch("ee.licensing.managed_ai.chat_completion")
-    async def test_stream_completion_uses_managed_gateway(self, mock_call):
-        mock_call.return_value = {
-            "choices": [{"message": {"content": "falcon managed"}}],
-            "usage": {"total_tokens": 4},
-        }
+    async def test_stream_completion_uses_managed_gateway(self):
+        payloads = []
 
-        client = FalconLLMClient()
-        chunks = []
-        async for chunk in client.stream_completion(
-            [{"role": "user", "content": "analyze"}],
-            tools=[{"type": "function", "function": {"name": "create"}}],
+        async def managed_stream(payload):
+            payloads.append(payload)
+            yield {
+                "choices": [
+                    {
+                        "delta": {"content": "falcon managed"},
+                        "finish_reason": None,
+                    }
+                ]
+            }
+            yield {"choices": [{"delta": {}, "finish_reason": "stop"}]}
+
+        with patch(
+            "ee.licensing.managed_ai.stream_chat_completion",
+            new=managed_stream,
         ):
-            chunks.append(chunk)
+            client = FalconLLMClient()
+            chunks = [
+                chunk
+                async for chunk in client.stream_completion(
+                    [{"role": "user", "content": "analyze"}],
+                    tools=[{"type": "function", "function": {"name": "create"}}],
+                )
+            ]
 
         assert chunks[0]["choices"][0]["delta"]["content"] == "falcon managed"
         assert chunks[-1]["choices"][0]["finish_reason"] == "stop"
-        payload = mock_call.call_args.args[0]
+        payload = payloads[0]
         assert payload["model"] == "falcon_ai"
         assert payload["messages"] == [{"role": "user", "content": "analyze"}]
-        assert payload["tools"] == [{"type": "function", "function": {"name": "create"}}]
+        assert payload["tools"] == [
+            {"type": "function", "function": {"name": "create"}}
+        ]
+        assert payload["stream"] is True


### PR DESCRIPTION
## Summary

Managed Falcon (`falcon_ai`) called the gateway with `stream=false` and reconstructed OpenAI-style chunks from the one-shot response. That adapter dropped `message.tool_calls` and forced `finish_reason="stop"`, so the agent-builder — which drives entirely through tool calls — produced nothing on the managed/cloud path, and even text was withheld until the model finished. This replaces the one-shot adapter with true authenticated gateway SSE, forwarding native chunks incrementally while preserving the existing cloud-internal-key vs self-hosted-activation-token routing.

## Linked issues

Closes #
Linear:

## Type of change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📖 Documentation only
- [ ] 🧹 Chore / refactor (no user-visible change)
- [ ] 🚀 Performance improvement
- [ ] 🧪 Test-only change

---

## 1) What changes were done

**A. Async managed-AI SSE transport (`licensing/activation_client.py`)**

- Added `dispatch_managed_stream()` — async POST via `httpx.AsyncClient.stream()`, sends bearer auth + `x-agentcc-include-metadata`, parses `data:` events, ignores blank/comment/keepalive lines, stops on `[DONE]`, yields raw OpenAI chunks.
- Extracted `_raise_for_managed_status()` so sync and async paths share identical 401/403/429/5xx → `ManagedServiceError` mapping and cannot drift.
- Added `stream_managed_service()` — self-hosted wrapper that fetches the activation token off the event loop and invalidates it on 401 (`TOKEN_EXPIRED`).

**B. Cloud-vs-EE stream routing (`licensing/managed_ai.py`)**

- Added `stream_chat_completion()` mirroring `chat_completion()`'s `DeploymentMode.is_cloud()` decision: cloud uses `AGENTCC_INTERNAL_API_KEY` and never touches the token cache; self-hosted uses the activation token.
- Extracted `_cloud_gateway_credentials()` (shared by the sync and stream cloud paths).
- Non-streaming `chat_completion()` unchanged for Turing / Protect / summaries.

**C. Falcon native streaming (`falcon_ai/llm_client.py`)**

- `_stream_managed()` now sends `stream: true` + `stream_options.include_usage` and forwards native gateway chunks: incremental text, fragmented tool-call arguments, stable indexes, usage-only chunks, and `agentcc_metadata` (accumulated into `_gateway_cost`).
- Normalizes provider `finish_reason: "length"` → Falcon's `"max_tokens"`; otherwise leaves chunks unchanged.

---

## 2) Why the changes were done

- **Product/UX:** Falcon agent produced nothing on cloud because tool calls were dropped; streaming also means first token/tool-call now surfaces immediately instead of after the whole completion.
- **Technical:** The gateway already speaks OpenAI SSE with incremental tool arguments, usage, and metadata. Forwarding native chunks removes a lossy reconstruction layer instead of patching it.
- **Architecture:** One status-mapping helper and one credentials helper keep the sync and async transports from diverging; the cloud/EE auth split is unchanged.

---

## 3) Tests written + scenarios each covers

**`licensing/tests/test_activation_client.py`** — async stream transport

- `TestManagedStreamDispatch::test_yields_data_events_and_stops_at_done` — `data:` parsing, keepalive/blank/comment skip, `[DONE]` stop, auth + metadata headers.
- `TestManagedStreamDispatch::test_maps_gateway_status` — 403/429/5xx → typed error.
- `TestManagedStreamDispatch::test_maps_transport_failure` — timeout/connect → typed error.
- `TestStreamManagedService::test_unauthorized_invalidates_cached_token` — self-hosted 401 invalidates token (`TOKEN_EXPIRED`).

**`licensing/tests/test_managed_ai_transport.py`** *(EE repo)* — cloud vs self-hosted stream routing

- `TestCloudStreamTransport::test_cloud_stream_uses_internal_key_without_activation` — cloud stream hits internal gateway, no activation.
- `TestCloudStreamTransport::test_self_hosted_stream_uses_activation_transport` — EE stream uses activation token, no internal-settings read.

**`falcon_ai/tests/test_llm_client_streaming.py`** — Falcon SSE forwarding

- `test_managed_stream_forwards_incremental_tool_calls_usage_and_metadata` — multi-chunk text, fragmented multi-tool-call args with stable indexes, `finish_reason=tool_calls`, usage-only + `agentcc_metadata` chunk, `_gateway_cost`.
- `test_managed_stream_normalizes_length_finish_reason` — `length` → `max_tokens`.

**`licensing/tests/test_managed_clients.py`** — updated the Falcon managed-stream test to drive real SSE chunks (`stream: true`) instead of the one-shot mock.

> Note: pytest not run locally — Docker `backend` container unavailable this session. Verified via `py_compile`, `git diff --check`, and IDE diagnostics. Needs a CI/container run.
