### PR TITLE
Feature/webhook alert notifications

### DIFF
--- a/frontend/src/sections/projects/Alerts/common.js
+++ b/frontend/src/sections/projects/Alerts/common.js
@@ -169,6 +169,10 @@ export const notificationOptions = [
     label: "Slack",
     value: "slack",
   },
+  {
+    label: "Webhook",
+    value: "webhook",
+  },
 ];
 
 export const timeOptions = [

--- a/frontend/src/sections/projects/Alerts/components/AlertSettingsForm.jsx
+++ b/frontend/src/sections/projects/Alerts/components/AlertSettingsForm.jsx
@@ -321,12 +321,15 @@ export default function AlertSettingsForm({
       convertFiltersToPayload(data?.filters);
 
     const isSlack = data?.notification?.method === "slack";
+    const isWebhook = data?.notification?.method === "webhook";
     const notificationPayload = {
-      notification_emails: isSlack ? [] : data?.notification?.emails ?? [],
+      notification_emails:
+        !isSlack && !isWebhook ? data?.notification?.emails ?? [] : [],
       slack_webhook_url: isSlack
         ? data?.notification?.slack?.webhookUrl ?? ""
         : "",
       slack_notes: isSlack ? data?.notification?.slack?.notes ?? "" : "",
+      webhook_url: isWebhook ? data?.notification?.webhook?.url ?? "" : "",
     };
     if (
       selectedMetricOptions?.length > 0 &&
@@ -1025,6 +1028,24 @@ export default function AlertSettingsForm({
                     fullWidth
                     multiline
                     rows={4}
+                  />
+                </Stack>
+              </ShowComponent>
+              <ShowComponent condition={selectedNotificationMethod === "webhook"}>
+                <Stack
+                  sx={{
+                    padding: 3,
+                    gap: 3,
+                  }}
+                >
+                  <FormTextFieldV2
+                    control={control}
+                    required
+                    placeholder="Enter webhook URL (e.g. https://example.com/webhook)"
+                    fieldName="notification.webhook.url"
+                    label="Webhook URL"
+                    size="small"
+                    fullWidth
                   />
                 </Stack>
               </ShowComponent>

--- a/frontend/src/sections/projects/Alerts/components/validation.js
+++ b/frontend/src/sections/projects/Alerts/components/validation.js
@@ -62,7 +62,7 @@ export const AlertConfigValidationSchema = z
     ),
     notification: z
       .object({
-        method: z.enum(["email", "slack"], {
+        method: z.enum(["email", "slack", "webhook"], {
           required_error: "Select notification method",
         }),
         emails: z
@@ -73,6 +73,11 @@ export const AlertConfigValidationSchema = z
           .object({
             webhookUrl: z.string().optional(),
             notes: z.string().optional(),
+          })
+          .optional(),
+        webhook: z
+          .object({
+            url: z.string().optional(),
           })
           .optional(),
       })
@@ -101,6 +106,25 @@ export const AlertConfigValidationSchema = z
                 path: ["slack", "webhookUrl"],
                 code: "custom",
                 message: "Invalid Slack webhook URL",
+              });
+            }
+          }
+        }
+
+        if (notif.method === "webhook") {
+          if (!notif.webhook || !notif.webhook.url) {
+            ctx.addIssue({
+              path: ["webhook", "url"],
+              code: "custom",
+              message: "Webhook URL is required",
+            });
+          } else {
+            const urlPattern = /^(https?:\/\/)[^\s/$.?#].[^\s]*$/i;
+            if (!urlPattern.test(notif.webhook.url)) {
+              ctx.addIssue({
+                path: ["webhook", "url"],
+                code: "custom",
+                message: "Invalid webhook URL",
               });
             }
           }
@@ -262,6 +286,11 @@ const numberOr = (value, fallback) => {
 };
 
 export function getDefaultAlertConfigValues(existingConfig = {}) {
+  const webhookUrl = readAlertField(
+    existingConfig,
+    "webhookUrl",
+    "webhook_url",
+  );
   const slackWebhookUrl = readAlertField(
     existingConfig,
     "slackWebhookUrl",
@@ -323,12 +352,19 @@ export function getDefaultAlertConfigValues(existingConfig = {}) {
       ALERT_CONFIG_DEFAULTS.warning_threshold_value,
     ),
     notification: {
-      method: slackWebhookUrl ? "slack" : "email",
+      method: webhookUrl
+        ? "webhook"
+        : slackWebhookUrl
+          ? "slack"
+          : "email",
       emails: notificationEmails || [],
       slack: {
         webhookUrl: slackWebhookUrl || "",
         notes:
           readAlertField(existingConfig, "slackNotes", "slack_notes") || "",
+      },
+      webhook: {
+        url: webhookUrl || "",
       },
     },
   };

--- a/futureagi/tracer/migrations/0098_useralertmonitor_webhook_url.py
+++ b/futureagi/tracer/migrations/0098_useralertmonitor_webhook_url.py
@@ -1,0 +1,16 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("tracer", "0097_eval_logger_task_created_idx"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="useralertmonitor",
+            name="webhook_url",
+            field=models.URLField(blank=True, null=True),
+        ),
+    ]

--- a/futureagi/tracer/models/monitor.py
+++ b/futureagi/tracer/models/monitor.py
@@ -1,11 +1,10 @@
 import uuid
 
+from accounts.models.organization import Organization
+from accounts.models.user import User
 from django.contrib.postgres.fields import ArrayField
 from django.core.validators import MinValueValidator
 from django.db import models
-
-from accounts.models.organization import Organization
-from accounts.models.user import User
 from tfc.utils.base_model import BaseModel
 from tracer.models.project import Project
 
@@ -133,6 +132,7 @@ class UserAlertMonitor(BaseModel):
     notification_emails: ArrayField = ArrayField(models.EmailField(), default=list)
     slack_webhook_url = models.URLField(null=True, blank=True)
     slack_notes = models.TextField(null=True, blank=True)
+    webhook_url = models.URLField(null=True, blank=True)
 
     # Monitor state and configuration
     is_mute = models.BooleanField(default=False)

--- a/futureagi/tracer/tests/test_webhook_notification.py
+++ b/futureagi/tracer/tests/test_webhook_notification.py
@@ -1,0 +1,364 @@
+"""
+Webhook notification channel tests.
+
+Tests for creating/updating/duplicating monitors with webhook_url
+and for the _send_webhook_notification delivery function.
+"""
+
+import uuid
+from unittest.mock import MagicMock, patch
+
+import pytest
+from django.test import override_settings
+from rest_framework import status
+
+from tracer.models.monitor import UserAlertMonitor, UserAlertMonitorLog
+from tracer.utils.monitor import (
+    _handle_alert_trigger,
+    _send_webhook_notification,
+)
+
+
+def get_result(response):
+    """Extract result from API response wrapper."""
+    data = response.json()
+    return data.get("result", data)
+
+
+# ── API Tests ──────────────────────────────────────────────────────────
+
+
+@pytest.mark.integration
+@pytest.mark.api
+class TestWebhookMonitorAPI:
+    """Tests for webhook_url field on /tracer/user-alerts/ endpoints."""
+
+    @pytest.mark.requires_ee
+    def test_create_monitor_with_webhook_url(self, auth_client, observe_project):
+        """Create a new monitor with a webhook notification URL."""
+        response = auth_client.post(
+            "/tracer/user-alerts/",
+            {
+                "project": str(observe_project.id),
+                "name": "Webhook Alert",
+                "metric_type": "count_of_errors",
+                "threshold_operator": "greater_than",
+                "threshold_type": "static",
+                "critical_threshold_value": 0.15,
+                "alert_frequency": 60,
+                "webhook_url": "https://example.com/webhook",
+            },
+            format="json",
+        )
+        assert response.status_code == status.HTTP_200_OK
+        monitor = UserAlertMonitor.objects.get(name="Webhook Alert")
+        assert monitor.webhook_url == "https://example.com/webhook"
+
+    @pytest.mark.requires_ee
+    def test_create_monitor_without_webhook_url(self, auth_client, observe_project):
+        """Monitors created without webhook_url should have it as None."""
+        response = auth_client.post(
+            "/tracer/user-alerts/",
+            {
+                "project": str(observe_project.id),
+                "name": "No Webhook Alert",
+                "metric_type": "count_of_errors",
+                "threshold_operator": "greater_than",
+                "threshold_type": "static",
+                "critical_threshold_value": 0.15,
+                "alert_frequency": 60,
+            },
+            format="json",
+        )
+        assert response.status_code == status.HTTP_200_OK
+        monitor = UserAlertMonitor.objects.get(name="No Webhook Alert")
+        assert monitor.webhook_url is None
+
+    @pytest.mark.requires_ee
+    def test_update_monitor_webhook_url(self, auth_client, user_alert_monitor):
+        """PATCH should update the webhook_url field."""
+        response = auth_client.patch(
+            f"/tracer/user-alerts/{user_alert_monitor.id}/",
+            {"webhook_url": "https://example.com/updated-webhook"},
+            format="json",
+        )
+        assert response.status_code == status.HTTP_200_OK
+        user_alert_monitor.refresh_from_db()
+        assert user_alert_monitor.webhook_url == "https://example.com/updated-webhook"
+
+    @pytest.mark.requires_ee
+    def test_duplicate_monitor_copies_webhook_url(
+        self, auth_client, user_alert_monitor
+    ):
+        """Duplicate action should preserve webhook_url."""
+        user_alert_monitor.webhook_url = "https://example.com/webhook"
+        user_alert_monitor.save(update_fields=["webhook_url"])
+
+        response = auth_client.post(
+            "/tracer/user-alerts/duplicate/",
+            {"id": str(user_alert_monitor.id), "name": "Webhook Copy"},
+            format="json",
+        )
+        assert response.status_code == status.HTTP_200_OK
+        copied = UserAlertMonitor.objects.get(name="Webhook Copy")
+        assert copied.webhook_url == "https://example.com/webhook"
+
+    @pytest.mark.requires_ee
+    def test_get_monitor_returns_webhook_url(self, auth_client, user_alert_monitor):
+        """GET details should include webhook_url in response."""
+        user_alert_monitor.webhook_url = "https://example.com/webhook"
+        user_alert_monitor.save(update_fields=["webhook_url"])
+
+        response = auth_client.get(
+            f"/tracer/user-alerts/{user_alert_monitor.id}/details/"
+        )
+        assert response.status_code == status.HTTP_200_OK
+        result = get_result(response)
+        assert result["webhook_url"] == "https://example.com/webhook"
+
+
+# ── Unit Tests: _send_webhook_notification ─────────────────────────────
+
+
+@pytest.mark.unit
+class TestSendWebhookNotification:
+    """Unit tests for the _send_webhook_notification function."""
+
+    def _make_monitor(self, webhook_url=None):
+        """Create a mock monitor object."""
+        monitor = MagicMock()
+        monitor.id = uuid.uuid4()
+        monitor.name = "Test Monitor"
+        monitor.webhook_url = webhook_url
+        monitor.metric_type = "count_of_errors"
+        monitor.project_id = uuid.uuid4()
+        monitor.project.name = "Test Project"
+        return monitor
+
+    def test_skips_when_no_url(self):
+        """Should return immediately when webhook_url is not set."""
+        monitor = self._make_monitor(webhook_url=None)
+        with patch("tracer.utils.monitor.requests.post") as mock_post:
+            _send_webhook_notification(monitor, "test msg", "critical")
+            mock_post.assert_not_called()
+
+    def test_skips_when_empty_url(self):
+        """Should return immediately when webhook_url is empty string."""
+        monitor = self._make_monitor(webhook_url="")
+        with patch("tracer.utils.monitor.requests.post") as mock_post:
+            _send_webhook_notification(monitor, "test msg", "critical")
+            mock_post.assert_not_called()
+
+    @override_settings(APP_URL="app.futureagi.com")
+    def test_sends_correct_payload(self):
+        """Should POST a JSON payload with required fields."""
+        monitor = self._make_monitor(webhook_url="https://example.com/webhook")
+
+        with patch("tracer.utils.monitor.requests.post") as mock_post:
+            mock_post.return_value = MagicMock(status_code=200)
+            mock_post.return_value.raise_for_status = MagicMock()
+
+            _send_webhook_notification(
+                monitor,
+                "threshold breached",
+                "critical",
+                current_value=0.95,
+                threshold_value=0.5,
+            )
+
+            mock_post.assert_called_once()
+            call_kwargs = mock_post.call_args
+            payload = call_kwargs.kwargs.get("json") or call_kwargs[1].get("json")
+
+            assert payload["event"] == "alert.triggered"
+            assert payload["alert_type"] == "critical"
+            assert payload["monitor"]["id"] == str(monitor.id)
+            assert payload["monitor"]["name"] == "Test Monitor"
+            assert payload["project"]["id"] == str(monitor.project_id)
+            assert payload["metric"] == "count_of_errors"
+            assert payload["current_value"] == 0.95
+            assert payload["threshold_value"] == 0.5
+            assert payload["message"] == "threshold breached"
+            assert "timestamp" in payload
+            assert payload["dashboard_url"] == "app.futureagi.com/dashboard/alerts"
+
+    def test_sends_correct_headers(self):
+        """Should include Content-Type and User-Agent headers."""
+        monitor = self._make_monitor(webhook_url="https://example.com/webhook")
+
+        with patch("tracer.utils.monitor.requests.post") as mock_post:
+            mock_post.return_value = MagicMock(status_code=200)
+            mock_post.return_value.raise_for_status = MagicMock()
+
+            _send_webhook_notification(monitor, "msg", "warning")
+
+            call_kwargs = mock_post.call_args
+            headers = call_kwargs.kwargs.get("headers") or call_kwargs[1].get("headers")
+            assert headers["Content-Type"] == "application/json"
+            assert headers["User-Agent"] == "FutureAGI-Alerts/1.0"
+
+    def test_uses_correct_url(self):
+        """Should POST to the monitor's webhook_url."""
+        url = "https://hooks.example.com/my-webhook"
+        monitor = self._make_monitor(webhook_url=url)
+
+        with patch("tracer.utils.monitor.requests.post") as mock_post:
+            mock_post.return_value = MagicMock(status_code=200)
+            mock_post.return_value.raise_for_status = MagicMock()
+
+            _send_webhook_notification(monitor, "msg", "critical")
+
+            assert mock_post.call_args[0][0] == url
+
+    def test_uses_timeout(self):
+        """Should set a reasonable timeout on the HTTP request."""
+        monitor = self._make_monitor(webhook_url="https://example.com/webhook")
+
+        with patch("tracer.utils.monitor.requests.post") as mock_post:
+            mock_post.return_value = MagicMock(status_code=200)
+            mock_post.return_value.raise_for_status = MagicMock()
+
+            _send_webhook_notification(monitor, "msg", "critical")
+
+            call_kwargs = mock_post.call_args
+            timeout = call_kwargs.kwargs.get("timeout") or call_kwargs[1].get("timeout")
+            assert timeout == 10
+
+    def test_failure_is_logged_not_raised(self):
+        """HTTP errors should be logged, not raised."""
+        monitor = self._make_monitor(webhook_url="https://example.com/webhook")
+
+        with patch("tracer.utils.monitor.requests.post") as mock_post:
+            mock_post.side_effect = Exception("Connection refused")
+
+            # Should NOT raise
+            _send_webhook_notification(monitor, "msg", "critical")
+
+    def test_http_error_status_logged_not_raised(self):
+        """Non-2xx responses should be caught by raise_for_status."""
+        monitor = self._make_monitor(webhook_url="https://example.com/webhook")
+
+        with patch("tracer.utils.monitor.requests.post") as mock_post:
+            mock_resp = MagicMock(status_code=500)
+            mock_resp.raise_for_status.side_effect = Exception("500 Server Error")
+            mock_post.return_value = mock_resp
+
+            # Should NOT raise
+            _send_webhook_notification(monitor, "msg", "critical")
+
+    @override_settings(APP_URL=None)
+    def test_empty_dashboard_url_when_no_app_url(self):
+        """When APP_URL is not configured, dashboard_url should be empty."""
+        monitor = self._make_monitor(webhook_url="https://example.com/webhook")
+
+        with patch("tracer.utils.monitor.requests.post") as mock_post:
+            mock_post.return_value = MagicMock(status_code=200)
+            mock_post.return_value.raise_for_status = MagicMock()
+
+            _send_webhook_notification(monitor, "msg", "critical")
+
+            payload = mock_post.call_args.kwargs.get("json") or mock_post.call_args[
+                1
+            ].get("json")
+            assert payload["dashboard_url"] == ""
+
+
+# ── Unit Tests: _handle_alert_trigger with webhook ────────────────────
+
+
+@pytest.mark.unit
+class TestHandleAlertTriggerWebhook:
+    """Tests that _handle_alert_trigger calls webhook alongside email/Slack."""
+
+    @pytest.mark.django_db
+    def test_calls_webhook_notification(self, user_alert_monitor):
+        """_handle_alert_trigger should call _send_webhook_notification."""
+        user_alert_monitor.webhook_url = "https://example.com/webhook"
+        user_alert_monitor.save(update_fields=["webhook_url"])
+
+        with (
+            patch("tracer.utils.monitor._send_alert_email") as mock_email,
+            patch("tracer.utils.monitor._send_slack_notification") as mock_slack,
+            patch("tracer.utils.monitor._send_webhook_notification") as mock_webhook,
+        ):
+            _handle_alert_trigger(
+                user_alert_monitor,
+                "test message",
+                "critical",
+                current_value=0.9,
+                threshold_value=0.5,
+            )
+
+            mock_email.assert_called_once()
+            mock_slack.assert_called_once()
+            mock_webhook.assert_called_once_with(
+                user_alert_monitor,
+                "test message",
+                "critical",
+                0.9,
+                0.5,
+            )
+
+    @pytest.mark.django_db
+    def test_webhook_failure_does_not_block_email(self, user_alert_monitor):
+        """A failing webhook should not prevent email from being sent."""
+        user_alert_monitor.webhook_url = "https://example.com/webhook"
+        user_alert_monitor.save(update_fields=["webhook_url"])
+
+        with (
+            patch("tracer.utils.monitor._send_alert_email") as mock_email,
+            patch("tracer.utils.monitor._send_slack_notification") as mock_slack,
+            patch("tracer.utils.monitor.requests.post") as mock_post,
+        ):
+            mock_post.side_effect = Exception("Connection refused")
+
+            _handle_alert_trigger(
+                user_alert_monitor,
+                "test message",
+                "critical",
+            )
+
+            # Email and Slack should still be called despite webhook failure
+            mock_email.assert_called_once()
+            mock_slack.assert_called_once()
+
+    @pytest.mark.django_db
+    def test_creates_log_entry(self, user_alert_monitor):
+        """_handle_alert_trigger should create a UserAlertMonitorLog."""
+        with (
+            patch("tracer.utils.monitor._send_alert_email"),
+            patch("tracer.utils.monitor._send_slack_notification"),
+            patch("tracer.utils.monitor._send_webhook_notification"),
+        ):
+            _handle_alert_trigger(
+                user_alert_monitor,
+                "log test",
+                "warning",
+            )
+
+        log = UserAlertMonitorLog.objects.get(alert=user_alert_monitor)
+        assert log.message == "log test"
+        assert log.type == "warning"
+
+    @pytest.mark.django_db
+    def test_backward_compatible_without_value_kwargs(self, user_alert_monitor):
+        """_handle_alert_trigger should work without current_value/threshold_value."""
+        with (
+            patch("tracer.utils.monitor._send_alert_email"),
+            patch("tracer.utils.monitor._send_slack_notification"),
+            patch("tracer.utils.monitor._send_webhook_notification") as mock_webhook,
+        ):
+            # Call without the new kwargs — backward compatible
+            _handle_alert_trigger(
+                user_alert_monitor,
+                "test message",
+                "critical",
+            )
+
+            mock_webhook.assert_called_once_with(
+                user_alert_monitor,
+                "test message",
+                "critical",
+                None,
+                None,
+            )

--- a/futureagi/tracer/utils/monitor.py
+++ b/futureagi/tracer/utils/monitor.py
@@ -1,20 +1,20 @@
 from datetime import datetime, timedelta
-from typing import TYPE_CHECKING, Optional, Tuple
+from typing import TYPE_CHECKING, Optional
 
 if TYPE_CHECKING:
     from tracer.services.clickhouse.query_builders.monitor_metrics import (
         MonitorMetricsQueryBuilder,
     )
 
+import requests
 import structlog
+from django.conf import settings
 from django.core.exceptions import ValidationError as DjangoValidationError
 from django.db.models import DurationField, ExpressionWrapper, F, Q
 from django.db.models.functions import Now
 from django.utils import timezone
 from django.utils.dateparse import parse_datetime
 from slack_sdk.webhook import WebhookClient
-
-logger = structlog.get_logger(__name__)
 from tfc.temporal import temporal_activity
 from tfc.utils.email import email_helper
 from tracer.models.custom_eval_config import CustomEvalConfig, EvalOutputType
@@ -27,6 +27,8 @@ from tracer.models.monitor import (
     UserAlertMonitorLog,
 )
 from tracer.services.clickhouse.query_service import AnalyticsQueryService
+
+logger = structlog.get_logger(__name__)
 
 # Pruned monitor queries scale with the window, not table size; 30s covers the
 # historical window crossing the hot/cold TTL boundary.
@@ -166,12 +168,64 @@ def _send_slack_notification(
         )
 
 
+def _send_webhook_notification(
+    monitor: UserAlertMonitor,
+    message: str,
+    alert_type: str,
+    current_value: float | None = None,
+    threshold_value: float | None = None,
+) -> None:
+    """Sends a webhook notification for an alert."""
+    if not monitor.webhook_url:
+        return
+
+    app_url = (getattr(settings, "APP_URL", "") or "").rstrip("/")
+    dashboard_link = f"{app_url}/dashboard/alerts" if app_url else ""
+
+    payload = {
+        "event": "alert.triggered",
+        "alert_type": alert_type,
+        "monitor": {
+            "id": str(monitor.id),
+            "name": monitor.name,
+        },
+        "project": {
+            "id": str(monitor.project_id),
+            "name": monitor.project.name if monitor.project else None,
+        },
+        "metric": monitor.metric_type,
+        "current_value": current_value,
+        "threshold_value": threshold_value,
+        "message": message,
+        "timestamp": timezone.now().isoformat(),
+        "dashboard_url": dashboard_link,
+    }
+
+    headers = {
+        "Content-Type": "application/json",
+        "User-Agent": "FutureAGI-Alerts/1.0",
+    }
+
+    try:
+        resp = requests.post(
+            monitor.webhook_url, json=payload, headers=headers, timeout=10
+        )
+        resp.raise_for_status()
+        logger.info(f"Sent {alert_type} webhook notification for monitor {monitor.id}")
+    except Exception as e:
+        logger.error(
+            f"Failed to send {alert_type} webhook notification for monitor {monitor.id}: {e}"
+        )
+
+
 def _handle_alert_trigger(
     monitor: UserAlertMonitor,
     message: str,
     alert_type: str,
-    time_window_start: Optional[datetime] = None,
-    now: Optional[datetime] = None,
+    time_window_start: datetime | None = None,
+    now: datetime | None = None,
+    current_value: float | None = None,
+    threshold_value: float | None = None,
 ) -> None:
     """Handles the actions when an alert is triggered."""
     UserAlertMonitorLog.objects.create(
@@ -189,6 +243,9 @@ def _handle_alert_trigger(
     )
     _send_alert_email(monitor, message, alert_type)
     _send_slack_notification(monitor, message, alert_type)
+    _send_webhook_notification(
+        monitor, message, alert_type, current_value, threshold_value
+    )
 
 
 @temporal_activity(
@@ -290,7 +347,7 @@ def _get_metric_value(
     start_time: datetime,
     end_time: datetime,
     builder: Optional["MonitorMetricsQueryBuilder"] = None,
-) -> Optional[float]:
+) -> float | None:
     """Metric value for the time window, from ClickHouse. Raises on CH errors."""
     analytics = AnalyticsQueryService()
     builder = builder or build_monitor_ch_builder(monitor)
@@ -320,7 +377,7 @@ def _get_historical_stats(
     start_time: datetime,
     end_time: datetime,
     builder: Optional["MonitorMetricsQueryBuilder"] = None,
-) -> Tuple[Optional[float], Optional[float]]:
+) -> tuple[float | None, float | None]:
     """Historical (mean, stddev) for the window, from ClickHouse. Raises on CH errors."""
     analytics = AnalyticsQueryService()
     builder = builder or build_monitor_ch_builder(monitor)
@@ -388,7 +445,15 @@ def _check_static_threshold(
             f"({current_value:.2f}) breached the {alert_type} threshold "
             f"({monitor.threshold_operator} {threshold_val})."
         )
-        _handle_alert_trigger(monitor, message, alert_type, time_window_start, now)
+        _handle_alert_trigger(
+            monitor,
+            message,
+            alert_type,
+            time_window_start,
+            now,
+            current_value=current_value,
+            threshold_value=threshold_val,
+        )
 
 
 def _check_percentage_change_threshold(
@@ -454,7 +519,15 @@ def _check_percentage_change_threshold(
             f"({monitor.threshold_operator} {threshold_val:.2f}) based on historical data "
             f"(mean: {historical_mean:.2f}, stddev: {historical_stddev:.2f})."
         )
-        _handle_alert_trigger(monitor, message, alert_type, time_window_start, now)
+        _handle_alert_trigger(
+            monitor,
+            message,
+            alert_type,
+            time_window_start,
+            now,
+            current_value=current_value,
+            threshold_value=threshold_val,
+        )
 
 
 def _compare(value1: float, operator: str, value2: float) -> bool:

--- a/futureagi/tracer/views/monitor.py
+++ b/futureagi/tracer/views/monitor.py
@@ -13,7 +13,6 @@ from rest_framework.decorators import action
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
 from rest_framework.viewsets import ModelViewSet
-
 from tfc.utils.api_contracts import validated_request
 from tfc.utils.api_serializers import ApiErrorResponseSerializer
 from tfc.utils.base_viewset import (
@@ -509,9 +508,7 @@ class UserAlertMonitorView(BaseModelViewSetMixinWithUserOrg, ModelViewSet):
         except Exception as e:
             # Server-side failure: log the detail, return a generic 5xx (a 400
             # with raw str(e) both misclassifies it and leaks internals).
-            logger.error(
-                "monitor_list_failed", error=str(e), exc_info=True
-            )
+            logger.error("monitor_list_failed", error=str(e), exc_info=True)
             return self._gm.internal_server_error_response(
                 "Failed to fetch monitors list"
             )
@@ -633,6 +630,7 @@ class UserAlertMonitorView(BaseModelViewSetMixinWithUserOrg, ModelViewSet):
             notification_emails=monitor.notification_emails,
             slack_webhook_url=monitor.slack_webhook_url,
             slack_notes=monitor.slack_notes,
+            webhook_url=monitor.webhook_url,
             is_mute=False,
             filters=monitor.filters,
             logs=[


### PR DESCRIPTION
## Summary

Adds a **"Webhook"** notification channel to Alert Monitors alongside the existing Email and Slack options. When an alert fires and a webhook URL is configured, the system POSTs a structured JSON payload containing the metric name, current value, threshold value, severity, project info, and a dashboard link to the user's endpoint. This enables integration with PagerDuty, Opsgenie, Microsoft Teams, or any internal automation without requiring native support for each service.

## Linked issues

Closes #1668

## Type of change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📖 Documentation only
- [ ] 🧹 Chore / refactor (no user-visible change)
- [ ] 🚀 Performance improvement
- [ ] 🧪 Test-only change

---

## 1) What changes were done

**A. Model — new `webhook_url` field**

- Added `webhook_url = models.URLField(null=True, blank=True)` to `UserAlertMonitor` in `tracer/models/monitor.py` (line 136), next to the existing `slack_webhook_url` and `slack_notes` fields.
- Generated migration `0097_useralertmonitor_webhook_url.py` — single nullable `AddField`, zero-downtime safe for existing data.
- No serializer changes needed — `UserAlertMonitorSerializer` uses `fields = "__all__"`, so the new field is automatically included in API request/response.

**B. Backend delivery — `_send_webhook_notification`**

- Added `_send_webhook_notification()` in `tracer/utils/monitor.py` following the exact same pattern as `_send_slack_notification`:
  - Guarded by `if not monitor.webhook_url: return`
  - Wrapped in its own `try/except` — a failed webhook never raises
  - Logs success (`INFO`) and failure (`ERROR`) via `structlog`
  - Uses `requests.post()` with a 10-second timeout
- JSON payload includes: `event`, `alert_type`, `monitor` (id + name), `project` (id + name), `metric`, `current_value`, `threshold_value`, `message`, `timestamp`, `dashboard_url`
- Dashboard URL built from `settings.APP_URL` following the same pattern as `accounts/views/aws_marketplace.py`

**C. Passing raw metric values through the notification pipeline**

- Extended `_handle_alert_trigger()` signature with optional `current_value` and `threshold_value` kwargs (backward-compatible — defaults to `None`).
- Updated both call sites (`_check_static_threshold` line 773, `_check_percentage_change_threshold` line 1053) to pass the raw numeric values that were already in scope but previously only embedded in the formatted message string.
- This was specifically called out in the issue description as a required change.

**D. Duplicate action**

- Added `webhook_url=monitor.webhook_url` to the `duplicate` action in `tracer/views/monitor.py` so duplicated monitors preserve webhook configuration (same pattern as `slack_webhook_url`).

**E. Frontend — notification option, form, and validation**

- Added `{ label: "Webhook", value: "webhook" }` to `notificationOptions` in `common.js`.
- Extended `notification.method` enum from `z.enum(["email", "slack"])` to `z.enum(["email", "slack", "webhook"])` in `validation.js`.
- Added `superRefine` validation for webhook URL: required when method is `"webhook"`, must match `https?://` pattern.
- Added `webhook` object to schema and `getDefaultAlertConfigValues` with auto-detection of existing `webhookUrl` config.
- Added conditional `<ShowComponent>` block in `AlertSettingsForm.jsx` (after the Slack block) with a required "Webhook URL" text field.
- Extended `notificationPayload` builder (line 355) to map `notification.webhook.url` → `webhook_url` in the API payload.

---

## 2) Why the changes were done

- **Product/UX:** Issue #1668 — users need a universal escape hatch for alert delivery. Webhooks enable integration with any HTTP-callback service without FutureAGI building native integrations for each. Currently only Email and Slack are supported.
- **Technical:** Followed the existing notification pattern exactly (`_send_slack_notification` is the template). Each channel is a standalone function with its own `try/except`, called sequentially from `_handle_alert_trigger`. No new services, queues, dependencies, or infrastructure — just one new function and one new model field.
- **Architecture:** Extended `_handle_alert_trigger`'s signature with `current_value`/`threshold_value` kwargs (as the issue explicitly requested) so the webhook payload contains structured numeric data rather than only the pre-formatted message string. The kwargs default to `None` for full backward compatibility.

---

## 3) Tests written + scenarios each covers

**`tracer/tests/test_webhook_notification.py`** — webhook notification channel tests

**API tests (TestWebhookMonitorAPI):**
- `test_create_monitor_with_webhook_url` — POST creates a monitor with webhook_url persisted
- `test_create_monitor_without_webhook_url` — monitors without webhook_url have it as None (backward compat)
- `test_update_monitor_webhook_url` — PATCH updates the webhook_url field
- `test_duplicate_monitor_copies_webhook_url` — duplicate action preserves webhook config
- `test_get_monitor_returns_webhook_url` — GET details includes webhook_url in response

**Unit tests (TestSendWebhookNotification):**
- `test_skips_when_no_url` — early return, no HTTP call when webhook_url is None
- `test_skips_when_empty_url` — early return when webhook_url is empty string
- `test_sends_correct_payload` — verifies all required JSON fields (event, alert_type, monitor, project, metric, current_value, threshold_value, message, timestamp, dashboard_url)
- `test_sends_correct_headers` — Content-Type and User-Agent headers
- `test_uses_correct_url` — POST target matches monitor.webhook_url
- `test_uses_timeout` — 10-second timeout on HTTP request
- `test_failure_is_logged_not_raised` — connection errors don't propagate
- `test_http_error_status_logged_not_raised` — 500 responses caught by raise_for_status
- `test_empty_dashboard_url_when_no_app_url` — graceful handling when APP_URL is not configured

**Integration tests (TestHandleAlertTriggerWebhook):**
- `test_calls_webhook_notification` — _handle_alert_trigger fans out to all three channels
- `test_webhook_failure_does_not_block_email` — email and Slack still fire after webhook failure
- `test_creates_log_entry` — UserAlertMonitorLog created correctly
- `test_backward_compatible_without_value_kwargs` — calling without current_value/threshold_value works (None passed through)

---

## 4) How to run / test

### Backend tests

```bash
cd futureagi
source .venv/bin/activate

# Run webhook tests only:
bin/test tracer/tests/test_webhook_notification.py -v

# Run all monitor tests:
bin/test tracer/tests/test_monitor.py tracer/tests/test_webhook_notification.py -v

# Run unit tests (no DB required):
bin/test tracer/tests/test_webhook_notification.py -v -k "TestSendWebhookNotification"
```

### UI steps (manual)

1. Start the stack: `docker compose up -d`
2. Log in at **http://localhost:3031**
3. Navigate to **Project → Alerts → Create Alert**
4. In the **"Define Notification"** section, verify three radio options: **Email**, **Slack**, **Webhook**
5. Select **Webhook** → a "Webhook URL" text field should appear
6. Enter a URL (e.g. from [webhook.site](https://webhook.site))
7. Fill remaining alert fields and submit
8. Lower the threshold to trigger an alert
9. Verify JSON payload arrives at the webhook endpoint


---

## 6) Edge cases & considerations

- **`webhook_url` is None or empty**: early return in `_send_webhook_notification`, no HTTP call — matches Slack pattern
- **Webhook returns HTTP 500**: caught by `raise_for_status()` inside `try/except`, logged as ERROR, email and Slack still sent
- **Webhook times out (>10s)**: `requests.post(timeout=10)` raises, caught and logged, other channels unaffected
- **All three channels configured (email + Slack + webhook)**: all three fire independently, failures isolated
- **APP_URL not configured**: `dashboard_url` set to empty string instead of crashing
- **Existing monitors**: `webhook_url` is nullable, defaults to `None` — all existing monitors unaffected
- **Migration safety**: single nullable `AddField`, no default value computation, safe for zero-downtime deploy

---

## 8) Architectural / important decisions

- **Followed Slack pattern exactly**: `_send_webhook_notification` mirrors `_send_slack_notification` in structure (guard → build payload → try/except → log). This keeps the notification fan-out predictable and reviewable.
- **Extended `_handle_alert_trigger` signature instead of parsing message**: The issue explicitly asked for raw `current_value` and `threshold_value` in the payload. Rather than regex-parsing the formatted message string, added optional kwargs to `_handle_alert_trigger` and passed them from both call sites. The kwargs default to `None` for full backward compatibility.
- **Used `requests` library**: Already a direct dependency (`requirements.txt` line 1096: `requests==2.32.4`) and used extensively across the codebase (40+ import sites). No new dependency.
- **No HMAC/SSRF/retries**: Not mentioned in the issue requirements. Can be added as follow-up PRs if maintainers want them.

---

## Checklist

- [x] My code follows the [style guide](../CONTRIBUTING.md#code-style)
- [x] I've added tests that prove my fix is effective or that my feature works
- [ ] `bin/test` passes locally (backend)
- [ ] `yarn test:run` passes locally (frontend)
- [ ] `yarn contracts:check` passes if API surface changed
- [ ] I've updated the documentation where relevant
- [x] No hardcoded secrets, URLs, or PII
- [ ] I've signed the [CLA](../CONTRIBUTING.md#contributor-license-agreement-cla)
- [x] PR title follows Conventional Commits
- [ ] Linear issue is linked and updated with status
