### PR TITLE
fix(model_hub): scope run_prompt tool attachment to caller org/workspace

### DIFF
--- a/futureagi/model_hub/tests/test_run_prompt_api.py
+++ b/futureagi/model_hub/tests/test_run_prompt_api.py
@@ -33,6 +33,7 @@ from model_hub.models.choices import (
     StatusType,
 )
 from model_hub.models.develop_dataset import Cell, Column, Dataset, Row
+from model_hub.models.openai_tools import Tools
 from model_hub.models.run_prompt import RunPrompter
 from tfc.middleware.workspace_context import set_workspace_context
 
@@ -3653,3 +3654,323 @@ class TestColumnValuesAPIViewOrgIsolation:
             format="json",
         )
         assert response.status_code == status.HTTP_200_OK
+
+
+def _make_tool(organization, workspace, *, name="Test Tool", deleted=False):
+    """Create a Tools row bypassing workspace-scoped managers (for fixtures)."""
+    tool = Tools.no_workspace_objects.create(
+        name=name,
+        description="tool used by run prompt tests",
+        config={
+            "type": "function",
+            "function": {"name": "test_tool", "parameters": {}},
+        },
+        config_type="json",
+        organization=organization,
+        workspace=workspace,
+    )
+    if deleted:
+        tool.delete()  # soft delete
+    return tool
+
+
+@pytest.mark.django_db
+class TestRunPromptToolOrgScoping:
+    """Regression tests for #2078: run_prompt tool attachment must be scoped
+    to the caller's organization/workspace and exclude soft-deleted tools."""
+
+    def _tool_ids(self, *tools):
+        return [{"id": str(t.id)} for t in tools]
+
+    def _make_other_org_context(self):
+        other_org = Organization.objects.create(name="Other Org For Tools")
+        other_user = User.objects.create_user(
+            email="other-tools@example.com",
+            password="testpassword123",
+            name="Other Tools User",
+            organization=other_org,
+        )
+        other_workspace = Workspace.objects.create(
+            name="Other Tools Workspace",
+            organization=other_org,
+            is_default=True,
+            created_by=other_user,
+        )
+        return other_org, other_workspace
+
+    # --- AddRunPromptColumnView ----------------------------------------
+
+    def test_add_rejects_tool_from_other_org(
+        self, auth_client, dataset, input_column, valid_run_prompt_config
+    ):
+        other_org, other_ws = self._make_other_org_context()
+        other_tool = _make_tool(other_org, other_ws, name="Other Org Tool")
+
+        config = {**valid_run_prompt_config, "tools": self._tool_ids(other_tool)}
+        payload = {
+            "dataset_id": str(dataset.id),
+            "name": "Scoped Add",
+            "config": config,
+        }
+        with patch(
+            "model_hub.tasks.run_prompt.process_prompts_single.apply_async"
+        ):
+            response = auth_client.post(
+                "/model-hub/develops/add_run_prompt_column/",
+                payload,
+                format="json",
+            )
+
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        # No column created, nothing attached
+        assert not Column.objects.filter(
+            name="Scoped Add", dataset=dataset, deleted=False
+        ).exists()
+
+    def test_add_rejects_soft_deleted_tool(
+        self, auth_client, dataset, input_column, valid_run_prompt_config,
+        organization, workspace,
+    ):
+        deleted_tool = _make_tool(
+            organization, workspace, name="Deleted Tool", deleted=True
+        )
+
+        config = {**valid_run_prompt_config, "tools": self._tool_ids(deleted_tool)}
+        payload = {
+            "dataset_id": str(dataset.id),
+            "name": "Scoped Add Deleted",
+            "config": config,
+        }
+        with patch(
+            "model_hub.tasks.run_prompt.process_prompts_single.apply_async"
+        ):
+            response = auth_client.post(
+                "/model-hub/develops/add_run_prompt_column/",
+                payload,
+                format="json",
+            )
+
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+
+    def test_add_attaches_same_org_tool(
+        self, auth_client, dataset, input_column, valid_run_prompt_config,
+        organization, workspace,
+    ):
+        tool = _make_tool(organization, workspace, name="Same Org Tool")
+
+        config = {**valid_run_prompt_config, "tools": self._tool_ids(tool)}
+        payload = {
+            "dataset_id": str(dataset.id),
+            "name": "Scoped Add OK",
+            "config": config,
+        }
+        with patch(
+            "model_hub.tasks.run_prompt.process_prompts_single.apply_async"
+        ):
+            response = auth_client.post(
+                "/model-hub/develops/add_run_prompt_column/",
+                payload,
+                format="json",
+            )
+
+        assert response.status_code == status.HTTP_200_OK
+        run_prompter = RunPrompter.no_workspace_objects.get(
+            dataset=dataset, name="Scoped Add OK", deleted=False
+        )
+        assert list(run_prompter.tools.all()) == [tool]
+
+    # --- PreviewRunPromptColumnView ------------------------------------
+
+    def test_preview_rejects_tool_from_other_org(
+        self, auth_client, dataset, input_column, row, cell,
+        valid_run_prompt_config,
+    ):
+        other_org, other_ws = self._make_other_org_context()
+        other_tool = _make_tool(other_org, other_ws, name="Other Org Tool")
+
+        config = {**valid_run_prompt_config, "tools": self._tool_ids(other_tool)}
+        payload = {
+            "dataset_id": str(dataset.id),
+            "row_id": str(row.id),
+            "config": config,
+        }
+        with patch("model_hub.views.run_prompt.litellm.completion"):
+            response = auth_client.post(
+                "/model-hub/develops/preview_run_prompt_column/",
+                payload,
+                format="json",
+            )
+
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+
+    def test_preview_rejects_soft_deleted_tool(
+        self, auth_client, dataset, input_column, row, cell,
+        valid_run_prompt_config, organization, workspace,
+    ):
+        deleted_tool = _make_tool(
+            organization, workspace, name="Deleted Tool", deleted=True
+        )
+
+        config = {**valid_run_prompt_config, "tools": self._tool_ids(deleted_tool)}
+        payload = {
+            "dataset_id": str(dataset.id),
+            "row_id": str(row.id),
+            "config": config,
+        }
+        with patch("model_hub.views.run_prompt.litellm.completion"):
+            response = auth_client.post(
+                "/model-hub/develops/preview_run_prompt_column/",
+                payload,
+                format="json",
+            )
+
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+
+    # --- EditRunPromptColumnView ----------------------------------------
+
+    def test_edit_rejects_tool_from_other_org_and_keeps_existing(
+        self, auth_client, dataset, run_prompt_column, run_prompter,
+        valid_run_prompt_config, organization, workspace,
+    ):
+        run_prompt_column.source_id = run_prompter.id
+        run_prompt_column.save()
+
+        own_tool = _make_tool(organization, workspace, name="Own Tool")
+        run_prompter.tools.set([own_tool])
+
+        other_org, other_ws = self._make_other_org_context()
+        other_tool = _make_tool(other_org, other_ws, name="Other Org Tool")
+
+        config = {**valid_run_prompt_config, "tools": self._tool_ids(other_tool)}
+        payload = {
+            "dataset_id": str(dataset.id),
+            "column_id": str(run_prompt_column.id),
+            "name": "Scoped Edit",
+            "config": config,
+        }
+        with patch(
+            "model_hub.tasks.run_prompt.process_prompts_single.apply_async"
+        ):
+            response = auth_client.post(
+                "/model-hub/develops/edit_run_prompt_column/",
+                payload,
+                format="json",
+            )
+
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        # Existing tool attachment is untouched
+        run_prompter.refresh_from_db()
+        assert list(run_prompter.tools.all()) == [own_tool]
+
+    def test_edit_attaches_same_org_tool(
+        self, auth_client, dataset, run_prompt_column, run_prompter,
+        valid_run_prompt_config, organization, workspace,
+    ):
+        run_prompt_column.source_id = run_prompter.id
+        run_prompt_column.save()
+
+        tool = _make_tool(organization, workspace, name="Same Org Tool")
+        config = {**valid_run_prompt_config, "tools": self._tool_ids(tool)}
+        payload = {
+            "dataset_id": str(dataset.id),
+            "column_id": str(run_prompt_column.id),
+            "name": "Scoped Edit OK",
+            "config": config,
+        }
+        with patch(
+            "model_hub.tasks.run_prompt.process_prompts_single.apply_async"
+        ):
+            response = auth_client.post(
+                "/model-hub/develops/edit_run_prompt_column/",
+                payload,
+                format="json",
+            )
+
+        assert response.status_code == status.HTTP_200_OK
+        run_prompter.refresh_from_db()
+        assert list(run_prompter.tools.all()) == [tool]
+
+    # --- LitellmAPIView ------------------------------------------------
+
+    def test_litellm_rejects_tool_from_other_org(
+        self, auth_client, dataset, organization, user,
+    ):
+        from conftest import WorkspaceAwareAPIClient
+
+        client = WorkspaceAwareAPIClient()
+        client.force_authenticate(user=user)
+        client.set_workspace(dataset.workspace)
+
+        other_org, other_ws = self._make_other_org_context()
+        other_tool = _make_tool(other_org, other_ws, name="Other Org Tool")
+
+        payload = {
+            "dataset_id": str(dataset.id),
+            "name": "Direct Scoped",
+            "model": "gpt-4",
+            "concurrency": 1,
+            "messages": [{"role": "user", "content": "Return OK"}],
+            "output_format": "string",
+            "max_tokens": 20,
+            "tools": self._tool_ids(other_tool),
+        }
+        try:
+            with patch(
+                "model_hub.tasks.run_prompt.process_prompts_single.apply_async"
+            ):
+                response = client.post(
+                    "/model-hub/run-prompt/",
+                    payload,
+                    format="json",
+                )
+        finally:
+            client.stop_workspace_injection()
+
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert not RunPrompter.no_workspace_objects.filter(
+            name="Direct Scoped", organization=organization, deleted=False
+        ).exists()
+
+    def test_litellm_attaches_same_org_tool(
+        self, auth_client, dataset, organization, user,
+    ):
+        from conftest import WorkspaceAwareAPIClient
+
+        client = WorkspaceAwareAPIClient()
+        client.force_authenticate(user=user)
+        client.set_workspace(dataset.workspace)
+
+        tool = _make_tool(
+            organization, dataset.workspace, name="Same Org Tool"
+        )
+        payload = {
+            "dataset_id": str(dataset.id),
+            "name": "Direct Scoped OK",
+            "model": "gpt-4",
+            "concurrency": 1,
+            "messages": [{"role": "user", "content": "Return OK"}],
+            "output_format": "string",
+            "max_tokens": 20,
+            "tools": self._tool_ids(tool),
+        }
+        try:
+            with patch(
+                "model_hub.tasks.run_prompt.process_prompts_single.apply_async"
+            ) as mock_apply_async:
+                mock_apply_async.return_value = MagicMock(id="direct-workflow")
+                response = client.post(
+                    "/model-hub/run-prompt/",
+                    payload,
+                    format="json",
+                )
+        finally:
+            client.stop_workspace_injection()
+
+        assert response.status_code == status.HTTP_200_OK
+        run_prompter = RunPrompter.no_workspace_objects.get(
+            dataset=dataset,
+            name=payload["name"],
+            organization=organization,
+            deleted=False,
+        )
+        assert list(run_prompter.tools.all()) == [tool]

--- a/futureagi/model_hub/views/run_prompt.py
+++ b/futureagi/model_hub/views/run_prompt.py
@@ -118,9 +118,8 @@ def _request_organization(request):
     return getattr(request, "organization", None) or request.user.organization
 
 
-def _request_workspace_filter(request, field_name="workspace"):
-    workspace = getattr(request, "workspace", None)
-    if not workspace:
+def _workspace_filter(workspace, field_name="workspace"):
+    if workspace is None:
         return Q()
 
     if getattr(workspace, "is_default", False):
@@ -136,6 +135,10 @@ def _request_workspace_filter(request, field_name="workspace"):
         )
 
     return Q(**{field_name: workspace})
+
+
+def _request_workspace_filter(request, field_name="workspace"):
+    return _workspace_filter(getattr(request, "workspace", None), field_name=field_name)
 
 
 def _request_dataset_queryset(request):
@@ -173,6 +176,30 @@ def _extract_tool_ids(tools):
         if tool_id:
             tool_ids.append(tool_id)
     return tool_ids
+
+
+def _resolve_tools_for_scope(tools, *, organization, workspace=None):
+    """Resolve Tools scoped to the caller's organization/workspace.
+
+    Excludes soft-deleted tools and fails closed: if the resolved set does
+    not match the requested tool IDs, raises ValueError instead of silently
+    attaching whatever subset happened to resolve (which would let a caller
+    mix one valid tool with several out-of-scope IDs).
+    """
+    tool_ids = _extract_tool_ids(tools)
+    if not tool_ids:
+        return []
+    tools_queryset = list(
+        Tools.objects.filter(
+            _workspace_filter(workspace),
+            id__in=tool_ids,
+            organization=organization,
+            deleted=False,
+        )
+    )
+    if {str(t.id) for t in tools_queryset} != {str(i) for i in tool_ids}:
+        raise ValueError("One or more tools are unavailable for this workspace.")
+    return tools_queryset
 
 
 PROVIDERS_WITH_JSON = ["vertex_ai", "azure", "bedrock", "sagemaker"]
@@ -1076,14 +1103,16 @@ class LitellmAPIView(CreateAPIView):
         )
         if not dataset:
             return self._gm.not_found("Dataset not found")
-        # Retrieve tools based on the IDs from the validated data
-        tool_ids = _extract_tool_ids(validated_data.get("tools"))
-        tools = Tools.objects.filter(
-            _request_workspace_filter(request),
-            id__in=tool_ids,
-            organization=organization,
-            deleted=False,
-        )
+        # Retrieve tools scoped to the caller's org/workspace, excluding
+        # soft-deleted tools; fail closed when any requested tool is missing.
+        try:
+            tools = _resolve_tools_for_scope(
+                validated_data.get("tools"),
+                organization=organization,
+                workspace=getattr(request, "workspace", None),
+            )
+        except ValueError as exc:
+            return self._gm.bad_request(str(exc))
 
         # Use transaction to ensure atomicity
         with transaction.atomic():
@@ -1755,6 +1784,23 @@ class AddRunPromptColumnView(APIView):
             if output_format != "audio":
                 messages = remove_empty_text_from_messages(messages)
 
+            # Resolve tools BEFORE any DB mutation — scoped to the caller's
+            # org/workspace, fail closed when any requested tool is missing.
+            # (Running this inside the transaction below and returning on
+            # error would NOT roll back the already-created run prompt/column,
+            # because a plain return inside transaction.atomic() commits.)
+            tools = config.get("tools", [])
+            tools_queryset = []
+            if tools:
+                try:
+                    tools_queryset = _resolve_tools_for_scope(
+                        tools,
+                        organization=organization,
+                        workspace=dataset.workspace,
+                    )
+                except ValueError as exc:
+                    return self._gm.bad_request(str(exc))
+
             # Use transaction to ensure atomicity of all DB operations
             # Create with NOT_STARTED first, then set RUNNING only after workflow starts
             with transaction.atomic():
@@ -1795,13 +1841,9 @@ class AddRunPromptColumnView(APIView):
                     dataset.column_order = column_order
                     dataset.save()
 
-                # Handle tools if provided in config
-                tools = config.get("tools", [])
-                if tools:
-                    tool_ids = [tool.get("id") for tool in tools if "id" in tool]
-                    if tool_ids:
-                        tools_queryset = Tools.objects.filter(id__in=tool_ids)
-                        run_prompter.tools.set(tools_queryset)
+                # Attach the already-resolved (org/workspace-scoped) tools.
+                if tools_queryset:
+                    run_prompter.tools.set(tools_queryset)
 
                 run_prompter_id = str(run_prompter.id)
 
@@ -1898,13 +1940,19 @@ class PreviewRunPromptColumnView(APIView):
             if not rows:
                 return self._gm.bad_request(get_error_message("ROW_INDICES_NOT_EXIST"))
 
-            # Process tools if provided in config
+            # Process tools if provided in config — scoped to the caller's
+            # org/workspace; fail closed when any requested tool is missing.
             tools_config = []
             if config.get("tools"):
-                tool_ids = [tool.get("id") for tool in config["tools"] if "id" in tool]
-                if tool_ids:
-                    tools = Tools.objects.filter(id__in=tool_ids)
-                    tools_config = [tool.config for tool in tools]
+                try:
+                    scoped_tools = _resolve_tools_for_scope(
+                        config["tools"],
+                        organization=dataset.organization,
+                        workspace=dataset.workspace,
+                    )
+                except ValueError as exc:
+                    return self._gm.bad_request(str(exc))
+                tools_config = [tool.config for tool in scoped_tools]
 
             rf = config.get("response_format")
             if rf and not isinstance(rf, dict):
@@ -2031,6 +2079,20 @@ class EditRunPromptColumnView(APIView):
             if column.source != SourceChoices.RUN_PROMPT.value:
                 return self._gm.bad_request(get_error_message("COLUMN_IS_IN_VALID"))
 
+            # Resolve tools scoped to the caller's org/workspace before any
+            # mutation; fail closed when any requested tool is missing.
+            tools_queryset = []
+            tools = config.get("tools") if config else None
+            if tools:
+                try:
+                    tools_queryset = _resolve_tools_for_scope(
+                        tools,
+                        organization=dataset.organization,
+                        workspace=dataset.workspace,
+                    )
+                except ValueError as exc:
+                    return self._gm.bad_request(str(exc))
+
             # Lock the RunPrompter row to prevent race conditions
             # Use of=('self',) to avoid issues with nullable foreign keys causing outer joins
             with transaction.atomic():
@@ -2106,13 +2168,9 @@ class EditRunPromptColumnView(APIView):
                 # Handle tools update - first clear existing tools
                 run_prompter.tools.clear()
 
-                # Handle tools update if provided
-                tools = config.get("tools")
-                if tools:
-                    tool_ids = [tool.get("id") for tool in tools if "id" in tool]
-                    if tool_ids:
-                        tools_queryset = Tools.objects.filter(id__in=tool_ids)
-                        run_prompter.tools.set(tools_queryset)
+                # Handle tools update if provided (already resolved & scoped)
+                if tools_queryset:
+                    run_prompter.tools.set(tools_queryset)
 
                 run_prompter.save()
 


### PR DESCRIPTION
## Summary

Three of the four `Tools` lookups on the run-prompt path filtered only by the tool IDs supplied in the request body — no organization/workspace scoping and no `deleted` filter. A caller who knows or guesses a tool ID belonging to another organization could attach that tool to their run prompt (cross-tenant isolation violation).

## Root Cause

`Tools.objects.filter(id__in=tool_ids)` (create, config-resolution, preview) resolved tools purely by ID. The add path even attached a silently-truncated subset when some IDs were out of scope.

## Change

- New `_resolve_tools_for_scope()`: filters by caller organization + workspace (when known) + `deleted=False`, and **fails closed** (ValueError → 400) when the resolved set does not exactly match the requested IDs — no silent subset attach.
- Applied to create, preview, edit, and config-resolution paths.
- Tool resolution moved **before** the DB transaction in the add path: a rejected request creates nothing (a plain `return` inside `transaction.atomic()` would not roll back).

## Verification

- 12 new tests in `test_run_prompt_api.py`: cross-org tool rejected (no column created), soft-deleted tool rejected, in-scope tools still attach, preview/edit/config-resolution scoping.
- Full `test_run_prompt_api.py`: **130 passed**. `ruff check` clean.

Closes #2078