### PR TITLE
fix: correct invalid CSS width on Add Filter button icon

### DIFF
--- a/frontend/src/sections/develop-detail/DataTab/DevelopFilters/DevelopFilterRow.jsx
+++ b/frontend/src/sections/develop-detail/DataTab/DevelopFilters/DevelopFilterRow.jsx
@@ -108,7 +108,7 @@ const DevelopFilterRow = ({
               <SvgColor
                 src="/assets/icons/ic_add.svg"
                 sx={{
-                  width: "20ox !important",
+                  width: "20px !important",
                   height: "20px !important",
                   color: "primary.main",
                 }}

--- a/frontend/src/sections/evals/DevelopFilters/DevelopFilterRow.jsx
+++ b/frontend/src/sections/evals/DevelopFilters/DevelopFilterRow.jsx
@@ -76,7 +76,7 @@ const DevelopFilterRow = ({
               <SvgColor
                 src="/assets/icons/ic_add.svg"
                 sx={{
-                  width: "20ox !important",
+                  width: "20px !important",
                   height: "20px !important",
                   color: "primary.main",
                 }}


### PR DESCRIPTION
## Summary

The Add Filter button's icon sets `width: "20ox !important"` — an invalid CSS length (`ox` instead of `px`). Browsers discard the declaration, so the icon renders at its intrinsic width while `height: "20px !important"` applies, leaving a mismatched width/height and a misaligned filter row.

Replaces `20ox` with `20px` in both files that carry the typo.

## Changes

- `frontend/src/sections/develop-detail/DataTab/DevelopFilters/DevelopFilterRow.jsx` line 111
- `frontend/src/sections/evals/DevelopFilters/DevelopFilterRow.jsx` line 79

## Verification

- Repo-wide search for `20ox` now returns zero results
- Change is a pure string correction; no behavior changes

Fixes #1967