### PR TITLE
fix(annotations): numeric input bounds, text placeholder, add-items spacing, and badge colors

### DIFF
--- a/frontend/src/sections/annotations/labels/create-label-drawer.jsx
+++ b/frontend/src/sections/annotations/labels/create-label-drawer.jsx
@@ -64,7 +64,7 @@ const DEFAULT_SETTINGS = {
   },
   numeric: { min: 0, max: 10, step_size: 1, display_type: "slider" },
   text: {
-    placeholder: "Enter your feedback...",
+    placeholder: "",
     max_length: 500,
     min_length: 0,
   },

--- a/frontend/src/sections/annotations/labels/settings/text-settings.jsx
+++ b/frontend/src/sections/annotations/labels/settings/text-settings.jsx
@@ -16,7 +16,7 @@ export default function TextSettings({ control }) {
           <TextField
             {...field}
             label="Placeholder Text"
-            placeholder="Enter your feedback..."
+            placeholder="Enter text..."
             size="small"
             fullWidth
           />

--- a/frontend/src/sections/annotations/queues/annotate/label-input.jsx
+++ b/frontend/src/sections/annotations/queues/annotate/label-input.jsx
@@ -18,6 +18,7 @@ import {
   Typography,
 } from "@mui/material";
 import { alpha } from "@mui/material/styles";
+import { enqueueSnackbar } from "notistack";
 import Iconify from "src/components/iconify";
 
 const LABEL_COLORS = {
@@ -636,12 +637,25 @@ function NumericInput({ settings, value, onChange, inputRef }) {
   const step = Number(rawStep) > 0 ? Number(rawStep) : 1;
   const displayType = settings.display_type || "slider";
 
-  const clamp = (nextValue) => Math.max(min, Math.min(max, nextValue));
-  const handleNumberChange = (nextValue) => {
-    const n = nextValue === "" ? null : Number(nextValue);
-    if (n === null || !Number.isNaN(n)) {
-      onChange(n === null ? n : clamp(n));
+  const handleNumberChange = (event) => {
+    const raw = event.target.value;
+    if (raw === "") {
+      onChange(null);
+      return;
     }
+    const n = Number(raw);
+    if (Number.isNaN(n)) return;
+    if (n > max) {
+      enqueueSnackbar(`Maximum value is ${max} only`, { variant: "warning" });
+      return;
+    }
+   
+    if (/^-?0\d/.test(raw)) event.target.value = String(n);
+    onChange(n);
+  };
+
+  const handleNumberBlur = () => {
+    if (value !== null && value !== undefined && value < min) onChange(min);
   };
 
   if (displayType === "button") {
@@ -684,7 +698,8 @@ function NumericInput({ settings, value, onChange, inputRef }) {
           type="number"
           size="small"
           value={value ?? ""}
-          onChange={(e) => handleNumberChange(e.target.value)}
+          onChange={handleNumberChange}
+          onBlur={handleNumberBlur}
           inputProps={{ min, max, step }}
           sx={{
             width: 96,
@@ -711,7 +726,8 @@ function NumericInput({ settings, value, onChange, inputRef }) {
         type="number"
         size="small"
         value={value ?? min}
-        onChange={(e) => handleNumberChange(e.target.value)}
+        onChange={handleNumberChange}
+        onBlur={handleNumberBlur}
         inputProps={{ min, max, step }}
         sx={{
           width: 64,

--- a/frontend/src/sections/annotations/queues/items/add-items-dialog.jsx
+++ b/frontend/src/sections/annotations/queues/items/add-items-dialog.jsx
@@ -1567,7 +1567,7 @@ export function DatasetRowSelector({ onSetSelection, onSelectAll }) {
         sx={{
           py: 2,
           display: "flex",
-          alignItems: "center",
+          alignItems: "start",
           gap: 2,
           flexWrap: "wrap",
           flexShrink: 0,
@@ -1579,7 +1579,7 @@ export function DatasetRowSelector({ onSetSelection, onSelectAll }) {
           label="Dataset"
           value={datasetId}
           onChange={handleDatasetChange}
-          sx={{ minWidth: 220, flex: "1 1 260px" }}
+          sx={{ minWidth: 540, flex: "0 1 280px" }}
           required
           SelectProps={{
             MenuProps: {
@@ -2150,7 +2150,7 @@ function TraceSelector({
         sx={{
           py: 2,
           display: "flex",
-          alignItems: "center",
+          alignItems: "start",
           gap: 2,
           flexShrink: 0,
           flexWrap: "wrap",
@@ -2193,7 +2193,7 @@ function TraceSelector({
             />
           )}
           ListboxProps={{ style: { maxHeight: 300 } }}
-          sx={{ minWidth: 220, flex: "1 1 280px" }}
+          sx={{ minWidth: 540, flex: "0 1 280px" }}
         />
 
         {isPrototype && (
@@ -2203,7 +2203,7 @@ function TraceSelector({
             label="Version"
             value={versionId}
             onChange={handleVersionChange}
-            sx={{ minWidth: 180, flex: "1 1 220px" }}
+            sx={{ minWidth: 540, flex: "0 1 220px" }}
             required
             InputProps={{
               endAdornment: (
@@ -2807,7 +2807,7 @@ function SpanSelector({ onSetSelection, onSelectAll }) {
         sx={{
           py: 2,
           display: "flex",
-          alignItems: "center",
+          alignItems: "start",
           gap: 2,
           flexShrink: 0,
           flexWrap: "wrap",
@@ -2850,7 +2850,7 @@ function SpanSelector({ onSetSelection, onSelectAll }) {
             />
           )}
           ListboxProps={{ style: { maxHeight: 300 } }}
-          sx={{ minWidth: 220, flex: "1 1 280px" }}
+          sx={{ minWidth: 540, flex: "0 1 280px" }}
         />
 
         {isPrototype && (
@@ -2860,7 +2860,7 @@ function SpanSelector({ onSetSelection, onSelectAll }) {
             label="Version"
             value={versionId}
             onChange={handleVersionChange}
-            sx={{ minWidth: 180, flex: "1 1 220px" }}
+            sx={{ minWidth: 540, flex: "0 1 220px" }}
             required
             InputProps={{
               endAdornment: (
@@ -3382,7 +3382,7 @@ function SessionSelector({ onSetSelection, onSelectAll }) {
         sx={{
           py: 2,
           display: "flex",
-          alignItems: "center",
+          alignItems: "start",
           gap: 2,
           flexShrink: 0,
           flexWrap: "wrap",
@@ -3425,7 +3425,7 @@ function SessionSelector({ onSetSelection, onSelectAll }) {
             />
           )}
           ListboxProps={{ style: { maxHeight: 300 } }}
-          sx={{ minWidth: 220, flex: "1 1 280px" }}
+          sx={{ minWidth: 540, flex: "0 1 280px" }}
         />
 
         {isPrototype && (
@@ -3435,7 +3435,7 @@ function SessionSelector({ onSetSelection, onSelectAll }) {
             label="Version"
             value={versionId}
             onChange={handleVersionChange}
-            sx={{ minWidth: 180, flex: "1 1 220px" }}
+            sx={{ minWidth: 540, flex: "0 1 220px" }}
             required
             InputProps={{
               endAdornment: (
@@ -4441,7 +4441,7 @@ function SimulationSelector({ onSetSelection }) {
         sx={{
           py: 2,
           display: "flex",
-          alignItems: "center",
+          alignItems: "start",
           gap: 2,
           flexShrink: 0,
           flexWrap: "wrap",
@@ -4453,7 +4453,7 @@ function SimulationSelector({ onSetSelection }) {
           label="Test"
           value={testId}
           onChange={handleTestChange}
-          sx={{ minWidth: 220, flex: "1 1 280px" }}
+          sx={{ minWidth: 540, flex: "0 1 280px" }}
           required
           InputLabelProps={{ shrink: true }}
           InputProps={{
@@ -4485,7 +4485,7 @@ function SimulationSelector({ onSetSelection }) {
             </MenuItem>
           )}
           {tests.map((t) => (
-            <MenuItem key={t.id} value={t.id} sx={{ width: "100%" }}>
+            <MenuItem key={t.id} value={t.id} sx={{ maxWidth: 540 }}>
               <CustomTooltip
                 size="small"
                 arrow
@@ -4522,7 +4522,7 @@ function SimulationSelector({ onSetSelection }) {
             label="Execution run"
             value={executionRunId}
             onChange={handleExecutionRunChange}
-            sx={{ minWidth: 220, flex: "1 1 320px" }}
+            sx={{ minWidth: 540, flex: "0 1 280px" }}
             required
             InputLabelProps={{ shrink: true }}
             InputProps={{
@@ -4561,7 +4561,7 @@ function SimulationSelector({ onSetSelection }) {
             {(executionRuns || []).map((run) => {
               const label = formatExecutionRunLabel(run);
               return (
-                <MenuItem key={run.id} value={run.id} sx={{ width: "100%" }}>
+                <MenuItem key={run.id} value={run.id} sx={{ maxWidth: 540 }}>
                   <CustomTooltip
                     size="small"
                     arrow

--- a/frontend/src/sections/annotations/queues/items/item-status-badge.jsx
+++ b/frontend/src/sections/annotations/queues/items/item-status-badge.jsx
@@ -4,11 +4,11 @@ import { Chip } from "@mui/material";
 const STATUS_CONFIG = {
   pending: { label: "Pending Annotation", color: "default" },
   in_progress: { label: "In Progress", color: "info" },
-  in_review: { label: "In Review", color: "warning" },
+  in_review: { label: "In Review", color: "primary" },
   needs_changes: { label: "Needs Changes", color: "error" },
   resubmitted: { label: "Resubmitted", color: "info" },
   completed: { label: "Completed", color: "success" },
-  skipped: { label: "Skipped", color: "warning" },
+  skipped: { label: "Skipped", color: "default" },
 };
 
 export default function ItemStatusBadge({ status, label }) {

--- a/frontend/src/sections/annotations/queues/items/source-badge.jsx
+++ b/frontend/src/sections/annotations/queues/items/source-badge.jsx
@@ -1,12 +1,21 @@
 import PropTypes from "prop-types";
 import { Chip } from "@mui/material";
+import { alpha } from "@mui/material/styles";
+
+const simulationSx = {
+  color: (theme) =>
+    theme.palette.mode === "light"
+      ? theme.palette.orange[700]
+      : theme.palette.orange[300],
+  bgcolor: (theme) => alpha(theme.palette.orange[500], 0.16),
+};
 
 const SOURCE_CONFIG = {
   dataset_row: { label: "Dataset Row", color: "primary" },
   trace: { label: "Trace", color: "secondary" },
   observation_span: { label: "Span", color: "info" },
   prototype_run: { label: "Prototype", color: "success" },
-  call_execution: { label: "Simulation", color: "warning" },
+  call_execution: { label: "Simulation", sx: simulationSx },
 };
 
 export default function SourceBadge({ sourceType }) {
@@ -20,6 +29,7 @@ export default function SourceBadge({ sourceType }) {
       color={config.color}
       size="small"
       variant="soft"
+      sx={config.sx}
     />
   );
 }


### PR DESCRIPTION
Three annotation fixes, one commit each.

### Numeric label input accepts values past the max [TH-5855](https://linear.app/future-agi/issue/TH-5855)

Typing a number above the label's max used to clamp on every keystroke, so `15` rewrote itself to `10` under the cursor. Values past the max are now refused outright and a snackbar says what the maximum is, matching the existing behaviour in `star-settings.jsx`. Below-min is still allowed while typing — otherwise `10` is untypeable when the min is `5` — and blur clamps it up.

Typing onto the slider's resting `0` also left a leading zero (`05`): the parsed value is unchanged, so React never rewrote the field. That is now stripped.

### Placeholder text renders as prefilled content [TH-5866](https://linear.app/future-agi/issue/TH-5866)

The text label's default settings seeded `placeholder` with a real value, so the drawer showed it as black, selectable, editable text — and it was saved to the label as though the annotator had typed it. The default is now empty, which lets the field's own `placeholder` attribute render as a grey hint. The hint string matches the fallback that annotators actually see when the field is left blank.

### Extra space in the add items dialog [TH-5880](https://linear.app/future-agi/issue/TH-5880)

The source pickers used `flex: "1 1 …"`, so a lone select stretched across the whole drawer and a pair split it in half. They now hold a fixed width (`0 1`, `minWidth: 540`) and top-align, consistently across the Dataset, Trace, Span, Session and Simulation tabs.

### Testing

`npx vitest run src/sections/annotations` — 309 tests pass. The snackbar and the leading-zero strip have not been checked in a browser yet.


### Yellow badges are hard to read [TH-5890](https://linear.app/future-agi/issue/TH-5890)

The soft chip variant tints its background to 16% opacity, so `warning` — a pale `#F5E65F` with an olive `dark` of `#B8AC47` — washed out in the items table. Simulation now uses the theme's orange scale (the remaining palette slots were `error`, wrong signal for a source type, and `default`, which reads as disabled). In Review moves to `primary`, and Skipped to `default`, since it is a terminal state that does not need an attention color.
