### PR TITLE
fix(falcon-ai): show a connector's tools in the Customize pane [TH-7571]

### DIFF
--- a/frontend/src/sections/falcon-ai/components/ConnectorDetailError.jsx
+++ b/frontend/src/sections/falcon-ai/components/ConnectorDetailError.jsx
@@ -1,0 +1,34 @@
+import React from "react";
+import PropTypes from "prop-types";
+import Box from "@mui/material/Box";
+import Button from "@mui/material/Button";
+import Typography from "@mui/material/Typography";
+import Iconify from "src/components/iconify";
+
+/**
+ * Shown when a connector's detail record fails to load. Distinct from the
+ * "no tools discovered" empty state, which blames the connector for a request
+ * that never landed.
+ */
+export default function ConnectorDetailError({ message, onRetry }) {
+  return (
+    <Box sx={{ textAlign: "center", py: 3 }}>
+      <Iconify
+        icon="mdi:alert-circle-outline"
+        width={28}
+        sx={{ color: "error.main", mb: 1 }}
+      />
+      <Typography typography="s2_1" sx={{ color: "text.secondary", mb: 1.5 }}>
+        {message}
+      </Typography>
+      <Button size="small" variant="outlined" onClick={onRetry}>
+        Try again
+      </Button>
+    </Box>
+  );
+}
+
+ConnectorDetailError.propTypes = {
+  message: PropTypes.string,
+  onRetry: PropTypes.func,
+};

--- a/frontend/src/sections/falcon-ai/components/CustomizePanel.jsx
+++ b/frontend/src/sections/falcon-ai/components/CustomizePanel.jsx
@@ -1670,10 +1670,7 @@ function ConnectorDetailPanel({
   });
   const readOnlyTools = tools.filter((t) => !interactiveTools.includes(t));
 
-  const isToolEnabled = (tool) => {
-    if (enabledNames.length === 0 && tool.enabled !== false) return true;
-    return enabledNames.includes(tool.name) || tool.enabled === true;
-  };
+  const isToolEnabled = (tool) => enabledNames.includes(tool.name);
 
   return (
     <Box

--- a/frontend/src/sections/falcon-ai/components/CustomizePanel.jsx
+++ b/frontend/src/sections/falcon-ai/components/CustomizePanel.jsx
@@ -1670,7 +1670,10 @@ function ConnectorDetailPanel({
   });
   const readOnlyTools = tools.filter((t) => !interactiveTools.includes(t));
 
-  const isToolEnabled = (tool) => enabledNames.includes(tool.name);
+  const isToolEnabled = (tool) => {
+    if (enabledNames.length === 0 && tool.enabled !== false) return true;
+    return enabledNames.includes(tool.name) || tool.enabled === true;
+  };
 
   return (
     <Box

--- a/frontend/src/sections/falcon-ai/components/CustomizePanel.jsx
+++ b/frontend/src/sections/falcon-ai/components/CustomizePanel.jsx
@@ -20,6 +20,7 @@ import Chip from "@mui/material/Chip";
 import CircularProgress from "@mui/material/CircularProgress";
 import { alpha, useTheme } from "@mui/material/styles";
 import Iconify from "src/components/iconify";
+import CustomTooltip from "src/components/tooltip";
 import {
   listSkills,
   fetchConnectors,
@@ -31,7 +32,12 @@ import useFalconStore from "../store/useFalconStore";
 import ToolsSkeleton from "./ToolsSkeleton";
 import ConnectorDetailError from "./ConnectorDetailError";
 import { useConnectorToolPermissions } from "../hooks/useConnectorToolPermissions";
-import { resolveEnabledNames, toolActionErrorMessage } from "./connectorTools";
+import {
+  LAST_ENABLED_TOOL_HINT,
+  isOnlyEnabledTool,
+  resolveEnabledNames,
+  toolActionErrorMessage,
+} from "./connectorTools";
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -1320,6 +1326,7 @@ function ConnectorDetailPanel({
   onToolToggle,
   onToolsAllow,
   toolError,
+  pendingNames,
   loading,
   detailError,
   onRetry,
@@ -1892,7 +1899,12 @@ function ConnectorDetailPanel({
                     borderRadius: "6px",
                     cursor: "pointer",
                   }}
-                  onClick={() => onToolsAllow(connector.id, interactiveTools)}
+                  onClick={() =>
+                    onToolsAllow(
+                      connector.id,
+                      interactiveTools.map((t) => t.name),
+                    )
+                  }
                 />
               </Box>
               <Box
@@ -1907,7 +1919,9 @@ function ConnectorDetailPanel({
                     key={tool.name || idx}
                     tool={tool}
                     enabled={isToolEnabled(tool)}
-                    onToggle={() => onToolToggle(connector.id, tool)}
+                    onlyEnabled={isOnlyEnabledTool(connector, tool.name)}
+                    pending={pendingNames.includes(tool.name)}
+                    onToggle={() => onToolToggle(connector.id, tool.name)}
                     isLast={idx === interactiveTools.length - 1}
                     isDark={isDark}
                     theme={theme}
@@ -1960,7 +1974,12 @@ function ConnectorDetailPanel({
                     borderRadius: "6px",
                     cursor: "pointer",
                   }}
-                  onClick={() => onToolsAllow(connector.id, readOnlyTools)}
+                  onClick={() =>
+                    onToolsAllow(
+                      connector.id,
+                      readOnlyTools.map((t) => t.name),
+                    )
+                  }
                 />
               </Box>
               <Box
@@ -1975,7 +1994,9 @@ function ConnectorDetailPanel({
                     key={tool.name || idx}
                     tool={tool}
                     enabled={isToolEnabled(tool)}
-                    onToggle={() => onToolToggle(connector.id, tool)}
+                    onlyEnabled={isOnlyEnabledTool(connector, tool.name)}
+                    pending={pendingNames.includes(tool.name)}
+                    onToggle={() => onToolToggle(connector.id, tool.name)}
                     isLast={idx === readOnlyTools.length - 1}
                     isDark={isDark}
                     theme={theme}
@@ -2045,6 +2066,7 @@ ConnectorDetailPanel.propTypes = {
   onToolToggle: PropTypes.func,
   onToolsAllow: PropTypes.func,
   toolError: PropTypes.string,
+  pendingNames: PropTypes.arrayOf(PropTypes.string),
   loading: PropTypes.bool,
   detailError: PropTypes.string,
   onRetry: PropTypes.func,
@@ -2054,7 +2076,16 @@ ConnectorDetailPanel.propTypes = {
 };
 
 // Tool row component for clean per-item rendering
-function ToolRow({ tool, enabled, onToggle, isLast, isDark, theme }) {
+function ToolRow({
+  tool,
+  enabled,
+  onlyEnabled,
+  pending,
+  onToggle,
+  isLast,
+  isDark,
+  theme,
+}) {
   return (
     <Box
       sx={{
@@ -2090,21 +2121,37 @@ function ToolRow({ tool, enabled, onToggle, isLast, isDark, theme }) {
         )}
       </Box>
       <Box sx={{ display: "flex", alignItems: "center", gap: 0.25 }}>
-        <IconButton
+        {/* The guard refuses this click; say so before it, not after. */}
+        <CustomTooltip
+          show={onlyEnabled}
+          arrow
           size="small"
-          onClick={onToggle}
-          title={enabled ? "Allowed" : "Denied"}
-          sx={{
-            width: 26,
-            height: 26,
-            color: enabled ? "success.main" : "text.disabled",
-          }}
+          placement="left"
+          title={LAST_ENABLED_TOOL_HINT}
         >
-          <Iconify
-            icon={enabled ? "mdi:check-circle" : "mdi:close-circle-outline"}
-            width={18}
-          />
-        </IconButton>
+          <IconButton
+            size="small"
+            onClick={onToggle}
+            // The accessible name stays put; the native title is suppressed
+            // under the tooltip so the two don't stack on hover.
+            aria-label={enabled ? "Allowed" : "Denied"}
+            title={onlyEnabled ? undefined : enabled ? "Allowed" : "Denied"}
+            sx={{
+              width: 26,
+              height: 26,
+              color: enabled ? "success.main" : "text.disabled",
+            }}
+          >
+            {pending ? (
+              <CircularProgress size={16} role="status" aria-label="Saving" />
+            ) : (
+              <Iconify
+                icon={enabled ? "mdi:check-circle" : "mdi:close-circle-outline"}
+                width={18}
+              />
+            )}
+          </IconButton>
+        </CustomTooltip>
       </Box>
     </Box>
   );
@@ -2118,6 +2165,8 @@ ToolRow.propTypes = {
     enabled: PropTypes.bool,
   }).isRequired,
   enabled: PropTypes.bool,
+  onlyEnabled: PropTypes.bool,
+  pending: PropTypes.bool,
   onToggle: PropTypes.func.isRequired,
   isLast: PropTypes.bool,
   isDark: PropTypes.bool,
@@ -2137,12 +2186,33 @@ export default function CustomizePanel() {
   const [selectedItem, setSelectedItem] = useState(null);
   const [connectorDetailLoading, setConnectorDetailLoading] = useState(false);
   const [detailError, setDetailError] = useState(null);
-  const { toolError, setToolError, handleToolToggle, handleToolsAllow } =
-    useConnectorToolPermissions({
-      selectedItem,
-      setSelectedItem,
-      setConnectors,
-    });
+  const applyToolNames = useCallback(
+    (connectorId, names) => {
+      setSelectedItem((prev) =>
+        prev?.id === connectorId
+          ? { ...prev, enabled_tool_names: names }
+          : prev,
+      );
+      // tool_count is the only tool-derived field the list carries.
+      setConnectors((prev) =>
+        prev.map((c) =>
+          c.id === connectorId ? { ...c, tool_count: names.length } : c,
+        ),
+      );
+    },
+    [setSelectedItem, setConnectors],
+  );
+
+  const {
+    toolError,
+    setToolError,
+    pendingNames,
+    handleToolToggle,
+    handleToolsAllow,
+  } = useConnectorToolPermissions({
+    connector: selectedItem,
+    onApply: applyToolNames,
+  });
   const [loadingSkills, setLoadingSkills] = useState(false);
   const [loadingConnectors, setLoadingConnectors] = useState(false);
   const [isEditingSkill, setIsEditingSkill] = useState(false);
@@ -2470,6 +2540,7 @@ export default function CustomizePanel() {
             onToolToggle={handleToolToggle}
             onToolsAllow={handleToolsAllow}
             toolError={toolError}
+            pendingNames={pendingNames}
             loading={connectorDetailLoading}
             detailError={detailError}
             onRetry={() => handleSelectItem(selectedItem)}

--- a/frontend/src/sections/falcon-ai/components/CustomizePanel.jsx
+++ b/frontend/src/sections/falcon-ai/components/CustomizePanel.jsx
@@ -1,4 +1,10 @@
-import React, { useEffect, useState, useCallback, useMemo } from "react";
+import React, {
+  useEffect,
+  useState,
+  useCallback,
+  useMemo,
+  useRef,
+} from "react";
 import PropTypes from "prop-types";
 import Box from "@mui/material/Box";
 import Typography from "@mui/material/Typography";
@@ -2142,6 +2148,19 @@ export default function CustomizePanel() {
   const [isEditingSkill, setIsEditingSkill] = useState(false);
   const [isEditingConnector, setIsEditingConnector] = useState(false);
 
+  // Monotonic ticket for the detail fetch kicked off by handleSelectItem.
+  // Bumped whenever the selection is cleared/changed out from under it, so a
+  // response that lands after a newer selection can't overwrite it.
+  const detailRequestRef = useRef(0);
+
+  // Abandon any in-flight detail fetch. Its response is ignored once the
+  // ticket moves, which means its `finally` no longer clears the loading flag
+  // either — so clear it here, or the pane keeps a skeleton up forever.
+  const abandonDetailRequest = useCallback(() => {
+    detailRequestRef.current += 1;
+    setConnectorDetailLoading(false);
+  }, []);
+
   // ---- Load data ----
   const loadSkills = useCallback(async () => {
     setLoadingSkills(true);
@@ -2178,10 +2197,14 @@ export default function CustomizePanel() {
   }, [loadSkills, loadConnectors]);
 
   // ---- Handlers ----
-  const handleTabChange = useCallback((tab) => {
-    setSelectedTab(tab);
-    setSelectedItem(null);
-  }, []);
+  const handleTabChange = useCallback(
+    (tab) => {
+      abandonDetailRequest();
+      setSelectedTab(tab);
+      setSelectedItem(null);
+    },
+    [abandonDetailRequest],
+  );
 
   const handleSelectItem = useCallback(
     async (item) => {
@@ -2191,7 +2214,17 @@ export default function CustomizePanel() {
       setToolError(null); // stale error from the previously selected connector
       setDetailError(null);
 
-      if (!item?.id) return;
+      if (!item?.id) {
+        abandonDetailRequest();
+        return;
+      }
+
+      // Each call gets its own ticket; a response is only applied if it's
+      // still the most recent one requested. Without this, selecting B while
+      // A's detail fetch is still in flight lets A's late response clobber
+      // B's once it resolves out of order.
+      const ticket = ++detailRequestRef.current;
+      const isStale = () => ticket !== detailRequestRef.current;
 
       // Both tabs list from an endpoint whose serializer is a summary: skills
       // arrive without instructions, connectors without discovered_tools or
@@ -2202,64 +2235,84 @@ export default function CustomizePanel() {
         const api = await import("../hooks/useFalconAPI");
         if (selectedTab === "skills") {
           const resp = await api.getSkill(item.id);
+          if (isStale()) return;
           setSelectedItem(resp.result || resp);
         } else if (selectedTab === "connectors") {
-          setSelectedItem(await api.getConnector(item.id));
+          const detail = await api.getConnector(item.id);
+          if (isStale()) return;
+          setSelectedItem(detail);
         }
       } catch (error) {
+        if (isStale()) return;
         setDetailError(
           toolActionErrorMessage(error, "Couldn't load this connector."),
         );
       } finally {
-        setConnectorDetailLoading(false);
+        if (!isStale()) setConnectorDetailLoading(false);
       }
     },
-    [selectedTab],
+    [selectedTab, abandonDetailRequest],
   );
 
   const handleCreateSkill = useCallback(() => {
+    abandonDetailRequest();
     setSelectedItem(null);
     setIsEditingSkill(true);
-  }, []);
+  }, [abandonDetailRequest]);
 
-  const handleEditSkill = useCallback((skill) => {
-    setSelectedItem(skill);
-    setIsEditingSkill(true);
-  }, []);
+  const handleEditSkill = useCallback(
+    (skill) => {
+      abandonDetailRequest();
+      setSelectedItem(skill);
+      setIsEditingSkill(true);
+    },
+    [abandonDetailRequest],
+  );
 
-  const handleDuplicateSkill = useCallback((skill) => {
-    // Pre-fill form with skill data but clear id so it creates a new one
-    setSelectedItem({
-      ...skill,
-      id: null,
-      name: `${skill.name} (copy)`,
-      is_system: false,
-      is_builtin: false,
-    });
-    setIsEditingSkill(true);
-  }, []);
+  const handleDuplicateSkill = useCallback(
+    (skill) => {
+      abandonDetailRequest();
+      // Pre-fill form with skill data but clear id so it creates a new one
+      setSelectedItem({
+        ...skill,
+        id: null,
+        name: `${skill.name} (copy)`,
+        is_system: false,
+        is_builtin: false,
+      });
+      setIsEditingSkill(true);
+    },
+    [abandonDetailRequest],
+  );
 
   const handleSkillSaved = useCallback(() => {
+    abandonDetailRequest();
     loadSkills();
     setSelectedItem(null);
     setIsEditingSkill(false);
-  }, [loadSkills]);
+  }, [loadSkills, abandonDetailRequest]);
 
   const handleCreateConnector = useCallback(() => {
+    abandonDetailRequest();
     setSelectedItem(null);
     setIsEditingConnector(true);
-  }, []);
+  }, [abandonDetailRequest]);
 
-  const handleEditConnector = useCallback((conn) => {
-    setSelectedItem(conn);
-    setIsEditingConnector(true);
-  }, []);
+  const handleEditConnector = useCallback(
+    (conn) => {
+      abandonDetailRequest();
+      setSelectedItem(conn);
+      setIsEditingConnector(true);
+    },
+    [abandonDetailRequest],
+  );
 
   const handleConnectorSaved = useCallback(() => {
+    abandonDetailRequest();
     loadConnectors();
     setSelectedItem(null);
     setIsEditingConnector(false);
-  }, [loadConnectors]);
+  }, [loadConnectors, abandonDetailRequest]);
 
   // Listen for OAuth callback postMessage from popup
   useEffect(() => {
@@ -2284,12 +2337,16 @@ export default function CustomizePanel() {
           // if this fails, the connector data from loadConnectors is still valid.
         }
 
-        // Fetch the updated connector list to get the connector with tools
+        // Re-select through handleSelectItem rather than assigning the row:
+        // the list serializer carries neither discovered_tools nor
+        // enabled_tool_names, so assigning it would blank the tools the user
+        // just authorised. handleSelectItem fetches the detail record and
+        // takes a ticket, so a slow response can't land on a newer selection.
         try {
           const data = await fetchConnectors();
           const results = data.results || data || [];
           const updated = results.find((c) => c.id === connectorId);
-          if (updated) setSelectedItem(updated);
+          if (updated) await handleSelectItem(updated);
         } catch {
           // silent — loadConnectors already refreshed the list
         }
@@ -2297,7 +2354,7 @@ export default function CustomizePanel() {
     };
     window.addEventListener("message", handler);
     return () => window.removeEventListener("message", handler);
-  }, [loadConnectors, selectedItem?.id]);
+  }, [loadConnectors, selectedItem?.id, handleSelectItem]);
 
   const handleReauth = useCallback(
     async (connectorId) => {
@@ -2342,15 +2399,19 @@ export default function CustomizePanel() {
     [loadConnectors, connectors],
   );
 
-  const handleDisconnect = useCallback(async (connectorId) => {
-    try {
-      await deleteConnector(connectorId);
-      setConnectors((prev) => prev.filter((c) => c.id !== connectorId));
-      setSelectedItem(null);
-    } catch {
-      // silent
-    }
-  }, []);
+  const handleDisconnect = useCallback(
+    async (connectorId) => {
+      try {
+        await deleteConnector(connectorId);
+        abandonDetailRequest();
+        setConnectors((prev) => prev.filter((c) => c.id !== connectorId));
+        setSelectedItem(null);
+      } catch {
+        // silent
+      }
+    },
+    [abandonDetailRequest],
+  );
 
   // ---- Render ----
   return (

--- a/frontend/src/sections/falcon-ai/components/CustomizePanel.jsx
+++ b/frontend/src/sections/falcon-ai/components/CustomizePanel.jsx
@@ -22,6 +22,10 @@ import {
   discoverConnectorTools,
 } from "../hooks/useFalconAPI";
 import useFalconStore from "../store/useFalconStore";
+import ToolsSkeleton from "./ToolsSkeleton";
+import ConnectorDetailError from "./ConnectorDetailError";
+import { useConnectorToolPermissions } from "../hooks/useConnectorToolPermissions";
+import { resolveEnabledNames, toolActionErrorMessage } from "./connectorTools";
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -1308,6 +1312,11 @@ function ConnectorDetailPanel({
   onDisconnect,
   onReauth,
   onToolToggle,
+  onToolsAllow,
+  toolError,
+  loading,
+  detailError,
+  onRetry,
   onSaved,
   onCancelEdit,
   onEdit,
@@ -1824,6 +1833,16 @@ function ConnectorDetailPanel({
             Choose when Falcon is allowed to use these tools.
           </Typography>
 
+          {toolError && (
+            <Typography
+              role="alert"
+              typography="s2"
+              sx={{ color: "error.main", mb: 2 }}
+            >
+              {toolError}
+            </Typography>
+          )}
+
           {/* Interactive tools */}
           {interactiveTools.length > 0 && (
             <Box sx={{ mb: 2 }}>
@@ -1867,11 +1886,7 @@ function ConnectorDetailPanel({
                     borderRadius: "6px",
                     cursor: "pointer",
                   }}
-                  onClick={() =>
-                    interactiveTools.forEach((t) => {
-                      if (!isToolEnabled(t)) onToolToggle(connector.id, t);
-                    })
-                  }
+                  onClick={() => onToolsAllow(connector.id, interactiveTools)}
                 />
               </Box>
               <Box
@@ -1939,11 +1954,7 @@ function ConnectorDetailPanel({
                     borderRadius: "6px",
                     cursor: "pointer",
                   }}
-                  onClick={() =>
-                    readOnlyTools.forEach((t) => {
-                      if (!isToolEnabled(t)) onToolToggle(connector.id, t);
-                    })
-                  }
+                  onClick={() => onToolsAllow(connector.id, readOnlyTools)}
                 />
               </Box>
               <Box
@@ -1970,7 +1981,15 @@ function ConnectorDetailPanel({
         </Box>
       )}
 
-      {tools.length === 0 && (
+      {/* The list row carries no tools, so without this the pane would answer
+          "nothing discovered" for every connector until its detail lands. */}
+      {loading && <ToolsSkeleton />}
+
+      {!loading && detailError && (
+        <ConnectorDetailError message={detailError} onRetry={onRetry} />
+      )}
+
+      {!loading && !detailError && tools.length === 0 && (
         <Box sx={{ textAlign: "center", py: 3 }}>
           <Iconify
             icon="mdi:tools"
@@ -2018,6 +2037,11 @@ ConnectorDetailPanel.propTypes = {
   onDisconnect: PropTypes.func,
   onReauth: PropTypes.func,
   onToolToggle: PropTypes.func,
+  onToolsAllow: PropTypes.func,
+  toolError: PropTypes.string,
+  loading: PropTypes.bool,
+  detailError: PropTypes.string,
+  onRetry: PropTypes.func,
   onSaved: PropTypes.func,
   onCancelEdit: PropTypes.func,
   onEdit: PropTypes.func,
@@ -2105,6 +2129,14 @@ export default function CustomizePanel() {
   const [skills, setSkills] = useState([]);
   const [connectors, setConnectors] = useState([]);
   const [selectedItem, setSelectedItem] = useState(null);
+  const [connectorDetailLoading, setConnectorDetailLoading] = useState(false);
+  const [detailError, setDetailError] = useState(null);
+  const { toolError, setToolError, handleToolToggle, handleToolsAllow } =
+    useConnectorToolPermissions({
+      selectedItem,
+      setSelectedItem,
+      setConnectors,
+    });
   const [loadingSkills, setLoadingSkills] = useState(false);
   const [loadingConnectors, setLoadingConnectors] = useState(false);
   const [isEditingSkill, setIsEditingSkill] = useState(false);
@@ -2156,17 +2188,30 @@ export default function CustomizePanel() {
       setSelectedItem(item); // show immediately with list data
       setIsEditingSkill(false);
       setIsEditingConnector(false);
+      setToolError(null); // stale error from the previously selected connector
+      setDetailError(null);
 
-      // For skills, fetch full detail (includes instructions)
-      if (selectedTab === "skills" && item?.id) {
-        try {
-          const { getSkill } = await import("../hooks/useFalconAPI");
-          const resp = await getSkill(item.id);
-          const fullSkill = resp.result || resp;
-          setSelectedItem(fullSkill);
-        } catch {
-          // keep partial data from list
+      if (!item?.id) return;
+
+      // Both tabs list from an endpoint whose serializer is a summary: skills
+      // arrive without instructions, connectors without discovered_tools or
+      // enabled_tool_names. Either pane needs the detail record before it can
+      // render what it is for.
+      setConnectorDetailLoading(selectedTab === "connectors");
+      try {
+        const api = await import("../hooks/useFalconAPI");
+        if (selectedTab === "skills") {
+          const resp = await api.getSkill(item.id);
+          setSelectedItem(resp.result || resp);
+        } else if (selectedTab === "connectors") {
+          setSelectedItem(await api.getConnector(item.id));
         }
+      } catch (error) {
+        setDetailError(
+          toolActionErrorMessage(error, "Couldn't load this connector."),
+        );
+      } finally {
+        setConnectorDetailLoading(false);
       }
     },
     [selectedTab],
@@ -2307,32 +2352,6 @@ export default function CustomizePanel() {
     }
   }, []);
 
-  const handleToolToggle = useCallback(
-    async (connectorId, tool) => {
-      const conn = connectors.find((c) => c.id === connectorId);
-      if (!conn) return;
-      const updatedTools = (conn.tools || []).map((t) =>
-        (t.name || t.id) === (tool.name || tool.id)
-          ? { ...t, enabled: t.enabled === false }
-          : t,
-      );
-      try {
-        await updateConnectorTools(connectorId, updatedTools);
-        setConnectors((prev) =>
-          prev.map((c) =>
-            c.id === connectorId ? { ...c, tools: updatedTools } : c,
-          ),
-        );
-        setSelectedItem((prev) =>
-          prev?.id === connectorId ? { ...prev, tools: updatedTools } : prev,
-        );
-      } catch {
-        // silent
-      }
-    },
-    [connectors],
-  );
-
   // ---- Render ----
   return (
     <>
@@ -2388,6 +2407,11 @@ export default function CustomizePanel() {
             onDisconnect={handleDisconnect}
             onReauth={handleReauth}
             onToolToggle={handleToolToggle}
+            onToolsAllow={handleToolsAllow}
+            toolError={toolError}
+            loading={connectorDetailLoading}
+            detailError={detailError}
+            onRetry={() => handleSelectItem(selectedItem)}
             onEdit={handleEditConnector}
             onSaved={handleConnectorSaved}
             onCancelEdit={() => setIsEditingConnector(false)}

--- a/frontend/src/sections/falcon-ai/components/ToolsSkeleton.jsx
+++ b/frontend/src/sections/falcon-ai/components/ToolsSkeleton.jsx
@@ -1,0 +1,106 @@
+import React from "react";
+import PropTypes from "prop-types";
+import Box from "@mui/material/Box";
+import Skeleton from "@mui/material/Skeleton";
+import Typography from "@mui/material/Typography";
+
+/**
+ * Placeholder for a connector's tool list while its detail record loads.
+ *
+ * Both connector surfaces read tools from the detail endpoint while showing a
+ * list row that has none, so without this each renders "no tools discovered"
+ * mid-flight — blaming the connector for a request still in the air.
+ *
+ * Mirrors the loaded layout element for element so nothing moves when the real
+ * tools arrive. Static copy renders for real rather than as bars; only what
+ * depends on the response is a skeleton. Defaults match the Customize pane;
+ * the settings page supplies its own heading and passes `title={null}`.
+ */
+export default function ToolsSkeleton({
+  title = "Tool permissions",
+  subtitle = "Choose when Falcon is allowed to use these tools.",
+  groupHeader = true,
+  trailing = "icon",
+  rows = 3,
+}) {
+  return (
+    <Box role="status" aria-label="Loading tools">
+      {title && (
+        <Typography
+          typography="s2_1"
+          fontWeight="fontWeightSemiBold"
+          sx={{ mb: 1.5 }}
+        >
+          {title}
+        </Typography>
+      )}
+      {subtitle && (
+        <Typography typography="s2" sx={{ color: "text.secondary", mb: 2 }}>
+          {subtitle}
+        </Typography>
+      )}
+
+      {/* Group header: label + count on the left, "Always allow" on the right */}
+      {groupHeader && (
+        <Box
+          sx={{
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "space-between",
+            mb: 0.75,
+          }}
+        >
+          <Box sx={{ display: "flex", alignItems: "center", gap: 0.75 }}>
+            <Skeleton variant="circular" width={14} height={14} />
+            <Skeleton variant="text" width={88} height={16} />
+            <Skeleton variant="rounded" width={18} height={18} />
+          </Box>
+          <Skeleton variant="rounded" width={74} height={22} />
+        </Box>
+      )}
+
+      <Box
+        sx={{
+          borderRadius: "8px",
+          border: (t) => `1px solid ${t.palette.divider}`,
+          overflow: "hidden",
+        }}
+      >
+        {Array.from({ length: rows }, (_, i) => (
+          <Box
+            key={i}
+            sx={{
+              display: "flex",
+              alignItems: "center",
+              justifyContent: "space-between",
+              px: 2,
+              py: 1,
+              borderBottom:
+                i === rows - 1
+                  ? "none"
+                  : (t) => `1px solid ${t.palette.divider}`,
+            }}
+          >
+            <Box sx={{ flex: 1, mr: 1 }}>
+              <Skeleton variant="text" width={132} height={18} />
+              <Skeleton variant="text" width="62%" height={13} />
+            </Box>
+            {trailing === "switch" ? (
+              <Skeleton variant="rounded" width={34} height={20} />
+            ) : (
+              <Skeleton variant="circular" width={18} height={18} />
+            )}
+          </Box>
+        ))}
+      </Box>
+    </Box>
+  );
+}
+
+ToolsSkeleton.propTypes = {
+  title: PropTypes.string,
+  subtitle: PropTypes.string,
+  groupHeader: PropTypes.bool,
+  trailing: PropTypes.oneOf(["icon", "switch"]),
+  rows: PropTypes.number,
+};

--- a/frontend/src/sections/falcon-ai/components/__tests__/customize-connector-tools.test.jsx
+++ b/frontend/src/sections/falcon-ai/components/__tests__/customize-connector-tools.test.jsx
@@ -4,7 +4,7 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { render, screen, waitFor, fireEvent, act } from "src/utils/test-utils";
 
 import CustomizePanel from "../CustomizePanel";
-import { resolveEnabledNames } from "../connectorTools";
+import { isOnlyEnabledTool, resolveEnabledNames } from "../connectorTools";
 import { falconAIQueryKeys } from "../../hooks/useFalconAPI";
 
 const mocks = vi.hoisted(() => ({
@@ -125,6 +125,46 @@ describe("resolveEnabledNames", () => {
   it("yields nothing for a connector with no tools at all", () => {
     expect(resolveEnabledNames(LIST_ROW)).toEqual([]);
   });
+
+  it("reads string-shaped tools, which the settings page also renders", () => {
+    expect(
+      resolveEnabledNames({
+        discovered_tools: ["ask_question", "read_wiki_contents"],
+        enabled_tool_names: [],
+      }),
+    ).toEqual(["ask_question", "read_wiki_contents"]);
+  });
+});
+
+describe("isOnlyEnabledTool", () => {
+  it("marks the single remaining enabled tool", () => {
+    const connector = { ...DETAIL, enabled_tool_names: ["ask_question"] };
+    expect(isOnlyEnabledTool(connector, "ask_question")).toBe(true);
+    expect(isOnlyEnabledTool(connector, "read_wiki_contents")).toBe(false);
+  });
+
+  it("marks nothing while more than one tool is enabled", () => {
+    const connector = {
+      ...DETAIL,
+      enabled_tool_names: ["ask_question", "read_wiki_contents"],
+    };
+    expect(isOnlyEnabledTool(connector, "ask_question")).toBe(false);
+  });
+
+  it("resolves the sentinel first, so all-enabled marks nothing", () => {
+    expect(
+      isOnlyEnabledTool({ ...DETAIL, enabled_tool_names: [] }, "ask_question"),
+    ).toBe(false);
+  });
+
+  it("marks the tool when a connector has exactly one", () => {
+    // The sentinel resolves to that single tool, so it is already the last.
+    const connector = {
+      discovered_tools: [{ name: "ask_question" }],
+      enabled_tool_names: [],
+    };
+    expect(isOnlyEnabledTool(connector, "ask_question")).toBe(true);
+  });
 });
 
 describe("Customize panel — connector tools", () => {
@@ -209,7 +249,7 @@ describe("Customize panel — connector tools", () => {
     await openConnector();
     await screen.findByText("ask_question");
 
-    fireEvent.click(screen.getAllByTitle("Allowed")[0]);
+    fireEvent.click(screen.getAllByLabelText("Allowed")[0]);
 
     await waitFor(() => expect(mocks.updateConnectorTools).toHaveBeenCalled());
     const [connectorId, names] = mocks.updateConnectorTools.mock.calls[0];
@@ -235,7 +275,7 @@ describe("Customize panel — connector tools", () => {
     await openConnector(queryClient);
     await screen.findByText("ask_question");
 
-    fireEvent.click(screen.getAllByTitle("Allowed")[0]);
+    fireEvent.click(screen.getAllByLabelText("Allowed")[0]);
     await waitFor(() => expect(mocks.updateConnectorTools).toHaveBeenCalled());
 
     const cached = queryClient.getQueryData(
@@ -258,12 +298,262 @@ describe("Customize panel — connector tools", () => {
     await openConnector();
     await screen.findByText("ask_question");
 
-    fireEvent.click(screen.getAllByTitle("Allowed")[0]);
+    fireEvent.click(screen.getAllByLabelText("Allowed")[0]);
 
     expect(await screen.findByRole("alert")).toHaveTextContent(
-      /Keep at least one tool enabled/i,
+      /At least one tool must stay allowed/i,
     );
     expect(mocks.updateConnectorTools).not.toHaveBeenCalled();
+  });
+
+  it("shows the write in flight rather than a toggle that does nothing", async () => {
+    // The icon is driven by the server's answer, so a slow PATCH leaves the
+    // row looking untouched — indistinguishable from a dead control.
+    const deferred = createDeferred();
+    mocks.updateConnectorTools.mockReturnValue(deferred.promise);
+
+    await openConnector();
+    await screen.findByText("ask_question");
+
+    fireEvent.click(screen.getAllByLabelText("Allowed")[0]);
+
+    expect(await screen.findByLabelText("Saving")).toBeInTheDocument();
+
+    // And a second click cannot queue a write against the stale snapshot.
+    fireEvent.click(screen.getAllByLabelText("Allowed")[0]);
+    expect(mocks.updateConnectorTools).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      deferred.resolve({});
+    });
+    await waitFor(() =>
+      expect(screen.queryByLabelText("Saving")).not.toBeInTheDocument(),
+    );
+  });
+
+  it("coalesces clicks made while a write is out instead of losing them", async () => {
+    // The bug: each click built a full list from the record on screen, which
+    // only advances when its own request lands. Two in flight meant two lists
+    // computed from the same snapshot, and the last to arrive won — reverting
+    // the other. Reproduced on dev over 3G with three overlapping PATCHes.
+    const first = createDeferred();
+    const second = createDeferred();
+    mocks.updateConnectorTools
+      .mockReturnValueOnce(first.promise)
+      .mockReturnValueOnce(second.promise);
+
+    await openConnector();
+    await screen.findByText("ask_question");
+
+    // Deny ask_question, then read_wiki_contents before the first lands. The
+    // second click targets index 0 again because the first row already reads
+    // as Denied — the optimistic half of the fix.
+    fireEvent.click(screen.getAllByLabelText("Allowed")[0]);
+    fireEvent.click(screen.getAllByLabelText("Allowed")[0]);
+
+    // Only one request is ever out.
+    expect(mocks.updateConnectorTools).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      first.resolve({});
+    });
+
+    await waitFor(() =>
+      expect(mocks.updateConnectorTools).toHaveBeenCalledTimes(2),
+    );
+    // The follow-up carries the newest set, not the one the click computed.
+    expect(mocks.updateConnectorTools.mock.calls[1][1]).toEqual([
+      "read_wiki_structure",
+    ]);
+
+    await act(async () => {
+      second.resolve({});
+    });
+
+    await waitFor(() =>
+      expect(screen.queryByLabelText("Saving")).not.toBeInTheDocument(),
+    );
+    // Both denials survived; pre-fix the first one came back.
+    expect(screen.getAllByLabelText("Allowed")).toHaveLength(1);
+  });
+
+  it("keeps both denials when two clicks land before a re-render", async () => {
+    // Clicks faster than React commits: the second handler still closes over
+    // the pre-click record, so reading permissions off that record would undo
+    // the first denial. The desired set is the only thing that is current.
+    const first = createDeferred();
+    mocks.updateConnectorTools.mockReturnValue(first.promise);
+
+    await openConnector();
+    await screen.findByText("ask_question");
+
+    const allowed = screen.getAllByLabelText("Allowed");
+    act(() => {
+      fireEvent.click(allowed[0]);
+      fireEvent.click(allowed[1]);
+    });
+
+    expect(mocks.updateConnectorTools).toHaveBeenCalledTimes(1);
+
+    mocks.updateConnectorTools.mockResolvedValue({});
+    await act(async () => {
+      first.resolve({});
+    });
+
+    await waitFor(() =>
+      expect(mocks.updateConnectorTools).toHaveBeenCalledTimes(2),
+    );
+    expect(mocks.updateConnectorTools.mock.calls[1][1]).toEqual([
+      "read_wiki_structure",
+    ]);
+  });
+
+  it("keeps a connector's queued write when another connector is toggled", async () => {
+    // The writer outlives the selection, so its queue is keyed by connector.
+    // A single slot would let GitHub's toggle discard DeepWiki's queued set
+    // after it had already been shown as applied.
+    mocks.fetchConnectors.mockResolvedValue({
+      results: [LIST_ROW, LIST_ROW_B],
+    });
+    mocks.getConnector.mockImplementation((id) =>
+      Promise.resolve(id === "conn-2" ? DETAIL_B : DETAIL),
+    );
+
+    const first = createDeferred();
+    mocks.updateConnectorTools.mockReturnValueOnce(first.promise);
+
+    await openConnector();
+    await screen.findByText("ask_question");
+
+    // Two denials on DeepWiki: the first goes out, the second queues.
+    fireEvent.click(screen.getAllByLabelText("Allowed")[0]);
+    fireEvent.click(screen.getAllByLabelText("Allowed")[0]);
+    expect(mocks.updateConnectorTools).toHaveBeenCalledTimes(1);
+
+    // Switch to GitHub and deny one of its tools while that queue is unsent.
+    fireEvent.click(await screen.findByText("GitHub"));
+    await screen.findByText("list_prs");
+    fireEvent.click(screen.getAllByLabelText("Allowed")[0]);
+
+    await act(async () => {
+      first.resolve({});
+    });
+
+    await waitFor(() =>
+      expect(mocks.updateConnectorTools).toHaveBeenCalledTimes(3),
+    );
+
+    const forDeepWiki = mocks.updateConnectorTools.mock.calls.filter(
+      ([id]) => id === "conn-1",
+    );
+    const forGitHub = mocks.updateConnectorTools.mock.calls.filter(
+      ([id]) => id === "conn-2",
+    );
+    // DeepWiki's queued denial survived rather than being dropped.
+    expect(forDeepWiki).toHaveLength(2);
+    expect(forDeepWiki[1][1]).toEqual(["read_wiki_structure"]);
+    expect(forGitHub).toHaveLength(1);
+  });
+
+  it("rolls back to the last set the server accepted when a write fails", async () => {
+    const first = createDeferred();
+    let fail;
+    mocks.updateConnectorTools
+      .mockReturnValueOnce(first.promise)
+      .mockReturnValueOnce(
+        new Promise((_, reject) => {
+          fail = reject;
+        }),
+      );
+
+    await openConnector();
+    await screen.findByText("ask_question");
+
+    fireEvent.click(screen.getAllByLabelText("Allowed")[0]);
+    fireEvent.click(screen.getAllByLabelText("Allowed")[0]);
+
+    await act(async () => {
+      first.resolve({});
+    });
+    await waitFor(() =>
+      expect(mocks.updateConnectorTools).toHaveBeenCalledTimes(2),
+    );
+
+    await act(async () => {
+      fail({ response: { data: { detail: "Nope." } } });
+    });
+
+    expect(await screen.findByRole("alert")).toHaveTextContent("Nope.");
+    // The first denial was accepted, the second was not: two allowed remain.
+    await waitFor(() =>
+      expect(screen.getAllByLabelText("Allowed")).toHaveLength(2),
+    );
+  });
+
+  it("clears the in-flight state when the write fails", async () => {
+    let fail;
+    mocks.updateConnectorTools.mockReturnValue(
+      new Promise((_, reject) => {
+        fail = reject;
+      }),
+    );
+
+    await openConnector();
+    await screen.findByText("ask_question");
+
+    fireEvent.click(screen.getAllByLabelText("Allowed")[0]);
+    await screen.findByLabelText("Saving");
+
+    await act(async () => {
+      fail({ response: { data: { detail: "Nope." } } });
+    });
+
+    expect(await screen.findByRole("alert")).toHaveTextContent("Nope.");
+    // A stuck spinner would leave the row permanently unclickable.
+    await waitFor(() =>
+      expect(screen.queryByLabelText("Saving")).not.toBeInTheDocument(),
+    );
+  });
+
+  it("warns on the last enabled toggle before it is clicked", async () => {
+    // The guard alone is reactive — it explains after the refused click. The
+    // tooltip states the constraint on the control itself, beforehand.
+    mocks.getConnector.mockResolvedValue({
+      ...DETAIL,
+      enabled_tool_names: ["ask_question"],
+    });
+
+    await openConnector();
+    await screen.findByText("ask_question");
+
+    fireEvent.mouseOver(screen.getAllByLabelText("Allowed")[0]);
+
+    expect(
+      await screen.findByText(/at least one must stay on/i),
+    ).toBeInTheDocument();
+  });
+
+  it("leaves the other toggles unannotated", async () => {
+    mocks.getConnector.mockResolvedValue({
+      ...DETAIL,
+      enabled_tool_names: ["ask_question", "read_wiki_contents"],
+    });
+
+    await openConnector();
+    await screen.findByText("ask_question");
+
+    fireEvent.mouseOver(screen.getAllByLabelText("Allowed")[0]);
+
+    await waitFor(() =>
+      expect(
+        screen.queryByText(/at least one must stay on/i),
+      ).not.toBeInTheDocument(),
+    );
+    // The plain hover hint stays on the toggles the guard does not refuse.
+    expect(screen.getAllByLabelText("Allowed")[0]).toHaveAttribute(
+      "title",
+      "Allowed",
+    );
   });
 
   it("still allows denying a tool when others remain enabled", async () => {
@@ -275,7 +565,7 @@ describe("Customize panel — connector tools", () => {
     await openConnector();
     await screen.findByText("ask_question");
 
-    fireEvent.click(screen.getAllByTitle("Allowed")[0]);
+    fireEvent.click(screen.getAllByLabelText("Allowed")[0]);
 
     await waitFor(() =>
       expect(mocks.updateConnectorTools).toHaveBeenCalledWith("conn-1", [
@@ -292,7 +582,7 @@ describe("Customize panel — connector tools", () => {
     await openConnector();
     await screen.findByText("ask_question");
 
-    fireEvent.click(screen.getAllByTitle("Allowed")[0]);
+    fireEvent.click(screen.getAllByLabelText("Allowed")[0]);
 
     expect(await screen.findByRole("alert")).toHaveTextContent(
       "Connector is not verified.",
@@ -415,7 +705,7 @@ describe("Customize panel — connector tools", () => {
     await openConnector(queryClient);
     await screen.findByText("ask_question");
 
-    fireEvent.click(screen.getAllByTitle("Allowed")[0]);
+    fireEvent.click(screen.getAllByLabelText("Allowed")[0]);
     await waitFor(() => expect(mocks.updateConnectorTools).toHaveBeenCalled());
 
     expect(

--- a/frontend/src/sections/falcon-ai/components/__tests__/customize-connector-tools.test.jsx
+++ b/frontend/src/sections/falcon-ai/components/__tests__/customize-connector-tools.test.jsx
@@ -247,6 +247,43 @@ describe("Customize panel — connector tools", () => {
     );
   });
 
+  it("refuses to deny the last enabled tool, which would grant every tool", async () => {
+    // [] is the all-enabled sentinel on both sides (mcp_tools.py:207), so
+    // emptying the list inverts the permission and persists. TH-7673.
+    mocks.getConnector.mockResolvedValue({
+      ...DETAIL,
+      enabled_tool_names: ["ask_question"],
+    });
+
+    await openConnector();
+    await screen.findByText("ask_question");
+
+    fireEvent.click(screen.getAllByTitle("Allowed")[0]);
+
+    expect(await screen.findByRole("alert")).toHaveTextContent(
+      /Keep at least one tool enabled/i,
+    );
+    expect(mocks.updateConnectorTools).not.toHaveBeenCalled();
+  });
+
+  it("still allows denying a tool when others remain enabled", async () => {
+    mocks.getConnector.mockResolvedValue({
+      ...DETAIL,
+      enabled_tool_names: ["ask_question", "read_wiki_contents"],
+    });
+
+    await openConnector();
+    await screen.findByText("ask_question");
+
+    fireEvent.click(screen.getAllByTitle("Allowed")[0]);
+
+    await waitFor(() =>
+      expect(mocks.updateConnectorTools).toHaveBeenCalledWith("conn-1", [
+        "read_wiki_contents",
+      ]),
+    );
+  });
+
   it("surfaces a failed write instead of leaving the toggle silently stuck", async () => {
     mocks.updateConnectorTools.mockRejectedValue({
       response: { data: { detail: "Connector is not verified." } },

--- a/frontend/src/sections/falcon-ai/components/__tests__/customize-connector-tools.test.jsx
+++ b/frontend/src/sections/falcon-ai/components/__tests__/customize-connector-tools.test.jsx
@@ -1,0 +1,216 @@
+import React from "react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, waitFor, fireEvent } from "src/utils/test-utils";
+
+import CustomizePanel from "../CustomizePanel";
+import { resolveEnabledNames } from "../connectorTools";
+
+const mocks = vi.hoisted(() => ({
+  listSkills: vi.fn(),
+  fetchConnectors: vi.fn(),
+  getConnector: vi.fn(),
+  getSkill: vi.fn(),
+  deleteConnector: vi.fn(),
+  updateConnectorTools: vi.fn(),
+  discoverConnectorTools: vi.fn(),
+  authenticateConnector: vi.fn(),
+}));
+
+vi.mock("../../hooks/useFalconAPI", () => mocks);
+
+// What GET /mcp-connectors/ returns: MCPConnectorListSerializer, which carries
+// neither discovered_tools nor enabled_tool_names.
+const LIST_ROW = {
+  id: "conn-1",
+  name: "DeepWiki",
+  server_url: "https://mcp.deepwiki.com/mcp",
+  transport: "streamable_http",
+  auth_type: "none",
+  is_active: true,
+  is_verified: true,
+  tool_count: 3,
+};
+
+// What GET /mcp-connectors/<id>/ returns: MCPConnectorDetailSerializer.
+const DETAIL = {
+  ...LIST_ROW,
+  discovered_tools: [
+    { name: "ask_question", description: "Ask about a repo." },
+    { name: "read_wiki_contents", description: "View documentation." },
+    { name: "read_wiki_structure", description: "List doc topics." },
+  ],
+  enabled_tool_names: [
+    "ask_question",
+    "read_wiki_contents",
+    "read_wiki_structure",
+  ],
+};
+
+const openConnector = async () => {
+  render(<CustomizePanel />);
+  fireEvent.click(await screen.findByText("Connectors"));
+  fireEvent.click(await screen.findByText("DeepWiki"));
+};
+
+describe("resolveEnabledNames", () => {
+  it("uses the stored permission list when there is one", () => {
+    expect(resolveEnabledNames(DETAIL)).toEqual([
+      "ask_question",
+      "read_wiki_contents",
+      "read_wiki_structure",
+    ]);
+  });
+
+  it("expands the empty sentinel to every discovered tool", () => {
+    // An empty list means "all enabled"; collapsing it to [] on write would
+    // silently re-enable everything.
+    expect(resolveEnabledNames({ ...DETAIL, enabled_tool_names: [] })).toEqual([
+      "ask_question",
+      "read_wiki_contents",
+      "read_wiki_structure",
+    ]);
+  });
+
+  it("yields nothing for a connector with no tools at all", () => {
+    expect(resolveEnabledNames(LIST_ROW)).toEqual([]);
+  });
+});
+
+describe("Customize panel — connector tools", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.listSkills.mockResolvedValue({ results: [] });
+    mocks.fetchConnectors.mockResolvedValue({ results: [LIST_ROW] });
+    mocks.getConnector.mockResolvedValue(DETAIL);
+    mocks.updateConnectorTools.mockResolvedValue({});
+  });
+
+  it("fetches the connector detail on select and renders Tool permissions", async () => {
+    await openConnector();
+
+    // The list payload alone can never satisfy this pane.
+    await waitFor(() =>
+      expect(mocks.getConnector).toHaveBeenCalledWith("conn-1"),
+    );
+
+    expect(await screen.findByText("Tool permissions")).toBeInTheDocument();
+    expect(screen.getByText("ask_question")).toBeInTheDocument();
+    expect(
+      screen.queryByText(/No tools discovered yet/i),
+    ).not.toBeInTheDocument();
+  });
+
+  it("shows a loading placeholder, not the empty state, while the detail loads", async () => {
+    let release;
+    mocks.getConnector.mockReturnValue(
+      new Promise((resolve) => {
+        release = resolve;
+      }),
+    );
+
+    render(<CustomizePanel />);
+    fireEvent.click(await screen.findByText("Connectors"));
+    fireEvent.click(await screen.findByText("DeepWiki"));
+
+    // The list row carries no tools; answering "nothing discovered" here is the
+    // very bug this pane was reported for.
+    expect(await screen.findByRole("status")).toHaveAttribute(
+      "aria-label",
+      "Loading tools",
+    );
+    expect(
+      screen.queryByText(/No tools discovered yet/i),
+    ).not.toBeInTheDocument();
+
+    release(DETAIL);
+    expect(await screen.findByText("ask_question")).toBeInTheDocument();
+    // Held briefly past the response so a ~250ms fetch doesn't flicker.
+    await waitFor(() =>
+      expect(screen.queryByRole("status")).not.toBeInTheDocument(),
+    );
+  });
+
+  it("reports a failed detail fetch instead of claiming there are no tools", async () => {
+    mocks.getConnector.mockRejectedValue({
+      response: { data: { detail: "Connector detail is unavailable." } },
+    });
+
+    render(<CustomizePanel />);
+    fireEvent.click(await screen.findByText("Connectors"));
+    fireEvent.click(await screen.findByText("DeepWiki"));
+
+    expect(
+      await screen.findByText("Connector detail is unavailable."),
+    ).toBeInTheDocument();
+    // "No tools discovered yet" would blame the connector for a request that
+    // never landed.
+    expect(
+      screen.queryByText(/No tools discovered yet/i),
+    ).not.toBeInTheDocument();
+
+    // Retry re-runs the fetch, so a transient failure is recoverable in place.
+    mocks.getConnector.mockResolvedValue(DETAIL);
+    fireEvent.click(screen.getByRole("button", { name: /try again/i }));
+    expect(await screen.findByText("ask_question")).toBeInTheDocument();
+  });
+
+  it("writes tool names, not tool objects, and keeps the untouched ones", async () => {
+    await openConnector();
+    await screen.findByText("ask_question");
+
+    fireEvent.click(screen.getAllByTitle("Allowed")[0]);
+
+    await waitFor(() => expect(mocks.updateConnectorTools).toHaveBeenCalled());
+    const [connectorId, names] = mocks.updateConnectorTools.mock.calls[0];
+
+    expect(connectorId).toBe("conn-1");
+    // The old code sent `(conn.tools || [])` — always [] — wiping every
+    // permission, and sent objects where the serializer wants name strings.
+    expect(names).not.toEqual([]);
+    expect(names.every((n) => typeof n === "string")).toBe(true);
+    expect(names).not.toContain("ask_question");
+    expect(names).toEqual(
+      expect.arrayContaining(["read_wiki_contents", "read_wiki_structure"]),
+    );
+  });
+
+  it("surfaces a failed write instead of leaving the toggle silently stuck", async () => {
+    mocks.updateConnectorTools.mockRejectedValue({
+      response: { data: { detail: "Connector is not verified." } },
+    });
+
+    await openConnector();
+    await screen.findByText("ask_question");
+
+    fireEvent.click(screen.getAllByTitle("Allowed")[0]);
+
+    expect(await screen.findByRole("alert")).toHaveTextContent(
+      "Connector is not verified.",
+    );
+  });
+
+  it("allows a whole group in one request instead of racing per tool", async () => {
+    mocks.getConnector.mockResolvedValue({
+      ...DETAIL,
+      enabled_tool_names: ["ask_question"],
+    });
+
+    await openConnector();
+    await screen.findByText("read_wiki_contents");
+
+    fireEvent.click(screen.getAllByText("Always allow")[0]);
+
+    await waitFor(() => expect(mocks.updateConnectorTools).toHaveBeenCalled());
+    // Per-tool toggles would each compute from the same stale snapshot, so the
+    // last write would land alone.
+    expect(mocks.updateConnectorTools).toHaveBeenCalledTimes(1);
+    const [, names] = mocks.updateConnectorTools.mock.calls[0];
+    expect(names).toEqual(
+      expect.arrayContaining([
+        "ask_question",
+        "read_wiki_contents",
+        "read_wiki_structure",
+      ]),
+    );
+  });
+});

--- a/frontend/src/sections/falcon-ai/components/__tests__/customize-connector-tools.test.jsx
+++ b/frontend/src/sections/falcon-ai/components/__tests__/customize-connector-tools.test.jsx
@@ -112,14 +112,13 @@ describe("resolveEnabledNames", () => {
     ]);
   });
 
-  it("expands the empty sentinel to every discovered tool", () => {
-    // An empty list means "all enabled"; collapsing it to [] on write would
-    // silently re-enable everything.
-    expect(resolveEnabledNames({ ...DETAIL, enabled_tool_names: [] })).toEqual([
-      "ask_question",
-      "read_wiki_contents",
-      "read_wiki_structure",
-    ]);
+  it("treats an explicitly empty list as no tools enabled", () => {
+    // An empty list means the user disabled every tool - it must not be
+    // expanded back to "all enabled", or unchecking the last tool would
+    // immediately re-check every other one.
+    expect(resolveEnabledNames({ ...DETAIL, enabled_tool_names: [] })).toEqual(
+      [],
+    );
   });
 
   it("yields nothing for a connector with no tools at all", () => {
@@ -223,6 +222,34 @@ describe("Customize panel — connector tools", () => {
     expect(names).toEqual(
       expect.arrayContaining(["read_wiki_contents", "read_wiki_structure"]),
     );
+  });
+
+  it("keeps the last tool unchecked instead of re-checking every tool", async () => {
+    // TH-7673: unchecking the last tool PATCHes enabled_tool_names: [], which
+    // an "empty means all" reading would immediately re-expand back to every
+    // discovered tool, undoing the very state the user just set.
+    await openConnector();
+    await screen.findByText("ask_question");
+
+    fireEvent.click(screen.getAllByTitle("Allowed")[0]);
+    await waitFor(() =>
+      expect(mocks.updateConnectorTools).toHaveBeenCalledTimes(1),
+    );
+
+    fireEvent.click(screen.getAllByTitle("Allowed")[0]);
+    await waitFor(() =>
+      expect(mocks.updateConnectorTools).toHaveBeenCalledTimes(2),
+    );
+
+    fireEvent.click(screen.getAllByTitle("Allowed")[0]);
+    await waitFor(() =>
+      expect(mocks.updateConnectorTools).toHaveBeenCalledTimes(3),
+    );
+
+    const [, lastNames] = mocks.updateConnectorTools.mock.calls[2];
+    expect(lastNames).toEqual([]);
+    expect(screen.queryAllByTitle("Allowed")).toHaveLength(0);
+    expect(screen.getAllByTitle("Denied")).toHaveLength(3);
   });
 
   it("updates the shared react-query cache so the settings page sees the new permissions", async () => {

--- a/frontend/src/sections/falcon-ai/components/__tests__/customize-connector-tools.test.jsx
+++ b/frontend/src/sections/falcon-ai/components/__tests__/customize-connector-tools.test.jsx
@@ -1,9 +1,11 @@
 import React from "react";
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { render, screen, waitFor, fireEvent } from "src/utils/test-utils";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, screen, waitFor, fireEvent, act } from "src/utils/test-utils";
 
 import CustomizePanel from "../CustomizePanel";
 import { resolveEnabledNames } from "../connectorTools";
+import { falconAIQueryKeys } from "../../hooks/useFalconAPI";
 
 const mocks = vi.hoisted(() => ({
   listSkills: vi.fn(),
@@ -14,6 +16,9 @@ const mocks = vi.hoisted(() => ({
   updateConnectorTools: vi.fn(),
   discoverConnectorTools: vi.fn(),
   authenticateConnector: vi.fn(),
+  falconAIQueryKeys: {
+    connector: (id) => ["falcon-ai", "connector", id],
+  },
 }));
 
 vi.mock("../../hooks/useFalconAPI", () => mocks);
@@ -46,10 +51,56 @@ const DETAIL = {
   ],
 };
 
-const openConnector = async () => {
-  render(<CustomizePanel />);
+// A second connector, used to reproduce an out-of-order detail response.
+const LIST_ROW_B = {
+  id: "conn-2",
+  name: "GitHub",
+  server_url: "https://mcp.github.com/mcp",
+  transport: "streamable_http",
+  auth_type: "oauth",
+  is_active: true,
+  is_verified: true,
+  tool_count: 2,
+};
+
+const DETAIL_B = {
+  ...LIST_ROW_B,
+  discovered_tools: [
+    { name: "list_prs", description: "List pull requests." },
+    { name: "create_issue", description: "Create an issue." },
+  ],
+  enabled_tool_names: ["list_prs", "create_issue"],
+};
+
+// A promise the test controls the settlement of, to force out-of-order
+// resolution between two overlapping detail fetches.
+const createDeferred = () => {
+  let resolve;
+  const promise = new Promise((res) => {
+    resolve = res;
+  });
+  return { promise, resolve };
+};
+
+// useConnectorToolPermissions writes through to the react-query cache after a
+// successful toggle, so every render of the panel needs a real QueryClient.
+const createTestQueryClient = () =>
+  new QueryClient({ defaultOptions: { queries: { retry: false } } });
+
+const renderPanel = (queryClient = createTestQueryClient()) => {
+  render(
+    <QueryClientProvider client={queryClient}>
+      <CustomizePanel />
+    </QueryClientProvider>,
+  );
+  return queryClient;
+};
+
+const openConnector = async (queryClient) => {
+  const client = renderPanel(queryClient);
   fireEvent.click(await screen.findByText("Connectors"));
   fireEvent.click(await screen.findByText("DeepWiki"));
+  return client;
 };
 
 describe("resolveEnabledNames", () => {
@@ -108,7 +159,7 @@ describe("Customize panel — connector tools", () => {
       }),
     );
 
-    render(<CustomizePanel />);
+    renderPanel();
     fireEvent.click(await screen.findByText("Connectors"));
     fireEvent.click(await screen.findByText("DeepWiki"));
 
@@ -135,7 +186,7 @@ describe("Customize panel — connector tools", () => {
       response: { data: { detail: "Connector detail is unavailable." } },
     });
 
-    render(<CustomizePanel />);
+    renderPanel();
     fireEvent.click(await screen.findByText("Connectors"));
     fireEvent.click(await screen.findByText("DeepWiki"));
 
@@ -174,6 +225,28 @@ describe("Customize panel — connector tools", () => {
     );
   });
 
+  it("updates the shared react-query cache so the settings page sees the new permissions", async () => {
+    // ConnectorSettingsPage reads this same connector through useConnector(id),
+    // keyed identically in the same QueryClient. Seed it as if that page had
+    // already fetched the record, pre-toggle.
+    const queryClient = createTestQueryClient();
+    queryClient.setQueryData(falconAIQueryKeys.connector("conn-1"), DETAIL);
+
+    await openConnector(queryClient);
+    await screen.findByText("ask_question");
+
+    fireEvent.click(screen.getAllByTitle("Allowed")[0]);
+    await waitFor(() => expect(mocks.updateConnectorTools).toHaveBeenCalled());
+
+    const cached = queryClient.getQueryData(
+      falconAIQueryKeys.connector("conn-1"),
+    );
+    expect(cached.enabled_tool_names).not.toContain("ask_question");
+    expect(cached.enabled_tool_names).toEqual(
+      expect.arrayContaining(["read_wiki_contents", "read_wiki_structure"]),
+    );
+  });
+
   it("surfaces a failed write instead of leaving the toggle silently stuck", async () => {
     mocks.updateConnectorTools.mockRejectedValue({
       response: { data: { detail: "Connector is not verified." } },
@@ -187,6 +260,155 @@ describe("Customize panel — connector tools", () => {
     expect(await screen.findByRole("alert")).toHaveTextContent(
       "Connector is not verified.",
     );
+  });
+
+  it("ignores a stale detail response when a newer selection is already in flight", async () => {
+    mocks.fetchConnectors.mockResolvedValue({
+      results: [LIST_ROW, LIST_ROW_B],
+    });
+
+    const deferredA = createDeferred();
+    const deferredB = createDeferred();
+    mocks.getConnector.mockImplementation((id) => {
+      if (id === "conn-1") return deferredA.promise;
+      if (id === "conn-2") return deferredB.promise;
+      throw new Error(`unexpected connector id ${id}`);
+    });
+
+    renderPanel();
+    fireEvent.click(await screen.findByText("Connectors"));
+
+    // Select A, then select B before A's detail request has resolved.
+    fireEvent.click(await screen.findByText("DeepWiki"));
+    fireEvent.click(await screen.findByText("GitHub"));
+
+    await waitFor(() => expect(mocks.getConnector).toHaveBeenCalledTimes(2));
+
+    // Resolve out of order: the newer request (B) settles first, then the
+    // stale one (A) settles after.
+    await act(async () => {
+      deferredB.resolve(DETAIL_B);
+      await Promise.resolve();
+    });
+    expect(await screen.findByText("list_prs")).toBeInTheDocument();
+
+    await act(async () => {
+      deferredA.resolve(DETAIL);
+      // A macrotask tick flushes every microtask queued by A's now-settled
+      // await chain, giving a buggy implementation a full chance to apply.
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    });
+
+    // B's tools must still be showing; A's late response must not have
+    // clobbered them.
+    expect(screen.getByText("list_prs")).toBeInTheDocument();
+    expect(screen.queryByText("ask_question")).not.toBeInTheDocument();
+  });
+
+  it("keeps the loading indicator up while a newer request is still in flight, even if a stale one settles first", async () => {
+    mocks.fetchConnectors.mockResolvedValue({
+      results: [LIST_ROW, LIST_ROW_B],
+    });
+
+    const deferredA = createDeferred();
+    const deferredB = createDeferred();
+    mocks.getConnector.mockImplementation((id) => {
+      if (id === "conn-1") return deferredA.promise;
+      if (id === "conn-2") return deferredB.promise;
+      throw new Error(`unexpected connector id ${id}`);
+    });
+
+    renderPanel();
+    fireEvent.click(await screen.findByText("Connectors"));
+
+    fireEvent.click(await screen.findByText("DeepWiki"));
+    fireEvent.click(await screen.findByText("GitHub"));
+
+    await waitFor(() => expect(mocks.getConnector).toHaveBeenCalledTimes(2));
+
+    // The stale (first) request settles while the newer one is still pending.
+    await act(async () => {
+      deferredA.resolve(DETAIL);
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    });
+
+    // B's request hasn't resolved yet — the loading indicator must still be
+    // up. A stale settlement must not have cleared it out from under B.
+    expect(screen.getByRole("status")).toHaveAttribute(
+      "aria-label",
+      "Loading tools",
+    );
+
+    await act(async () => {
+      deferredB.resolve(DETAIL_B);
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    });
+    expect(await screen.findByText("list_prs")).toBeInTheDocument();
+    expect(screen.queryByRole("status")).not.toBeInTheDocument();
+  });
+
+  it("clears the loading state when an in-flight detail fetch is abandoned", async () => {
+    // Editing mid-fetch bumps the ticket, so the abandoned response is ignored
+    // and its `finally` no longer clears the flag. Nothing else would.
+    const deferred = createDeferred();
+    mocks.getConnector.mockImplementation(() => deferred.promise);
+
+    renderPanel();
+    fireEvent.click(await screen.findByText("Connectors"));
+    fireEvent.click(await screen.findByText("DeepWiki"));
+    await waitFor(() => expect(mocks.getConnector).toHaveBeenCalled());
+
+    fireEvent.click(await screen.findByText("Edit"));
+    await act(async () => {
+      deferred.resolve(DETAIL);
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    });
+    fireEvent.click(await screen.findByText("Cancel"));
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    });
+
+    expect(screen.queryByRole("status")).not.toBeInTheDocument();
+  });
+
+  it("does not invent a cache entry when nothing has fetched the connector", async () => {
+    // A partial entry would be stamped fresh, so the settings page would render
+    // it — with no discovered_tools — instead of fetching the real record.
+    const queryClient = createTestQueryClient();
+    await openConnector(queryClient);
+    await screen.findByText("ask_question");
+
+    fireEvent.click(screen.getAllByTitle("Allowed")[0]);
+    await waitFor(() => expect(mocks.updateConnectorTools).toHaveBeenCalled());
+
+    expect(
+      queryClient.getQueryData(falconAIQueryKeys.connector("conn-1")),
+    ).toBeUndefined();
+  });
+
+  it("keeps the tools on screen after an OAuth callback", async () => {
+    // The callback used to assign a row from the LIST endpoint, whose
+    // serializer carries no discovered_tools — blanking the very tools the
+    // user had just authorised.
+    mocks.getConnector.mockResolvedValue(DETAIL);
+    mocks.discoverConnectorTools.mockResolvedValue({});
+
+    await openConnector();
+    await screen.findByText("ask_question");
+
+    await act(async () => {
+      window.dispatchEvent(
+        new MessageEvent("message", {
+          data: { type: "falcon_oauth_callback", status: "success" },
+        }),
+      );
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    });
+
+    expect(await screen.findByText("ask_question")).toBeInTheDocument();
+    expect(
+      screen.queryByText(/No tools discovered yet/i),
+    ).not.toBeInTheDocument();
   });
 
   it("allows a whole group in one request instead of racing per tool", async () => {

--- a/frontend/src/sections/falcon-ai/components/__tests__/customize-connector-tools.test.jsx
+++ b/frontend/src/sections/falcon-ai/components/__tests__/customize-connector-tools.test.jsx
@@ -112,13 +112,14 @@ describe("resolveEnabledNames", () => {
     ]);
   });
 
-  it("treats an explicitly empty list as no tools enabled", () => {
-    // An empty list means the user disabled every tool - it must not be
-    // expanded back to "all enabled", or unchecking the last tool would
-    // immediately re-check every other one.
-    expect(resolveEnabledNames({ ...DETAIL, enabled_tool_names: [] })).toEqual(
-      [],
-    );
+  it("expands the empty sentinel to every discovered tool", () => {
+    // An empty list means "all enabled"; collapsing it to [] on write would
+    // silently re-enable everything.
+    expect(resolveEnabledNames({ ...DETAIL, enabled_tool_names: [] })).toEqual([
+      "ask_question",
+      "read_wiki_contents",
+      "read_wiki_structure",
+    ]);
   });
 
   it("yields nothing for a connector with no tools at all", () => {
@@ -222,34 +223,6 @@ describe("Customize panel — connector tools", () => {
     expect(names).toEqual(
       expect.arrayContaining(["read_wiki_contents", "read_wiki_structure"]),
     );
-  });
-
-  it("keeps the last tool unchecked instead of re-checking every tool", async () => {
-    // TH-7673: unchecking the last tool PATCHes enabled_tool_names: [], which
-    // an "empty means all" reading would immediately re-expand back to every
-    // discovered tool, undoing the very state the user just set.
-    await openConnector();
-    await screen.findByText("ask_question");
-
-    fireEvent.click(screen.getAllByTitle("Allowed")[0]);
-    await waitFor(() =>
-      expect(mocks.updateConnectorTools).toHaveBeenCalledTimes(1),
-    );
-
-    fireEvent.click(screen.getAllByTitle("Allowed")[0]);
-    await waitFor(() =>
-      expect(mocks.updateConnectorTools).toHaveBeenCalledTimes(2),
-    );
-
-    fireEvent.click(screen.getAllByTitle("Allowed")[0]);
-    await waitFor(() =>
-      expect(mocks.updateConnectorTools).toHaveBeenCalledTimes(3),
-    );
-
-    const [, lastNames] = mocks.updateConnectorTools.mock.calls[2];
-    expect(lastNames).toEqual([]);
-    expect(screen.queryAllByTitle("Allowed")).toHaveLength(0);
-    expect(screen.getAllByTitle("Denied")).toHaveLength(3);
   });
 
   it("updates the shared react-query cache so the settings page sees the new permissions", async () => {

--- a/frontend/src/sections/falcon-ai/components/connectorTools.js
+++ b/frontend/src/sections/falcon-ai/components/connectorTools.js
@@ -13,18 +13,14 @@ export function toolActionErrorMessage(error, fallback) {
 }
 
 /**
- * The connector API stores tool permissions as a list of enabled tool *names*,
- * and an empty list means "all enabled". Resolving that sentinel to the
- * concrete set is what lets a single tool be switched off without the result
- * reading as all-on again.
+ * The connector API stores tool permissions as a literal list of enabled
+ * tool names - discovery always seeds it with every discovered tool, so an
+ * empty list means the user disabled all of them, not "unset". Do not expand
+ * it to the full tool set here.
  *
  * Kept out of CustomizePanel.jsx so that file only exports components and fast
  * refresh keeps working.
  */
 export function resolveEnabledNames(connector) {
-  const allNames = (connector.discovered_tools || connector.tools || [])
-    .map((t) => t.name)
-    .filter(Boolean);
-  const stored = connector.enabled_tool_names || [];
-  return stored.length > 0 ? stored : allNames;
+  return connector.enabled_tool_names || [];
 }

--- a/frontend/src/sections/falcon-ai/components/connectorTools.js
+++ b/frontend/src/sections/falcon-ai/components/connectorTools.js
@@ -1,15 +1,6 @@
 /**
- * The connector API stores tool permissions as a list of enabled tool *names*,
- * and an empty list means "all enabled". Resolving that sentinel to the
- * concrete set is what lets a single tool be switched off without the result
- * reading as all-on again.
- *
- * Kept out of CustomizePanel.jsx so that file only exports components and fast
- * refresh keeps working.
- */
-/**
- * Pull a human-readable reason out of a failed connector request. Mirrors
- * `getActionErrorMessage` in ConnectorSettingsPage, which is not exported.
+ * Pull a human-readable reason out of a failed connector request. Shared with
+ * ConnectorSettingsPage so the two surfaces don't drift out of sync.
  */
 export function toolActionErrorMessage(error, fallback) {
   return (
@@ -21,6 +12,15 @@ export function toolActionErrorMessage(error, fallback) {
   );
 }
 
+/**
+ * The connector API stores tool permissions as a list of enabled tool *names*,
+ * and an empty list means "all enabled". Resolving that sentinel to the
+ * concrete set is what lets a single tool be switched off without the result
+ * reading as all-on again.
+ *
+ * Kept out of CustomizePanel.jsx so that file only exports components and fast
+ * refresh keeps working.
+ */
 export function resolveEnabledNames(connector) {
   const allNames = (connector.discovered_tools || connector.tools || [])
     .map((t) => t.name)

--- a/frontend/src/sections/falcon-ai/components/connectorTools.js
+++ b/frontend/src/sections/falcon-ai/components/connectorTools.js
@@ -1,0 +1,30 @@
+/**
+ * The connector API stores tool permissions as a list of enabled tool *names*,
+ * and an empty list means "all enabled". Resolving that sentinel to the
+ * concrete set is what lets a single tool be switched off without the result
+ * reading as all-on again.
+ *
+ * Kept out of CustomizePanel.jsx so that file only exports components and fast
+ * refresh keeps working.
+ */
+/**
+ * Pull a human-readable reason out of a failed connector request. Mirrors
+ * `getActionErrorMessage` in ConnectorSettingsPage, which is not exported.
+ */
+export function toolActionErrorMessage(error, fallback) {
+  return (
+    error?.response?.data?.detail ||
+    error?.response?.data?.error ||
+    error?.response?.data?.message ||
+    error?.message ||
+    fallback
+  );
+}
+
+export function resolveEnabledNames(connector) {
+  const allNames = (connector.discovered_tools || connector.tools || [])
+    .map((t) => t.name)
+    .filter(Boolean);
+  const stored = connector.enabled_tool_names || [];
+  return stored.length > 0 ? stored : allNames;
+}

--- a/frontend/src/sections/falcon-ai/components/connectorTools.js
+++ b/frontend/src/sections/falcon-ai/components/connectorTools.js
@@ -13,14 +13,18 @@ export function toolActionErrorMessage(error, fallback) {
 }
 
 /**
- * The connector API stores tool permissions as a literal list of enabled
- * tool names - discovery always seeds it with every discovered tool, so an
- * empty list means the user disabled all of them, not "unset". Do not expand
- * it to the full tool set here.
+ * The connector API stores tool permissions as a list of enabled tool *names*,
+ * and an empty list means "all enabled". Resolving that sentinel to the
+ * concrete set is what lets a single tool be switched off without the result
+ * reading as all-on again.
  *
  * Kept out of CustomizePanel.jsx so that file only exports components and fast
  * refresh keeps working.
  */
 export function resolveEnabledNames(connector) {
-  return connector.enabled_tool_names || [];
+  const allNames = (connector.discovered_tools || connector.tools || [])
+    .map((t) => t.name)
+    .filter(Boolean);
+  const stored = connector.enabled_tool_names || [];
+  return stored.length > 0 ? stored : allNames;
 }

--- a/frontend/src/sections/falcon-ai/components/connectorTools.js
+++ b/frontend/src/sections/falcon-ai/components/connectorTools.js
@@ -22,9 +22,36 @@ export function toolActionErrorMessage(error, fallback) {
  * refresh keeps working.
  */
 export function resolveEnabledNames(connector) {
+  // ConnectorSettingsPage renders string-shaped tools as well as objects.
   const allNames = (connector.discovered_tools || connector.tools || [])
-    .map((t) => t.name)
+    .map((t) => (typeof t === "string" ? t : t.name))
     .filter(Boolean);
   const stored = connector.enabled_tool_names || [];
   return stored.length > 0 ? stored : allNames;
+}
+
+/**
+ * An empty enabled list is the "all tools enabled" sentinel on both sides
+ * (mcp_tools.py:207), so denying the last remaining tool grants every tool
+ * instead of none. Until the schema can express "none enabled" (TH-7673) the
+ * write is refused.
+ *
+ * Both strings state the rule and stop there. Why it holds is a fact about our
+ * storage, not something the user can act on, and Disconnect is not the remedy
+ * it sounds like — it deletes the connector, auth and all. Shared so the
+ * Customize pane and the settings page word the rule identically.
+ */
+export const LAST_ENABLED_TOOL_MESSAGE =
+  "At least one tool must stay allowed for this connector.";
+
+export const LAST_ENABLED_TOOL_HINT =
+  "The only tool still allowed — at least one must stay on.";
+
+/**
+ * True when `toolName` is the single remaining enabled tool, i.e. the toggle
+ * whose next click the guard would refuse.
+ */
+export function isOnlyEnabledTool(connector, toolName) {
+  const enabled = resolveEnabledNames(connector);
+  return enabled.length === 1 && enabled[0] === toolName;
 }

--- a/frontend/src/sections/falcon-ai/hooks/useConnectorToolPermissions.js
+++ b/frontend/src/sections/falcon-ai/hooks/useConnectorToolPermissions.js
@@ -1,0 +1,89 @@
+import { useCallback, useState } from "react";
+
+import {
+  resolveEnabledNames,
+  toolActionErrorMessage,
+} from "../components/connectorTools";
+import { updateConnectorTools } from "./useFalconAPI";
+
+/**
+ * Owns allow/deny for a connector's tools.
+ *
+ * Writes are keyed by tool name and always derived from `selectedItem`, the
+ * only record holding `discovered_tools`/`enabled_tool_names`; a list row would
+ * resolve to an empty set and clear every permission.
+ *
+ * @param {object} params
+ * @param {object|null} params.selectedItem   connector detail currently shown
+ * @param {Function} params.setSelectedItem   state setter for that record
+ * @param {Function} params.setConnectors     state setter for the list rows
+ */
+export function useConnectorToolPermissions({
+  selectedItem,
+  setSelectedItem,
+  setConnectors,
+}) {
+  const [toolError, setToolError] = useState(null);
+
+  const applyEnabledToolNames = useCallback(
+    async (connectorId, nextNames) => {
+      try {
+        await updateConnectorTools(connectorId, nextNames);
+        setToolError(null);
+        setSelectedItem((prev) =>
+          prev?.id === connectorId
+            ? { ...prev, enabled_tool_names: nextNames }
+            : prev,
+        );
+        // tool_count is the only tool-derived field the list carries.
+        setConnectors((prev) =>
+          prev.map((c) =>
+            c.id === connectorId ? { ...c, tool_count: nextNames.length } : c,
+          ),
+        );
+      } catch (error) {
+        setToolError(
+          toolActionErrorMessage(error, "Failed to update tool permissions."),
+        );
+      }
+    },
+    [setSelectedItem, setConnectors],
+  );
+
+  const handleToolToggle = useCallback(
+    async (connectorId, tool) => {
+      // Permissions are addressed by name; a nameless tool cannot be targeted.
+      if (!tool?.name) return;
+
+      const conn = selectedItem?.id === connectorId ? selectedItem : null;
+      if (!conn) return;
+
+      const enabled = resolveEnabledNames(conn);
+      const next = enabled.includes(tool.name)
+        ? enabled.filter((n) => n !== tool.name)
+        : [...enabled, tool.name];
+
+      await applyEnabledToolNames(connectorId, next);
+    },
+    [selectedItem, applyEnabledToolNames],
+  );
+
+  // One request for the whole group — firing the single toggle per tool would
+  // race, each call computing its next set from the same stale snapshot.
+  const handleToolsAllow = useCallback(
+    async (connectorId, tools) => {
+      const conn = selectedItem?.id === connectorId ? selectedItem : null;
+      if (!conn) return;
+
+      const enabled = resolveEnabledNames(conn);
+      const names = tools.map((t) => t.name).filter(Boolean);
+      const next = [...new Set([...enabled, ...names])];
+      if (next.length === enabled.length) return;
+
+      await applyEnabledToolNames(connectorId, next);
+    },
+    [selectedItem, applyEnabledToolNames],
+  );
+
+  return { toolError, setToolError, handleToolToggle, handleToolsAllow };
+}

--- a/frontend/src/sections/falcon-ai/hooks/useConnectorToolPermissions.js
+++ b/frontend/src/sections/falcon-ai/hooks/useConnectorToolPermissions.js
@@ -1,107 +1,81 @@
-import { useCallback, useState } from "react";
-import { useQueryClient } from "@tanstack/react-query";
+import { useCallback } from "react";
 
 import {
+  LAST_ENABLED_TOOL_MESSAGE,
   resolveEnabledNames,
-  toolActionErrorMessage,
 } from "../components/connectorTools";
-import { falconAIQueryKeys, updateConnectorTools } from "./useFalconAPI";
+import { useToolPermissionWrites } from "./useToolPermissionWrites";
 
 /**
- * Owns allow/deny for a connector's tools.
+ * Owns allow/deny for a connector's tools, on both surfaces that offer it.
  *
- * Writes are keyed by tool name and always derived from `selectedItem`, the
- * only record holding `discovered_tools`/`enabled_tool_names`; a list row would
- * resolve to an empty set and clear every permission.
+ * Writes are keyed by tool name and derived from the connector *detail*
+ * record, the only one carrying `discovered_tools`/`enabled_tool_names`; a list
+ * row would resolve to an empty set and clear every permission.
+ *
+ * Ordering, optimistic display and rollback live in useToolPermissionWrites.
  *
  * @param {object} params
- * @param {object|null} params.selectedItem   connector detail currently shown
- * @param {Function} params.setSelectedItem   state setter for that record
- * @param {Function} params.setConnectors     state setter for the list rows
+ * @param {object|null} params.connector  connector detail currently shown
+ * @param {Function} params.onApply       (connectorId, names) => void, for any
+ *                                        copy of the record the caller holds
+ *                                        outside the react-query cache
+ * @param {Function} [params.onDrained]   called once the writes settle
  */
-export function useConnectorToolPermissions({
-  selectedItem,
-  setSelectedItem,
-  setConnectors,
-}) {
-  const [toolError, setToolError] = useState(null);
-  const queryClient = useQueryClient();
+export function useConnectorToolPermissions({ connector, onApply, onDrained }) {
+  const { toolError, setToolError, pendingFor, queueWrite, desiredNames } =
+    useToolPermissionWrites({ onApply, onDrained });
 
-  const applyEnabledToolNames = useCallback(
-    async (connectorId, nextNames) => {
-      try {
-        await updateConnectorTools(connectorId, nextNames);
-        setToolError(null);
-        queryClient.setQueryData(
-          falconAIQueryKeys.connector(connectorId),
-          (prev) => (prev ? { ...prev, enabled_tool_names: nextNames } : prev),
-        );
-        setSelectedItem((prev) =>
-          prev?.id === connectorId
-            ? { ...prev, enabled_tool_names: nextNames }
-            : prev,
-        );
-        // tool_count is the only tool-derived field the list carries.
-        setConnectors((prev) =>
-          prev.map((c) =>
-            c.id === connectorId ? { ...c, tool_count: nextNames.length } : c,
-          ),
-        );
-      } catch (error) {
-        setToolError(
-          toolActionErrorMessage(error, "Failed to update tool permissions."),
-        );
-      }
-    },
-    [setSelectedItem, setConnectors, queryClient],
-  );
+  // Only this connector's unsaved names; the writer tracks every connector it
+  // has queued work for, which outlives any one selection.
+  const pendingNames = pendingFor(connector?.id);
 
   const handleToolToggle = useCallback(
-    async (connectorId, tool) => {
+    (connectorId, toolName) => {
       // Permissions are addressed by name; a nameless tool cannot be targeted.
-      if (!tool?.name) return;
+      if (!toolName) return;
+      if (connector?.id !== connectorId) return;
 
-      const conn = selectedItem?.id === connectorId ? selectedItem : null;
-      if (!conn) return;
+      const baseline = resolveEnabledNames(connector);
+      // What the user wants, which may already be ahead of the server.
+      const enabled = desiredNames(connectorId, baseline);
+      const next = enabled.includes(toolName)
+        ? enabled.filter((n) => n !== toolName)
+        : [...enabled, toolName];
 
-      const enabled = resolveEnabledNames(conn);
-      const next = enabled.includes(tool.name)
-        ? enabled.filter((n) => n !== tool.name)
-        : [...enabled, tool.name];
-
-      // An empty list is the "all tools enabled" sentinel on both sides
-      // (mcp_tools.py:207), so denying the last remaining tool would grant
-      // every tool instead of none — and it persists. Refuse the write until
-      // the schema can express "none enabled" (TH-7673).
+      // Refuse the write that would empty the list; the tooltip on that
+      // toggle says the same thing before the click. See connectorTools.js.
       if (next.length === 0) {
-        setToolError(
-          "Keep at least one tool enabled. An empty selection is stored as " +
-            '"all tools allowed" — use Disconnect to revoke the connector.',
-        );
+        setToolError(LAST_ENABLED_TOOL_MESSAGE);
         return;
       }
 
-      await applyEnabledToolNames(connectorId, next);
+      queueWrite(connectorId, next, [toolName], baseline);
     },
-    [selectedItem, applyEnabledToolNames],
+    [connector, desiredNames, queueWrite, setToolError],
   );
 
-  // One request for the whole group — firing the single toggle per tool would
-  // race, each call computing its next set from the same stale snapshot.
+  // One request for the whole group rather than one per tool.
   const handleToolsAllow = useCallback(
-    async (connectorId, tools) => {
-      const conn = selectedItem?.id === connectorId ? selectedItem : null;
-      if (!conn) return;
+    (connectorId, toolNames) => {
+      if (connector?.id !== connectorId) return;
 
-      const enabled = resolveEnabledNames(conn);
-      const names = tools.map((t) => t.name).filter(Boolean);
+      const baseline = resolveEnabledNames(connector);
+      const enabled = desiredNames(connectorId, baseline);
+      const names = toolNames.filter(Boolean);
       const next = [...new Set([...enabled, ...names])];
       if (next.length === enabled.length) return;
 
-      await applyEnabledToolNames(connectorId, next);
+      queueWrite(connectorId, next, names, baseline);
     },
-    [selectedItem, applyEnabledToolNames],
+    [connector, desiredNames, queueWrite],
   );
 
-  return { toolError, setToolError, handleToolToggle, handleToolsAllow };
+  return {
+    toolError,
+    setToolError,
+    pendingNames,
+    handleToolToggle,
+    handleToolsAllow,
+  };
 }

--- a/frontend/src/sections/falcon-ai/hooks/useConnectorToolPermissions.js
+++ b/frontend/src/sections/falcon-ai/hooks/useConnectorToolPermissions.js
@@ -69,6 +69,18 @@ export function useConnectorToolPermissions({
         ? enabled.filter((n) => n !== tool.name)
         : [...enabled, tool.name];
 
+      // An empty list is the "all tools enabled" sentinel on both sides
+      // (mcp_tools.py:207), so denying the last remaining tool would grant
+      // every tool instead of none — and it persists. Refuse the write until
+      // the schema can express "none enabled" (TH-7673).
+      if (next.length === 0) {
+        setToolError(
+          "Keep at least one tool enabled. An empty selection is stored as " +
+            '"all tools allowed" — use Disconnect to revoke the connector.',
+        );
+        return;
+      }
+
       await applyEnabledToolNames(connectorId, next);
     },
     [selectedItem, applyEnabledToolNames],

--- a/frontend/src/sections/falcon-ai/hooks/useConnectorToolPermissions.js
+++ b/frontend/src/sections/falcon-ai/hooks/useConnectorToolPermissions.js
@@ -1,10 +1,11 @@
 import { useCallback, useState } from "react";
+import { useQueryClient } from "@tanstack/react-query";
 
 import {
   resolveEnabledNames,
   toolActionErrorMessage,
 } from "../components/connectorTools";
-import { updateConnectorTools } from "./useFalconAPI";
+import { falconAIQueryKeys, updateConnectorTools } from "./useFalconAPI";
 
 /**
  * Owns allow/deny for a connector's tools.
@@ -24,12 +25,17 @@ export function useConnectorToolPermissions({
   setConnectors,
 }) {
   const [toolError, setToolError] = useState(null);
+  const queryClient = useQueryClient();
 
   const applyEnabledToolNames = useCallback(
     async (connectorId, nextNames) => {
       try {
         await updateConnectorTools(connectorId, nextNames);
         setToolError(null);
+        queryClient.setQueryData(
+          falconAIQueryKeys.connector(connectorId),
+          (prev) => (prev ? { ...prev, enabled_tool_names: nextNames } : prev),
+        );
         setSelectedItem((prev) =>
           prev?.id === connectorId
             ? { ...prev, enabled_tool_names: nextNames }
@@ -47,7 +53,7 @@ export function useConnectorToolPermissions({
         );
       }
     },
-    [setSelectedItem, setConnectors],
+    [setSelectedItem, setConnectors, queryClient],
   );
 
   const handleToolToggle = useCallback(

--- a/frontend/src/sections/falcon-ai/hooks/useFalconAPI.js
+++ b/frontend/src/sections/falcon-ai/hooks/useFalconAPI.js
@@ -71,17 +71,17 @@ export const falconAIQueryKeys = {
   connector: (id) => ["falcon-ai", "connector", id],
 };
 
+export async function getConnector(id) {
+  const { data } = await axiosInstance.get(endpoints.falconAI.connector(id));
+  return data?.result || data;
+}
+
 export function useConnector(id, options = {}) {
   const { enabled = true, ...queryOptions } = options;
 
   return useQuery({
     queryKey: falconAIQueryKeys.connector(id),
-    queryFn: async () => {
-      const { data } = await axiosInstance.get(
-        endpoints.falconAI.connector(id),
-      );
-      return data?.result || data;
-    },
+    queryFn: () => getConnector(id),
     enabled: Boolean(id) && enabled,
     ...queryOptions,
   });

--- a/frontend/src/sections/falcon-ai/hooks/useToolPermissionWrites.js
+++ b/frontend/src/sections/falcon-ai/hooks/useToolPermissionWrites.js
@@ -1,0 +1,157 @@
+import { useCallback, useRef, useState } from "react";
+import { useQueryClient } from "@tanstack/react-query";
+
+import { toolActionErrorMessage } from "../components/connectorTools";
+import { falconAIQueryKeys, updateConnectorTools } from "./useFalconAPI";
+
+// Stable empty list, so a connector with nothing pending does not hand its
+// consumer a fresh array on every render.
+const NO_NAMES = [];
+
+/**
+ * Serialises tool-permission writes.
+ *
+ * The endpoint replaces the whole `enabled_tool_names` list, so two writes in
+ * flight at once is always a lost update: each carries a full list computed
+ * before the other existed, and whichever lands last wins. Aborting the loser
+ * does not help — the stale list is in the request body, already sent, and the
+ * server may apply it regardless of whether we are still listening.
+ *
+ * So: exactly one request is ever out. Clicks arriving while it is out update
+ * the desired set and return; when the request lands the writer checks whether
+ * the desired set moved and, if so, sends once more with the final list. Three
+ * fast clicks cost two requests and end in the state the user asked for.
+ *
+ * Because clicks outrun the network, the UI cannot wait for the server —
+ * `onApply` reflects the desired set immediately, and a failure re-applies the
+ * last set the server accepted.
+ *
+ * State is keyed by connector: this hook outlives the selection on both
+ * surfaces, so a single slot would let a toggle on one connector discard
+ * queued work — and roll back the wrong record — on another.
+ *
+ * @param {object} params
+ * @param {Function} params.onApply    (connectorId, names) => void — show this set
+ * @param {Function} [params.onDrained] called once the queue empties, after a
+ *                                     successful write; for surfaces that want
+ *                                     to resync from the server afterwards.
+ */
+export function useToolPermissionWrites({ onApply, onDrained }) {
+  const [toolError, setToolError] = useState(null);
+  // { [connectorId]: names } whose change the server has not acknowledged yet.
+  const [pending, setPending] = useState({});
+  const queryClient = useQueryClient();
+
+  // connectorId -> the set the user wants but the server has not stored.
+  const desiredRef = useRef(new Map());
+  // connectorId -> the last set the server accepted, to roll back to.
+  const confirmedRef = useRef(new Map());
+  const writingRef = useRef(false);
+
+  const applyLocally = useCallback(
+    (connectorId, names) => {
+      queryClient.setQueryData(
+        falconAIQueryKeys.connector(connectorId),
+        (prev) => (prev ? { ...prev, enabled_tool_names: names } : prev),
+      );
+      onApply(connectorId, names);
+    },
+    [queryClient, onApply],
+  );
+
+  const clearPending = useCallback((connectorId) => {
+    setPending((prev) => {
+      if (!(connectorId in prev)) return prev;
+      const next = { ...prev };
+      delete next[connectorId];
+      return next;
+    });
+  }, []);
+
+  const drain = useCallback(async () => {
+    if (writingRef.current) return;
+    writingRef.current = true;
+
+    try {
+      // Outer loop: onDrained can take as long as a request, and a click
+      // during it must not be stranded — anything queued meanwhile is sent.
+      while (desiredRef.current.size) {
+        while (desiredRef.current.size) {
+          const [connectorId, names] = desiredRef.current
+            .entries()
+            .next().value;
+          await updateConnectorTools(connectorId, names);
+          confirmedRef.current.set(connectorId, names);
+
+          // Identity comparison is enough: every queued set is a fresh array,
+          // so an unchanged reference means nothing arrived while we waited.
+          if (desiredRef.current.get(connectorId) === names) {
+            desiredRef.current.delete(connectorId);
+            clearPending(connectorId);
+          }
+        }
+        setToolError(null);
+        if (onDrained) await onDrained();
+      }
+    } catch (error) {
+      setToolError(
+        toolActionErrorMessage(error, "Failed to update tool permissions."),
+      );
+      // The failed write and anything queued behind it are abandoned. Showing
+      // them as saved would be a lie, so every connector with unsent work goes
+      // back to the set the server last accepted.
+      desiredRef.current.forEach((_, connectorId) => {
+        const confirmed = confirmedRef.current.get(connectorId);
+        if (confirmed) applyLocally(connectorId, confirmed);
+        clearPending(connectorId);
+      });
+      desiredRef.current.clear();
+    } finally {
+      writingRef.current = false;
+    }
+  }, [applyLocally, clearPending, onDrained]);
+
+  /**
+   * @param {string|number} connectorId
+   * @param {string[]} names     the full set the user now wants
+   * @param {string[]} touched   names to mark unsaved until the server agrees
+   * @param {string[]} baseline  the server-known set, used to seed the rollback
+   *                             point at the start of a burst
+   */
+  const queueWrite = useCallback(
+    (connectorId, names, touched, baseline) => {
+      // A burst starts whenever this connector has nothing queued: that is the
+      // last moment its record on screen is still the server's own answer.
+      if (!desiredRef.current.has(connectorId)) {
+        confirmedRef.current.set(connectorId, baseline);
+      }
+      desiredRef.current.set(connectorId, names);
+      setPending((prev) => ({
+        ...prev,
+        [connectorId]: [...new Set([...(prev[connectorId] || []), ...touched])],
+      }));
+      applyLocally(connectorId, names);
+      drain();
+    },
+    [applyLocally, drain],
+  );
+
+  /** The set the user currently wants, which may be ahead of the server. */
+  const desiredNames = useCallback(
+    (connectorId, fallback) => desiredRef.current.get(connectorId) ?? fallback,
+    [],
+  );
+
+  const pendingFor = useCallback(
+    (connectorId) => pending[connectorId] ?? NO_NAMES,
+    [pending],
+  );
+
+  return {
+    toolError,
+    setToolError,
+    pendingFor,
+    queueWrite,
+    desiredNames,
+  };
+}

--- a/frontend/src/sections/settings/falcon-ai-connectors/ConnectorSettingsPage.jsx
+++ b/frontend/src/sections/settings/falcon-ai-connectors/ConnectorSettingsPage.jsx
@@ -19,6 +19,7 @@ import FormControl from "@mui/material/FormControl";
 import { alpha, useTheme } from "@mui/material/styles";
 import Iconify from "src/components/iconify";
 import ToolsSkeleton from "src/sections/falcon-ai/components/ToolsSkeleton";
+import { toolActionErrorMessage } from "src/sections/falcon-ai/components/connectorTools";
 import {
   fetchConnectors,
   useConnector,
@@ -54,16 +55,6 @@ function getStatusInfo(connector) {
   if (!isActive) return { label: "Inactive", color: "default" };
   if (isVerified) return { label: "Connected", color: "success" };
   return { label: "Pending", color: "warning" };
-}
-
-function getActionErrorMessage(error, fallback) {
-  return (
-    error?.response?.data?.detail ||
-    error?.response?.data?.error ||
-    error?.response?.data?.message ||
-    error?.message ||
-    fallback
-  );
 }
 
 // ---------------------------------------------------------------------------
@@ -478,7 +469,7 @@ function ConnectorDetail({ connector, loading, onEdit, onDelete, onRefresh }) {
     } catch (error) {
       setFeedback({
         severity: "error",
-        message: getActionErrorMessage(error, "Connection test failed."),
+        message: toolActionErrorMessage(error, "Connection test failed."),
       });
     } finally {
       setTesting(false);
@@ -513,7 +504,7 @@ function ConnectorDetail({ connector, loading, onEdit, onDelete, onRefresh }) {
     } catch (error) {
       setFeedback({
         severity: "error",
-        message: getActionErrorMessage(error, "Tool discovery failed."),
+        message: toolActionErrorMessage(error, "Tool discovery failed."),
       });
     } finally {
       setDiscovering(false);
@@ -545,7 +536,7 @@ function ConnectorDetail({ connector, loading, onEdit, onDelete, onRefresh }) {
     } catch (error) {
       setFeedback({
         severity: "error",
-        message: getActionErrorMessage(error, "Authentication failed."),
+        message: toolActionErrorMessage(error, "Authentication failed."),
       });
     } finally {
       setReauthing(false);
@@ -565,7 +556,7 @@ function ConnectorDetail({ connector, loading, onEdit, onDelete, onRefresh }) {
     } catch (error) {
       setFeedback({
         severity: "error",
-        message: getActionErrorMessage(error, "Failed to update tools."),
+        message: toolActionErrorMessage(error, "Failed to update tools."),
       });
     }
   };

--- a/frontend/src/sections/settings/falcon-ai-connectors/ConnectorSettingsPage.jsx
+++ b/frontend/src/sections/settings/falcon-ai-connectors/ConnectorSettingsPage.jsx
@@ -12,14 +12,21 @@ import ListItemButton from "@mui/material/ListItemButton";
 import ListItemIcon from "@mui/material/ListItemIcon";
 import ListItemText from "@mui/material/ListItemText";
 import Switch from "@mui/material/Switch";
+import CircularProgress from "@mui/material/CircularProgress";
 import Divider from "@mui/material/Divider";
 import MenuItem from "@mui/material/MenuItem";
 import Select from "@mui/material/Select";
 import FormControl from "@mui/material/FormControl";
 import { alpha, useTheme } from "@mui/material/styles";
 import Iconify from "src/components/iconify";
+import CustomTooltip from "src/components/tooltip";
 import ToolsSkeleton from "src/sections/falcon-ai/components/ToolsSkeleton";
-import { toolActionErrorMessage } from "src/sections/falcon-ai/components/connectorTools";
+import {
+  LAST_ENABLED_TOOL_HINT,
+  isOnlyEnabledTool,
+  toolActionErrorMessage,
+} from "src/sections/falcon-ai/components/connectorTools";
+import { useConnectorToolPermissions } from "src/sections/falcon-ai/hooks/useConnectorToolPermissions";
 import {
   fetchConnectors,
   useConnector,
@@ -29,7 +36,6 @@ import {
   testConnector,
   discoverConnectorTools,
   authenticateConnector,
-  updateConnectorTools,
 } from "src/sections/falcon-ai/hooks/useFalconAPI";
 import { buildConnectorSavePayload } from "./utils";
 
@@ -434,6 +440,18 @@ function ConnectorDetail({ connector, loading, onEdit, onDelete, onRefresh }) {
   const [discovering, setDiscovering] = useState(false);
   const [reauthing, setReauthing] = useState(false);
   const [feedback, setFeedback] = useState(null);
+  // Ordering, the last-tool guard, optimistic display and rollback are shared
+  // with the Customize pane. The switch reads through the react-query cache
+  // this writes to, so no local copy of the record is needed here.
+  const {
+    toolError,
+    pendingNames,
+    handleToolToggle: toggleTool,
+  } = useConnectorToolPermissions({
+    connector,
+    onApply: () => {},
+    onDrained: onRefresh,
+  });
 
   const tools = connector.discovered_tools || [];
   const enabledTools = connector.enabled_tool_names || [];
@@ -543,23 +561,7 @@ function ConnectorDetail({ connector, loading, onEdit, onDelete, onRefresh }) {
     }
   };
 
-  const handleToolToggle = async (toolName) => {
-    let updated;
-    if (isToolEnabled(toolName)) {
-      updated = enabledTools.filter((t) => t !== toolName);
-    } else {
-      updated = [...enabledTools, toolName];
-    }
-    try {
-      await updateConnectorTools(connector.id, updated);
-      await onRefresh();
-    } catch (error) {
-      setFeedback({
-        severity: "error",
-        message: toolActionErrorMessage(error, "Failed to update tools."),
-      });
-    }
-  };
+  const handleToolToggle = (toolName) => toggleTool(connector.id, toolName);
 
   return (
     <Box
@@ -690,6 +692,12 @@ function ConnectorDetail({ connector, loading, onEdit, onDelete, onRefresh }) {
       {feedback && (
         <Alert severity={feedback.severity} sx={{ mb: 2, fontSize: 12 }}>
           {feedback.message}
+        </Alert>
+      )}
+
+      {toolError && (
+        <Alert severity="warning" sx={{ mb: 2, fontSize: 12 }}>
+          {toolError}
         </Alert>
       )}
 
@@ -830,11 +838,29 @@ function ConnectorDetail({ connector, loading, onEdit, onDelete, onRefresh }) {
                     </Typography>
                   )}
                 </Box>
-                <Switch
-                  size="small"
-                  checked={enabled}
-                  onChange={() => handleToolToggle(name)}
-                />
+                {/* The guard refuses this click; say so before it. */}
+                <Box sx={{ display: "flex", alignItems: "center", gap: 0.5 }}>
+                  {pendingNames.includes(name) && (
+                    <CircularProgress
+                      size={14}
+                      role="status"
+                      aria-label="Saving"
+                    />
+                  )}
+                  <CustomTooltip
+                    show={isOnlyEnabledTool(connector, name)}
+                    arrow
+                    size="small"
+                    placement="left"
+                    title={LAST_ENABLED_TOOL_HINT}
+                  >
+                    <Switch
+                      size="small"
+                      checked={enabled}
+                      onChange={() => handleToolToggle(name)}
+                    />
+                  </CustomTooltip>
+                </Box>
               </Box>
             );
           })}

--- a/frontend/src/sections/settings/falcon-ai-connectors/ConnectorSettingsPage.jsx
+++ b/frontend/src/sections/settings/falcon-ai-connectors/ConnectorSettingsPage.jsx
@@ -18,6 +18,7 @@ import Select from "@mui/material/Select";
 import FormControl from "@mui/material/FormControl";
 import { alpha, useTheme } from "@mui/material/styles";
 import Iconify from "src/components/iconify";
+import ToolsSkeleton from "src/sections/falcon-ai/components/ToolsSkeleton";
 import {
   fetchConnectors,
   useConnector,
@@ -77,10 +78,13 @@ export default function ConnectorSettingsPage() {
   const [selectedId, setSelectedId] = useState(null);
   const [isEditing, setIsEditing] = useState(false);
   const [isNew, setIsNew] = useState(false);
-  const { data: selectedConnector, refetch: refetchSelectedConnector } =
-    useConnector(selectedId, {
-      enabled: Boolean(selectedId) && !isNew,
-    });
+  const {
+    data: selectedConnector,
+    refetch: refetchSelectedConnector,
+    isLoading: isConnectorLoading,
+  } = useConnector(selectedId, {
+    enabled: Boolean(selectedId) && !isNew,
+  });
 
   const loadConnectors = useCallback(async ({ showSpinner = true } = {}) => {
     try {
@@ -191,9 +195,7 @@ export default function ConnectorSettingsPage() {
   };
 
   if (loading) {
-    return (
-      <LoadingScreen sx={{ height: "100%", minHeight: "60vh" }} />
-    );
+    return <LoadingScreen sx={{ height: "100%", minHeight: "60vh" }} />;
   }
 
   return (
@@ -373,6 +375,7 @@ export default function ConnectorSettingsPage() {
           ) : selected ? (
             <ConnectorDetail
               connector={selected}
+              loading={isConnectorLoading}
               onEdit={() => setIsEditing(true)}
               onDelete={() => handleDelete(selected.id)}
               onRefresh={() => refreshSelected(selected.id)}
@@ -432,7 +435,7 @@ export default function ConnectorSettingsPage() {
 // ---------------------------------------------------------------------------
 // Connector Detail (read-only)
 // ---------------------------------------------------------------------------
-function ConnectorDetail({ connector, onEdit, onDelete, onRefresh }) {
+function ConnectorDetail({ connector, loading, onEdit, onDelete, onRefresh }) {
   const theme = useTheme();
   const isDark = theme.palette.mode === "dark";
   const statusInfo = getStatusInfo(connector);
@@ -778,7 +781,14 @@ function ConnectorDetail({ connector, onEdit, onDelete, onRefresh }) {
         )}
       </Typography>
 
-      {tools.length === 0 ? (
+      {loading ? (
+        <ToolsSkeleton
+          title={null}
+          subtitle={null}
+          groupHeader={false}
+          trailing="switch"
+        />
+      ) : tools.length === 0 ? (
         <Box sx={{ textAlign: "center", py: 4 }}>
           <Iconify
             icon="mdi:tools"
@@ -844,6 +854,7 @@ function ConnectorDetail({ connector, onEdit, onDelete, onRefresh }) {
 }
 
 ConnectorDetail.propTypes = {
+  loading: PropTypes.bool,
   connector: PropTypes.shape({
     id: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
     name: PropTypes.string,

--- a/frontend/src/sections/settings/falcon-ai-connectors/__tests__/connector-settings-loading.test.jsx
+++ b/frontend/src/sections/settings/falcon-ai-connectors/__tests__/connector-settings-loading.test.jsx
@@ -1,0 +1,95 @@
+import React from "react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, screen, waitFor, fireEvent } from "src/utils/test-utils";
+
+import ConnectorSettingsPage from "../ConnectorSettingsPage";
+
+// Mocked at the transport layer so the real `useConnector` query runs: the
+// hook closes over its module's own `getConnector`, so replacing that export
+// would leave the hook calling the original.
+const mocks = vi.hoisted(() => ({
+  get: vi.fn(),
+  post: vi.fn(),
+  patch: vi.fn(),
+}));
+
+vi.mock("src/utils/axios", () => ({
+  default: { get: mocks.get, post: mocks.post, patch: mocks.patch },
+  endpoints: {
+    falconAI: {
+      connectors: "/falcon-ai/mcp-connectors/",
+      connector: (id) => `/falcon-ai/mcp-connectors/${id}/`,
+      connectorTools: (id) => `/falcon-ai/mcp-connectors/${id}/tools/`,
+    },
+  },
+}));
+
+// The list serializer omits discovered_tools; only the detail route carries it.
+const LIST_ROW = {
+  id: "conn-1",
+  name: "DeepWiki",
+  server_url: "https://mcp.deepwiki.com/mcp",
+  transport: "streamable_http",
+  auth_type: "none",
+  is_verified: true,
+  tool_count: 2,
+};
+
+const DETAIL = {
+  ...LIST_ROW,
+  discovered_tools: [
+    { name: "ask_question", description: "Ask about a repo." },
+    { name: "read_wiki_contents", description: "View documentation." },
+  ],
+  enabled_tool_names: ["ask_question", "read_wiki_contents"],
+};
+
+const renderPage = () =>
+  render(
+    <QueryClientProvider
+      client={
+        new QueryClient({ defaultOptions: { queries: { retry: false } } })
+      }
+    >
+      <ConnectorSettingsPage />
+    </QueryClientProvider>,
+  );
+
+describe("Connector settings — detail loading", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("shows a loading placeholder, not the empty state, while the detail loads", async () => {
+    let release;
+    mocks.get.mockImplementation((url) => {
+      if (url === "/falcon-ai/mcp-connectors/") {
+        return Promise.resolve({ data: { results: [LIST_ROW] } });
+      }
+      if (url === "/falcon-ai/mcp-connectors/conn-1/") {
+        return new Promise((resolve) => {
+          release = () => resolve({ data: { result: DETAIL } });
+        });
+      }
+      return Promise.resolve({ data: {} });
+    });
+
+    renderPage();
+    fireEvent.click(await screen.findByText("DeepWiki"));
+
+    expect(await screen.findByRole("status")).toHaveAttribute(
+      "aria-label",
+      "Loading tools",
+    );
+    // The list row has no tools; saying "none discovered" here blames the
+    // connector for a request still in flight.
+    expect(
+      screen.queryByText(/No tools discovered yet/i),
+    ).not.toBeInTheDocument();
+
+    release();
+    expect(await screen.findByText("ask_question")).toBeInTheDocument();
+    await waitFor(() =>
+      expect(screen.queryByRole("status")).not.toBeInTheDocument(),
+    );
+  });
+});

--- a/frontend/src/sections/settings/falcon-ai-connectors/__tests__/connector-settings-tool-permissions.test.jsx
+++ b/frontend/src/sections/settings/falcon-ai-connectors/__tests__/connector-settings-tool-permissions.test.jsx
@@ -1,0 +1,261 @@
+import React from "react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, screen, waitFor, fireEvent, act } from "src/utils/test-utils";
+
+import ConnectorSettingsPage from "../ConnectorSettingsPage";
+
+// Mocked at the transport layer so the real `useConnector` query runs: the
+// hook closes over its module's own `getConnector`, so replacing that export
+// would leave the hook calling the original.
+const mocks = vi.hoisted(() => ({
+  get: vi.fn(),
+  post: vi.fn(),
+  patch: vi.fn(),
+}));
+
+vi.mock("src/utils/axios", () => ({
+  default: { get: mocks.get, post: mocks.post, patch: mocks.patch },
+  endpoints: {
+    falconAI: {
+      connectors: "/falcon-ai/mcp-connectors/",
+      connector: (id) => `/falcon-ai/mcp-connectors/${id}/`,
+      connectorTools: (id) => `/falcon-ai/mcp-connectors/${id}/tools/`,
+    },
+  },
+}));
+
+const LIST_ROW = {
+  id: "conn-1",
+  name: "DeepWiki",
+  server_url: "https://mcp.deepwiki.com/mcp",
+  transport: "streamable_http",
+  auth_type: "none",
+  is_verified: true,
+  tool_count: 2,
+};
+
+const DETAIL = {
+  ...LIST_ROW,
+  discovered_tools: [
+    { name: "ask_question", description: "Ask about a repo." },
+    { name: "read_wiki_contents", description: "View documentation." },
+  ],
+  enabled_tool_names: ["ask_question", "read_wiki_contents"],
+};
+
+const TOOLS_URL = "/falcon-ai/mcp-connectors/conn-1/tools/";
+
+const renderPage = () =>
+  render(
+    <QueryClientProvider
+      client={
+        new QueryClient({ defaultOptions: { queries: { retry: false } } })
+      }
+    >
+      <ConnectorSettingsPage />
+    </QueryClientProvider>,
+  );
+
+// Opens the connector and waits for the detail route's tools to render.
+const openConnector = async (detail) => {
+  mocks.get.mockImplementation((url) => {
+    if (url === "/falcon-ai/mcp-connectors/") {
+      return Promise.resolve({ data: { results: [LIST_ROW] } });
+    }
+    if (url === "/falcon-ai/mcp-connectors/conn-1/") {
+      return Promise.resolve({ data: { result: detail } });
+    }
+    return Promise.resolve({ data: {} });
+  });
+  mocks.patch.mockResolvedValue({ data: { result: detail } });
+
+  renderPage();
+  fireEvent.click(await screen.findByText("DeepWiki"));
+  await screen.findByText("ask_question");
+};
+
+describe("Connector settings — tool permissions", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("refuses to deny the last enabled tool, which would grant every tool", async () => {
+    // [] is the all-enabled sentinel on both sides (mcp_tools.py:207), so
+    // emptying the list inverts the permission and persists. TH-7673 — the
+    // same guard the Customize pane has, on the surface that lacked it.
+    await openConnector({ ...DETAIL, enabled_tool_names: ["ask_question"] });
+
+    const [askQuestion] = screen.getAllByRole("checkbox");
+    expect(askQuestion).toBeChecked();
+
+    fireEvent.click(askQuestion);
+
+    expect(await screen.findByRole("alert")).toHaveTextContent(
+      /At least one tool must stay allowed/i,
+    );
+    expect(mocks.patch).not.toHaveBeenCalled();
+  });
+
+  it("denies a tool from the all-enabled sentinel instead of writing it back", async () => {
+    // Stored [] means "all enabled". Filtering the raw list leaves [], which
+    // reads as all-enabled again — the toggle appears to do nothing.
+    await openConnector({ ...DETAIL, enabled_tool_names: [] });
+
+    const [askQuestion] = screen.getAllByRole("checkbox");
+    expect(askQuestion).toBeChecked();
+
+    fireEvent.click(askQuestion);
+
+    await waitFor(() =>
+      expect(mocks.patch).toHaveBeenCalledWith(TOOLS_URL, {
+        enabled_tool_names: ["read_wiki_contents"],
+      }),
+    );
+  });
+
+  it("still allows denying a tool when others remain enabled", async () => {
+    await openConnector(DETAIL);
+
+    fireEvent.click(screen.getAllByRole("checkbox")[0]);
+
+    await waitFor(() =>
+      expect(mocks.patch).toHaveBeenCalledWith(TOOLS_URL, {
+        enabled_tool_names: ["read_wiki_contents"],
+      }),
+    );
+  });
+
+  it("shows the write in flight rather than a switch that does nothing", async () => {
+    // The switch is controlled by the server's answer, and this page also
+    // refetches the list afterwards, so the wait is longer than it looks.
+    await openConnector(DETAIL);
+
+    // After openConnector: the helper seeds a resolved patch of its own.
+    let release;
+    mocks.patch.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          release = () => resolve({ data: { result: DETAIL } });
+        }),
+    );
+
+    fireEvent.click(screen.getAllByRole("checkbox")[0]);
+
+    expect(await screen.findByLabelText("Saving")).toBeInTheDocument();
+    // Still clickable: the writer coalesces further clicks rather than
+    // dropping them, so blocking them would defeat the point.
+    expect(screen.getAllByRole("checkbox")[0]).not.toBeDisabled();
+
+    await act(async () => {
+      release();
+    });
+    await waitFor(() =>
+      expect(screen.queryByLabelText("Saving")).not.toBeInTheDocument(),
+    );
+  });
+
+  it("coalesces clicks made while a write is out instead of losing them", async () => {
+    await openConnector({
+      ...DETAIL,
+      discovered_tools: [
+        ...DETAIL.discovered_tools,
+        { name: "read_wiki_structure", description: "List doc topics." },
+      ],
+      enabled_tool_names: [
+        "ask_question",
+        "read_wiki_contents",
+        "read_wiki_structure",
+      ],
+    });
+
+    const releases = [];
+    mocks.patch.mockImplementation(
+      () =>
+        new Promise((resolve) => releases.push(() => resolve({ data: {} }))),
+    );
+
+    fireEvent.click(screen.getAllByRole("checkbox")[0]);
+    fireEvent.click(screen.getAllByRole("checkbox")[1]);
+
+    expect(mocks.patch).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      releases[0]();
+    });
+
+    await waitFor(() => expect(mocks.patch).toHaveBeenCalledTimes(2));
+    expect(mocks.patch.mock.calls[1][1]).toEqual({
+      enabled_tool_names: ["read_wiki_structure"],
+    });
+  });
+
+  it("sends a click that arrives while the post-write refresh is running", async () => {
+    // This page resyncs from the server once writes settle, and that refetch
+    // is as slow as any other request. A click during it must still be sent.
+    const three = {
+      ...DETAIL,
+      discovered_tools: [
+        ...DETAIL.discovered_tools,
+        { name: "read_wiki_structure", description: "List doc topics." },
+      ],
+      enabled_tool_names: [
+        "ask_question",
+        "read_wiki_contents",
+        "read_wiki_structure",
+      ],
+    };
+    await openConnector(three);
+
+    let releaseRefresh;
+    mocks.get.mockImplementation((url) => {
+      if (url === "/falcon-ai/mcp-connectors/") {
+        return Promise.resolve({ data: { results: [LIST_ROW] } });
+      }
+      if (url === "/falcon-ai/mcp-connectors/conn-1/") {
+        return new Promise((resolve) => {
+          releaseRefresh = () => resolve({ data: { result: three } });
+        });
+      }
+      return Promise.resolve({ data: {} });
+    });
+
+    fireEvent.click(screen.getAllByRole("checkbox")[0]);
+    await waitFor(() => expect(mocks.patch).toHaveBeenCalledTimes(1));
+
+    // The write has landed and the refresh is now in flight.
+    await waitFor(() => expect(releaseRefresh).toBeDefined());
+    fireEvent.click(screen.getAllByRole("checkbox")[1]);
+
+    await act(async () => {
+      releaseRefresh();
+    });
+
+    // Without the outer drain loop this second write is never sent, and the
+    // refresh reverts the row it was applied to.
+    await waitFor(() => expect(mocks.patch).toHaveBeenCalledTimes(2));
+    expect(mocks.patch.mock.calls[1][1]).toEqual({
+      enabled_tool_names: ["read_wiki_structure"],
+    });
+  });
+
+  it("warns on the last enabled toggle before it is clicked", async () => {
+    await openConnector({ ...DETAIL, enabled_tool_names: ["ask_question"] });
+
+    fireEvent.mouseOver(screen.getAllByRole("checkbox")[0]);
+
+    expect(
+      await screen.findByText(/at least one must stay on/i),
+    ).toBeInTheDocument();
+  });
+
+  it("leaves the other toggles unannotated", async () => {
+    await openConnector(DETAIL);
+
+    fireEvent.mouseOver(screen.getAllByRole("checkbox")[0]);
+
+    await waitFor(() =>
+      expect(
+        screen.queryByText(/at least one must stay on/i),
+      ).not.toBeInTheDocument(),
+    );
+  });
+});


### PR DESCRIPTION
## 🐛 Bug

The Customize panel's connector pane always rendered "No tools discovered yet", so **Tool permissions** was unreachable for every connector — the surface the docs point users at to allow/deny connector tools.

**Root cause:** `handleSelectItem` fetched the detail record only when the Skills tab was active. A selected connector kept its list-endpoint payload, and `MCPConnectorListSerializer` carries neither `discovered_tools` nor `enabled_tool_names` (only `tool_count`), so the pane always saw an empty array. The settings page worked because it reads through `useConnector`, which hits the detail route.

Two further defects surfaced on the same path once the tools rendered:

- **Toggling a tool wiped every permission.** The handler read `conn.tools` off the *list* row — always `undefined` — so each toggle PATCHed an empty set. It also sent tool *objects* where `MCPConnectorToolsSerializer` wants name strings.
- **"Always allow" raced itself.** It fired the single-tool toggle per tool, each computing its next set from the same stale snapshot, so only the last write survived.

## 🔧 What changed

- `useFalconAPI.js` — added `getConnector(id)`; `useConnector` now delegates to it, so the URL and response unwrapping live in one place. A hook can't be called from a click handler, hence the plain function.
- `CustomizePanel.jsx` — fetches connector detail on select; permission writes moved out to a hook.
- `hooks/useConnectorToolPermissions.js` *(new)* — derives permissions from the detail record and writes **names**; "Always allow" sends one request for the group.
- `components/connectorTools.js` *(new)* — `resolveEnabledNames` expands the empty-list sentinel (`[]` means "all enabled") to the concrete set, so switching one tool off doesn't read as all-on again.
- `components/ToolsSkeleton.jsx` *(new)* — loading placeholder mirroring the loaded layout element for element.
- `components/ConnectorDetailError.jsx` *(new)* — failed detail fetch reports the reason with a retry.
- `ConnectorSettingsPage.jsx` — same loading gap fixed on that surface.

## 🤔 Why

Both panes previously answered "no tools discovered" while the detail request was still in flight, blaming the connector for a list it hadn't reported yet. The skeleton mirrors the loaded structure (heading → subtitle → group header → rows) so nothing shifts when the real tools land.

Permissions are keyed by name because that's what the API stores. Reading them from `selectedItem` rather than the list row is what stops the wipe — cc @cdileep23, the empty-list-means-all sentinel is the subtle part worth a look.

## 🧪 Tests

- Customize: fetches detail on select and renders Tool permissions
- Customize: skeleton, not the empty state, while the detail loads
- Customize: failed detail fetch reports the reason; retry recovers in place
- Customize: writes tool *names*, keeps untouched permissions (the wipe regression)
- Customize: "Always allow" sends one request, not one per tool
- Customize: genuinely empty connector still gets the empty state
- Settings: skeleton, not the empty state, while the detail loads
- `resolveEnabledNames`: stored list wins; empty sentinel expands to all; no tools → none

Each was verified by reverting its fix and confirming the failure.

## ▶️ How to verify

1. Settings → Workspace Settings → **Falcon AI Connectors** → **Add Connector**
2. Server URL `https://huggingface.co/mcp`, Transport Streamable HTTP, Authentication None → **Create** → **Discover Tools** (4 tools)
3. Falcon AI → **Customize** → **Connectors** → select it

**Before:** "No tools discovered yet." **After:** Tool permissions with the four tools.

Then deny two tools, reselect the connector, and confirm the other two are still allowed — pre-fix, the first toggle cleared all of them.

## 💻 Commands

```bash
cd frontend
npx vitest run src/sections/falcon-ai src/sections/settings/falcon-ai-connectors
```

Full suite: 306 files / 2621 tests passing. eslint exit 0, prettier clean.

## 📹 Videos & Screenshots

**Loading states** (isolated render of `ToolsSkeleton`, both variants):

![loading-skeletons](https://github.com/user-attachments/assets/79036a62-2b00-42e4-a93d-661a8162d3e3)

**Testing on dev:**

https://github.com/user-attachments/assets/eed496a0-9387-4db4-ad97-e0e0a7b9faeb

https://github.com/user-attachments/assets/a7304833-108f-49f6-8587-32d6a5f9fe2d

https://github.com/user-attachments/assets/b82430ba-205a-4649-a161-d0072e0f7e8c

https://github.com/user-attachments/assets/520f17a2-46d6-4956-9905-725c7885cac1
