### PR TITLE
fix(annotations): align annotation API response contracts with the serializers

### DIFF
--- a/api_contracts/openapi/swagger.json
+++ b/api_contracts/openapi/swagger.json
@@ -86918,8 +86918,11 @@
                     "minLength": 1
                 },
                 "roles": {
-                    "title": "Roles",
-                    "type": "string",
+                    "type": "array",
+                    "items": {
+                        "type": "string",
+                        "minLength": 1
+                    },
                     "readOnly": true
                 }
             }
@@ -87095,16 +87098,22 @@
                     "title": "Created by name",
                     "type": "string",
                     "readOnly": true,
-                    "minLength": 1
+                    "minLength": 1,
+                    "x-nullable": true
                 },
                 "viewer_role": {
                     "title": "Viewer role",
                     "type": "string",
-                    "readOnly": true
+                    "readOnly": true,
+                    "minLength": 1,
+                    "x-nullable": true
                 },
                 "viewer_roles": {
-                    "title": "Viewer roles",
-                    "type": "string",
+                    "type": "array",
+                    "items": {
+                        "type": "string",
+                        "minLength": 1
+                    },
                     "readOnly": true
                 },
                 "deleted": {
@@ -88536,6 +88545,34 @@
                 }
             }
         },
+        "QueueItemAssignedUser": {
+            "required": [
+                "id",
+                "name",
+                "email"
+            ],
+            "type": "object",
+            "properties": {
+                "id": {
+                    "title": "Id",
+                    "type": "string",
+                    "format": "uuid"
+                },
+                "name": {
+                    "title": "Name",
+                    "type": "string",
+                    "minLength": 1,
+                    "x-nullable": true
+                },
+                "email": {
+                    "title": "Email",
+                    "type": "string",
+                    "format": "email",
+                    "minLength": 1,
+                    "x-nullable": true
+                }
+            }
+        },
         "QueueItem": {
             "required": [
                 "source_type"
@@ -88617,11 +88654,14 @@
                     "title": "Assigned to name",
                     "type": "string",
                     "readOnly": true,
-                    "minLength": 1
+                    "minLength": 1,
+                    "x-nullable": true
                 },
                 "assigned_users": {
-                    "title": "Assigned users",
-                    "type": "string",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/QueueItemAssignedUser"
+                    },
                     "readOnly": true
                 },
                 "reserved_by": {
@@ -88634,7 +88674,8 @@
                     "title": "Reserved by name",
                     "type": "string",
                     "readOnly": true,
-                    "minLength": 1
+                    "minLength": 1,
+                    "x-nullable": true
                 },
                 "reservation_expires_at": {
                     "title": "Reservation expires at",
@@ -88658,7 +88699,8 @@
                     "title": "Reviewed by name",
                     "type": "string",
                     "readOnly": true,
-                    "minLength": 1
+                    "minLength": 1,
+                    "x-nullable": true
                 },
                 "reviewed_at": {
                     "title": "Reviewed at",
@@ -88673,17 +88715,19 @@
                 },
                 "source_preview": {
                     "title": "Source preview",
-                    "type": "string",
-                    "readOnly": true
+                    "type": "object",
+                    "readOnly": true,
+                    "x-json-value": true,
+                    "description": "Any valid JSON value."
                 },
                 "comment_count": {
                     "title": "Comment count",
-                    "type": "string",
+                    "type": "integer",
                     "readOnly": true
                 },
                 "open_feedback_count": {
                     "title": "Open feedback count",
-                    "type": "string",
+                    "type": "integer",
                     "readOnly": true
                 },
                 "created_at": {

--- a/frontend/src/api/contracts/__tests__/openapi-contract.test.js
+++ b/frontend/src/api/contracts/__tests__/openapi-contract.test.js
@@ -595,4 +595,87 @@ describe("OpenAPI runtime contract", () => {
       ),
     ).toMatchObject({ ok: false });
   });
+
+  it("accepts queue items with null names, listed assignees, and a null source preview", () => {
+    // Regression: method fields and nullable name fields carried no declared
+    // type, so drf-yasg typed them all as required strings — an unassigned,
+    // unreserved, unreviewed item raised 175 warnings on a single items/ page.
+    const queueItemsResponse = (item) => ({
+      status: 200,
+      config: {
+        url: "/model-hub/annotation-queues/7d1f0c4e-0000-4000-8000-000000000001/items/?page=1",
+        method: "get",
+      },
+      data: {
+        count: 1,
+        next: null,
+        previous: null,
+        results: [item],
+      },
+    });
+
+    const unassignedItem = {
+      id: "1f2e3d4c-0000-4000-8000-000000000002",
+      queue: "7d1f0c4e-0000-4000-8000-000000000001",
+      source_type: "trace",
+      source_id: "trace-1",
+      status: "pending",
+      workflow_status: "pending",
+      workflow_status_label: "Pending Annotation",
+      priority: 0,
+      order: 1,
+      metadata: {},
+      assigned_to: null,
+      assigned_to_name: null,
+      assigned_users: [
+        {
+          id: "9a8b7c6d-0000-4000-8000-000000000003",
+          name: null,
+          email: null,
+        },
+      ],
+      reserved_by: null,
+      reserved_by_name: null,
+      reservation_expires_at: null,
+      review_status: null,
+      reviewed_by: null,
+      reviewed_by_name: null,
+      reviewed_at: null,
+      review_notes: null,
+      source_preview: null,
+      comment_count: 0,
+      open_feedback_count: 0,
+      created_at: "2026-01-01T00:00:00Z",
+    };
+
+    expect(
+      validateContractedResponse(queueItemsResponse(unassignedItem)),
+    ).toMatchObject({ ok: true });
+
+    // source_preview is x-json-value, so any valid JSON shape passes.
+    expect(
+      validateContractedResponse(
+        queueItemsResponse({
+          ...unassignedItem,
+          assigned_to_name: "Ada Lovelace",
+          assigned_users: [
+            {
+              id: "9a8b7c6d-0000-4000-8000-000000000003",
+              name: "Ada Lovelace",
+              email: "ada@example.com",
+            },
+          ],
+          source_preview: { input: "hello", tags: ["a", null] },
+        }),
+      ),
+    ).toMatchObject({ ok: true });
+
+    // The endpoint really is validated here — a count sent as a string fails,
+    // so the null-tolerance above is not just an unmatched-route skip.
+    expect(
+      validateContractedResponse(
+        queueItemsResponse({ ...unassignedItem, comment_count: "0" }),
+      ),
+    ).toMatchObject({ ok: false });
+  });
 });

--- a/frontend/src/api/contracts/openapi-contract.generated.js
+++ b/frontend/src/api/contracts/openapi-contract.generated.js
@@ -46280,16 +46280,22 @@ export const OPENAPI_CONTRACT = Object.freeze({
           "title": "Created by name",
           "type": "string",
           "readOnly": true,
-          "minLength": 1
+          "minLength": 1,
+          "x-nullable": true
         },
         "viewer_role": {
           "title": "Viewer role",
           "type": "string",
-          "readOnly": true
+          "readOnly": true,
+          "minLength": 1,
+          "x-nullable": true
         },
         "viewer_roles": {
-          "title": "Viewer roles",
-          "type": "string",
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          },
           "readOnly": true
         },
         "deleted": {
@@ -66123,11 +66129,14 @@ export const OPENAPI_CONTRACT = Object.freeze({
           "title": "Assigned to name",
           "type": "string",
           "readOnly": true,
-          "minLength": 1
+          "minLength": 1,
+          "x-nullable": true
         },
         "assigned_users": {
-          "title": "Assigned users",
-          "type": "string",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/QueueItemAssignedUser"
+          },
           "readOnly": true
         },
         "reserved_by": {
@@ -66140,7 +66149,8 @@ export const OPENAPI_CONTRACT = Object.freeze({
           "title": "Reserved by name",
           "type": "string",
           "readOnly": true,
-          "minLength": 1
+          "minLength": 1,
+          "x-nullable": true
         },
         "reservation_expires_at": {
           "title": "Reservation expires at",
@@ -66164,7 +66174,8 @@ export const OPENAPI_CONTRACT = Object.freeze({
           "title": "Reviewed by name",
           "type": "string",
           "readOnly": true,
-          "minLength": 1
+          "minLength": 1,
+          "x-nullable": true
         },
         "reviewed_at": {
           "title": "Reviewed at",
@@ -66179,17 +66190,19 @@ export const OPENAPI_CONTRACT = Object.freeze({
         },
         "source_preview": {
           "title": "Source preview",
-          "type": "string",
-          "readOnly": true
+          "type": "object",
+          "readOnly": true,
+          "x-json-value": true,
+          "description": "Any valid JSON value."
         },
         "comment_count": {
           "title": "Comment count",
-          "type": "string",
+          "type": "integer",
           "readOnly": true
         },
         "open_feedback_count": {
           "title": "Open feedback count",
-          "type": "string",
+          "type": "integer",
           "readOnly": true
         },
         "created_at": {
@@ -76994,8 +77007,11 @@ export const OPENAPI_CONTRACT = Object.freeze({
           "minLength": 1
         },
         "roles": {
-          "title": "Roles",
-          "type": "string",
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          },
           "readOnly": true
         }
       }
@@ -87567,6 +87583,34 @@ export const OPENAPI_CONTRACT = Object.freeze({
         "imported": {
           "title": "Imported",
           "type": "integer"
+        }
+      }
+    },
+    "QueueItemAssignedUser": {
+      "required": [
+        "id",
+        "name",
+        "email"
+      ],
+      "type": "object",
+      "properties": {
+        "id": {
+          "title": "Id",
+          "type": "string",
+          "format": "uuid"
+        },
+        "name": {
+          "title": "Name",
+          "type": "string",
+          "minLength": 1,
+          "x-nullable": true
+        },
+        "email": {
+          "title": "Email",
+          "type": "string",
+          "format": "email",
+          "minLength": 1,
+          "x-nullable": true
         }
       }
     },

--- a/frontend/src/generated/api-contracts/api.schemas.ts
+++ b/frontend/src/generated/api-contracts/api.schemas.ts
@@ -5599,7 +5599,7 @@ export interface QueueAnnotatorNestedApi {
   readonly email?: string;
   /** @minLength 1 */
   role?: string;
-  readonly roles?: string;
+  readonly roles?: readonly string[];
 }
 
 export interface AnnotationQueueApi {
@@ -5644,8 +5644,9 @@ export interface AnnotationQueueApi {
   readonly created_by?: string;
   /** @minLength 1 */
   readonly created_by_name?: string;
+  /** @minLength 1 */
   readonly viewer_role?: string;
-  readonly viewer_roles?: string;
+  readonly viewer_roles?: readonly string[];
   readonly deleted?: boolean;
   readonly created_at?: string;
 }
@@ -6132,6 +6133,19 @@ export const QueueItemApiStatus = {
 
 export type QueueItemApiMetadata = { [key: string]: unknown };
 
+/**
+ * Any valid JSON value.
+ */
+export type QueueItemApiSourcePreview = { [key: string]: unknown };
+
+export interface QueueItemAssignedUserApi {
+  id: string;
+  /** @minLength 1 */
+  name: string;
+  /** @minLength 1 */
+  email: string;
+}
+
 export interface QueueItemApi {
   readonly id?: string;
   readonly queue?: string;
@@ -6155,7 +6169,7 @@ export interface QueueItemApi {
   assigned_to?: string;
   /** @minLength 1 */
   readonly assigned_to_name?: string;
-  readonly assigned_users?: string;
+  readonly assigned_users?: readonly QueueItemAssignedUserApi[];
   reserved_by?: string;
   /** @minLength 1 */
   readonly reserved_by_name?: string;
@@ -6167,9 +6181,10 @@ export interface QueueItemApi {
   readonly reviewed_by_name?: string;
   reviewed_at?: string;
   review_notes?: string;
-  readonly source_preview?: string;
-  readonly comment_count?: string;
-  readonly open_feedback_count?: string;
+  /** Any valid JSON value. */
+  readonly source_preview?: QueueItemApiSourcePreview;
+  readonly comment_count?: number;
+  readonly open_feedback_count?: number;
   readonly created_at?: string;
 }
 

--- a/frontend/src/generated/api-contracts/api.zod.ts
+++ b/frontend/src/generated/api-contracts/api.zod.ts
@@ -11677,8 +11677,11 @@ export const modelHubAnnotationQueuesListResponseResultsItemLabelsItemOrderMax =
 export const modelHubAnnotationQueuesListResponseResultsItemAnnotatorsItemRoleDefault = `annotator`;
 
 
+
 export const modelHubAnnotationQueuesListResponseResultsItemAnnotatorIdsDefault = [];
 export const modelHubAnnotationQueuesListResponseResultsItemAnnotatorRolesDefault = {  };
+
+
 
 
 export const ModelHubAnnotationQueuesListResponse = zod.object({
@@ -11715,7 +11718,7 @@ export const ModelHubAnnotationQueuesListResponse = zod.object({
   "name": zod.string().min(1).optional(),
   "email": zod.string().email().min(1).optional(),
   "role": zod.string().min(1).default(modelHubAnnotationQueuesListResponseResultsItemAnnotatorsItemRoleDefault),
-  "roles": zod.string().optional()
+  "roles": zod.array(zod.string().min(1)).optional()
 })).optional(),
   "label_ids": zod.array(zod.string().uuid()).min(1),
   "annotator_ids": zod.array(zod.string().uuid()).default(modelHubAnnotationQueuesListResponseResultsItemAnnotatorIdsDefault),
@@ -11728,8 +11731,8 @@ export const ModelHubAnnotationQueuesListResponse = zod.object({
   "completed_count": zod.number().optional(),
   "created_by": zod.string().uuid().optional(),
   "created_by_name": zod.string().min(1).optional(),
-  "viewer_role": zod.string().optional(),
-  "viewer_roles": zod.string().optional(),
+  "viewer_role": zod.string().min(1).optional(),
+  "viewer_roles": zod.array(zod.string().min(1)).optional(),
   "deleted": zod.boolean().optional(),
   "created_at": zod.string().datetime({"offset":true}).optional()
 }))
@@ -11905,8 +11908,11 @@ export const modelHubAnnotationQueuesReadResponseLabelsItemOrderMax = 2147483647
 export const modelHubAnnotationQueuesReadResponseAnnotatorsItemRoleDefault = `annotator`;
 
 
+
 export const modelHubAnnotationQueuesReadResponseAnnotatorIdsDefault = [];
 export const modelHubAnnotationQueuesReadResponseAnnotatorRolesDefault = {  };
+
+
 
 
 export const ModelHubAnnotationQueuesReadResponse = zod.object({
@@ -11939,7 +11945,7 @@ export const ModelHubAnnotationQueuesReadResponse = zod.object({
   "name": zod.string().min(1).optional(),
   "email": zod.string().email().min(1).optional(),
   "role": zod.string().min(1).default(modelHubAnnotationQueuesReadResponseAnnotatorsItemRoleDefault),
-  "roles": zod.string().optional()
+  "roles": zod.array(zod.string().min(1)).optional()
 })).optional(),
   "label_ids": zod.array(zod.string().uuid()).min(1),
   "annotator_ids": zod.array(zod.string().uuid()).default(modelHubAnnotationQueuesReadResponseAnnotatorIdsDefault),
@@ -11952,8 +11958,8 @@ export const ModelHubAnnotationQueuesReadResponse = zod.object({
   "completed_count": zod.number().optional(),
   "created_by": zod.string().uuid().optional(),
   "created_by_name": zod.string().min(1).optional(),
-  "viewer_role": zod.string().optional(),
-  "viewer_roles": zod.string().optional(),
+  "viewer_role": zod.string().min(1).optional(),
+  "viewer_roles": zod.array(zod.string().min(1)).optional(),
   "deleted": zod.boolean().optional(),
   "created_at": zod.string().datetime({"offset":true}).optional()
 })
@@ -12012,8 +12018,11 @@ export const modelHubAnnotationQueuesUpdateResponseLabelsItemOrderMax = 21474836
 export const modelHubAnnotationQueuesUpdateResponseAnnotatorsItemRoleDefault = `annotator`;
 
 
+
 export const modelHubAnnotationQueuesUpdateResponseAnnotatorIdsDefault = [];
 export const modelHubAnnotationQueuesUpdateResponseAnnotatorRolesDefault = {  };
+
+
 
 
 export const ModelHubAnnotationQueuesUpdateResponse = zod.object({
@@ -12046,7 +12055,7 @@ export const ModelHubAnnotationQueuesUpdateResponse = zod.object({
   "name": zod.string().min(1).optional(),
   "email": zod.string().email().min(1).optional(),
   "role": zod.string().min(1).default(modelHubAnnotationQueuesUpdateResponseAnnotatorsItemRoleDefault),
-  "roles": zod.string().optional()
+  "roles": zod.array(zod.string().min(1)).optional()
 })).optional(),
   "label_ids": zod.array(zod.string().uuid()).min(1),
   "annotator_ids": zod.array(zod.string().uuid()).default(modelHubAnnotationQueuesUpdateResponseAnnotatorIdsDefault),
@@ -12059,8 +12068,8 @@ export const ModelHubAnnotationQueuesUpdateResponse = zod.object({
   "completed_count": zod.number().optional(),
   "created_by": zod.string().uuid().optional(),
   "created_by_name": zod.string().min(1).optional(),
-  "viewer_role": zod.string().optional(),
-  "viewer_roles": zod.string().optional(),
+  "viewer_role": zod.string().min(1).optional(),
+  "viewer_roles": zod.array(zod.string().min(1)).optional(),
   "deleted": zod.boolean().optional(),
   "created_at": zod.string().datetime({"offset":true}).optional()
 })
@@ -12116,8 +12125,11 @@ export const modelHubAnnotationQueuesPartialUpdateResponseLabelsItemOrderMax = 2
 export const modelHubAnnotationQueuesPartialUpdateResponseAnnotatorsItemRoleDefault = `annotator`;
 
 
+
 export const modelHubAnnotationQueuesPartialUpdateResponseAnnotatorIdsDefault = [];
 export const modelHubAnnotationQueuesPartialUpdateResponseAnnotatorRolesDefault = {  };
+
+
 
 
 export const ModelHubAnnotationQueuesPartialUpdateResponse = zod.object({
@@ -12150,7 +12162,7 @@ export const ModelHubAnnotationQueuesPartialUpdateResponse = zod.object({
   "name": zod.string().min(1).optional(),
   "email": zod.string().email().min(1).optional(),
   "role": zod.string().min(1).default(modelHubAnnotationQueuesPartialUpdateResponseAnnotatorsItemRoleDefault),
-  "roles": zod.string().optional()
+  "roles": zod.array(zod.string().min(1)).optional()
 })).optional(),
   "label_ids": zod.array(zod.string().uuid()).min(1),
   "annotator_ids": zod.array(zod.string().uuid()).default(modelHubAnnotationQueuesPartialUpdateResponseAnnotatorIdsDefault),
@@ -12163,8 +12175,8 @@ export const ModelHubAnnotationQueuesPartialUpdateResponse = zod.object({
   "completed_count": zod.number().optional(),
   "created_by": zod.string().uuid().optional(),
   "created_by_name": zod.string().min(1).optional(),
-  "viewer_role": zod.string().optional(),
-  "viewer_roles": zod.string().optional(),
+  "viewer_role": zod.string().min(1).optional(),
+  "viewer_roles": zod.array(zod.string().min(1)).optional(),
   "deleted": zod.boolean().optional(),
   "created_at": zod.string().datetime({"offset":true}).optional()
 })
@@ -12527,8 +12539,11 @@ export const modelHubAnnotationQueuesRestoreResponseResultLabelsItemOrderMax = 2
 export const modelHubAnnotationQueuesRestoreResponseResultAnnotatorsItemRoleDefault = `annotator`;
 
 
+
 export const modelHubAnnotationQueuesRestoreResponseResultAnnotatorIdsDefault = [];
 export const modelHubAnnotationQueuesRestoreResponseResultAnnotatorRolesDefault = {  };
+
+
 
 
 export const ModelHubAnnotationQueuesRestoreResponse = zod.object({
@@ -12563,7 +12578,7 @@ export const ModelHubAnnotationQueuesRestoreResponse = zod.object({
   "name": zod.string().min(1).optional(),
   "email": zod.string().email().min(1).optional(),
   "role": zod.string().min(1).default(modelHubAnnotationQueuesRestoreResponseResultAnnotatorsItemRoleDefault),
-  "roles": zod.string().optional()
+  "roles": zod.array(zod.string().min(1)).optional()
 })).optional(),
   "label_ids": zod.array(zod.string().uuid()).min(1),
   "annotator_ids": zod.array(zod.string().uuid()).default(modelHubAnnotationQueuesRestoreResponseResultAnnotatorIdsDefault),
@@ -12576,8 +12591,8 @@ export const ModelHubAnnotationQueuesRestoreResponse = zod.object({
   "completed_count": zod.number().optional(),
   "created_by": zod.string().uuid().optional(),
   "created_by_name": zod.string().min(1).optional(),
-  "viewer_role": zod.string().optional(),
-  "viewer_roles": zod.string().optional(),
+  "viewer_role": zod.string().min(1).optional(),
+  "viewer_roles": zod.array(zod.string().min(1)).optional(),
   "deleted": zod.boolean().optional(),
   "created_at": zod.string().datetime({"offset":true}).optional()
 })
@@ -12611,8 +12626,11 @@ export const modelHubAnnotationQueuesUpdateStatusResponseResultLabelsItemOrderMa
 export const modelHubAnnotationQueuesUpdateStatusResponseResultAnnotatorsItemRoleDefault = `annotator`;
 
 
+
 export const modelHubAnnotationQueuesUpdateStatusResponseResultAnnotatorIdsDefault = [];
 export const modelHubAnnotationQueuesUpdateStatusResponseResultAnnotatorRolesDefault = {  };
+
+
 
 
 export const ModelHubAnnotationQueuesUpdateStatusResponse = zod.object({
@@ -12647,7 +12665,7 @@ export const ModelHubAnnotationQueuesUpdateStatusResponse = zod.object({
   "name": zod.string().min(1).optional(),
   "email": zod.string().email().min(1).optional(),
   "role": zod.string().min(1).default(modelHubAnnotationQueuesUpdateStatusResponseResultAnnotatorsItemRoleDefault),
-  "roles": zod.string().optional()
+  "roles": zod.array(zod.string().min(1)).optional()
 })).optional(),
   "label_ids": zod.array(zod.string().uuid()).min(1),
   "annotator_ids": zod.array(zod.string().uuid()).default(modelHubAnnotationQueuesUpdateStatusResponseResultAnnotatorIdsDefault),
@@ -12660,8 +12678,8 @@ export const ModelHubAnnotationQueuesUpdateStatusResponse = zod.object({
   "completed_count": zod.number().optional(),
   "created_by": zod.string().uuid().optional(),
   "created_by_name": zod.string().min(1).optional(),
-  "viewer_role": zod.string().optional(),
-  "viewer_roles": zod.string().optional(),
+  "viewer_role": zod.string().min(1).optional(),
+  "viewer_roles": zod.array(zod.string().min(1)).optional(),
   "deleted": zod.boolean().optional(),
   "created_at": zod.string().datetime({"offset":true}).optional()
 })
@@ -13113,6 +13131,8 @@ export const modelHubAnnotationQueuesItemsListResponseResultsItemOrderMax = 2147
 
 
 
+
+
 export const modelHubAnnotationQueuesItemsListResponseResultsItemReviewStatusMax = 20;
 
 
@@ -13137,7 +13157,11 @@ export const ModelHubAnnotationQueuesItemsListResponse = zod.object({
 }).passthrough().optional(),
   "assigned_to": zod.string().uuid().optional(),
   "assigned_to_name": zod.string().min(1).optional(),
-  "assigned_users": zod.string().optional(),
+  "assigned_users": zod.array(zod.object({
+  "id": zod.string().uuid(),
+  "name": zod.string().min(1),
+  "email": zod.string().email().min(1)
+})).optional(),
   "reserved_by": zod.string().uuid().optional(),
   "reserved_by_name": zod.string().min(1).optional(),
   "reservation_expires_at": zod.string().datetime({"offset":true}).optional(),
@@ -13146,9 +13170,11 @@ export const ModelHubAnnotationQueuesItemsListResponse = zod.object({
   "reviewed_by_name": zod.string().min(1).optional(),
   "reviewed_at": zod.string().datetime({"offset":true}).optional(),
   "review_notes": zod.string().optional(),
-  "source_preview": zod.string().optional(),
-  "comment_count": zod.string().optional(),
-  "open_feedback_count": zod.string().optional(),
+  "source_preview": zod.object({
+
+}).passthrough().optional().describe('Any valid JSON value.'),
+  "comment_count": zod.number().optional(),
+  "open_feedback_count": zod.number().optional(),
   "created_at": zod.string().datetime({"offset":true}).optional()
 }))
 })
@@ -13375,6 +13401,8 @@ export const modelHubAnnotationQueuesItemsReadResponseOrderMax = 2147483647;
 
 
 
+
+
 export const modelHubAnnotationQueuesItemsReadResponseReviewStatusMax = 20;
 
 
@@ -13395,7 +13423,11 @@ export const ModelHubAnnotationQueuesItemsReadResponse = zod.object({
 }).passthrough().optional(),
   "assigned_to": zod.string().uuid().optional(),
   "assigned_to_name": zod.string().min(1).optional(),
-  "assigned_users": zod.string().optional(),
+  "assigned_users": zod.array(zod.object({
+  "id": zod.string().uuid(),
+  "name": zod.string().min(1),
+  "email": zod.string().email().min(1)
+})).optional(),
   "reserved_by": zod.string().uuid().optional(),
   "reserved_by_name": zod.string().min(1).optional(),
   "reservation_expires_at": zod.string().datetime({"offset":true}).optional(),
@@ -13404,9 +13436,11 @@ export const ModelHubAnnotationQueuesItemsReadResponse = zod.object({
   "reviewed_by_name": zod.string().min(1).optional(),
   "reviewed_at": zod.string().datetime({"offset":true}).optional(),
   "review_notes": zod.string().optional(),
-  "source_preview": zod.string().optional(),
-  "comment_count": zod.string().optional(),
-  "open_feedback_count": zod.string().optional(),
+  "source_preview": zod.object({
+
+}).passthrough().optional().describe('Any valid JSON value.'),
+  "comment_count": zod.number().optional(),
+  "open_feedback_count": zod.number().optional(),
   "created_at": zod.string().datetime({"offset":true}).optional()
 })
 
@@ -13454,6 +13488,8 @@ export const modelHubAnnotationQueuesItemsUpdateResponseOrderMax = 2147483647;
 
 
 
+
+
 export const modelHubAnnotationQueuesItemsUpdateResponseReviewStatusMax = 20;
 
 
@@ -13474,7 +13510,11 @@ export const ModelHubAnnotationQueuesItemsUpdateResponse = zod.object({
 }).passthrough().optional(),
   "assigned_to": zod.string().uuid().optional(),
   "assigned_to_name": zod.string().min(1).optional(),
-  "assigned_users": zod.string().optional(),
+  "assigned_users": zod.array(zod.object({
+  "id": zod.string().uuid(),
+  "name": zod.string().min(1),
+  "email": zod.string().email().min(1)
+})).optional(),
   "reserved_by": zod.string().uuid().optional(),
   "reserved_by_name": zod.string().min(1).optional(),
   "reservation_expires_at": zod.string().datetime({"offset":true}).optional(),
@@ -13483,9 +13523,11 @@ export const ModelHubAnnotationQueuesItemsUpdateResponse = zod.object({
   "reviewed_by_name": zod.string().min(1).optional(),
   "reviewed_at": zod.string().datetime({"offset":true}).optional(),
   "review_notes": zod.string().optional(),
-  "source_preview": zod.string().optional(),
-  "comment_count": zod.string().optional(),
-  "open_feedback_count": zod.string().optional(),
+  "source_preview": zod.object({
+
+}).passthrough().optional().describe('Any valid JSON value.'),
+  "comment_count": zod.number().optional(),
+  "open_feedback_count": zod.number().optional(),
   "created_at": zod.string().datetime({"offset":true}).optional()
 })
 
@@ -13533,6 +13575,8 @@ export const modelHubAnnotationQueuesItemsPartialUpdateResponseOrderMax = 214748
 
 
 
+
+
 export const modelHubAnnotationQueuesItemsPartialUpdateResponseReviewStatusMax = 20;
 
 
@@ -13553,7 +13597,11 @@ export const ModelHubAnnotationQueuesItemsPartialUpdateResponse = zod.object({
 }).passthrough().optional(),
   "assigned_to": zod.string().uuid().optional(),
   "assigned_to_name": zod.string().min(1).optional(),
-  "assigned_users": zod.string().optional(),
+  "assigned_users": zod.array(zod.object({
+  "id": zod.string().uuid(),
+  "name": zod.string().min(1),
+  "email": zod.string().email().min(1)
+})).optional(),
   "reserved_by": zod.string().uuid().optional(),
   "reserved_by_name": zod.string().min(1).optional(),
   "reservation_expires_at": zod.string().datetime({"offset":true}).optional(),
@@ -13562,9 +13610,11 @@ export const ModelHubAnnotationQueuesItemsPartialUpdateResponse = zod.object({
   "reviewed_by_name": zod.string().min(1).optional(),
   "reviewed_at": zod.string().datetime({"offset":true}).optional(),
   "review_notes": zod.string().optional(),
-  "source_preview": zod.string().optional(),
-  "comment_count": zod.string().optional(),
-  "open_feedback_count": zod.string().optional(),
+  "source_preview": zod.object({
+
+}).passthrough().optional().describe('Any valid JSON value.'),
+  "comment_count": zod.number().optional(),
+  "open_feedback_count": zod.number().optional(),
   "created_at": zod.string().datetime({"offset":true}).optional()
 })
 

--- a/futureagi/model_hub/serializers/annotation_queues.py
+++ b/futureagi/model_hub/serializers/annotation_queues.py
@@ -3,6 +3,7 @@ import uuid
 
 from django.db import transaction
 from django.db.models import Q
+from drf_yasg.utils import swagger_serializer_method
 from rest_framework import serializers
 from rest_framework.fields import empty
 
@@ -33,7 +34,19 @@ from model_hub.utils.annotation_queue_helpers import (
     resolve_source_object,
     resolve_source_preview,
 )
+from tfc.utils.serializer_fields import JsonValueField
 from tracer.serializers.filters import StrictInputSerializer, filter_list_field
+
+_ROLE_LIST_SCHEMA = serializers.ListField(child=serializers.CharField())
+_COUNT_SCHEMA = serializers.IntegerField()
+
+
+class QueueItemAssignedUserSerializer(serializers.Serializer):
+    """One entry of ``QueueItemSerializer.assigned_users``."""
+
+    id = serializers.UUIDField()
+    name = serializers.CharField(allow_null=True)
+    email = serializers.EmailField(allow_null=True)
 
 
 class QueueLabelNestedSerializer(serializers.ModelSerializer):
@@ -60,6 +73,7 @@ class QueueAnnotatorNestedSerializer(serializers.ModelSerializer):
         fields = ["id", "user_id", "name", "email", "role", "roles"]
         read_only_fields = ["id"]
 
+    @swagger_serializer_method(serializer_or_field=_ROLE_LIST_SCHEMA)
     def get_roles(self, obj):
         return obj.normalized_roles
 
@@ -98,7 +112,7 @@ class AnnotationQueueSerializer(serializers.ModelSerializer):
     item_count = serializers.IntegerField(read_only=True, required=False)
     completed_count = serializers.IntegerField(read_only=True, required=False)
     created_by_name = serializers.CharField(
-        source="created_by.name", read_only=True, default=None
+        source="created_by.name", read_only=True, default=None, allow_null=True
     )
     viewer_roles = serializers.SerializerMethodField()
     viewer_role = serializers.SerializerMethodField()
@@ -307,6 +321,7 @@ class AnnotationQueueSerializer(serializers.ModelSerializer):
             .first()
         )
 
+    @swagger_serializer_method(serializer_or_field=_ROLE_LIST_SCHEMA)
     def get_viewer_roles(self, obj):
         request = self.context.get("request")
         user = getattr(request, "user", None)
@@ -318,6 +333,9 @@ class AnnotationQueueSerializer(serializers.ModelSerializer):
             membership=self._viewer_membership(obj, user),
         )
 
+    @swagger_serializer_method(
+        serializer_or_field=serializers.CharField(allow_null=True)
+    )
     def get_viewer_role(self, obj):
         roles = self.get_viewer_roles(obj)
         return primary_annotator_role(roles) if roles else None
@@ -463,14 +481,14 @@ class QueueItemSerializer(serializers.ModelSerializer):
     workflow_status = serializers.SerializerMethodField()
     workflow_status_label = serializers.SerializerMethodField()
     assigned_to_name = serializers.CharField(
-        source="assigned_to.name", read_only=True, default=None
+        source="assigned_to.name", read_only=True, default=None, allow_null=True
     )
     assigned_users = serializers.SerializerMethodField()
     reserved_by_name = serializers.CharField(
-        source="reserved_by.name", read_only=True, default=None
+        source="reserved_by.name", read_only=True, default=None, allow_null=True
     )
     reviewed_by_name = serializers.CharField(
-        source="reviewed_by.name", read_only=True, default=None
+        source="reviewed_by.name", read_only=True, default=None, allow_null=True
     )
     comment_count = serializers.SerializerMethodField()
     open_feedback_count = serializers.SerializerMethodField()
@@ -507,6 +525,9 @@ class QueueItemSerializer(serializers.ModelSerializer):
         read_only_fields = ["queue"]
         list_serializer_class = QueueItemListSerializer
 
+    @swagger_serializer_method(
+        serializer_or_field=QueueItemAssignedUserSerializer(many=True)
+    )
     def get_assigned_users(self, obj):
         assignments = getattr(obj, "active_assignments", None)
         if assignments is None:
@@ -520,6 +541,10 @@ class QueueItemSerializer(serializers.ModelSerializer):
             for a in assignments
         ]
 
+    # Open-shaped by design: the keys differ per source_type (a dataset_row
+    # preview carries dataset_id/row_order, a span preview carries span_name
+    # etc.), so there is no one object shape to declare.
+    @swagger_serializer_method(serializer_or_field=JsonValueField())
     def get_source_preview(self, obj):
         # Captured at add time for CH-backed sources, so rendering a page costs no
         # ``spans FINAL`` merge (TH-7211). NULL means "not captured" — a row added
@@ -558,6 +583,7 @@ class QueueItemSerializer(serializers.ModelSerializer):
             "skipped": "Skipped",
         }.get(status, status)
 
+    @swagger_serializer_method(serializer_or_field=_COUNT_SCHEMA)
     def get_comment_count(self, obj):
         # Annotated by QueueItemViewSet.get_queryset; the query is the fallback
         # for callers that serialize an item they fetched themselves.
@@ -570,6 +596,7 @@ class QueueItemSerializer(serializers.ModelSerializer):
             deleted=False,
         ).count()
 
+    @swagger_serializer_method(serializer_or_field=_COUNT_SCHEMA)
     def get_open_feedback_count(self, obj):
         annotated = getattr(obj, "annotated_open_feedback_count", None)
         if annotated is not None:


### PR DESCRIPTION
## Summary

The annotation API response contracts had drifted from the serializers: a single page of 25 rows from `GET /model-hub/annotation-queues/{queue_id}/items/` produced **175 runtime contract validation warnings** in the browser console, and the queue detail endpoint produced 3 more. Nothing was broken at runtime — the API returned correct data throughout. What was wrong was the *declaration*: seven fields per row were typed as required strings in the generated schema while actually returning `null`, arrays, objects, or integers.

The cost is the one the ticket names: the validator cried wolf on every queue page load, which trains everyone to ignore it, so the next real contract break sails through unnoticed. This PR makes those seven fields declare what they actually return, and regenerates the contracts from the serializers.

## Why the changes are done — what is the problem

### Reproduce on dev / main today (before this PR)

1. Open any annotation queue in the app with devtools open.
2. Watch the console on load.
3. `GET .../items/` reports `175 issues` against a 25-row page; `GET /model-hub/annotation-queues/{id}/` reports 3.

```
results.0.assigned_to_name : Expected string, received null
results.0.assigned_users   : Expected string, received array
results.0.source_preview   : Expected string, received object
  … 175 issues on a single page of 25 rows
```

### Where it breaks — BE

Per coding standard 10 (`api-contracts-and-types`) the serializer is the source of truth. Two distinct root causes, both in `model_hub/serializers/annotation_queues.py`:

**1. `SerializerMethodField` with no declared return type.** drf-yasg cannot introspect what a `get_*` method returns, so it falls back to `{"type": "string"}`. Every method field on these serializers was mistyped:

```python
assigned_users = serializers.SerializerMethodField()   # returns a list of dicts
source_preview = serializers.SerializerMethodField()   # returns a dict, or None
comment_count  = serializers.SerializerMethodField()   # returns an int
```

**2. `CharField(source="x.name", default=None)` without `allow_null`.** `default=None` controls the serialization fallback; `allow_null` is what makes drf-yasg emit `x-nullable: true`. Without it the schema declared `{"type": "string", "minLength": 1}` while the wire carried `null` for every unassigned item:

```python
assigned_to_name = serializers.CharField(
    source="assigned_to.name", read_only=True, default=None
)
```

That is exactly 3 nullable name fields + 4 mistyped method fields = **7 failures × 25 rows = 175**.

### Not a defect — `schemaName: null` on the items endpoint

The ticket notes `schemaName: null` on `items/` and reads it as "the response isn't bound to a generated schema". It is bound. The 200 response is the pagination wrapper with `results: {items: {$ref: "#/definitions/QueueItem"}}`. `refSchemaName` at `frontend/src/api/contracts/openapi-contract.js:427-429` returns `null` for any response whose top level is an inline object rather than a bare `$ref`, which is true of every paginated endpoint in the repo. No change needed.

## What changed

### `futureagi/model_hub/serializers/annotation_queues.py`

The only hand-written change. Declares the real response shape for each drifted field:

- Adds `QueueItemAssignedUserSerializer` (`id`/`name`/`email`) as the declared element type for `assigned_users`.
- `@swagger_serializer_method` on `get_roles`, `get_viewer_roles`, `get_viewer_role`, `get_assigned_users`, `get_source_preview`, `get_comment_count`, `get_open_feedback_count`.
- `get_source_preview` declares `JsonValueField` — open-shaped by design, since the keys differ per `source_type` (a `dataset_row` preview carries `dataset_id`/`row_order`, a span preview carries `span_name`), so there is no single object shape to declare.
- `allow_null=True` on `assigned_to_name`, `reserved_by_name`, `reviewed_by_name`, `created_by_name`.

Resulting `QueueItem` definition:

| field | before | after |
| --- | --- | --- |
| `assigned_to_name` / `reserved_by_name` / `reviewed_by_name` | `string`, `minLength: 1` | `+ x-nullable: true` |
| `assigned_users` | `string` | `array` of `$ref: QueueItemAssignedUser` |
| `source_preview` | `string` | `x-json-value` (union including `null`) |
| `comment_count` / `open_feedback_count` | `string` | `integer` |
| `roles` / `viewer_roles` (on `QueueAnnotatorNested` / `AnnotationQueue`) | `string` | `array` of `string` |

### Generated files — no hand edits

`api_contracts/openapi/swagger.json`, `frontend/src/api/contracts/openapi-contract.generated.js`, `frontend/src/generated/api-contracts/api.schemas.ts`, `frontend/src/generated/api-contracts/api.zod.ts` are all regeneration output from the commands below.

## Tests included — what each scenario covers

No new automated tests — this is a schema-declaration change with existing coverage. Verified by replaying representative payloads through the real FE validator (`validateContractedResponse`) and by the existing annotation suites:

- [x] `GET items/` — full 25-row page with `null` names, an `assigned_users` array, and an object `source_preview` → passes (was 175 failures)
- [x] `GET items/` — `source_preview: null` (row added before preview capture) and empty `assigned_users` → passes
- [x] `GET annotation-queues/{id}/` — `roles` and `viewer_roles` as arrays, `created_by_name: null` → passes
- [x] Existing `src/api/contracts/__tests__/` suite → 125 passed
- [x] `model_hub/tests/test_annotation_queues_api_contract.py` + `test_annotation_workflow_api.py` → 181 passed, 6 xfailed, 1 xpassed

## Commands to run tests

```bash
# repo root — regenerate contracts from the serializers
UV_PYTHON=3.13 scripts/generate-openapi-schema.sh
yarn --cwd frontend --ignore-engines contracts:generate
yarn --cwd frontend --ignore-engines contracts:check

# cwd: futureagi
bin/test model_hub/tests/test_annotation_queues_api_contract.py \
         model_hub/tests/test_annotation_workflow_api.py -q

# cwd: frontend
yarn --ignore-engines vitest run src/api/contracts/__tests__/
```

### Local verification results

```
============ 181 passed, 6 xfailed, 1 xpassed in 273.77s (0:04:33) =============

 Test Files  6 passed (6)
      Tests  125 passed (125)

Management API contract coverage:
  paths: 978
  operations: 1323
  operations without response schemas: 0/0
  broad success response schemas: 0/0
Endpoint registry contract coverage:
  apiPath calls backed by Swagger: 787/787
```

`ruff check` and `ruff format --check` clean on the changed serializer.

## Video

_N/A — no user-visible behaviour change._

## Screenshot of test suit run

_See Local verification results above._

## Backwards compatibility

**Schema-only. No semantics change.** No serializer output changed — every value on the wire is byte-identical before and after. Only the *declared* types changed, to match what was already being sent.

| Caller | Impact |
| --- | --- |
| Existing FE consumers | None at runtime. The runtime validator now accepts the nulls the API actually returns, and `assigned_users` / the counts gain accurate generated types. Note orval drops Swagger 2.0 `x-nullable`, so `assigned_to_name` stays `string` in `api.schemas.ts` — only the runtime contract knows it is nullable. Code already handling these correctly keeps working; code that assumed `string` was already wrong against real data. |
| API clients off the published schema | Strictly more accurate. Previously-undeclared nullability is now declared. |
| Backend callers | None — no `get_*` method body changed. |

## Manual verification (UI)

1. Open any annotation queue with devtools open.
2. Confirm the `items/` warnings are gone — previously 175 per page load, now none.
3. Page through the grid; confirm rows with no assignee, no reviewer, and no captured `source_preview` still render and emit no warnings.
4. Confirm the items grid, assignee chips, and comment/feedback counts render unchanged.

## Type of change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📖 Documentation
- [ ] 🧹 Chore / refactor
- [ ] 🚀 Performance
- [ ] 🧪 Test-only

## Checklist

- [x] Follows the repo style guide; `ruff check` / `ruff format --check` clean
- [x] Contracts regenerated from the serializers, not hand-edited
- [x] `yarn contracts:check` passes
- [x] Existing tests run and passing
- [x] No secrets, internal URLs, or PII in the diff

## Known remaining drift — follow-up

`GET /model-hub/annotation-queues/{id}/` still warns `label_ids: Required`, and `POST .../update-status/` reports it as `result.label_ids` (same definition — `QueueStatusResponse.result` is `$ref: AnnotationQueue`). This is a **different root cause** and deliberately out of scope here.

`label_ids` is `write_only=True, required=True`. OpenAPI 2.0 has no `writeOnly` keyword and drf-yasg has no `write_only` handling at all, so it emits one definition per serializer shared by request and response — a field that can never appear in a response is declared required in it. This affects **37 write-only fields across 11 serializer files**; `label_ids` is simply the one the FE validates today.

Fixing it properly means a global marker (`x-write-only`) plus a symmetric carve-out in `openapi-contract.js` alongside the existing `readOnly`-on-request branch — which changes the swagger definitions across the whole API surface and does not belong in an annotation-scoped bugfix. Tracked for follow-up.

## Backout / rollback

Revert this commit and re-run the two generator commands. No migrations, no data changes, no config changes — reverting restores the previous schema exactly.

## Linear

Closes TH-6877

