### PR TITLE
fix(annotations): archive action visibility and settings-tab archive

### DIFF
--- a/frontend/src/sections/annotations/labels/annotation-label-table.jsx
+++ b/frontend/src/sections/annotations/labels/annotation-label-table.jsx
@@ -463,9 +463,10 @@ export default function AnnotationLabelTable({
               onClick={() => handleAction("archive")}
               sx={{ color: "error.main" }}
             >
-              <SvgColor
-                src="/assets/icons/ic_delete.svg"
-                sx={{ width: 18, height: 18, mr: 1, color: "error.main" }}
+              <Iconify
+                icon="solar:archive-down-bold"
+                width={18}
+                sx={{ mr: 1, color: "error.main" }}
               />
               Archive
             </MenuItem>

--- a/frontend/src/sections/annotations/queues/__tests__/annotation-queue-empty.test.jsx
+++ b/frontend/src/sections/annotations/queues/__tests__/annotation-queue-empty.test.jsx
@@ -16,7 +16,9 @@ describe("AnnotationQueueEmpty", () => {
   it("renders heading and description", () => {
     render(<AnnotationQueueEmpty onCreateClick={() => {}} />);
 
-    expect(screen.getByText("No annotation queues yet")).toBeInTheDocument();
+    expect(
+      screen.getByText("No Active annotation queues yet"),
+    ).toBeInTheDocument();
     expect(
       screen.getByText(/Create your first annotation queue/),
     ).toBeInTheDocument();

--- a/frontend/src/sections/annotations/queues/annotation-queue-empty.jsx
+++ b/frontend/src/sections/annotations/queues/annotation-queue-empty.jsx
@@ -37,7 +37,7 @@ export default function AnnotationQueueEmpty({ onCreateClick }) {
         />
       </Box>
       <Typography variant="h6" gutterBottom>
-        No annotation queues yet
+        No Active annotation queues yet
       </Typography>
       <Typography variant="body2" color="text.secondary" sx={{ mb: 3 }}>
         Create your first annotation queue to start collecting human feedback.

--- a/frontend/src/sections/annotations/queues/annotation-queue-table.jsx
+++ b/frontend/src/sections/annotations/queues/annotation-queue-table.jsx
@@ -871,12 +871,12 @@ export default function AnnotationQueueTable({
 
               <MenuItem
                 onClick={() => handleAction("archive")}
-                sx={{ color: "warning.main" }}
+                sx={{ color: "error.main" }}
               >
                 <Iconify
                   icon="solar:archive-down-bold"
                   width={18}
-                  sx={{ mr: 1 }}
+                  sx={{ mr: 1, color: "error.main" }}
                 />
                 Archive
               </MenuItem>

--- a/frontend/src/sections/annotations/queues/view/annotation-queues-view.jsx
+++ b/frontend/src/sections/annotations/queues/view/annotation-queues-view.jsx
@@ -277,6 +277,71 @@ export default function AnnotationQueuesView() {
       <Box sx={{ flexShrink: 0, px: 3 }}>
         <AnnotationsTabs />
       </Box>
+      <Stack
+        direction="row"
+        spacing={2}
+        mb={2}
+        alignItems="center"
+        flexShrink={0}
+      >
+        <FormSearchField
+          size="small"
+          placeholder="Search"
+          searchQuery={searchInput}
+          onChange={handleSearch}
+          sx={{
+            minWidth: "250px",
+            "& .MuiOutlinedInput-root": { height: "30px" },
+          }}
+        />
+        <ToggleButtonGroup
+          exclusive
+          size="small"
+          value={filters.archived ? "archived" : "active"}
+          onChange={handleArchiveViewChange}
+          sx={{
+            height: 30,
+            "& .MuiToggleButton-root": {
+              px: 1.25,
+              borderRadius: "4px",
+              typography: "s2",
+              fontWeight: "fontWeightMedium",
+            },
+          }}
+        >
+          <ToggleButton value="active">Active</ToggleButton>
+          <ToggleButton value="archived">Archived</ToggleButton>
+        </ToggleButtonGroup>
+        <TextField
+          size="small"
+          select
+          value={filters.status}
+          onChange={handleStatusFilter}
+          sx={{ minWidth: 160 }}
+          SelectProps={{
+            displayEmpty: true,
+            renderValue: (v) =>
+              STATUS_OPTIONS.find((o) => o.value === v)?.label ||
+              "All Statuses",
+          }}
+        >
+          {STATUS_OPTIONS.map((opt) => (
+            <MenuItem key={opt.value} value={opt.value}>
+              {opt.label}
+            </MenuItem>
+          ))}
+        </TextField>
+        <Box sx={{ flex: 1 }} />
+        <Button
+          variant="contained"
+          color="primary"
+          startIcon={<Iconify icon="mingcute:add-line" />}
+          onClick={handleCreateNew}
+          disabled={!canWrite}
+        >
+          Create Queue
+        </Button>
+      </Stack>
 
       {isEmpty ? (
         <AnnotationQueueEmpty onCreateClick={handleCreateNew} />
@@ -290,72 +355,6 @@ export default function AnnotationQueuesView() {
             px: 3,
           }}
         >
-          <Stack
-            direction="row"
-            spacing={2}
-            mb={2}
-            alignItems="center"
-            flexShrink={0}
-          >
-            <FormSearchField
-              size="small"
-              placeholder="Search"
-              searchQuery={searchInput}
-              onChange={handleSearch}
-              sx={{
-                minWidth: "250px",
-                "& .MuiOutlinedInput-root": { height: "30px" },
-              }}
-            />
-            <ToggleButtonGroup
-              exclusive
-              size="small"
-              value={filters.archived ? "archived" : "active"}
-              onChange={handleArchiveViewChange}
-              sx={{
-                height: 30,
-                "& .MuiToggleButton-root": {
-                  px: 1.25,
-                  borderRadius: "4px",
-                  typography: "s2",
-                  fontWeight: "fontWeightMedium",
-                },
-              }}
-            >
-              <ToggleButton value="active">Active</ToggleButton>
-              <ToggleButton value="archived">Archived</ToggleButton>
-            </ToggleButtonGroup>
-            <TextField
-              size="small"
-              select
-              value={filters.status}
-              onChange={handleStatusFilter}
-              sx={{ minWidth: 160 }}
-              SelectProps={{
-                displayEmpty: true,
-                renderValue: (v) =>
-                  STATUS_OPTIONS.find((o) => o.value === v)?.label ||
-                  "All Statuses",
-              }}
-            >
-              {STATUS_OPTIONS.map((opt) => (
-                <MenuItem key={opt.value} value={opt.value}>
-                  {opt.label}
-                </MenuItem>
-              ))}
-            </TextField>
-            <Box sx={{ flex: 1 }} />
-            <Button
-              variant="contained"
-              color="primary"
-              startIcon={<Iconify icon="mingcute:add-line" />}
-              onClick={handleCreateNew}
-              disabled={!canWrite}
-            >
-              Create Queue
-            </Button>
-          </Stack>
-
           <AnnotationQueueTable
             data={results}
             loading={isLoading}

--- a/frontend/src/sections/annotations/queues/view/queue-settings-tab.jsx
+++ b/frontend/src/sections/annotations/queues/view/queue-settings-tab.jsx
@@ -23,8 +23,11 @@ import {
   TextField,
   Typography,
 } from "@mui/material";
+import { LoadingButton } from "@mui/lab";
 import { Controller, useForm, FormProvider } from "react-hook-form";
+import Iconify from "src/components/iconify";
 import {
+  useArchiveAnnotationQueue,
   useHardDeleteAnnotationQueue,
   useUpdateAnnotationQueue,
   useUpdateAnnotationQueueStatus,
@@ -78,11 +81,20 @@ const RESERVATION_TIMEOUT_OPTIONS = [
 ];
 
 export default function QueueSettingsTab({ queue, queueId, creatorId }) {
+  const navigate = useNavigate();
   const { mutate: updateQueue, isPending: isUpdating } =
     useUpdateAnnotationQueue();
   const { mutate: updateStatus, isPending: isStatusUpdating } =
     useUpdateAnnotationQueueStatus();
+  const { mutate: archiveQueue, isPending: isArchiving } =
+    useArchiveAnnotationQueue();
   const isPending = isUpdating || isStatusUpdating;
+
+
+  const handleArchive = () => {
+    navigate("/dashboard/annotations/queues");
+    archiveQueue(queueId);
+  };
 
   const methods = useForm({
     defaultValues: {
@@ -494,7 +506,24 @@ export default function QueueSettingsTab({ queue, queueId, creatorId }) {
           </Card>
 
           {/* Save */}
-          <Box sx={{ display: "flex", justifyContent: "flex-end", pb: 3 }}>
+          <Box
+            sx={{
+              display: "flex",
+              justifyContent: "flex-end",
+              gap: 2,
+              pb: 3,
+            }}
+          >
+            <LoadingButton
+              type="button"
+              variant="outlined"
+              color="error"
+              loading={isArchiving}
+              startIcon={<Iconify icon="solar:archive-down-bold" />}
+              onClick={handleArchive}
+            >
+              Archive Queue
+            </LoadingButton>
             <Button
               type="submit"
               variant="contained"


### PR DESCRIPTION
Two archive-related fixes on the annotation queues, one commit each.

### Archive action invisible in light theme [TH-5844](https://linear.app/future-agi/issue/TH-5844)

The Archive item in the queue actions menu was `warning.main` — `#F5E65F`, a pale yellow that all but disappears as flat text on the light popover. It is now `error.main`, with the icon colored explicitly rather than left to inherit.

The icons were also inconsistent between the two tables: the labels table showed `ic_delete.svg`, a trash can, for an action that archives rather than deletes. Both tables now use `solar:archive-down-bold` for Archive and `solar:archive-up-bold` for Restore, with Edit and Duplicate keeping their existing `SvgColor` assets.

Also included: the queues view now keeps its filter bar above the empty state, so the search, Active/Archived toggle, and status filter stay reachable when a tab has no rows, and the empty-state copy names the Active tab. The empty-state test was updated to match.

### Archive from the queue settings tab [TH-5842](https://linear.app/future-agi/issue/TH-5842)

Archiving previously required going back to the list. There is now an Archive Queue button beside Save Changes in the settings tab. It archives immediately with no confirmation dialog, as requested — the archive is a soft delete, so recovery is via the Archived tab.

One detail worth knowing: the handler navigates to the queue list *before* firing the mutation. `useArchiveAnnotationQueue` invalidates the whole `["annotation-queues"]` key, which is a prefix of both `detail(id)` and `progress(id)`. With the detail page still mounted, that invalidation refetched the queue and its progress for a queue that had just been archived. Unmounting first leaves no active observer, so only the list refetches.

### Testing

`npx vitest run src/sections/annotations` — 309 tests pass. The archive button and the menu colors have not been checked in a browser.
