### PR TITLE
fix(model_hub): persist terminal run-prompt status and gate usage events on saved work

### DIFF
--- a/futureagi/model_hub/tests/test_run_prompt_status_persist.py
+++ b/futureagi/model_hub/tests/test_run_prompt_status_persist.py
@@ -1,0 +1,355 @@
+"""run-prompt terminal status persistence and usage-event gating (issue #2080).
+
+Two defects on the run-prompt execution path in
+``futureagi/model_hub/views/run_prompt.py``:
+
+1. Terminal status can be lost — if the save that records a cell's terminal
+   status fails, the row is left non-terminal with nothing retrying it.
+2. Usage events can be emitted for unpersisted results — the usage/billing
+   event used to be emitted before the cell result was persisted.
+
+These tests pin the fixed contract:
+
+- terminal status is always persisted (retry + queryset-level fallback,
+  failing loudly if even the fallback cannot record it);
+- the usage event is emitted only after a successful persist of a success
+  (PASS) cell — never for failed calls, and never for work whose result was
+  not saved.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from model_hub.models.choices import CellStatus, StatusType
+from model_hub.models.develop_dataset import Cell
+from model_hub.views.run_prompt import RunPrompts, _persist_cell_result
+
+
+def _make_task(edit_mode=False):
+    """Build a RunPrompts instance with mocked model attributes, no DB."""
+    task = RunPrompts.__new__(RunPrompts)
+    task.run_prompt_id = "prompt-123"
+    task.tools_config = []
+    task.run_prompt_model = MagicMock()
+    task.run_prompt_model.organization.id = "org-1"
+    task.run_prompt_model.dataset = MagicMock()
+    task.run_prompt_model.dataset.id = "ds-1"
+    task.run_prompt_model.model = "gpt-4o"
+    task.run_prompt_model.messages = [{"role": "user", "content": "hi"}]
+    task.run_prompt_model.temperature = 0.7
+    task.run_prompt_model.frequency_penalty = 0.0
+    task.run_prompt_model.presence_penalty = 0.0
+    task.run_prompt_model.top_p = 1.0
+    task.run_prompt_model.response_format = None
+    task.run_prompt_model.tool_choice = None
+    task.run_prompt_model.output_format = "string"
+    task.run_prompt_model.run_prompt_config = {}
+    task.run_prompt_model.concurrency = 4
+    task.is_editing = edit_mode
+    return task
+
+
+def _make_row_column():
+    row = MagicMock()
+    row.id = "row-1"
+    column = MagicMock()
+    column.id = "col-1"
+    return row, column
+
+
+@pytest.fixture
+def cell_objects():
+    """Mock Cell.objects for the duration of a test."""
+    with patch("model_hub.views.run_prompt.Cell.objects") as mock_objects:
+        yield mock_objects
+
+
+@pytest.fixture
+def process_row_env(cell_objects):
+    """Patch every external call site used by RunPrompts.process_row."""
+    with (
+        patch(
+            "model_hub.views.run_prompt.log_and_deduct_cost_for_api_request",
+            new=None,
+        ),
+        patch("model_hub.views.run_prompt.populate_placeholders") as mock_populate,
+        patch(
+            "model_hub.views.run_prompt.remove_empty_text_from_messages"
+        ) as mock_remove_empty,
+        patch("model_hub.views.run_prompt.RunPrompt") as mock_run_prompt,
+        patch(
+            "model_hub.views.run_prompt.close_old_connections"
+        ) as mock_close,
+        patch("ee.usage.services.emitter.emit") as mock_emit,
+    ):
+        yield {
+            "cell_objects": cell_objects,
+            "populate_placeholders": mock_populate,
+            "remove_empty_text_from_messages": mock_remove_empty,
+            "run_prompt": mock_run_prompt,
+            "close_old_connections": mock_close,
+            "emit": mock_emit,
+        }
+
+
+class TestUsageEventGating:
+    """The usage/billing event fires only after a persisted success cell."""
+
+    def test_usage_event_emitted_after_cell_persist_on_success(
+        self, process_row_env
+    ):
+        env = process_row_env
+        env["run_prompt"].return_value.litellm_response.return_value = (
+            "generated",
+            {
+                "metadata": {
+                    "usage": {"prompt_tokens": 5, "completion_tokens": 7},
+                    "response_time": 0.5,
+                }
+            },
+        )
+        task = _make_task()
+        row, column = _make_row_column()
+
+        events = []
+        env["cell_objects"].create.side_effect = (
+            lambda **kwargs: events.append("create") or MagicMock()
+        )
+        env["emit"].side_effect = lambda *a, **kw: events.append("emit")
+
+        task.process_row(row, column)
+
+        # Emitted exactly once, and strictly AFTER the cell was persisted.
+        env["emit"].assert_called_once()
+        assert events == ["create", "emit"]
+        create_kwargs = env["cell_objects"].create.call_args[1]
+        assert create_kwargs["status"] == CellStatus.PASS.value
+        assert create_kwargs["prompt_tokens"] == 5
+        assert create_kwargs["completion_tokens"] == 7
+
+    def test_no_usage_event_on_failed_llm_call(self, process_row_env):
+        env = process_row_env
+        env["run_prompt"].return_value.litellm_response.side_effect = Exception(
+            "provider error"
+        )
+        task = _make_task()
+        row, column = _make_row_column()
+
+        task.process_row(row, column)
+
+        # The failed call still persists a terminal ERROR cell, but is never
+        # billed (issue #2080: no usage event for failed work).
+        env["emit"].assert_not_called()
+        create_kwargs = env["cell_objects"].create.call_args[1]
+        assert create_kwargs["status"] == CellStatus.ERROR.value
+
+    def test_no_usage_event_when_persist_fails_and_status_fallback_applied(
+        self, process_row_env
+    ):
+        env = process_row_env
+        env["run_prompt"].return_value.litellm_response.return_value = (
+            "generated",
+            {"metadata": {"usage": {}, "response_time": 0.5}},
+        )
+        # The full persist fails on both attempts; only the queryset-level
+        # status fallback succeeds.
+        env["cell_objects"].create.side_effect = [
+            Exception("db down"),
+            Exception("db down"),
+        ]
+        env["cell_objects"].filter.return_value.update.return_value = 1
+        task = _make_task()
+        row, column = _make_row_column()
+
+        task.process_row(row, column)
+
+        # The terminal status was recorded via the fallback, but the result
+        # was never saved — so no usage event (issue #2080).
+        env["emit"].assert_not_called()
+        update_kwargs = env["cell_objects"].filter.return_value.update.call_args[1]
+        assert update_kwargs["status"] == CellStatus.PASS.value
+
+    def test_raises_loudly_when_terminal_status_cannot_be_recorded(
+        self, process_row_env
+    ):
+        env = process_row_env
+        env["run_prompt"].return_value.litellm_response.return_value = (
+            "generated",
+            {"metadata": {"usage": {}, "response_time": 0.5}},
+        )
+        # Full persist fails twice AND the queryset fallback fails: the row
+        # must not be left silently non-terminal (issue #2080).
+        env["cell_objects"].create.side_effect = Exception("db down")
+        env["cell_objects"].filter.return_value.update.side_effect = Exception(
+            "fallback failed"
+        )
+        task = _make_task()
+        row, column = _make_row_column()
+
+        with pytest.raises(Exception, match="fallback failed"):
+            task.process_row(row, column)
+        env["emit"].assert_not_called()
+
+
+class TestCellPersistTerminalStatus:
+    """The cell persist helper always reaches a terminal status."""
+
+    def test_persists_on_first_attempt(self, cell_objects):
+        persisted = _persist_cell_result(
+            dataset=MagicMock(),
+            column=MagicMock(),
+            row=MagicMock(),
+            value="ok",
+            value_info=None,
+            status=CellStatus.PASS.value,
+            edit_mode=False,
+        )
+        assert persisted is True
+        cell_objects.create.assert_called_once()
+        cell_objects.filter.return_value.update.assert_not_called()
+
+    def test_retries_then_succeeds(self, cell_objects):
+        cell_objects.create.side_effect = [
+            Exception("transient"),
+            MagicMock(),
+        ]
+        persisted = _persist_cell_result(
+            dataset=MagicMock(),
+            column=MagicMock(),
+            row=MagicMock(),
+            value="ok",
+            value_info=None,
+            status=CellStatus.PASS.value,
+            edit_mode=False,
+        )
+        assert persisted is True
+        assert cell_objects.create.call_count == 2
+        cell_objects.filter.return_value.update.assert_not_called()
+
+    def test_falls_back_to_status_only_update(self, cell_objects):
+        cell_objects.create.side_effect = [
+            Exception("db down"),
+            Exception("db down"),
+        ]
+        cell_objects.filter.return_value.update.return_value = 1
+        persisted = _persist_cell_result(
+            dataset=MagicMock(),
+            column=MagicMock(),
+            row=MagicMock(),
+            value="ok",
+            value_info=None,
+            status=CellStatus.ERROR.value,
+            edit_mode=False,
+        )
+        assert persisted is False
+        update_kwargs = cell_objects.filter.return_value.update.call_args[1]
+        assert update_kwargs["status"] == CellStatus.ERROR.value
+
+    def test_raises_when_even_fallback_fails(self, cell_objects):
+        cell_objects.create.side_effect = Exception("db down")
+        cell_objects.filter.return_value.update.side_effect = Exception(
+            "fallback failed"
+        )
+        with pytest.raises(Exception, match="fallback failed"):
+            _persist_cell_result(
+                dataset=MagicMock(),
+                column=MagicMock(),
+                row=MagicMock(),
+                value="ok",
+                value_info=None,
+                status=CellStatus.ERROR.value,
+                edit_mode=False,
+            )
+
+    def test_edit_mode_updates_existing_cell(self, cell_objects):
+        existing = MagicMock()
+        cell_objects.get.return_value = existing
+        persisted = _persist_cell_result(
+            dataset=MagicMock(),
+            column=MagicMock(),
+            row=MagicMock(),
+            value="updated",
+            value_info={"reason": "x"},
+            status=CellStatus.PASS.value,
+            edit_mode=True,
+        )
+        assert persisted is True
+        existing.save.assert_called_once()
+        assert existing.status == CellStatus.PASS.value
+        assert existing.value == "updated"
+        cell_objects.create.assert_not_called()
+
+    def test_edit_mode_creates_when_cell_missing(self, cell_objects):
+        cell_objects.get.side_effect = Cell.DoesNotExist
+        persisted = _persist_cell_result(
+            dataset=MagicMock(),
+            column=MagicMock(),
+            row=MagicMock(),
+            value="new",
+            value_info=None,
+            status=CellStatus.PASS.value,
+            edit_mode=True,
+        )
+        assert persisted is True
+        cell_objects.create.assert_called_once()
+
+
+class TestRunPromptTerminalFailure:
+    """The run_prompter FAILED status is persisted or the failure is loud."""
+
+    @patch.object(RunPrompts, "load_run_prompt_id")
+    @patch("model_hub.views.run_prompt.create_run_prompt_column")
+    @patch("model_hub.views.run_prompt.Dataset.objects")
+    @patch("model_hub.views.run_prompt.Row.objects")
+    @patch("model_hub.views.run_prompt.RunPrompter.objects")
+    def test_failed_status_persist_failure_raises_loudly(
+        self,
+        mock_prompter_objects,
+        mock_row_objects,
+        mock_dataset_objects,
+        mock_create_column,
+        mock_load,
+    ):
+        """A FAILED persist that cannot be recorded must not be swallowed."""
+        from django.utils import timezone
+
+        start_updated_at = timezone.now()
+        task = RunPrompts.__new__(RunPrompts)
+        task.run_prompt_id = "prompt-123"
+        task.tools_config = []
+        task.run_prompt_model = MagicMock()
+        task.run_prompt_model.updated_at = start_updated_at
+        task.run_prompt_model.dataset.id = "ds-1"
+        task.run_prompt_model.name = "test prompt"
+        task.run_prompt_model.output_format = "string"
+        task.run_prompt_model.response_format = None
+        task.run_prompt_model.concurrency = 1
+
+        dataset_mock = MagicMock()
+        dataset_mock.column_order = []
+        mock_dataset_objects.filter.return_value.get.return_value = dataset_mock
+        mock_create_column.return_value = (MagicMock(), False)
+
+        row = MagicMock()
+        row.id = "row-1"
+        mock_row_objects.filter.return_value.order_by.return_value = [row]
+
+        # The queued work itself fails...
+        with patch.object(
+            RunPrompts, "process_row", side_effect=Exception("row boom")
+        ):
+            # ...and the FAILED persist also fails.
+            qs = MagicMock()
+            qs.values.return_value.first.return_value = {
+                "status": StatusType.RUNNING.value,
+                "updated_at": start_updated_at,
+            }
+            qs.update.side_effect = Exception("terminal update failed")
+            mock_prompter_objects.filter.return_value = qs
+
+            with pytest.raises(Exception, match="terminal update failed") as exc_info:
+                task.run_prompt(edit_mode=False)
+
+        # The original row failure is preserved as the cause of the loud raise.
+        assert str(exc_info.value.__cause__) == "row boom"

--- a/futureagi/model_hub/views/run_prompt.py
+++ b/futureagi/model_hub/views/run_prompt.py
@@ -1146,6 +1146,109 @@ class LitellmAPIView(CreateAPIView):
         return self._gm.success_response("success")
 
 
+def _persist_cell_result(
+    *,
+    dataset,
+    column,
+    row,
+    value,
+    value_info,
+    status,
+    edit_mode,
+    run_prompt_id=None,
+    row_id=None,
+):
+    """Persist a processed cell result with a terminal-status guarantee.
+
+    issue #2080: the terminal status must never be silently lost. The full
+    persist (value + value_infos + status) is attempted, retried once on
+    failure, and if it still fails a queryset-level status-only ``.update()``
+    fallback records at least the terminal status. If even the fallback
+    fails, the error is raised loudly instead of leaving the row
+    non-terminal.
+
+    Returns ``True`` when the full result was persisted, ``False`` when only
+    the terminal status could be recorded via the queryset fallback.
+    """
+    token_kwargs = {}
+    if value_info:
+        metadata = value_info.get("metadata", {})
+        usage = metadata.get("usage", {})
+        token_kwargs = {
+            "prompt_tokens": usage.get("prompt_tokens", None),
+            "completion_tokens": usage.get("completion_tokens", None),
+            "response_time": metadata.get("response_time", None),
+        }
+
+    base_kwargs = {
+        "dataset": dataset,
+        "column": column,
+        "row": row,
+        "value": str(value),
+        "value_infos": json.dumps(value_info) if value_info else json.dumps({}),
+        "status": status,
+        **token_kwargs,
+    }
+
+    def _do_persist():
+        if edit_mode:
+            try:
+                cell = Cell.objects.get(
+                    dataset=dataset, column=column, row=row, deleted=False
+                )
+                for field, field_value in base_kwargs.items():
+                    setattr(cell, field, field_value)
+                cell.save()
+                return cell
+            except Cell.DoesNotExist:
+                pass
+        return Cell.objects.create(**base_kwargs)
+
+    try:
+        _do_persist()
+    except Exception as persist_error:
+        logger.warning(
+            "RunPrompts_process_row_cell_persist_retry",
+            run_prompt_id=run_prompt_id,
+            row_id=row_id,
+            error=str(persist_error),
+        )
+        try:
+            _do_persist()
+        except Exception as retry_error:
+            # The full persist failed twice — fall back to a queryset-level
+            # status-only update so the cell still reaches a terminal state.
+            try:
+                updated = Cell.objects.filter(
+                    dataset=dataset, column=column, row=row, deleted=False
+                ).update(status=status)
+            except Exception as fallback_error:
+                logger.critical(
+                    "RunPrompts_process_row_terminal_status_unpersisted",
+                    run_prompt_id=run_prompt_id,
+                    row_id=row_id,
+                    error=str(fallback_error),
+                )
+                raise
+            if not updated:
+                logger.critical(
+                    "RunPrompts_process_row_terminal_status_unpersisted_no_row",
+                    run_prompt_id=run_prompt_id,
+                    row_id=row_id,
+                    status=status,
+                )
+                raise retry_error
+            logger.error(
+                "RunPrompts_process_row_status_only_persisted",
+                run_prompt_id=run_prompt_id,
+                row_id=row_id,
+                status=status,
+                error=str(retry_error),
+            )
+            return False
+    return True
+
+
 class RunPrompts:
     def __init__(self, run_prompt_id):
         self.run_prompt_id = run_prompt_id
@@ -1313,8 +1416,16 @@ class RunPrompts:
                         f"run_prompt {self.run_prompt_id} was modified during failed execution "
                         f"(status={current_status}). Not setting to FAILED."
                     )
-            except Exception:
-                pass
+            except Exception as terminal_status_error:
+                # issue #2080: never silently leave the prompt non-terminal.
+                # If the FAILED status itself cannot be recorded, fail loudly
+                # rather than leaving the row stuck in a non-terminal state.
+                logger.critical(
+                    "RunPrompts_terminal_status_persist_failed",
+                    run_prompt_id=str(self.run_prompt_id),
+                    error=str(terminal_status_error),
+                )
+                raise terminal_status_error from e
             raise
 
     def process_row(self, row, column, edit_mode=False):
@@ -1396,30 +1507,10 @@ class RunPrompts:
                             row_id=row_id,
                         )
 
-                # Dual-write: emit usage event for new billing system
-                try:
-                    try:
-                        from ee.usage.schemas.events import UsageEvent
-                    except ImportError:
-                        UsageEvent = None
-                    try:
-                        from ee.usage.services.emitter import emit
-                    except ImportError:
-                        emit = None
-
-                    if emit is not None and UsageEvent is not None:
-                        emit(
-                            UsageEvent(
-                                org_id=str(self.run_prompt_model.organization.id),
-                                event_type=APICallTypeChoices.DATASET_RUN_PROMPT.value,
-                                properties={
-                                    "source": "dataset_run_prompt",
-                                    "source_id": str(self.run_prompt_id),
-                                },
-                            )
-                        )
-                except Exception:
-                    pass  # Metering failure must not break the action
+                # NOTE: the usage/billing event is deliberately NOT emitted here.
+                # It is emitted only after the cell result has been persisted and
+                # the call reached a success state (see below), so a failed
+                # persist never bills work whose result was not saved (#2080).
 
                 logger.info(
                     "RunPrompts_process_row_populating_placeholders",
@@ -1532,142 +1623,62 @@ class RunPrompts:
                     run_prompt_id=str(self.run_prompt_id),
                     row_id=row_id,
                 )
-                try:
-                    # First try to get the existing cell
-                    cell = Cell.objects.get(
-                        dataset=self.run_prompt_model.dataset,
-                        column=column,
-                        row=row,
-                        deleted=False,  # Add this to ensure we only get active cells
-                    )
-                    logger.info(
-                        "RunPrompts_process_row_existing_cell_found",
-                        run_prompt_id=str(self.run_prompt_id),
-                        row_id=row_id,
-                        cell_id=str(cell.id),
-                    )
-                    # Update the existing cell
-                    # Note: Media (image/audio) is already uploaded to S3 in litellm_response()
-                    cell.value = str(response)
-                    cell.value_infos = (
-                        json.dumps(value_info) if value_info else json.dumps({})
-                    )
-                    cell.status = status
-
-                    if value_info:
-                        cell.prompt_tokens = (
-                            value_info.get("metadata", {})
-                            .get("usage", {})
-                            .get("prompt_tokens", None)
-                        )
-                        cell.completion_tokens = (
-                            value_info.get("metadata", {})
-                            .get("usage", {})
-                            .get("completion_tokens", None)
-                        )
-                        cell.response_time = value_info.get("metadata", {}).get(
-                            "response_time", None
-                        )
-
-                    cell.save()
-                    logger.info(
-                        "cell_updated",
-                        cell_id=str(cell.id),
-                        row_id=row_id,
-                        run_prompt_id=str(self.run_prompt_id),
-                        status=status,
-                    )
-                except Cell.DoesNotExist:
-                    logger.info(
-                        "RunPrompts_process_row_cell_not_found_creating_new",
-                        run_prompt_id=str(self.run_prompt_id),
-                        row_id=row_id,
-                    )
-                    # Create a new cell if none exists
-                    prompt_tokens = None
-                    completion_tokens = None
-                    response_time = None
-                    if value_info:
-                        prompt_tokens = (
-                            value_info.get("metadata", {})
-                            .get("usage", {})
-                            .get("prompt_tokens", None)
-                        )
-                        completion_tokens = (
-                            value_info.get("metadata", {})
-                            .get("usage", {})
-                            .get("completion_tokens", None)
-                        )
-                        response_time = value_info.get("metadata", {}).get(
-                            "response_time", None
-                        )
-
-                    cell = Cell.objects.create(
-                        dataset=self.run_prompt_model.dataset,
-                        column=column,
-                        row=row,
-                        value=str(response),
-                        value_infos=(
-                            json.dumps(value_info) if value_info else json.dumps({})
-                        ),
-                        status=status,
-                        prompt_tokens=prompt_tokens,
-                        completion_tokens=completion_tokens,
-                        response_time=response_time,
-                    )
-                    logger.info(
-                        "cell_created_in_edit_mode",
-                        cell_id=str(cell.id),
-                        row_id=row_id,
-                        run_prompt_id=str(self.run_prompt_id),
-                        status=status,
-                    )
             else:
                 logger.info(
                     "RunPrompts_process_row_creating_new_cell",
                     run_prompt_id=str(self.run_prompt_id),
                     row_id=row_id,
                 )
-                prompt_tokens = (None,)
-                completion_tokens = (None,)
-                response_time = (None,)
-                if value_info:
-                    prompt_tokens = (
-                        value_info.get("metadata", {})
-                        .get("usage", {})
-                        .get("prompt_tokens", None)
-                    )
-                    completion_tokens = (
-                        value_info.get("metadata", {})
-                        .get("usage", {})
-                        .get("completion_tokens", None)
-                    )
-                    response_time = value_info.get("metadata", {}).get(
-                        "response_time", None
-                    )
 
-                # Create a Cell object for each processed row
-                # Note: Media (image/audio) is already uploaded to S3 in litellm_response()
-                cell = Cell.objects.create(
-                    dataset=self.run_prompt_model.dataset,
-                    column=column,
-                    row=row,
-                    value=str(response),
-                    value_infos=(
-                        json.dumps(value_info) if value_info else json.dumps({})
-                    ),
-                    status=status,
-                    prompt_tokens=prompt_tokens,
-                    completion_tokens=completion_tokens,
-                    response_time=response_time,
-                )
-                logger.info(
-                    "cell_created",
-                    cell_id=str(cell.id),
-                    row_id=row_id,
-                    run_prompt_id=str(self.run_prompt_id),
-                    status=status,
-                )
+            # Persist the cell with a terminal-status guarantee: the full
+            # result is written with a retry and a queryset-level status-only
+            # fallback so the cell always reaches a terminal state (#2080).
+            cell_persisted = _persist_cell_result(
+                dataset=self.run_prompt_model.dataset,
+                column=column,
+                row=row,
+                value=response,
+                value_info=value_info,
+                status=status,
+                edit_mode=self.is_editing,
+                run_prompt_id=str(self.run_prompt_id),
+                row_id=row_id,
+            )
+            logger.info(
+                "RunPrompts_process_row_cell_persisted",
+                run_prompt_id=str(self.run_prompt_id),
+                row_id=row_id,
+                status=status,
+                cell_persisted=cell_persisted,
+            )
+
+            # Emit the usage/billing event only after the cell result has been
+            # persisted and the call reached a success state, so a failed
+            # persist never bills work whose result was not saved (#2080).
+            if cell_persisted and status == CellStatus.PASS.value:
+                try:
+                    try:
+                        from ee.usage.schemas.events import UsageEvent
+                    except ImportError:
+                        UsageEvent = None
+                    try:
+                        from ee.usage.services.emitter import emit
+                    except ImportError:
+                        emit = None
+
+                    if emit is not None and UsageEvent is not None:
+                        emit(
+                            UsageEvent(
+                                org_id=str(self.run_prompt_model.organization.id),
+                                event_type=APICallTypeChoices.DATASET_RUN_PROMPT.value,
+                                properties={
+                                    "source": "dataset_run_prompt",
+                                    "source_id": str(self.run_prompt_id),
+                                },
+                            )
+                        )
+                except Exception:
+                    pass  # Metering failure must not break the action
             logger.info(
                 "RunPrompts_process_row_completed",
                 run_prompt_id=str(self.run_prompt_id),


### PR DESCRIPTION
## Summary

Fixes #2080: two related defects on the run-prompt execution path in `futureagi/model_hub/views/run_prompt.py`:

1. **Terminal status could be lost.** If the save that records a cell's terminal status failed, the row was left in a non-terminal state with nothing retrying it — rows could sit indefinitely looking in-flight after the work had finished or failed. The run_prompter `FAILED`-status persist also swallowed failures with a bare `try/except: pass`.
2. **Usage events could be emitted for unpersisted results.** The usage/billing event was emitted *before* the cell result was persisted, so a failed persist could still bill the call.

## Root Cause

In `RunPrompts.process_row` the `emit(UsageEvent(...))` dual-write ran before placeholder population, the LLM call, and the cell persist — the event fired even when `Cell.objects.create()/save()` subsequently failed, and there was no mechanism to guarantee the terminal status if the persist itself failed. The run_prompter `FAILED` handler at the end of `run_prompt()` recorded the terminal status inside `except Exception: pass`, silently swallowing persist failures.

## Change

- **New `_persist_cell_result()` helper** — persists the cell result (value, value_infos, status, tokens) with a retry, then a queryset-level status-only `.update()` fallback so the cell always reaches a terminal state. If even the fallback cannot record the status, it raises loudly (original failure chained via `__cause__`) instead of silently leaving the row non-terminal.
- **Usage event gating** — the premature emit was removed; the usage/billing event is now emitted only **after** the cell has been persisted **and** the call reached a success (`PASS`) state. Never for failed calls, never for work whose result was not saved (fail-closed on billing).
- **Run_prompter `FAILED` persist** — a failed terminal-status write now logs at critical level and raises (chained to the original failure) instead of being swallowed.

## Verification

- New regression suite `futureagi/model_hub/tests/test_run_prompt_status_persist.py` — **11 tests, all passing**:
  - usage event emitted exactly once, strictly after cell persist, on success;
  - no usage event on failed LLM call (terminal `ERROR` cell still persisted);
  - no usage event when persist fails and only the status fallback records the terminal status;
  - raises loudly when the terminal status cannot be recorded at all;
  - persist retry, status-only fallback semantics, and edit-mode get-or-create behavior;
  - run_prompter `FAILED`-persist failure propagates loudly with the original row failure as `__cause__`.
- Sabotage-verified: reverting to the old behavior (unconditional emit + fallback treated as full persist) makes **3 of the 11 tests fail**, so the suite genuinely pins the fixed contract.
- `ruff check` clean on the changed files (no new findings vs. base).
- Full DB-backed suites (`test_run_prompt_api.py` and the `django_db` cases) require the Docker stack (ClickHouse/Postgres via `bin/test`) and run in CI; the new tests are mock-based and pass locally without services.

## Relationship to #2101

Our own PR #2101 (`fix/GH-2081-sanitize-run-prompt-errors`) bundles #2081/#2080/#2079. This PR is the **focused #2080-only** implementation, per the issue's own request to raise #2080 separately. #2101 removes the premature emit but does **not** re-add it after persist (its note says "see below", but the emit is never restored — billing would be dropped entirely), and its body claims a FAILED retry/fallback that is not present in its diff. This PR implements the complete #2080 contract (terminal status always persisted + usage emitted only for persisted success) and is independently mergeable on top of either version of the #2101 changes (small overlap in the removed-emit region, trivially resolvable).

## Files

- `futureagi/model_hub/views/run_prompt.py` — `_persist_cell_result()` helper, emit gating, loud FAILED-persist handling
- `futureagi/model_hub/tests/test_run_prompt_status_persist.py` — new regression suite (11 tests)

Closes #2080
