### PR TITLE
feat(gateway): add OrcaRouter provider preset

### DIFF
--- a/agentcc-gateway/config.example.yaml
+++ b/agentcc-gateway/config.example.yaml
@@ -243,6 +243,12 @@ providers:
   #     - openai/gpt-4o
   #     - anthropic/claude-3.5-sonnet
 
+  # orcarouter:
+  #   api_key: "${ORCAROUTER_API_KEY}"
+  #   type: "orcarouter"
+  #   models:
+  #     - orcarouter/auto
+
 # Explicit model-to-provider mapping (overrides provider-level models).
 # model_map:
 #   gpt-4o: openai

--- a/agentcc-gateway/internal/providers/presets.go
+++ b/agentcc-gateway/internal/providers/presets.go
@@ -22,6 +22,7 @@ var KnownProviders = map[string]ProviderPreset{
 	"anyscale":    {BaseURL: "https://api.endpoints.anyscale.com", APIFormat: "openai"},
 	"replicate":   {BaseURL: "https://api.replicate.com", APIFormat: "openai"},
 	"openrouter":  {BaseURL: "https://openrouter.ai/api", APIFormat: "openai"},
+	"orcarouter":  {BaseURL: "https://api.orcarouter.ai", APIFormat: "openai"},
 	"azure":       {APIFormat: "azure"},
 }
 

--- a/agentcc-gateway/internal/providers/presets_test.go
+++ b/agentcc-gateway/internal/providers/presets_test.go
@@ -146,6 +146,7 @@ func TestPreset_KnownProvidersComplete(t *testing.T) {
 		"anyscale":    {BaseURL: "https://api.endpoints.anyscale.com", APIFormat: "openai"},
 		"replicate":   {BaseURL: "https://api.replicate.com", APIFormat: "openai"},
 		"openrouter":  {BaseURL: "https://openrouter.ai/api", APIFormat: "openai"},
+		"orcarouter":  {BaseURL: "https://api.orcarouter.ai", APIFormat: "openai"},
 		"azure":       {BaseURL: "", APIFormat: "azure"},
 	}
 

--- a/agentcc-gateway/internal/server/integration_test.go
+++ b/agentcc-gateway/internal/server/integration_test.go
@@ -66,6 +66,16 @@ func createRealServer(t *testing.T) *Server {
 		}
 	}
 
+	// OrcaRouter (OpenAI-compatible)
+	if key := os.Getenv("ORCAROUTER_API_KEY"); key != "" {
+		cfg.Providers["orcarouter"] = config.ProviderConfig{
+			BaseURL:   "https://api.orcarouter.ai",
+			APIKey:    key,
+			APIFormat: "openai",
+			Models:    []string{"orcarouter/auto"},
+		}
+	}
+
 	registry, err := providers.NewRegistry(cfg)
 	if err != nil {
 		t.Fatalf("creating registry: %v", err)
@@ -281,6 +291,31 @@ func TestIntegration_OpenRouter_NonStreaming(t *testing.T) {
 	var resp models.ChatCompletionResponse
 	json.Unmarshal(w.Body.Bytes(), &resp)
 	t.Logf("OpenRouter response: id=%s model=%s choices=%d", resp.ID, resp.Model, len(resp.Choices))
+}
+
+// --- OrcaRouter ---
+
+func TestIntegration_OrcaRouter_NonStreaming(t *testing.T) {
+	skipIfNoKey(t, "ORCAROUTER_API_KEY")
+	srv := createRealServer(t)
+
+	reqBody := `{"model":"orcarouter/auto","messages":[{"role":"user","content":"Say hello in exactly 3 words."}],"max_tokens":20}`
+	req := httptest.NewRequest("POST", "/v1/chat/completions", bytes.NewBufferString(reqBody))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	srv.httpServer.Handler.ServeHTTP(w, req)
+
+	if w.Code == 502 && strings.Contains(w.Body.String(), "401") {
+		t.Skip("OrcaRouter API key expired/invalid, skipping")
+	}
+	if w.Code != 200 {
+		t.Fatalf("OrcaRouter non-streaming: status=%d body=%s", w.Code, w.Body.String())
+	}
+
+	var resp models.ChatCompletionResponse
+	json.Unmarshal(w.Body.Bytes(), &resp)
+	t.Logf("OrcaRouter response: id=%s model=%s choices=%d", resp.ID, resp.Model, len(resp.Choices))
 }
 
 // --- List Models ---


### PR DESCRIPTION
## Summary

Adds **[OrcaRouter](https://www.orcarouter.ai)** as a first-class, named provider in the Agent Command Center gateway, mirroring the existing `openrouter` preset. OrcaRouter is an OpenAI-compatible model routing gateway that exposes models from OpenAI, Anthropic, Google, DeepSeek and others behind a single endpoint and API key. It also runs gateway-level, zero-trust security for AI agents on the same endpoint — screening every prompt/response and governing every tool call on a default-deny basis, with no application code changes.

I'm an engineer on the OrcaRouter team.

## Linked issues

Closes #
Linear: (none — small, self-contained provider addition)

## Type of change

- [x] ✨ New feature (non-breaking change which adds functionality)
- [x] 🧪 Test-only change (new integration coverage mirroring OpenRouter)

---

## 1) What changes were done

**A. Named `orcarouter` provider preset**

- `agentcc-gateway/internal/providers/presets.go`: adds `"orcarouter": {BaseURL: "https://api.orcarouter.ai", APIFormat: "openai"}` to `KnownProviders`, right next to the `openrouter` entry. Setting `type: "orcarouter"` in gateway config now auto-fills `base_url` and `api_format`, so no custom-endpoint boilerplate is needed.
- `agentcc-gateway/config.example.yaml`: adds a commented `orcarouter` provider block (with `ORCAROUTER_API_KEY` and `orcarouter/auto`) next to the `openrouter` example.

**B. Test coverage**

- `agentcc-gateway/internal/providers/presets_test.go`: adds `orcarouter` to the `TestPreset_KnownProvidersComplete` expected set (the table-driven `TestPreset_AllKnownProviders_ApplyDefaults` picks it up automatically).
- `agentcc-gateway/internal/server/integration_test.go`: adds an `orcarouter` provider to the live-test server helper (guarded by `ORCAROUTER_API_KEY`) and a `TestIntegration_OrcaRouter_NonStreaming` mirroring the OpenRouter test.

## 2) Why the changes were done

- **Product/UX:** gateway users can now select OrcaRouter as a named provider (`type: "orcarouter"`) with one line, the same way they select OpenRouter today — rather than hand-wiring a generic OpenAI-compatible endpoint.
- **Technical:** the preset keeps base URL and API format correct automatically. `https://api.orcarouter.ai` (no `/v1`) matches the existing preset convention; the gateway appends `/v1/...` for chat completions, models, etc. (and auto-discovery hits `https://api.orcarouter.ai/v1/models`, which serves the live model list).
- **Architecture:** no changes to provider resolution, routing, or translation — OrcaRouter speaks OpenAI-compatible wire format, so it slots into the existing `openai` provider path.

## 3) Tests written + scenarios each covers

**`internal/providers/presets_test.go`**

- `TestPreset_KnownProvidersComplete/orcarouter` — preset present with the correct base URL and API format.
- `TestPreset_AllKnownProviders_ApplyDefaults/orcarouter` — `applyProviderPreset` fills base URL + API format for an empty orcarouter config.

**`internal/server/integration_test.go`** (`//go:build integration`, skipped without a key)

- `TestIntegration_OrcaRouter_NonStreaming` — real chat completion through the gateway to `https://api.orcarouter.ai` with model `orcarouter/auto`, asserts HTTP 200.

> Run result: `go build ./...`, `go vet ./...` (incl. `-tags integration`), and `go test ./internal/providers/... ./internal/config/... ./internal/server/` all pass. The OrcaRouter integration test was executed live with a real key — HTTP 200, response `model=MiniMax-M2.7`. `GET https://api.orcarouter.ai/v1/models` returns 193 models (incl. `orcarouter/auto`).

## 4) How to run / test

```bash
cd agentcc-gateway

# Unit tests (presets + server)
go test ./internal/providers/... ./internal/config/... ./internal/server/

# Live provider test (requires ORCAROUTER_API_KEY)
ORCAROUTER_API_KEY=sk-orca-... go test -tags integration ./internal/server/ -run TestIntegration_OrcaRouter_NonStreaming -v
```

### Config

```yaml
providers:
  orcarouter:
    api_key: "${ORCAROUTER_API_KEY}"
    type: "orcarouter"
    models:
      - orcarouter/auto
```

## 5) Screenshots / recordings

Live test output:

```
=== RUN   TestIntegration_OrcaRouter_NonStreaming
INFO provider registered name=orcarouter format=openai base_url=https://api.orcarouter.ai
--- PASS: TestIntegration_OrcaRouter_NonStreaming (1.62s)
```

## 6) Edge cases & considerations

- **Base URL trailing `/v1`:** the preset omits the `/v1` suffix (consistent with every other preset). The gateway's `endpoint()` and `/v1/models` auto-discovery both build the correct `https://api.orcarouter.ai/v1/...` URLs.
- **Key missing:** with no `ORCAROUTER_API_KEY`, the live integration test is skipped via `skipIfNoKey` — no CI impact.
- **Models:** `orcarouter/auto` is OrcaRouter's virtual router model; users may list any model from `GET /v1/models` instead.

## 7) Pre-existing issues (NOT introduced by this PR)

None.

## 8) Architectural / important decisions

- **Named preset over generic endpoint:** mirroring the `openrouter` preset gives OrcaRouter a discoverable, first-class provider type instead of asking users to hand-configure a custom OpenAI-compatible endpoint.

## Checklist

- [x] My code follows the [style guide](../CONTRIBUTING.md#code-style)
- [x] I've added tests that prove my fix is effective or that my feature works
- [x] `bin/test` — N/A (Go gateway; `go test` run instead)
- [x] I've updated the documentation where relevant (`config.example.yaml`)
- [x] No hardcoded secrets, URLs, or PII
- [x] I've signed the [CLA](../CONTRIBUTING.md#contributor-license-agreement-cla)
- [x] PR title follows Conventional Commits
