### PR TITLE
Normalize placeholder names with spaces in all template formats (#2082)

### DIFF
--- a/api_contracts/openapi/swagger.json
+++ b/api_contracts/openapi/swagger.json
@@ -86918,8 +86918,11 @@
                     "minLength": 1
                 },
                 "roles": {
-                    "title": "Roles",
-                    "type": "string",
+                    "type": "array",
+                    "items": {
+                        "type": "string",
+                        "minLength": 1
+                    },
                     "readOnly": true
                 }
             }
@@ -87095,16 +87098,22 @@
                     "title": "Created by name",
                     "type": "string",
                     "readOnly": true,
-                    "minLength": 1
+                    "minLength": 1,
+                    "x-nullable": true
                 },
                 "viewer_role": {
                     "title": "Viewer role",
                     "type": "string",
-                    "readOnly": true
+                    "readOnly": true,
+                    "minLength": 1,
+                    "x-nullable": true
                 },
                 "viewer_roles": {
-                    "title": "Viewer roles",
-                    "type": "string",
+                    "type": "array",
+                    "items": {
+                        "type": "string",
+                        "minLength": 1
+                    },
                     "readOnly": true
                 },
                 "deleted": {
@@ -88536,6 +88545,34 @@
                 }
             }
         },
+        "QueueItemAssignedUser": {
+            "required": [
+                "id",
+                "name",
+                "email"
+            ],
+            "type": "object",
+            "properties": {
+                "id": {
+                    "title": "Id",
+                    "type": "string",
+                    "format": "uuid"
+                },
+                "name": {
+                    "title": "Name",
+                    "type": "string",
+                    "minLength": 1,
+                    "x-nullable": true
+                },
+                "email": {
+                    "title": "Email",
+                    "type": "string",
+                    "format": "email",
+                    "minLength": 1,
+                    "x-nullable": true
+                }
+            }
+        },
         "QueueItem": {
             "required": [
                 "source_type"
@@ -88617,11 +88654,14 @@
                     "title": "Assigned to name",
                     "type": "string",
                     "readOnly": true,
-                    "minLength": 1
+                    "minLength": 1,
+                    "x-nullable": true
                 },
                 "assigned_users": {
-                    "title": "Assigned users",
-                    "type": "string",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/QueueItemAssignedUser"
+                    },
                     "readOnly": true
                 },
                 "reserved_by": {
@@ -88634,7 +88674,8 @@
                     "title": "Reserved by name",
                     "type": "string",
                     "readOnly": true,
-                    "minLength": 1
+                    "minLength": 1,
+                    "x-nullable": true
                 },
                 "reservation_expires_at": {
                     "title": "Reservation expires at",
@@ -88658,7 +88699,8 @@
                     "title": "Reviewed by name",
                     "type": "string",
                     "readOnly": true,
-                    "minLength": 1
+                    "minLength": 1,
+                    "x-nullable": true
                 },
                 "reviewed_at": {
                     "title": "Reviewed at",
@@ -88673,17 +88715,19 @@
                 },
                 "source_preview": {
                     "title": "Source preview",
-                    "type": "string",
-                    "readOnly": true
+                    "type": "object",
+                    "readOnly": true,
+                    "x-json-value": true,
+                    "description": "Any valid JSON value."
                 },
                 "comment_count": {
                     "title": "Comment count",
-                    "type": "string",
+                    "type": "integer",
                     "readOnly": true
                 },
                 "open_feedback_count": {
                     "title": "Open feedback count",
-                    "type": "string",
+                    "type": "integer",
                     "readOnly": true
                 },
                 "created_at": {

--- a/frontend/src/api/contracts/__tests__/openapi-contract.test.js
+++ b/frontend/src/api/contracts/__tests__/openapi-contract.test.js
@@ -595,4 +595,87 @@ describe("OpenAPI runtime contract", () => {
       ),
     ).toMatchObject({ ok: false });
   });
+
+  it("accepts queue items with null names, listed assignees, and a null source preview", () => {
+    // Regression: method fields and nullable name fields carried no declared
+    // type, so drf-yasg typed them all as required strings — an unassigned,
+    // unreserved, unreviewed item raised 175 warnings on a single items/ page.
+    const queueItemsResponse = (item) => ({
+      status: 200,
+      config: {
+        url: "/model-hub/annotation-queues/7d1f0c4e-0000-4000-8000-000000000001/items/?page=1",
+        method: "get",
+      },
+      data: {
+        count: 1,
+        next: null,
+        previous: null,
+        results: [item],
+      },
+    });
+
+    const unassignedItem = {
+      id: "1f2e3d4c-0000-4000-8000-000000000002",
+      queue: "7d1f0c4e-0000-4000-8000-000000000001",
+      source_type: "trace",
+      source_id: "trace-1",
+      status: "pending",
+      workflow_status: "pending",
+      workflow_status_label: "Pending Annotation",
+      priority: 0,
+      order: 1,
+      metadata: {},
+      assigned_to: null,
+      assigned_to_name: null,
+      assigned_users: [
+        {
+          id: "9a8b7c6d-0000-4000-8000-000000000003",
+          name: null,
+          email: null,
+        },
+      ],
+      reserved_by: null,
+      reserved_by_name: null,
+      reservation_expires_at: null,
+      review_status: null,
+      reviewed_by: null,
+      reviewed_by_name: null,
+      reviewed_at: null,
+      review_notes: null,
+      source_preview: null,
+      comment_count: 0,
+      open_feedback_count: 0,
+      created_at: "2026-01-01T00:00:00Z",
+    };
+
+    expect(
+      validateContractedResponse(queueItemsResponse(unassignedItem)),
+    ).toMatchObject({ ok: true });
+
+    // source_preview is x-json-value, so any valid JSON shape passes.
+    expect(
+      validateContractedResponse(
+        queueItemsResponse({
+          ...unassignedItem,
+          assigned_to_name: "Ada Lovelace",
+          assigned_users: [
+            {
+              id: "9a8b7c6d-0000-4000-8000-000000000003",
+              name: "Ada Lovelace",
+              email: "ada@example.com",
+            },
+          ],
+          source_preview: { input: "hello", tags: ["a", null] },
+        }),
+      ),
+    ).toMatchObject({ ok: true });
+
+    // The endpoint really is validated here — a count sent as a string fails,
+    // so the null-tolerance above is not just an unmatched-route skip.
+    expect(
+      validateContractedResponse(
+        queueItemsResponse({ ...unassignedItem, comment_count: "0" }),
+      ),
+    ).toMatchObject({ ok: false });
+  });
 });

--- a/frontend/src/api/contracts/openapi-contract.generated.js
+++ b/frontend/src/api/contracts/openapi-contract.generated.js
@@ -46280,16 +46280,22 @@ export const OPENAPI_CONTRACT = Object.freeze({
           "title": "Created by name",
           "type": "string",
           "readOnly": true,
-          "minLength": 1
+          "minLength": 1,
+          "x-nullable": true
         },
         "viewer_role": {
           "title": "Viewer role",
           "type": "string",
-          "readOnly": true
+          "readOnly": true,
+          "minLength": 1,
+          "x-nullable": true
         },
         "viewer_roles": {
-          "title": "Viewer roles",
-          "type": "string",
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          },
           "readOnly": true
         },
         "deleted": {
@@ -66123,11 +66129,14 @@ export const OPENAPI_CONTRACT = Object.freeze({
           "title": "Assigned to name",
           "type": "string",
           "readOnly": true,
-          "minLength": 1
+          "minLength": 1,
+          "x-nullable": true
         },
         "assigned_users": {
-          "title": "Assigned users",
-          "type": "string",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/QueueItemAssignedUser"
+          },
           "readOnly": true
         },
         "reserved_by": {
@@ -66140,7 +66149,8 @@ export const OPENAPI_CONTRACT = Object.freeze({
           "title": "Reserved by name",
           "type": "string",
           "readOnly": true,
-          "minLength": 1
+          "minLength": 1,
+          "x-nullable": true
         },
         "reservation_expires_at": {
           "title": "Reservation expires at",
@@ -66164,7 +66174,8 @@ export const OPENAPI_CONTRACT = Object.freeze({
           "title": "Reviewed by name",
           "type": "string",
           "readOnly": true,
-          "minLength": 1
+          "minLength": 1,
+          "x-nullable": true
         },
         "reviewed_at": {
           "title": "Reviewed at",
@@ -66179,17 +66190,19 @@ export const OPENAPI_CONTRACT = Object.freeze({
         },
         "source_preview": {
           "title": "Source preview",
-          "type": "string",
-          "readOnly": true
+          "type": "object",
+          "readOnly": true,
+          "x-json-value": true,
+          "description": "Any valid JSON value."
         },
         "comment_count": {
           "title": "Comment count",
-          "type": "string",
+          "type": "integer",
           "readOnly": true
         },
         "open_feedback_count": {
           "title": "Open feedback count",
-          "type": "string",
+          "type": "integer",
           "readOnly": true
         },
         "created_at": {
@@ -76994,8 +77007,11 @@ export const OPENAPI_CONTRACT = Object.freeze({
           "minLength": 1
         },
         "roles": {
-          "title": "Roles",
-          "type": "string",
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          },
           "readOnly": true
         }
       }
@@ -87567,6 +87583,34 @@ export const OPENAPI_CONTRACT = Object.freeze({
         "imported": {
           "title": "Imported",
           "type": "integer"
+        }
+      }
+    },
+    "QueueItemAssignedUser": {
+      "required": [
+        "id",
+        "name",
+        "email"
+      ],
+      "type": "object",
+      "properties": {
+        "id": {
+          "title": "Id",
+          "type": "string",
+          "format": "uuid"
+        },
+        "name": {
+          "title": "Name",
+          "type": "string",
+          "minLength": 1,
+          "x-nullable": true
+        },
+        "email": {
+          "title": "Email",
+          "type": "string",
+          "format": "email",
+          "minLength": 1,
+          "x-nullable": true
         }
       }
     },

--- a/frontend/src/generated/api-contracts/api.schemas.ts
+++ b/frontend/src/generated/api-contracts/api.schemas.ts
@@ -5599,7 +5599,7 @@ export interface QueueAnnotatorNestedApi {
   readonly email?: string;
   /** @minLength 1 */
   role?: string;
-  readonly roles?: string;
+  readonly roles?: readonly string[];
 }
 
 export interface AnnotationQueueApi {
@@ -5644,8 +5644,9 @@ export interface AnnotationQueueApi {
   readonly created_by?: string;
   /** @minLength 1 */
   readonly created_by_name?: string;
+  /** @minLength 1 */
   readonly viewer_role?: string;
-  readonly viewer_roles?: string;
+  readonly viewer_roles?: readonly string[];
   readonly deleted?: boolean;
   readonly created_at?: string;
 }
@@ -6132,6 +6133,19 @@ export const QueueItemApiStatus = {
 
 export type QueueItemApiMetadata = { [key: string]: unknown };
 
+/**
+ * Any valid JSON value.
+ */
+export type QueueItemApiSourcePreview = { [key: string]: unknown };
+
+export interface QueueItemAssignedUserApi {
+  id: string;
+  /** @minLength 1 */
+  name: string;
+  /** @minLength 1 */
+  email: string;
+}
+
 export interface QueueItemApi {
   readonly id?: string;
   readonly queue?: string;
@@ -6155,7 +6169,7 @@ export interface QueueItemApi {
   assigned_to?: string;
   /** @minLength 1 */
   readonly assigned_to_name?: string;
-  readonly assigned_users?: string;
+  readonly assigned_users?: readonly QueueItemAssignedUserApi[];
   reserved_by?: string;
   /** @minLength 1 */
   readonly reserved_by_name?: string;
@@ -6167,9 +6181,10 @@ export interface QueueItemApi {
   readonly reviewed_by_name?: string;
   reviewed_at?: string;
   review_notes?: string;
-  readonly source_preview?: string;
-  readonly comment_count?: string;
-  readonly open_feedback_count?: string;
+  /** Any valid JSON value. */
+  readonly source_preview?: QueueItemApiSourcePreview;
+  readonly comment_count?: number;
+  readonly open_feedback_count?: number;
   readonly created_at?: string;
 }
 

--- a/frontend/src/generated/api-contracts/api.zod.ts
+++ b/frontend/src/generated/api-contracts/api.zod.ts
@@ -11677,8 +11677,11 @@ export const modelHubAnnotationQueuesListResponseResultsItemLabelsItemOrderMax =
 export const modelHubAnnotationQueuesListResponseResultsItemAnnotatorsItemRoleDefault = `annotator`;
 
 
+
 export const modelHubAnnotationQueuesListResponseResultsItemAnnotatorIdsDefault = [];
 export const modelHubAnnotationQueuesListResponseResultsItemAnnotatorRolesDefault = {  };
+
+
 
 
 export const ModelHubAnnotationQueuesListResponse = zod.object({
@@ -11715,7 +11718,7 @@ export const ModelHubAnnotationQueuesListResponse = zod.object({
   "name": zod.string().min(1).optional(),
   "email": zod.string().email().min(1).optional(),
   "role": zod.string().min(1).default(modelHubAnnotationQueuesListResponseResultsItemAnnotatorsItemRoleDefault),
-  "roles": zod.string().optional()
+  "roles": zod.array(zod.string().min(1)).optional()
 })).optional(),
   "label_ids": zod.array(zod.string().uuid()).min(1),
   "annotator_ids": zod.array(zod.string().uuid()).default(modelHubAnnotationQueuesListResponseResultsItemAnnotatorIdsDefault),
@@ -11728,8 +11731,8 @@ export const ModelHubAnnotationQueuesListResponse = zod.object({
   "completed_count": zod.number().optional(),
   "created_by": zod.string().uuid().optional(),
   "created_by_name": zod.string().min(1).optional(),
-  "viewer_role": zod.string().optional(),
-  "viewer_roles": zod.string().optional(),
+  "viewer_role": zod.string().min(1).optional(),
+  "viewer_roles": zod.array(zod.string().min(1)).optional(),
   "deleted": zod.boolean().optional(),
   "created_at": zod.string().datetime({"offset":true}).optional()
 }))
@@ -11905,8 +11908,11 @@ export const modelHubAnnotationQueuesReadResponseLabelsItemOrderMax = 2147483647
 export const modelHubAnnotationQueuesReadResponseAnnotatorsItemRoleDefault = `annotator`;
 
 
+
 export const modelHubAnnotationQueuesReadResponseAnnotatorIdsDefault = [];
 export const modelHubAnnotationQueuesReadResponseAnnotatorRolesDefault = {  };
+
+
 
 
 export const ModelHubAnnotationQueuesReadResponse = zod.object({
@@ -11939,7 +11945,7 @@ export const ModelHubAnnotationQueuesReadResponse = zod.object({
   "name": zod.string().min(1).optional(),
   "email": zod.string().email().min(1).optional(),
   "role": zod.string().min(1).default(modelHubAnnotationQueuesReadResponseAnnotatorsItemRoleDefault),
-  "roles": zod.string().optional()
+  "roles": zod.array(zod.string().min(1)).optional()
 })).optional(),
   "label_ids": zod.array(zod.string().uuid()).min(1),
   "annotator_ids": zod.array(zod.string().uuid()).default(modelHubAnnotationQueuesReadResponseAnnotatorIdsDefault),
@@ -11952,8 +11958,8 @@ export const ModelHubAnnotationQueuesReadResponse = zod.object({
   "completed_count": zod.number().optional(),
   "created_by": zod.string().uuid().optional(),
   "created_by_name": zod.string().min(1).optional(),
-  "viewer_role": zod.string().optional(),
-  "viewer_roles": zod.string().optional(),
+  "viewer_role": zod.string().min(1).optional(),
+  "viewer_roles": zod.array(zod.string().min(1)).optional(),
   "deleted": zod.boolean().optional(),
   "created_at": zod.string().datetime({"offset":true}).optional()
 })
@@ -12012,8 +12018,11 @@ export const modelHubAnnotationQueuesUpdateResponseLabelsItemOrderMax = 21474836
 export const modelHubAnnotationQueuesUpdateResponseAnnotatorsItemRoleDefault = `annotator`;
 
 
+
 export const modelHubAnnotationQueuesUpdateResponseAnnotatorIdsDefault = [];
 export const modelHubAnnotationQueuesUpdateResponseAnnotatorRolesDefault = {  };
+
+
 
 
 export const ModelHubAnnotationQueuesUpdateResponse = zod.object({
@@ -12046,7 +12055,7 @@ export const ModelHubAnnotationQueuesUpdateResponse = zod.object({
   "name": zod.string().min(1).optional(),
   "email": zod.string().email().min(1).optional(),
   "role": zod.string().min(1).default(modelHubAnnotationQueuesUpdateResponseAnnotatorsItemRoleDefault),
-  "roles": zod.string().optional()
+  "roles": zod.array(zod.string().min(1)).optional()
 })).optional(),
   "label_ids": zod.array(zod.string().uuid()).min(1),
   "annotator_ids": zod.array(zod.string().uuid()).default(modelHubAnnotationQueuesUpdateResponseAnnotatorIdsDefault),
@@ -12059,8 +12068,8 @@ export const ModelHubAnnotationQueuesUpdateResponse = zod.object({
   "completed_count": zod.number().optional(),
   "created_by": zod.string().uuid().optional(),
   "created_by_name": zod.string().min(1).optional(),
-  "viewer_role": zod.string().optional(),
-  "viewer_roles": zod.string().optional(),
+  "viewer_role": zod.string().min(1).optional(),
+  "viewer_roles": zod.array(zod.string().min(1)).optional(),
   "deleted": zod.boolean().optional(),
   "created_at": zod.string().datetime({"offset":true}).optional()
 })
@@ -12116,8 +12125,11 @@ export const modelHubAnnotationQueuesPartialUpdateResponseLabelsItemOrderMax = 2
 export const modelHubAnnotationQueuesPartialUpdateResponseAnnotatorsItemRoleDefault = `annotator`;
 
 
+
 export const modelHubAnnotationQueuesPartialUpdateResponseAnnotatorIdsDefault = [];
 export const modelHubAnnotationQueuesPartialUpdateResponseAnnotatorRolesDefault = {  };
+
+
 
 
 export const ModelHubAnnotationQueuesPartialUpdateResponse = zod.object({
@@ -12150,7 +12162,7 @@ export const ModelHubAnnotationQueuesPartialUpdateResponse = zod.object({
   "name": zod.string().min(1).optional(),
   "email": zod.string().email().min(1).optional(),
   "role": zod.string().min(1).default(modelHubAnnotationQueuesPartialUpdateResponseAnnotatorsItemRoleDefault),
-  "roles": zod.string().optional()
+  "roles": zod.array(zod.string().min(1)).optional()
 })).optional(),
   "label_ids": zod.array(zod.string().uuid()).min(1),
   "annotator_ids": zod.array(zod.string().uuid()).default(modelHubAnnotationQueuesPartialUpdateResponseAnnotatorIdsDefault),
@@ -12163,8 +12175,8 @@ export const ModelHubAnnotationQueuesPartialUpdateResponse = zod.object({
   "completed_count": zod.number().optional(),
   "created_by": zod.string().uuid().optional(),
   "created_by_name": zod.string().min(1).optional(),
-  "viewer_role": zod.string().optional(),
-  "viewer_roles": zod.string().optional(),
+  "viewer_role": zod.string().min(1).optional(),
+  "viewer_roles": zod.array(zod.string().min(1)).optional(),
   "deleted": zod.boolean().optional(),
   "created_at": zod.string().datetime({"offset":true}).optional()
 })
@@ -12527,8 +12539,11 @@ export const modelHubAnnotationQueuesRestoreResponseResultLabelsItemOrderMax = 2
 export const modelHubAnnotationQueuesRestoreResponseResultAnnotatorsItemRoleDefault = `annotator`;
 
 
+
 export const modelHubAnnotationQueuesRestoreResponseResultAnnotatorIdsDefault = [];
 export const modelHubAnnotationQueuesRestoreResponseResultAnnotatorRolesDefault = {  };
+
+
 
 
 export const ModelHubAnnotationQueuesRestoreResponse = zod.object({
@@ -12563,7 +12578,7 @@ export const ModelHubAnnotationQueuesRestoreResponse = zod.object({
   "name": zod.string().min(1).optional(),
   "email": zod.string().email().min(1).optional(),
   "role": zod.string().min(1).default(modelHubAnnotationQueuesRestoreResponseResultAnnotatorsItemRoleDefault),
-  "roles": zod.string().optional()
+  "roles": zod.array(zod.string().min(1)).optional()
 })).optional(),
   "label_ids": zod.array(zod.string().uuid()).min(1),
   "annotator_ids": zod.array(zod.string().uuid()).default(modelHubAnnotationQueuesRestoreResponseResultAnnotatorIdsDefault),
@@ -12576,8 +12591,8 @@ export const ModelHubAnnotationQueuesRestoreResponse = zod.object({
   "completed_count": zod.number().optional(),
   "created_by": zod.string().uuid().optional(),
   "created_by_name": zod.string().min(1).optional(),
-  "viewer_role": zod.string().optional(),
-  "viewer_roles": zod.string().optional(),
+  "viewer_role": zod.string().min(1).optional(),
+  "viewer_roles": zod.array(zod.string().min(1)).optional(),
   "deleted": zod.boolean().optional(),
   "created_at": zod.string().datetime({"offset":true}).optional()
 })
@@ -12611,8 +12626,11 @@ export const modelHubAnnotationQueuesUpdateStatusResponseResultLabelsItemOrderMa
 export const modelHubAnnotationQueuesUpdateStatusResponseResultAnnotatorsItemRoleDefault = `annotator`;
 
 
+
 export const modelHubAnnotationQueuesUpdateStatusResponseResultAnnotatorIdsDefault = [];
 export const modelHubAnnotationQueuesUpdateStatusResponseResultAnnotatorRolesDefault = {  };
+
+
 
 
 export const ModelHubAnnotationQueuesUpdateStatusResponse = zod.object({
@@ -12647,7 +12665,7 @@ export const ModelHubAnnotationQueuesUpdateStatusResponse = zod.object({
   "name": zod.string().min(1).optional(),
   "email": zod.string().email().min(1).optional(),
   "role": zod.string().min(1).default(modelHubAnnotationQueuesUpdateStatusResponseResultAnnotatorsItemRoleDefault),
-  "roles": zod.string().optional()
+  "roles": zod.array(zod.string().min(1)).optional()
 })).optional(),
   "label_ids": zod.array(zod.string().uuid()).min(1),
   "annotator_ids": zod.array(zod.string().uuid()).default(modelHubAnnotationQueuesUpdateStatusResponseResultAnnotatorIdsDefault),
@@ -12660,8 +12678,8 @@ export const ModelHubAnnotationQueuesUpdateStatusResponse = zod.object({
   "completed_count": zod.number().optional(),
   "created_by": zod.string().uuid().optional(),
   "created_by_name": zod.string().min(1).optional(),
-  "viewer_role": zod.string().optional(),
-  "viewer_roles": zod.string().optional(),
+  "viewer_role": zod.string().min(1).optional(),
+  "viewer_roles": zod.array(zod.string().min(1)).optional(),
   "deleted": zod.boolean().optional(),
   "created_at": zod.string().datetime({"offset":true}).optional()
 })
@@ -13113,6 +13131,8 @@ export const modelHubAnnotationQueuesItemsListResponseResultsItemOrderMax = 2147
 
 
 
+
+
 export const modelHubAnnotationQueuesItemsListResponseResultsItemReviewStatusMax = 20;
 
 
@@ -13137,7 +13157,11 @@ export const ModelHubAnnotationQueuesItemsListResponse = zod.object({
 }).passthrough().optional(),
   "assigned_to": zod.string().uuid().optional(),
   "assigned_to_name": zod.string().min(1).optional(),
-  "assigned_users": zod.string().optional(),
+  "assigned_users": zod.array(zod.object({
+  "id": zod.string().uuid(),
+  "name": zod.string().min(1),
+  "email": zod.string().email().min(1)
+})).optional(),
   "reserved_by": zod.string().uuid().optional(),
   "reserved_by_name": zod.string().min(1).optional(),
   "reservation_expires_at": zod.string().datetime({"offset":true}).optional(),
@@ -13146,9 +13170,11 @@ export const ModelHubAnnotationQueuesItemsListResponse = zod.object({
   "reviewed_by_name": zod.string().min(1).optional(),
   "reviewed_at": zod.string().datetime({"offset":true}).optional(),
   "review_notes": zod.string().optional(),
-  "source_preview": zod.string().optional(),
-  "comment_count": zod.string().optional(),
-  "open_feedback_count": zod.string().optional(),
+  "source_preview": zod.object({
+
+}).passthrough().optional().describe('Any valid JSON value.'),
+  "comment_count": zod.number().optional(),
+  "open_feedback_count": zod.number().optional(),
   "created_at": zod.string().datetime({"offset":true}).optional()
 }))
 })
@@ -13375,6 +13401,8 @@ export const modelHubAnnotationQueuesItemsReadResponseOrderMax = 2147483647;
 
 
 
+
+
 export const modelHubAnnotationQueuesItemsReadResponseReviewStatusMax = 20;
 
 
@@ -13395,7 +13423,11 @@ export const ModelHubAnnotationQueuesItemsReadResponse = zod.object({
 }).passthrough().optional(),
   "assigned_to": zod.string().uuid().optional(),
   "assigned_to_name": zod.string().min(1).optional(),
-  "assigned_users": zod.string().optional(),
+  "assigned_users": zod.array(zod.object({
+  "id": zod.string().uuid(),
+  "name": zod.string().min(1),
+  "email": zod.string().email().min(1)
+})).optional(),
   "reserved_by": zod.string().uuid().optional(),
   "reserved_by_name": zod.string().min(1).optional(),
   "reservation_expires_at": zod.string().datetime({"offset":true}).optional(),
@@ -13404,9 +13436,11 @@ export const ModelHubAnnotationQueuesItemsReadResponse = zod.object({
   "reviewed_by_name": zod.string().min(1).optional(),
   "reviewed_at": zod.string().datetime({"offset":true}).optional(),
   "review_notes": zod.string().optional(),
-  "source_preview": zod.string().optional(),
-  "comment_count": zod.string().optional(),
-  "open_feedback_count": zod.string().optional(),
+  "source_preview": zod.object({
+
+}).passthrough().optional().describe('Any valid JSON value.'),
+  "comment_count": zod.number().optional(),
+  "open_feedback_count": zod.number().optional(),
   "created_at": zod.string().datetime({"offset":true}).optional()
 })
 
@@ -13454,6 +13488,8 @@ export const modelHubAnnotationQueuesItemsUpdateResponseOrderMax = 2147483647;
 
 
 
+
+
 export const modelHubAnnotationQueuesItemsUpdateResponseReviewStatusMax = 20;
 
 
@@ -13474,7 +13510,11 @@ export const ModelHubAnnotationQueuesItemsUpdateResponse = zod.object({
 }).passthrough().optional(),
   "assigned_to": zod.string().uuid().optional(),
   "assigned_to_name": zod.string().min(1).optional(),
-  "assigned_users": zod.string().optional(),
+  "assigned_users": zod.array(zod.object({
+  "id": zod.string().uuid(),
+  "name": zod.string().min(1),
+  "email": zod.string().email().min(1)
+})).optional(),
   "reserved_by": zod.string().uuid().optional(),
   "reserved_by_name": zod.string().min(1).optional(),
   "reservation_expires_at": zod.string().datetime({"offset":true}).optional(),
@@ -13483,9 +13523,11 @@ export const ModelHubAnnotationQueuesItemsUpdateResponse = zod.object({
   "reviewed_by_name": zod.string().min(1).optional(),
   "reviewed_at": zod.string().datetime({"offset":true}).optional(),
   "review_notes": zod.string().optional(),
-  "source_preview": zod.string().optional(),
-  "comment_count": zod.string().optional(),
-  "open_feedback_count": zod.string().optional(),
+  "source_preview": zod.object({
+
+}).passthrough().optional().describe('Any valid JSON value.'),
+  "comment_count": zod.number().optional(),
+  "open_feedback_count": zod.number().optional(),
   "created_at": zod.string().datetime({"offset":true}).optional()
 })
 
@@ -13533,6 +13575,8 @@ export const modelHubAnnotationQueuesItemsPartialUpdateResponseOrderMax = 214748
 
 
 
+
+
 export const modelHubAnnotationQueuesItemsPartialUpdateResponseReviewStatusMax = 20;
 
 
@@ -13553,7 +13597,11 @@ export const ModelHubAnnotationQueuesItemsPartialUpdateResponse = zod.object({
 }).passthrough().optional(),
   "assigned_to": zod.string().uuid().optional(),
   "assigned_to_name": zod.string().min(1).optional(),
-  "assigned_users": zod.string().optional(),
+  "assigned_users": zod.array(zod.object({
+  "id": zod.string().uuid(),
+  "name": zod.string().min(1),
+  "email": zod.string().email().min(1)
+})).optional(),
   "reserved_by": zod.string().uuid().optional(),
   "reserved_by_name": zod.string().min(1).optional(),
   "reservation_expires_at": zod.string().datetime({"offset":true}).optional(),
@@ -13562,9 +13610,11 @@ export const ModelHubAnnotationQueuesItemsPartialUpdateResponse = zod.object({
   "reviewed_by_name": zod.string().min(1).optional(),
   "reviewed_at": zod.string().datetime({"offset":true}).optional(),
   "review_notes": zod.string().optional(),
-  "source_preview": zod.string().optional(),
-  "comment_count": zod.string().optional(),
-  "open_feedback_count": zod.string().optional(),
+  "source_preview": zod.object({
+
+}).passthrough().optional().describe('Any valid JSON value.'),
+  "comment_count": zod.number().optional(),
+  "open_feedback_count": zod.number().optional(),
   "created_at": zod.string().datetime({"offset":true}).optional()
 })
 

--- a/frontend/src/sections/annotations/labels/annotation-label-table.jsx
+++ b/frontend/src/sections/annotations/labels/annotation-label-table.jsx
@@ -463,9 +463,10 @@ export default function AnnotationLabelTable({
               onClick={() => handleAction("archive")}
               sx={{ color: "error.main" }}
             >
-              <SvgColor
-                src="/assets/icons/ic_delete.svg"
-                sx={{ width: 18, height: 18, mr: 1, color: "error.main" }}
+              <Iconify
+                icon="solar:archive-down-bold"
+                width={18}
+                sx={{ mr: 1, color: "error.main" }}
               />
               Archive
             </MenuItem>

--- a/frontend/src/sections/annotations/queues/__tests__/annotation-queue-empty.test.jsx
+++ b/frontend/src/sections/annotations/queues/__tests__/annotation-queue-empty.test.jsx
@@ -16,7 +16,9 @@ describe("AnnotationQueueEmpty", () => {
   it("renders heading and description", () => {
     render(<AnnotationQueueEmpty onCreateClick={() => {}} />);
 
-    expect(screen.getByText("No annotation queues yet")).toBeInTheDocument();
+    expect(
+      screen.getByText("No Active annotation queues yet"),
+    ).toBeInTheDocument();
     expect(
       screen.getByText(/Create your first annotation queue/),
     ).toBeInTheDocument();

--- a/frontend/src/sections/annotations/queues/annotation-queue-empty.jsx
+++ b/frontend/src/sections/annotations/queues/annotation-queue-empty.jsx
@@ -37,7 +37,7 @@ export default function AnnotationQueueEmpty({ onCreateClick }) {
         />
       </Box>
       <Typography variant="h6" gutterBottom>
-        No annotation queues yet
+        No Active annotation queues yet
       </Typography>
       <Typography variant="body2" color="text.secondary" sx={{ mb: 3 }}>
         Create your first annotation queue to start collecting human feedback.

--- a/frontend/src/sections/annotations/queues/annotation-queue-table.jsx
+++ b/frontend/src/sections/annotations/queues/annotation-queue-table.jsx
@@ -871,12 +871,12 @@ export default function AnnotationQueueTable({
 
               <MenuItem
                 onClick={() => handleAction("archive")}
-                sx={{ color: "warning.main" }}
+                sx={{ color: "error.main" }}
               >
                 <Iconify
                   icon="solar:archive-down-bold"
                   width={18}
-                  sx={{ mr: 1 }}
+                  sx={{ mr: 1, color: "error.main" }}
                 />
                 Archive
               </MenuItem>

--- a/frontend/src/sections/annotations/queues/view/annotation-queues-view.jsx
+++ b/frontend/src/sections/annotations/queues/view/annotation-queues-view.jsx
@@ -277,6 +277,71 @@ export default function AnnotationQueuesView() {
       <Box sx={{ flexShrink: 0, px: 3 }}>
         <AnnotationsTabs />
       </Box>
+      <Stack
+        direction="row"
+        spacing={2}
+        mb={2}
+        alignItems="center"
+        flexShrink={0}
+      >
+        <FormSearchField
+          size="small"
+          placeholder="Search"
+          searchQuery={searchInput}
+          onChange={handleSearch}
+          sx={{
+            minWidth: "250px",
+            "& .MuiOutlinedInput-root": { height: "30px" },
+          }}
+        />
+        <ToggleButtonGroup
+          exclusive
+          size="small"
+          value={filters.archived ? "archived" : "active"}
+          onChange={handleArchiveViewChange}
+          sx={{
+            height: 30,
+            "& .MuiToggleButton-root": {
+              px: 1.25,
+              borderRadius: "4px",
+              typography: "s2",
+              fontWeight: "fontWeightMedium",
+            },
+          }}
+        >
+          <ToggleButton value="active">Active</ToggleButton>
+          <ToggleButton value="archived">Archived</ToggleButton>
+        </ToggleButtonGroup>
+        <TextField
+          size="small"
+          select
+          value={filters.status}
+          onChange={handleStatusFilter}
+          sx={{ minWidth: 160 }}
+          SelectProps={{
+            displayEmpty: true,
+            renderValue: (v) =>
+              STATUS_OPTIONS.find((o) => o.value === v)?.label ||
+              "All Statuses",
+          }}
+        >
+          {STATUS_OPTIONS.map((opt) => (
+            <MenuItem key={opt.value} value={opt.value}>
+              {opt.label}
+            </MenuItem>
+          ))}
+        </TextField>
+        <Box sx={{ flex: 1 }} />
+        <Button
+          variant="contained"
+          color="primary"
+          startIcon={<Iconify icon="mingcute:add-line" />}
+          onClick={handleCreateNew}
+          disabled={!canWrite}
+        >
+          Create Queue
+        </Button>
+      </Stack>
 
       {isEmpty ? (
         <AnnotationQueueEmpty onCreateClick={handleCreateNew} />
@@ -290,72 +355,6 @@ export default function AnnotationQueuesView() {
             px: 3,
           }}
         >
-          <Stack
-            direction="row"
-            spacing={2}
-            mb={2}
-            alignItems="center"
-            flexShrink={0}
-          >
-            <FormSearchField
-              size="small"
-              placeholder="Search"
-              searchQuery={searchInput}
-              onChange={handleSearch}
-              sx={{
-                minWidth: "250px",
-                "& .MuiOutlinedInput-root": { height: "30px" },
-              }}
-            />
-            <ToggleButtonGroup
-              exclusive
-              size="small"
-              value={filters.archived ? "archived" : "active"}
-              onChange={handleArchiveViewChange}
-              sx={{
-                height: 30,
-                "& .MuiToggleButton-root": {
-                  px: 1.25,
-                  borderRadius: "4px",
-                  typography: "s2",
-                  fontWeight: "fontWeightMedium",
-                },
-              }}
-            >
-              <ToggleButton value="active">Active</ToggleButton>
-              <ToggleButton value="archived">Archived</ToggleButton>
-            </ToggleButtonGroup>
-            <TextField
-              size="small"
-              select
-              value={filters.status}
-              onChange={handleStatusFilter}
-              sx={{ minWidth: 160 }}
-              SelectProps={{
-                displayEmpty: true,
-                renderValue: (v) =>
-                  STATUS_OPTIONS.find((o) => o.value === v)?.label ||
-                  "All Statuses",
-              }}
-            >
-              {STATUS_OPTIONS.map((opt) => (
-                <MenuItem key={opt.value} value={opt.value}>
-                  {opt.label}
-                </MenuItem>
-              ))}
-            </TextField>
-            <Box sx={{ flex: 1 }} />
-            <Button
-              variant="contained"
-              color="primary"
-              startIcon={<Iconify icon="mingcute:add-line" />}
-              onClick={handleCreateNew}
-              disabled={!canWrite}
-            >
-              Create Queue
-            </Button>
-          </Stack>
-
           <AnnotationQueueTable
             data={results}
             loading={isLoading}

--- a/frontend/src/sections/annotations/queues/view/queue-settings-tab.jsx
+++ b/frontend/src/sections/annotations/queues/view/queue-settings-tab.jsx
@@ -23,8 +23,11 @@ import {
   TextField,
   Typography,
 } from "@mui/material";
+import { LoadingButton } from "@mui/lab";
 import { Controller, useForm, FormProvider } from "react-hook-form";
+import Iconify from "src/components/iconify";
 import {
+  useArchiveAnnotationQueue,
   useHardDeleteAnnotationQueue,
   useUpdateAnnotationQueue,
   useUpdateAnnotationQueueStatus,
@@ -78,11 +81,20 @@ const RESERVATION_TIMEOUT_OPTIONS = [
 ];
 
 export default function QueueSettingsTab({ queue, queueId, creatorId }) {
+  const navigate = useNavigate();
   const { mutate: updateQueue, isPending: isUpdating } =
     useUpdateAnnotationQueue();
   const { mutate: updateStatus, isPending: isStatusUpdating } =
     useUpdateAnnotationQueueStatus();
+  const { mutate: archiveQueue, isPending: isArchiving } =
+    useArchiveAnnotationQueue();
   const isPending = isUpdating || isStatusUpdating;
+
+
+  const handleArchive = () => {
+    navigate("/dashboard/annotations/queues");
+    archiveQueue(queueId);
+  };
 
   const methods = useForm({
     defaultValues: {
@@ -494,7 +506,24 @@ export default function QueueSettingsTab({ queue, queueId, creatorId }) {
           </Card>
 
           {/* Save */}
-          <Box sx={{ display: "flex", justifyContent: "flex-end", pb: 3 }}>
+          <Box
+            sx={{
+              display: "flex",
+              justifyContent: "flex-end",
+              gap: 2,
+              pb: 3,
+            }}
+          >
+            <LoadingButton
+              type="button"
+              variant="outlined"
+              color="error"
+              loading={isArchiving}
+              startIcon={<Iconify icon="solar:archive-down-bold" />}
+              onClick={handleArchive}
+            >
+              Archive Queue
+            </LoadingButton>
             <Button
               type="submit"
               variant="contained"

--- a/futureagi/agent_playground/services/engine/runners/llm_prompt.py
+++ b/futureagi/agent_playground/services/engine/runners/llm_prompt.py
@@ -28,6 +28,7 @@ from typing import Any
 from agent_playground.services.engine.node_runner import BaseNodeRunner, register_runner
 from agent_playground.services.engine.utils.json_path import resolve_variable
 from agentic_eval.core_evals.run_prompt.litellm_response import RunPrompt
+from model_hub.views.utils.utils import normalize_var_name
 
 # Regex pattern to match {{variable}} placeholders (with optional whitespace)
 _PLACEHOLDER_PATTERN = re.compile(r"\{\{\s*(?P<placeholder>.*?)\s*\}\}")
@@ -229,7 +230,8 @@ class LLMPromptRunner(BaseNodeRunner):
                     except (ValueError, TypeError):
                         pass
                 # Nest dot-notation keys: "Node1.response" -> context["Node1"]["response"]
-                parts = key.split(".")
+                # Normalize each part to be a valid Jinja2 identifier (spaces -> underscores)
+                parts = [normalize_var_name(p) for p in key.split(".")]
                 target = context
                 for part in parts[:-1]:
                     target = target.setdefault(part, {})

--- a/futureagi/model_hub/serializers/annotation_queues.py
+++ b/futureagi/model_hub/serializers/annotation_queues.py
@@ -3,6 +3,7 @@ import uuid
 
 from django.db import transaction
 from django.db.models import Q
+from drf_yasg.utils import swagger_serializer_method
 from rest_framework import serializers
 from rest_framework.fields import empty
 
@@ -33,7 +34,19 @@ from model_hub.utils.annotation_queue_helpers import (
     resolve_source_object,
     resolve_source_preview,
 )
+from tfc.utils.serializer_fields import JsonValueField
 from tracer.serializers.filters import StrictInputSerializer, filter_list_field
+
+_ROLE_LIST_SCHEMA = serializers.ListField(child=serializers.CharField())
+_COUNT_SCHEMA = serializers.IntegerField()
+
+
+class QueueItemAssignedUserSerializer(serializers.Serializer):
+    """One entry of ``QueueItemSerializer.assigned_users``."""
+
+    id = serializers.UUIDField()
+    name = serializers.CharField(allow_null=True)
+    email = serializers.EmailField(allow_null=True)
 
 
 class QueueLabelNestedSerializer(serializers.ModelSerializer):
@@ -60,6 +73,7 @@ class QueueAnnotatorNestedSerializer(serializers.ModelSerializer):
         fields = ["id", "user_id", "name", "email", "role", "roles"]
         read_only_fields = ["id"]
 
+    @swagger_serializer_method(serializer_or_field=_ROLE_LIST_SCHEMA)
     def get_roles(self, obj):
         return obj.normalized_roles
 
@@ -98,7 +112,7 @@ class AnnotationQueueSerializer(serializers.ModelSerializer):
     item_count = serializers.IntegerField(read_only=True, required=False)
     completed_count = serializers.IntegerField(read_only=True, required=False)
     created_by_name = serializers.CharField(
-        source="created_by.name", read_only=True, default=None
+        source="created_by.name", read_only=True, default=None, allow_null=True
     )
     viewer_roles = serializers.SerializerMethodField()
     viewer_role = serializers.SerializerMethodField()
@@ -307,6 +321,7 @@ class AnnotationQueueSerializer(serializers.ModelSerializer):
             .first()
         )
 
+    @swagger_serializer_method(serializer_or_field=_ROLE_LIST_SCHEMA)
     def get_viewer_roles(self, obj):
         request = self.context.get("request")
         user = getattr(request, "user", None)
@@ -318,6 +333,9 @@ class AnnotationQueueSerializer(serializers.ModelSerializer):
             membership=self._viewer_membership(obj, user),
         )
 
+    @swagger_serializer_method(
+        serializer_or_field=serializers.CharField(allow_null=True)
+    )
     def get_viewer_role(self, obj):
         roles = self.get_viewer_roles(obj)
         return primary_annotator_role(roles) if roles else None
@@ -463,14 +481,14 @@ class QueueItemSerializer(serializers.ModelSerializer):
     workflow_status = serializers.SerializerMethodField()
     workflow_status_label = serializers.SerializerMethodField()
     assigned_to_name = serializers.CharField(
-        source="assigned_to.name", read_only=True, default=None
+        source="assigned_to.name", read_only=True, default=None, allow_null=True
     )
     assigned_users = serializers.SerializerMethodField()
     reserved_by_name = serializers.CharField(
-        source="reserved_by.name", read_only=True, default=None
+        source="reserved_by.name", read_only=True, default=None, allow_null=True
     )
     reviewed_by_name = serializers.CharField(
-        source="reviewed_by.name", read_only=True, default=None
+        source="reviewed_by.name", read_only=True, default=None, allow_null=True
     )
     comment_count = serializers.SerializerMethodField()
     open_feedback_count = serializers.SerializerMethodField()
@@ -507,6 +525,9 @@ class QueueItemSerializer(serializers.ModelSerializer):
         read_only_fields = ["queue"]
         list_serializer_class = QueueItemListSerializer
 
+    @swagger_serializer_method(
+        serializer_or_field=QueueItemAssignedUserSerializer(many=True)
+    )
     def get_assigned_users(self, obj):
         assignments = getattr(obj, "active_assignments", None)
         if assignments is None:
@@ -520,6 +541,10 @@ class QueueItemSerializer(serializers.ModelSerializer):
             for a in assignments
         ]
 
+    # Open-shaped by design: the keys differ per source_type (a dataset_row
+    # preview carries dataset_id/row_order, a span preview carries span_name
+    # etc.), so there is no one object shape to declare.
+    @swagger_serializer_method(serializer_or_field=JsonValueField())
     def get_source_preview(self, obj):
         # Captured at add time for CH-backed sources, so rendering a page costs no
         # ``spans FINAL`` merge (TH-7211). NULL means "not captured" — a row added
@@ -558,6 +583,7 @@ class QueueItemSerializer(serializers.ModelSerializer):
             "skipped": "Skipped",
         }.get(status, status)
 
+    @swagger_serializer_method(serializer_or_field=_COUNT_SCHEMA)
     def get_comment_count(self, obj):
         # Annotated by QueueItemViewSet.get_queryset; the query is the fallback
         # for callers that serialize an item they fetched themselves.
@@ -570,6 +596,7 @@ class QueueItemSerializer(serializers.ModelSerializer):
             deleted=False,
         ).count()
 
+    @swagger_serializer_method(serializer_or_field=_COUNT_SCHEMA)
     def get_open_feedback_count(self, obj):
         annotated = getattr(obj, "annotated_open_feedback_count", None)
         if annotated is not None:

--- a/futureagi/model_hub/tests/test_annotation_labels_api.py
+++ b/futureagi/model_hub/tests/test_annotation_labels_api.py
@@ -13,6 +13,14 @@ import uuid
 import pytest
 from rest_framework import status
 
+from accounts.models.organization_membership import OrganizationMembership
+from accounts.models.user import User
+from accounts.models.workspace import WorkspaceMembership
+from conftest import WorkspaceAwareAPIClient
+from model_hub.models.develop_annotations import AnnotationsLabels
+from tfc.constants.levels import Level
+from tfc.constants.roles import OrganizationRoles
+
 BASE_URL = "/model-hub/annotations-labels/"
 
 
@@ -446,6 +454,128 @@ class TestArchiveAndRestore:
         # Don't archive — try to restore directly
         resp = auth_client.post(restore_url(label_id))
         assert resp.status_code == status.HTTP_404_NOT_FOUND
+
+
+@pytest.fixture
+def membership_only_user(db, organization, workspace):
+    """A member whose org access comes only from ``OrganizationMembership``.
+
+    ``User.organization`` is the legacy nullable FK. Members provisioned through
+    RBAC never get it populated — they reach their organization through an
+    active membership row instead.
+    """
+    user = User.objects.create_user(
+        email=f"membership-only-{uuid.uuid4().hex[:8]}@futureagi.com",
+        password="testpassword123",
+        name="Membership Only User",
+        organization=None,
+        organization_role=None,
+    )
+    org_membership = OrganizationMembership.no_workspace_objects.create(
+        user=user,
+        organization=organization,
+        role=OrganizationRoles.MEMBER,
+        level=Level.MEMBER,
+        is_active=True,
+    )
+    WorkspaceMembership.no_workspace_objects.create(
+        user=user,
+        workspace=workspace,
+        role=OrganizationRoles.WORKSPACE_MEMBER,
+        level=Level.WORKSPACE_MEMBER,
+        is_active=True,
+        organization_membership=org_membership,
+    )
+    # ``assign_workspace_organization_post_save`` backfills a blank organization
+    # from the thread-local context, which the ``user`` fixture sets. Null the FK
+    # through the queryset so no signal fires — this user must reach its org
+    # through the membership alone.
+    User.objects.filter(pk=user.pk).update(organization=None)
+    user.refresh_from_db()
+    return user
+
+
+@pytest.fixture
+def membership_only_client(membership_only_user, workspace):
+    """Workspace-scoped client, so ``request.organization`` is populated."""
+    client = WorkspaceAwareAPIClient()
+    client.force_authenticate(user=membership_only_user)
+    client.set_workspace(workspace)
+    yield client
+    client.stop_workspace_injection()
+
+
+@pytest.fixture
+def membership_only_client_without_workspace(membership_only_user):
+    """No workspace header, so the view must fall back to active membership."""
+    client = WorkspaceAwareAPIClient()
+    client.force_authenticate(user=membership_only_user)
+    yield client
+    client.stop_workspace_injection()
+
+
+@pytest.mark.django_db
+class TestRestoreOrganizationScoping:
+    """Restore must scope by the resolved org, not ``user.organization``.
+
+    ``restore`` used to filter on ``request.user.organization``. That FK is NULL
+    for membership-only users, so the lookup became ``organization_id IS NULL``;
+    ``AnnotationsLabels.organization`` is non-nullable, so every restore 404'd
+    even though the label was listable. The rest of this module passes either
+    way because its fixtures set the legacy FK — these two do not.
+    """
+
+    @staticmethod
+    def _create_and_archive(client, name):
+        create_resp = create_label(client, name=name)
+        assert create_resp.status_code == status.HTTP_200_OK, create_resp.data
+        label_id = create_resp.data["result"]["id"]
+
+        delete_resp = client.delete(detail_url(label_id))
+        assert delete_resp.status_code in (
+            status.HTTP_200_OK,
+            status.HTTP_204_NO_CONTENT,
+        ), delete_resp.data
+        return label_id
+
+    def test_restore_for_member_without_legacy_user_organization(
+        self, membership_only_client, membership_only_user
+    ):
+        """Org comes from the request, not the null ``user.organization`` FK."""
+        # Canary: if a fixture ever backfills the FK this stops covering the
+        # regression, so fail loudly rather than pass vacuously.
+        assert membership_only_user.organization_id is None
+
+        name = "Membership Only Restorable"
+        label_id = self._create_and_archive(membership_only_client, name)
+
+        resp = membership_only_client.post(restore_url(label_id))
+
+        assert resp.status_code == status.HTTP_200_OK, resp.data
+        assert resp.data["status"] is True
+        assert resp.data["result"]["archived"] is False
+
+        list_resp = membership_only_client.get(BASE_URL, {"search": name})
+        assert [str(row["id"]) for row in list_resp.data["results"]] == [str(label_id)]
+
+    def test_restore_falls_back_to_active_membership(
+        self, membership_only_client_without_workspace, membership_only_user
+    ):
+        """No workspace header: the org resolves from the active membership."""
+        assert membership_only_user.organization_id is None
+
+        client = membership_only_client_without_workspace
+        label_id = self._create_and_archive(client, "Membership Fallback Restorable")
+
+        resp = client.post(restore_url(label_id))
+
+        assert resp.status_code == status.HTTP_200_OK, resp.data
+        assert resp.data["status"] is True
+        assert resp.data["result"]["archived"] is False
+
+        restored = AnnotationsLabels.all_objects.get(pk=label_id)
+        assert restored.deleted is False
+        assert restored.deleted_at is None
 
 
 # ---------------------------------------------------------------------------

--- a/futureagi/model_hub/tests/test_voice_annotation_regressions_e2e.py
+++ b/futureagi/model_hub/tests/test_voice_annotation_regressions_e2e.py
@@ -868,14 +868,13 @@ class TestVoiceAnnotationRegressionE2E:
     ):
         """voice_call_detail must surface the simulation path context.
 
-        The ``OPTIMIZE TABLE spans FINAL`` below works around a production bug:
-        ``voice_call_detail``'s root-span query has no ``FINAL`` and no
-        ``argMax(_, _version)`` dedup, so it can return a stale
-        ReplacingMergeTree row and drop ``call_execution_id``. Delete the
-        OPTIMIZE once the query is fixed.
+        The fixture seeds this span without eval_attributes and the re-seed
+        below adds them, so two ReplacingMergeTree rows share the id. The
+        endpoint's root-span query reads with ``FINAL``, so the later,
+        eval-bearing row must win without any table maintenance here — this
+        doubles as the regression test for that dedup.
         """
         from tracer.tests._ch_seed import (
-            _get_ch_client,
             seed_ch_span,
             seed_ch_trace,
         )
@@ -918,14 +917,6 @@ class TestVoiceAnnotationRegressionE2E:
         # (PG tracer_trace is dropped on CH25), so the trace row must be seeded too;
         # seeding only the span leaves the traces lookup empty (404).
         seed_ch_trace(observe_trace)
-        # The fixture seeded this span without eval_attributes and the re-seed
-        # above added them, so two ReplacingMergeTree rows share the id. Merge
-        # them so the later, eval-bearing row wins deterministically.
-        _ch = _get_ch_client()
-        try:
-            _ch.command("OPTIMIZE TABLE spans FINAL")
-        finally:
-            _ch.close()
 
         resp = auth_client.get(
             "/tracer/trace/voice_call_detail/",

--- a/futureagi/model_hub/views/develop_annotations.py
+++ b/futureagi/model_hub/views/develop_annotations.py
@@ -440,7 +440,7 @@ class AnnotationsLabelsViewSet(BaseModelViewSetMixinWithUserOrg, viewsets.ModelV
             label = AnnotationsLabels.all_objects.get(
                 pk=pk,
                 deleted=True,
-                organization=request.user.organization,
+                organization=get_request_organization(request),
             )
         except AnnotationsLabels.DoesNotExist:
             return self._gm.not_found("Label not found or not archived.")

--- a/futureagi/model_hub/views/run_prompt.py
+++ b/futureagi/model_hub/views/run_prompt.py
@@ -451,28 +451,66 @@ def render_template(
         template_format = DEFAULT_TEMPLATE_FORMAT
 
     if template_format == TEMPLATE_FORMAT_FSTRING:
-        return template_str.format(**context)
-
-    elif template_format == TEMPLATE_FORMAT_MUSTACHE:
-        return chevron.render(template_str, context)
-
-    elif template_format == TEMPLATE_FORMAT_JINJA2:
-        # Pre-process: handle variable names with spaces (Jinja2 doesn't allow them)
+        # Normalize variable names in template to match normalized context keys
+        # Python's str.format() requires valid identifiers (no spaces)
+        from model_hub.views.utils.utils import normalize_var_name
         import re
 
-        processed = template_str
-        safe_ctx = dict(context)
-        raw_vars = re.findall(r"\{\{\s*([^{}]+?)\s*\}\}", processed)
-        for var_name in raw_vars:
-            stripped = var_name.strip()
-            if " " in stripped and stripped in safe_ctx:
-                processed = processed.replace(
-                    "{{" + var_name + "}}", str(safe_ctx.pop(stripped))
-                )
-                processed = processed.replace(
-                    "{{ " + stripped + " }}", str(context.get(stripped, ""))
-                )
-        return _jinja2_env.from_string(processed).render(**safe_ctx)
+        def normalize_placeholder(match):
+            var_name = match.group(1).strip()
+            parts = var_name.split(".")
+            normalized_parts = [normalize_var_name(p) for p in parts]
+            return "{" + ".".join(normalized_parts) + "}"
+
+        processed = re.sub(
+            r"\{\{\s*([^{}]+?)\s*\}\}",
+            normalize_placeholder,
+            template_str
+        )
+        # Also convert {{var}} to {var} for f-string format
+        processed = processed.replace("{{", "{").replace("}}", "}")
+        return processed.format(**context)
+
+    elif template_format == TEMPLATE_FORMAT_MUSTACHE:
+        # Normalize variable names in template to match normalized context keys
+        # Mustache/chevron allows spaces in keys but we normalize for consistency
+        # with Jinja2 and to handle nested paths with spaces
+        from model_hub.views.utils.utils import normalize_var_name
+        import re
+
+        def normalize_placeholder(match):
+            var_name = match.group(1).strip()
+            parts = var_name.split(".")
+            normalized_parts = [normalize_var_name(p) for p in parts]
+            return "{{" + ".".join(normalized_parts) + "}}"
+
+        processed = re.sub(
+            r"\{\{\s*([^{}]+?)\s*\}\}",
+            normalize_placeholder,
+            template_str
+        )
+        return chevron.render(processed, context)
+
+    elif template_format == TEMPLATE_FORMAT_JINJA2:
+        # Normalize variable names in template to match normalized context keys
+        # This handles spaces and other invalid chars in variable names
+        # e.g., {{Input Column}} -> {{Input_Column}}, {{Input Column.subfield}} -> {{Input_Column.subfield}}
+        from model_hub.views.utils.utils import normalize_var_name
+        import re
+
+        def normalize_placeholder(match):
+            var_name = match.group(1).strip()
+            # Split by dot to handle nested paths, normalize each part
+            parts = var_name.split(".")
+            normalized_parts = [normalize_var_name(p) for p in parts]
+            return "{{" + ".".join(normalized_parts) + "}}"
+
+        processed = re.sub(
+            r"\{\{\s*([^{}]+?)\s*\}\}",
+            normalize_placeholder,
+            template_str
+        )
+        return _jinja2_env.from_string(processed).render(**context)
 
     else:
         raise ValueError(
@@ -534,7 +572,9 @@ def populate_placeholders(
                     }
 
                     # Build nested structure based on column name (e.g., account.name)
-                    parts = column.name.split(".")
+                    # Normalize each part to be a valid Jinja2 identifier (spaces -> underscores)
+                    from model_hub.views.utils.utils import normalize_var_name
+                    parts = [normalize_var_name(p) for p in column.name.split(".")]
                     current = context
 
                     # Determine the value to store - parse JSON for dot notation access.

--- a/futureagi/model_hub/views/utils/utils.py
+++ b/futureagi/model_hub/views/utils/utils.py
@@ -50,6 +50,33 @@ def sanitize_uuid_for_jinja(uuid_str: str) -> str:
     return sanitized
 
 
+def normalize_var_name(var_name: str) -> str:
+    """
+    Normalize a variable name to be a valid Jinja2/Python identifier.
+
+    Replaces spaces with underscores and handles other invalid characters.
+    This allows placeholders like {{Input Column}} to work by mapping them
+    to context keys like "Input_Column".
+
+    Args:
+        var_name: Variable name that may contain spaces or other invalid chars
+
+    Returns:
+        Normalized variable name safe for Jinja2 (e.g., "Input Column" -> "Input_Column")
+    """
+    if not var_name:
+        return var_name
+    # Replace spaces with underscores
+    normalized = var_name.replace(" ", "_")
+    # Replace other invalid characters (non-alphanumeric, non-underscore)
+    # but preserve dots for nested access
+    normalized = re.sub(r"[^\w.]", "_", normalized)
+    # Python/Jinja2 identifiers cannot start with digits
+    if normalized and normalized[0].isdigit():
+        normalized = "_" + normalized
+    return normalized
+
+
 def sanitize_uuids_in_template(text: str) -> str:
     """
     Replace UUID placeholders in template text with sanitized versions.

--- a/futureagi/tracer/management/commands/backfill_eval_score.py
+++ b/futureagi/tracer/management/commands/backfill_eval_score.py
@@ -1,49 +1,12 @@
-"""
-Backfill the ``usage_apicalllog.eval_score`` materialized column.
+"""Re-materialize ``usage_apicalllog.eval_score`` on rows already on disk.
 
-``eval_score`` is MATERIALIZED, so its value is computed once at INSERT and
-stored in the part. Changing the expression (schema.py's ``CH_EVAL_SCORE_EXPR``)
-therefore only affects rows written after the change — every row already on
-disk keeps whatever the old expression produced. ``ALTER TABLE ... MODIFY
-COLUMN`` in ``POST_DDL_ALTERS`` updates the metadata but does NOT rewrite
-existing parts; only ``MATERIALIZE COLUMN`` does, and that is a mutation, so it
-must not run on every app boot.
+Sequence: DROP INDEX, MODIFY, ADD INDEX, MATERIALIZE COLUMN, MATERIALIZE INDEX.
 
-Hence this command: run it once per environment after deploying the structured-
-eval-output fix, and the already-ingested rows start reporting their real score
-instead of 0.
-
-The ``idx_eval_score`` minmax skip index has to be rebuilt in the same pass.
-Re-materializing the column leaves the index holding the OLD min/max, and
-``MATERIALIZE INDEX`` on its own does not repair it — verified against
-ClickHouse 25.3, where a row backfilled to 1.0 stayed invisible to
-``WHERE eval_score >= 1.0`` until the index was dropped and re-added. A stale
-skip index prunes whole granules, so eval_score filters and breakdowns come
-back empty rather than wrong-looking, which is why the sequence below is
-DROP INDEX -> MODIFY -> ADD INDEX -> MATERIALIZE COLUMN -> MATERIALIZE INDEX.
-
-Usage on prod:
-
-    # 1. See how many rows are actually wrong before touching anything:
-    python manage.py backfill_eval_score --dry-run
-
-    # 2. Run it. Chunked by partition (toYYYYMM(created_at)) so each mutation
-    #    rewrites one month of parts at a time instead of the whole table:
-    python manage.py backfill_eval_score --no-confirm
-
-    # 3. Re-run the dry-run to confirm the affected count is now 0.
-
-Notes:
-  * Idempotent — a second run finds nothing to fix and exits without
-    submitting a mutation.
-  * ``--force`` rebuilds and re-materializes even when no row disagrees with
-    the expression. The stored values and the ``idx_eval_score`` skip index go
-    stale independently, and a current column with a stale index reports
-    "already up to date" while filters keep pruning real rows away.
-  * Refuses to start when an eval_score MATERIALIZE mutation is already
-    in flight, so overlapping deploys cannot stack mutations on one table.
-  * Only rewrites the eval_score column and its index; no other column is
-    touched and no row is deleted.
+* ``MODIFY COLUMN`` is metadata-only and does not rewrite stored parts.
+* ``MATERIALIZE COLUMN`` does, but it is a mutation, so it cannot run on boot.
+* ``idx_eval_score`` keeps its pre-backfill bounds unless dropped and re-added
+  (``MATERIALIZE INDEX`` alone does not repair it), and a stale skip index
+  prunes granules, so eval_score filters return nothing at all.
 """
 
 from __future__ import annotations
@@ -55,8 +18,7 @@ COLUMN = "eval_score"
 INDEX = "idx_eval_score"
 INDEX_DEF = f"{INDEX} {COLUMN} TYPE minmax GRANULARITY 1"
 
-# Rows whose stored eval_score disagrees with what the current expression
-# would produce. Structured outputs stored under the old expression are 0.
+# Structured-output rows whose stored eval_score disagrees with the expression.
 _AFFECTED_COUNT = """
 SELECT count()
 FROM {table}
@@ -73,8 +35,8 @@ WHERE table = '{table}' AND database = currentDatabase() AND active
 ORDER BY partition DESC
 """
 
-# position() rather than LIKE '%…%': the driver runs printf-style substitution
-# over every query, so a literal % here is read as a format spec and raises.
+# position() rather than LIKE: the driver runs printf substitution over every
+# query, so a literal % here is read as a format spec and raises.
 _IN_FLIGHT = """
 SELECT count()
 FROM system.mutations
@@ -83,12 +45,7 @@ WHERE table = '{table}' AND NOT is_done AND position(command, '{column}') > 0
 
 
 def rebuild_statements(table: str = TABLE) -> list[str]:
-    """The DDL that carries a new eval_score expression onto an existing table.
-
-    The index is dropped around the MODIFY and re-added after it; leaving it in
-    place keeps it pruning granules on the pre-backfill min/max, and
-    MATERIALIZE INDEX alone does not repair that.
-    """
+    """DDL carrying a new eval_score expression onto an existing table."""
     from tracer.services.clickhouse.schema import CH_EVAL_SCORE_EXPR
 
     return [
@@ -129,7 +86,11 @@ class Command(BaseCommand):
         parser.add_argument(
             "--force",
             action="store_true",
-            help="Rebuild even when no row is stale, to repair a stale skip index.",
+            help=(
+                "Rebuild and re-materialize unconditionally. The stale count "
+                "only looks at structured outputs, so use this to repair a "
+                "stale skip index or drift on any other output shape."
+            ),
         )
 
     def handle(self, *args, **opts):
@@ -154,7 +115,12 @@ class Command(BaseCommand):
         self.stdout.write(f"rows with a stale {COLUMN}: {affected}")
 
         if affected == 0 and not opts["force"]:
-            self.stdout.write(self.style.SUCCESS(f"✓ {COLUMN} is already up to date — nothing to do."))
+            self.stdout.write(
+                self.style.SUCCESS(
+                    f"{COLUMN} is already up to date, nothing to do. "
+                    "Re-run with --force to rebuild anyway."
+                )
+            )
             return
 
         if opts["dry_run"]:
@@ -164,8 +130,8 @@ class Command(BaseCommand):
         in_flight = self._scalar(ch, _IN_FLIGHT.format(table=TABLE, column=COLUMN))
         if in_flight:
             raise CommandError(
-                f"{in_flight} {COLUMN} mutation(s) already running on {TABLE} — "
-                "wait for them to finish (see system.mutations) before re-running."
+                f"{in_flight} {COLUMN} mutation(s) already running on {TABLE}. "
+                "Wait for them to finish (see system.mutations) before re-running."
             )
 
         if not opts["no_confirm"]:
@@ -192,7 +158,7 @@ class Command(BaseCommand):
 
         self.stdout.write(
             self.style.SUCCESS(
-                "✓ mutation(s) submitted. They run asynchronously — poll "
+                "mutation(s) submitted. They run asynchronously, so poll "
                 f"system.mutations for table='{TABLE}', then re-run with "
                 "--dry-run to confirm the affected count is 0."
             )

--- a/futureagi/tracer/management/commands/backfill_eval_score.py
+++ b/futureagi/tracer/management/commands/backfill_eval_score.py
@@ -1,0 +1,207 @@
+"""
+Backfill the ``usage_apicalllog.eval_score`` materialized column.
+
+``eval_score`` is MATERIALIZED, so its value is computed once at INSERT and
+stored in the part. Changing the expression (schema.py's ``CH_EVAL_SCORE_EXPR``)
+therefore only affects rows written after the change — every row already on
+disk keeps whatever the old expression produced. ``ALTER TABLE ... MODIFY
+COLUMN`` in ``POST_DDL_ALTERS`` updates the metadata but does NOT rewrite
+existing parts; only ``MATERIALIZE COLUMN`` does, and that is a mutation, so it
+must not run on every app boot.
+
+Hence this command: run it once per environment after deploying the structured-
+eval-output fix, and the already-ingested rows start reporting their real score
+instead of 0.
+
+The ``idx_eval_score`` minmax skip index has to be rebuilt in the same pass.
+Re-materializing the column leaves the index holding the OLD min/max, and
+``MATERIALIZE INDEX`` on its own does not repair it — verified against
+ClickHouse 25.3, where a row backfilled to 1.0 stayed invisible to
+``WHERE eval_score >= 1.0`` until the index was dropped and re-added. A stale
+skip index prunes whole granules, so eval_score filters and breakdowns come
+back empty rather than wrong-looking, which is why the sequence below is
+DROP INDEX -> MODIFY -> ADD INDEX -> MATERIALIZE COLUMN -> MATERIALIZE INDEX.
+
+Usage on prod:
+
+    # 1. See how many rows are actually wrong before touching anything:
+    python manage.py backfill_eval_score --dry-run
+
+    # 2. Run it. Chunked by partition (toYYYYMM(created_at)) so each mutation
+    #    rewrites one month of parts at a time instead of the whole table:
+    python manage.py backfill_eval_score --no-confirm
+
+    # 3. Re-run the dry-run to confirm the affected count is now 0.
+
+Notes:
+  * Idempotent — a second run finds nothing to fix and exits without
+    submitting a mutation.
+  * ``--force`` rebuilds and re-materializes even when no row disagrees with
+    the expression. The stored values and the ``idx_eval_score`` skip index go
+    stale independently, and a current column with a stale index reports
+    "already up to date" while filters keep pruning real rows away.
+  * Refuses to start when an eval_score MATERIALIZE mutation is already
+    in flight, so overlapping deploys cannot stack mutations on one table.
+  * Only rewrites the eval_score column and its index; no other column is
+    touched and no row is deleted.
+"""
+
+from __future__ import annotations
+
+from django.core.management.base import BaseCommand, CommandError
+
+TABLE = "usage_apicalllog"
+COLUMN = "eval_score"
+INDEX = "idx_eval_score"
+INDEX_DEF = f"{INDEX} {COLUMN} TYPE minmax GRANULARITY 1"
+
+# Rows whose stored eval_score disagrees with what the current expression
+# would produce. Structured outputs stored under the old expression are 0.
+_AFFECTED_COUNT = """
+SELECT count()
+FROM {table}
+WHERE _peerdb_is_deleted = 0
+  AND {predicate}
+  AND {column} != {expr}
+"""
+
+# system.parts spans every database on the server, so scope it to this one.
+_PARTITIONS = """
+SELECT DISTINCT partition
+FROM system.parts
+WHERE table = '{table}' AND database = currentDatabase() AND active
+ORDER BY partition DESC
+"""
+
+# position() rather than LIKE '%…%': the driver runs printf-style substitution
+# over every query, so a literal % here is read as a format spec and raises.
+_IN_FLIGHT = """
+SELECT count()
+FROM system.mutations
+WHERE table = '{table}' AND NOT is_done AND position(command, '{column}') > 0
+"""
+
+
+def rebuild_statements(table: str = TABLE) -> list[str]:
+    """The DDL that carries a new eval_score expression onto an existing table.
+
+    The index is dropped around the MODIFY and re-added after it; leaving it in
+    place keeps it pruning granules on the pre-backfill min/max, and
+    MATERIALIZE INDEX alone does not repair that.
+    """
+    from tracer.services.clickhouse.schema import CH_EVAL_SCORE_EXPR
+
+    return [
+        f"ALTER TABLE {table} DROP INDEX IF EXISTS {INDEX}",
+        f"ALTER TABLE {table} MODIFY COLUMN {COLUMN} Float64 MATERIALIZED {CH_EVAL_SCORE_EXPR}",
+        f"ALTER TABLE {table} ADD INDEX IF NOT EXISTS {INDEX_DEF}",
+    ]
+
+
+def materialize_statements(table: str = TABLE, partition: str | None = None) -> list[str]:
+    """Mutations that rewrite the stored column and rebuild its index."""
+    scope = f" IN PARTITION {partition}" if partition is not None else ""
+    return [
+        f"ALTER TABLE {table} MATERIALIZE COLUMN {COLUMN}{scope}",
+        f"ALTER TABLE {table} MATERIALIZE INDEX {INDEX}{scope}",
+    ]
+
+
+class Command(BaseCommand):
+    help = "Re-materialize usage_apicalllog.eval_score so existing rows pick up the current extraction."
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--dry-run",
+            action="store_true",
+            help="Report the affected row count without submitting a mutation.",
+        )
+        parser.add_argument(
+            "--no-confirm",
+            action="store_true",
+            help="Skip the interactive prompt (for CI/CD and deploy automation).",
+        )
+        parser.add_argument(
+            "--whole-table",
+            action="store_true",
+            help="Materialize the whole table in one mutation instead of per partition.",
+        )
+        parser.add_argument(
+            "--force",
+            action="store_true",
+            help="Rebuild even when no row is stale, to repair a stale skip index.",
+        )
+
+    def handle(self, *args, **opts):
+        from tracer.services.clickhouse.client import get_clickhouse_client
+        from tracer.services.clickhouse.eval_expressions import (
+            eval_has_structured_score,
+        )
+        from tracer.services.clickhouse.schema import (
+            CH_EVAL_SCORE_EXPR,
+            EVAL_OUTPUT_JSON_ARGS,
+        )
+
+        ch = get_clickhouse_client()
+
+        predicate = eval_has_structured_score(EVAL_OUTPUT_JSON_ARGS)
+        affected = self._scalar(
+            ch,
+            _AFFECTED_COUNT.format(
+                table=TABLE, column=COLUMN, expr=CH_EVAL_SCORE_EXPR, predicate=predicate
+            ),
+        )
+        self.stdout.write(f"rows with a stale {COLUMN}: {affected}")
+
+        if affected == 0 and not opts["force"]:
+            self.stdout.write(self.style.SUCCESS(f"✓ {COLUMN} is already up to date — nothing to do."))
+            return
+
+        if opts["dry_run"]:
+            self.stdout.write("--dry-run: no mutation submitted.")
+            return
+
+        in_flight = self._scalar(ch, _IN_FLIGHT.format(table=TABLE, column=COLUMN))
+        if in_flight:
+            raise CommandError(
+                f"{in_flight} {COLUMN} mutation(s) already running on {TABLE} — "
+                "wait for them to finish (see system.mutations) before re-running."
+            )
+
+        if not opts["no_confirm"]:
+            scope = f"{affected} rows" if affected else "every row (forced)"
+            answer = input(f"Re-materialize {COLUMN} for {scope}? [y/N] ")
+            if answer.strip().lower() not in ("y", "yes"):
+                self.stdout.write("aborted.")
+                return
+
+        for sql in rebuild_statements():
+            ch.execute(sql)
+            self.stdout.write(f"  {sql}")
+
+        if opts["whole_table"]:
+            targets = [None]
+        else:
+            targets = [row[0] for row in ch.execute(_PARTITIONS.format(table=TABLE))]
+            self.stdout.write(f"materializing across {len(targets)} partition(s)")
+
+        for target in targets:
+            for sql in materialize_statements(partition=target):
+                ch.execute(sql)
+                self.stdout.write(f"  submitted: {sql}")
+
+        self.stdout.write(
+            self.style.SUCCESS(
+                "✓ mutation(s) submitted. They run asynchronously — poll "
+                f"system.mutations for table='{TABLE}', then re-run with "
+                "--dry-run to confirm the affected count is 0."
+            )
+        )
+
+    @staticmethod
+    def _scalar(ch, sql) -> int:
+        rows = ch.execute(sql)
+        if not rows:
+            return 0
+        first = rows[0]
+        return int(first[0] if isinstance(first, (list, tuple)) else first)

--- a/futureagi/tracer/management/commands/backfill_eval_score.py
+++ b/futureagi/tracer/management/commands/backfill_eval_score.py
@@ -1,12 +1,6 @@
 """Re-materialize ``usage_apicalllog.eval_score`` on rows already on disk.
 
 Sequence: DROP INDEX, MODIFY, ADD INDEX, MATERIALIZE COLUMN, MATERIALIZE INDEX.
-
-* ``MODIFY COLUMN`` is metadata-only and does not rewrite stored parts.
-* ``MATERIALIZE COLUMN`` does, but it is a mutation, so it cannot run on boot.
-* ``idx_eval_score`` keeps its pre-backfill bounds unless dropped and re-added
-  (``MATERIALIZE INDEX`` alone does not repair it), and a stale skip index
-  prunes granules, so eval_score filters return nothing at all.
 """
 
 from __future__ import annotations

--- a/futureagi/tracer/services/clickhouse/eval_expressions.py
+++ b/futureagi/tracer/services/clickhouse/eval_expressions.py
@@ -1,15 +1,13 @@
-"""Shared eval-output SQL expressions.
-
-A leaf module: ``schema.py`` and the query builders both read these, and
-``query_builders/__init__`` imports all 15 builder modules, so putting them
-there would pull that whole tree into ``schema.py`` at import time.
-"""
+"""Shared eval-output SQL, kept leaf-level so ``schema.py`` can import it."""
 
 # Structured evals nest their number here: {"score": 0.5, "choice": "Partial"}.
 EVAL_STRUCTURED_SCORE_KEY = "score"
 
 EVAL_TRUTHY_OUTPUTS = ("passed", "pass", "true", "1")
 EVAL_FALSY_OUTPUTS = ("failed", "fail", "false", "0")
+
+# JSONType names for a real number. A null or a string score is not scorable.
+EVAL_NUMERIC_JSON_TYPES = ("Double", "Int64", "UInt64")
 
 # A bare number rendered as text, e.g. "0.8".
 EVAL_NUMERIC_OUTPUT_PATTERN = "^-?[0-9]+\\.?[0-9]*$"
@@ -21,9 +19,12 @@ def sql_str_set(values: tuple[str, ...]) -> str:
 
 
 def eval_has_structured_score(json_args: str) -> str:
-    """SQL predicate: does this row's eval output carry a nested score?
+    """SQL predicate: does this row's eval output nest a NUMERIC score?
 
-    ``json_args`` is spliced into ``JSONHas(...)``: a column holding the
-    serialized output, or a comma-joined argument fragment.
+    Typed, not ``JSONHas``: the extractor beside it scores null/string as 0.
+    ``json_args`` is a column, or a comma-joined JSON argument fragment.
     """
-    return f"JSONHas({json_args}, '{EVAL_STRUCTURED_SCORE_KEY}')"
+    return (
+        f"(JSONType({json_args}, '{EVAL_STRUCTURED_SCORE_KEY}') "
+        f"IN {sql_str_set(EVAL_NUMERIC_JSON_TYPES)})"
+    )

--- a/futureagi/tracer/services/clickhouse/eval_expressions.py
+++ b/futureagi/tracer/services/clickhouse/eval_expressions.py
@@ -1,0 +1,35 @@
+"""Shared eval-output SQL expressions.
+
+A leaf module on purpose: both ``schema.py`` (which renders the DDL) and the
+query builders read these, and ``query_builders/__init__`` eagerly imports
+every builder, so ``schema.py`` must not reach into that package.
+"""
+
+# Structured (choice-based) evals nest their number under this key —
+# {"score": 0.5, "choice": "Partial"} — while score evals emit a bare scalar.
+EVAL_STRUCTURED_SCORE_KEY = "score"
+
+# Eval outputs that are pass/fail strings rather than numbers.
+EVAL_TRUTHY_OUTPUTS = ("passed", "pass", "true", "1")
+EVAL_FALSY_OUTPUTS = ("failed", "fail", "false", "0")
+
+# A bare number rendered as text, e.g. "0.8" — the scalar-output eval shape.
+EVAL_NUMERIC_OUTPUT_PATTERN = "^-?[0-9]+\\.?[0-9]*$"
+
+
+def sql_str_set(values: tuple[str, ...]) -> str:
+    """Render a tuple of strings as a SQL ``IN`` list, e.g. ``('pass', '1')``."""
+    return "(" + ", ".join(f"'{v}'" for v in values) + ")"
+
+
+def eval_has_structured_score(json_args: str) -> str:
+    """SQL predicate: does this row's eval output carry a nested numeric score?
+
+    ``json_args`` is spliced straight into ``JSONHas(...)``, so it is
+    deliberately called two ways: with a bare column that already holds the
+    serialized output (``e.eval_output_str``), and with the comma-joined
+    argument fragment that digs the output out of ``config``
+    (``EVAL_OUTPUT_JSON_ARGS``). Callers that read ``eval_score`` need this to
+    tell a genuine 0.0 from "no number here".
+    """
+    return f"JSONHas({json_args}, '{EVAL_STRUCTURED_SCORE_KEY}')"

--- a/futureagi/tracer/services/clickhouse/eval_expressions.py
+++ b/futureagi/tracer/services/clickhouse/eval_expressions.py
@@ -1,19 +1,17 @@
 """Shared eval-output SQL expressions.
 
-A leaf module on purpose: both ``schema.py`` (which renders the DDL) and the
-query builders read these, and ``query_builders/__init__`` eagerly imports
-every builder, so ``schema.py`` must not reach into that package.
+A leaf module: ``schema.py`` and the query builders both read these, and
+``query_builders/__init__`` imports all 15 builder modules, so putting them
+there would pull that whole tree into ``schema.py`` at import time.
 """
 
-# Structured (choice-based) evals nest their number under this key —
-# {"score": 0.5, "choice": "Partial"} — while score evals emit a bare scalar.
+# Structured evals nest their number here: {"score": 0.5, "choice": "Partial"}.
 EVAL_STRUCTURED_SCORE_KEY = "score"
 
-# Eval outputs that are pass/fail strings rather than numbers.
 EVAL_TRUTHY_OUTPUTS = ("passed", "pass", "true", "1")
 EVAL_FALSY_OUTPUTS = ("failed", "fail", "false", "0")
 
-# A bare number rendered as text, e.g. "0.8" — the scalar-output eval shape.
+# A bare number rendered as text, e.g. "0.8".
 EVAL_NUMERIC_OUTPUT_PATTERN = "^-?[0-9]+\\.?[0-9]*$"
 
 
@@ -23,13 +21,9 @@ def sql_str_set(values: tuple[str, ...]) -> str:
 
 
 def eval_has_structured_score(json_args: str) -> str:
-    """SQL predicate: does this row's eval output carry a nested numeric score?
+    """SQL predicate: does this row's eval output carry a nested score?
 
-    ``json_args`` is spliced straight into ``JSONHas(...)``, so it is
-    deliberately called two ways: with a bare column that already holds the
-    serialized output (``e.eval_output_str``), and with the comma-joined
-    argument fragment that digs the output out of ``config``
-    (``EVAL_OUTPUT_JSON_ARGS``). Callers that read ``eval_score`` need this to
-    tell a genuine 0.0 from "no number here".
+    ``json_args`` is spliced into ``JSONHas(...)``: a column holding the
+    serialized output, or a comma-joined argument fragment.
     """
     return f"JSONHas({json_args}, '{EVAL_STRUCTURED_SCORE_KEY}')"

--- a/futureagi/tracer/services/clickhouse/query_builders/dashboard.py
+++ b/futureagi/tracer/services/clickhouse/query_builders/dashboard.py
@@ -210,6 +210,22 @@ def _eval_source_bucket_expr(exclude: str) -> str:
     return "".join(parts)
 
 
+def eval_pass_expr(score_col: str, output_str_col: str) -> str:
+    """SQL predicate: this eval row reads as a pass, by score or by output text."""
+    return (
+        f"({score_col} >= 1.0 OR lower({output_str_col}) IN "
+        f"{sql_str_set(EVAL_TRUTHY_OUTPUTS)})"
+    )
+
+
+def eval_fail_expr(score_col: str, output_str_col: str) -> str:
+    """SQL predicate: this eval row reads as a fail."""
+    return (
+        f"({score_col} < 1.0 AND lower({output_str_col}) NOT IN "
+        f"{sql_str_set(EVAL_TRUTHY_OUTPUTS)})"
+    )
+
+
 def rescale_rate_to_percent(agg_expr: str, aggregation: str) -> str:
     """Wrap *agg_expr* in ``(... ) * 100`` for averaging aggregations.
 
@@ -718,8 +734,8 @@ class DashboardQueryBuilder:
         _output_str_lower = "lower(e.eval_output_str)"
         _truthy = sql_str_set(EVAL_TRUTHY_OUTPUTS)
         _falsy = sql_str_set(EVAL_FALSY_OUTPUTS)
-        _is_pass = f"(e.eval_score >= 1.0 OR {_output_str_lower} IN {_truthy})"
-        _is_fail = f"(e.eval_score < 1.0 AND {_output_str_lower} NOT IN {_truthy})"
+        _is_pass = eval_pass_expr("e.eval_score", "e.eval_output_str")
+        _is_fail = eval_fail_expr("e.eval_score", "e.eval_output_str")
         _unified_score = f"if({_is_pass}, 1.0, e.eval_score)"
 
         _EVAL_AGGREGATIONS: dict[str, str] = {
@@ -1482,9 +1498,12 @@ class DashboardQueryBuilder:
 
                 # Use materialized columns for fast extraction
                 if output_type == "PASS_FAIL":
+                    _passed = eval_pass_expr(
+                        f"{alias}.eval_score", f"{alias}.eval_output_str"
+                    )
                     val_expr = (
                         f"if({alias}.id IS NULL, '(not set)', "
-                        f"if({alias}.eval_output_str = 'Passed', 'Pass', 'Fail'))"
+                        f"if({_passed}, 'Pass', 'Fail'))"
                     )
                 elif output_type in ("CHOICE", "CHOICES"):
                     val_expr = (
@@ -1695,7 +1714,8 @@ class DashboardQueryBuilder:
                 output_type = (f.get("output_type") or "SCORE").upper()
                 # config is double-encoded
                 if output_type == "PASS_FAIL":
-                    eval_col = "if(eval_output_str = 'Passed', 1.0, 0.0)"
+                    _passed = eval_pass_expr("eval_score", "eval_output_str")
+                    eval_col = f"if({_passed}, 1.0, 0.0)"
                 else:
                     eval_col = "eval_score"
 

--- a/futureagi/tracer/services/clickhouse/query_builders/dashboard.py
+++ b/futureagi/tracer/services/clickhouse/query_builders/dashboard.py
@@ -18,6 +18,13 @@ import re
 from datetime import UTC, date, datetime, timedelta
 from typing import Any
 
+from tracer.services.clickhouse.eval_expressions import (
+    EVAL_FALSY_OUTPUTS,
+    EVAL_NUMERIC_OUTPUT_PATTERN,
+    EVAL_TRUTHY_OUTPUTS,
+    eval_has_structured_score,
+    sql_str_set,
+)
 from tracer.services.clickhouse.query_builders.expressions import (
     annotation_numeric_value_expr,
 )
@@ -709,14 +716,10 @@ class DashboardQueryBuilder:
         params["workspace_id"] = self.workspace_id
 
         _output_str_lower = "lower(e.eval_output_str)"
-        _is_pass = (
-            f"(e.eval_score >= 1.0 OR {_output_str_lower} IN "
-            "('passed', 'pass', 'true', '1'))"
-        )
-        _is_fail = (
-            f"(e.eval_score < 1.0 AND {_output_str_lower} NOT IN "
-            "('passed', 'pass', 'true', '1'))"
-        )
+        _truthy = sql_str_set(EVAL_TRUTHY_OUTPUTS)
+        _falsy = sql_str_set(EVAL_FALSY_OUTPUTS)
+        _is_pass = f"(e.eval_score >= 1.0 OR {_output_str_lower} IN {_truthy})"
+        _is_fail = f"(e.eval_score < 1.0 AND {_output_str_lower} NOT IN {_truthy})"
         _unified_score = f"if({_is_pass}, 1.0, e.eval_score)"
 
         _EVAL_AGGREGATIONS: dict[str, str] = {
@@ -735,13 +738,17 @@ class DashboardQueryBuilder:
             if output_type == "PASS_FAIL":
                 col_expr = _unified_score
             else:
-                # Some templates with missing output_type still emit pass/fail strings.
+                # Some templates with missing output_type still emit pass/fail
+                # strings; structured evals emit {"score": …, "choice": …}.
+                _has_number = (
+                    f"match(e.eval_output_str, '{EVAL_NUMERIC_OUTPUT_PATTERN}') "
+                    f"OR {eval_has_structured_score('e.eval_output_str')}"
+                )
                 col_expr = (
                     "if(e.eval_output_str = '', NULL, "
-                    f"if({_output_str_lower} IN ('passed', 'pass', 'true', '1'), 1.0, "
-                    f"if({_output_str_lower} IN ('failed', 'fail', 'false', '0'), 0.0, "
-                    "if(match(e.eval_output_str, '^-?[0-9]+\\.?[0-9]*$'), "
-                    "e.eval_score, NULL))))"
+                    f"if({_output_str_lower} IN {_truthy}, 1.0, "
+                    f"if({_output_str_lower} IN {_falsy}, 0.0, "
+                    f"if({_has_number}, e.eval_score, NULL))))"
                 )
             agg_expr = AGGREGATIONS.get(aggregation, "avg({col})").format(col=col_expr)
 

--- a/futureagi/tracer/services/clickhouse/query_builders/dashboard.py
+++ b/futureagi/tracer/services/clickhouse/query_builders/dashboard.py
@@ -738,8 +738,8 @@ class DashboardQueryBuilder:
             if output_type == "PASS_FAIL":
                 col_expr = _unified_score
             else:
-                # Some templates with missing output_type still emit pass/fail
-                # strings; structured evals emit {"score": …, "choice": …}.
+                # Templates with no output_type still emit pass/fail strings,
+                # bare numbers, or a structured object carrying a score.
                 _has_number = (
                     f"match(e.eval_output_str, '{EVAL_NUMERIC_OUTPUT_PATTERN}') "
                     f"OR {eval_has_structured_score('e.eval_output_str')}"

--- a/futureagi/tracer/services/clickhouse/schema.py
+++ b/futureagi/tracer/services/clickhouse/schema.py
@@ -34,6 +34,11 @@ from __future__ import annotations
 import os
 import re
 
+from tracer.services.clickhouse.eval_expressions import (
+    EVAL_STRUCTURED_SCORE_KEY,
+    eval_has_structured_score,
+)
+
 # Resolve the configured CH database name for use in DDL templates.
 # Falls back to "futureagi" which is the production default.
 _CH_DATABASE = os.getenv("CH_DATABASE", "futureagi")
@@ -1726,6 +1731,17 @@ WHERE c._peerdb_is_deleted = 0;
 #   simulation, SDK, playground) writes here with source_id = eval_template_id.
 # ---------------------------------------------------------------------------
 
+# Comma-joined JSON arguments, not a path: spliced into JSONExtract*(...) calls.
+EVAL_OUTPUT_JSON_ARGS = "JSONExtractString(config), 'output', 'output'"
+
+CH_EVAL_SCORE_EXPR = (
+    f"if({eval_has_structured_score(EVAL_OUTPUT_JSON_ARGS)}, "
+    f"JSONExtractFloat({EVAL_OUTPUT_JSON_ARGS}, '{EVAL_STRUCTURED_SCORE_KEY}'), "
+    f"JSONExtractFloat({EVAL_OUTPUT_JSON_ARGS}))"
+)
+
+CH_EVAL_OUTPUT_STR_EXPR = f"JSONExtractString({EVAL_OUTPUT_JSON_ARGS})"
+
 CDC_USAGE_APICALLLOG = """
 CREATE TABLE IF NOT EXISTS usage_apicalllog (
     id Int64,
@@ -1749,8 +1765,9 @@ CREATE TABLE IF NOT EXISTS usage_apicalllog (
 
     -- Materialized columns: pre-extracted from config JSON at insert time.
     -- Config is double-encoded (JSONB string), so JSONExtractString unwraps first.
-    eval_score Float64 MATERIALIZED JSONExtractFloat(JSONExtractString(config), 'output', 'output'),
-    eval_output_str String MATERIALIZED JSONExtractString(JSONExtractString(config), 'output', 'output'),
+    -- The two placeholders below are substituted from the CH_EVAL_* constants.
+    eval_score Float64 MATERIALIZED __CH_EVAL_SCORE_EXPR__,
+    eval_output_str String MATERIALIZED __CH_EVAL_OUTPUT_STR_EXPR__,
     eval_trace_id String MATERIALIZED JSONExtractString(JSONExtractString(config), 'trace_id'),
     eval_dataset_id String MATERIALIZED JSONExtractString(JSONExtractString(config), 'dataset_id'),
 
@@ -1785,7 +1802,9 @@ ENGINE = ReplicatedReplacingMergeTree('/clickhouse/tables/{shard}/usage_apicalll
 PARTITION BY toYYYYMM(created_at)
 ORDER BY (organization_id, source_id, created_at, id)
 SETTINGS index_granularity = 8192;
-"""
+""".replace("__CH_EVAL_SCORE_EXPR__", CH_EVAL_SCORE_EXPR).replace(
+    "__CH_EVAL_OUTPUT_STR_EXPR__", CH_EVAL_OUTPUT_STR_EXPR
+)
 
 # ============================================================================
 # Ordered list of all DDL statements
@@ -1896,11 +1915,14 @@ SCHEMA_DDL_STATEMENTS: list[tuple[str, str]] = [
 # that PeerDB may recreate without them during RESYNC operations.
 POST_DDL_ALTERS: list[str] = [
     "ALTER TABLE usage_apicalllog ADD COLUMN IF NOT EXISTS "
-    "eval_score Float64 MATERIALIZED "
-    "JSONExtractFloat(JSONExtractString(config), 'output', 'output')",
+    f"eval_score Float64 MATERIALIZED {CH_EVAL_SCORE_EXPR}",
+    # ADD COLUMN IF NOT EXISTS no-ops once the column exists, so an already-
+    # deployed table keeps its old expression until MODIFYed. Metadata-only;
+    # existing rows are backfilled by the backfill_eval_score command.
+    "ALTER TABLE usage_apicalllog MODIFY COLUMN "
+    f"eval_score Float64 MATERIALIZED {CH_EVAL_SCORE_EXPR}",
     "ALTER TABLE usage_apicalllog ADD COLUMN IF NOT EXISTS "
-    "eval_output_str String MATERIALIZED "
-    "JSONExtractString(JSONExtractString(config), 'output', 'output')",
+    f"eval_output_str String MATERIALIZED {CH_EVAL_OUTPUT_STR_EXPR}",
     "ALTER TABLE usage_apicalllog ADD COLUMN IF NOT EXISTS "
     "eval_trace_id String MATERIALIZED "
     "JSONExtractString(JSONExtractString(config), 'trace_id')",

--- a/futureagi/tracer/services/clickhouse/schema.py
+++ b/futureagi/tracer/services/clickhouse/schema.py
@@ -1917,9 +1917,7 @@ POST_DDL_ALTERS: list[str] = [
     "ALTER TABLE usage_apicalllog ADD COLUMN IF NOT EXISTS "
     f"eval_score Float64 MATERIALIZED {CH_EVAL_SCORE_EXPR}",
     # ADD COLUMN IF NOT EXISTS no-ops once the column exists, so a deployed
-    # table keeps its old expression until MODIFYed. No DROP/ADD index
-    # sandwich here: Code 524 fires on a TYPE change, and the type is restated
-    # unchanged. Existing rows are backfilled by backfill_eval_score.
+    # table keeps its old expression until MODIFYed.
     "ALTER TABLE usage_apicalllog MODIFY COLUMN "
     f"eval_score Float64 MATERIALIZED {CH_EVAL_SCORE_EXPR}",
     # Restores idx_eval_score if a backfill run died between its DROP and ADD.

--- a/futureagi/tracer/services/clickhouse/schema.py
+++ b/futureagi/tracer/services/clickhouse/schema.py
@@ -1916,11 +1916,15 @@ SCHEMA_DDL_STATEMENTS: list[tuple[str, str]] = [
 POST_DDL_ALTERS: list[str] = [
     "ALTER TABLE usage_apicalllog ADD COLUMN IF NOT EXISTS "
     f"eval_score Float64 MATERIALIZED {CH_EVAL_SCORE_EXPR}",
-    # ADD COLUMN IF NOT EXISTS no-ops once the column exists, so an already-
-    # deployed table keeps its old expression until MODIFYed. Metadata-only;
-    # existing rows are backfilled by the backfill_eval_score command.
+    # ADD COLUMN IF NOT EXISTS no-ops once the column exists, so a deployed
+    # table keeps its old expression until MODIFYed. No DROP/ADD index
+    # sandwich here: Code 524 fires on a TYPE change, and the type is restated
+    # unchanged. Existing rows are backfilled by backfill_eval_score.
     "ALTER TABLE usage_apicalllog MODIFY COLUMN "
     f"eval_score Float64 MATERIALIZED {CH_EVAL_SCORE_EXPR}",
+    # Restores idx_eval_score if a backfill run died between its DROP and ADD.
+    "ALTER TABLE usage_apicalllog ADD INDEX IF NOT EXISTS "
+    "idx_eval_score eval_score TYPE minmax GRANULARITY 1",
     "ALTER TABLE usage_apicalllog ADD COLUMN IF NOT EXISTS "
     f"eval_output_str String MATERIALIZED {CH_EVAL_OUTPUT_STR_EXPR}",
     "ALTER TABLE usage_apicalllog ADD COLUMN IF NOT EXISTS "

--- a/futureagi/tracer/tests/test_clickhouse.py
+++ b/futureagi/tracer/tests/test_clickhouse.py
@@ -242,11 +242,7 @@ class TestClickHouseSchema:
         )
 
     def test_eval_score_expression_reads_structured_and_scalar_outputs(self):
-        """One expression covers ``{"score": …}`` objects and bare numbers.
-
-        Choice-based evals nest their number under ``score``; score evals emit
-        a bare scalar. Dropping either branch blanks one family of widgets.
-        """
+        """Dropping either branch blanks one family of eval widgets."""
         from tracer.services.clickhouse.schema import (
             CDC_USAGE_APICALLLOG,
             CH_EVAL_SCORE_EXPR,
@@ -255,10 +251,7 @@ class TestClickHouseSchema:
         assert (
             "JSONHas(JSONExtractString(config), 'output', 'output', 'score')"
             in CH_EVAL_SCORE_EXPR
-        ), (
-            "eval_score must branch on the nested score key; without it a "
-            "structured output extracts as 0."
-        )
+        ), "without the nested-score branch a structured output extracts as 0."
         assert (
             "JSONExtractFloat(JSONExtractString(config), 'output', 'output'))"
             in CH_EVAL_SCORE_EXPR
@@ -280,10 +273,7 @@ class TestClickHouseSchema:
         assert (
             "usage_apicalllog MODIFY COLUMN eval_score Float64 "
             f"MATERIALIZED {CH_EVAL_SCORE_EXPR}" in joined
-        ), (
-            "POST_DDL_ALTERS must MODIFY eval_score; ADD COLUMN IF NOT EXISTS "
-            "no-ops on a deployed table and leaves the old expression in place."
-        )
+        ), "ADD COLUMN IF NOT EXISTS no-ops on a deployed table; MODIFY does not."
         assert (
             "usage_apicalllog ADD COLUMN IF NOT EXISTS eval_score Float64 "
             f"MATERIALIZED {CH_EVAL_SCORE_EXPR}" in joined
@@ -292,11 +282,13 @@ class TestClickHouseSchema:
             "usage_apicalllog ADD COLUMN IF NOT EXISTS eval_output_str String "
             f"MATERIALIZED {CH_EVAL_OUTPUT_STR_EXPR}" in joined
         )
+        assert (
+            "usage_apicalllog ADD INDEX IF NOT EXISTS idx_eval_score "
+            "eval_score TYPE minmax GRANULARITY 1" in joined
+        ), "a backfill dying between its DROP and ADD otherwise loses the index."
 
     def test_backfill_queries_survive_driver_parameter_substitution(self):
-        """The driver runs ``query % params`` on everything it executes, so a
-        literal ``%`` in one of these templates raises before it reaches CH.
-        """
+        """A literal ``%`` in a template raises before it reaches CH."""
         from tracer.management.commands import backfill_eval_score as cmd
         from tracer.services.clickhouse.eval_expressions import (
             eval_has_structured_score,
@@ -325,9 +317,7 @@ class TestClickHouseSchema:
                 pytest.fail(f"{name} is not substitution-safe: {exc}")
 
     def test_backfill_partition_scan_is_scoped_to_this_database(self):
-        """system.parts spans every database; an unscoped scan would pick up
-        the same table name in test_futureagi and materialize the wrong parts.
-        """
+        """An unscoped system.parts scan materializes another database's parts."""
         from tracer.management.commands import backfill_eval_score as cmd
 
         assert "database = currentDatabase()" in cmd._PARTITIONS
@@ -365,9 +355,7 @@ class TestClickHouseSchema:
         assert not any("ALTER TABLE" in q for q in ch.executed)
 
     def test_backfill_force_rebuilds_when_no_row_is_stale(self):
-        """A current column can still carry a stale index, so --force has to
-        run the rebuild that the "nothing to do" early return would skip.
-        """
+        """--force runs the rebuild the "nothing to do" early return skips."""
         from io import StringIO
 
         from django.core.management import call_command

--- a/futureagi/tracer/tests/test_clickhouse.py
+++ b/futureagi/tracer/tests/test_clickhouse.py
@@ -58,6 +58,26 @@ class TestNonTerminalEvalMarker:
 # ============================================================================
 
 
+def _fake_backfill_client(affected=0, in_flight=0, partitions=("202601", "202602")):
+    """A CH client stub that answers backfill_eval_score's three read queries."""
+    client = mock.MagicMock()
+    client.executed = []
+
+    def execute(query, *args, **kwargs):
+        client.executed.append(query)
+        collapsed = " ".join(query.split())
+        if collapsed.startswith("SELECT count() FROM system.mutations"):
+            return [(in_flight,)]
+        if collapsed.startswith("SELECT count() FROM usage_apicalllog"):
+            return [(affected,)]
+        if collapsed.startswith("SELECT DISTINCT partition"):
+            return [(p,) for p in partitions]
+        return []
+
+    client.execute = execute
+    return client
+
+
 @pytest.mark.unit
 class TestClickHouseSchema:
     """Test schema DDL generation."""
@@ -220,6 +240,157 @@ class TestClickHouseSchema:
             "POST_DDL_ALTERS must order DROP INDEX → MODIFY COLUMN → ADD INDEX "
             "for idx_trace_id; ClickHouse refuses to alter an indexed column."
         )
+
+    def test_eval_score_expression_reads_structured_and_scalar_outputs(self):
+        """One expression covers ``{"score": …}`` objects and bare numbers.
+
+        Choice-based evals nest their number under ``score``; score evals emit
+        a bare scalar. Dropping either branch blanks one family of widgets.
+        """
+        from tracer.services.clickhouse.schema import (
+            CDC_USAGE_APICALLLOG,
+            CH_EVAL_SCORE_EXPR,
+        )
+
+        assert (
+            "JSONHas(JSONExtractString(config), 'output', 'output', 'score')"
+            in CH_EVAL_SCORE_EXPR
+        ), (
+            "eval_score must branch on the nested score key; without it a "
+            "structured output extracts as 0."
+        )
+        assert (
+            "JSONExtractFloat(JSONExtractString(config), 'output', 'output'))"
+            in CH_EVAL_SCORE_EXPR
+        ), "eval_score must keep the bare-scalar fallback for score evals."
+        assert (
+            f"eval_score Float64 MATERIALIZED {CH_EVAL_SCORE_EXPR}"
+            in CDC_USAGE_APICALLLOG
+        )
+
+    def test_post_ddl_alters_modifies_eval_score_on_existing_tables(self):
+        """ALTER statements bring an already-created usage_apicalllog forward."""
+        from tracer.services.clickhouse.schema import (
+            CH_EVAL_OUTPUT_STR_EXPR,
+            CH_EVAL_SCORE_EXPR,
+            POST_DDL_ALTERS,
+        )
+
+        joined = "\n".join(POST_DDL_ALTERS)
+        assert (
+            "usage_apicalllog MODIFY COLUMN eval_score Float64 "
+            f"MATERIALIZED {CH_EVAL_SCORE_EXPR}" in joined
+        ), (
+            "POST_DDL_ALTERS must MODIFY eval_score; ADD COLUMN IF NOT EXISTS "
+            "no-ops on a deployed table and leaves the old expression in place."
+        )
+        assert (
+            "usage_apicalllog ADD COLUMN IF NOT EXISTS eval_score Float64 "
+            f"MATERIALIZED {CH_EVAL_SCORE_EXPR}" in joined
+        )
+        assert (
+            "usage_apicalllog ADD COLUMN IF NOT EXISTS eval_output_str String "
+            f"MATERIALIZED {CH_EVAL_OUTPUT_STR_EXPR}" in joined
+        )
+
+    def test_backfill_queries_survive_driver_parameter_substitution(self):
+        """The driver runs ``query % params`` on everything it executes, so a
+        literal ``%`` in one of these templates raises before it reaches CH.
+        """
+        from tracer.management.commands import backfill_eval_score as cmd
+        from tracer.services.clickhouse.eval_expressions import (
+            eval_has_structured_score,
+        )
+        from tracer.services.clickhouse.schema import (
+            CH_EVAL_SCORE_EXPR,
+            EVAL_OUTPUT_JSON_ARGS,
+        )
+
+        templates = {
+            "_PARTITIONS": cmd._PARTITIONS.format(table=cmd.TABLE),
+            "_IN_FLIGHT": cmd._IN_FLIGHT.format(table=cmd.TABLE, column=cmd.COLUMN),
+            "_AFFECTED_COUNT": cmd._AFFECTED_COUNT.format(
+                table=cmd.TABLE,
+                column=cmd.COLUMN,
+                expr=CH_EVAL_SCORE_EXPR,
+                predicate=eval_has_structured_score(EVAL_OUTPUT_JSON_ARGS),
+            ),
+            # Travels through ch.execute() from rebuild_statements/POST_DDL_ALTERS.
+            "CH_EVAL_SCORE_EXPR": CH_EVAL_SCORE_EXPR,
+        }
+        for name, sql in templates.items():
+            try:
+                sql % {}
+            except (TypeError, ValueError) as exc:
+                pytest.fail(f"{name} is not substitution-safe: {exc}")
+
+    def test_backfill_partition_scan_is_scoped_to_this_database(self):
+        """system.parts spans every database; an unscoped scan would pick up
+        the same table name in test_futureagi and materialize the wrong parts.
+        """
+        from tracer.management.commands import backfill_eval_score as cmd
+
+        assert "database = currentDatabase()" in cmd._PARTITIONS
+
+    def test_backfill_dry_run_counts_without_mutating(self):
+        """--dry-run reports the stale rows and stops before any ALTER."""
+        from io import StringIO
+
+        from django.core.management import call_command
+
+        from tracer.services.clickhouse import client as ch_client
+
+        ch = _fake_backfill_client(affected=7)
+        out = StringIO()
+        with mock.patch.object(ch_client, "get_clickhouse_client", lambda: ch):
+            call_command("backfill_eval_score", "--dry-run", stdout=out)
+
+        assert "rows with a stale eval_score: 7" in out.getvalue()
+        assert "--dry-run: no mutation submitted." in out.getvalue()
+        assert not any("ALTER TABLE" in q for q in ch.executed)
+
+    def test_backfill_refuses_to_stack_on_an_in_flight_mutation(self):
+        """Overlapping deploys must not queue a second eval_score mutation."""
+        from io import StringIO
+
+        from django.core.management import CommandError, call_command
+
+        from tracer.services.clickhouse import client as ch_client
+
+        ch = _fake_backfill_client(affected=7, in_flight=1)
+        with mock.patch.object(ch_client, "get_clickhouse_client", lambda: ch):
+            with pytest.raises(CommandError, match="already running"):
+                call_command("backfill_eval_score", "--no-confirm", stdout=StringIO())
+
+        assert not any("ALTER TABLE" in q for q in ch.executed)
+
+    def test_backfill_force_rebuilds_when_no_row_is_stale(self):
+        """A current column can still carry a stale index, so --force has to
+        run the rebuild that the "nothing to do" early return would skip.
+        """
+        from io import StringIO
+
+        from django.core.management import call_command
+
+        from tracer.services.clickhouse import client as ch_client
+
+        ch = _fake_backfill_client(affected=0)
+        out = StringIO()
+        with mock.patch.object(ch_client, "get_clickhouse_client", lambda: ch):
+            call_command("backfill_eval_score", "--force", "--no-confirm", stdout=out)
+
+        altered = [q for q in ch.executed if q.startswith("ALTER TABLE")]
+        assert any("DROP INDEX IF EXISTS idx_eval_score" in q for q in altered)
+        assert any("ADD INDEX IF NOT EXISTS idx_eval_score" in q for q in altered)
+        # One MATERIALIZE COLUMN + one MATERIALIZE INDEX per partition.
+        assert sum("MATERIALIZE COLUMN" in q for q in altered) == 2
+        assert sum("MATERIALIZE INDEX" in q for q in altered) == 2
+        assert "materializing across 2 partition(s)" in out.getvalue()
+
+        unforced = _fake_backfill_client(affected=0)
+        with mock.patch.object(ch_client, "get_clickhouse_client", lambda: unforced):
+            call_command("backfill_eval_score", "--no-confirm", stdout=StringIO())
+        assert not any("ALTER TABLE" in q for q in unforced.executed)
 
     def test_mv_recreate_manifest_consistency(self):
         """Every MV_RECREATE_MANIFEST entry must resolve to a real DDL constant."""

--- a/futureagi/tracer/tests/test_clickhouse.py
+++ b/futureagi/tracer/tests/test_clickhouse.py
@@ -249,9 +249,12 @@ class TestClickHouseSchema:
         )
 
         assert (
-            "JSONHas(JSONExtractString(config), 'output', 'output', 'score')"
-            in CH_EVAL_SCORE_EXPR
-        ), "without the nested-score branch a structured output extracts as 0."
+            "JSONType(JSONExtractString(config), 'output', 'output', 'score') "
+            "IN ('Double', 'Int64', 'UInt64')" in CH_EVAL_SCORE_EXPR
+        ), (
+            "the nested-score branch must gate on the value's type: JSONHas is "
+            "true for a null or string score that JSONExtractFloat reads as 0."
+        )
         assert (
             "JSONExtractFloat(JSONExtractString(config), 'output', 'output'))"
             in CH_EVAL_SCORE_EXPR

--- a/futureagi/tracer/tests/test_clickhouse_integration.py
+++ b/futureagi/tracer/tests/test_clickhouse_integration.py
@@ -17,10 +17,12 @@ Covered:
 - SimulationQueryBuilder integration (system metrics, breakdowns, filters)
 - DatasetQueryBuilder integration (system metrics, breakdowns)
 - usage_apicalllog eval-score materialization per eval-output shape
+- an opt-in eval-score backfill benchmark, see TestEvalScoreBackfillAtScale
 """
 
 import json
 import os
+import time
 import uuid
 from datetime import datetime, timezone
 
@@ -60,6 +62,211 @@ EVAL_OUTPUT_SHAPES: tuple[tuple[str, dict, float, bool], ...] = (
 
 EVAL_SCORED_SHAPES = tuple(s for s in EVAL_OUTPUT_SHAPES if s[3])
 EVAL_SCORED_AVERAGE = 0.625
+
+EVAL_SHAPE_PAYLOADS = {label: payload for label, payload, _s, _h in EVAL_OUTPUT_SHAPES}
+EVAL_SHAPE_SCORES = {label: score for label, _p, score, _h in EVAL_OUTPUT_SHAPES}
+
+# ---------------------------------------------------------------------------
+# Backfill benchmark seeding (opt-in, see TestEvalScoreBackfillAtScale)
+# ---------------------------------------------------------------------------
+
+# Unqualified: the benchmark client sets _TEST_DATABASE as its default, so the
+# command's own currentDatabase()-scoped partition query works verbatim.
+_BENCH_TABLE = "usage_apicalllog_bench"
+
+# Upper bounds per 100k rows, so the production mix is expressible exactly:
+# structured outputs are a 1.56% slice, split 76 / 18 / 6 inside that slice.
+BENCH_BUCKET_SCALE = 100_000
+BENCH_MIX: tuple[tuple[int, str], ...] = (
+    (1_186, "structured_complete"),
+    (1_467, "structured_incomplete"),
+    (1_560, "structured_partial"),
+    (41_560, "scalar_score"),
+    (81_560, "text_output"),
+    (BENCH_BUCKET_SCALE, "no_output"),
+)
+
+# Repeated prose plus a random tail, so a seeded row weighs about what a
+# production row weighs on disk rather than compressing away to nothing.
+BENCH_REASON_REPEATS = 20
+BENCH_REASON_RANDOM_BYTES = 600
+BENCH_REASON_SENTENCES: tuple[str, ...] = (
+    "The response addresses every requirement stated in the user prompt.",
+    "Key steps in the reasoning chain are present and ordered correctly.",
+    "The assistant restated the constraint before applying it to the answer.",
+    "No unsupported factual claims were introduced beyond the given context.",
+    "The final paragraph summarises the outcome without adding new content.",
+    "Tone stays consistent with the system instruction throughout the turn.",
+    "One requested field is missing from the structured portion of the reply.",
+    "The answer stops short of covering the third sub question that was asked.",
+    "Formatting follows the requested schema and parses without modification.",
+    "Citations map to passages that actually appear in the retrieved context.",
+    "The model hedged where the context was genuinely ambiguous, which is fine.",
+    "A minor arithmetic slip appears in the intermediate calculation step.",
+    "Latency stayed inside the budget configured for this evaluation template.",
+    "The refusal was appropriate given the policy category that was triggered.",
+    "Coverage of the source document is partial but the omissions are minor.",
+    "The reply repeats the question back before answering, which is redundant.",
+    "Instructions about output length were respected within a small margin.",
+    "The completion resolves the ambiguity by asking a clarifying question.",
+    "Nothing in the transcript indicates the tool call result was ignored.",
+    "The grader found the response complete against all listed criteria.",
+)
+
+# Small blocks: a seeded row carries kilobytes of config, so the default block
+# size builds multi-GB buffers and a modest box runs out of memory mid-seed.
+BENCH_SEED_SETTINGS = (
+    "max_insert_threads = 1, max_threads = 1, max_memory_usage = 1400000000, "
+    "max_block_size = 1024, max_insert_block_size = 32768, "
+    "min_insert_block_size_rows = 32768, min_insert_block_size_bytes = 0"
+)
+BENCH_READ_SETTINGS = "max_memory_usage = 1400000000, max_threads = 3"
+BENCH_SETTLED_PARTS = 16
+
+
+def _bench_sql_literal(value: str) -> str:
+    return "'" + value.replace("\\", "\\\\").replace("'", "\\'") + "'"
+
+
+def _bench_multi_if(column: str, value_for_label) -> str:
+    """Render BENCH_MIX as a multiIf over a per-row bucket column."""
+    branches = [
+        f"{column} < {upper}, {_bench_sql_literal(value_for_label(label))}"
+        for upper, label in BENCH_MIX[:-1]
+    ]
+    branches.append(_bench_sql_literal(value_for_label(BENCH_MIX[-1][1])))
+    return "multiIf(" + ", ".join(branches) + ")"
+
+
+def _bench_output_fragment(label: str) -> str:
+    """The opening of one row's config, carrying that shape's eval output."""
+    output = EVAL_SHAPE_PAYLOADS[label]["output"]
+    if "output" not in output:
+        return '"output":{'
+    return '"output":{"output":' + json.dumps(output["output"]) + ","
+
+
+def _bench_reason_sql() -> str:
+    pool = "multiIf(" + ", ".join(
+        f"modulo(number, {len(BENCH_REASON_SENTENCES)}) = {i}, "
+        f"{_bench_sql_literal(sentence)}"
+        for i, sentence in enumerate(BENCH_REASON_SENTENCES[:-1])
+    ) + f", {_bench_sql_literal(BENCH_REASON_SENTENCES[-1])})"
+    return (
+        f"concat(repeat(concat({pool}, ' '), {BENCH_REASON_REPEATS}), "
+        f"hex(randomString({BENCH_REASON_RANDOM_BYTES})))"
+    )
+
+
+def _bench_ddl(table: str, shape: str) -> str:
+    """Canonical DDL, optionally wound to the shape PeerDB built in production."""
+    from tracer.services.clickhouse.schema import (
+        CDC_USAGE_APICALLLOG,
+        _to_single_node_engine,
+    )
+
+    ddl = _to_single_node_engine(CDC_USAGE_APICALLLOG).replace(
+        "CREATE TABLE IF NOT EXISTS usage_apicalllog",
+        f"CREATE TABLE IF NOT EXISTS {table}",
+    )
+    if shape != "prod":
+        return ddl
+
+    ddl = ddl.replace("PARTITION BY toYYYYMM(created_at)\n", "").replace(
+        "ORDER BY (organization_id, source_id, created_at, id)", "ORDER BY id"
+    )
+    assert "PARTITION BY" not in ddl and "ORDER BY id" in ddl, (
+        "the production table shape could not be derived from the canonical DDL"
+    )
+    return ddl
+
+
+def _bench_seed(client, table: str, rows: int, shape: str) -> None:
+    from tracer.services.clickhouse.schema import EVAL_OUTPUT_JSON_ARGS
+
+    client.command(f"DROP TABLE IF EXISTS {table}")
+    client.command(_bench_ddl(table, shape))
+    # Wind the expression back to the one a deployed cluster still carries, so
+    # every seeded row lands genuinely stale.
+    client.command(
+        f"ALTER TABLE {table} MODIFY COLUMN eval_score Float64 "
+        f"MATERIALIZED JSONExtractFloat({EVAL_OUTPUT_JSON_ARGS})"
+    )
+
+    label_expr = _bench_multi_if("bucket", lambda label: label)
+    output_expr = _bench_multi_if("bucket", _bench_output_fragment)
+    if shape == "prod":
+        created_expr = "now64(6) - toIntervalSecond(modulo(number, 15552000))"
+    else:
+        created_expr = (
+            "toDateTime64('2026-01-01 00:00:00', 6) + "
+            f"toIntervalSecond(intDiv(number * 15552000, {rows}))"
+        )
+
+    # One tenant, as a single customer's table looks, and merges held off until
+    # the seed is in so they do not compete with it for memory.
+    org = "toUUID('11111111-1111-1111-1111-111111111111')"
+    client.command(f"SYSTEM STOP MERGES {table}")
+
+    written = 0
+    while written < rows:
+        take = min(500_000, rows - written)
+        client.command(
+            f"""
+            INSERT INTO {table}
+                (id, log_id, organization_id, workspace_id, status, reference_id,
+                 config, source, source_id, created_at, updated_at,
+                 _peerdb_synced_at, _peerdb_is_deleted, _peerdb_version)
+            SELECT toInt64(number), generateUUIDv4(), {org}, {org}, 'success', label,
+                   toJSONString(concat('{{', output, '"reason":"', reason,
+                       '"}},"trace_id":"', toString(generateUUIDv4()),
+                       '","model":"gpt-4o-mini","latency_ms":',
+                       toString(modulo(number, 5000) + 120), '}}')),
+                   'tracer', 'bench-template', created, created, created, 0, 1
+            FROM (
+                SELECT number, modulo(number, {BENCH_BUCKET_SCALE}) AS bucket,
+                       {label_expr} AS label,
+                       {output_expr} AS output,
+                       {_bench_reason_sql()} AS reason,
+                       {created_expr} AS created
+                FROM numbers({written}, {take})
+            )
+            SETTINGS {BENCH_SEED_SETTINGS}
+            """
+        )
+        written += take
+
+    client.command(f"SYSTEM START MERGES {table}")
+    _bench_settle(client, table)
+
+
+def _bench_settle(client, table: str, timeout: int = 600) -> None:
+    """Let merges consolidate the seed so timings are not merge noise.
+
+    Bounded: a fully merged table takes far longer than the timings are worth,
+    and a part count in the low tens already matches a real table's layout.
+    """
+    deadline = time.time() + timeout
+    last, stable = None, 0
+    while time.time() < deadline:
+        merging = client.query(
+            "SELECT count() FROM system.merges "
+            f"WHERE database = '{_TEST_DATABASE}' AND table = '{table}'"
+        ).result_rows[0][0]
+        parts = client.query(
+            "SELECT count() FROM system.parts WHERE active "
+            f"AND database = '{_TEST_DATABASE}' AND table = '{table}'"
+        ).result_rows[0][0]
+        if parts <= BENCH_SETTLED_PARTS:
+            return
+        if merging == 0 and parts == last:
+            stable += 1
+            if stable >= 3:
+                return
+        else:
+            stable = 0
+        last = parts
+        time.sleep(5)
 
 
 @pytest.fixture(scope="session")
@@ -651,3 +858,189 @@ class TestEvalScoreMaterialization:
             "the eval_score minmax index disagrees with the stored rows after "
             f"the backfill, so filters prune real rows away: {counts}"
         )
+
+
+# ===========================================================================
+# F. TestEvalScoreBackfillAtScale
+# ===========================================================================
+
+
+@pytest.fixture
+def ch_backfill_bench_table(ch_schema):
+    """Seed a large usage_apicalllog copy, or skip when the run is not opted in."""
+    rows = int(os.environ.get("EVAL_SCORE_BENCH_ROWS", "0"))
+    if rows <= 0:
+        pytest.skip(
+            "set EVAL_SCORE_BENCH_ROWS to run the eval_score backfill benchmark"
+        )
+
+    import clickhouse_connect
+
+    shape = os.environ.get("EVAL_SCORE_BENCH_SHAPE", "prod")
+    client = clickhouse_connect.get_client(
+        host=os.environ.get("CH_TEST_HOST", "localhost"),
+        port=int(os.environ.get("CH_TEST_PORT", "18123")),
+        database=_TEST_DATABASE,
+        send_receive_timeout=14400,
+        settings={"max_execution_time": 14400},
+    )
+
+    started = time.perf_counter()
+    _bench_seed(client, _BENCH_TABLE, rows, shape)
+
+    yield {
+        "client": client,
+        "table": _BENCH_TABLE,
+        "rows": rows,
+        "shape": shape,
+        "seed_seconds": time.perf_counter() - started,
+    }
+
+    client.command(f"DROP TABLE IF EXISTS {_BENCH_TABLE}")
+    client.close()
+
+
+@pytest.mark.benchmark
+@pytest.mark.skipif(
+    not os.environ.get("EVAL_SCORE_BENCH_ROWS"),
+    reason="set EVAL_SCORE_BENCH_ROWS to run the eval_score backfill benchmark",
+)
+class TestEvalScoreBackfillAtScale:
+    """Time the eval_score backfill on a large table and prove it stays correct.
+
+    Opt-in twice over: the ``benchmark`` marker is deselected by the default
+    addopts, and the fixture skips unless ``EVAL_SCORE_BENCH_ROWS`` is set. A
+    ten million row seed must never run in an ordinary suite invocation.
+
+        EVAL_SCORE_BENCH_ROWS=10000000 pytest
+            tracer/tests/test_clickhouse_integration.py -m benchmark -k AtScale -s
+
+    ``EVAL_SCORE_BENCH_SHAPE`` picks the table shape: ``prod`` (default,
+    unpartitioned and ordered by id, which is what PeerDB built) or
+    ``canonical`` (the schema.py DDL, partitioned by month).
+    """
+
+    @staticmethod
+    def _timed(call):
+        started = time.perf_counter()
+        result = call()
+        return time.perf_counter() - started, result
+
+    def _stale_count(self, client, table):
+        from tracer.management.commands.backfill_eval_score import _AFFECTED_COUNT
+        from tracer.services.clickhouse.eval_expressions import (
+            eval_has_structured_score,
+        )
+        from tracer.services.clickhouse.schema import (
+            CH_EVAL_SCORE_EXPR,
+            EVAL_OUTPUT_JSON_ARGS,
+        )
+
+        sql = _AFFECTED_COUNT.format(
+            table=table,
+            column="eval_score",
+            expr=CH_EVAL_SCORE_EXPR,
+            predicate=eval_has_structured_score(EVAL_OUTPUT_JSON_ARGS),
+        )
+        seconds, result = self._timed(
+            lambda: client.query(f"{sql}\nSETTINGS {BENCH_READ_SETTINGS}")
+        )
+        return seconds, int(result.result_rows[0][0])
+
+    def test_backfill_scales_and_leaves_every_shape_correct(
+        self, ch_backfill_bench_table
+    ):
+        """The real backfill statements, timed, against a table of real size."""
+        from tracer.management.commands.backfill_eval_score import (
+            _PARTITIONS,
+            materialize_statements,
+            rebuild_statements,
+        )
+
+        client = ch_backfill_bench_table["client"]
+        table = ch_backfill_bench_table["table"]
+        rows = ch_backfill_bench_table["rows"]
+
+        size = client.query(
+            "SELECT sum(rows), sum(bytes_on_disk), count() FROM system.parts "
+            f"WHERE database = '{_TEST_DATABASE}' AND table = '{table}' AND active"
+        ).result_rows[0]
+
+        dry_run_cold, stale_before = self._stale_count(client, table)
+        assert stale_before > 0, (
+            "the seed is not stale, so this run would time a no-op backfill"
+        )
+
+        rebuild_seconds = 0.0
+        for statement in rebuild_statements(table):
+            seconds, _ = self._timed(lambda s=statement: client.command(s))
+            rebuild_seconds += seconds
+
+        partitions = [
+            row[0] for row in client.query(_PARTITIONS.format(table=table)).result_rows
+        ]
+        assert partitions, "the backfill found no partitions to materialize"
+
+        column_seconds = index_seconds = 0.0
+        for partition in partitions:
+            column_sql, index_sql = materialize_statements(table, partition)
+            # mutations_sync = 2 so the wall time is completion, not submission.
+            seconds, _ = self._timed(
+                lambda s=column_sql: client.command(f"{s} SETTINGS mutations_sync = 2")
+            )
+            column_seconds += seconds
+            seconds, _ = self._timed(
+                lambda s=index_sql: client.command(f"{s} SETTINGS mutations_sync = 2")
+            )
+            index_seconds += seconds
+
+        dry_run_after, stale_after = self._stale_count(client, table)
+
+        parity = {
+            use_skip_indexes: int(
+                client.query(
+                    f"SELECT count() FROM {table} WHERE eval_score >= 1.0 "
+                    f"SETTINGS use_skip_indexes = {use_skip_indexes}, "
+                    f"{BENCH_READ_SETTINGS}"
+                ).result_rows[0][0]
+            )
+            for use_skip_indexes in (0, 1)
+        }
+        scores = dict(
+            client.query(
+                f"SELECT reference_id, eval_score FROM {table} "
+                f"GROUP BY reference_id, eval_score SETTINGS {BENCH_READ_SETTINGS}"
+            ).result_rows
+        )
+
+        print(
+            "\n".join(
+                [
+                    "",
+                    f"eval_score backfill, {rows:,} rows, "
+                    f"{ch_backfill_bench_table['shape']} table shape",
+                    f"  rows on disk           {size[0]:,} in {size[2]} active parts",
+                    f"  bytes on disk          {size[1]:,} "
+                    f"({size[1] / max(size[0], 1):.0f} per row)",
+                    f"  seed                   {ch_backfill_bench_table['seed_seconds']:8.2f}s",
+                    f"  dry-run scan           {dry_run_cold:8.2f}s  ({stale_before:,} stale)",
+                    f"  rebuild DDL, 3 stmts   {rebuild_seconds:8.2f}s",
+                    f"  MATERIALIZE COLUMN     {column_seconds:8.2f}s  "
+                    f"over {len(partitions)} partition(s)",
+                    f"  MATERIALIZE INDEX      {index_seconds:8.2f}s",
+                    f"  dry-run scan after     {dry_run_after:8.2f}s  ({stale_after:,} stale)",
+                    "",
+                ]
+            )
+        )
+
+        assert stale_after == 0, (
+            f"{stale_after} rows are still stale after the backfill"
+        )
+        assert parity[1] == parity[0], (
+            "the eval_score minmax index disagrees with the stored rows after "
+            f"the backfill, so filters prune real rows away: {parity}"
+        )
+        assert scores == {
+            label: EVAL_SHAPE_SCORES[label] for _bound, label in BENCH_MIX
+        }, f"a seeded output shape resolved to the wrong score: {scores}"

--- a/futureagi/tracer/tests/test_clickhouse_integration.py
+++ b/futureagi/tracer/tests/test_clickhouse_integration.py
@@ -58,7 +58,6 @@ EVAL_OUTPUT_SHAPES: tuple[tuple[str, dict, float, bool], ...] = (
     ("no_output", {"output": {}}, 0.0, False),
 )
 
-# The number-carrying shapes and the mean a dashboard average returns over them.
 EVAL_SCORED_SHAPES = tuple(s for s in EVAL_OUTPUT_SHAPES if s[3])
 EVAL_SCORED_AVERAGE = 0.625
 
@@ -226,13 +225,8 @@ def ch_dataset_data(ch_schema):
 def ch_eval_output_rows(ch_schema):
     """Recreate usage_apicalllog from the canonical DDL and seed every shape.
 
-    The table is dropped first because ``CREATE TABLE IF NOT EXISTS`` keeps a
-    stale MATERIALIZED expression from an earlier run — the exact drift the
-    POST_DDL_ALTERS ``MODIFY COLUMN`` exists to repair on deployed clusters.
-
-    Rows land twice: once under ``all_shapes_source_id`` (one per shape) and
-    once under ``scored_shapes_source_id`` (number-carrying shapes only), so a
-    dashboard average can be read back without the pass/fail row skewing it.
+    Dropped first because ``CREATE TABLE IF NOT EXISTS`` would keep a stale
+    MATERIALIZED expression from an earlier run.
     """
     from tracer.services.clickhouse.schema import (
         CDC_USAGE_APICALLLOG,
@@ -546,9 +540,7 @@ class TestEvalScoreMaterialization:
     """Eval scores read back out of a real ClickHouse instance."""
 
     def test_every_eval_output_shape_materializes_its_score(self, ch_eval_output_rows):
-        """Structured outputs resolve to their nested score; scalar and text
-        outputs keep the value they always had.
-        """
+        """Structured outputs resolve to their nested score; the rest hold."""
         result = ch_eval_output_rows["client"].query(
             f"SELECT reference_id, eval_score FROM {_EVAL_TABLE} "
             f"WHERE source_id = '{ch_eval_output_rows['all_shapes_source_id']}'"
@@ -561,9 +553,7 @@ class TestEvalScoreMaterialization:
     def test_structured_eval_output_str_holds_the_nested_object(
         self, ch_eval_output_rows
     ):
-        """Readers branch on eval_output_str, so a structured row must carry
-        the serialized object there rather than an empty string.
-        """
+        """Readers branch on eval_output_str, so it must not be empty here."""
         label, payload, _score, _has_number = EVAL_OUTPUT_SHAPES[0]
         result = ch_eval_output_rows["client"].query(
             f"SELECT eval_output_str FROM {_EVAL_TABLE} "
@@ -574,9 +564,7 @@ class TestEvalScoreMaterialization:
         assert json.loads(result.result_rows[0][0]) == payload["output"]["output"]
 
     def test_dashboard_average_counts_structured_eval_scores(self, ch_eval_output_rows):
-        """The widget SQL, executed for real, averages structured outputs
-        alongside scalar ones instead of dropping the structured rows.
-        """
+        """The real widget SQL averages structured rows instead of dropping them."""
         from tracer.services.clickhouse.query_builders.dashboard import (
             DashboardQueryBuilder,
         )
@@ -608,12 +596,7 @@ class TestEvalScoreMaterialization:
     def test_backfill_leaves_the_score_index_agreeing_with_the_rows(
         self, ch_eval_output_rows
     ):
-        """A backfilled row has to stay visible to a filter on eval_score.
-
-        The minmax index keeps the pre-backfill bounds unless it is dropped and
-        re-added, and a stale one prunes whole granules — the filter then
-        returns nothing at all rather than something obviously wrong.
-        """
+        """A backfilled row has to stay visible to a filter on eval_score."""
         from tracer.management.commands.backfill_eval_score import (
             materialize_statements,
             rebuild_statements,
@@ -633,8 +616,7 @@ class TestEvalScoreMaterialization:
                 f"CREATE TABLE IF NOT EXISTS {table}",
             )
         )
-        # Wind the table back to the expression a deployed cluster still has,
-        # so the rows below store the values it would have produced.
+        # Wind the table back to the expression a deployed cluster still has.
         client.command(
             f"ALTER TABLE {table} MODIFY COLUMN eval_score Float64 "
             f"MATERIALIZED JSONExtractFloat({EVAL_OUTPUT_JSON_ARGS})"
@@ -667,5 +649,5 @@ class TestEvalScoreMaterialization:
         client.command(f"DROP TABLE IF EXISTS {table}")
         assert counts[1] == counts[0] == expected, (
             "the eval_score minmax index disagrees with the stored rows after "
-            f"the backfill — filters prune real rows away: {counts}"
+            f"the backfill, so filters prune real rows away: {counts}"
         )

--- a/futureagi/tracer/tests/test_clickhouse_integration.py
+++ b/futureagi/tracer/tests/test_clickhouse_integration.py
@@ -35,7 +35,7 @@ import pytest
 _TEST_DATABASE = "test_futureagi"
 _EVAL_TABLE = f"{_TEST_DATABASE}.usage_apicalllog"
 
-# (label, config payload, the eval_score it must materialize, carries a number)
+# (label, config payload, the eval_score it must materialize, holds a real number)
 EVAL_OUTPUT_SHAPES: tuple[tuple[str, dict, float, bool], ...] = (
     (
         "structured_complete",
@@ -55,6 +55,18 @@ EVAL_OUTPUT_SHAPES: tuple[tuple[str, dict, float, bool], ...] = (
         0.2,
         True,
     ),
+    (
+        "structured_null_score",
+        {"output": {"output": {"score": None, "choice": "Unknown"}}},
+        0.0,
+        False,
+    ),
+    (
+        "structured_text_score",
+        {"output": {"output": {"score": "high"}}},
+        0.0,
+        False,
+    ),
     ("scalar_score", {"output": {"output": 0.8}}, 0.8, True),
     ("text_output", {"output": {"output": "Passed"}}, 0.0, False),
     ("no_output", {"output": {}}, 0.0, False),
@@ -62,6 +74,13 @@ EVAL_OUTPUT_SHAPES: tuple[tuple[str, dict, float, bool], ...] = (
 
 EVAL_SCORED_SHAPES = tuple(s for s in EVAL_OUTPUT_SHAPES if s[3])
 EVAL_SCORED_AVERAGE = 0.625
+
+# Over every shape: the four numbers above plus "Passed" read as 1.0. The empty,
+# null-score and text-score rows are excluded rather than averaged in as 0.
+EVAL_ALL_SHAPES_AVERAGE = 0.7
+
+# Every path that answers "did this eval pass?" has to name this same set.
+EVAL_PASSING_SHAPES = frozenset({"structured_complete", "text_output"})
 
 EVAL_SHAPE_PAYLOADS = {label: payload for label, payload, _s, _h in EVAL_OUTPUT_SHAPES}
 EVAL_SHAPE_SCORES = {label: score for label, _p, score, _h in EVAL_OUTPUT_SHAPES}
@@ -458,8 +477,10 @@ def ch_eval_output_rows(ch_schema):
 
     def _seed(source_id, shapes, first_id):
         for offset, (label, payload, _score, _has_number) in enumerate(shapes):
+            # trace_id: eval filters select on eval_trace_id, so it names the row.
             # config is double-encoded (a JSON string holding JSON) in CH.
-            literal = json.dumps(payload).replace("\\", "\\\\").replace("'", "\\'")
+            config = dict(payload, trace_id=label)
+            literal = json.dumps(config).replace("\\", "\\\\").replace("'", "\\'")
             client.command(
                 f"""
                 INSERT INTO {_EVAL_TABLE}
@@ -770,8 +791,17 @@ class TestEvalScoreMaterialization:
 
         assert json.loads(result.result_rows[0][0]) == payload["output"]["output"]
 
-    def test_dashboard_average_counts_structured_eval_scores(self, ch_eval_output_rows):
-        """The real widget SQL averages structured rows instead of dropping them."""
+    @pytest.mark.parametrize(
+        ("source_key", "expected"),
+        [
+            ("scored_shapes_source_id", EVAL_SCORED_AVERAGE),
+            ("all_shapes_source_id", EVAL_ALL_SHAPES_AVERAGE),
+        ],
+    )
+    def test_dashboard_average_counts_only_the_shapes_it_can_score(
+        self, ch_eval_output_rows, source_key, expected
+    ):
+        """Structured rows are averaged in; a null or text score stays excluded."""
         from tracer.services.clickhouse.query_builders.dashboard import (
             DashboardQueryBuilder,
         )
@@ -786,7 +816,7 @@ class TestEvalScoreMaterialization:
                     "id": "structured_eval",
                     "name": "structured_eval",
                     "type": "eval_metric",
-                    "config_id": ch_eval_output_rows["scored_shapes_source_id"],
+                    "config_id": ch_eval_output_rows[source_key],
                     "aggregation": "avg",
                 }
             ],
@@ -796,9 +826,80 @@ class TestEvalScoreMaterialization:
 
         result = ch_eval_output_rows["client"].query(sql_test, parameters=params)
 
-        assert [row[1] for row in result.result_rows] == [
-            pytest.approx(EVAL_SCORED_AVERAGE)
-        ]
+        assert [row[1] for row in result.result_rows] == [pytest.approx(expected)]
+
+    def test_pass_fail_paths_classify_every_row_the_same_way(self, ch_eval_output_rows):
+        """One eval, three widgets: the time series, the breakdown label and the
+        filter have to reach the same verdict on the same row.
+        """
+        from tracer.services.clickhouse.query_builders.dashboard import (
+            DashboardQueryBuilder,
+        )
+
+        client = ch_eval_output_rows["client"]
+        source_id = ch_eval_output_rows["all_shapes_source_id"]
+        metric = {
+            "id": "pass_fail_eval",
+            "name": "pass_fail_eval",
+            "type": "eval_metric",
+            "config_id": source_id,
+            "output_type": "PASS_FAIL",
+            "aggregation": "pass_count",
+        }
+        config = {
+            "organization_id": ch_eval_output_rows["organization_id"],
+            "workspace_id": ch_eval_output_rows["workspace_id"],
+            "granularity": "day",
+            "time_range": {"preset": "7D"},
+            "metrics": [metric],
+            "breakdowns": [metric],
+        }
+
+        def _run(sql, params=None):
+            return client.query(
+                sql.replace("usage_apicalllog", _EVAL_TABLE), parameters=params
+            ).result_rows
+
+        builder = DashboardQueryBuilder(config)
+
+        sql, params, _ = builder.build_all_queries()[0]
+        time_series_passes = sum(row[1] for row in _run(sql, params))
+
+        label_expr = builder._resolve_all_breakdowns({})[0]["expr"]
+        breakdown_passes = {
+            label
+            for label, verdict in _run(
+                f"SELECT reference_id, {label_expr} FROM usage_apicalllog AS ev0 "
+                f"WHERE source_id = '{source_id}'"
+            )
+            if verdict == "Pass"
+        }
+
+        clauses, filter_params = builder._build_subquery_filters(
+            [
+                {
+                    "metric_type": "eval_metric",
+                    "metric_name": source_id,
+                    "output_type": "PASS_FAIL",
+                    "operator": "equal_to",
+                    "value": 1.0,
+                }
+            ],
+            {},
+            "f_",
+        )
+        subquery = clauses[0][clauses[0].index("(") + 1 : clauses[0].rindex(")")]
+        filter_passes = {row[0] for row in _run(subquery, filter_params)}
+
+        assert breakdown_passes == filter_passes == set(EVAL_PASSING_SHAPES), (
+            "the breakdown label and the eval filter disagree on which rows "
+            f"passed: breakdown {sorted(breakdown_passes)}, "
+            f"filter {sorted(filter_passes)}"
+        )
+        assert time_series_passes == len(EVAL_PASSING_SHAPES), (
+            "the time series counts a different number of passes than the "
+            f"breakdown and the filter do: {time_series_passes}"
+        )
 
     def test_backfill_leaves_the_score_index_agreeing_with_the_rows(
         self, ch_eval_output_rows

--- a/futureagi/tracer/tests/test_clickhouse_integration.py
+++ b/futureagi/tracer/tests/test_clickhouse_integration.py
@@ -16,8 +16,10 @@ Covered:
 - Connection and schema lifecycle
 - SimulationQueryBuilder integration (system metrics, breakdowns, filters)
 - DatasetQueryBuilder integration (system metrics, breakdowns)
+- usage_apicalllog eval-score materialization per eval-output shape
 """
 
+import json
 import os
 import uuid
 from datetime import datetime, timezone
@@ -29,6 +31,36 @@ import pytest
 # ---------------------------------------------------------------------------
 
 _TEST_DATABASE = "test_futureagi"
+_EVAL_TABLE = f"{_TEST_DATABASE}.usage_apicalllog"
+
+# (label, config payload, the eval_score it must materialize, carries a number)
+EVAL_OUTPUT_SHAPES: tuple[tuple[str, dict, float, bool], ...] = (
+    (
+        "structured_complete",
+        {"output": {"output": {"score": 1, "choice": "Complete"}}},
+        1.0,
+        True,
+    ),
+    (
+        "structured_partial",
+        {"output": {"output": {"score": 0.5, "choice": "Partial"}}},
+        0.5,
+        True,
+    ),
+    (
+        "structured_incomplete",
+        {"output": {"output": {"score": 0.2, "choice": "Incomplete"}}},
+        0.2,
+        True,
+    ),
+    ("scalar_score", {"output": {"output": 0.8}}, 0.8, True),
+    ("text_output", {"output": {"output": "Passed"}}, 0.0, False),
+    ("no_output", {"output": {}}, 0.0, False),
+)
+
+# The number-carrying shapes and the mean a dashboard average returns over them.
+EVAL_SCORED_SHAPES = tuple(s for s in EVAL_OUTPUT_SHAPES if s[3])
+EVAL_SCORED_AVERAGE = 0.625
 
 
 @pytest.fixture(scope="session")
@@ -186,6 +218,75 @@ def ch_dataset_data(ch_schema):
 
     try:
         client.command(f"TRUNCATE TABLE {_TEST_DATABASE}.model_hub_cell")
+    except Exception:
+        pass
+
+
+@pytest.fixture
+def ch_eval_output_rows(ch_schema):
+    """Recreate usage_apicalllog from the canonical DDL and seed every shape.
+
+    The table is dropped first because ``CREATE TABLE IF NOT EXISTS`` keeps a
+    stale MATERIALIZED expression from an earlier run — the exact drift the
+    POST_DDL_ALTERS ``MODIFY COLUMN`` exists to repair on deployed clusters.
+
+    Rows land twice: once under ``all_shapes_source_id`` (one per shape) and
+    once under ``scored_shapes_source_id`` (number-carrying shapes only), so a
+    dashboard average can be read back without the pass/fail row skewing it.
+    """
+    from tracer.services.clickhouse.schema import (
+        CDC_USAGE_APICALLLOG,
+        _to_single_node_engine,
+    )
+
+    client = ch_schema
+    organization_id = str(uuid.uuid4())
+    workspace_id = str(uuid.uuid4())
+    all_shapes_source_id = str(uuid.uuid4())
+    scored_shapes_source_id = str(uuid.uuid4())
+
+    ddl = _to_single_node_engine(CDC_USAGE_APICALLLOG).replace(
+        "CREATE TABLE IF NOT EXISTS usage_apicalllog",
+        f"CREATE TABLE IF NOT EXISTS {_EVAL_TABLE}",
+    )
+    client.command(f"DROP TABLE IF EXISTS {_EVAL_TABLE}")
+    client.command(ddl)
+
+    # Backdated so clock skew against the CH container can't push rows past "now".
+    seeded_at = "now64(6) - toIntervalHour(1)"
+
+    def _seed(source_id, shapes, first_id):
+        for offset, (label, payload, _score, _has_number) in enumerate(shapes):
+            # config is double-encoded (a JSON string holding JSON) in CH.
+            literal = json.dumps(payload).replace("\\", "\\\\").replace("'", "\\'")
+            client.command(
+                f"""
+                INSERT INTO {_EVAL_TABLE}
+                    (id, log_id, organization_id, workspace_id, status,
+                     reference_id, config, source, source_id,
+                     created_at, updated_at,
+                     _peerdb_synced_at, _peerdb_is_deleted, _peerdb_version)
+                SELECT {first_id + offset}, generateUUIDv4(),
+                       toUUID('{organization_id}'), toUUID('{workspace_id}'),
+                       'success', '{label}', toJSONString('{literal}'),
+                       'tracer', '{source_id}',
+                       {seeded_at}, {seeded_at}, {seeded_at}, 0, 1
+                """
+            )
+
+    _seed(all_shapes_source_id, EVAL_OUTPUT_SHAPES, 1)
+    _seed(scored_shapes_source_id, EVAL_SCORED_SHAPES, 101)
+
+    yield {
+        "client": client,
+        "organization_id": organization_id,
+        "workspace_id": workspace_id,
+        "all_shapes_source_id": all_shapes_source_id,
+        "scored_shapes_source_id": scored_shapes_source_id,
+    }
+
+    try:
+        client.command(f"TRUNCATE TABLE {_EVAL_TABLE}")
     except Exception:
         pass
 
@@ -433,3 +534,138 @@ class TestDatasetQueryBuilderIntegration:
         queries = builder.build_all_queries()
         sql, _, _ = queries[0]
         assert "breakdown_value" in sql
+
+
+# ===========================================================================
+# F. TestEvalScoreMaterialization
+# ===========================================================================
+
+
+@pytest.mark.integration
+class TestEvalScoreMaterialization:
+    """Eval scores read back out of a real ClickHouse instance."""
+
+    def test_every_eval_output_shape_materializes_its_score(self, ch_eval_output_rows):
+        """Structured outputs resolve to their nested score; scalar and text
+        outputs keep the value they always had.
+        """
+        result = ch_eval_output_rows["client"].query(
+            f"SELECT reference_id, eval_score FROM {_EVAL_TABLE} "
+            f"WHERE source_id = '{ch_eval_output_rows['all_shapes_source_id']}'"
+        )
+
+        assert dict(result.result_rows) == {
+            label: score for label, _payload, score, _has_number in EVAL_OUTPUT_SHAPES
+        }
+
+    def test_structured_eval_output_str_holds_the_nested_object(
+        self, ch_eval_output_rows
+    ):
+        """Readers branch on eval_output_str, so a structured row must carry
+        the serialized object there rather than an empty string.
+        """
+        label, payload, _score, _has_number = EVAL_OUTPUT_SHAPES[0]
+        result = ch_eval_output_rows["client"].query(
+            f"SELECT eval_output_str FROM {_EVAL_TABLE} "
+            f"WHERE source_id = '{ch_eval_output_rows['all_shapes_source_id']}' "
+            f"AND reference_id = '{label}'"
+        )
+
+        assert json.loads(result.result_rows[0][0]) == payload["output"]["output"]
+
+    def test_dashboard_average_counts_structured_eval_scores(self, ch_eval_output_rows):
+        """The widget SQL, executed for real, averages structured outputs
+        alongside scalar ones instead of dropping the structured rows.
+        """
+        from tracer.services.clickhouse.query_builders.dashboard import (
+            DashboardQueryBuilder,
+        )
+
+        config = {
+            "organization_id": ch_eval_output_rows["organization_id"],
+            "workspace_id": ch_eval_output_rows["workspace_id"],
+            "granularity": "day",
+            "time_range": {"preset": "7D"},
+            "metrics": [
+                {
+                    "id": "structured_eval",
+                    "name": "structured_eval",
+                    "type": "eval_metric",
+                    "config_id": ch_eval_output_rows["scored_shapes_source_id"],
+                    "aggregation": "avg",
+                }
+            ],
+        }
+        sql, params, _ = DashboardQueryBuilder(config).build_all_queries()[0]
+        sql_test = sql.replace("usage_apicalllog", _EVAL_TABLE)
+
+        result = ch_eval_output_rows["client"].query(sql_test, parameters=params)
+
+        assert [row[1] for row in result.result_rows] == [
+            pytest.approx(EVAL_SCORED_AVERAGE)
+        ]
+
+    def test_backfill_leaves_the_score_index_agreeing_with_the_rows(
+        self, ch_eval_output_rows
+    ):
+        """A backfilled row has to stay visible to a filter on eval_score.
+
+        The minmax index keeps the pre-backfill bounds unless it is dropped and
+        re-added, and a stale one prunes whole granules — the filter then
+        returns nothing at all rather than something obviously wrong.
+        """
+        from tracer.management.commands.backfill_eval_score import (
+            materialize_statements,
+            rebuild_statements,
+        )
+        from tracer.services.clickhouse.schema import (
+            CDC_USAGE_APICALLLOG,
+            EVAL_OUTPUT_JSON_ARGS,
+            _to_single_node_engine,
+        )
+
+        client = ch_eval_output_rows["client"]
+        table = f"{_EVAL_TABLE}_deployed"
+        client.command(f"DROP TABLE IF EXISTS {table}")
+        client.command(
+            _to_single_node_engine(CDC_USAGE_APICALLLOG).replace(
+                "CREATE TABLE IF NOT EXISTS usage_apicalllog",
+                f"CREATE TABLE IF NOT EXISTS {table}",
+            )
+        )
+        # Wind the table back to the expression a deployed cluster still has,
+        # so the rows below store the values it would have produced.
+        client.command(
+            f"ALTER TABLE {table} MODIFY COLUMN eval_score Float64 "
+            f"MATERIALIZED JSONExtractFloat({EVAL_OUTPUT_JSON_ARGS})"
+        )
+        for offset, (_label, payload, _score, _has_number) in enumerate(
+            EVAL_SCORED_SHAPES
+        ):
+            literal = json.dumps(payload).replace("\\", "\\\\").replace("'", "\\'")
+            client.command(
+                f"INSERT INTO {table} (id, log_id, organization_id, status, config, "
+                "source, source_id, created_at, updated_at, _peerdb_synced_at, "
+                "_peerdb_is_deleted, _peerdb_version) SELECT "
+                f"{201 + offset}, generateUUIDv4(), generateUUIDv4(), 'success', "
+                f"toJSONString('{literal}'), 'tracer', 'deployed', "
+                "now64(6), now64(6), now64(6), 0, 1"
+            )
+
+        for statement in rebuild_statements(table) + materialize_statements(table):
+            client.command(f"{statement} SETTINGS mutations_sync = 2")
+
+        expected = sum(1 for _l, _p, score, _h in EVAL_SCORED_SHAPES if score >= 1.0)
+        counts = {
+            skip_indexes: client.query(
+                f"SELECT count() FROM {table} WHERE eval_score >= 1.0 "
+                f"SETTINGS use_skip_indexes = {skip_indexes}"
+            ).result_rows[0][0]
+            for skip_indexes in (0, 1)
+        }
+
+        client.command(f"DROP TABLE IF EXISTS {table}")
+        assert counts[1] == counts[0] == expected, (
+            "the eval_score minmax index disagrees with the stored rows after "
+            f"the backfill — filters prune real rows away: {counts}"
+        )

--- a/futureagi/tracer/tests/test_dashboard.py
+++ b/futureagi/tracer/tests/test_dashboard.py
@@ -1604,9 +1604,8 @@ class TestDashboardQueryBuilder:
         assert "sum(e.eval_score)" not in sql
 
     def test_eval_metric_avg_keeps_structured_score_rows(self):
-        """A ``{"score": …, "choice": …}`` output is not numeric text, so the
-        numeric-detection branch must also accept the nested score — otherwise
-        every structured row is NULLed out of the aggregate.
+        """A structured output is not numeric text, so the numeric-detection
+        branch must accept the nested score or every such row is NULLed out.
         """
         config = {
             "project_ids": ["proj1"],

--- a/futureagi/tracer/tests/test_dashboard.py
+++ b/futureagi/tracer/tests/test_dashboard.py
@@ -1603,6 +1603,30 @@ class TestDashboardQueryBuilder:
         assert "lower(e.eval_output_str) IN ('passed', 'pass', 'true', '1')" in sql
         assert "sum(e.eval_score)" not in sql
 
+    def test_eval_metric_avg_keeps_structured_score_rows(self):
+        """A ``{"score": …, "choice": …}`` output is not numeric text, so the
+        numeric-detection branch must also accept the nested score — otherwise
+        every structured row is NULLed out of the aggregate.
+        """
+        config = {
+            "project_ids": ["proj1"],
+            "granularity": "day",
+            "time_range": {"preset": "7D"},
+            "metrics": [
+                {
+                    "id": "e2",
+                    "name": "conversation_hallucination",
+                    "type": "eval_metric",
+                    "config_id": str(uuid.uuid4()),
+                    "aggregation": "avg",
+                }
+            ],
+        }
+        builder = DashboardQueryBuilder(config)
+        queries = builder.build_all_queries()
+        sql, _, _ = queries[0]
+        assert "JSONHas(e.eval_output_str, 'score')" in sql
+
     def test_eval_metric_combines_project_and_dataset_breakdowns(self):
         config = {
             "project_ids": ["proj1"],

--- a/futureagi/tracer/tests/test_dashboard.py
+++ b/futureagi/tracer/tests/test_dashboard.py
@@ -1624,7 +1624,63 @@ class TestDashboardQueryBuilder:
         builder = DashboardQueryBuilder(config)
         queries = builder.build_all_queries()
         sql, _, _ = queries[0]
-        assert "JSONHas(e.eval_output_str, 'score')" in sql
+        assert (
+            "JSONType(e.eval_output_str, 'score') IN ('Double', 'Int64', 'UInt64')"
+            in sql
+        )
+
+    def test_pass_fail_paths_render_one_shared_predicate(self):
+        """The time-series predicate is unchanged to the byte, and the breakdown
+        label and the eval filter now render it instead of a 'Passed' literal.
+        """
+        eval_id = str(uuid.uuid4())
+        metric = {
+            "id": "e_pf",
+            "name": "pass_fail_eval",
+            "type": "eval_metric",
+            "config_id": eval_id,
+            "output_type": "PASS_FAIL",
+            "aggregation": "pass_rate",
+        }
+        builder = DashboardQueryBuilder(
+            {
+                "project_ids": ["proj1"],
+                "organization_id": str(uuid.uuid4()),
+                "granularity": "day",
+                "time_range": {"preset": "7D"},
+                "metrics": [metric],
+                "breakdowns": [metric],
+            }
+        )
+
+        sql, _, _ = builder.build_all_queries()[0]
+        breakdown_expr = builder._resolve_all_breakdowns({})[0]["expr"]
+        filter_clauses, _ = builder._build_subquery_filters(
+            [
+                {
+                    "metric_type": "eval_metric",
+                    "metric_name": eval_id,
+                    "output_type": "PASS_FAIL",
+                    "operator": "equal_to",
+                    "value": 1.0,
+                }
+            ],
+            {},
+            "f_",
+        )
+
+        assert (
+            "(e.eval_score >= 1.0 OR lower(e.eval_output_str) IN "
+            "('passed', 'pass', 'true', '1'))" in sql
+        ), "the time-series pass predicate must render exactly as it did before"
+        assert (
+            "(ev0.eval_score >= 1.0 OR lower(ev0.eval_output_str) IN "
+            "('passed', 'pass', 'true', '1'))" in breakdown_expr
+        ), "the PASS_FAIL breakdown label must not read a structured row as Fail"
+        assert (
+            "(eval_score >= 1.0 OR lower(eval_output_str) IN "
+            "('passed', 'pass', 'true', '1'))" in filter_clauses[0]
+        ), "the PASS_FAIL eval filter must select what the widget labels Pass"
 
     def test_eval_metric_combines_project_and_dataset_breakdowns(self):
         config = {

--- a/futureagi/tracer/tests/test_voice_call_detail_final_dedup.py
+++ b/futureagi/tracer/tests/test_voice_call_detail_final_dedup.py
@@ -1,0 +1,173 @@
+"""voice_call_detail must collapse ReplacingMergeTree version rows.
+
+Re-ingesting a span (poll/webhook upsert) writes a second CH row with the
+same sort key and a higher ``_version``; until background merges run, both
+rows coexist. The endpoint reads with ``FINAL`` so the newest version wins
+and tombstones (``is_deleted=1``) drop out. These tests seed duplicate
+versions directly and pin that behavior end-to-end.
+"""
+
+import uuid
+from datetime import timedelta
+
+import pytest
+from django.utils import timezone
+from rest_framework import status
+
+from model_hub.models.ai_model import AIModel
+from tracer.models.observation_span import ObservationSpan
+from tracer.models.project import Project
+from tracer.models.trace import Trace
+from tracer.tests._ch_seed import seed_ch_span, seed_ch_trace
+
+VOICE_CALL_DETAIL_URL = "/tracer/trace/voice_call_detail/"
+
+
+@pytest.fixture
+def observe_project(db, organization, workspace):
+    return Project.objects.create(
+        name=f"Voice Detail Dedup {uuid.uuid4().hex[:8]}",
+        organization=organization,
+        workspace=workspace,
+        model_type=AIModel.ModelTypes.GENERATIVE_LLM,
+        trace_type="observe",
+    )
+
+
+@pytest.fixture
+def observe_trace(db, observe_project):
+    trace = Trace.objects.create(
+        project=observe_project,
+        name="Voice dedup trace",
+        input={"prompt": "hi"},
+        output={"response": "hello"},
+    )
+    seed_ch_trace(trace)
+    return trace
+
+
+def _make_root_span(project, trace, raw_log: dict) -> ObservationSpan:
+    return ObservationSpan.objects.create(
+        id=f"voice_root_{uuid.uuid4().hex[:16]}",
+        project=project,
+        trace=trace,
+        name="Voice root conversation",
+        observation_type="conversation",
+        provider="vapi",
+        start_time=timezone.now() - timedelta(seconds=30),
+        end_time=timezone.now(),
+        latency_ms=1000,
+        status="OK",
+        span_attributes={"raw_log": raw_log},
+    )
+
+
+def _get_detail(auth_client, trace):
+    return auth_client.get(VOICE_CALL_DETAIL_URL, {"trace_id": str(trace.id)})
+
+
+@pytest.mark.django_db
+class TestVoiceCallDetailFinalDedup:
+    def test_root_span_latest_version_wins(
+        self, auth_client, observe_project, observe_trace
+    ):
+        """The production TH-7458 shape: a stale 'in-progress' stub is
+        superseded by a re-ingested 'ended' row with recordings — the detail
+        endpoint must serve the newer version."""
+        span = _make_root_span(
+            observe_project,
+            observe_trace,
+            {"id": "call-123", "status": "in-progress"},
+        )
+        seed_ch_span(span)
+
+        span.span_attributes = {
+            "raw_log": {
+                "id": "call-123",
+                "status": "ended",
+                "recordingUrl": "https://recordings.example/call-123.wav",
+            }
+        }
+        span.save(update_fields=["span_attributes"])
+        seed_ch_span(span)  # second CH row, same sort key, higher _version
+
+        resp = _get_detail(auth_client, observe_trace)
+        assert resp.status_code == status.HTTP_200_OK, resp.data
+        result = resp.data["result"]
+        assert result["status"] == "completed"
+        assert result["recording_url"] == "https://recordings.example/call-123.wav"
+
+    def test_idempotent_reingest_serves_one_call(
+        self, auth_client, observe_project, observe_trace
+    ):
+        """Re-fetching the same call twice (the remediation script re-runs are
+        idempotent) writes two identical CH rows — FINAL must still resolve to a
+        single, correct call rather than erroring or duplicating."""
+        span = _make_root_span(
+            observe_project,
+            observe_trace,
+            {"id": "call-456", "status": "ended"},
+        )
+        seed_ch_span(span)
+        seed_ch_span(span)  # identical re-ingest, same sort key + status
+
+        resp = _get_detail(auth_client, observe_trace)
+        assert resp.status_code == status.HTTP_200_OK, resp.data
+        assert resp.data["result"]["status"] == "completed"
+        assert resp.data["result"]["call_id"] == "call-456"
+
+    def test_child_span_versions_collapse_to_one_entry(
+        self, auth_client, observe_project, observe_trace
+    ):
+        """A re-ingested child span must appear once, with the newest fields."""
+        root = _make_root_span(
+            observe_project,
+            observe_trace,
+            {"id": "call-789", "status": "ended"},
+        )
+        seed_ch_span(root)
+
+        child = ObservationSpan.objects.create(
+            id=f"voice_child_{uuid.uuid4().hex[:16]}",
+            project=observe_project,
+            trace=observe_trace,
+            parent_span_id=root.id,
+            name="llm turn v1",
+            observation_type="generation",
+            start_time=timezone.now() - timedelta(seconds=20),
+            end_time=timezone.now() - timedelta(seconds=19),
+            latency_ms=500,
+            status="OK",
+        )
+        seed_ch_span(child)
+
+        child.name = "llm turn v2"
+        child.save(update_fields=["name"])
+        seed_ch_span(child)
+
+        resp = _get_detail(auth_client, observe_trace)
+        assert resp.status_code == status.HTTP_200_OK, resp.data
+        spans = resp.data["result"]["observation_span"]
+        child_entries = [s for s in spans if s["id"] == child.id]
+        assert len(child_entries) == 1
+        assert child_entries[0]["name"] == "llm turn v2"
+
+    def test_tombstoned_root_span_is_not_resurrected(
+        self, auth_client, observe_project, observe_trace
+    ):
+        """Dropping the explicit ``is_deleted = 0`` predicate must not leak
+        deleted spans: the two-arg RMT engine removes tombstoned rows under
+        FINAL, so a soft-deleted call returns 404 — the stale live version
+        must not be resurrected."""
+        span = _make_root_span(
+            observe_project,
+            observe_trace,
+            {"id": "call-del", "status": "ended"},
+        )
+        seed_ch_span(span)
+
+        span.deleted = True
+        seed_ch_span(span)  # tombstone: is_deleted=1, higher _version
+
+        resp = _get_detail(auth_client, observe_trace)
+        assert resp.status_code == status.HTTP_404_NOT_FOUND

--- a/futureagi/tracer/views/trace.py
+++ b/futureagi/tracer/views/trace.py
@@ -2635,13 +2635,13 @@ class TraceView(BaseModelViewSetMixin, ModelViewSet):
             attrs_number,
             attrs_bool,
             toJSONString(metadata) AS metadata_json
-        FROM spans
+        FROM spans FINAL
         WHERE project_id = toUUID(%(project_id)s)
           AND trace_id = %(trace_id)s
-          AND is_deleted = 0
           AND (parent_span_id IS NULL OR parent_span_id = '')
           AND observation_type = 'conversation'
         LIMIT 1
+        SETTINGS use_skip_indexes_if_final = 1
         """
         root_result = analytics.execute_ch_query(
             root_query,
@@ -2741,13 +2741,13 @@ class TraceView(BaseModelViewSetMixin, ModelViewSet):
             toJSONString(metadata) AS metadata_json,
             status_message,
             tags
-        FROM spans
+        FROM spans FINAL
         WHERE project_id = toUUID(%(project_id)s)
           AND trace_id = %(trace_id)s
-          AND is_deleted = 0
           AND parent_span_id IS NOT NULL
         ORDER BY start_time ASC
         LIMIT 1 BY id
+        SETTINGS use_skip_indexes_if_final = 1
         """
         child_result = analytics.execute_ch_query(
             child_query,


### PR DESCRIPTION
## Problem
model_hub placeholders with spaces in the name (e.g. {{Input Column}}) cannot be rendered — Jinja2, f-string and mustache require valid identifiers or normalized keys.

## Fix
Add normalize_var_name() (spaces -> underscores, strip invalid chars, guard leading digits) and apply it in the LLM prompt runner context building, f-string and mustache rendering paths. 3 files, +87/-18.