### PR TITLE
fix(tracer): skip malformed eval_tags instead of breaking span evals

### DIFF
--- a/futureagi/tracer/utils/eval.py
+++ b/futureagi/tracer/utils/eval.py
@@ -2195,7 +2195,8 @@ def eval_observation_span_runner(observation_span_id, eval_tags):
 
             if (
                 type == "OBSERVATION_SPAN_TYPE"
-                and eval_tag.get("value").lower() == observation_span.observation_type
+                and (eval_tag.get("value") or "").lower()
+                == observation_span.observation_type
             ):
                 try:
                     evaluate_observation_span(

--- a/futureagi/tracer/utils/eval.py
+++ b/futureagi/tracer/utils/eval.py
@@ -2195,7 +2195,8 @@ def eval_observation_span_runner(observation_span_id, eval_tags):
 
             if (
                 type == "OBSERVATION_SPAN_TYPE"
-                and (eval_tag.get("value") or "").lower()
+                and custom_eval_config_id
+                and str(eval_tag.get("value") or "").lower()
                 == observation_span.observation_type
             ):
                 try:

--- a/futureagi/tracer/views/observation_span.py
+++ b/futureagi/tracer/views/observation_span.py
@@ -848,7 +848,9 @@ class ObservationSpanView(BaseModelViewSetMixin, ModelViewSet):
             }
 
             custom_eval_config_ids = {
-                eval_tag["custom_eval_config_id"] for eval_tag in eval_tags
+                eval_tag["custom_eval_config_id"]
+                for eval_tag in eval_tags
+                if eval_tag["type"] == "OBSERVATION_SPAN_TYPE"
             }
             custom_eval_configs = CustomEvalConfig.objects.filter(
                 id__in=custom_eval_config_ids, deleted=False
@@ -859,7 +861,7 @@ class ObservationSpanView(BaseModelViewSetMixin, ModelViewSet):
                 for span in observation_spans:
                     if (
                         span.observation_type
-                        != eval_config_mapping.get(str(custom_eval_config.id)).lower()
+                        != (eval_config_mapping.get(str(custom_eval_config.id)) or "").lower()
                     ):
                         continue
 

--- a/futureagi/tracer/views/observation_span.py
+++ b/futureagi/tracer/views/observation_span.py
@@ -842,15 +842,19 @@ class ObservationSpanView(BaseModelViewSetMixin, ModelViewSet):
             eval_tags = observation_span_obj.project_version.eval_tags
 
             eval_config_mapping = {
-                str(eval_tag["custom_eval_config_id"]): eval_tag["value"]
+                str(eval_tag.get("custom_eval_config_id")): str(
+                    eval_tag.get("value") or ""
+                )
                 for eval_tag in eval_tags
-                if eval_tag["type"] == "OBSERVATION_SPAN_TYPE"
+                if eval_tag.get("type") == "OBSERVATION_SPAN_TYPE"
+                and eval_tag.get("custom_eval_config_id") is not None
             }
 
             custom_eval_config_ids = {
-                eval_tag["custom_eval_config_id"]
+                eval_tag.get("custom_eval_config_id")
                 for eval_tag in eval_tags
-                if eval_tag["type"] == "OBSERVATION_SPAN_TYPE"
+                if eval_tag.get("type") == "OBSERVATION_SPAN_TYPE"
+                and eval_tag.get("custom_eval_config_id") is not None
             }
             custom_eval_configs = CustomEvalConfig.objects.filter(
                 id__in=custom_eval_config_ids, deleted=False
@@ -861,7 +865,9 @@ class ObservationSpanView(BaseModelViewSetMixin, ModelViewSet):
                 for span in observation_spans:
                     if (
                         span.observation_type
-                        != (eval_config_mapping.get(str(custom_eval_config.id)) or "").lower()
+                        != (
+                            eval_config_mapping.get(str(custom_eval_config.id)) or ""
+                        ).lower()
                     ):
                         continue
 


### PR DESCRIPTION
## Problem

`ProjectVersion.eval_tags` is persisted straight from client payloads with no per-entry schema, so `type` or `value` can be `None`. Two readers then raise `AttributeError: 'NoneType' object has no attribute 'lower'`:

- the observation-span view builds its config id set from every tag but its value mapping only from span-type tags, so a mis-targeted or malformed tag makes `mapping.get(...).lower()` raise and the eval panel return a permanent generic 400
- `eval_observation_span_runner` calls `eval_tag.get("value").lower()` unguarded, aborting the loop so every remaining eval for that span is skipped

Fixes #2025.

## Fix

- The config id set is now filtered to `OBSERVATION_SPAN_TYPE` tags, matching the value mapping.
- Both `.lower()` calls are guarded with `or ""`, so malformed entries are skipped instead of breaking the endpoint or the eval loop.

## Test

The tracer test harness (Django + fixtures) is not available in this environment; the two guarded expressions were verified directly against the issue's verbatim repro payload (mis-targeted tag + span-type tag with `value: None`), and both changed files compile cleanly.

```
guard logic verified
COMPILE_OK
```
