### PR TITLE
fix(tracer): serve camelCase register options in the TypeScript onboarding snippets [TH-7548]

### DIFF
--- a/frontend/src/sections/project/ProjectFtux.jsx
+++ b/frontend/src/sections/project/ProjectFtux.jsx
@@ -5,6 +5,7 @@ import { useLocation } from "react-router-dom";
 
 import NewExperiment from "./NewProject/NewExperiment";
 import NewObserve from "./NewProject/NewObserve";
+import { PROJECT_FTUX_COPY } from "./common";
 
 const ProjectFtux = () => {
   const location = useLocation();
@@ -15,6 +16,10 @@ const ProjectFtux = () => {
     const isObserve = currentPath.includes("observe");
     setIsObserve(isObserve);
   }, [currentPath]);
+
+  const copy = isObserve
+    ? PROJECT_FTUX_COPY.observe
+    : PROJECT_FTUX_COPY.experiment;
 
   return (
     <Box
@@ -38,11 +43,11 @@ const ProjectFtux = () => {
         />
         <Box sx={{ height: "10px" }} />
         <Typography fontSize="20px" fontWeight={700} color="text.primary">
-          Welcome to {isObserve ? `Observe` : `Prototype`}
+          {copy.title}
         </Typography>
         <Box sx={{ height: "5px" }} />
         <Typography fontSize="14px" color="text.secondary">
-          Create a project to experiment on your model
+          {copy.description}
         </Typography>
         <Box sx={{ height: "20px" }} />
       </Box>

--- a/frontend/src/sections/project/ProjectFtux.test.jsx
+++ b/frontend/src/sections/project/ProjectFtux.test.jsx
@@ -1,0 +1,48 @@
+import { describe, it, expect, vi } from "vitest";
+import { renderWithRouter, screen } from "src/utils/test-utils";
+import ProjectFtux from "./ProjectFtux";
+import { PROJECT_FTUX_COPY, PROJECT_LIST_SUBTITLE } from "./common";
+
+vi.mock("./NewProject/NewObserve", () => ({ default: () => <div /> }));
+vi.mock("./NewProject/NewExperiment", () => ({ default: () => <div /> }));
+
+const PROMISES_A_CREATE_ACTION = /create a project/i;
+
+describe("ProjectFtux", () => {
+  it("greets an Observe user on the observe route", () => {
+    renderWithRouter(<ProjectFtux />, { route: "/dashboard/observe" });
+
+    expect(
+      screen.getByText(PROJECT_FTUX_COPY.observe.title),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(PROJECT_FTUX_COPY.observe.description),
+    ).toBeInTheDocument();
+  });
+
+  it("greets a Prototype user on its own route", () => {
+    renderWithRouter(<ProjectFtux />, { route: "/dashboard/prototype" });
+
+    expect(
+      screen.getByText(PROJECT_FTUX_COPY.experiment.title),
+    ).toBeInTheDocument();
+  });
+
+  it("never promises a create action, since the screen has none", () => {
+    renderWithRouter(<ProjectFtux />, { route: "/dashboard/observe" });
+
+    expect(
+      screen.queryByText(PROMISES_A_CREATE_ACTION),
+    ).not.toBeInTheDocument();
+  });
+});
+
+describe("project screen copy", () => {
+  it("promises no create action on either surface", () => {
+    [
+      PROJECT_FTUX_COPY.observe.description,
+      PROJECT_FTUX_COPY.experiment.description,
+      PROJECT_LIST_SUBTITLE,
+    ].forEach((copy) => expect(copy).not.toMatch(PROMISES_A_CREATE_ACTION));
+  });
+});

--- a/frontend/src/sections/project/ProjectWrapperView.jsx
+++ b/frontend/src/sections/project/ProjectWrapperView.jsx
@@ -32,6 +32,7 @@ import {
   PROJECT_FILTER_PROPERTIES,
   PROJECT_FILTER_DEFAULT_OPERATORS,
   PROJECT_FILTER_DEFAULT_ROW,
+  PROJECT_LIST_SUBTITLE,
   projectOperatorFilter,
 } from "./common";
 
@@ -211,7 +212,7 @@ const ProjectWrapperView = () => {
                 color="text.primary"
                 fontWeight={"fontWeightRegular"}
               >
-                Create a project to experiment on your model
+                {PROJECT_LIST_SUBTITLE}
               </Typography>
             </Box>
           </Box>

--- a/frontend/src/sections/project/common.js
+++ b/frontend/src/sections/project/common.js
@@ -63,6 +63,25 @@ export const PROJECT_FILTER_DEFAULT_ROW = {
   value: [],
 };
 
+// These screens have no create form; the project row is made at ingest by
+// get_or_create_project, so every surface says that instead of promising one.
+const PROJECT_CREATED_AT_INGEST =
+  "Your project is created automatically when the first trace arrives.";
+
+export const PROJECT_FTUX_COPY = {
+  observe: {
+    title: "Welcome to Observe",
+    description: `${PROJECT_CREATED_AT_INGEST} Run the snippet below to send one.`,
+  },
+  experiment: {
+    title: "Welcome to Prototype",
+    description: `${PROJECT_CREATED_AT_INGEST} Run the snippet below to send one.`,
+  },
+};
+
+// The populated list renders no snippet of its own; Add Project opens it.
+export const PROJECT_LIST_SUBTITLE = `${PROJECT_CREATED_AT_INGEST} Add Project opens the snippet.`;
+
 // Operators apply_project_list_filters can honor; hides the rest from the panel.
 const PROJECT_FILTER_SUPPORTED_OPS = new Set([
   "in",

--- a/futureagi/tracer/tests/test_project.py
+++ b/futureagi/tracer/tests/test_project.py
@@ -5,6 +5,7 @@ Tests for /tracer/project/ endpoints.
 """
 
 import json
+import re
 import uuid
 from datetime import UTC, timedelta
 
@@ -15,7 +16,7 @@ from rest_framework import status
 from accounts.models.user import OrgApiKey
 from model_hub.models.ai_model import AIModel
 from tracer.models.observation_span import ObservationSpan
-from tracer.models.project import Project
+from tracer.models.project import PROJECT_TYPES, Project
 from tracer.models.trace import Trace
 from tracer.models.trace_session import TraceSession
 
@@ -23,6 +24,40 @@ AUTH_REQUIRED_STATUS_CODES = (
     status.HTTP_401_UNAUTHORIZED,
     status.HTTP_403_FORBIDDEN,
 )
+
+PYTHON_LANGUAGE = "Python"
+TYPESCRIPT_LANGUAGE = "TypeScript"
+SDK_CODE_PROJECT_TYPES = tuple(value for value, _label in PROJECT_TYPES)
+
+# RegisterOptions accepted by register() in @traceai/fi-core 1.0.0 (otel.d.ts).
+FI_CORE_REGISTER_OPTIONS = frozenset(
+    {
+        "projectName",
+        "projectType",
+        "projectVersionName",
+        "evalTags",
+        "sessionName",
+        "metadata",
+        "batch",
+        "setGlobalTracerProvider",
+        "headers",
+        "verbose",
+        "endpoint",
+        "idGenerator",
+        "transport",
+    }
+)
+
+EXPERIMENT_TYPESCRIPT_REGISTER_OPTIONS = frozenset(
+    {"projectType", "projectName", "projectVersionName"}
+)
+OBSERVE_TYPESCRIPT_REGISTER_OPTIONS = frozenset({"projectType", "projectName"})
+PYTHON_REGISTER_KWARGS = ("project_type=", "project_name=")
+
+REGISTER_OPTIONS_BLOCK_PATTERN = re.compile(
+    r"register\(\s*\{(.*?)\n\s*\}\s*\)", re.DOTALL
+)
+REGISTER_OPTION_KEY_PATTERN = re.compile(r"^\s*([A-Za-z_$][\w$]*)\s*:", re.MULTILINE)
 
 
 def get_result(response):
@@ -55,6 +90,13 @@ def _traffic_sum(graph_payload):
 
 def get_result_from_graph(payload):
     return payload.get("result", payload)
+
+
+def extract_register_option_keys(typescript_snippet):
+    """Extract the option keys passed to register({...}) in a TypeScript snippet."""
+    options_block = REGISTER_OPTIONS_BLOCK_PATTERN.search(typescript_snippet)
+    assert options_block is not None, "snippet does not call register() with options"
+    return set(REGISTER_OPTION_KEY_PATTERN.findall(options_block.group(1)))
 
 
 @pytest.mark.integration
@@ -713,6 +755,50 @@ class TestProjectSDKCodeAPI:
             "/tracer/project/project_sdk_code/", {"project_type": "invalid"}
         )
         assert response.status_code == status.HTTP_400_BAD_REQUEST
+
+    def test_get_sdk_code_experiment_typescript_register_options(self, auth_client):
+        """Experiment TypeScript snippet passes exactly the camelCase register options."""
+        response = auth_client.get(
+            "/tracer/project/project_sdk_code/", {"project_type": "experiment"}
+        )
+        assert response.status_code == status.HTTP_200_OK
+        snippet = get_result(response)["project_add_code"][TYPESCRIPT_LANGUAGE]
+        assert (
+            extract_register_option_keys(snippet)
+            == EXPERIMENT_TYPESCRIPT_REGISTER_OPTIONS
+        )
+
+    def test_get_sdk_code_observe_typescript_register_options(self, auth_client):
+        """Observe TypeScript snippet passes exactly the camelCase register options."""
+        response = auth_client.get(
+            "/tracer/project/project_sdk_code/", {"project_type": "observe"}
+        )
+        assert response.status_code == status.HTTP_200_OK
+        snippet = get_result(response)["project_add_code"][TYPESCRIPT_LANGUAGE]
+        assert (
+            extract_register_option_keys(snippet) == OBSERVE_TYPESCRIPT_REGISTER_OPTIONS
+        )
+
+    def test_get_sdk_code_typescript_options_accepted_by_sdk(self, auth_client):
+        """TypeScript snippets only pass options the SDK's register() accepts."""
+        for project_type in SDK_CODE_PROJECT_TYPES:
+            response = auth_client.get(
+                "/tracer/project/project_sdk_code/", {"project_type": project_type}
+            )
+            assert response.status_code == status.HTTP_200_OK
+            snippet = get_result(response)["project_add_code"][TYPESCRIPT_LANGUAGE]
+            assert extract_register_option_keys(snippet) <= FI_CORE_REGISTER_OPTIONS
+
+    def test_get_sdk_code_python_keeps_snake_case_kwargs(self, auth_client):
+        """Python snippets keep the snake_case kwargs the Python SDK requires."""
+        for project_type in SDK_CODE_PROJECT_TYPES:
+            response = auth_client.get(
+                "/tracer/project/project_sdk_code/", {"project_type": project_type}
+            )
+            assert response.status_code == status.HTTP_200_OK
+            snippet = get_result(response)["project_add_code"][PYTHON_LANGUAGE]
+            for kwarg in PYTHON_REGISTER_KWARGS:
+                assert kwarg in snippet
 
 
 @pytest.mark.integration

--- a/futureagi/tracer/utils/constants.py
+++ b/futureagi/tracer/utils/constants.py
@@ -1,7 +1,11 @@
+from enum import Enum
+
 from tracer.utils.filter_operators import (
     LIST_FILTER_OPS,
     NO_VALUE_FILTER_OPS,
     RANGE_FILTER_OPS,
+)
+from tracer.utils.filter_operators import (
     SPAN_ATTR_ALLOWED_OPS as CONTRACT_SPAN_ATTR_ALLOWED_OPS,
 )
 
@@ -30,9 +34,9 @@ trace_provider = register(
 import { register, ProjectType } from "@traceai/fi-core";
 
 const tracerProvider = register({
-    project_type: ProjectType.EXPERIMENT,
-    project_name: "FUTURE_AGI",
-    project_version_name: "openai-exp",
+    projectType: ProjectType.EXPERIMENT,
+    projectName: "FUTURE_AGI",
+    projectVersionName: "openai-exp",
 });
 """,
 }
@@ -53,8 +57,8 @@ trace_provider = register(
 import { register, ProjectType } from "@traceai/fi-core";
 
 const tracerProvider = register({
-    project_type: ProjectType.OBSERVE,
-    project_name: "openai_project",
+    projectType: ProjectType.OBSERVE,
+    projectName: "openai_project",
 });
 """,
 }
@@ -379,9 +383,6 @@ PortkeyInstrumentor().instrument(tracer_provider=tracer_provider)
         },
     },
 }
-
-
-from enum import Enum
 
 
 class FilterType(Enum):


### PR DESCRIPTION
## Summary

The TypeScript onboarding snippet we hand every new user cannot work as printed. It passes snake_case keys to `register()`, which only accepts camelCase.

Two consequences, and the quieter one is the worse one:

- With no env var set, the first run throws before any user code executes: `Error: FI_PROJECT_NAME is not set`.
- With `FI_PROJECT_NAME` set, there is no throw at all. `projectType` is dropped just as silently and defaults to `EXPERIMENT`, so a user following the **Observe** snippet gets an EXPERIMENT-typed project and no error anywhere.

This changes both TypeScript code blocks to camelCase, and fixes the two project screens that told users to "create a project" on surfaces that have no create form.

Python is unaffected and deliberately untouched.

## Why it breaks / where

`register()` in `@traceai/fi-core` declares camelCase options only. From the published package, `dist/src/otel.d.ts:81`:

```ts
export interface RegisterOptions {
    projectName?: string;
    projectType?: ProjectType;
    projectVersionName?: string;
    ...
}
```

There is no snake_case aliasing anywhere in the SDK. The `project_name` constant at `otel.ts:33` is the OTel resource attribute key on the wire, not an options key.

Our snippet passed `project_name`, so `projectName` was `undefined`, the env fallback found nothing, and it threw at `otel.js:453`. `projectType` took the same path to `otel.js:433`, where the default is `EXPERIMENT`.

Reproduced against the real published SDK in an ESM project:

```
BEFORE  register({"project_type":"observe","project_name":"openai_project"})
  -> THREW: FI_PROJECT_NAME is not set

AFTER   register({"projectType":"observe","projectName":"openai_project"})
  -> OK. resource: {"project_name":"openai_project","project_type":"observe", ...}
```

### The copy half

Both project screens said "Create a project to experiment on your model":

- `ProjectFtux.jsx`, the zero-project screen
- `ProjectWrapperView.jsx:214`, the populated list header, which every user sees on every visit

`POST /tracer/project/` does exist (`tracer/views/project.py:190`, covered by `TestProjectCreateAPI` in this same test file). What does not exist is any path from these screens to it: `ProjectRightSection.jsx:86`'s "Add Project" button only opens a drawer rendering the same snippet, and `axios.js` maps the URL without ever POSTing to it from here.

That is deliberate rather than missing. Observe projects are keyed by name at ingest via `get_or_create_project` (`tracer/utils/otel.py:1103`), so a manually created project sits orphaned unless the user later types a `projectName` that matches it exactly. A create form on these screens invites that mismatch. The copy now says what actually happens.

## What changed

| File | Change |
| -- | -- |
| `futureagi/tracer/utils/constants.py` | `PROTOTYPE_CODEBLOCK["TypeScript"]` and `OBSERVE_CODEBLOCK["TypeScript"]` now pass `projectType` / `projectName` / `projectVersionName`. Python blocks unchanged. |
| `futureagi/tracer/utils/constants.py` | `from enum import Enum` moved to the top. See "The import move" below. |
| `frontend/src/sections/project/common.js` | One `PROJECT_CREATED_AT_INGEST` sentence, shared by `PROJECT_FTUX_COPY` and the new `PROJECT_LIST_SUBTITLE`. |
| `frontend/src/sections/project/ProjectFtux.jsx` | Reads `PROJECT_FTUX_COPY`. |
| `frontend/src/sections/project/ProjectWrapperView.jsx` | Reads `PROJECT_LIST_SUBTITLE` instead of the hardcoded duplicate. |
| `futureagi/tracer/tests/test_project.py` | 4 tests added to the existing `TestProjectSDKCodeAPI`. |
| `frontend/src/sections/project/ProjectFtux.test.jsx` | New file. No `ProjectFtux` test existed. |

### The import move

`from enum import Enum` sat at line 386, mid-file, and the repo's lint chain fails E402 on any commit that touches this file. The chain is `.husky/pre-commit` to `lint-staged` to `scripts/lint-staged-python.sh` to `uv run ruff check --fix` under `set -euo pipefail`. E402 has no autofix and `per-file-ignores` exempts `conftest.py` only, so it exits 1. Note the ruff block in `.pre-commit-config.yaml` is commented out and ruff runs in no CI workflow, so this is a local-commit gate, not a CI one.

A `# noqa: E402` would also have cleared it. Moving the import is the better fix given it is a two-line no-op, but it was a choice, not a forced one. The split into two `filter_operators` imports is ruff's own autofix output, not hand-editing.

## Tests included

| Test | Asserts | Red without the fix |
| -- | -- | -- |
| `test_get_sdk_code_experiment_typescript_register_options` | served Experiment snippet's option key set is exactly the camelCase set | yes |
| `test_get_sdk_code_observe_typescript_register_options` | served Observe snippet's option key set is exactly the camelCase set | yes |
| `test_get_sdk_code_typescript_options_accepted_by_sdk` | every key the snippet passes is one `RegisterOptions` accepts | yes |
| `test_get_sdk_code_python_keeps_snake_case_kwargs` | Python blocks keep `project_type=` / `project_name=` | guard branch, proven to fail when Python is camelCased |
| `ProjectFtux` greets an Observe user | title and description from the real imported constant, on the real route | yes |
| `ProjectFtux` greets a Prototype user | the other branch's title, on its own route | yes |
| `ProjectFtux` promises no create action | rendered screen carries no "create a project" text | yes |
| project screen copy promises no create action | both FTUX descriptions **and** `PROJECT_LIST_SUBTITLE` | yes, verified by putting the old string back |

Backend tests drive the real endpoint through `auth_client`, not the constants module, so they assert what the API actually serves to the UI. They compare the extracted key **set**, so a snake_case key added later also fails, which a substring check would miss.

The third backend test cannot fail independently today, since the two equality tests above it pin the exact set. It is kept because it states the durable contract rather than a snapshot: if a future snippet legitimately gains `sessionName`, the equality test gets updated and this one still guards against a key the SDK would ignore.

## Commands / verification

```bash
# backend
cd futureagi && source .venv/bin/activate
set -a && source .env.test.local && set +a
pytest tracer/tests/test_project.py -q
# 47 passed

# frontend
cd frontend
npx vitest run src/sections/project/ProjectFtux.test.jsx src/sections/project/NewProject
# 3 files, 6 tests passed
```

Red→green proven by reverting: 3 of the 4 new backend tests fail with `constants.py` reverted, and the copy guard fails when the old string is put back on either surface.

Note on CI coverage: the feature-branch frontend job runs `yarn test:unit` with `--testNamePattern="unit|Unit"`, so these frontend tests do not gate this PR. They run under `test:run` on `dev` after merge.

## Video

![TH-7548 walkthrough](https://raw.githubusercontent.com/abhijaisrivastava15/th7548-proof/main/th7548-walkthrough.gif)

BEFORE is `origin/dev`, AFTER is this branch, same click path on both: the Tracing
list header, then Add Project into the Typescript tab. Project rows are blurred in
capture because they are local dev project names and this clip is hosted publicly
(see "A note on where this media is hosted" below).

Same clip as MP4 if you want to scrub it: [`th7548-walkthrough.mp4`](https://raw.githubusercontent.com/abhijaisrivastava15/th7548-proof/main/th7548-walkthrough.mp4)

## Screenshot: before / after on the Observe onboarding screen

![Observe onboarding snippet, before and after](https://raw.githubusercontent.com/abhijaisrivastava15/th7548-proof/main/th7548-before-after.png)

And the copy half, on the populated Tracing list header that every user sees on every visit:

![Tracing list header, before and after](https://raw.githubusercontent.com/abhijaisrivastava15/th7548-proof/main/th7548-copy-before-after.png)

## Screenshot: local test suite run

![local test suite run](https://raw.githubusercontent.com/abhijaisrivastava15/th7548-proof/main/th7548-test-suite.png)

## A note on where this media is hosted

These render from a separate public assets repo
([`abhijaisrivastava15/th7548-proof`](https://github.com/abhijaisrivastava15/th7548-proof))
rather than GitHub's own user-attachments CDN. That CDN requires a logged-in browser
session, and every github.com **web** page for my account currently returns the
mandatory "Enable two-factor authentication" interstitial, so no compose surface
renders and no upload token can be obtained. The API and `gh` are unaffected, which
is why everything else here worked. Nothing is committed into this PR's branch.

## Backwards compatibility

| Caller | Reads | Affected |
| -- | -- | -- |
| `tracer/views/project.py:project_sdk_code` | `PROTOTYPE_CODEBLOCK` / `OBSERVE_CODEBLOCK` | serves the new string, no shape change |
| `frontend .../NewObserve.jsx`, `NewExperiment.jsx` | `project_add_code` envelope | unaffected, response shape identical |
| `frontend/scripts/api-journeys/journeys/app-core.mjs:12423` | `project_add_code.Python` | unaffected, Python blocks untouched |
| `frontend .../ProjectWrapperView.jsx` | renders `<ProjectFtux />`, and now `PROJECT_LIST_SUBTITLE` | copy only |

Blast radius checked at repo root with no path filter: `PROTOTYPE_CODEBLOCK` / `OBSERVE_CODEBLOCK` are referenced only by `constants.py` and `views/project.py`; `ProjectFtux` only by its own file and `ProjectWrapperView.jsx`.

## Manual verification

Ran the exact snippet the platform serves, verbatim, in a real ESM project against the published `@traceai/fi-core@1.0.0`. Before the change it throws; after it returns a provider carrying `project_type: "observe"`.

Then confirmed on the running dashboard: Observe → Add Project → Typescript tab renders camelCase. That is the screen the proof shots are taken from.

## Out of scope

- **Traces actually landing.** A user who copies the fixed snippet still sees zero spans, because of ESM import ordering, the `openai` major range, and the missing flush on exit. That is TH-7549, assigned to Kartik. This PR's job is that the snippet no longer throws or silently mis-types the project, and the screens no longer lie.
- **Wiring a create form** to the existing `POST /tracer/project/`. Reasoning above; if we want it, it needs the name-matching problem solved first.
- **The Observe Python/TypeScript gap.** The Python Observe block teaches `session_name`; the TypeScript one has no `sessionName`. The SDK supports it. The new tests lock in today's shape, so closing that gap means updating them.

## Type

Bug fix.

## Checklist

- [x] Root cause fixed, not worked around
- [x] Behavioral tests on the real call path, red if the fix is reverted
- [x] Negative branch covered (Python blocks stay snake_case)
- [x] Full test file green locally
- [x] Rebased on latest `dev`
- [x] Shared copy lives in one constant, both surfaces read it
- [x] No ticket references or AI attribution in source or test names

## Known pre-existing failures, not from this PR

The frontend suite has 33 failing test files on clean `origin/dev`, from a zustand store in `src/sections/develop-detail/states.jsx` calling `localStorage.getItem` inside an initializer that runs eagerly at import. Verified by reverting this branch's changes and re-running: identical failures. This appears to be a local jsdom artifact and may not reproduce in CI.

## Backout

Revert the single commit. Two string constants, one shared copy constant, and tests. Nothing persists and no migration is involved.

## Linear

Closes TH-7548
