### PR TITLE
fix(frontend): surface duplicate-evaluation failures in the drawer dialog

### DIFF
--- a/frontend/src/sections/common/EvaluationDrawer/DuplicateEvals.jsx
+++ b/frontend/src/sections/common/EvaluationDrawer/DuplicateEvals.jsx
@@ -41,6 +41,19 @@ const DuplicateEvals = ({ open, onClose, evalId, onSubmit }) => {
       handleClose();
       onSubmit(data?.data?.result);
     },
+    onError: (error) => {
+      const data = error?.response?.data;
+      let message = data?.error;
+      if (!message && typeof data?.result === "string") {
+        message = data.result;
+      }
+      if (!message && data?.result && typeof data.result === "object") {
+        message = Object.values(data.result).flat().join(", ");
+      }
+      enqueueSnackbar(message || "Failed to duplicate evaluation", {
+        variant: "error",
+      });
+    },
   });
 
   const handleNameTransformation = (event) => {


### PR DESCRIPTION
## Problem

The duplicate-evaluation dialog uses `useMutation` with only an `onSuccess` callback. Every failure path — a backend 400, a network drop, a contract validation error — resolves to the same user-visible outcome: nothing. The spinner stops, the dialog stays open, and no feedback is surfaced.

Fixes #2017.

## Fix

Added an `onError` handler that extracts the backend message (`error`, a string `result`, or a flattened field-error object such as `{ eval_template_id: [...] }`) and shows an error snackbar via the existing `enqueueSnackbar` convention (same pattern as `BaseStatusCellRenderer`).

## Test

`eslint` passes on the changed file. The three documented failure shapes (field-error object, string result, network rejection with no data) each fall back to a readable message.

```
cd frontend && ./node_modules/.bin/eslint src/sections/common/EvaluationDrawer/DuplicateEvals.jsx
```
