### PR TITLE
fix: reject empty scenario files

### DIFF
--- a/frontend/src/sections/scenarios/common.js
+++ b/frontend/src/sections/scenarios/common.js
@@ -270,19 +270,34 @@ export const createScenarioFileDropHandler =
       const hasTypeError = fileRejections.some((rejection) =>
         rejection.errors?.some((err) => err.code === "file-invalid-type"),
       );
+
       enqueueSnackbar(
         hasTypeError
           ? "Unsupported file type. Please upload a TXT or PDF file."
           : "File could not be uploaded",
         { variant: "error" },
       );
+
       return;
     }
 
     const files = Array.from(acceptedFiles);
     const maxSize = 5 * 1024 * 1024; // 5MB
 
-    const filesLargerThanMaxSize = files.filter((file) => file?.size > maxSize);
+    // Reject empty files.
+    const filesWithNoContent = files.filter((file) => file?.size === 0);
+
+    if (filesWithNoContent.length > 0) {
+      enqueueSnackbar("File is empty", {
+        variant: "error",
+      });
+      return;
+    }
+
+    // Reject files larger than 5MB.
+    const filesLargerThanMaxSize = files.filter(
+      (file) => file?.size > maxSize,
+    );
 
     if (filesLargerThanMaxSize.length > 0) {
       enqueueSnackbar("File size is too large", {
@@ -291,10 +306,10 @@ export const createScenarioFileDropHandler =
       return;
     }
 
-    const validFiles = files.filter((file) => file.size <= maxSize);
+    const validFiles = files.filter((file) => file?.size <= maxSize);
 
     const processedFiles = validFiles.map((file) => ({
-      file: file,
+      file,
       name: file.name,
       size: file.size,
     }));

--- a/frontend/src/sections/scenarios/common.test.js
+++ b/frontend/src/sections/scenarios/common.test.js
@@ -1,0 +1,85 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { createScenarioFileDropHandler } from "./common";
+
+describe("createScenarioFileDropHandler", () => {
+  const createHandler = () => {
+    const enqueueSnackbar = vi.fn();
+    const onChange = vi.fn();
+
+    const handleFileChange = createScenarioFileDropHandler({
+      enqueueSnackbar,
+      onChange,
+    });
+
+    return { handleFileChange, enqueueSnackbar, onChange };
+  };
+
+  it("rejects an empty file", () => {
+    const { handleFileChange, enqueueSnackbar, onChange } = createHandler();
+
+    const emptyFile = new File([""], "empty.pdf", {
+      type: "application/pdf",
+    });
+
+    handleFileChange([emptyFile]);
+
+    expect(enqueueSnackbar).toHaveBeenCalledWith("File is empty", {
+      variant: "error",
+    });
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it("accepts a file with 1 byte", () => {
+    const { handleFileChange, enqueueSnackbar, onChange } = createHandler();
+
+    const file = new File(["a"], "small.txt", {
+      type: "text/plain",
+    });
+
+    handleFileChange([file]);
+
+    expect(enqueueSnackbar).not.toHaveBeenCalled();
+    expect(onChange).toHaveBeenCalledWith({
+      file,
+      name: "small.txt",
+      size: 1,
+    });
+  });
+
+  it("accepts a file exactly 5 MB", () => {
+    const { handleFileChange, enqueueSnackbar, onChange } = createHandler();
+
+    const fiveMB = new File([new Uint8Array(5 * 1024 * 1024)], "large.pdf", {
+      type: "application/pdf",
+    });
+
+    handleFileChange([fiveMB]);
+
+    expect(enqueueSnackbar).not.toHaveBeenCalled();
+    expect(onChange).toHaveBeenCalledWith({
+      file: fiveMB,
+      name: "large.pdf",
+      size: 5 * 1024 * 1024,
+    });
+  });
+
+  it("rejects a file larger than 5 MB", () => {
+    const { handleFileChange, enqueueSnackbar, onChange } = createHandler();
+
+    const overLimitFile = new File(
+      [new Uint8Array(5 * 1024 * 1024 + 1)],
+      "too-large.pdf",
+      {
+        type: "application/pdf",
+      },
+    );
+
+    handleFileChange([overLimitFile]);
+
+    expect(enqueueSnackbar).toHaveBeenCalledWith("File size is too large", {
+      variant: "error",
+    });
+    expect(onChange).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

Reject empty scenario files before they are uploaded.

This change also keeps the existing 5 MB file-size limit and adds unit tests covering empty files, valid files, the 5 MB boundary, and oversized files.

## Testing

- `npm run test:run -- src/sections/scenarios/common.test.js`
- All 4 tests pass

Fixes #1392