### PR TITLE
fix(theme): make dark-mode checkboxes visible in every state

### DIFF
--- a/frontend/src/theme/overrides/components/checkbox.js
+++ b/frontend/src/theme/overrides/components/checkbox.js
@@ -10,8 +10,9 @@ export function checkbox(theme) {
           padding: theme.spacing(1),
           color: lightMode
             ? theme.palette.black?.o20
-            : theme.palette.grey?.[600],
-          "&.Mui-checked": {
+            : theme.palette.border?.bright,
+
+          "&.Mui-checked, &.MuiCheckbox-indeterminate": {
             color: theme.palette.purple?.[300],
             ...(!lightMode && {
               "& path[stroke]": { stroke: theme.palette.background.paper },


### PR DESCRIPTION
Fixes [TH-6912](https://linear.app/future-agi/issue/TH-6912/dataset-selected-evaluation-checkbox-is-barely-visible-in-add).

Checkboxes were hard or impossible to read on the dark theme, in two separate ways. Both live in the global `MuiCheckbox` override, so this fixes them everywhere, not just in the eval drawer.

**Unchecked — outline too dark.** The dark branch used `grey[600]` (`#605C70`), a leftover from the light purple-tinted ramp. The unchecked icon is only a 1.5px `stroke="currentColor"` outline, and `#605C70` on the dark paper (`#111111`) is ~2.9:1 — under the 3:1 WCAG minimum for UI component boundaries, so the box faded out. It now uses `border.bright` (`#71717a`), the dark palette's own brightest border token, at ~3.9:1 against paper and ~4.6:1 against the default background.

**Indeterminate — invisible white-on-white.** MUI's base styles color *both* `Mui-checked` and `MuiCheckbox-indeterminate` with `palette.primary.main`, which is `#FAFAFA` in this theme. The override only re-styled `&.Mui-checked`, so a partial selection rendered as a near-white filled square — and the indeterminate icon's dash is hardcoded `stroke="#fff"`, leaving white on white. That was the reported case: a fully-checked box read fine while "1 of 2 selected" showed a blank block. The selector now covers both states, so indeterminate gets the same `purple[300]` fill with the dash recolored to the paper background.

Light mode's unchecked color is untouched. Its indeterminate fill shifts from `primary.main` (`#7857FC`) to `purple[300]` (`#9A8EFF`), matching what checked boxes there already use.

### Testing
Not yet exercised in a running app — the diagnosis came from the palette values and MUI's base styles, plus a screenshot of the broken indeterminate state. Worth a look on dark at all three states of the eval drawer's "select all" header checkbox (empty / 1 of 2 / 2 of 2) and a confirmation that light mode is unchanged.

### Note for reviewer
`MuiRadio` has the identical `grey[600]` line in `radio.js`, and `RadioIcon` is a similarly thin ring, so unchecked radios are just as faint on dark. Left out of this PR to keep it scoped to the reported issue — happy to fold it in here or file a follow-up.
