### PR TITLE
fix(tracer): stop skipped and unknown-verdict evals from corrupting score graphs

### DIFF
--- a/futureagi/tracer/utils/graphs.py
+++ b/futureagi/tracer/utils/graphs.py
@@ -680,7 +680,7 @@ class GraphEngine:
 
     def _process_string_output(self, eval_log, current_data, valid_scores):
         """Helper method for processing string outputs"""
-        output_lower = eval_log.output_str.lower()
+        output_lower = eval_log.output_str.strip().lower()
         if output_lower == "passed":
             valid_scores.append(100)
             current_data["passed_count"] += 1
@@ -690,9 +690,8 @@ class GraphEngine:
             if eval_log.trace.id not in current_data["failed_traces_ids"]:
                 current_data["failed_traces_count"] += 1
                 current_data["failed_traces_ids"].add(eval_log.trace.id)
-        else:
-            valid_scores.append(100)
-            current_data["passed_count"] += 1
+        # Unknown verdicts contribute no score: an eval that did not emit a
+        # Pass/Fail verdict must not inflate the pass rate.
 
     def _calculate_final_score(
         self, valid_scores, total_count, empty_count, eval_response_data
@@ -709,7 +708,7 @@ class GraphEngine:
                 "percentile_empty": lambda: (
                     (empty_count / total_count * 100) if total_count > 0 else 0
                 ),
-                "average": lambda: round(sum(valid_scores) / total_count, 2),
+                "average": lambda: round(sum(valid_scores) / len(valid_scores), 2),
                 "standard_deviation": lambda: np.std(valid_scores),
                 "p50": lambda: np.median(valid_scores),
                 "p75": lambda: np.quantile(valid_scores, q=0.75),


### PR DESCRIPTION
## What does this PR address?

Two silent scoring errors in `GraphEngine._score_evals_property` (`futureagi/tracer/utils/graphs.py`), the code behind the eval score trend graphs:

1. **Skipped/empty eval rows deflated the average.** The `"average"` property computed `sum(valid_scores) / total_count`, where `total_count` includes rows that were skipped earlier in the loop because all output fields were empty (the skip path that sets `skipped_reason` and writes no `output_str`). One pass + one skipped eval therefore rendered an average of 50 instead of 100. The average should be over the rows that actually produced a score.
2. **Unrecognized verdicts counted as passes.** `_process_string_output` appended 100 and incremented `passed_count` for any string that wasn't `"failed"`/`"error"` — including verdicts like `"N/A"` or `"skipped"`. A custom eval that failed to emit a Pass/Fail verdict silently inflated the pass rate.

## Fix

- `"average"`: divide by `len(valid_scores)` instead of `total_count` (empty rows no longer deflate the trend line).
- `_process_string_output`: strip the verdict before comparing (whitespace artifacts), and unrecognized verdicts now contribute no score and no pass/fail count — consistent with how the rest of the codebase excludes `output_str="ERROR"` rows from pass counts rather than counting them as failures.

## Test

The Django harness isn't available locally (same constraint as #2145), so verification is at the logic level plus compile:

- A scripted matrix mirroring the two methods: pass+skip → average 100 (was 50), unknown verdict "N/A" → no pass count / no score (was pass 100), genuine pass+fail → 50 unchanged, whitespace/case variants still recognized.
- `py_compile` clean; ruff 0.14.2 clean on the changed file (the 5 pre-existing E402 import-placement findings in graphs.py are untouched).

## Diff Scope

1 file, +4/-5 (futureagi/tracer/utils/graphs.py).