### PR TITLE
fix(model_hub): route Python-code columns through the sandbox (dead `exec` path)

### DIFF
--- a/futureagi/model_hub/views/develop_dataset.py
+++ b/futureagi/model_hub/views/develop_dataset.py
@@ -9898,43 +9898,35 @@ class ExecutePythonCodeView(APIView):
             # Create kwargs from cell data
             kwargs = {cell.column.name: cell.value for cell in cells}
 
-            # Restricted globals - only safe builtins
-            safe_builtins = {
-                "abs": abs,
-                "all": all,
-                "any": any,
-                "bool": bool,
-                "dict": dict,
-                "enumerate": enumerate,
-                "filter": filter,
-                "float": float,
-                "int": int,
-                "len": len,
-                "list": list,
-                "map": map,
-                "max": max,
-                "min": min,
-                "range": range,
-                "round": round,
-                "set": set,
-                "sorted": sorted,
-                "str": str,
-                "sum": sum,
-                "tuple": tuple,
-                "zip": zip,
-            }
-            _global_namespace = {"__builtins__": safe_builtins}
-            local_namespace = {}
+            # Execute the provided code inside the hardened sandbox
+            # (nsjail executor with a RestrictedPython subprocess fallback)
+            # instead of the removed in-process exec(). The sandbox restricts
+            # builtins/imports itself, so the previous local safe_builtins /
+            # exec scaffolding is no longer needed. User code must define a
+            # top-level `main(input_data)` (or `evaluate(input_data)`) entry
+            # point that receives the row's column values as a dict.
+            from agentic_eval.core_evals.fi_utils.sandbox import (
+                execute_sandboxed_python,
+            )
 
-            # Execute the provided code with restricted globals
-            # WARNING: This still has security implications and should be properly sandboxed
-            # exec(code, _global_namespace, local_namespace)  # nosec B102 - sandboxed execution
+            sandbox_result = execute_sandboxed_python(
+                code=code,
+                input_data=kwargs,
+                timeout=30,
+            )
 
-            # Validate presence of `main()` function
-            if "main" not in local_namespace or not callable(local_namespace["main"]):
-                raise ValueError("Code must define a callable 'main' function.")
+            if (
+                not isinstance(sandbox_result, dict)
+                or sandbox_result.get("status") != "success"
+            ):
+                reason = (
+                    sandbox_result.get("data")
+                    if isinstance(sandbox_result, dict)
+                    else "Sandboxed execution failed."
+                )
+                return str(reason), {"reason": str(reason)}
 
-            result = local_namespace["main"](**kwargs)
+            result = sandbox_result.get("data")
 
             return str(result), None
 

--- a/futureagi/model_hub/views/dynamic_columns.py
+++ b/futureagi/model_hub/views/dynamic_columns.py
@@ -1305,45 +1305,35 @@ class ExecutePythonCodeView(APIView):
             # Create kwargs from cell data
             kwargs = {cell.column.name: cell.value for cell in cells}
 
-            # Restricted globals - only safe builtins
-            safe_builtins = {
-                "abs": abs,
-                "all": all,
-                "any": any,
-                "bool": bool,
-                "dict": dict,
-                "enumerate": enumerate,
-                "filter": filter,
-                "float": float,
-                "int": int,
-                "len": len,
-                "list": list,
-                "map": map,
-                "max": max,
-                "min": min,
-                "range": range,
-                "round": round,
-                "set": set,
-                "sorted": sorted,
-                "str": str,
-                "sum": sum,
-                "tuple": tuple,
-                "zip": zip,
-            }
-            _global_namespace = {"__builtins__": safe_builtins}
-            local_namespace = {}
+            # Execute the provided code inside the hardened sandbox
+            # (nsjail executor with a RestrictedPython subprocess fallback)
+            # instead of the removed in-process exec(). The sandbox restricts
+            # builtins/imports itself, so the previous local safe_builtins /
+            # exec scaffolding is no longer needed. User code must define a
+            # top-level `main(input_data)` (or `evaluate(input_data)`) entry
+            # point that receives the row's column values as a dict.
+            from agentic_eval.core_evals.fi_utils.sandbox import (
+                execute_sandboxed_python,
+            )
 
-            # Execute the provided code with restricted globals
-            # WARNING: This still has security implications and should be properly sandboxed
-            # exec(
-            #     code, global_namespace, local_namespace
-            # )  # nosec B102 - sandboxed execution
+            sandbox_result = execute_sandboxed_python(
+                code=code,
+                input_data=kwargs,
+                timeout=30,
+            )
 
-            # Validate presence of `main()` function
-            if "main" not in local_namespace or not callable(local_namespace["main"]):
-                raise ValueError("Code must define a callable 'main' function.")
+            if (
+                not isinstance(sandbox_result, dict)
+                or sandbox_result.get("status") != "success"
+            ):
+                reason = (
+                    sandbox_result.get("data")
+                    if isinstance(sandbox_result, dict)
+                    else "Sandboxed execution failed."
+                )
+                return str(reason), {"reason": str(reason)}
 
-            result = local_namespace["main"](**kwargs)
+            result = sandbox_result.get("data")
 
             return str(result), None
 


### PR DESCRIPTION

> ⚠️ **NEEDS MAINTAINER/AUTHOR REVIEW — sandbox wiring inferred.** See
> "Uncertainty / decisions that need confirmation" below. The dead-code
> diagnosis is certain; the exact user-code calling convention after wiring is
> a judgement call that a maintainer should confirm.

## Summary
The "Python code" dataset column feature is currently **dead**. The in-process
`exec(...)` that used to run the user's code was commented out (with a `nosec`
note), so `local_namespace` is always empty and the code immediately hits:

```python
if "main" not in local_namespace or not callable(local_namespace["main"]):
    raise ValueError("Code must define a callable 'main' function.")
```

Every invocation raises `"Code must define a callable 'main' function."`,
regardless of what the user submits.

This PR removes the dead `exec` + `main()` scaffolding at both call sites and
routes the user code through the repository's existing hardened sandbox
(`execute_sandboxed_python`), which is the same executor the eval engine uses
(`agentic_eval/core_evals/fi_utils/fi_code_execution.py`).

## What changed
Two structurally identical call sites, both
`_execute_python_code(self, row, code)`:

- `futureagi/model_hub/views/develop_dataset.py` (~line 9901–9939,
  `ExecutePythonCodeView`)
- `futureagi/model_hub/views/dynamic_columns.py` (~line 1308–1348)

At each site the removed block was:
1. a local `safe_builtins` dict + `_global_namespace` / `local_namespace`
   (scaffolding that only existed to feed the commented-out `exec`),
2. the commented-out `exec(...)`,
3. the `if "main" not in local_namespace ...` guard, and
4. `result = local_namespace["main"](**kwargs)`.

It is replaced with:

```python
from agentic_eval.core_evals.fi_utils.sandbox import (
    execute_sandboxed_python,
)

sandbox_result = execute_sandboxed_python(
    code=code,
    input_data=kwargs,
    timeout=30,
)

if (
    not isinstance(sandbox_result, dict)
    or sandbox_result.get("status") != "success"
):
    reason = (
        sandbox_result.get("data")
        if isinstance(sandbox_result, dict)
        else "Sandboxed execution failed."
    )
    return str(reason), {"reason": str(reason)}

result = sandbox_result.get("data")
return str(result), None
```

`execute_sandboxed_python(code, input_data, timeout) -> dict` runs the code
under the nsjail code-executor service (Tier 1) with a RestrictedPython
subprocess fallback (Tier 2), and returns `{"status": "success"|"error",
"data": ...}`. The `(result, None)` / `(error_str, {"reason": ...})` return
contract of the original method is preserved. The import path matches the
existing `from agentic_eval.core_evals.fi_utils...` imports already at the top
of both files.

## Why
- The feature is 100% non-functional today (always raises), so this is a
  bug fix, not a behaviour change for any working path.
- Re-enabling a plain in-process `exec` of user code would be a serious RCE
  risk. The repo already ships a purpose-built, multi-layer sandbox for exactly
  this ("execute user-provided code"); reusing it is the safe, codebase-
  consistent fix rather than re-introducing `exec`.

## Uncertainty / decisions that need confirmation
The **calling convention for the user's code changed**, and this is the part a
maintainer should confirm:

- The old (dead) code called `local_namespace["main"](**kwargs)` — i.e. it
  expanded each row column into a **named keyword argument** (`main(col_a,
  col_b, ...)`).
- The sandbox instead calls the user's entry point with a **single dict
  positional argument** and requires the entry point to be named `main` **or**
  `evaluate`: `main(input_data)` / `evaluate(input_data)` (see
  `_build_python_sandbox_script` and the JS/PY entry regex in
  `fi_code_execution.py`).

I passed the per-row `kwargs` dict as `input_data`, adopting the sandbox's
documented `main(input_data)` / `evaluate(input_data)` contract. Because the
feature has been dead, there is no working production user code to preserve, so
aligning to the sandbox contract (the same one the eval engine exposes) is the
most consistent choice. **However**, if the product intends to keep the old
`main(**column_kwargs)` signature, the maintainer should either (a) update the
user-facing docs/UI to the `main(input_data)` form, or (b) request a thin
adapter be generated around the user code before sandboxing. I did **not**
invent any adapter or private API — only the public `execute_sandboxed_python`
entry point is used.

Also worth a maintainer's eye: the pre-existing `contains_sql` / dangerous-
import / dangerous-pattern string checks earlier in each method are left intact
(defense in depth) and are unaffected by this change.

## Testing
- `python -m py_compile` on both changed files: **passes**.
- Verified no residual references to the removed scaffolding
  (`local_namespace`, `_global_namespace`, `safe_builtins`, the "Code must
  define a callable 'main' function" string) remain outside the new comment.
- Verified the `execute_sandboxed_python` import path matches existing
  `agentic_eval.core_evals.fi_utils.*` imports already present in both files.
- No runtime/integration test was run: exercising the sandbox needs the nsjail
  executor service (or the RestrictedPython fallback subprocess) and Django DB
  fixtures — out of scope for a static change. **Recommend the maintainer run
  the Python-code-column flow end-to-end** to confirm the entry-point contract.


Fixes #2134
