### PR TITLE
Fix critical authentication vulnerabilities

### DIFF
--- a/agentcc-gateway/internal/mcp/server.go
+++ b/agentcc-gateway/internal/mcp/server.go
@@ -177,21 +177,24 @@ func (s *Server) HandlePost(w http.ResponseWriter, r *http.Request) {
 	// Per-key tool filtering: authenticate bearer token and inject allowed/denied tools into context.
 	req := r
 	if s.keyAuth != nil {
-		if rawKey := extractBearerToken(r); rawKey != "" {
-			allowed, denied, valid := s.keyAuth.AuthenticateKey(rawKey)
-			if !valid {
-				writeJSONRPCError(w, msg.ID, ErrCodeInvalidRequest, "invalid or inactive API key")
-				return
-			}
-			ctx := r.Context()
-			if len(allowed) > 0 {
-				ctx = context.WithValue(ctx, ctxKeyAllowedTools, allowed)
-			}
-			if len(denied) > 0 {
-				ctx = context.WithValue(ctx, ctxKeyDeniedTools, denied)
-			}
-			req = r.WithContext(ctx)
+		rawKey := extractBearerToken(r)
+		if rawKey == "" {
+			writeJSONRPCError(w, msg.ID, ErrCodeInvalidRequest, "missing API key")
+			return
 		}
+		allowed, denied, valid := s.keyAuth.AuthenticateKey(rawKey)
+		if !valid {
+			writeJSONRPCError(w, msg.ID, ErrCodeInvalidRequest, "invalid or inactive API key")
+			return
+		}
+		ctx := r.Context()
+		if len(allowed) > 0 {
+			ctx = context.WithValue(ctx, ctxKeyAllowedTools, allowed)
+		}
+		if len(denied) > 0 {
+			ctx = context.WithValue(ctx, ctxKeyDeniedTools, denied)
+		}
+		req = r.WithContext(ctx)
 	}
 
 	// Route by method.

--- a/agentcc-gateway/internal/mcp/server_test.go
+++ b/agentcc-gateway/internal/mcp/server_test.go
@@ -434,6 +434,10 @@ func TestServerToolCallWithMockUpstream(t *testing.T) {
 // --- Helpers ---
 
 func initializeSession(t *testing.T, s *Server) string {
+	return initializeSessionWithHeaders(t, s, nil)
+}
+
+func initializeSessionWithHeaders(t *testing.T, s *Server, headers map[string]string) string {
 	t.Helper()
 	params := InitializeParams{
 		ProtocolVersion: ProtocolVersion,
@@ -446,7 +450,7 @@ func initializeSession(t *testing.T, s *Server) string {
 		Method:  MethodInitialize,
 		Params:  paramsData,
 	}
-	w := postMCP(t, s, msg, nil)
+	w := postMCP(t, s, msg, headers)
 	sessionID := w.Header().Get("MCP-Session-Id")
 	if sessionID == "" {
 		t.Fatal("failed to initialize session")
@@ -662,7 +666,9 @@ func TestPerKeyToolFiltering_AllowedList(t *testing.T) {
 		},
 	})
 
-	sessionID := initializeSession(t, s)
+	sessionID := initializeSessionWithHeaders(t, s, map[string]string{
+		"Authorization": "Bearer key-readonly",
+	})
 
 	// List tools with the readonly key — should only see list_repos.
 	msg := &Message{JSONRPC: "2.0", ID: json.RawMessage(`2`), Method: MethodToolsList}
@@ -706,7 +712,9 @@ func TestPerKeyToolFiltering_DeniedList(t *testing.T) {
 		},
 	})
 
-	sessionID := initializeSession(t, s)
+	sessionID := initializeSessionWithHeaders(t, s, map[string]string{
+		"Authorization": "Bearer key-safe",
+	})
 
 	// List tools with denied key — should not see delete_repo.
 	msg := &Message{JSONRPC: "2.0", ID: json.RawMessage(`2`), Method: MethodToolsList}
@@ -764,7 +772,7 @@ func TestPerKeyToolFiltering_InvalidKeyRejected(t *testing.T) {
 	}
 }
 
-func TestPerKeyToolFiltering_NoKeyPassesThrough(t *testing.T) {
+func TestPerKeyToolFiltering_NoKeyRejected(t *testing.T) {
 	s := newTestServer(t)
 	defer s.Close()
 
@@ -782,21 +790,20 @@ func TestPerKeyToolFiltering_NoKeyPassesThrough(t *testing.T) {
 		},
 	})
 
-	sessionID := initializeSession(t, s)
-
-	// List tools WITHOUT an Authorization header — should see all tools (no filtering).
-	msg := &Message{JSONRPC: "2.0", ID: json.RawMessage(`2`), Method: MethodToolsList}
-	w := postMCP(t, s, msg, map[string]string{"MCP-Session-Id": sessionID})
+	params := InitializeParams{
+		ProtocolVersion: ProtocolVersion,
+		ClientInfo:      Implementation{Name: "test", Version: "1.0"},
+	}
+	paramsData, _ := json.Marshal(params)
+	msg := &Message{JSONRPC: "2.0", ID: json.RawMessage(`1`), Method: MethodInitialize, Params: paramsData}
+	w := postMCP(t, s, msg, nil)
 
 	resp := decodeResponse(t, w)
-	if resp.Error != nil {
-		t.Fatalf("unexpected error: %s", resp.Error.Message)
+	if resp.Error == nil {
+		t.Fatal("expected error for missing API key")
 	}
-
-	var result ListToolsResult
-	json.Unmarshal(resp.Result, &result)
-	if len(result.Tools) != 2 {
-		t.Fatalf("expected 2 tools with no auth header, got %d", len(result.Tools))
+	if resp.Error.Code != ErrCodeInvalidRequest {
+		t.Fatalf("expected code %d, got %d", ErrCodeInvalidRequest, resp.Error.Code)
 	}
 }
 
@@ -834,7 +841,9 @@ func TestPerKeyToolFiltering_ToolCallBlocked(t *testing.T) {
 		},
 	})
 
-	sessionID := initializeSession(t, s)
+	sessionID := initializeSessionWithHeaders(t, s, map[string]string{
+		"Authorization": "Bearer restricted",
+	})
 
 	// Try calling the denied tool.
 	params := ToolCallParams{Name: "srv_secret_tool", Arguments: map[string]interface{}{}}

--- a/agentcc-gateway/internal/middleware/auth.go
+++ b/agentcc-gateway/internal/middleware/auth.go
@@ -9,8 +9,8 @@ import (
 )
 
 // KeyAuth returns middleware that validates API keys from the Authorization
-// header before any handler runs. Routes that do not start with "/v1/" are
-// passed through without authentication (health checks, admin routes, etc.).
+// header before any handler runs. Only explicitly public health/discovery
+// routes and the separately authenticated admin namespace bypass API-key auth.
 //
 // If keyStore is nil, auth is considered disabled and all requests pass through.
 func KeyAuth(keyStore *auth.KeyStore, enabled ...bool) func(http.Handler) http.Handler {
@@ -21,8 +21,7 @@ func KeyAuth(keyStore *auth.KeyStore, enabled ...bool) func(http.Handler) http.H
 
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			// Skip auth for non-API routes (health, admin, etc.).
-			if !strings.HasPrefix(r.URL.Path, "/v1/") {
+			if isPublicOrSeparatelyAuthenticatedPath(r.URL.Path) {
 				next.ServeHTTP(w, r)
 				return
 			}
@@ -51,6 +50,15 @@ func KeyAuth(keyStore *auth.KeyStore, enabled ...bool) func(http.Handler) http.H
 
 			next.ServeHTTP(w, r)
 		})
+	}
+}
+
+func isPublicOrSeparatelyAuthenticatedPath(path string) bool {
+	switch path {
+	case "/healthz", "/readyz", "/livez", "/.well-known/agent.json":
+		return true
+	default:
+		return strings.HasPrefix(path, "/-/")
 	}
 }
 

--- a/agentcc-gateway/internal/middleware/auth_test.go
+++ b/agentcc-gateway/internal/middleware/auth_test.go
@@ -1,0 +1,67 @@
+package middleware
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/futureagi/agentcc-gateway/internal/auth"
+	"github.com/futureagi/agentcc-gateway/internal/config"
+)
+
+func TestKeyAuthFailsClosedForNonPublicRoutes(t *testing.T) {
+	keyStore := auth.NewKeyStore(config.AuthConfig{Keys: []config.AuthKeyConfig{{
+		Name: "test",
+		Key:  "valid-key",
+	}}})
+	handler := KeyAuth(keyStore, true)(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	}))
+
+	for _, path := range []string{"/v1/models", "/mcp", "/a2a", "/future-route"} {
+		t.Run(path, func(t *testing.T) {
+			request := httptest.NewRequest(http.MethodGet, path, nil)
+			response := httptest.NewRecorder()
+			handler.ServeHTTP(response, request)
+			if response.Code != http.StatusUnauthorized {
+				t.Fatalf("expected 401 for %s, got %d", path, response.Code)
+			}
+		})
+	}
+}
+
+func TestKeyAuthExplicitBypasses(t *testing.T) {
+	keyStore := auth.NewKeyStore(config.AuthConfig{})
+	handler := KeyAuth(keyStore, true)(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	}))
+
+	for _, path := range []string{"/healthz", "/readyz", "/livez", "/.well-known/agent.json", "/-/config"} {
+		t.Run(path, func(t *testing.T) {
+			request := httptest.NewRequest(http.MethodGet, path, nil)
+			response := httptest.NewRecorder()
+			handler.ServeHTTP(response, request)
+			if response.Code != http.StatusNoContent {
+				t.Fatalf("expected bypass for %s, got %d", path, response.Code)
+			}
+		})
+	}
+}
+
+func TestKeyAuthAcceptsValidKeyOnMCP(t *testing.T) {
+	keyStore := auth.NewKeyStore(config.AuthConfig{Keys: []config.AuthKeyConfig{{
+		Name: "test",
+		Key:  "valid-key",
+	}}})
+	handler := KeyAuth(keyStore, true)(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	}))
+
+	request := httptest.NewRequest(http.MethodPost, "/mcp", nil)
+	request.Header.Set("Authorization", "Bearer valid-key")
+	response := httptest.NewRecorder()
+	handler.ServeHTTP(response, request)
+	if response.Code != http.StatusNoContent {
+		t.Fatalf("expected authenticated MCP request to pass, got %d", response.Code)
+	}
+}

--- a/futureagi/saml2_auth/tests/test_security.py
+++ b/futureagi/saml2_auth/tests/test_security.py
@@ -1,0 +1,126 @@
+from types import SimpleNamespace
+
+import pytest
+
+from accounts.models.auth_token import AuthToken
+from accounts.models.organization import Organization
+from accounts.models.organization_membership import OrganizationMembership
+from accounts.models.user import User
+from saml2_auth.models import SAMLMetadataModel
+from tfc.constants.levels import Level
+from tfc.constants.roles import OrganizationRoles
+
+pytestmark = [pytest.mark.django_db, pytest.mark.api]
+
+
+def _saml_record(organization, relay_state, *, enabled=True):
+    return SAMLMetadataModel.no_workspace_objects.create(
+        organization=organization,
+        identity_type=SAMLMetadataModel.IDENTITY_OKTA,
+        relay_state=relay_state,
+        is_enabled=enabled,
+        meta="",
+    )
+
+
+def test_idp_admin_endpoints_are_scoped_to_request_organization(
+    auth_client, organization
+):
+    own_record = _saml_record(organization, "own-relay")
+    foreign_org = Organization.objects.create(name="Foreign Organization")
+    foreign_record = _saml_record(foreign_org, "foreign-relay")
+
+    response = auth_client.get("/saml2_auth/idp-uploads/")
+
+    assert response.status_code == 200
+    results = response.json()["result"]["results"]
+    assert [item["id"] for item in results] == [str(own_record.id)]
+
+    response = auth_client.get(f"/saml2_auth/idp-uploads/{foreign_record.id}/")
+    assert response.status_code == 404
+
+    response = auth_client.delete(f"/saml2_auth/idp-uploads/{foreign_record.id}/")
+    assert response.status_code == 404
+    foreign_record.refresh_from_db()
+    assert foreign_record.deleted is False
+
+
+def test_idp_admin_endpoints_require_org_admin(auth_client, user, organization):
+    membership = OrganizationMembership.no_workspace_objects.get(
+        user=user, organization=organization
+    )
+    membership.level = Level.MEMBER
+    membership.role = OrganizationRoles.MEMBER
+    membership.save(update_fields=["level", "role", "updated_at"])
+
+    response = auth_client.get("/saml2_auth/idp-uploads/")
+
+    assert response.status_code == 403
+
+
+def test_acs_rejects_user_without_membership_in_saml_organization(
+    api_client, organization, monkeypatch
+):
+    saml_record = _saml_record(organization, "trusted-relay")
+    foreign_org = Organization.objects.create(name="Victim Organization")
+    victim = User.objects.create_user(
+        email="victim@example.com",
+        password="irrelevant",
+        name="Victim",
+        organization=foreign_org,
+    )
+    OrganizationMembership.no_workspace_objects.create(
+        user=victim,
+        organization=foreign_org,
+        role=OrganizationRoles.OWNER,
+        level=Level.OWNER,
+        is_active=True,
+    )
+
+    class FakeAuthnResponse:
+        def get_identity(self):
+            return {
+                "email": [victim.email],
+                "first_name": ["Victim"],
+                "last_name": ["User"],
+            }
+
+        def get_subject(self):
+            return SimpleNamespace(text=victim.email)
+
+    class FakeSAMLClient:
+        def parse_authn_request_response(self, *_args, **_kwargs):
+            return FakeAuthnResponse()
+
+    monkeypatch.setattr(
+        "saml2_auth.views._get_saml_client",
+        lambda record, _acs_url: (FakeSAMLClient(), record.identity_type),
+    )
+
+    response = api_client.post(
+        "/saml2_auth/acs/",
+        {"SAMLResponse": "signed-response", "RelayState": saml_record.relay_state},
+    )
+
+    assert response.status_code == 302
+    assert "sso_token" not in response["Location"]
+    assert not AuthToken.no_workspace_objects.filter(user=victim).exists()
+    victim.refresh_from_db()
+    assert victim.organization == foreign_org
+
+
+def test_acs_rejects_disabled_identity_provider(api_client, organization, monkeypatch):
+    saml_record = _saml_record(organization, "disabled-relay", enabled=False)
+
+    def fail_if_called(*_args, **_kwargs):
+        raise AssertionError("disabled IdP metadata must not be loaded")
+
+    monkeypatch.setattr("saml2_auth.views._get_saml_client", fail_if_called)
+
+    response = api_client.post(
+        "/saml2_auth/acs/",
+        {"SAMLResponse": "signed-response", "RelayState": saml_record.relay_state},
+    )
+
+    assert response.status_code == 302
+    assert "sso_token" not in response["Location"]

--- a/futureagi/saml2_auth/tests/test_security_unit.py
+++ b/futureagi/saml2_auth/tests/test_security_unit.py
@@ -1,0 +1,20 @@
+from types import SimpleNamespace
+
+from saml2_auth.models import SAMLMetadataModel
+from saml2_auth.views import _get_metadata
+
+
+def test_metadata_loader_uses_the_supplied_organization_record(tmp_path, monkeypatch):
+    record = SimpleNamespace(
+        relay_state="organization-specific-relay",
+        meta="<EntityDescriptor />",
+        identity_type=SAMLMetadataModel.IDENTITY_OKTA,
+    )
+    monkeypatch.setattr("saml2_auth.views.BASE_DIR", str(tmp_path))
+
+    metadata, identity_type = _get_metadata(record)
+
+    metadata_path = tmp_path / "metadata" / "organization-specific-relay.xml"
+    assert metadata == {"local": [str(metadata_path)]}
+    assert identity_type == SAMLMetadataModel.IDENTITY_OKTA
+    assert metadata_path.read_text() == record.meta

--- a/futureagi/saml2_auth/views.py
+++ b/futureagi/saml2_auth/views.py
@@ -7,7 +7,6 @@ import requests
 # from accounts.models.user_permissions import UserPermission
 import structlog
 from django.core.cache import cache
-from django.db.models import Q
 from django.http import HttpResponse, HttpResponseRedirect
 from django.utils import timezone
 from django.utils.http import urlsafe_base64_encode
@@ -27,6 +26,7 @@ from accounts.models.auth_token import (
     AuthToken,
     AuthTokenType,
 )
+from accounts.models.organization_membership import OrganizationMembership
 from accounts.models.user import User
 from accounts.utils import first_signup, get_request_organization, is_work_email
 from analytics.utils import (
@@ -49,6 +49,7 @@ from saml2_auth.serializers import (
     SAMLUrlResponseSerializer,
 )
 from tfc.middleware.workspace_context import get_current_organization
+from tfc.permissions.rbac import IsOrganizationAdmin
 
 # from user.permissions_manager import PermissionManager
 # from authentications.programatic_authentication import IsAuthenticated
@@ -151,8 +152,7 @@ except Exception:
     import urllib.parse
 
 
-def _get_metadata(alias):
-    saml_metadata_model = SAMLMetadataModel.objects.filter(identity_type=alias).first()
+def _get_metadata(saml_metadata_model):
     meta_dir = os.path.join(
         BASE_DIR,
         "metadata",
@@ -167,8 +167,8 @@ def _get_metadata(alias):
     return {"local": [meta_file_path]}, saml_metadata_model.identity_type
 
 
-def _get_saml_client(alias, acs_url):
-    metadata, identity_type = _get_metadata(alias)
+def _get_saml_client(saml_metadata_model, acs_url):
+    metadata, identity_type = _get_metadata(saml_metadata_model)
     saml_settings = {
         "metadata": metadata,
         "service": {
@@ -248,13 +248,11 @@ class ACSView(APIView):
         try:
             resp = request.POST.get("SAMLResponse", None)
             relay_state = request.POST.get("RelayState", "None Provided")
-            saml_obj = SAMLMetadataModel.objects.get(relay_state=relay_state)
-            if not saml_obj:
-                raise Exception("RelayState No Valid")
-
-            saml_client, identity_type = _get_saml_client(
-                saml_obj.identity_type, get_assertion_url
+            saml_obj = SAMLMetadataModel.objects.get(
+                relay_state=relay_state, deleted=False, is_enabled=True
             )
+
+            saml_client, identity_type = _get_saml_client(saml_obj, get_assertion_url)
 
             if not resp:
                 raise Exception("Unauthorised")
@@ -314,13 +312,19 @@ class ACSView(APIView):
 
             # user_name = authn_response.get_subject().text
 
-            user_model = User.objects.filter(email=user_email).get()
+            user_model = User.objects.get(email=user_email)
 
             if not user_model.is_active:
                 raise Exception("User is no longer active.")
 
-            user_model.organization = saml_obj.organization
-            user_model.save()
+            if not OrganizationMembership.no_workspace_objects.filter(
+                user=user_model,
+                organization=saml_obj.organization,
+                is_active=True,
+                deleted=False,
+            ).exists():
+                raise Exception("User does not belong to this organization.")
+
             access_token = AuthToken.objects.create(
                 user=user_model,
                 auth_type=AuthTokenType.ACCESS.value,
@@ -392,16 +396,15 @@ class IDPLoginView(APIView):
                 logger.info("User Not Found")
                 return self._gm.bad_request(msg)
 
-            org_name = (get_current_organization() or user.organization).name
+            organization = get_current_organization() or user.organization
             saml_data = SAMLMetadataModel.objects.filter(
-                Q(relay_state__istartswith=f"{org_name}")
+                organization=organization, deleted=False, is_enabled=True
             ).first()
 
             if not saml_data:
                 logger.info("Saml Data does not Exist")
                 return self._gm.bad_request(msg)
 
-            alias = saml_data.identity_type
             next_url = request.GET.get("next", default_next_url)
 
             try:
@@ -413,7 +416,9 @@ class IDPLoginView(APIView):
                 next_url = request.GET.get("next", default_next_url)
             request.session["login_next_url"] = next_url
 
-            saml_client, identity_type = _get_saml_client(alias, get_assertion_url)
+            saml_client, identity_type = _get_saml_client(
+                saml_data, get_assertion_url
+            )
             _, info = saml_client.prepare_for_authenticate()
 
             redirect_url = None
@@ -467,13 +472,20 @@ class IDPUploadViews(viewsets.ModelViewSet):
     _gm = GeneralMethods()
     parser_classes = (FormParser, MultiPartParser)
     # authentication_classes = (ProgrammaticAuthentication,)
-    permission_classes = (IsAuthenticated,)
-    # rbac = 'idp'
+    permission_classes = (IsAuthenticated, IsOrganizationAdmin)
     queryset = SAMLMetadataModel.objects.filter(deleted=False)
     lookup_field = "id"
     lookup_url_kwarg = "id"
     http_method_names = ["get", "post", "head", "delete", "options", "put"]
     parser_classes = (FormParser, MultiPartParser)
+
+    def get_queryset(self):
+        organization = get_request_organization(self.request)
+        if organization is None:
+            return SAMLMetadataModel.objects.none()
+        return SAMLMetadataModel.objects.filter(
+            deleted=False, organization=organization
+        )
 
     def get_serializer_class(self):
         if self.request.method == "GET":
@@ -521,31 +533,17 @@ class IDPUploadViews(viewsets.ModelViewSet):
         }
     )
     def retrieve(self, request, *args, **kwargs):
-        try:
-            uuid = kwargs.get(self.lookup_url_kwarg)
-            data = {}
-            existing_saml_metadata_model = SAMLMetadataModel.objects.get(
-                id=uuid, deleted=False
-            )
-            if existing_saml_metadata_model:
-                data["is_enabled"] = existing_saml_metadata_model.is_enabled
-                data["identity_type"] = existing_saml_metadata_model.identity_type
-                name = existing_saml_metadata_model.name
-                if (
-                    not existing_saml_metadata_model.name
-                    or existing_saml_metadata_model.name == "null"
-                ):
-                    name = existing_saml_metadata_model.get_identity_type
-                data["name"] = name
-                data["acs_url"] = get_assertion_url
-                data["audience_url"] = get_entity_id
-            return self._gm.success_response(data)
-        except SAMLMetadataModel.DoesNotExist:
-            return self._gm.bad_request("Invalid saml group.")
-        except Exception as e:
-            logger.error(e)
-            traceback.print_exc()
-            return self._gm.internal_server_error_response(get_error_message("US25"))
+        existing_saml_metadata_model = self.get_object()
+        data = {
+            "is_enabled": existing_saml_metadata_model.is_enabled,
+            "identity_type": existing_saml_metadata_model.identity_type,
+            "name": existing_saml_metadata_model.name,
+            "acs_url": get_assertion_url,
+            "audience_url": get_entity_id,
+        }
+        if not data["name"] or data["name"] == "null":
+            data["name"] = existing_saml_metadata_model.get_identity_type
+        return self._gm.success_response(data)
 
     @swagger_auto_schema(
         request_body=no_body,
@@ -592,18 +590,11 @@ class IDPUploadViews(viewsets.ModelViewSet):
         }
     )
     def destroy(self, request, *args, **kwargs):
-        try:
-            uuid = kwargs.get(self.lookup_url_kwarg)
-            obj = SAMLMetadataModel.objects.get(id=uuid)
-            obj.deleted = True
-            obj.deleted_at = datetime.datetime.now()
-            obj.save()
-            return self._gm.success_response("Success")
-        except SAMLMetadataModel.DoesNotExist:
-            return self._gm.bad_request("Invalid saml group.")
-        except Exception as e:
-            logger.error(e)
-            return self._gm.internal_server_error_response(get_error_message("US25"))
+        obj = self.get_object()
+        obj.deleted = True
+        obj.deleted_at = timezone.now()
+        obj.save(update_fields=["deleted", "deleted_at", "updated_at"])
+        return self._gm.success_response("Success")
 
     @swagger_auto_schema(
         request_body=no_body,
@@ -616,14 +607,13 @@ class IDPUploadViews(viewsets.ModelViewSet):
         },
     )
     def update(self, request, *args, **kwargs):
+        saml_model = self.get_object()
         try:
-            uuid = kwargs.get(self.lookup_url_kwarg)
             form = IDPUploadForm(request.POST, request.FILES)
-            saml_model = SAMLMetadataModel.objects.filter(id=uuid, deleted=False).get()
             if not form.is_valid():
                 return self._gm.bad_request(_format_form_errors(form.errors))
             data = form.cleaned_data
-            data["organization"] = get_request_organization(request)
+            data.pop("organization", None)
             if int(saml_model.identity_type) != int(
                 data.get("identity_type")
             ) and not data.get("file"):
@@ -634,10 +624,8 @@ class IDPUploadViews(viewsets.ModelViewSet):
                     data["meta"] = meta.decode()
                 except Exception:
                     logger.info("No file in update SSO.")
-            SAMLMetadataModel.objects.filter(id=uuid).update(**data)
+            self.get_queryset().filter(id=saml_model.id).update(**data)
             return self._gm.success_response("Success")
-        except SAMLMetadataModel.DoesNotExist:
-            return self._gm.bad_request("Invalid saml group.")
         except Exception as e:
             traceback.print_exc()
             logger.error(e)


### PR DESCRIPTION
## What changed

- Bind SAML metadata loading and login initiation to the exact organization IdP record.
- Require enabled, non-deleted IdP configuration and an existing active organization membership before issuing a SAML session.
- Remove assertion-driven organization reassignment.
- Require organization-admin access for IdP configuration and scope list, retrieve, update, and delete operations to the caller's organization.
- Make gateway API-key middleware protect all routes by default except explicit health/discovery and separately authenticated admin paths.
- Make MCP per-key authentication reject missing credentials when key authentication is configured.
- Add regression coverage for SAML tenant isolation, IdP administration, and gateway/MCP fail-closed behavior.

## Why

The security audit identified four critical authentication and authorization vulnerabilities: cross-tenant SAML account takeover, globally selected SAML trust metadata, cross-tenant IdP configuration access, and unauthenticated MCP tool execution.

The root causes were trust decisions based on global IdP type or attacker-controlled relay state, missing organization membership checks, unscoped administration querysets, and route/authentication logic that treated absent credentials as unrestricted access.

## Impact

SAML assertions can only authenticate existing active members of the IdP's organization, IdP configuration is restricted to organization administrators within their tenant, and configured gateway authentication now fails closed for MCP and future non-public routes.

## Validation

- `python3 -m compileall -q futureagi/saml2_auth/views.py futureagi/saml2_auth/tests/test_security.py futureagi/saml2_auth/tests/test_security_unit.py`
- `uvx ruff check futureagi/saml2_auth/views.py futureagi/saml2_auth/tests/test_security.py futureagi/saml2_auth/tests/test_security_unit.py`
- `uv run pytest saml2_auth/tests/test_security_unit.py saml2_auth/tests/test_api_contract_debt.py -q` — 8 passed
- `git diff --check`

