### PR TITLE
fix: Fix session eval scores aggregation for ClickHouse

### DIFF
--- a/futureagi/tracer/tests/test_trace_session.py
+++ b/futureagi/tracer/tests/test_trace_session.py
@@ -544,3 +544,16 @@ class TestRetrieveClickhouseInnerPGBound:
 
         response = auth_client.get(f"/tracer/trace-session/{trace_session.id}/")
         assert response.status_code != 500
+
+
+class TestRetrieveClickhouseEvalQueryNullSafety:
+    """Guard against regressing the NULL-safe ``output_str`` filter."""
+
+    def test_eval_subquery_uses_ifnull_output_str_guard(self):
+        import inspect
+
+        from tracer.views.trace_session import TraceSessionView
+
+        source = inspect.getsource(TraceSessionView._retrieve_clickhouse)
+        assert "ifNull(output_str, '') != 'ERROR'" in source
+        assert "AND output_str != 'ERROR'" not in source

--- a/futureagi/tracer/tests/test_trace_session_ch_query.py
+++ b/futureagi/tracer/tests/test_trace_session_ch_query.py
@@ -21,13 +21,12 @@ These tests pin:
 
 import os
 import uuid
-from datetime import datetime, timedelta, timezone
+from datetime import UTC, datetime, timedelta
 
 import pytest
 
 # Cycle-breaker -- same rationale as test_eval_task_runtime.
 import model_hub.tasks  # noqa: F401, E402
-
 
 _TEST_DATABASE = "test_trace_session_ch_query"
 
@@ -127,7 +126,7 @@ class TestTraceListingCHQuery:
     def _exec(self, client, query, params):
         rows, columns = client.execute(query, params, with_column_types=True)
         col_names = [c[0] for c in columns]
-        return [dict(zip(col_names, row)) for row in rows]
+        return [dict(zip(col_names, row, strict=False)) for row in rows]
 
     def test_query_parses_without_alias_collision(self, ch_spans_table):
         """The original bug raised ILLEGAL_AGGREGATION at parse/analysis
@@ -157,7 +156,7 @@ class TestTraceListingCHQuery:
         client = ch_spans_table
         project_id = str(uuid.uuid4())
         session_id = str(uuid.uuid4())
-        base = datetime(2026, 5, 11, 8, 52, 9, tzinfo=timezone.utc)
+        base = datetime(2026, 5, 11, 8, 52, 9, tzinfo=UTC)
 
         # Pick trace ids so the alphabetically-first one starts LATER.
         trace_late_alpha = "00000000-0000-0000-0000-000000000001"
@@ -233,7 +232,7 @@ class TestTraceListingCHQuery:
         client = ch_spans_table
         project_id = str(uuid.uuid4())
         session_id = str(uuid.uuid4())
-        base = datetime(2026, 5, 11, 8, 52, 9, tzinfo=timezone.utc)
+        base = datetime(2026, 5, 11, 8, 52, 9, tzinfo=UTC)
         trace_id = str(uuid.uuid4())
 
         columns = (
@@ -293,6 +292,120 @@ class TestTraceListingCHQuery:
         # clickhouse-driver returns DateTime64 as naive datetimes; the
         # value is in UTC but tzinfo is dropped, so compare via the
         # naive form of our base instant.
-        assert rows[0]["trace_min_start_time"] == (
-            base + timedelta(seconds=1)
-        ).replace(tzinfo=None)
+        assert rows[0]["trace_min_start_time"] == (base + timedelta(seconds=1)).replace(
+            tzinfo=None
+        )
+
+
+def _session_eval_aggregation_query(database: str, *, null_safe: bool) -> str:
+    """Eval subquery from ``_retrieve_clickhouse``.
+
+    ``null_safe=False`` reproduces the pre-fix filter that excluded every
+    successful row with a NULL ``output_str`` under ClickHouse's
+    three-valued logic.
+    """
+    output_str_guard = (
+        "ifNull(output_str, '') != 'ERROR'" if null_safe else "output_str != 'ERROR'"
+    )
+    return f"""
+        SELECT
+            toString(trace_id) AS trace_id,
+            toString(custom_eval_config_id) AS config_id,
+            round(avg(output_float) * 100, 2) AS float_score,
+            round(avg(CASE WHEN output_bool = 1 THEN 100.0
+                           WHEN output_bool = 0 THEN 0.0
+                           ELSE NULL END), 2) AS bool_score,
+            count(output_float) AS float_count,
+            count(output_bool) AS bool_count
+        FROM {database}.tracer_eval_logger FINAL
+        WHERE trace_id IN %(trace_ids)s
+          AND custom_eval_config_id IN %(config_ids)s
+          AND _peerdb_is_deleted = 0
+          AND (deleted = 0 OR deleted IS NULL)
+          AND {output_str_guard}
+          AND (error = 0 OR error IS NULL)
+        GROUP BY trace_id, custom_eval_config_id
+    """
+
+
+@pytest.fixture(scope="module")
+def ch_eval_logger_table(ch_client):
+    """Minimal ``tracer_eval_logger`` table for session eval aggregation."""
+    ch_client.execute(f"CREATE DATABASE IF NOT EXISTS {_TEST_DATABASE}")
+    ch_client.execute(f"DROP TABLE IF EXISTS {_TEST_DATABASE}.tracer_eval_logger")
+    ch_client.execute(
+        f"""
+        CREATE TABLE {_TEST_DATABASE}.tracer_eval_logger (
+            id UUID,
+            trace_id Nullable(UUID),
+            custom_eval_config_id UUID,
+            output_bool Nullable(UInt8),
+            output_float Nullable(Float64),
+            output_str Nullable(String),
+            error UInt8 DEFAULT 0,
+            deleted UInt8 DEFAULT 0,
+            _peerdb_is_deleted UInt8 DEFAULT 0
+        ) ENGINE = ReplacingMergeTree()
+        ORDER BY (trace_id, custom_eval_config_id, id)
+        SETTINGS allow_nullable_key = 1
+        """
+    )
+    yield ch_client
+    ch_client.execute(f"DROP TABLE IF EXISTS {_TEST_DATABASE}.tracer_eval_logger")
+
+
+@pytest.mark.integration
+class TestSessionEvalAggregationCHQuery:
+    """NULL-safe ``output_str`` guard on the session-detail eval subquery."""
+
+    def _exec(self, client, query, params):
+        rows, columns = client.execute(query, params, with_column_types=True)
+        col_names = [c[0] for c in columns]
+        return [dict(zip(col_names, row, strict=False)) for row in rows]
+
+    def test_null_output_str_included_with_ifnull_guard(self, ch_eval_logger_table):
+        """Successful eval rows with NULL ``output_str`` must aggregate.
+
+        Most evaluators leave ``output_str`` NULL; a bare
+        ``output_str != 'ERROR'`` evaluates to NULL (not TRUE) in
+        ClickHouse and silently drops the row — the bug that left
+        ``evals_metrics`` empty on session detail.
+        """
+        client = ch_eval_logger_table
+        trace_id = str(uuid.uuid4())
+        config_id = str(uuid.uuid4())
+        row_id = str(uuid.uuid4())
+
+        client.execute(
+            f"""
+            INSERT INTO {_TEST_DATABASE}.tracer_eval_logger
+                (id, trace_id, custom_eval_config_id,
+                 output_float, output_str, error, deleted, _peerdb_is_deleted)
+            VALUES
+                ('{row_id}', '{trace_id}', '{config_id}',
+                 0.85, NULL, 0, 0, 0)
+            """
+        )
+
+        params = {
+            "trace_ids": (trace_id,),
+            "config_ids": (config_id,),
+        }
+
+        buggy_rows = self._exec(
+            client,
+            _session_eval_aggregation_query(_TEST_DATABASE, null_safe=False),
+            params,
+        )
+        assert buggy_rows == [], "bare output_str != 'ERROR' must exclude NULL rows"
+
+        fixed_rows = self._exec(
+            client,
+            _session_eval_aggregation_query(_TEST_DATABASE, null_safe=True),
+            params,
+        )
+        assert len(fixed_rows) == 1
+        assert fixed_rows[0]["trace_id"] == trace_id
+        assert fixed_rows[0]["config_id"] == config_id
+        assert fixed_rows[0]["float_count"] == 1
+        assert fixed_rows[0]["float_score"] == 85.0

--- a/futureagi/tracer/views/trace_session.py
+++ b/futureagi/tracer/views/trace_session.py
@@ -3,7 +3,7 @@ import json
 import traceback
 from collections import defaultdict
 from dataclasses import asdict
-from typing import Any, Dict, List, Optional
+from typing import Any
 
 try:
     import orjson
@@ -16,7 +16,7 @@ import pandas as pd
 import structlog
 
 logger = structlog.get_logger(__name__)
-from django.db import OperationalError, connection, models, transaction
+from django.db import OperationalError, models
 from django.db.models import (
     Avg,
     Case,
@@ -599,7 +599,7 @@ class TraceSessionView(BaseModelViewSetMixin, ModelViewSet):
                   AND custom_eval_config_id IN %(config_ids)s
                   AND _peerdb_is_deleted = 0
                   AND (deleted = 0 OR deleted IS NULL)
-                  AND output_str != 'ERROR'
+                  AND ifNull(output_str, '') != 'ERROR'
                   AND (error = 0 OR error IS NULL)
                 GROUP BY trace_id, custom_eval_config_id
             """
@@ -720,7 +720,7 @@ class TraceSessionView(BaseModelViewSetMixin, ModelViewSet):
                     if ch_column == "first_message"
                     else "argMax(input, start_time)"
                 )
-                search_clause = f"AND val ILIKE %(search)s" if search else ""
+                search_clause = "AND val ILIKE %(search)s" if search else ""
                 query = f"""
                 SELECT DISTINCT val FROM (
                     SELECT {agg_expr} AS val
@@ -1479,8 +1479,8 @@ class TraceSessionView(BaseModelViewSetMixin, ModelViewSet):
         # resolve it to a set of EndUser UUIDs and pass an end_user_id IN(...)
         # synthetic filter instead (the CH `spans` table keys users via the
         # UUID column `end_user_id`, not the string `user_id`).
-        user_id_raw: Optional[str] = user_id_qp or None
-        _remaining: List[Dict] = []
+        user_id_raw: str | None = user_id_qp or None
+        _remaining: list[dict] = []
         for _f in filters:
             _col, _cfg = FilterEngine._normalize_filter_params(_f)
             _col_type = _cfg.get("col_type", "NORMAL")
@@ -1498,7 +1498,7 @@ class TraceSessionView(BaseModelViewSetMixin, ModelViewSet):
         # both the UUIDs (to inject as a synthetic end_user_id IN(...)
         # filter) and the display fields (to stitch onto the formatted
         # output later) — fetch them together to save a round-trip.
-        end_user_display: Optional[Dict[str, Any]] = None
+        end_user_display: dict[str, Any] | None = None
         if user_id_raw:
             _eu_qs = EndUser.objects.filter(
                 user_id=user_id_raw,
@@ -1634,7 +1634,7 @@ class TraceSessionView(BaseModelViewSetMixin, ModelViewSet):
                         attr_query, attr_params, timeout_ms=5000
                     )
                     # Aggregate per session: session_id -> {attr_key -> set(values)}
-                    aggregated_attrs: Dict[str, Dict] = {}
+                    aggregated_attrs: dict[str, dict] = {}
                     for attr_row in attr_result.data:
                         sid = str(attr_row.get("session_id", ""))
                         # Skip if this session already has max keys


### PR DESCRIPTION
Supersedes #988 with the branch renamed to `fix/session-eval-scores` as requested by @abhijaisrivastava15 in #988.

## Summary
When retrieving session details with ClickHouse enabled, successful evaluations were missing due to an incorrect `NULL` check. In ClickHouse, `output_str != 'ERROR'` evaluates to `NULL` (falsy) when `output_str` is `NULL`. Since most successful evaluations have a `NULL` output string, they were silently filtered out of the session evaluation aggregation.

This PR replaces the bare `output_str != 'ERROR'` clause in the ClickHouse aggregation subquery with a null-safe guard `ifNull(output_str, '') != 'ERROR'`, matching the pattern established in other list views.

## Linked issues
Closes #987

## Type of change
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📖 Documentation only
- [ ] 🧹 Chore / refactor (no user-visible change)
- [ ] 🚀 Performance improvement
- [x] 🧪 Test-only change

## How was this tested?
1. Added `TestRetrieveClickhouseEvalQueryNullSafety` to `futureagi/tracer/tests/test_trace_session.py` to verify the presence of the `ifNull` guard via source inspection.
2. Added `TestSessionEvalAggregationCHQuery` to `futureagi/tracer/tests/test_trace_session_ch_query.py` to verify that rows with `output_str = NULL` are correctly aggregated when the `ifNull` guard is present, and excluded when it is absent.
3. Fixed the `tracer_eval_logger` ReplacingMergeTree test fixture configuration to include `SETTINGS allow_nullable_key = 1` so that ClickHouse permits the nullable `trace_id` in the sorting key.
4. Verified that all 32 targeted unit/integration tests pass cleanly via `bin/test --no-services`.

## Checklist
- [x] My code follows the style guide
- [x] I've added tests that prove my fix is effective or that my feature works
- [x] `make check-all` / `yarn check-all` passes locally (ran ruff + target tests)
- [x] I've updated the documentation where relevant
- [x] No hardcoded secrets, URLs, or PII
- [x] I've signed the CLA