### PR TITLE
fix(agentic_eval): replace bare `except:` with `except Exception:`

### DIFF
--- a/futureagi/agentic_eval/core/embeddings/embedding_manager.py
+++ b/futureagi/agentic_eval/core/embeddings/embedding_manager.py
@@ -961,7 +961,7 @@ class EmbeddingManager:
                     top_k,
                     syn_data_flag,
                 )
-            except:
+            except Exception:
                 traceback.print_exc()
             # print(f"[FEEDBACK QUERY] retrieve_rag_based_examples: returned {len(results)} results", flush=True)
 

--- a/futureagi/agentic_eval/core/llm/llm.py
+++ b/futureagi/agentic_eval/core/llm/llm.py
@@ -1734,7 +1734,7 @@ class LLM:
                                     },
                                 }
                             )
-                        except:
+                        except Exception:
                             # If conversion fails, keep original format
                             new_content.append(content)
                     elif (
@@ -1750,7 +1750,7 @@ class LLM:
                             new_content.append(
                                 {"type": "image_url", "image_url": {"url": url}}
                             )
-                        except:
+                        except Exception:
                             # If conversion fails, keep original format
                             new_content.append(content)
                     else:

--- a/futureagi/agentic_eval/core_evals/fi_evals/function/functions.py
+++ b/futureagi/agentic_eval/core_evals/fi_evals/function/functions.py
@@ -1344,7 +1344,7 @@ def contains_valid_link(text, **kwargs):
                         "result": False,
                         "reason": f"link {matched_url} found in output but is invalid",
                     }
-            except:
+            except Exception:
                 return {
                     "result": False,
                     "reason": f"link {matched_url} found in output but is invalid",
@@ -1380,7 +1380,7 @@ def no_invalid_links(text, **kwargs):
                         "result": False,
                         "reason": f"link {matched_url} found in output but is invalid",
                     }
-            except:
+            except Exception:
                 return {
                     "result": False,
                     "reason": f"link {matched_url} found in output but is invalid",


### PR DESCRIPTION

Fixes #1465

## Summary
Bare `except:` clauses in the agentic eval package catch **every** exception,
including `KeyboardInterrupt` and `SystemExit`. This makes long-running eval
runs impossible to interrupt with Ctrl-C and can swallow interpreter-shutdown
signals. This PR narrows each bare clause to `except Exception:` so those
control-flow exceptions propagate and runs stay killable. Behaviour for
ordinary errors is unchanged.

## What changed
Every bare `except:` in `futureagi/agentic_eval/` was changed to
`except Exception:` (5 sites, indentation preserved exactly). No
`except SomethingSpecific:` clause was touched.

- `futureagi/agentic_eval/core/llm/llm.py:1737`
- `futureagi/agentic_eval/core/llm/llm.py:1753`
- `futureagi/agentic_eval/core/embeddings/embedding_manager.py:964`
- `futureagi/agentic_eval/core_evals/fi_evals/function/functions.py:1347`
- `futureagi/agentic_eval/core_evals/fi_evals/function/functions.py:1383`

> Note: issue #1465 estimated ~7 sites; a full `grep -rnE "except\s*:"` over
> `futureagi/agentic_eval/**/*.py` found exactly 5. All 5 are fixed.

## Why
`KeyboardInterrupt` and `SystemExit` derive from `BaseException`, not
`Exception`. A bare `except:` therefore intercepts them, defeating Ctrl-C and
clean shutdown. `except Exception:` preserves the intended error handling while
letting those signals through — the standard, lint-recommended (PEP 8 / `E722`)
pattern.

## Testing
- `python -m py_compile` on all three changed files: **passes**.
- `grep -rnE "except\s*:" futureagi/agentic_eval --include="*.py"` after the
  change returns **no matches**.
- No behavioural test added; the change is a pure exception-scope narrowing.
