### PR TITLE
fix(tool-eval): restore VapiService access in ToolEvalAgent

### DIFF
--- a/futureagi/ee/agenthub/tool_eval_agent/tool_eval_agent.py
+++ b/futureagi/ee/agenthub/tool_eval_agent/tool_eval_agent.py
@@ -27,6 +27,10 @@ try:
     from ee.voice.services.types.voice import TranscriptMessage
 except ImportError:
     TranscriptMessage = None
+try:
+    from ee.voice.services.vapi_service import VapiService
+except ImportError:
+    VapiService = None
 from tracer.models.observability_provider import ProviderChoices
 
 
@@ -65,6 +69,18 @@ class ToolEvalAgent:
                 max_tokens=max_tokens,
                 provider=provider,
             )
+        self._vapi_service_inst = None
+
+    @property
+    def vapi_service(self):
+        """Lazy-instantiated VapiService instance."""
+        if self._vapi_service_inst is None:
+            if VapiService is None:
+                from ee.voice.services.vapi_service import VapiService as LazyVapiService
+                self._vapi_service_inst = LazyVapiService()
+            else:
+                self._vapi_service_inst = VapiService()
+        return self._vapi_service_inst
 
     def evaluate_tool_calls(
         self, messages: list[TranscriptMessage]
@@ -271,9 +287,10 @@ class ToolEvalAgent:
         if not vapi_data:
             # Fetch from VAPI API if not stored
             try:
-                vapi_data = self.vapi_service.get_call(
-                    call_execution.service_provider_call_id
-                )
+                if call_execution.service_provider_call_id:
+                    vapi_data = self.vapi_service.fetch_call(
+                        call_execution.service_provider_call_id
+                    )
             except Exception as e:
                 logger.error(f"Error fetching VAPI data: {str(e)}")
 
@@ -304,10 +321,14 @@ class ToolEvalAgent:
 
             # Use provided API key or fall back to default vapi_service
             if api_key:
-                vapi_service = VapiService(api_key=api_key)
-                vapi_data = vapi_service.get_call(vapi_call_id)
+                if VapiService is None:
+                    from ee.voice.services.vapi_service import VapiService as LazyVapiService
+                    vapi_inst = LazyVapiService(api_key=api_key)
+                else:
+                    vapi_inst = VapiService(api_key=api_key)
+                vapi_data = vapi_inst.fetch_call(vapi_call_id)
             else:
-                vapi_data = self.vapi_service.get_call(vapi_call_id)
+                vapi_data = self.vapi_service.fetch_call(vapi_call_id)
 
             # Extract messages from artifact
             artifact = vapi_data.get("artifact", {})


### PR DESCRIPTION
## Summary

`ToolEvalAgent._get_vapi_conversation_context()` currently fails when retrieving legacy VAPI conversation data because `VapiService` is not imported and `self.vapi_service` is not initialized.

This causes runtime `NameError` / `AttributeError` failures when VAPI conversation context is requested.

Closes #2156

## Type of change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change
- [ ] 📖 Documentation only
- [ ] 🧹 Chore / refactor
- [ ] 🚀 Performance improvement
- [ ] 🧪 Test-only change

---

## 1) What changes were done

**`futureagi/ee/agenthub/tool_eval_agent/tool_eval_agent.py`**

- Added the missing `VapiService` import.
- Added lazy access to `VapiService` through the `ToolEvalAgent` `vapi_service` property.
- Updated VAPI provider calls to use `fetch_call()`, which returns the raw VAPI response containing the required `artifact` and `messages` data.

---

## 2) Why the changes were done

`_get_vapi_conversation_context()` referenced `VapiService` without importing it.

When no API key was provided, the method also attempted to access `self.vapi_service`, although the attribute was never initialized.

As a result, legacy VAPI conversation context retrieval failed at runtime.

The fix restores the intended VAPI service access path and allows the conversation context to be retrieved correctly.

---

## 3) Tests / Verification

- `python3 -m py_compile futureagi/ee/agenthub/tool_eval_agent/tool_eval_agent.py`
- `ruff check futureagi/ee/agenthub/tool_eval_agent/tool_eval_agent.py`
- Verified that no `F821` undefined-name errors remain for `VapiService` or `vapi_service.

## Checklist

- [x] My code follows the code style guidelines
- [ ] I've added tests that prove my fix is effective
- [x] Python syntax verification passes
- [x] Ruff checks pass
- [x] No hardcoded secrets, URLs, or PII
- [x] PR title follows Conventional Commits (`fix: ...`)
- [x] Issue is linked (`#2156`)