### PR TITLE
fix(fi-collector): honor admin.addr config and serve /metrics

### DIFF
--- a/fi-collector/cmd/fi-collector/main.go
+++ b/fi-collector/cmd/fi-collector/main.go
@@ -53,15 +53,10 @@ type rootConfig struct {
 	Admin  adminConfig     `yaml:"admin"`
 }
 
-// defaultAdminAddr is the internal-only admin listener. Loopback by
-// default: /healthz and /metrics are for the local host / container health
-// checks, not for external scraping, so the default must not bind on
-// 0.0.0.0. Deployments that need it on the wire set admin.addr (or
-// FI_ADMIN_ADDR) explicitly.
+// defaultAdminAddr is the internal-only admin listener (loopback default).
 const defaultAdminAddr = "127.0.0.1:9464"
 
-// resolveAdminAddr returns the configured admin listener address, falling
-// back to defaultAdminAddr when admin.addr is unset.
+// resolveAdminAddr returns the configured admin address or the loopback default.
 func resolveAdminAddr(cfg rootConfig) string {
 	if cfg.Admin.Addr != "" {
 		return cfg.Admin.Addr
@@ -129,9 +124,7 @@ func main() {
 	}
 	srv := server.New(cfg.Server, writer, authenticator, usageEmitter, metering, opts...)
 
-	// Admin HTTP server — internal only: /healthz (container health checks)
-	// and /metrics (Prometheus text exposition). Honors admin.addr from the
-	// YAML config (fallback defaultAdminAddr).
+	// Admin HTTP server — internal only, honors admin.addr.
 	go runAdmin(resolveAdminAddr(cfg), writer, log)
 
 	ctx, cancel := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
@@ -239,9 +232,7 @@ func applyEnvOverrides(log *slog.Logger, c *rootConfig) {
 		c.Writer.DeadLetterFile = v
 	}
 	if v := os.Getenv("FI_ADMIN_ADDR"); v != "" {
-		// Already referenced by docker-compose.yml and
-		// docker-compose.standalone.yml; wire it up so it is not silently
-		// ignored like admin.addr used to be.
+		// Already referenced by the docker-compose files; wire it up.
 		c.Admin.Addr = v
 	}
 	// Auth overrides (auth is active when PG_WRITE is set)
@@ -256,10 +247,7 @@ func applyEnvOverrides(log *slog.Logger, c *rootConfig) {
 	}
 }
 
-// newAdminMux builds the admin HTTP mux: /healthz (container health
-// checks) and /metrics (Prometheus text exposition of writer + Go runtime
-// stats). Extracted from runAdmin so tests can exercise the handlers
-// without binding a socket.
+// newAdminMux builds the admin HTTP mux (/healthz, /metrics); extracted for tests.
 func newAdminMux(w *chwriter.Writer, log *slog.Logger) *http.ServeMux {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/healthz", func(rw http.ResponseWriter, r *http.Request) {
@@ -279,11 +267,7 @@ func newAdminMux(w *chwriter.Writer, log *slog.Logger) *http.ServeMux {
 	return mux
 }
 
-// writeMetrics renders a minimal Prometheus text exposition (format 0.0.4)
-// of the writer's lifetime stats plus basic Go runtime gauges. The
-// fi-collector deliberately stays stdlib-only (no prometheus client
-// dependency), so this is the honest, dependency-free surface the config
-// comment promises at /metrics.
+// writeMetrics renders a stdlib-only Prometheus text exposition (format 0.0.4).
 func writeMetrics(rw http.ResponseWriter, w *chwriter.Writer) {
 	rw.Header().Set("Content-Type", "text/plain; version=0.0.4; charset=utf-8")
 	s := w.Snapshot()
@@ -306,8 +290,7 @@ func writeMetrics(rw http.ResponseWriter, w *chwriter.Writer) {
 	fmt.Fprintf(rw, "# HELP go_memstats_heap_objects Number of allocated objects.\n# TYPE go_memstats_heap_objects gauge\ngo_memstats_heap_objects %d\n", ms.HeapObjects)
 }
 
-// runAdmin serves /healthz and /metrics for container health checks and
-// local scraping.
+// runAdmin serves the admin listener (health checks + local scraping).
 func runAdmin(addr string, w *chwriter.Writer, log *slog.Logger) {
 	srv := &http.Server{Addr: addr, Handler: newAdminMux(w, log), ReadHeaderTimeout: 5 * time.Second}
 	if err := srv.ListenAndServe(); err != nil && err != http.ErrServerClosed {

--- a/fi-collector/cmd/fi-collector/main.go
+++ b/fi-collector/cmd/fi-collector/main.go
@@ -13,8 +13,10 @@
 //  3. Environment overrides (FI_CH_URL, FI_GRPC_ADDR, FI_HTTP_ADDR,
 //     FI_GRPC_MAX_RECV_MIB, FI_DEAD_LETTER_FILE, ...)
 //
-// Health surfaces:
+// Health surfaces (internal-only admin listener, default 127.0.0.1:9464,
+// configurable via admin.addr or FI_ADMIN_ADDR):
 //   - /healthz (HTTP 200 unless writer dead-letter rate > threshold)
+//   - /metrics (Prometheus text exposition of writer + Go runtime stats)
 //   - Structured logs on stderr (JSON lines)
 package main
 
@@ -22,10 +24,12 @@ import (
 	"context"
 	"encoding/json"
 	"flag"
+	"fmt"
 	"log/slog"
 	"net/http"
 	"os"
 	"os/signal"
+	"runtime"
 	"strconv"
 	"syscall"
 	"time"
@@ -38,10 +42,31 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
+type adminConfig struct {
+	Addr string `yaml:"addr"`
+}
+
 type rootConfig struct {
 	Writer chwriter.Config `yaml:"writer"`
 	Server server.Config   `yaml:"server"`
 	Auth   auth.Config     `yaml:"auth"`
+	Admin  adminConfig     `yaml:"admin"`
+}
+
+// defaultAdminAddr is the internal-only admin listener. Loopback by
+// default: /healthz and /metrics are for the local host / container health
+// checks, not for external scraping, so the default must not bind on
+// 0.0.0.0. Deployments that need it on the wire set admin.addr (or
+// FI_ADMIN_ADDR) explicitly.
+const defaultAdminAddr = "127.0.0.1:9464"
+
+// resolveAdminAddr returns the configured admin listener address, falling
+// back to defaultAdminAddr when admin.addr is unset.
+func resolveAdminAddr(cfg rootConfig) string {
+	if cfg.Admin.Addr != "" {
+		return cfg.Admin.Addr
+	}
+	return defaultAdminAddr
 }
 
 func main() {
@@ -104,8 +129,10 @@ func main() {
 	}
 	srv := server.New(cfg.Server, writer, authenticator, usageEmitter, metering, opts...)
 
-	// Admin HTTP server — internal only, health check endpoint.
-	go runAdmin(":9464", writer, log)
+	// Admin HTTP server — internal only: /healthz (container health checks)
+	// and /metrics (Prometheus text exposition). Honors admin.addr from the
+	// YAML config (fallback defaultAdminAddr).
+	go runAdmin(resolveAdminAddr(cfg), writer, log)
 
 	ctx, cancel := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
 	defer cancel()
@@ -211,6 +238,12 @@ func applyEnvOverrides(log *slog.Logger, c *rootConfig) {
 	if v := os.Getenv("FI_DEAD_LETTER_FILE"); v != "" {
 		c.Writer.DeadLetterFile = v
 	}
+	if v := os.Getenv("FI_ADMIN_ADDR"); v != "" {
+		// Already referenced by docker-compose.yml and
+		// docker-compose.standalone.yml; wire it up so it is not silently
+		// ignored like admin.addr used to be.
+		c.Admin.Addr = v
+	}
 	// Auth overrides (auth is active when PG_WRITE is set)
 	if v := os.Getenv("FI_PG_WRITE"); v != "" {
 		c.Auth.PGWrite = v
@@ -223,8 +256,11 @@ func applyEnvOverrides(log *slog.Logger, c *rootConfig) {
 	}
 }
 
-// runAdmin serves /healthz for container health checks.
-func runAdmin(addr string, w *chwriter.Writer, log *slog.Logger) {
+// newAdminMux builds the admin HTTP mux: /healthz (container health
+// checks) and /metrics (Prometheus text exposition of writer + Go runtime
+// stats). Extracted from runAdmin so tests can exercise the handlers
+// without binding a socket.
+func newAdminMux(w *chwriter.Writer, log *slog.Logger) *http.ServeMux {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/healthz", func(rw http.ResponseWriter, r *http.Request) {
 		s := w.Snapshot()
@@ -237,7 +273,43 @@ func runAdmin(addr string, w *chwriter.Writer, log *slog.Logger) {
 		rw.WriteHeader(200)
 		_ = json.NewEncoder(rw).Encode(map[string]any{"status": "ok", "stats": s})
 	})
-	srv := &http.Server{Addr: addr, Handler: mux, ReadHeaderTimeout: 5 * time.Second}
+	mux.HandleFunc("/metrics", func(rw http.ResponseWriter, r *http.Request) {
+		writeMetrics(rw, w)
+	})
+	return mux
+}
+
+// writeMetrics renders a minimal Prometheus text exposition (format 0.0.4)
+// of the writer's lifetime stats plus basic Go runtime gauges. The
+// fi-collector deliberately stays stdlib-only (no prometheus client
+// dependency), so this is the honest, dependency-free surface the config
+// comment promises at /metrics.
+func writeMetrics(rw http.ResponseWriter, w *chwriter.Writer) {
+	rw.Header().Set("Content-Type", "text/plain; version=0.0.4; charset=utf-8")
+	s := w.Snapshot()
+	var ms runtime.MemStats
+	runtime.ReadMemStats(&ms)
+
+	write := func(name, help, typ string, value uint64) {
+		fmt.Fprintf(rw, "# HELP %s %s\n# TYPE %s %s\n%s %d\n", name, help, name, typ, name, value)
+	}
+	write("fi_collector_batches_inserted_total", "Batches inserted into ClickHouse.", "counter", s.BatchesInserted)
+	write("fi_collector_rows_inserted_total", "Rows inserted into ClickHouse.", "counter", s.RowsInserted)
+	write("fi_collector_batches_retried_total", "Batches that needed at least one retry.", "counter", s.BatchesRetried)
+	write("fi_collector_rows_dead_lettered_total", "Rows persisted to the dead-letter file.", "counter", s.RowsDeadLettered)
+	write("fi_collector_batches_failed_total", "Batches that exhausted their retry budget.", "counter", s.BatchesFailed)
+	write("fi_collector_curated_batches_inserted_total", "Curated-dimension batches inserted.", "counter", s.CuratedBatchesInserted)
+	write("fi_collector_curated_batches_failed_total", "Curated-dimension batches failed.", "counter", s.CuratedBatchesFailed)
+
+	fmt.Fprintf(rw, "# HELP go_goroutines Number of goroutines that currently exist.\n# TYPE go_goroutines gauge\ngo_goroutines %d\n", runtime.NumGoroutine())
+	fmt.Fprintf(rw, "# HELP go_memstats_alloc_bytes Number of bytes allocated and still in use.\n# TYPE go_memstats_alloc_bytes gauge\ngo_memstats_alloc_bytes %d\n", ms.Alloc)
+	fmt.Fprintf(rw, "# HELP go_memstats_heap_objects Number of allocated objects.\n# TYPE go_memstats_heap_objects gauge\ngo_memstats_heap_objects %d\n", ms.HeapObjects)
+}
+
+// runAdmin serves /healthz and /metrics for container health checks and
+// local scraping.
+func runAdmin(addr string, w *chwriter.Writer, log *slog.Logger) {
+	srv := &http.Server{Addr: addr, Handler: newAdminMux(w, log), ReadHeaderTimeout: 5 * time.Second}
 	if err := srv.ListenAndServe(); err != nil && err != http.ErrServerClosed {
 		log.Warn("admin server stopped", "err", err)
 	}

--- a/fi-collector/cmd/fi-collector/main_test.go
+++ b/fi-collector/cmd/fi-collector/main_test.go
@@ -3,11 +3,16 @@ package main
 import (
 	"bytes"
 	"encoding/json"
+	"io"
 	"log/slog"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/future-agi/future-agi/fi-collector/pkg/chwriter"
 )
 
 // logLines parses newline-delimited slog JSON output into a slice of
@@ -106,5 +111,134 @@ func TestLoadPriceTable_SkippedEntriesWarns(t *testing.T) {
 	}
 	if !sawSkippedWarn {
 		t.Error("want a WARN log reporting the skipped-entry count")
+	}
+}
+
+// testWriter builds a chwriter.Writer that never connects anywhere (New
+// only assembles the struct); the dead-letter file lands in a temp dir so
+// the test does not touch /var/lib.
+func testWriter(t *testing.T) *chwriter.Writer {
+	t.Helper()
+	w, err := chwriter.New(chwriter.Config{
+		URL:            "http://127.0.0.1:1",
+		DeadLetterFile: filepath.Join(t.TempDir(), "dead_letter.jsonl"),
+	})
+	if err != nil {
+		t.Fatalf("chwriter.New: %v", err)
+	}
+	return w
+}
+
+// TestLoadConfig_AdminAddr proves the documented admin.addr key is parsed
+// into rootConfig instead of being silently discarded by yaml.Unmarshal
+// (issue #2135).
+func TestLoadConfig_AdminAddr(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "collector.yaml")
+	body := "admin:\n  addr: \":19464\"\n"
+	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	var buf bytes.Buffer
+	log := slog.New(slog.NewJSONHandler(&buf, nil))
+	cfg := loadConfig(log, path)
+	if cfg.Admin.Addr != ":19464" {
+		t.Fatalf("want admin.addr=:19464, got %q", cfg.Admin.Addr)
+	}
+}
+
+// TestApplyEnvOverrides_AdminAddr proves FI_ADMIN_ADDR (already referenced
+// by the docker-compose files) overrides admin.addr instead of being
+// silently ignored (issue #2135).
+func TestApplyEnvOverrides_AdminAddr(t *testing.T) {
+	t.Setenv("FI_ADMIN_ADDR", ":19464")
+	cfg := rootConfig{Admin: adminConfig{Addr: ":9464"}}
+	applyEnvOverrides(slog.New(slog.NewJSONHandler(&bytes.Buffer{}, nil)), &cfg)
+	if cfg.Admin.Addr != ":19464" {
+		t.Fatalf("want FI_ADMIN_ADDR=:19464, got %q", cfg.Admin.Addr)
+	}
+}
+
+// TestResolveAdminAddr proves the fallback default is the loopback-only
+// 127.0.0.1:9464 (internal-only admin surface must not bind 0.0.0.0 by
+// default) and that a configured addr wins.
+func TestResolveAdminAddr(t *testing.T) {
+	if got := resolveAdminAddr(rootConfig{}); got != defaultAdminAddr {
+		t.Fatalf("want default %q, got %q", defaultAdminAddr, got)
+	}
+	if got := resolveAdminAddr(rootConfig{Admin: adminConfig{Addr: ":9464"}}); got != ":9464" {
+		t.Fatalf("want configured :9464, got %q", got)
+	}
+}
+
+// TestAdminMux_ServesHealthzAndMetrics proves the admin mux serves both
+// documented endpoints: /healthz (200 + ok) and /metrics (200 + Prometheus
+// text exposition with writer stats) — the latter was a 404 before
+// issue #2135.
+func TestAdminMux_ServesHealthzAndMetrics(t *testing.T) {
+	w := testWriter(t)
+	log := slog.New(slog.NewJSONHandler(&bytes.Buffer{}, nil))
+	srv := httptest.NewServer(newAdminMux(w, log))
+	defer srv.Close()
+
+	// /healthz
+	resp, err := http.Get(srv.URL + "/healthz")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("want /healthz 200, got %d", resp.StatusCode)
+	}
+	var hz map[string]any
+	if err := json.NewDecoder(resp.Body).Decode(&hz); err != nil {
+		t.Fatalf("decode /healthz: %v", err)
+	}
+	if hz["status"] != "ok" {
+		t.Fatalf("want status ok, got %v", hz["status"])
+	}
+
+	// /metrics
+	resp, err = http.Get(srv.URL + "/metrics")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("want /metrics 200, got %d", resp.StatusCode)
+	}
+	if ct := resp.Header.Get("Content-Type"); !strings.HasPrefix(ct, "text/plain") {
+		t.Fatalf("want text/plain content type, got %q", ct)
+	}
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, want := range []string{
+		"# TYPE fi_collector_batches_inserted_total counter",
+		"fi_collector_batches_inserted_total 0",
+		"fi_collector_rows_inserted_total 0",
+		"# TYPE go_goroutines gauge",
+	} {
+		if !strings.Contains(string(body), want) {
+			t.Errorf("want /metrics body to contain %q", want)
+		}
+	}
+}
+
+// TestAdminMux_UnknownPathNotFound proves the admin mux does not silently
+// serve undocumented paths.
+func TestAdminMux_UnknownPathNotFound(t *testing.T) {
+	w := testWriter(t)
+	log := slog.New(slog.NewJSONHandler(&bytes.Buffer{}, nil))
+	srv := httptest.NewServer(newAdminMux(w, log))
+	defer srv.Close()
+
+	resp, err := http.Get(srv.URL + "/nope")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusNotFound {
+		t.Fatalf("want /nope 404, got %d", resp.StatusCode)
 	}
 }

--- a/fi-collector/cmd/fi-collector/main_test.go
+++ b/fi-collector/cmd/fi-collector/main_test.go
@@ -114,9 +114,7 @@ func TestLoadPriceTable_SkippedEntriesWarns(t *testing.T) {
 	}
 }
 
-// testWriter builds a chwriter.Writer that never connects anywhere (New
-// only assembles the struct); the dead-letter file lands in a temp dir so
-// the test does not touch /var/lib.
+// testWriter builds a chwriter.Writer that never connects; dead-letter file in a temp dir.
 func testWriter(t *testing.T) *chwriter.Writer {
 	t.Helper()
 	w, err := chwriter.New(chwriter.Config{
@@ -129,9 +127,7 @@ func testWriter(t *testing.T) *chwriter.Writer {
 	return w
 }
 
-// TestLoadConfig_AdminAddr proves the documented admin.addr key is parsed
-// into rootConfig instead of being silently discarded by yaml.Unmarshal
-// (issue #2135).
+// TestLoadConfig_AdminAddr proves admin.addr is parsed, not discarded (issue #2135).
 func TestLoadConfig_AdminAddr(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "collector.yaml")
 	body := "admin:\n  addr: \":19464\"\n"
@@ -146,9 +142,7 @@ func TestLoadConfig_AdminAddr(t *testing.T) {
 	}
 }
 
-// TestApplyEnvOverrides_AdminAddr proves FI_ADMIN_ADDR (already referenced
-// by the docker-compose files) overrides admin.addr instead of being
-// silently ignored (issue #2135).
+// TestApplyEnvOverrides_AdminAddr proves FI_ADMIN_ADDR overrides admin.addr (issue #2135).
 func TestApplyEnvOverrides_AdminAddr(t *testing.T) {
 	t.Setenv("FI_ADMIN_ADDR", ":19464")
 	cfg := rootConfig{Admin: adminConfig{Addr: ":9464"}}
@@ -158,9 +152,7 @@ func TestApplyEnvOverrides_AdminAddr(t *testing.T) {
 	}
 }
 
-// TestResolveAdminAddr proves the fallback default is the loopback-only
-// 127.0.0.1:9464 (internal-only admin surface must not bind 0.0.0.0 by
-// default) and that a configured addr wins.
+// TestResolveAdminAddr proves the loopback default and that a configured addr wins.
 func TestResolveAdminAddr(t *testing.T) {
 	if got := resolveAdminAddr(rootConfig{}); got != defaultAdminAddr {
 		t.Fatalf("want default %q, got %q", defaultAdminAddr, got)
@@ -170,10 +162,7 @@ func TestResolveAdminAddr(t *testing.T) {
 	}
 }
 
-// TestAdminMux_ServesHealthzAndMetrics proves the admin mux serves both
-// documented endpoints: /healthz (200 + ok) and /metrics (200 + Prometheus
-// text exposition with writer stats) — the latter was a 404 before
-// issue #2135.
+// TestAdminMux_ServesHealthzAndMetrics proves the admin mux serves both documented endpoints.
 func TestAdminMux_ServesHealthzAndMetrics(t *testing.T) {
 	w := testWriter(t)
 	log := slog.New(slog.NewJSONHandler(&bytes.Buffer{}, nil))
@@ -225,8 +214,7 @@ func TestAdminMux_ServesHealthzAndMetrics(t *testing.T) {
 	}
 }
 
-// TestAdminMux_UnknownPathNotFound proves the admin mux does not silently
-// serve undocumented paths.
+// TestAdminMux_UnknownPathNotFound proves undocumented paths stay 404.
 func TestAdminMux_UnknownPathNotFound(t *testing.T) {
 	w := testWriter(t)
 	log := slog.New(slog.NewJSONHandler(&bytes.Buffer{}, nil))

--- a/fi-collector/config/collector.yaml
+++ b/fi-collector/config/collector.yaml
@@ -51,9 +51,5 @@ auth:
   redis_addr: ""
 
 admin:
-  # Internal-only admin listener: /healthz (container health checks) and
-  # /metrics (Prometheus text exposition of writer + Go runtime stats).
-  # Loopback-only by default — the admin surface is for the local host /
-  # container, not for external scraping. Override via FI_ADMIN_ADDR (the
-  # docker-compose files set it to ":9464" to expose the port mapping).
+  # Internal-only admin listener, loopback by default; override via FI_ADMIN_ADDR.
   addr: "127.0.0.1:9464" # /healthz and /metrics

--- a/fi-collector/config/collector.yaml
+++ b/fi-collector/config/collector.yaml
@@ -51,4 +51,9 @@ auth:
   redis_addr: ""
 
 admin:
-  addr: ":9464" # /healthz and /metrics
+  # Internal-only admin listener: /healthz (container health checks) and
+  # /metrics (Prometheus text exposition of writer + Go runtime stats).
+  # Loopback-only by default — the admin surface is for the local host /
+  # container, not for external scraping. Override via FI_ADMIN_ADDR (the
+  # docker-compose files set it to ":9464" to expose the port mapping).
+  addr: "127.0.0.1:9464" # /healthz and /metrics


### PR DESCRIPTION
## Summary

Fixes #2135. The documented `admin.addr` config key was silently ignored (no `Admin` field in `rootConfig`, so `yaml.Unmarshal` discarded it), the admin listener address was hardcoded to `:9464`, and the documented `/metrics` endpoint returned 404 because `runAdmin` only registered `/healthz`.

## Root Cause

- `fi-collector/cmd/fi-collector/main.go:41-45` — `rootConfig` had only `Writer`/`Server`/`Auth`; the `admin` YAML key was dropped by `yaml.Unmarshal` (unknown keys are silently ignored).
- `main.go:108` — `go runAdmin(":9464", ...)` hardcoded the address.
- `runAdmin` — served only `/healthz`; no `/metrics` handler.

## Change

- Add an `adminConfig` struct (`addr`) and an `Admin` field to `rootConfig`, so `admin.addr` is parsed and honored.
- Add `resolveAdminAddr(cfg)` with a loopback-only default `127.0.0.1:9464` — the admin surface is internal-only (per the config comment), so the default no longer binds `0.0.0.0`. Deployments that need the wire set `admin.addr` or `FI_ADMIN_ADDR`.
- Wire `FI_ADMIN_ADDR` into `applyEnvOverrides` — the docker-compose files (`docker-compose.yml`, `docker-compose.standalone.yml`) already reference it, so it was being silently ignored too.
- Serve `/metrics` in `runAdmin`: a stdlib-only Prometheus text exposition (format 0.0.4) of the writer lifetime stats (`fi_collector_*_total` counters) plus basic Go runtime gauges (`go_goroutines`, `go_memstats_*`). The fi-collector deliberately stays dependency-free, so this is the honest surface the config comment promises.
- Update `collector.yaml` default to `127.0.0.1:9464` with an explanatory comment.

## Verification

- `go build ./...` — OK
- `go vet ./...` — clean
- `go test ./...` — all packages pass; new tests cover:
  - `TestLoadConfig_AdminAddr` — `admin.addr` is parsed, not discarded
  - `TestApplyEnvOverrides_AdminAddr` — `FI_ADMIN_ADDR` overrides
  - `TestResolveAdminAddr` — loopback default + configured addr wins
  - `TestAdminMux_ServesHealthzAndMetrics` — `/healthz` 200 ok and `/metrics` 200 with Prometheus text body
  - `TestAdminMux_UnknownPathNotFound` — undocumented paths still 404

Closes #2135