### PR TITLE
fix: dedup voice_call_detail spans with FINAL

### DIFF
--- a/futureagi/model_hub/tests/test_voice_annotation_regressions_e2e.py
+++ b/futureagi/model_hub/tests/test_voice_annotation_regressions_e2e.py
@@ -868,14 +868,13 @@ class TestVoiceAnnotationRegressionE2E:
     ):
         """voice_call_detail must surface the simulation path context.
 
-        The ``OPTIMIZE TABLE spans FINAL`` below works around a production bug:
-        ``voice_call_detail``'s root-span query has no ``FINAL`` and no
-        ``argMax(_, _version)`` dedup, so it can return a stale
-        ReplacingMergeTree row and drop ``call_execution_id``. Delete the
-        OPTIMIZE once the query is fixed.
+        The fixture seeds this span without eval_attributes and the re-seed
+        below adds them, so two ReplacingMergeTree rows share the id. The
+        endpoint's root-span query reads with ``FINAL``, so the later,
+        eval-bearing row must win without any table maintenance here — this
+        doubles as the regression test for that dedup.
         """
         from tracer.tests._ch_seed import (
-            _get_ch_client,
             seed_ch_span,
             seed_ch_trace,
         )
@@ -918,14 +917,6 @@ class TestVoiceAnnotationRegressionE2E:
         # (PG tracer_trace is dropped on CH25), so the trace row must be seeded too;
         # seeding only the span leaves the traces lookup empty (404).
         seed_ch_trace(observe_trace)
-        # The fixture seeded this span without eval_attributes and the re-seed
-        # above added them, so two ReplacingMergeTree rows share the id. Merge
-        # them so the later, eval-bearing row wins deterministically.
-        _ch = _get_ch_client()
-        try:
-            _ch.command("OPTIMIZE TABLE spans FINAL")
-        finally:
-            _ch.close()
 
         resp = auth_client.get(
             "/tracer/trace/voice_call_detail/",

--- a/futureagi/tracer/tests/test_voice_call_detail_final_dedup.py
+++ b/futureagi/tracer/tests/test_voice_call_detail_final_dedup.py
@@ -1,0 +1,173 @@
+"""voice_call_detail must collapse ReplacingMergeTree version rows.
+
+Re-ingesting a span (poll/webhook upsert) writes a second CH row with the
+same sort key and a higher ``_version``; until background merges run, both
+rows coexist. The endpoint reads with ``FINAL`` so the newest version wins
+and tombstones (``is_deleted=1``) drop out. These tests seed duplicate
+versions directly and pin that behavior end-to-end.
+"""
+
+import uuid
+from datetime import timedelta
+
+import pytest
+from django.utils import timezone
+from rest_framework import status
+
+from model_hub.models.ai_model import AIModel
+from tracer.models.observation_span import ObservationSpan
+from tracer.models.project import Project
+from tracer.models.trace import Trace
+from tracer.tests._ch_seed import seed_ch_span, seed_ch_trace
+
+VOICE_CALL_DETAIL_URL = "/tracer/trace/voice_call_detail/"
+
+
+@pytest.fixture
+def observe_project(db, organization, workspace):
+    return Project.objects.create(
+        name=f"Voice Detail Dedup {uuid.uuid4().hex[:8]}",
+        organization=organization,
+        workspace=workspace,
+        model_type=AIModel.ModelTypes.GENERATIVE_LLM,
+        trace_type="observe",
+    )
+
+
+@pytest.fixture
+def observe_trace(db, observe_project):
+    trace = Trace.objects.create(
+        project=observe_project,
+        name="Voice dedup trace",
+        input={"prompt": "hi"},
+        output={"response": "hello"},
+    )
+    seed_ch_trace(trace)
+    return trace
+
+
+def _make_root_span(project, trace, raw_log: dict) -> ObservationSpan:
+    return ObservationSpan.objects.create(
+        id=f"voice_root_{uuid.uuid4().hex[:16]}",
+        project=project,
+        trace=trace,
+        name="Voice root conversation",
+        observation_type="conversation",
+        provider="vapi",
+        start_time=timezone.now() - timedelta(seconds=30),
+        end_time=timezone.now(),
+        latency_ms=1000,
+        status="OK",
+        span_attributes={"raw_log": raw_log},
+    )
+
+
+def _get_detail(auth_client, trace):
+    return auth_client.get(VOICE_CALL_DETAIL_URL, {"trace_id": str(trace.id)})
+
+
+@pytest.mark.django_db
+class TestVoiceCallDetailFinalDedup:
+    def test_root_span_latest_version_wins(
+        self, auth_client, observe_project, observe_trace
+    ):
+        """The production TH-7458 shape: a stale 'in-progress' stub is
+        superseded by a re-ingested 'ended' row with recordings — the detail
+        endpoint must serve the newer version."""
+        span = _make_root_span(
+            observe_project,
+            observe_trace,
+            {"id": "call-123", "status": "in-progress"},
+        )
+        seed_ch_span(span)
+
+        span.span_attributes = {
+            "raw_log": {
+                "id": "call-123",
+                "status": "ended",
+                "recordingUrl": "https://recordings.example/call-123.wav",
+            }
+        }
+        span.save(update_fields=["span_attributes"])
+        seed_ch_span(span)  # second CH row, same sort key, higher _version
+
+        resp = _get_detail(auth_client, observe_trace)
+        assert resp.status_code == status.HTTP_200_OK, resp.data
+        result = resp.data["result"]
+        assert result["status"] == "completed"
+        assert result["recording_url"] == "https://recordings.example/call-123.wav"
+
+    def test_idempotent_reingest_serves_one_call(
+        self, auth_client, observe_project, observe_trace
+    ):
+        """Re-fetching the same call twice (the remediation script re-runs are
+        idempotent) writes two identical CH rows — FINAL must still resolve to a
+        single, correct call rather than erroring or duplicating."""
+        span = _make_root_span(
+            observe_project,
+            observe_trace,
+            {"id": "call-456", "status": "ended"},
+        )
+        seed_ch_span(span)
+        seed_ch_span(span)  # identical re-ingest, same sort key + status
+
+        resp = _get_detail(auth_client, observe_trace)
+        assert resp.status_code == status.HTTP_200_OK, resp.data
+        assert resp.data["result"]["status"] == "completed"
+        assert resp.data["result"]["call_id"] == "call-456"
+
+    def test_child_span_versions_collapse_to_one_entry(
+        self, auth_client, observe_project, observe_trace
+    ):
+        """A re-ingested child span must appear once, with the newest fields."""
+        root = _make_root_span(
+            observe_project,
+            observe_trace,
+            {"id": "call-789", "status": "ended"},
+        )
+        seed_ch_span(root)
+
+        child = ObservationSpan.objects.create(
+            id=f"voice_child_{uuid.uuid4().hex[:16]}",
+            project=observe_project,
+            trace=observe_trace,
+            parent_span_id=root.id,
+            name="llm turn v1",
+            observation_type="generation",
+            start_time=timezone.now() - timedelta(seconds=20),
+            end_time=timezone.now() - timedelta(seconds=19),
+            latency_ms=500,
+            status="OK",
+        )
+        seed_ch_span(child)
+
+        child.name = "llm turn v2"
+        child.save(update_fields=["name"])
+        seed_ch_span(child)
+
+        resp = _get_detail(auth_client, observe_trace)
+        assert resp.status_code == status.HTTP_200_OK, resp.data
+        spans = resp.data["result"]["observation_span"]
+        child_entries = [s for s in spans if s["id"] == child.id]
+        assert len(child_entries) == 1
+        assert child_entries[0]["name"] == "llm turn v2"
+
+    def test_tombstoned_root_span_is_not_resurrected(
+        self, auth_client, observe_project, observe_trace
+    ):
+        """Dropping the explicit ``is_deleted = 0`` predicate must not leak
+        deleted spans: the two-arg RMT engine removes tombstoned rows under
+        FINAL, so a soft-deleted call returns 404 — the stale live version
+        must not be resurrected."""
+        span = _make_root_span(
+            observe_project,
+            observe_trace,
+            {"id": "call-del", "status": "ended"},
+        )
+        seed_ch_span(span)
+
+        span.deleted = True
+        seed_ch_span(span)  # tombstone: is_deleted=1, higher _version
+
+        resp = _get_detail(auth_client, observe_trace)
+        assert resp.status_code == status.HTTP_404_NOT_FOUND

--- a/futureagi/tracer/views/trace.py
+++ b/futureagi/tracer/views/trace.py
@@ -2635,13 +2635,13 @@ class TraceView(BaseModelViewSetMixin, ModelViewSet):
             attrs_number,
             attrs_bool,
             toJSONString(metadata) AS metadata_json
-        FROM spans
+        FROM spans FINAL
         WHERE project_id = toUUID(%(project_id)s)
           AND trace_id = %(trace_id)s
-          AND is_deleted = 0
           AND (parent_span_id IS NULL OR parent_span_id = '')
           AND observation_type = 'conversation'
         LIMIT 1
+        SETTINGS use_skip_indexes_if_final = 1
         """
         root_result = analytics.execute_ch_query(
             root_query,
@@ -2741,13 +2741,13 @@ class TraceView(BaseModelViewSetMixin, ModelViewSet):
             toJSONString(metadata) AS metadata_json,
             status_message,
             tags
-        FROM spans
+        FROM spans FINAL
         WHERE project_id = toUUID(%(project_id)s)
           AND trace_id = %(trace_id)s
-          AND is_deleted = 0
           AND parent_span_id IS NOT NULL
         ORDER BY start_time ASC
         LIMIT 1 BY id
+        SETTINGS use_skip_indexes_if_final = 1
         """
         child_result = analytics.execute_ch_query(
             child_query,


### PR DESCRIPTION
## Summary

`voice_call_detail` read the ClickHouse `spans` (ReplacingMergeTree) table without `FINAL`, so a re-ingested/upserted span served an arbitrary stale version — a completed voice call showed as **In progress** with no recordings, while the newer `ended` row existed in CH (and the voice-call *list* rendered it correctly, since its attrs query already uses `FINAL`). Surfaced in prod after the TH-7458 stuck-call remediation.

## Linked issues

Linear: Fixed TH-7512

## Type of change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

---

## 1) What changes were done

**A. `voice_call_detail` root + child span queries (`tracer/views/trace.py`)**

- `FROM spans` → `FROM spans FINAL`
- add `SETTINGS use_skip_indexes_if_final = 1` (bare `FINAL` disables skip indexes → full-scan/OOM on a trace-id read)
- drop the `is_deleted = 0` predicate — the two-arg `ReplacingMergeTree(_version, is_deleted)` engine already removes tombstones under `FINAL`, and keeping the predicate alongside the skip-index setting arms the documented resurrection bug (the `is_deleted` minmax index can prune the tombstone granule pre-merge)
- matches the canonical `CHSpanReader` idiom (`services/clickhouse/v2/span_reader.py`, `_FINAL_SKIP_INDEX_SETTINGS`) and the existing voice-call list attrs query

**B. Tests**

- `model_hub/tests/test_voice_annotation_regressions_e2e.py`: removed the `OPTIMIZE TABLE spans FINAL` workaround (its docstring asked for deletion once this query got `FINAL`) — now a genuine regression guard
- `tracer/tests/test_voice_call_detail_final_dedup.py` (new): latest-version-wins, idempotent re-ingest, child-span collapse, tombstone-not-resurrected (404)

## 2) Why the changes were done

- **Product/UX:** completed voice calls (with transcripts + recordings) rendered as stale "In progress" on the detail page after any re-ingest, until background merges eventually collapsed the duplicate — on settled partitions that may never happen.
- **Technical:** query-time dedup is the correct fix (no data migration, no `OPTIMIZE`); brings the last non-`FINAL` span read in line with the rest of the CH v2 read path.

## Testing

- `tracer/tests/test_voice_call_detail_final_dedup.py` — 4/4 pass
- `model_hub/tests/test_voice_annotation_regressions_e2e.py` — 56/56 pass
- `tracer/tests/test_voice_call_detail_org_scope.py` — 2/2 pass

## Follow-ups (not in this PR)

- prev/next navigation queries in `_get_trace_id_by_index_observe_clickhouse` have a milder stale-read variant
- `traces` project-lookup query in the same endpoint reads without `FINAL`
- `parent_span_id IS NOT NULL` is vacuously true (non-Nullable String) — root leaks into the child list
- no `max_memory_usage` cap / `start_time` bound on these analytics reads