### PR TITLE
feat(tasks): add a re-run button to the task detail header [TH-7298]

### DIFF
--- a/frontend/src/sections/common/EvalsTasks/EditTaskDrawer/TaskConfirmBox.jsx
+++ b/frontend/src/sections/common/EvalsTasks/EditTaskDrawer/TaskConfirmBox.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 import PropTypes from "prop-types";
 import {
   Dialog,
@@ -77,6 +77,12 @@ export default function TaskConfirmDialog({
   ...other
 }) {
   const [editType, setEditType] = useState("fresh_run");
+
+  // The dialog stays mounted between opens, so a previous "edit_rerun" pick
+  // would still be selected next time — and the other option deletes data.
+  useEffect(() => {
+    if (open) setEditType("fresh_run");
+  }, [open]);
 
   const handleConfirm = () => {
     onConfirm(editType);

--- a/frontend/src/sections/common/EvalsTasks/EditTaskDrawer/__tests__/TaskConfirmBox.test.jsx
+++ b/frontend/src/sections/common/EvalsTasks/EditTaskDrawer/__tests__/TaskConfirmBox.test.jsx
@@ -1,0 +1,57 @@
+import React from "react";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import TaskConfirmDialog from "../TaskConfirmBox";
+
+const renderDialog = (props) =>
+  render(
+    <TaskConfirmDialog
+      title="Update Task"
+      content="Select one of the options"
+      open
+      onClose={vi.fn()}
+      {...props}
+    />,
+  );
+
+describe("TaskConfirmDialog", () => {
+  it("reports the option the user picked", () => {
+    const onConfirm = vi.fn();
+    renderDialog({ onConfirm });
+
+    fireEvent.click(screen.getByText("Edit & Re-run Existing Evals"));
+    fireEvent.click(screen.getByRole("button", { name: /run task/i }));
+
+    expect(onConfirm).toHaveBeenCalledWith("edit_rerun");
+  });
+
+  it("resets to the safe default when reopened, so a past pick cannot leak into the next run", () => {
+    const onConfirm = vi.fn();
+    const { rerender } = renderDialog({ onConfirm });
+
+    fireEvent.click(screen.getByText("Edit & Re-run Existing Evals"));
+
+    rerender(
+      <TaskConfirmDialog
+        title="Update Task"
+        content="Select one of the options"
+        open={false}
+        onClose={vi.fn()}
+        onConfirm={onConfirm}
+      />,
+    );
+    rerender(
+      <TaskConfirmDialog
+        title="Update Task"
+        content="Select one of the options"
+        open
+        onClose={vi.fn()}
+        onConfirm={onConfirm}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /run task/i }));
+
+    expect(onConfirm).toHaveBeenCalledWith("fresh_run");
+  });
+});

--- a/frontend/src/sections/tasks/TaskDetailPage.jsx
+++ b/frontend/src/sections/tasks/TaskDetailPage.jsx
@@ -31,6 +31,7 @@ import {
   getNewTaskFilters,
 } from "./schema";
 import TaskConfirmDialog from "src/sections/common/EvalsTasks/EditTaskDrawer/TaskConfirmBox";
+import CustomTooltip from "src/components/tooltip/CustomTooltip";
 
 const getTaskDetailsErrorMessage = (error) =>
   error?.result ||
@@ -73,7 +74,7 @@ const TaskDetailPage = () => {
     RolePermission.OBSERVABILITY[PERMISSIONS.ADD_TASKS_ALERTS][role];
   const queryClient = useQueryClient();
   const [tab, setTab] = useState("details");
-  const [confirmOpen, setConfirmOpen] = useState(false);
+  const [confirmMode, setConfirmMode] = useState(null);
 
   // Test runner — imperative handle from the live preview
   const previewRef = useRef(null);
@@ -117,20 +118,27 @@ const TaskDetailPage = () => {
 
   // ── Mutations ──
   const { mutate: updateTask, isPending: isUpdating } = useMutation({
-    mutationFn: (data) =>
+    mutationFn: ({ payload }) =>
       axios.patch(endpoints.project.patchEvalTask(), {
-        ...data,
+        ...payload,
         eval_task_id: taskId,
       }),
-    onSuccess: () => {
+    onSuccess: (_data, { mode }) => {
       queryClient.invalidateQueries({ queryKey: ["taskDetails", taskId] });
       queryClient.invalidateQueries({ queryKey: ["eval-tasks"] });
-      enqueueSnackbar("Task updated successfully", { variant: "success" });
+      enqueueSnackbar(
+        mode === "rerun" ? "Re-run started" : "Task updated successfully",
+        { variant: "success" },
+      );
     },
-    onError: (err) => {
-      enqueueSnackbar(err?.response?.data?.result || "Failed to update task", {
-        variant: "error",
-      });
+    onError: (err, { mode }) => {
+      enqueueSnackbar(
+        err?.response?.data?.result ||
+          (mode === "rerun"
+            ? "Failed to start the re-run"
+            : "Failed to update task"),
+        { variant: "error" },
+      );
     },
   });
 
@@ -201,12 +209,22 @@ const TaskDetailPage = () => {
     },
   });
 
-  // Transform form → update payload (same logic as EditTaskDrawerV2)
-  const handleSave = useCallback(() => {
-    handleSubmit(() => {
-      setConfirmOpen(true);
-    })();
-  }, [handleSubmit]);
+  // Re-run is reachable from the Logs tab, where an invalid field isn't
+  // rendered — a silent validation failure would read as a broken button.
+  const openConfirm = useCallback(
+    (mode) =>
+      handleSubmit(
+        () => setConfirmMode(mode),
+        () => {
+          setTab("details");
+          enqueueSnackbar(
+            "Fix the highlighted fields before running this task.",
+            { variant: "error" },
+          );
+        },
+      )(),
+    [handleSubmit],
+  );
 
   const handleConfirm = useCallback(
     (editType) => {
@@ -232,10 +250,10 @@ const TaskDetailPage = () => {
         spans_limit: data.spansLimit ? Number(data.spansLimit) : undefined,
         edit_type: editType,
       };
-      updateTask(transformedData);
-      setConfirmOpen(false);
+      updateTask({ payload: transformedData, mode: confirmMode });
+      setConfirmMode(null);
     },
-    [formValues, updateTask],
+    [formValues, updateTask, confirmMode],
   );
 
   if (isLoading) {
@@ -303,6 +321,13 @@ const TaskDetailPage = () => {
   const canResume = status === "paused";
   const linkedTraceSource = getLinkedTraceSource(taskDetails);
 
+  // A re-run mid-flight would race the live run.
+  const rerunBlockedReason = !canEditTask
+    ? "You don't have permission to run tasks."
+    : status === "running" || status === "pending"
+      ? "Wait for the current run to finish."
+      : "";
+
   // Pause/Resume stay in the header
   const headerActions = (
     <>
@@ -354,6 +379,30 @@ const TaskDetailPage = () => {
           Resume
         </Button>
       )}
+      <CustomTooltip
+        show={!!rerunBlockedReason}
+        title={rerunBlockedReason}
+        size="small"
+      >
+        <span>
+          <LoadingButton
+            variant="outlined"
+            size="small"
+            onClick={() => openConfirm("rerun")}
+            loading={isUpdating}
+            disabled={!!rerunBlockedReason}
+            startIcon={<Iconify icon="solar:restart-linear" width={14} />}
+            sx={{
+              textTransform: "none",
+              fontWeight: 500,
+              fontSize: "12px",
+              height: 30,
+            }}
+          >
+            Re-run
+          </LoadingButton>
+        </span>
+      </CustomTooltip>
     </>
   );
 
@@ -515,7 +564,7 @@ const TaskDetailPage = () => {
           <LoadingButton
             variant="contained"
             size="small"
-            onClick={handleSave}
+            onClick={() => openConfirm("save")}
             loading={isUpdating}
             disabled={!canEditTask}
             sx={{ textTransform: "none", fontWeight: 500, minWidth: 140 }}
@@ -526,10 +575,11 @@ const TaskDetailPage = () => {
       )}
 
       <TaskConfirmDialog
-        title="Update Task"
+        title={confirmMode === "rerun" ? "Re-run Task" : "Update Task"}
         content="Select one of the options"
-        open={confirmOpen}
-        onClose={() => setConfirmOpen(false)}
+        confirmText={confirmMode === "rerun" ? "Re-run" : "Run task"}
+        open={!!confirmMode}
+        onClose={() => setConfirmMode(null)}
         onConfirm={handleConfirm}
         isLoading={isUpdating}
       />

--- a/frontend/src/sections/tasks/__tests__/TaskDetailPage.test.jsx
+++ b/frontend/src/sections/tasks/__tests__/TaskDetailPage.test.jsx
@@ -1,13 +1,15 @@
 import React from "react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { MemoryRouter, Route, Routes } from "react-router-dom";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import TaskDetailPage from "../TaskDetailPage";
 import { useGetTaskData } from "src/sections/common/EvalsTasks/common";
+import { enqueueSnackbar } from "src/components/snackbar";
 
 const axiosPatchMock = vi.hoisted(() => vi.fn());
 const axiosPostMock = vi.hoisted(() => vi.fn());
+const confirmDialogMock = vi.hoisted(() => vi.fn());
 
 vi.mock("src/utils/axios", () => ({
   default: {
@@ -80,7 +82,14 @@ vi.mock("../components/TaskUsageTab", () => ({
 }));
 
 vi.mock("src/sections/common/EvalsTasks/EditTaskDrawer/TaskConfirmBox", () => ({
-  default: () => null,
+  default: (props) => {
+    confirmDialogMock(props);
+    return props.open ? <div>{props.title}</div> : null;
+  },
+}));
+
+vi.mock("src/auth/hooks", () => ({
+  useAuthContext: () => ({ role: "Admin" }),
 }));
 
 const renderTaskDetail = (taskId = "missing-task") => {
@@ -121,6 +130,8 @@ describe("TaskDetailPage", () => {
     axiosPostMock.mockReset();
     axiosPostMock.mockResolvedValue({ data: { result: {} } });
     useGetTaskData.mockReset();
+    confirmDialogMock.mockReset();
+    enqueueSnackbar.mockReset();
   });
 
   it("shows a not-found state instead of an endless spinner when the task API fails", () => {
@@ -192,5 +203,160 @@ describe("TaskDetailPage", () => {
     expect(
       screen.getByRole("button", { name: /open source/i }),
     ).toBeInTheDocument();
+  });
+
+  it("labels the confirm dialog as an update when it comes from Save", async () => {
+    useGetTaskData.mockReturnValue({
+      data: loadedTask({ evals_applied: [{ id: "eval-1" }] }),
+      isLoading: false,
+      isError: false,
+    });
+
+    renderTaskDetail("task-1");
+    fireEvent.click(screen.getByRole("button", { name: /^save$/i }));
+
+    expect(await screen.findByText("Update Task")).toBeInTheDocument();
+    expect(confirmDialogMock).toHaveBeenLastCalledWith(
+      expect.objectContaining({ confirmText: "Run task" }),
+    );
+  });
+
+  it("opens the confirm dialog as a re-run when it comes from the header", async () => {
+    useGetTaskData.mockReturnValue({
+      data: loadedTask({ evals_applied: [{ id: "eval-1" }] }),
+      isLoading: false,
+      isError: false,
+    });
+
+    renderTaskDetail("task-1");
+    fireEvent.click(screen.getByRole("button", { name: /re-run/i }));
+
+    expect(await screen.findByText("Re-run Task")).toBeInTheDocument();
+    expect(confirmDialogMock).toHaveBeenLastCalledWith(
+      expect.objectContaining({ confirmText: "Re-run" }),
+    );
+  });
+
+  it("submits the same mutation Save uses when Re-run is confirmed", async () => {
+    useGetTaskData.mockReturnValue({
+      data: loadedTask({ evals_applied: [{ id: "eval-1" }] }),
+      isLoading: false,
+      isError: false,
+    });
+
+    renderTaskDetail("task-1");
+    fireEvent.click(screen.getByRole("button", { name: /re-run/i }));
+
+    await screen.findByText("Re-run Task");
+
+    const { onConfirm } = confirmDialogMock.mock.calls.at(-1)[0];
+    await act(async () => {
+      onConfirm("fresh_run");
+    });
+
+    await waitFor(() => {
+      expect(axiosPatchMock).toHaveBeenCalledWith(
+        "/tracer/eval-task/update_eval_task/",
+        expect.objectContaining({
+          edit_type: "fresh_run",
+          evals: ["eval-1"],
+          eval_task_id: "task-1",
+        }),
+      );
+    });
+  });
+
+  it("blocks re-running a task that is still going, which would race the live run", () => {
+    useGetTaskData.mockReturnValue({
+      data: loadedTask({
+        status: "running",
+        evals_applied: [{ id: "eval-1" }],
+      }),
+      isLoading: false,
+      isError: false,
+    });
+
+    renderTaskDetail("task-1");
+
+    expect(screen.getByRole("button", { name: /re-run/i })).toBeDisabled();
+  });
+
+  it("sends the user back to Details when a re-run is attempted on an invalid form", async () => {
+    useGetTaskData.mockReturnValue({
+      data: loadedTask({ evals_applied: [] }),
+      isLoading: false,
+      isError: false,
+    });
+
+    renderTaskDetail("task-1");
+    fireEvent.click(screen.getByRole("tab", { name: /logs/i }));
+    expect(screen.getByText("logs")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: /re-run/i }));
+
+    await waitFor(() => {
+      expect(enqueueSnackbar).toHaveBeenCalledWith(
+        "Fix the highlighted fields before running this task.",
+        { variant: "error" },
+      );
+    });
+    expect(screen.getByText("panels")).toBeInTheDocument();
+  });
+
+  it("reports a re-run, not an update, when the Re-run confirm resolves", async () => {
+    useGetTaskData.mockReturnValue({
+      data: loadedTask({ evals_applied: [{ id: "eval-1" }] }),
+      isLoading: false,
+      isError: false,
+    });
+
+    renderTaskDetail("task-1");
+    fireEvent.click(screen.getByRole("button", { name: /re-run/i }));
+
+    await screen.findByText("Re-run Task");
+
+    const { onConfirm } = confirmDialogMock.mock.calls.at(-1)[0];
+    await act(async () => {
+      onConfirm("fresh_run");
+    });
+
+    await waitFor(() => {
+      expect(enqueueSnackbar).toHaveBeenCalledWith("Re-run started", {
+        variant: "success",
+      });
+    });
+    expect(enqueueSnackbar).not.toHaveBeenCalledWith(
+      "Task updated successfully",
+      expect.anything(),
+    );
+  });
+
+  it("still reports an update, not a re-run, when the Save confirm resolves", async () => {
+    useGetTaskData.mockReturnValue({
+      data: loadedTask({ evals_applied: [{ id: "eval-1" }] }),
+      isLoading: false,
+      isError: false,
+    });
+
+    renderTaskDetail("task-1");
+    fireEvent.click(screen.getByRole("button", { name: /^save$/i }));
+
+    await screen.findByText("Update Task");
+
+    const { onConfirm } = confirmDialogMock.mock.calls.at(-1)[0];
+    await act(async () => {
+      onConfirm("edit");
+    });
+
+    await waitFor(() => {
+      expect(enqueueSnackbar).toHaveBeenCalledWith(
+        "Task updated successfully",
+        { variant: "success" },
+      );
+    });
+    expect(enqueueSnackbar).not.toHaveBeenCalledWith(
+      "Re-run started",
+      expect.anything(),
+    );
   });
 });

--- a/frontend/src/theme/overrides/components/__tests__/chip.test.js
+++ b/frontend/src/theme/overrides/components/__tests__/chip.test.js
@@ -1,0 +1,73 @@
+import { createTheme } from "@mui/material/styles";
+import { describe, expect, it } from "vitest";
+import { chip } from "../chip";
+
+const darkTheme = createTheme({ palette: { mode: "dark" } });
+
+// The override returns an array of style objects; flatten it the way emotion
+// would so a single assertion can look at the merged result.
+const rootStyles = (theme, ownerState) =>
+  Object.assign({}, ...chip(theme).MuiChip.styleOverrides.root({ ownerState }));
+
+describe("chip theme override", () => {
+  it("leaves a non-clickable filled default chip alone on hover", () => {
+    const styles = rootStyles(darkTheme, {
+      color: "default",
+      variant: "filled",
+    });
+
+    expect(styles["&:hover"]).toBeUndefined();
+  });
+
+  it("repaints a clickable filled default chip on hover, using the plain &:hover selector", () => {
+    const styles = rootStyles(darkTheme, {
+      color: "default",
+      variant: "filled",
+      clickable: true,
+    });
+
+    expect(styles["&:hover"]).toEqual({
+      backgroundColor: darkTheme.palette.grey[100],
+    });
+  });
+
+  it("leaves a non-clickable soft default chip alone on hover", () => {
+    const styles = rootStyles(darkTheme, {
+      color: "default",
+      variant: "soft",
+    });
+
+    expect(styles["&:hover"]).toBeUndefined();
+  });
+
+  it("repaints a clickable soft default chip on hover", () => {
+    const styles = rootStyles(darkTheme, {
+      color: "default",
+      variant: "soft",
+      clickable: true,
+    });
+
+    expect(styles["&:hover"]).toBeDefined();
+  });
+
+  it("leaves a non-clickable filled coloured chip alone on hover", () => {
+    const styles = rootStyles(darkTheme, {
+      color: "primary",
+      variant: "filled",
+    });
+
+    expect(styles["&:hover"]).toBeUndefined();
+  });
+
+  it("repaints a clickable filled coloured chip on hover", () => {
+    const styles = rootStyles(darkTheme, {
+      color: "primary",
+      variant: "filled",
+      clickable: true,
+    });
+
+    expect(styles["&:hover"]).toEqual({
+      backgroundColor: darkTheme.palette.primary.dark,
+    });
+  });
+});

--- a/frontend/src/theme/overrides/components/chip.js
+++ b/frontend/src/theme/overrides/components/chip.js
@@ -39,11 +39,15 @@ export function chip(theme) {
             ? theme.palette.common.white
             : theme.palette.grey[800],
           backgroundColor: theme.palette.text.primary,
-          "&:hover": {
-            backgroundColor: lightMode
-              ? theme.palette.grey[700]
-              : theme.palette.grey[100],
-          },
+          // Gated in JS, not via a class selector: the emitted rule must stay
+          // a plain `&:hover` or it outranks per-chip `sx` hover overrides.
+          ...(ownerState.clickable && {
+            "&:hover": {
+              backgroundColor: lightMode
+                ? theme.palette.grey[700]
+                : theme.palette.grey[100],
+            },
+          }),
           [`& .${chipClasses.icon}`]: {
             color: lightMode
               ? theme.palette.common.white
@@ -58,9 +62,11 @@ export function chip(theme) {
         ...(softVariant && {
           color: theme.palette.text.primary,
           backgroundColor: alpha(theme.palette.grey[500], 0.16),
-          "&:hover": {
-            backgroundColor: alpha(theme.palette.grey[500], 0.32),
-          },
+          ...(ownerState.clickable && {
+            "&:hover": {
+              backgroundColor: alpha(theme.palette.grey[500], 0.32),
+            },
+          }),
         }),
       }),
     };
@@ -73,17 +79,21 @@ export function chip(theme) {
         },
         // FILLED
         ...(filledVariant && {
-          "&:hover": {
-            backgroundColor: theme.palette[color].dark,
-          },
+          ...(ownerState.clickable && {
+            "&:hover": {
+              backgroundColor: theme.palette[color].dark,
+            },
+          }),
         }),
         // SOFT
         ...(softVariant && {
           color: theme.palette[color][lightMode ? "dark" : "light"],
           backgroundColor: alpha(theme.palette[color].main, 0.16),
-          "&:hover": {
-            backgroundColor: alpha(theme.palette[color].main, 0.32),
-          },
+          ...(ownerState.clickable && {
+            "&:hover": {
+              backgroundColor: alpha(theme.palette[color].main, 0.32),
+            },
+          }),
         }),
       }),
     }));


### PR DESCRIPTION
**Ticket:** [TH-7298](https://linear.app/future-agi/issue/TH-7298/allow-running-only-errored-evals-in-eval-task-or-re-run-whole-task) — Closes TH-7298

## What was the bug

The only way to re-run an eval task was the **Save** button, which lives in a footer that renders on the **Details** tab alone. A user looking at a failed run on the **Logs** tab had no way to re-run it without navigating back to Details and pressing a button labelled "Save" — a label that doesn't say "run".

Two smaller defects sat behind the same flow, plus one unrelated dark-theme bug in the shared chip styling.

## What changes have been done

- `src/sections/tasks/TaskDetailPage.jsx` — added a **Re-run** button to the header (visible on every tab); replaced the `confirmOpen` boolean with a `confirmMode` discriminator (`null | "save" | "rerun"`) so one dialog can word itself per entry point; gave the shared validated submit an `onInvalid` branch; threaded the mode through the mutation so the success toast reports a re-run.
- `src/sections/common/EvalsTasks/EditTaskDrawer/TaskConfirmBox.jsx` — reset the radio selection to `fresh_run` each time the dialog opens.
- `src/theme/overrides/components/chip.js` — gated four chip hover rules on `ownerState.clickable`.
- Tests added across all three areas (`chip.test.js`, `TaskConfirmBox.test.jsx`, `TaskDetailPage.test.jsx`).

## Why the changes

- **Re-run button.** The header's `actions` slot renders on all three tabs, so this is the only placement that makes re-running reachable from Logs. It reuses `openConfirm` and `handleConfirm` unchanged, so the payload is identical to Save's — there's a test asserting the PATCH body to keep it that way. The icon is `solar:restart-linear`: `solar:play-circle-linear` already means **Resume** in this same header, and `mdi:refresh` means "reload this view" everywhere else in the app.
- **Dialog reset.** `editType` was component state that never reset, so the dialog reopened on the previous pick. Harmless with one entry point; with two it's a wrong default on the option that deletes past evaluation data.
- **Validation feedback.** `handleSubmit` had no `onInvalid`, so an invalid form silently did nothing. From the Logs tab the offending field isn't even mounted, so the button looked broken. It now switches to Details — where the field errors render — and raises a toast.
- **Toast wording.** `onSuccess` said "Task updated successfully" regardless of entry point, so Re-run reported an update. The mode is passed as a mutation variable (not in the request body) and the toast now reads "Re-run started" on that path. Save's wording is unchanged.
- **Chip hover.** The theme declared a bare `&:hover` on every default filled chip. Chips setting their own `bgcolor` via `sx` won the base rule but lost the nested hover, so in dark mode they repainted to `grey[100]` with light text — unreadable. Gating in JS on `ownerState.clickable` keeps the emitted rule a plain `&:hover`, so per-chip `sx` overrides still win. Using a `.MuiChip-clickable:hover` selector instead would have raised specificity above `sx` and pushed the same bug onto clickable chips.

## Test cases — what each scenario covers

| # | Scenario | Expected |
|---|----------|----------|
| 1 | Re-run from the header | Dialog opens titled "Re-run Task" with a "Re-run" confirm button |
| 2 | Save from the footer | Dialog still titled "Update Task" with "Run task" — unchanged |
| 3 | Re-run confirmed | PATCH carries `edit_type` and the evals — identical body to Save |
| 4 | Re-run succeeds | Toast reads "Re-run started"; Save still reads "Task updated successfully" |
| 5 | Task is running or pending | Re-run disabled with a tooltip explaining why |
| 6 | Re-run on an invalid form from Logs | Switches to Details and raises an error toast instead of no-opping |
| 7 | Dialog reopened after picking "Edit & Re-run" | Selection is back on "Delete Past Data & Start Fresh" |
| 8 | Non-clickable chip hovered | No hover repaint — text stays readable in dark mode |
| 9 | Clickable chip hovered | Hover repaint preserved; per-chip `sx` overrides still win |

33 tests passing across `src/sections/tasks`, `src/sections/common/EvalsTasks`, `src/theme`.

## How to reproduce (original bug)

1. Open a task that has finished or failed
2. Go to the **Logs** tab
3. There is no way to re-run the task from here — the only control is Save, on the Details tab
4. Separately, in dark mode: hover a variable-mapping chip on the Details tab and the chip turns near-white with unreadable text

## Commands

```bash
cd frontend
npx vitest run src/sections/tasks src/sections/common/EvalsTasks src/theme
```

## Known follow-up

Re-run is disabled while a task is `running`/`pending`, but **Save** — which fires the same mutation — is not. Left as-is deliberately for this PR; worth a separate decision on whether Save should carry the same guard.

## Videos and screenshots

All captured against the local stack in dark theme.

**Re-run in the header — completed task**

![Re-run enabled](https://github.com/user-attachments/assets/24fb99d4-9869-4234-bb4c-d8cae01fcaa0)

**The dialog it opens** — titled "Re-run Task" with a "Re-run" confirm, versus Save's unchanged "Update Task" / "Run task"

![Re-run modal](https://github.com/user-attachments/assets/77953903-a470-450e-b371-31f80cac2c9e)

**Disabled while the task is running**, with the reason rather than a dead button

![Re-run disabled with tooltip](https://github.com/user-attachments/assets/da5d6be1-a3e9-4c78-9f03-1650bd6629df)

**Invalid form from the Logs tab** — previously a silent no-op. Now it returns to Details, where the offending field actually renders, and says so.

![Invalid form recovery](https://github.com/user-attachments/assets/022e2e24-ca6f-4095-8565-0b154e63a1ef)

**Chip hover in dark theme — before and after.** Same chip, hovered, in both shots.

Before — `rgb(240, 240, 245)` background under `rgb(161, 161, 170)` text:

![Chip hover before](https://github.com/user-attachments/assets/b9ad62eb-2f0e-4116-a201-2fbea5434624)

After — stays `rgb(24, 24, 27)`:

![Chip hover after](https://github.com/user-attachments/assets/8685e73d-b90a-48f9-8ae8-2a457407dcb5)

> Not captured: the "Re-run started" success toast. Confirming a re-run would actually run the task, and the dialog's default option deletes past evaluation data — covered by tests instead.
