### PR TITLE
Remove two dead components: ExperimentsTableListView (unscoped queryset) and JsonSyntax (XSS sink) (#2136)

### DIFF
--- a/frontend/src/components/traceDetail/SpanDetailPane.jsx
+++ b/frontend/src/components/traceDetail/SpanDetailPane.jsx
@@ -74,53 +74,6 @@ function stringify(val) {
   return JSON.stringify(val, null, 2);
 }
 
-/* ── JsonSyntax — lightweight JSON syntax highlighting ── */
-
-const JsonSyntax = ({ json }) => {
-  if (!json) return null;
-  // Regex-based syntax coloring — matches keys, strings, numbers, booleans, null
-  const parts = json.split(/("(?:[^"\\]|\\.)*")\s*:/g);
-  const result = [];
-  for (let i = 0; i < parts.length; i++) {
-    if (i % 2 === 1) {
-      // This is a key
-      result.push(
-        <span key={i} style={{ color: "var(--text-primary)", fontWeight: 500 }}>
-          {parts[i]}
-        </span>,
-      );
-      result.push(
-        <span key={`${i}c`} style={{ color: "var(--text-disabled)" }}>
-          :{" "}
-        </span>,
-      );
-    } else {
-      // This is value content — colorize inline
-      const chunk = parts[i];
-      const colored = chunk.replace(
-        /("(?:[^"\\]|\\.)*")|(\b(?:true|false)\b)|(\bnull\b)|(-?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)/g,
-        (match, str, bool, nul, num) => {
-          if (str)
-            return `<span style="color:var(--syntax-string)">${str}</span>`;
-          if (bool)
-            return `<span style="color:var(--syntax-boolean)">${match}</span>`;
-          if (nul)
-            return `<span style="color:var(--text-disabled)">${match}</span>`;
-          if (num)
-            return `<span style="color:var(--syntax-number)">${match}</span>`;
-          return match;
-        },
-      );
-      result.push(
-        <span key={i} dangerouslySetInnerHTML={{ __html: colored }} />,
-      );
-    }
-  }
-  return <>{result}</>;
-};
-
-JsonSyntax.propTypes = { json: PropTypes.string };
-
 /* ── MetricChip ───────────────────────────────────────── */
 
 const MetricChip = ({ label, value }) => (

--- a/futureagi/model_hub/views/experiments.py
+++ b/futureagi/model_hub/views/experiments.py
@@ -625,26 +625,6 @@ class ExperimentsTableView(APIView):
             return self._gm.bad_request(get_error_message("FAILED_TO_UPDATE_EXP"))
 
 
-class ExperimentsTableListView(generics.ListAPIView):
-    queryset = ExperimentsTable.objects.filter(deleted=False).all()
-    serializer_class = ExperimentsTableGetSerializer
-    pagination_class = ExtendedPageNumberPagination
-    filter_backends = [DjangoFilterBackend, OrderingFilter]
-    filterset_fields = ["status"]
-    search_fields = ["name", "dataset__name"]
-    ordering_fields = ["created_at", "name"]
-    ordering = ["-created_at"]
-
-    def list(self, request, *args, **kwargs):
-        queryset = self.filter_queryset(self.get_queryset())
-        page = self.paginate_queryset(queryset)
-        if page is not None:
-            serializer = self.get_serializer(page, many=True)
-            return self.get_paginated_response(serializer.data)
-        serializer = self.get_serializer(queryset, many=True)
-        return self._gm.success_response(serializer.data)
-
-
 class ExperimentsTableDetailView(BaseModelViewSetMixin, generics.ListAPIView):
     queryset = ExperimentsTable.objects.all()
     serializer_class = ExperimentsTableGetSerializer


### PR DESCRIPTION
## Problem
Two dead components: ExperimentsTableListView (unrouted ListAPIView with unscoped queryset) and JsonSyntax (never rendered, dangerouslySetInnerHTML XSS sink built via regex).

## Fix
- Removed ExperimentsTableListView (20 lines, no route registered)
- Removed JsonSyntax definition + propTypes (47 lines)
- 0 references remaining (verified global search); no orphan imports; ruff + eslint clean