### PR TITLE
fix(annotations): scope annotation label restore by the resolved organization

### DIFF
--- a/futureagi/model_hub/tests/test_annotation_labels_api.py
+++ b/futureagi/model_hub/tests/test_annotation_labels_api.py
@@ -13,6 +13,14 @@ import uuid
 import pytest
 from rest_framework import status
 
+from accounts.models.organization_membership import OrganizationMembership
+from accounts.models.user import User
+from accounts.models.workspace import WorkspaceMembership
+from conftest import WorkspaceAwareAPIClient
+from model_hub.models.develop_annotations import AnnotationsLabels
+from tfc.constants.levels import Level
+from tfc.constants.roles import OrganizationRoles
+
 BASE_URL = "/model-hub/annotations-labels/"
 
 
@@ -446,6 +454,128 @@ class TestArchiveAndRestore:
         # Don't archive — try to restore directly
         resp = auth_client.post(restore_url(label_id))
         assert resp.status_code == status.HTTP_404_NOT_FOUND
+
+
+@pytest.fixture
+def membership_only_user(db, organization, workspace):
+    """A member whose org access comes only from ``OrganizationMembership``.
+
+    ``User.organization`` is the legacy nullable FK. Members provisioned through
+    RBAC never get it populated — they reach their organization through an
+    active membership row instead.
+    """
+    user = User.objects.create_user(
+        email=f"membership-only-{uuid.uuid4().hex[:8]}@futureagi.com",
+        password="testpassword123",
+        name="Membership Only User",
+        organization=None,
+        organization_role=None,
+    )
+    org_membership = OrganizationMembership.no_workspace_objects.create(
+        user=user,
+        organization=organization,
+        role=OrganizationRoles.MEMBER,
+        level=Level.MEMBER,
+        is_active=True,
+    )
+    WorkspaceMembership.no_workspace_objects.create(
+        user=user,
+        workspace=workspace,
+        role=OrganizationRoles.WORKSPACE_MEMBER,
+        level=Level.WORKSPACE_MEMBER,
+        is_active=True,
+        organization_membership=org_membership,
+    )
+    # ``assign_workspace_organization_post_save`` backfills a blank organization
+    # from the thread-local context, which the ``user`` fixture sets. Null the FK
+    # through the queryset so no signal fires — this user must reach its org
+    # through the membership alone.
+    User.objects.filter(pk=user.pk).update(organization=None)
+    user.refresh_from_db()
+    return user
+
+
+@pytest.fixture
+def membership_only_client(membership_only_user, workspace):
+    """Workspace-scoped client, so ``request.organization`` is populated."""
+    client = WorkspaceAwareAPIClient()
+    client.force_authenticate(user=membership_only_user)
+    client.set_workspace(workspace)
+    yield client
+    client.stop_workspace_injection()
+
+
+@pytest.fixture
+def membership_only_client_without_workspace(membership_only_user):
+    """No workspace header, so the view must fall back to active membership."""
+    client = WorkspaceAwareAPIClient()
+    client.force_authenticate(user=membership_only_user)
+    yield client
+    client.stop_workspace_injection()
+
+
+@pytest.mark.django_db
+class TestRestoreOrganizationScoping:
+    """Restore must scope by the resolved org, not ``user.organization``.
+
+    ``restore`` used to filter on ``request.user.organization``. That FK is NULL
+    for membership-only users, so the lookup became ``organization_id IS NULL``;
+    ``AnnotationsLabels.organization`` is non-nullable, so every restore 404'd
+    even though the label was listable. The rest of this module passes either
+    way because its fixtures set the legacy FK — these two do not.
+    """
+
+    @staticmethod
+    def _create_and_archive(client, name):
+        create_resp = create_label(client, name=name)
+        assert create_resp.status_code == status.HTTP_200_OK, create_resp.data
+        label_id = create_resp.data["result"]["id"]
+
+        delete_resp = client.delete(detail_url(label_id))
+        assert delete_resp.status_code in (
+            status.HTTP_200_OK,
+            status.HTTP_204_NO_CONTENT,
+        ), delete_resp.data
+        return label_id
+
+    def test_restore_for_member_without_legacy_user_organization(
+        self, membership_only_client, membership_only_user
+    ):
+        """Org comes from the request, not the null ``user.organization`` FK."""
+        # Canary: if a fixture ever backfills the FK this stops covering the
+        # regression, so fail loudly rather than pass vacuously.
+        assert membership_only_user.organization_id is None
+
+        name = "Membership Only Restorable"
+        label_id = self._create_and_archive(membership_only_client, name)
+
+        resp = membership_only_client.post(restore_url(label_id))
+
+        assert resp.status_code == status.HTTP_200_OK, resp.data
+        assert resp.data["status"] is True
+        assert resp.data["result"]["archived"] is False
+
+        list_resp = membership_only_client.get(BASE_URL, {"search": name})
+        assert [str(row["id"]) for row in list_resp.data["results"]] == [str(label_id)]
+
+    def test_restore_falls_back_to_active_membership(
+        self, membership_only_client_without_workspace, membership_only_user
+    ):
+        """No workspace header: the org resolves from the active membership."""
+        assert membership_only_user.organization_id is None
+
+        client = membership_only_client_without_workspace
+        label_id = self._create_and_archive(client, "Membership Fallback Restorable")
+
+        resp = client.post(restore_url(label_id))
+
+        assert resp.status_code == status.HTTP_200_OK, resp.data
+        assert resp.data["status"] is True
+        assert resp.data["result"]["archived"] is False
+
+        restored = AnnotationsLabels.all_objects.get(pk=label_id)
+        assert restored.deleted is False
+        assert restored.deleted_at is None
 
 
 # ---------------------------------------------------------------------------

--- a/futureagi/model_hub/views/develop_annotations.py
+++ b/futureagi/model_hub/views/develop_annotations.py
@@ -440,7 +440,7 @@ class AnnotationsLabelsViewSet(BaseModelViewSetMixinWithUserOrg, viewsets.ModelV
             label = AnnotationsLabels.all_objects.get(
                 pk=pk,
                 deleted=True,
-                organization=request.user.organization,
+                organization=get_request_organization(request),
             )
         except AnnotationsLabels.DoesNotExist:
             return self._gm.not_found("Label not found or not archived.")


### PR DESCRIPTION
## Summary

`POST /model-hub/annotations-labels/{id}/restore/` returned `404 "Label not found or not archived."` for archived labels the same user could see in the list endpoint. The lookup was scoped by the legacy `user.organization` FK instead of the org the authenticator actually resolved for the request, so for a large class of users it could never match a row.

One-line fix: use the `get_request_organization` helper that this file already imports and already uses elsewhere.

## Why the changes are done — what is the problem

### Reproduce on dev today (before this PR)

1. Sign in as a user who joined an org by invite, or who has switched orgs at least once.
2. Archive an annotation label (or pick an existing archived one).
3. `GET /model-hub/annotations-labels/?archived=true` → the label **is** listed.
4. `POST /model-hub/annotations-labels/{that_id}/restore/` → **404**:

```json
{ "status": false, "type": "not_found", "code": "not_found",
  "detail": "Label not found or not archived." }
```

Confirmed on dev with label `f03e2aa1-a19d-447c-b56d-1601f7453a56`.

### Where it breaks — BE

`futureagi/model_hub/views/develop_annotations.py:440-444`

```python
label = AnnotationsLabels.all_objects.get(
    pk=pk,
    deleted=True,
    organization=request.user.organization,   # legacy FK
)
```

`User.organization` is `null=True` (`accounts/models/user.py:58-64`) and is only the **4th** entry in the authenticator's resolution order (`accounts/authentication.py:271-281`):

> 1. API key's organization · 2. `X-Organization-Id` header · 3. `user.config["currentOrganizationId"]` · 4. `user.organization` (legacy FK fallback) · 5. First active `OrganizationMembership`

Two distinct failure modes:

1. **Membership-only users** — joined by invite/SSO, no legacy FK — have `user.organization is None`. The filter degenerates to `organization_id IS NULL`; `AnnotationsLabels.organization` is non-nullable, so it matches **zero rows**. Restore could never succeed for these users, on any label.
2. **Users who switched orgs** — `request.organization` (resolved from header/config) diverges from the legacy FK, so restore 404s on labels the list endpoint returns. Same for system API keys, where `request.user` is merely the org's oldest user (`accounts/authentication.py:183-189`).

**The asymmetry is the tell.** Line 443 was the *only* site in this ~2000-line file using the bare legacy FK. Every other org-resolution site — 273, 463, 545, 597, 665, 1660, 2073 — already prefers `request.organization`. Critically, `get_queryset` (which powers `?archived=true`) uses `getattr(self.request, "organization", None)` at `:180` / `:187`. That is exactly why the label is *visible* but not *restorable*.

## What changed

### `futureagi/model_hub/views/develop_annotations.py`

```diff
-                organization=request.user.organization,
+                organization=get_request_organization(request),
```

`get_request_organization` (`accounts/utils.py:102-107`) prefers `request.organization` and falls back to the user's **active membership** (`get_user_organization`, `:90-99`) rather than the nullable legacy FK — covering both failure modes above.

No new import: it is already imported at line 10 and already used in this same viewset at line 416 (`perform_create`).

### `futureagi/model_hub/tests/test_annotation_labels_api.py`

New `TestRestoreOrganizationScoping` class plus a `membership_only_user` fixture — a user with a **null** legacy `organization` FK whose org access comes only from an active `OrganizationMembership`.

## Tests included — what each scenario covers

| # | Test | Setup | Action | What it pins |
| --- | --- | --- | --- | --- |
| 1 | `test_restore_for_member_without_legacy_user_organization` | Membership-only user, client sends `X-Workspace-Id` so `request.organization` **is** populated | Create → archive → restore | Restore resolves the org from the request, not the null FK |
| 2 | `test_restore_falls_back_to_active_membership` | Same user, **no** workspace header, so `request.organization` is never set | Create → archive → restore, then assert the DB row | The `get_user_organization` membership-fallback branch |

**Why two and not one:** test 1 alone would also pass under the weaker `getattr(request, "organization", None) or request.user.organization`. Only test 2 pins the membership fallback the fix actually relies on.

Both open with a canary — `assert membership_only_user.organization_id is None` — so the tests fail loudly rather than pass vacuously if a fixture ever backfills the FK.

**Proven red before green.** Reverting `develop_annotations.py:443` to `organization=request.user.organization` fails both with the exact production payload:

```
E   AssertionError: {'code': 'not_found', 'detail': 'Label not found or not archived.', ...}
FAILED ...::test_restore_for_member_without_legacy_user_organization
FAILED ...::test_restore_falls_back_to_active_membership
```

**Why the existing tests never caught this:** every other fixture sets `user.organization`, so the legacy FK and the resolved org always agree under test — a revert of this line stays green across the whole suite.

**One trap worth flagging for reviewers:** the naive fixture did *not* reproduce the bug. `assign_workspace_organization_post_save` (`tfc/utils/signals.py:91-99`) backfills any blank `organization` from the thread-local context, so `User.objects.create_user(..., organization=None)` silently came back with the FK populated and both tests passed for the wrong reason. The canary caught it. The fixture now nulls the FK via `User.objects.filter(pk=...).update(...)`, which bypasses signals. The pre-existing membership-only pattern at `test_develop_annotations_api.py:1085-1106` has the same latent issue — it just never asserts on the FK.

Also verified against the existing suites covering this endpoint:

- [x] `test_annotation_labels_api.py` — the DELETE + `POST /restore/` suite (`:385`)
- [x] `test_develop_annotations_api.py` — annotation label CRUD
- [x] `test_team_a_annotations_full_matrix.py` — exercises label restore directly (`:1125`)
- [x] `test_annotation_api_contract.py` — contract coverage for `/annotations-labels/{id}/restore/` (`:186`, `:255`)
- [x] Full annotation-queue suite — no collateral damage elsewhere in the area

## Commands to run tests

```bash
# cwd: futureagi

# the new regression tests on their own
bin/test model_hub/tests/test_annotation_labels_api.py -k RestoreOrganizationScoping -q

bin/test model_hub/tests/test_annotation_labels_api.py \
         model_hub/tests/test_develop_annotations_api.py -q

bin/test model_hub/tests/test_team_a_annotations_full_matrix.py \
         model_hub/tests/test_annotation_api_contract.py -q

# whole annotation-queue area
bin/test $(find model_hub/tests -name 'test_*queue*.py' | sort) -q
```

### Local verification results

```
model_hub/tests/test_annotation_labels_api.py ..
====================== 2 passed, 33 deselected in 26.58s =======================

model_hub/tests/test_annotation_labels_api.py ...........................
model_hub/tests/test_develop_annotations_api.py ..........................
============================= 110 passed in 23.78s =============================

model_hub/tests/test_team_a_annotations_full_matrix.py ...................
model_hub/tests/test_annotation_api_contract.py ..................
============================= 157 passed in 47.90s =============================
```

Whole annotation-queue area, 11 files:

```
collected 229 items

model_hub/tests/test_annotation_queues_api.py .............................. [ 27%]
model_hub/tests/test_annotation_queues_api_errors.py ....................... [ 55%]
model_hub/tests/test_annotation_queues_ch_sources.py .......                 [ 58%]
model_hub/tests/test_distributed_queue_progress.py ....                      [ 59%]
model_hub/tests/test_migration_backfill_queueitem_project.py .....           [ 62%]
model_hub/tests/test_per_queue_scoring_e2e.py ...............                [ 68%]
model_hub/tests/test_queue_archive_restore_e2e.py ......                     [ 71%]
model_hub/tests/test_queue_items_api.py ..............................       [ 84%]
model_hub/tests/test_annotation_queue_serializers.py ......................  [ 96%]
model_hub/tests/test_annotation_queues_api_contract.py ...                   [ 97%]
model_hub/tests/test_ch25_annotation_queue_session_validation_sliceE.py sssss [100%]

================== 224 passed, 5 skipped in 94.44s (0:01:34) ===================
```

(The 5 skips are the pre-existing CH25 session-validation slice, unrelated to this change.)

`ruff check` and `ruff format --check` clean on both changed files.

## Video

_N/A — API-only fix, no UI change._

## Screenshot of test suit run

_See Local verification results above._

## Backwards compatibility

**Strictly widening. No schema change, no contract change, no migration.**

| Caller | Impact |
| --- | --- |
| Users where the legacy FK already matched the resolved org | **No change.** `get_request_organization` returns `request.organization`, which is the same org. |
| Membership-only users (legacy FK null) | Restore now works instead of always 404ing. |
| Users who switched orgs / system API keys | Restore now resolves against the active org, matching what the list endpoint already returns. |
| Cross-org access | **Unchanged — not widened.** The lookup is still org-scoped; it is scoped by the *correctly resolved* org. `request.organization` is only set after `user.can_access_organization(org)` passes (`accounts/authentication.py:296-300`), so a user still cannot restore another org's label. |

## Manual verification (UI)

1. Sign in as a user who has switched orgs, or one who joined by invite.
2. Open annotation labels and toggle "show archived".
3. Restore an archived label — it now succeeds instead of returning 404.
4. Confirm the label reappears in the live (non-archived) list.
5. Confirm restoring a label id from a different org still returns 404.

## Type of change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📖 Documentation
- [ ] 🧹 Chore / refactor
- [ ] 🚀 Performance
- [ ] 🧪 Test-only

## Checklist

- [x] Follows the repo style guide; `ruff check` / `ruff format --check` clean
- [x] Reuses the existing `get_request_organization` helper rather than adding a new one
- [x] Regression test added, and verified to fail on the pre-fix line
- [x] Existing tests run and passing (110 + 157 + 224)
- [x] No secrets, internal URLs, or PII in the diff

## Follow-up (not in this PR)

1. **Repo-wide sweep** for bare `request.user.organization` without a `request.organization` fallback — likely to surface more of this same bug class. Only `develop_annotations.py` was audited here.
2. **Cross-tenant listing hole in the same file.** `get_queryset`'s `archived=true` / `include_archived` branches (`views/develop_annotations.py:176-190`) apply the organization filter only `if org is not None`, with no `else`. If `request.organization` is ever unset, those branches list archived labels across **all** organizations. Latent rather than actively exploitable — the authenticator almost always resolves an org — but it is a cross-tenant leak by construction. Test 2 deliberately avoids `?archived=true` so it does not depend on that behaviour.

## Backout / rollback

Revert this commit. Single-line change, no migrations, no config, no data changes.

## Linear

Closes TH-7531
