### PR TITLE
fix(simulate): reset scenario pagination to page 1 when search changes

### DIFF
--- a/frontend/src/components/run-tests/CreateRunTestPage.jsx
+++ b/frontend/src/components/run-tests/CreateRunTestPage.jsx
@@ -31,7 +31,6 @@ import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import axios, { endpoints } from "src/utils/axios";
 import { useSnackbar } from "notistack";
 import { useRouter } from "src/routes/hooks";
-import { useDebounce } from "src/hooks/use-debounce";
 import {
   EvalPickerDrawer,
   serializeEvalConfig,
@@ -45,6 +44,7 @@ import {
   chatEvalColumns,
   getVersionedEvalName,
   useAgentDefinitions,
+  useSearchedPagination,
 } from "./common";
 import { useNavigate } from "react-router";
 import { ShowComponent } from "../show";
@@ -215,13 +215,16 @@ const CreateRunTestPage = ({ open, onClose }) => {
     }
   }, [open]);
 
-  // Scenarios state
-  const [scenarioSearch, setScenarioSearch] = useState("");
-  const debouncedSearch = useDebounce(scenarioSearch, 500);
-  const [scenariosPagination, setScenariosPagination] = useState({
-    page: 1,
-    pageSize: 10,
-  });
+  // Scenarios state. The hook resets to page 1 whenever the debounced
+  // search term changes, so a filtered result set can never be asked for
+  // a page it no longer has ("Invalid page.", #1485).
+  const {
+    search: scenarioSearch,
+    setSearch: setScenarioSearch,
+    debouncedSearch,
+    pagination: scenariosPagination,
+    setPagination: setScenariosPagination,
+  } = useSearchedPagination();
 
   // Fetch scenarios with pagination
   const {

--- a/frontend/src/components/run-tests/CreateRunTestPage.jsx
+++ b/frontend/src/components/run-tests/CreateRunTestPage.jsx
@@ -215,9 +215,7 @@ const CreateRunTestPage = ({ open, onClose }) => {
     }
   }, [open]);
 
-  // Scenarios state. The hook resets to page 1 whenever the debounced
-  // search term changes, so a filtered result set can never be asked for
-  // a page it no longer has ("Invalid page.", #1485).
+  // Scenarios state
   const {
     search: scenarioSearch,
     setSearch: setScenarioSearch,

--- a/frontend/src/components/run-tests/__tests__/common.test.js
+++ b/frontend/src/components/run-tests/__tests__/common.test.js
@@ -1,0 +1,135 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import { useSearchedPagination } from "../common";
+
+// common.js also exports API hooks; keep the axios instance out of the test.
+vi.mock("src/utils/axios", () => ({
+  default: {},
+  endpoints: {},
+}));
+
+describe("useSearchedPagination", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  const flushDebounce = () => {
+    act(() => {
+      vi.advanceTimersByTime(500);
+    });
+  };
+
+  it("starts on page 1 with the default page size", () => {
+    const { result } = renderHook(() => useSearchedPagination());
+    flushDebounce();
+    expect(result.current.pagination).toEqual({ page: 1, pageSize: 10 });
+    expect(result.current.debouncedSearch).toBe("");
+  });
+
+  // #1485: searching from page 2+ must not request the stale page.
+  it("resets to page 1 when the debounced search term changes", () => {
+    const { result } = renderHook(() => useSearchedPagination());
+    flushDebounce();
+
+    act(() => {
+      result.current.setPagination((prev) => ({ ...prev, page: 3 }));
+    });
+    expect(result.current.pagination.page).toBe(3);
+
+    act(() => {
+      result.current.setSearch("morg");
+    });
+    flushDebounce();
+
+    expect(result.current.debouncedSearch).toBe("morg");
+    expect(result.current.pagination).toEqual({ page: 1, pageSize: 10 });
+  });
+
+  it("resets to page 1 when the search box is cleared", () => {
+    const { result } = renderHook(() => useSearchedPagination());
+    flushDebounce();
+
+    act(() => {
+      result.current.setSearch("morg");
+    });
+    flushDebounce();
+    act(() => {
+      result.current.setPagination((prev) => ({ ...prev, page: 2 }));
+    });
+
+    act(() => {
+      result.current.setSearch("");
+    });
+    flushDebounce();
+
+    expect(result.current.pagination.page).toBe(1);
+  });
+
+  it("preserves a changed page size across the reset", () => {
+    const { result } = renderHook(() => useSearchedPagination());
+    flushDebounce();
+
+    act(() => {
+      result.current.setPagination({ page: 4, pageSize: 25 });
+    });
+
+    act(() => {
+      result.current.setSearch("abc");
+    });
+    flushDebounce();
+
+    expect(result.current.pagination).toEqual({ page: 1, pageSize: 25 });
+  });
+
+  it("keeps the same state object when already on page 1 (no extra render)", () => {
+    const { result } = renderHook(() => useSearchedPagination());
+    flushDebounce();
+    const before = result.current.pagination;
+
+    act(() => {
+      result.current.setSearch("abc");
+    });
+    flushDebounce();
+
+    expect(result.current.pagination).toBe(before);
+  });
+
+  it("does not reset until the debounce delay has elapsed", () => {
+    const { result } = renderHook(() => useSearchedPagination());
+    flushDebounce();
+
+    act(() => {
+      result.current.setPagination((prev) => ({ ...prev, page: 2 }));
+    });
+    act(() => {
+      result.current.setSearch("mo");
+    });
+    act(() => {
+      vi.advanceTimersByTime(499);
+    });
+    expect(result.current.pagination.page).toBe(2);
+
+    act(() => {
+      vi.advanceTimersByTime(1);
+    });
+    expect(result.current.pagination.page).toBe(1);
+  });
+
+  it("leaves plain page navigation untouched", () => {
+    const { result } = renderHook(() => useSearchedPagination());
+    flushDebounce();
+
+    act(() => {
+      result.current.setPagination((prev) => ({ ...prev, page: 2 }));
+    });
+    act(() => {
+      result.current.setPagination((prev) => ({ ...prev, page: 5 }));
+    });
+
+    expect(result.current.pagination.page).toBe(5);
+  });
+});

--- a/frontend/src/components/run-tests/common.js
+++ b/frontend/src/components/run-tests/common.js
@@ -1,6 +1,27 @@
 import axios, { endpoints } from "src/utils/axios";
 import logger from "../../utils/logger";
 import { useInfiniteQuery } from "@tanstack/react-query";
+import { useEffect, useState } from "react";
+import { useDebounce } from "src/hooks/use-debounce";
+
+/**
+ * Search + pagination state for a server-paginated, searchable list.
+ *
+ * Resets to page 1 whenever the debounced search term changes: the filtered
+ * result set can have fewer pages than the current page, and requesting a
+ * page that no longer exists makes the backend answer "Invalid page." (#1485)
+ */
+export function useSearchedPagination(delay = 500, pageSize = 10) {
+  const [search, setSearch] = useState("");
+  const debouncedSearch = useDebounce(search, delay);
+  const [pagination, setPagination] = useState({ page: 1, pageSize });
+
+  useEffect(() => {
+    setPagination((prev) => (prev.page === 1 ? prev : { ...prev, page: 1 }));
+  }, [debouncedSearch]);
+
+  return { search, setSearch, debouncedSearch, pagination, setPagination };
+}
 
 /**
  * Enum for simulation source types - matches backend RunTest.SourceTypes


### PR DESCRIPTION
Heyyaaaa : ) 

Fixes #1485.

On "Run Simulation" → step 2 ("Choose Scenario(s)"), typing into the scenario search box while on page 2+ kept the stale page number in the request. Once the search narrowed the result set below that page, DRF's `PageNumberPagination` (via `ExtendedPageNumberPagination`) answered "Invalid page." and the scenario list disappeared.

## Change

- **`run-tests/common.js`** — new `useSearchedPagination(delay, pageSize)` hook holding the search + debounce + pagination trio, with one effect: whenever the debounced search term changes, reset `page` (and only `page`) to 1. This mirrors the reset the component already does in `onRowsPerPageChange` — the sibling case the issue points to.
- **`CreateRunTestPage.jsx`** — replaces the three loose `useState`/`useDebounce` declarations with the hook, destructured to the existing local names so the rest of the component is untouched.
- **`__tests__/common.test.js`** — 7 hook-level regression tests (per CONTRIBUTING's "every bug fix needs a regression test").

Details:

- The reset uses a functional update with a `prev.page === 1 ? prev : ...` guard, so the initial mount and any search change made while already on page 1 (including clearing the box) return the same state object — no extra render, no extra request.
- `pageSize` is preserved across the reset.
- The hook is declared before the scenarios `useQuery`, so on the render where `debouncedSearch` changes the reset lands immediately and the query the UI observes carries `page: 1` + the new term — the stale-page key is never the one displayed.

## Done-when checklist from the issue

- [x] Typing a search term on page 2+ resets pagination to page 1; the request reflecting the new search carries `page: 1`, so no "Invalid page" error.
- [x] Clearing the search box back to empty resets to page 1.
- [x] Changing the page size still resets to page 1 (`onRowsPerPageChange` untouched).
- [x] Page-to-page navigation and search filtering keep working — the effect only fires on `debouncedSearch` changes and only touches `page`.

## Tests

```
✓ starts on page 1 with the default page size
✓ resets to page 1 when the debounced search term changes
✓ resets to page 1 when the search box is cleared
✓ preserves a changed page size across the reset
✓ keeps the same state object when already on page 1 (no extra render)
✓ does not reset until the debounce delay has elapsed
✓ leaves plain page navigation untouched
```

`eslint` + `prettier --check` on all three files: no new warnings (the file's 6 pre-existing warnings are unchanged before/after).

## AI use

AI use: Claude Code wrote the fix and the regression tests from my direction; I reviewed the diff.

## E2E coverage

E2E: exempt (harness-gap the simulate area has no flow for the Run Simulation scenario picker)
