### PR TITLE
fix(agentic-eval): resolve Azure OpenAI model extraction TypeError

### DIFF
--- a/futureagi/agentic_eval/core_evals/fi_utils/extract_model.py
+++ b/futureagi/agentic_eval/core_evals/fi_utils/extract_model.py
@@ -266,13 +266,17 @@ def _extract_model_name(
         if invocation_params.get("model_name"):
             return invocation_params.get("model_name")
 
-        deployment_name = None
-        if serialized.get("kwargs").get("openai_api_version"):
-            deployment_name = serialized.get("kwargs").get("deployment_version")
-        deployment_version = None
-        if serialized.get("kwargs").get("deployment_name"):
-            deployment_name = serialized.get("kwargs").get("deployment_name")
-        return deployment_name + "-" + deployment_version
+        ser_kwargs = serialized.get("kwargs") or {}
+        deployment_name = ser_kwargs.get("deployment_name") or ser_kwargs.get("azure_deployment")
+        deployment_version = ser_kwargs.get("deployment_version") or ser_kwargs.get("openai_api_version")
+
+        if deployment_name and deployment_version:
+            return f"{deployment_name}-{deployment_version}"
+        elif deployment_name:
+            return deployment_name
+        elif deployment_version:
+            return deployment_version
+        return None
 
     # anthropic
     model = _extract_model_by_pattern("Anthropic", serialized, "model", "anthropic")

--- a/futureagi/agentic_eval/core_evals/fi_utils/tests/test_extract_model.py
+++ b/futureagi/agentic_eval/core_evals/fi_utils/tests/test_extract_model.py
@@ -46,3 +46,41 @@ class TestExtractModelName:
                 serialized, invocation_params={"model_name": "gpt-4-turbo"}
             )
         assert result == "gpt-4-turbo"
+
+    def test_azure_openai_deployment_name_and_version(self):
+        serialized = _azure_serialized("AzureOpenAI")
+        serialized["kwargs"] = {
+            "deployment_name": "gpt-4-deployment",
+            "deployment_version": "2023-05-15",
+        }
+        with (
+            patch(
+                "agentic_eval.core_evals.fi_utils.extract_model._extract_model_by_key",
+                return_value=None,
+            ),
+            patch(
+                "agentic_eval.core_evals.fi_utils.extract_model._extract_model_by_pattern",
+                return_value=None,
+            ),
+        ):
+            result = _extract_model_name(serialized)
+        assert result == "gpt-4-deployment-2023-05-15"
+
+    def test_azure_openai_deployment_name_only(self):
+        serialized = _azure_serialized("AzureOpenAI")
+        serialized["kwargs"] = {
+            "deployment_name": "gpt-35-turbo",
+        }
+        with (
+            patch(
+                "agentic_eval.core_evals.fi_utils.extract_model._extract_model_by_key",
+                return_value=None,
+            ),
+            patch(
+                "agentic_eval.core_evals.fi_utils.extract_model._extract_model_by_pattern",
+                return_value=None,
+            ),
+        ):
+            result = _extract_model_name(serialized)
+        assert result == "gpt-35-turbo"
+


### PR DESCRIPTION
## Summary

Fixes a `TypeError` in `_extract_model_name()` when extracting Azure OpenAI model names from serialized objects.

Previously, `deployment_version` could be `None` when concatenated with `deployment_name`, causing:

`TypeError: can only concatenate str (not "NoneType") to str`

## Linked issues

Closes #2158

## Type of change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change
- [ ] 📖 Documentation only
- [ ] 🧹 Chore / refactor
- [ ] 🚀 Performance improvement
- [ ] 🧪 Test-only change

---

## 1) What changes were done

**A. Azure OpenAI Model Extraction**

- Extract `deployment_name` with `azure_deployment` as fallback.
- Extract `deployment_version` with `openai_api_version` as fallback.
- Safely construct the model identifier when one or both values are available.
- Prevent `NoneType` string concatenation errors.

**B. Regression Tests**

Added tests covering:

- Azure OpenAI with deployment name and version.
- Azure OpenAI with deployment name only.

---

## 2) Why the changes were done

Azure OpenAI model extraction could fail at runtime when `deployment_version` was unavailable.

The fix ensures model extraction handles missing deployment metadata without raising a `TypeError`.

---

## 3) Tests written + scenarios each covers

**`agentic_eval/core_evals/fi_utils/tests/test_extract_model.py`**

- `test_azure_chat_openai_none_invocation_params`
- `test_azure_openai_returns_model_name_from_invocation_params`
- `test_azure_openai_deployment_name_and_version`
- `test_azure_openai_deployment_name_only`

> Run result: **4 passed**. Ruff clean.

---

## 4) How to run / test

```bash
cd futureagi
.venv/bin/pytest agentic_eval/core_evals/fi_utils/tests/test_extract_model.py
ruff check futureagi/agentic_eval/core_evals/fi_utils/extract_model.py futureagi/agentic_eval/core_evals/fi_utils/tests/test_extract_model.py
````

---

## Checklist

* [x] My code follows the code style guidelines
* [x] I've added tests that prove my fix is effective
* [x] All unit tests pass locally
* [x] Ruff checks pass cleanly
* [x] No hardcoded secrets, URLs, or PII
* [x] PR title follows Conventional Commits (`fix(agentic-eval): ...`)

