### PR TITLE
chore(ci): gate dev CDN auto-deploy behind DEV_CDN_AUTO_DEPLOY variable

### DIFF
--- a/.github/workflows/frontend-dev-cdn.yaml
+++ b/.github/workflows/frontend-dev-cdn.yaml
@@ -5,8 +5,8 @@ on:
     branches:
       - dev
     paths:
-      - 'frontend/**'
-      - '.github/workflows/frontend-dev-cdn.yaml'
+      - "frontend/**"
+      - ".github/workflows/frontend-dev-cdn.yaml"
   workflow_dispatch:
     inputs:
       branch:
@@ -16,6 +16,7 @@ on:
 
 jobs:
   deploy:
+    if: github.event_name == 'workflow_dispatch' || vars.DEV_CDN_AUTO_DEPLOY != 'false'
     runs-on: ubuntu-latest
     defaults:
       run:


### PR DESCRIPTION
## Why

The `Deploy Frontend to Dev CDN` workflow deploys on every push to `dev` (touching `frontend/**`) and also supports `workflow_dispatch` with a `branch` input for deploying an arbitrary branch to the dev CDN. While a dispatched branch is being tested on dev, any merge to `dev` re-triggers the push deploy and clobbers the pinned branch.

## What changed

One job-level condition added to `.github/workflows/frontend-dev-cdn.yaml`:

```yaml
jobs:
  deploy:
    if: github.event_name == 'workflow_dispatch' || vars.DEV_CDN_AUTO_DEPLOY != 'false'
```

(The quote changes on the `paths:` lines are from the repo prettier pre-commit hook.)

Behavior:

- **Variable not set → always auto-deploy** (unset evaluates to `''`, so `!= 'false'` is true). Nothing to configure for normal operation.
- `workflow_dispatch` always deploys, regardless of the variable — that is the override path.
- Push to `dev` is skipped only while the repository variable `DEV_CDN_AUTO_DEPLOY` is set to the string `false`. Any other value deploys.

Toggle:

```bash
gh variable set DEV_CDN_AUTO_DEPLOY --body false   # pause auto-deploys (pin a dispatched branch)
gh variable set DEV_CDN_AUTO_DEPLOY --body true    # resume auto-deploys
```

## Tests

- **New tests:** none — infra/workflow change; verified end-to-end instead (see below).
- **Existing tests:** unaffected (no application code touched).

## Test scenarios

| Scenario | Expected |
| --- | --- |
| Push to `dev`, variable unset | deploy job runs |
| Push to `dev`, `DEV_CDN_AUTO_DEPLOY=false` | deploy job shows as **skipped** (run still created — audit trail) |
| Push to `dev`, `DEV_CDN_AUTO_DEPLOY=true` (or any non-`false` value) | deploy job runs |
| `workflow_dispatch` any branch, variable `false` | deploy job runs (override) |

## Commands run

```bash
actionlint .github/workflows/frontend-dev-cdn.yaml
```

## How to test locally / after merge

1. Merge; push a trivial `frontend/**` change to `dev` with the variable unset → confirm the deploy runs.
2. `gh variable set DEV_CDN_AUTO_DEPLOY --body false`; push again → confirm the run's deploy job is skipped.
3. Trigger the workflow via **Run workflow** (any branch) → confirm it deploys.
4. `gh variable set DEV_CDN_AUTO_DEPLOY --body true` to restore normal behavior.

## Evidence

```
$ actionlint .github/workflows/frontend-dev-cdn.yaml
actionlint OK   (no findings, exit 0)
```

## Architectural rationale

A repository **variable** (not a secret) was chosen as the toggle: variables are readable in Settings → Actions → Variables and via API, usable directly in `if:` expressions through the `vars` context, and flippable with a single `gh variable set` command — no workflow edit, redeploy, or secret-handling ceremony. Alternatives considered: an auto-lock where dispatch writes the variable itself (needs `actions: write` on `GITHUB_TOKEN`; more moving parts) and a GitHub Environment with required reviewers (adds friction to every routine dev merge). The gate is job-level rather than trigger-level so skipped runs remain visible in the Actions tab as an audit trail.
