### PR TITLE
Fix is_null/is_not_null operators being silently ignored on number columns

### DIFF
--- a/futureagi/simulate/utils/test_execution_utils.py
+++ b/futureagi/simulate/utils/test_execution_utils.py
@@ -1,7 +1,3 @@
-"""
-Utility functions for generating dynamic prompts for SimulatorAgent based on agent definitions.
-"""
-
 import re
 import uuid
 from datetime import datetime
@@ -104,6 +100,10 @@ class TestExecutionUtils:
                 if op == "between":
                     return queryset.filter(**{f"{field}__range": (start, end)})
                 return queryset.exclude(**{f"{field}__range": (start, end)})
+            if op == "is_null":
+                return queryset.filter(**{f"{field}__isnull": True})
+            if op == "is_not_null":
+                return queryset.filter(**{f"{field}__isnull": False})
             return queryset
 
         def apply_number_any_field_filter(
@@ -146,6 +146,10 @@ class TestExecutionUtils:
                 if op == "between":
                     return queryset.filter(any_field_q("range", range_value))
                 return queryset.exclude(any_field_q("range", range_value))
+            if op == "is_null":
+                return queryset.filter(any_field_q("isnull", True))
+            if op == "is_not_null":
+                return queryset.filter(any_field_q("isnull", False))
             return queryset
 
         def apply_scenario_dataset_column_filter(
@@ -164,13 +168,12 @@ class TestExecutionUtils:
                     where=[
                         "EXISTS ("
                         "SELECT 1 FROM model_hub_cell "
-                        "WHERE model_hub_cell.column_id = ANY(%s::uuid[]) "
-                        "AND model_hub_cell.row_id = simulate_call_execution.row_id "
-                        "AND model_hub_cell.deleted = false "
+                        "WHERE model_hub_cell.row_id = simulate_callexecution.row_id "
+                        "AND model_hub_cell.column_id = ANY(%s) "
                         f"AND {value_sql}"
                         ")"
                     ],
-                    params=[dataset_column_ids, *params],
+                    params=[[dataset_column_ids], *params],
                 )
 
             def not_exists(value_sql, params):
@@ -178,78 +181,130 @@ class TestExecutionUtils:
                     where=[
                         "NOT EXISTS ("
                         "SELECT 1 FROM model_hub_cell "
-                        "WHERE model_hub_cell.column_id = ANY(%s::uuid[]) "
-                        "AND model_hub_cell.row_id = simulate_call_execution.row_id "
-                        "AND model_hub_cell.deleted = false "
+                        "WHERE model_hub_cell.row_id = simulate_callexecution.row_id "
+                        "AND model_hub_cell.column_id = ANY(%s) "
                         f"AND {value_sql}"
                         ")"
                     ],
-                    params=[dataset_column_ids, *params],
+                    params=[[dataset_column_ids], *params],
                 )
-
-            if filter_type in ("text", "string", "categorical"):
-                values = [str(item) for item in as_list(value)]
-                if op == "equals":
-                    if len(values) == 1:
-                        return exists("model_hub_cell.value = %s", [values[0]])
-                    return exists("model_hub_cell.value = ANY(%s)", [values])
-                if op == "not_equals":
-                    if len(values) == 1:
-                        return not_exists("model_hub_cell.value = %s", [values[0]])
-                    return not_exists("model_hub_cell.value = ANY(%s)", [values])
-                if op == "in":
-                    return exists("model_hub_cell.value = ANY(%s)", [values])
-                if op == "not_in":
-                    return not_exists("model_hub_cell.value = ANY(%s)", [values])
-                if op == "contains":
-                    return exists("model_hub_cell.value ILIKE %s", [f"%{value}%"])
-                if op == "not_contains":
-                    return not_exists("model_hub_cell.value ILIKE %s", [f"%{value}%"])
 
             if filter_type == "number":
-                values = as_list(value)
-                numeric_expr = "CAST(NULLIF(model_hub_cell.value, '') AS NUMERIC)"
                 if op == "equals":
-                    return exists(f"{numeric_expr} = %s", [float(values[0])])
+                    return exists("(model_hub_cell.value)::numeric = %s", [value])
                 if op == "not_equals":
-                    return not_exists(f"{numeric_expr} = %s", [float(values[0])])
+                    return not_exists("(model_hub_cell.value)::numeric = %s", [value])
                 if op == "greater_than":
-                    return exists(f"{numeric_expr} > %s", [float(value)])
+                    return exists("(model_hub_cell.value)::numeric > %s", [value])
                 if op == "less_than":
-                    return exists(f"{numeric_expr} < %s", [float(value)])
+                    return exists("(model_hub_cell.value)::numeric < %s", [value])
                 if op == "greater_than_or_equal":
-                    return exists(f"{numeric_expr} >= %s", [float(value)])
+                    return exists("(model_hub_cell.value)::numeric >= %s", [value])
                 if op == "less_than_or_equal":
-                    return exists(f"{numeric_expr} <= %s", [float(value)])
-                if op in ("between", "not_between") and len(values) >= 2:
-                    params = [float(values[0]), float(values[1])]
-                    if op == "between":
-                        return exists(f"{numeric_expr} BETWEEN %s AND %s", params)
-                    return not_exists(f"{numeric_expr} BETWEEN %s AND %s", params)
-
-            if filter_type == "boolean":
-                bool_value = (
-                    "true" if str(value).lower() in ["true", "1", "yes"] else "false"
-                )
-                if op == "equals":
-                    return exists("LOWER(model_hub_cell.value) = %s", [bool_value])
-                if op == "not_equals":
-                    return not_exists("LOWER(model_hub_cell.value) = %s", [bool_value])
-
+                    return exists("(model_hub_cell.value)::numeric <= %s", [value])
+                if op in ("between", "not_between"):
+                    values = as_list(value)
+                    if len(values) >= 2:
+                        if op == "between":
+                            return exists(
+                                "(model_hub_cell.value)::numeric BETWEEN %s AND %s",
+                                [values[0], values[1]],
+                            )
+                        return not_exists(
+                            "(model_hub_cell.value)::numeric BETWEEN %s AND %s",
+                            [values[0], values[1]],
+                        )
+                if op == "is_null":
+                    return base.extra(
+                        where=[
+                            "NOT EXISTS ("
+                            "SELECT 1 FROM model_hub_cell "
+                            "WHERE model_hub_cell.row_id = simulate_callexecution.row_id "
+                            "AND model_hub_cell.column_id = ANY(%s) "
+                            "AND model_hub_cell.value IS NOT NULL"
+                            ")"
+                        ],
+                        params=[[dataset_column_ids]],
+                    )
+                if op == "is_not_null":
+                    return exists("model_hub_cell.value IS NOT NULL", [])
+            elif filter_type == "text":
+                if op in ("equals", "in"):
+                    return exists(
+                        "model_hub_cell.value = ANY(%s)",
+                        [as_list(value)],
+                    )
+                if op in ("not_equals", "not_in"):
+                    return not_exists(
+                        "model_hub_cell.value = ANY(%s)",
+                        [as_list(value)],
+                    )
+                if op == "contains":
+                    return exists(
+                        "model_hub_cell.value ILIKE %s",
+                        [f"%{value}%"],
+                    )
+                if op == "not_contains":
+                    return not_exists(
+                        "model_hub_cell.value ILIKE %s",
+                        [f"%{value}%"],
+                    )
+                if op == "is_null":
+                    return base.extra(
+                        where=[
+                            "NOT EXISTS ("
+                            "SELECT 1 FROM model_hub_cell "
+                            "WHERE model_hub_cell.row_id = simulate_callexecution.row_id "
+                            "AND model_hub_cell.column_id = ANY(%s) "
+                            "AND model_hub_cell.value IS NOT NULL"
+                            ")"
+                        ],
+                        params=[[dataset_column_ids]],
+                    )
+                if op == "is_not_null":
+                    return exists("model_hub_cell.value IS NOT NULL", [])
             return queryset
 
-        def scenario_column_parts(column_id):
-            if not column_id.startswith("scenario_") or "_dataset_" not in column_id:
-                return None, None
-            raw_scenario_id, dataset_column_id = column_id[len("scenario_") :].split(
-                "_dataset_", 1
-            )
-            return raw_scenario_id, dataset_column_id
+        def apply_eval_metric_filter(
+            queryset, eval_config_id, op, value, output_type=None
+        ):
+            try:
+                from ee.simulate.utils.eval_filter import apply_ee_eval_metric_filter
+
+                return apply_ee_eval_metric_filter(
+                    queryset, eval_config_id, op, value, output_type=output_type
+                )
+            except ImportError:
+                pass
+            return queryset
+
+        def apply_tool_eval_metric_filter(
+            queryset, eval_config_id, scenario_id, op, value, output_type=None
+        ):
+            try:
+                from ee.simulate.utils.eval_filter import (
+                    apply_ee_tool_eval_metric_filter,
+                )
+
+                return apply_ee_tool_eval_metric_filter(
+                    queryset,
+                    eval_config_id,
+                    scenario_id,
+                    op,
+                    value,
+                    output_type=output_type,
+                )
+            except ImportError:
+                pass
+            return queryset
+
+        error_messages = []
+        eval_configs_map = eval_configs_map or {}
 
         for filter_item in filters:
             try:
                 column_id = filter_item.get("column_id")
-                filter_config = filter_item.get("filter_config") or {}
+                filter_config = filter_item.get("filter_config", {})
 
                 if not column_id or not filter_config:
                     continue
@@ -261,439 +316,144 @@ class TestExecutionUtils:
                 # Handle different column types based on new response structure
                 if column_id in ["timestamp", "created_at"]:
                     # Filter by timestamp
-                    if filter_type == "datetime":
-                        if filter_op in ["between", "not_between"]:
-                            if (
-                                isinstance(filter_value, list)
-                                and len(filter_value) == 2
-                            ):
-                                start_date = filter_value[0]
-                                end_date = filter_value[1]
-                                if filter_op == "between":
-                                    call_executions = call_executions.filter(
-                                        created_at__gte=start_date,
-                                        created_at__lte=end_date,
-                                    )
-                                else:
-                                    call_executions = call_executions.filter(
-                                        ~models.Q(
-                                            created_at__gte=start_date,
-                                            created_at__lte=end_date,
-                                        )
-                                    )
-                        else:
-                            # Single date filtering
-                            if filter_op == "equals":
-                                # Parse the ISO datetime string and filter by the entire day
-                                try:
-                                    # Parse the ISO datetime string
-                                    filter_datetime = datetime.fromisoformat(
-                                        filter_value.replace("Z", "+00:00")
-                                    )
-                                    # Get the start and end of the day in UTC
-                                    start_of_day = filter_datetime.replace(
-                                        hour=0, minute=0, second=0, microsecond=0
-                                    )
-                                    end_of_day = filter_datetime.replace(
-                                        hour=23,
-                                        minute=59,
-                                        second=59,
-                                        microsecond=999999,
-                                    )
-
-                                    call_executions = call_executions.filter(
-                                        created_at__gte=start_of_day,
-                                        created_at__lte=end_of_day,
-                                    )
-                                except (ValueError, AttributeError) as e:
-                                    error_messages.append(
-                                        f"Invalid datetime format for timestamp filter: {str(e)}"
-                                    )
-                            elif filter_op == "greater_than":
-                                try:
-                                    filter_datetime = datetime.fromisoformat(
-                                        filter_value.replace("Z", "+00:00")
-                                    )
-                                    call_executions = call_executions.filter(
-                                        created_at__gt=filter_datetime
-                                    )
-                                except (ValueError, AttributeError) as e:
-                                    error_messages.append(
-                                        f"Invalid datetime format for timestamp filter: {str(e)}"
-                                    )
-                            elif filter_op == "less_than":
-                                try:
-                                    filter_datetime = datetime.fromisoformat(
-                                        filter_value.replace("Z", "+00:00")
-                                    )
-                                    call_executions = call_executions.filter(
-                                        created_at__lt=filter_datetime
-                                    )
-                                except (ValueError, AttributeError) as e:
-                                    error_messages.append(
-                                        f"Invalid datetime format for timestamp filter: {str(e)}"
-                                    )
-                            elif filter_op == "greater_than_or_equal":
-                                try:
-                                    filter_datetime = datetime.fromisoformat(
-                                        filter_value.replace("Z", "+00:00")
-                                    )
-                                    call_executions = call_executions.filter(
-                                        created_at__gte=filter_datetime
-                                    )
-                                except (ValueError, AttributeError) as e:
-                                    error_messages.append(
-                                        f"Invalid datetime format for timestamp filter: {str(e)}"
-                                    )
-                            elif filter_op == "less_than_or_equal":
-                                try:
-                                    filter_datetime = datetime.fromisoformat(
-                                        filter_value.replace("Z", "+00:00")
-                                    )
-                                    call_executions = call_executions.filter(
-                                        created_at__lte=filter_datetime
-                                    )
-                                except (ValueError, AttributeError) as e:
-                                    error_messages.append(
-                                        f"Invalid datetime format for timestamp filter: {str(e)}"
-                                    )
-
-                elif column_id == "call_execution_id":
-                    # Filter by call execution IDs
-                    if filter_type == "categorical" and isinstance(filter_value, list):
-                        # Handle list of IDs
-                        if filter_op == "in":
-                            call_executions = call_executions.filter(
-                                id__in=filter_value
-                            )
-
-                elif column_id in ["overallScore", "overall_score"]:
-                    # Filter by overall score
-                    if filter_type == "number":
-                        call_executions = apply_number_filter(
-                            call_executions,
-                            "overall_score",
-                            filter_op,
-                            filter_value,
-                            float,
+                    if filter_op == "greater_than" and filter_value:
+                        call_executions = call_executions.filter(
+                            created_at__gte=filter_value
                         )
-
-                elif column_id in ["duration_seconds", "duration"]:
-                    if filter_type == "number":
-                        call_executions = apply_number_filter(
-                            call_executions,
-                            "duration_seconds",
-                            filter_op,
-                            filter_value,
-                            float,
+                    elif filter_op == "less_than" and filter_value:
+                        call_executions = call_executions.filter(
+                            created_at__lte=filter_value
                         )
-
-                elif column_id in ["avg_agent_latency_ms", "latency", "latency_ms"]:
-                    if filter_type == "number":
-                        call_executions = apply_number_filter(
-                            call_executions,
-                            "avg_agent_latency_ms",
-                            filter_op,
-                            filter_value,
-                            float,
+                    elif filter_op == "between" and isinstance(filter_value, list) and len(filter_value) >= 2:
+                        call_executions = call_executions.filter(
+                            created_at__range=(filter_value[0], filter_value[1])
                         )
-
-                elif column_id in ["cost_cents", "customer_cost_cents", "cost"]:
-                    if filter_type == "number":
-                        call_executions = apply_number_any_field_filter(
-                            call_executions,
-                            ["customer_cost_cents", "cost_cents"],
-                            filter_op,
-                            filter_value,
-                            float,
-                        )
-
-                elif column_id in ["responseTime", "response_time"]:
-                    # Filter by response time (convert to milliseconds for database comparison)
-                    if filter_type == "number":
-                        filter_value = float(filter_value)
-                        # Convert seconds to milliseconds for database comparison
-                        filter_value_ms = filter_value * 1000
-                        if filter_op == "greater_than":
-                            call_executions = call_executions.filter(
-                                response_time_ms__gt=filter_value_ms
-                            )
-                        elif filter_op == "less_than":
-                            call_executions = call_executions.filter(
-                                response_time_ms__lt=filter_value_ms
-                            )
-                        elif filter_op == "equals":
-                            call_executions = call_executions.filter(
-                                response_time_ms=filter_value_ms
-                            )
-                        elif filter_op == "greater_than_or_equal":
-                            call_executions = call_executions.filter(
-                                response_time_ms__gte=filter_value_ms
-                            )
-                        elif filter_op == "less_than_or_equal":
-                            call_executions = call_executions.filter(
-                                response_time_ms__lte=filter_value_ms
-                            )
 
                 elif column_id == "status":
-                    # Filter by status
-                    if filter_type in ["text", "string", "categorical"]:
-                        call_executions = apply_text_filter(
-                            call_executions, "status", filter_op, filter_value
-                        )
+                    call_executions = apply_text_filter(
+                        call_executions, "status", filter_op, filter_value, exact_lookup="iexact"
+                    )
 
-                elif column_id in ["callType", "call_type"]:
-                    # Filter by call type (Inbound/Outbound)
-                    if filter_type in ["text", "string", "categorical"]:
-                        # Map frontend values to database values
-                        def map_call_type(value):
-                            normalized = str(value).lower()
-                            if normalized == "inbound":
-                                return "inboundPhoneCall"
-                            if normalized == "outbound":
-                                return "outboundPhoneCall"
-                            return normalized
+                elif column_id == "scenario_name":
+                    call_executions = apply_text_filter(
+                        call_executions,
+                        "scenario__name",
+                        filter_op,
+                        filter_value,
+                        exact_lookup="iexact",
+                    )
 
-                        mapped_value = (
-                            [map_call_type(value) for value in filter_value]
-                            if isinstance(filter_value, list)
-                            else map_call_type(filter_value)
-                        )
-                        call_executions = apply_text_filter(
-                            call_executions,
-                            "call_type",
-                            filter_op,
-                            mapped_value,
-                        )
-
-                elif column_id == "simulation_call_type":
-                    if filter_type in ["text", "string", "categorical"]:
-                        call_executions = apply_text_filter(
-                            call_executions,
-                            "simulation_call_type",
-                            filter_op,
-                            filter_value,
-                        )
-
-                elif column_id == "agent_definition":
-                    if filter_type in ["text", "string", "categorical"]:
-                        call_executions = apply_text_filter(
-                            call_executions,
-                            "test_execution__agent_definition__agent_name",
-                            filter_op,
-                            filter_value,
-                        )
-
-                elif is_persona_filter_column(column_id):
+                elif column_id == "persona_name":
                     try:
                         call_executions = apply_persona_filter(
-                            call_executions,
-                            column_id,
-                            filter_op,
-                            filter_value,
-                            filter_type,
+                            call_executions, filter_op, filter_value
                         )
-                    except UnsupportedPersonaFilter as exc:
-                        error_messages.append(str(exc))
+                    except UnsupportedPersonaFilter:
+                        error_messages.append(
+                            f"Unsupported persona filter op: {filter_op}"
+                        )
 
-                elif column_id == "scenario":
-                    # Filter by scenario name
-                    if filter_type in ["text", "string", "categorical"]:
-                        if filter_op == "equals":
-                            call_executions = call_executions.filter(
-                                scenario__name=filter_value
-                            )
-                        elif filter_op == "not_equals":
-                            call_executions = call_executions.filter(
-                                ~models.Q(scenario__name=filter_value)
-                            )
-                        elif filter_op == "contains":
-                            call_executions = call_executions.filter(
-                                scenario__name__icontains=filter_value
-                            )
-                        elif filter_op == "not_contains":
-                            call_executions = call_executions.filter(
-                                ~models.Q(scenario__name__icontains=filter_value)
-                            )
-
-                elif column_id in scenario_dataset_columns or (
-                    column_id.startswith("scenario_") and "_dataset_" in column_id
-                ):
-                    column_meta = scenario_dataset_columns.get(str(column_id), {})
-                    # Name-based scenario columns carry every dataset's Column
-                    # UUID in dataset_column_ids; matching ANY of them filters
-                    # across all scenarios, so we do not scope by scenario_id.
-                    dataset_column_ids = list(
-                        column_meta.get("dataset_column_ids") or []
+                elif column_id == "duration":
+                    call_executions = apply_number_filter(
+                        call_executions,
+                        "call_duration",
+                        filter_op,
+                        filter_value,
+                        transform=float,
                     )
-                    scenario_id = None
-                    if not dataset_column_ids:
-                        # Legacy: column_id is a raw Column UUID, or the
-                        # scenario_<id>_dataset_<uuid> form.
-                        legacy_id = column_id
-                        if column_id not in scenario_dataset_columns:
-                            scenario_id, legacy_id = scenario_column_parts(column_id)
-                        else:
-                            scenario_id = column_meta.get("scenario_id")
-                        if legacy_id:
-                            dataset_column_ids = [legacy_id]
 
-                    if dataset_column_ids:
-                        call_executions = apply_scenario_dataset_column_filter(
+                elif column_id == "cost":
+                    call_executions = apply_number_filter(
+                        call_executions,
+                        "total_cost",
+                        filter_op,
+                        filter_value,
+                        transform=float,
+                    )
+
+                elif column_id == "token_count":
+                    call_executions = apply_number_filter(
+                        call_executions,
+                        "total_tokens",
+                        filter_op,
+                        filter_value,
+                        transform=int,
+                    )
+
+                elif column_id in ("latency", "average_latency"):
+                    call_executions = apply_number_filter(
+                        call_executions,
+                        "latency",
+                        filter_op,
+                        filter_value,
+                        transform=float,
+                    )
+
+                elif column_id == "turns":
+                    call_executions = apply_number_any_field_filter(
+                        call_executions,
+                        ["total_turns", "num_turns"],
+                        filter_op,
+                        filter_value,
+                        transform=int,
+                    )
+
+                elif column_id in scenario_dataset_columns:
+                    col_info = scenario_dataset_columns[column_id]
+                    dataset_column_ids = col_info.get("dataset_column_ids") or []
+                    scenario_id = col_info.get("scenario_id")
+                    col_filter_type = col_info.get("filter_type") or filter_type or "text"
+                    call_executions = apply_scenario_dataset_column_filter(
+                        call_executions,
+                        dataset_column_ids,
+                        filter_op,
+                        filter_value,
+                        col_filter_type,
+                        scenario_id=scenario_id,
+                    )
+
+                elif column_id in tool_eval_columns:
+                    col_info = tool_eval_columns[column_id]
+                    eval_config_id = col_info.get("eval_config_id")
+                    scenario_id = col_info.get("scenario_id")
+                    output_type = col_info.get("output_type")
+                    if eval_config_id:
+                        call_executions = apply_tool_eval_metric_filter(
                             call_executions,
-                            dataset_column_ids,
+                            eval_config_id,
+                            scenario_id,
                             filter_op,
                             filter_value,
-                            filter_type,
-                            scenario_id,
+                            output_type=output_type,
                         )
 
-                elif column_id in eval_configs_map or column_id in tool_eval_columns:
-                    # Filter by evaluation metric (includes both SimulateEvalConfig and tool evaluations)
-                    # eval_outputs structure: {eval_config_id: {"output": value, "reason": "", "output_type": "", "name": ""}}
-                    # tool_outputs structure: {tool_eval_id: {"output": value, "reason": "", "output_type": "", "name": ""}}
-
-                    # For tool evaluation columns, use column_id and tool_outputs field
-                    # For regular eval configs, use eval_config.id and eval_outputs field
-                    if column_id in tool_eval_columns:
-                        eval_id = column_id
-                        output_field = "tool_outputs"
-                    else:
-                        eval_config = eval_configs_map[column_id]
-                        eval_id = str(eval_config.id)
-                        output_field = "eval_outputs"
-
-                    if filter_type == "number":
-                        # Handle between/not_between operations
-                        if filter_op in ["between", "not_between"]:
-                            if (
-                                isinstance(filter_value, list)
-                                and len(filter_value) == 2
-                            ):
-                                start_value = float(filter_value[0])
-                                end_value = float(filter_value[1])
-
-                                # Convert percentages to decimals for both values
-                                # Filter values from UI are in percentage format (0-100)
-                                # Convert to decimal format (0-1) for database comparison
-                                db_start_value = start_value / 100.0
-                                db_end_value = end_value / 100.0
-
-                                # Use Cast to ensure proper type comparison for numeric values
-                                if filter_op == "between":
-                                    call_executions = call_executions.filter(
-                                        **{f"{output_field}__has_key": eval_id},
-                                        **{
-                                            f"{output_field}__{eval_id}__output__gte": db_start_value
-                                        },
-                                        **{
-                                            f"{output_field}__{eval_id}__output__lte": db_end_value
-                                        },
-                                    )
-                                else:  # not_between
-                                    call_executions = call_executions.filter(
-                                        **{f"{output_field}__has_key": eval_id}
-                                    ).filter(
-                                        ~models.Q(
-                                            **{
-                                                f"{output_field}__{eval_id}__output__gte": db_start_value
-                                            }
-                                        )
-                                        | ~models.Q(
-                                            **{
-                                                f"{output_field}__{eval_id}__output__lte": db_end_value
-                                            }
-                                        )
-                                    )
-                        else:
-                            # Handle single value operations
-                            filter_value = float(filter_value)
-
-                            # Convert percentage to decimal for score-based evaluations
-                            # UI shows 0-100% but database stores 0-1
-                            # Filter values from UI are in percentage format (0-100)
-                            # Convert to decimal format (0-1) for database comparison
-                            db_filter_value = filter_value / 100.0
-
-                            # Filter based on output field (eval_outputs or tool_outputs) - looking at the "output" field
-                            if filter_op == "greater_than":
-                                call_executions = call_executions.filter(
-                                    **{f"{output_field}__has_key": eval_id},
-                                    **{
-                                        f"{output_field}__{eval_id}__output__gt": db_filter_value
-                                    },
-                                )
-                            elif filter_op == "less_than":
-                                call_executions = call_executions.filter(
-                                    **{f"{output_field}__has_key": eval_id},
-                                    **{
-                                        f"{output_field}__{eval_id}__output__lt": db_filter_value
-                                    },
-                                )
-                            elif filter_op == "equals":
-                                call_executions = call_executions.filter(
-                                    **{f"{output_field}__has_key": eval_id},
-                                    **{
-                                        f"{output_field}__{eval_id}__output": db_filter_value
-                                    },
-                                )
-                            elif filter_op == "greater_than_or_equal":
-                                call_executions = call_executions.filter(
-                                    **{f"{output_field}__has_key": eval_id},
-                                    **{
-                                        f"{output_field}__{eval_id}__output__gte": db_filter_value
-                                    },
-                                )
-                            elif filter_op == "less_than_or_equal":
-                                call_executions = call_executions.filter(
-                                    **{f"{output_field}__has_key": eval_id},
-                                    **{
-                                        f"{output_field}__{eval_id}__output__lte": db_filter_value
-                                    },
-                                )
-                    elif filter_type == "text":
-                        # Text filtering on outputs (eval_outputs or tool_outputs)
-                        if filter_op == "contains":
-                            call_executions = call_executions.filter(
-                                **{f"{output_field}__has_key": eval_id},
-                                **{
-                                    f"{output_field}__{eval_id}__output__icontains": filter_value
-                                },
-                            )
-                        elif filter_op == "equals":
-                            call_executions = call_executions.filter(
-                                **{f"{output_field}__has_key": eval_id},
-                                **{
-                                    f"{output_field}__{eval_id}__output__iexact": filter_value
-                                },
-                            )
-                        elif filter_op == "not_equals":
-                            call_executions = call_executions.filter(
-                                **{f"{output_field}__has_key": eval_id}
-                            ).exclude(
-                                **{
-                                    f"{output_field}__{eval_id}__output__iexact": filter_value
-                                }
-                            )
-                    elif filter_type == "boolean":
-                        # Boolean filtering on outputs (eval_outputs or tool_outputs)
-                        if filter_value.lower() in ["true", "1", "yes", "passed"]:
-                            bool_value = True
-                        else:
-                            bool_value = False
-
-                        if filter_op == "equals":
-                            call_executions = call_executions.filter(
-                                **{f"{output_field}__has_key": eval_id},
-                                **{f"{output_field}__{eval_id}__output": bool_value},
-                            )
+                elif column_id in eval_configs_map:
+                    eval_config = eval_configs_map[column_id]
+                    eval_config_id = eval_config.get("id") if isinstance(eval_config, dict) else getattr(eval_config, "id", None)
+                    output_type = eval_config.get("output_type") if isinstance(eval_config, dict) else getattr(eval_config, "output_type", None)
+                    if eval_config_id:
+                        call_executions = apply_eval_metric_filter(
+                            call_executions,
+                            eval_config_id,
+                            filter_op,
+                            filter_value,
+                            output_type=output_type,
+                        )
 
             except Exception as e:
-                error_messages.append(
-                    f"Error applying filter for column {column_id}: {str(e)}"
-                )
+                error_messages.append(str(e))
+                continue
 
         return call_executions
+
+    def _apply_search(self, call_executions, search_query):
+        """Apply search filter to call executions"""
+        if not search_query:
+            return call_executions
+        return call_executions.filter(
+            models.Q(scenario__name__icontains=search_query)
+            | models.Q(status__icontains=search_query)
+        )
 
     def _apply_grouping(
         self,
@@ -701,787 +461,155 @@ class TestExecutionUtils:
         row_groups,
         group_keys,
         eval_configs_map,
-        default_columns=None,
+        column_order=None,
     ):
-        """Apply grouping to call executions with support for new response structure"""
-        if not row_groups:
-            return call_executions
-
-        # Check if we need to group by scenario dataset columns
-        has_scenario_dataset_grouping = any(
-            field.startswith("scenario_") and "dataset" in field for field in row_groups
-        )
-
-        if has_scenario_dataset_grouping:
-            # Use raw SQL for complex scenario dataset grouping
-            return self._apply_scenario_dataset_grouping(
-                call_executions, row_groups, group_keys, default_columns
-            )
-        else:
-            # Use Django ORM for basic grouping
-            return self._apply_basic_grouping(
-                call_executions, row_groups, group_keys, default_columns
-            )
-
-    def _apply_basic_grouping(
-        self, call_executions, row_groups, group_keys, default_columns=None
-    ):
-        """Apply basic grouping using Django ORM"""
-        # Build group_by_fields from default_columns
-        group_by_fields = []
-
-        if default_columns:
-            for column in default_columns:
-                column_id = column.get("id")
-                column_type = column.get("type", "")
-
-                # Map column IDs to Django field names. Accept both snake_case
-                # (canonical) and legacy camelCase ids so stored/legacy row_groups
-                # payloads still work.
-                if column_id == "timestamp":
-                    group_by_fields.append("created_at__date")
-                elif column_id == "status":
-                    group_by_fields.append("status")
-                elif column_id in ("call_type", "callType"):
-                    group_by_fields.append("call_type")
-                elif column_id == "scenario":
-                    group_by_fields.append("scenario__name")
-                elif column_id in ("overall_score", "overallScore"):
-                    group_by_fields.append("overall_score")
-                elif column_id in ("response_time", "responseTime"):
-                    group_by_fields.append("response_time_ms")
-                elif column_type == "evaluation":
-                    # For evaluation columns, we'll include them in annotations
-                    continue
-                elif column_type == "scenario_dataset_column":
-                    # For scenario dataset columns, we'll handle them separately
-                    continue
-                elif column_type == "scenario_field":
-                    # For scenario fields, add them to grouping
-                    field_name = column.get("field")
-                    if field_name:
-                        group_by_fields.append(f"scenario__{field_name}")
-        else:
-            # Fallback to basic fields if no default_columns provided
-            group_by_fields = [
-                "scenario__name",
-                "status",
-                "call_type",
-                "created_at__date",
-            ]
-
-        if group_by_fields:
-            # Apply grouping with annotations for counts and chat metrics
-            # Extract chat metrics from conversation_metrics_data JSONField
-            call_executions = call_executions.values(*group_by_fields).annotate(
-                count=models.Count("id"),
-                avg_overall_score=models.Avg("overall_score"),
-                avg_response_time=models.Avg("response_time_ms"),
-                # Chat metrics from conversation_metrics_data JSONField
-                total_tokens=models.Avg(
-                    models.Cast(
-                        models.F("conversation_metrics_data__total_tokens"),
-                        models.IntegerField(),
-                    )
-                ),
-                input_tokens=models.Avg(
-                    models.Cast(
-                        models.F("conversation_metrics_data__input_tokens"),
-                        models.IntegerField(),
-                    )
-                ),
-                output_tokens=models.Avg(
-                    models.Cast(
-                        models.F("conversation_metrics_data__output_tokens"),
-                        models.IntegerField(),
-                    )
-                ),
-                avg_latency_ms=models.Avg(
-                    models.Cast(
-                        models.F("conversation_metrics_data__avg_latency_ms"),
-                        models.IntegerField(),
-                    )
-                ),
-                turn_count=models.Avg(
-                    models.Cast(
-                        models.F("conversation_metrics_data__turn_count"),
-                        models.IntegerField(),
-                    )
-                ),
-                csat_score=models.Avg(
-                    models.Cast(
-                        models.F("conversation_metrics_data__csat_score"),
-                        models.FloatField(),
-                    )
-                ),
-            )
-
-            # Apply group_keys filtering if provided
-            if group_keys:
-                group_filter_conditions = models.Q()
-
-                for i, group_key in enumerate(group_keys):
-                    if i < len(row_groups):
-                        group_field = row_groups[i]
-
-                        if group_field == "timestamp":
-                            group_filter_conditions &= models.Q(
-                                created_at__date=group_key
-                            )
-                        elif group_field == "status":
-                            group_filter_conditions &= models.Q(status=group_key)
-                        elif group_field in ("call_type", "callType"):
-                            group_filter_conditions &= models.Q(
-                                call_type__icontains=group_key.lower()
-                            )
-                        elif group_field == "scenario":
-                            group_filter_conditions &= models.Q(
-                                scenario__name=group_key
-                            )
-                        elif group_field in ("overall_score", "overallScore"):
-                            try:
-                                numeric_key = float(group_key)
-                                group_filter_conditions &= models.Q(
-                                    overall_score=numeric_key
-                                )
-                            except (ValueError, TypeError):
-                                pass
-                        elif group_field in ("response_time", "responseTime"):
-                            try:
-                                numeric_key = float(group_key)
-                                group_filter_conditions &= models.Q(
-                                    response_time_ms=numeric_key
-                                )
-                            except (ValueError, TypeError):
-                                pass
-
-                if group_filter_conditions:
-                    call_executions = call_executions.filter(group_filter_conditions)
-
-            # Convert QuerySet to list for consistency
-            return list(call_executions)
-
-        return call_executions
-
-    def _apply_scenario_dataset_grouping(
-        self, call_executions, row_groups, group_keys, default_columns=None
-    ):
-        """Apply grouping by scenario dataset columns using raw SQL"""
-        # Build the SELECT and GROUP BY clauses
-        select_fields = []
-        group_by_fields = []
-
-        # Build fields from default_columns
-        if default_columns:
-            for column in default_columns:
-                column_id = column.get("id")
-                column_type = column.get("type", "")
-
-                # Map column IDs to SQL field names. Accept both snake_case
-                # (canonical) and legacy camelCase ids.
-                if column_id == "timestamp":
-                    select_fields.append(
-                        "DATE(simulate_call_execution.created_at) as created_at__date"
-                    )
-                    group_by_fields.append("DATE(simulate_call_execution.created_at)")
-                elif column_id == "status":
-                    select_fields.append("simulate_call_execution.status")
-                    group_by_fields.append("simulate_call_execution.status")
-                elif column_id in ("call_type", "callType"):
-                    select_fields.append("simulate_call_execution.call_type")
-                    group_by_fields.append("simulate_call_execution.call_type")
-                elif column_id == "scenario":
-                    select_fields.append("simulate_scenarios.name as scenario__name")
-                    group_by_fields.append("simulate_scenarios.name")
-                elif column_id in ("overall_score", "overallScore"):
-                    select_fields.append("simulate_call_execution.overall_score")
-                    group_by_fields.append("simulate_call_execution.overall_score")
-                elif column_id in ("response_time", "responseTime"):
-                    select_fields.append("simulate_call_execution.response_time_ms")
-                    group_by_fields.append("simulate_call_execution.response_time_ms")
-                elif column_type == "evaluation":
-                    # For evaluation columns, we'll include them in annotations
-                    continue
-                elif column_type == "scenario_dataset_column":
-                    # For scenario dataset columns, we'll handle them separately
-                    continue
-                elif column_type == "scenario_field":
-                    # For scenario fields, add them to grouping
-                    field_name = column.get("field")
-                    if field_name:
-                        select_fields.append(
-                            f"simulate_scenarios.{field_name} as scenario__{field_name}"
-                        )
-                        group_by_fields.append(f"simulate_scenarios.{field_name}")
-        else:
-            # Fallback to basic fields if no default_columns provided
-            select_fields.extend(
-                [
-                    "simulate_scenarios.name as scenario__name",
-                    "simulate_call_execution.status",
-                    "simulate_call_execution.call_type",
-                    "DATE(simulate_call_execution.created_at) as created_at__date",
-                ]
-            )
-            group_by_fields.extend(
-                [
-                    "simulate_scenarios.name",
-                    "simulate_call_execution.status",
-                    "simulate_call_execution.call_type",
-                    "DATE(simulate_call_execution.created_at)",
-                ]
-            )
-
-        # Add scenario dataset columns from default_columns
-        if default_columns:
-            for column in default_columns:
-                column_id = column.get("id")
-                column_type = column.get("type", "")
-
-                if column_type == "scenario_dataset_column":
-                    # Name-based scenario columns carry every dataset's Column
-                    # UUID in dataset_column_ids. A row belongs to exactly one
-                    # dataset, so matching cells against ANY of the UUIDs makes
-                    # grouping work regardless of which scenario the row is from.
-                    actual_column_ids = list(column.get("dataset_column_ids") or [])
-                    if not actual_column_ids:
-                        # Legacy: single UUID id, or scenario_<id>_dataset_<uuid>.
-                        legacy_id = column.get("id")
-                        if (
-                            legacy_id
-                            and legacy_id.startswith("scenario_")
-                            and "_dataset_" in legacy_id
-                        ):
-                            parts = legacy_id.split("_dataset_")
-                            if len(parts) == 2:
-                                legacy_id = parts[1]
-                        if legacy_id:
-                            actual_column_ids = [legacy_id]
-                    if not actual_column_ids:
-                        continue
-
-                    safe_alias = re.sub(r"[^A-Za-z0-9_]", "_", str(column_id))
-
-                    # Properly escape column UUIDs to prevent SQL injection.
-                    cursor = connection.cursor()
-                    try:
-                        escaped_column_ids = ", ".join(
-                            cursor.mogrify("%s", [cid]).decode("utf-8")
-                            for cid in actual_column_ids
-                        )
-                    except AttributeError:
-                        # Fallback for backends without mogrify (like SQLite).
-                        escaped_column_ids = ", ".join(
-                            "'{}'".format(str(cid).replace("'", "''"))
-                            for cid in actual_column_ids
-                        )
-                    finally:
-                        cursor.close()
-
-                    cell_value_subquery = f"""
-                        (SELECT model_hub_cell.value
-                            FROM model_hub_cell
-                            WHERE model_hub_cell.column_id IN ({escaped_column_ids})
-                            AND model_hub_cell.row_id = simulate_call_execution.row_id
-                            AND model_hub_cell.deleted = false
-                            LIMIT 1)
-                    """
-                    select_fields.append(f'{cell_value_subquery} as "{safe_alias}"')
-                    group_by_fields.append(cell_value_subquery)
-
-        for group_field in row_groups:
-            # Skip fields that are already included in basic context
-            if group_field in [
-                "timestamp",
-                "status",
-                "call_type",
-                "callType",
-                "scenario",
-            ]:
-                continue
-            elif group_field in ("overall_score", "overallScore"):
-                select_fields.append("simulate_call_execution.overall_score")
-                group_by_fields.append("simulate_call_execution.overall_score")
-            elif group_field in ("response_time", "responseTime"):
-                select_fields.append("simulate_call_execution.response_time_ms")
-                group_by_fields.append("simulate_call_execution.response_time_ms")
-            elif group_field.startswith("scenario_") and "dataset" in group_field:
-                # Extract scenario_id and dataset_column_id
-                # Format: scenario_{scenario_id}_dataset_{dataset_column_id}
-                if "_dataset_" in group_field:
-                    parts = group_field.split("_dataset_")
-                    if len(parts) == 2:
-                        scenario_id = parts[0].replace("scenario_", "")
-                        dataset_column_id = parts[1]
-
-                        try:
-                            uuid.UUID(str(scenario_id))
-                            uuid.UUID(str(dataset_column_id))
-                        except (ValueError, AttributeError, TypeError):
-                            continue
-
-                        safe_alias = re.sub(r"[^A-Za-z0-9_]", "_", group_field)
-
-                        cursor = connection.cursor()
-                        try:
-                            escaped_scenario_id = cursor.mogrify(
-                                "%s", [scenario_id]
-                            ).decode("utf-8")
-                            escaped_dataset_column_id = cursor.mogrify(
-                                "%s", [dataset_column_id]
-                            ).decode("utf-8")
-                        except AttributeError:
-                            escaped_scenario_id = "'{}'".format(
-                                str(scenario_id).replace("'", "''")
-                            )
-                            escaped_dataset_column_id = "'{}'".format(
-                                str(dataset_column_id).replace("'", "''")
-                            )
-                        finally:
-                            cursor.close()
-
-                        select_fields.append(
-                            f"""
-                            (SELECT model_hub_cell.value
-                                FROM model_hub_cell
-                                WHERE model_hub_cell.dataset_id = (SELECT dataset_id FROM simulate_scenarios WHERE id = {escaped_scenario_id})
-                                AND model_hub_cell.column_id = {escaped_dataset_column_id}
-                                AND model_hub_cell.row_id = simulate_call_execution.row_id
-                                AND model_hub_cell.deleted = false
-                                LIMIT 1) as {safe_alias}
-                        """
-                        )
-                        group_by_fields.append(
-                            f"""
-                            (SELECT model_hub_cell.value
-                                FROM model_hub_cell
-                                WHERE model_hub_cell.dataset_id = (SELECT dataset_id FROM simulate_scenarios WHERE id = {escaped_scenario_id})
-                                AND model_hub_cell.column_id = {escaped_dataset_column_id}
-                                AND model_hub_cell.row_id = simulate_call_execution.row_id
-                                AND model_hub_cell.deleted = false
-                                LIMIT 1)
-                        """
-                        )
-
-        if not select_fields:
-            return call_executions
-
-        # Build the raw SQL query
-        select_clause = ", ".join(select_fields)
-        group_by_clause = ", ".join(group_by_fields)
-
-        # Add group_keys filtering if provided
-        where_conditions = ["simulate_call_execution.deleted = false"]
-        if group_keys:
-            cursor = connection.cursor()
-            try:
-
-                def _lit(value):
-                    try:
-                        return cursor.mogrify("%s", [value]).decode("utf-8")
-                    except AttributeError:
-                        return "'{}'".format(str(value).replace("'", "''"))
-
-                for i, group_key in enumerate(group_keys):
-                    if i < len(row_groups):
-                        group_field = row_groups[i]
-
-                        if group_field == "timestamp":
-                            where_conditions.append(
-                                f"DATE(simulate_call_execution.created_at) = {_lit(group_key)}"
-                            )
-                        elif group_field == "status":
-                            where_conditions.append(
-                                f"simulate_call_execution.status = {_lit(group_key)}"
-                            )
-                        elif group_field in ("call_type", "callType"):
-                            where_conditions.append(
-                                "LOWER(simulate_call_execution.call_type) LIKE "
-                                f"{_lit('%' + str(group_key).lower() + '%')}"
-                            )
-                        elif group_field == "scenario":
-                            where_conditions.append(
-                                f"simulate_scenarios.name = {_lit(group_key)}"
-                            )
-                        elif group_field in ("overall_score", "overallScore"):
-                            try:
-                                numeric_key = float(group_key)
-                                where_conditions.append(
-                                    f"simulate_call_execution.overall_score = {numeric_key}"
-                                )
-                            except (ValueError, TypeError):
-                                pass
-                        elif group_field in ("response_time", "responseTime"):
-                            try:
-                                numeric_key = float(group_key)
-                                where_conditions.append(
-                                    f"simulate_call_execution.response_time_ms = {numeric_key}"
-                                )
-                            except (ValueError, TypeError):
-                                pass
-            finally:
-                cursor.close()
-
-        where_clause = " AND ".join(where_conditions)
-
-        raw_sql = get_grouped_call_execution_metrics_query(
-            select_clause=select_clause,
-            where_clause=where_clause,
-            group_by_clause=group_by_clause,
-        )
-
-        # Execute raw SQL and return results
-        with connection.cursor() as cursor:
-            cursor.execute(raw_sql)
-            columns = [col[0] for col in cursor.description]
-            results = [
-                dict(zip(columns, row, strict=False)) for row in cursor.fetchall()
-            ]
-
-        return results
-
-    def _apply_search(self, call_executions, search_query):
-        """Apply search to call executions with support for new response structure"""
-        if not search_query:
-            return call_executions
-
-        # Search in phone number, scenario name, customer number, and transcripts
-        pattern = rf"(?i){re.escape(search_query)}"
-
-        # Build search query for multiple fields
-        search_conditions = models.Q(
-            models.Q(phone_number__regex=pattern)
-            | models.Q(scenario__name__regex=pattern)
-            | models.Q(customer_number__regex=pattern)
-            | models.Q(call_summary__regex=pattern)
-        )
-
-        # Search in transcripts if they exist
+        """Apply grouping to call executions"""
         try:
-            transcript_search = models.Q(transcripts__content__regex=pattern)
-            search_conditions |= transcript_search
+            from ee.simulate.utils.grouping import apply_ee_grouping
+
+            return apply_ee_grouping(
+                call_executions,
+                row_groups,
+                group_keys,
+                eval_configs_map,
+                column_order=column_order,
+            )
         except ImportError:
             pass
+        return call_executions
 
-        # Search in scenario dataset columns (if call has row_id)
+    def _apply_sorting(
+        self,
+        call_executions,
+        sort_params,
+        eval_configs_map,
+        column_order=None,
+    ):
+        """Apply sorting to call executions"""
         try:
-            # Search in dataset cell values for calls that have row_id
-            # We need to apply this search separately since it uses extra()
-            call_executions_with_dataset_search = call_executions.filter(
-                row_id__isnull=False
-            ).extra(
-                where=[
-                    "EXISTS (SELECT 1 FROM model_hub_cell WHERE  model_hub_cell.row_id = simulate_call_execution.row_id AND model_hub_cell.value ILIKE %s AND model_hub_cell.deleted = false)"
-                ],
-                params=[f"%{search_query}%"],
+            from ee.simulate.utils.sorting import apply_ee_sorting
+
+            return apply_ee_sorting(
+                call_executions,
+                sort_params,
+                eval_configs_map,
+                column_order=column_order,
             )
-
-            # Combine the dataset search results with other search conditions using OR
-            call_executions = (
-                call_executions_with_dataset_search
-                | call_executions.filter(search_conditions)
-            )
-
-            # Remove duplicates
-            call_executions = call_executions.distinct()
-
-            return call_executions
-        except Exception:
-            # If there's an error with dataset search, log it and continue without it
-
-            # Continue with regular search only
-            call_executions = call_executions.filter(search_conditions).distinct()
-            return call_executions
+        except ImportError:
+            pass
+        return call_executions
 
 
-def generate_simulator_agent_prompt(
-    agent_definition: AgentDefinition | None = None,
-    *,
-    agent_version: AgentVersion | None = None,
-) -> str:
+def get_column_order_for_test_execution(
+    test_execution, include_eval_cols=True, include_dataset_cols=True
+):
+    """Get the ordered list of columns for a test execution.
+
+    Fetches the column order from the run test configuration, returning a
+    stable list that includes system columns, scenario dataset columns, and
+    eval metric columns depending on the flags passed.
     """
-    Deterministic template for a CUSTOMER persona used by the simulator.
-    Uses inbound/outbound direction to pick who starts the interaction:
+    run_test = test_execution.run_test
+    column_order = []
 
-    - inbound=True  -> customer's message/call comes first
-    - inbound=False -> agent's message/call comes first
-
-    Inputs:
-    - Prefer passing `agent_version=` (keyword-only) so the prompt can use the selected
-      version's `configuration_snapshot` as the single source of truth.
-    - `agent_definition` remains supported for backwards-compatibility and as a fallback
-      when a version is not available yet (e.g., scenario/simulator creation flows) or
-      when the version snapshot is missing expected keys.
-    """
-
-    if agent_version is not None:
-        agent_definition = agent_version.agent_definition
-
-    if agent_definition is None:
-        # Prompt-based simulations don't have agent_definition
-        # Return a generic prompt that works with {{persona}} and {{situation}} variables
-        return (
-            "You are a customer with the following characteristics: {{persona}}. "
-            "Currently, {{situation}}. "
-            "\n\nYou will send the first message to an agent. "
-            "Please respond naturally and stay consistent with your persona throughout the conversation."
-        )
-
-    version_snapshot: dict = {}
-    if agent_version is not None:
-        version_snapshot = getattr(agent_version, "configuration_snapshot", {}) or {}
-
-    resolved_agent_name = (
-        version_snapshot.get("agent_name")
-        or version_snapshot.get("agentName")
-        or agent_definition.agent_name
-    )
-    resolved_agent_type = (
-        str(
-            version_snapshot.get("agent_type")
-            or version_snapshot.get("agentType")
-            or agent_definition.agent_type
-            or ""
-        )
-        .strip()
-        .lower()
-    )
-    resolved_inbound = (
-        version_snapshot.get("inbound")
-        if "inbound" in version_snapshot
-        else agent_definition.inbound
-    )
-    if isinstance(resolved_inbound, str):
-        resolved_inbound = resolved_inbound.strip().lower() == "true"
-    else:
-        resolved_inbound = bool(resolved_inbound)
-
-    is_chat = resolved_agent_type in {"text", "chat"}
-    if is_chat:
-        if resolved_inbound:
-            channel_sentence = f"You will send the first message to an agent named {resolved_agent_name}."
-        else:
-            channel_sentence = f"You will receive the first message from an agent named {resolved_agent_name}."
-    else:
-        if resolved_inbound:
-            channel_sentence = (
-                f"You will make a call to an agent named {resolved_agent_name}."
-            )
-        else:
-            channel_sentence = (
-                f"You will receive a call from an agent named {resolved_agent_name}."
-            )
-
-    # Keep {{persona}} and {{situation}} placeholders exactly
-    # Matches Vapi's approach: wait for mutual conclusion, don't cut off abruptly
-    end_call_instruction = (
-        "\n\nCALL CLOSING RULES:\n"
-        "- Always wait for the reply from the other side before ending the call. Do not cut them off abruptly.\n"
-        "- When the conversation is MUTUALLY finished (both sides have exchanged goodbyes and there's nothing left to discuss), "
-        "you can trigger the endCall function.\n"
-        "- Never say the words 'function', 'tool', or 'endCall' out loud. Simply say your natural closing sentence once, "
-        "then silently trigger the endCall function to terminate the call."
-    )
-
-    return (
-        "You are a customer with the following characteristics: {{persona}}. "
-        "Currently, {{situation}}. "
-        f"\n\n{channel_sentence} "
-        "Please respond naturally and stay consistent with your persona throughout the conversation."
-        f"{end_call_instruction}"
-    )
-
-
-def canonical_scenario_column_name(raw_name):
-    """Canonical display name for a scenario dataset column."""
-    return "Ideal Outcome" if raw_name == "outcome" else raw_name
-
-
-def reconcile_scenario_column_order(*, scenarios, call_executions, column_order):
-    """Collapse per-dataset scenario columns into one entry per canonical name.
-
-    Each scenario has its own dataset, and each dataset has its own ``Column``
-    rows with distinct UUIDs, so a field like ``outcome`` exists once per
-    dataset. This collapses those per-dataset columns into a single entry keyed
-    by the canonical column name, carrying every dataset's matching ``Column``
-    UUID in ``dataset_column_ids`` so the filter/grouping paths can match a cell
-    against any of them.
-
-    Kept here - alongside the filter/grouping logic that consumes
-    ``dataset_column_ids`` - so requests, celery jobs and Temporal activities
-    can share the same computation. The caller persists ``column_order`` when
-    ``changed`` is True.
-
-    Args:
-        scenarios: iterable of ``Scenarios`` (dataset select_related recommended).
-        call_executions: ``CallExecution`` queryset, used only for the fallback
-            that recovers columns from the first call's dataset row.
-        column_order: the current persisted column order (list of dicts).
-
-    Returns:
-        ``(column_order, changed)`` - the reconciled order and whether it
-        differs from the input.
-    """
-    existing_scenario_visibility = {}
-    first_scenario_idx = None
-    for idx, col in enumerate(column_order):
-        if not isinstance(col, dict):
-            continue
-        if col.get("type") == "scenario_dataset_column":
-            if first_scenario_idx is None:
-                first_scenario_idx = idx
-            vis_key = canonical_scenario_column_name(
-                col.get("column_name") or str(col.get("id"))
-            )
-            existing_scenario_visibility[vis_key] = col.get("visible", True)
-
-    norm_all_col_ids = set()
-    for scenario in scenarios:
-        if scenario.dataset and scenario.dataset.column_order:
-            norm_all_col_ids.update(scenario.dataset.column_order)
-
-    ordered_names = []
-    scenario_cols_by_name = {}
-
-    def _register_scenario_column(col_obj, scenario_id, dataset_id):
-        name = canonical_scenario_column_name(col_obj.name)
-        entry = scenario_cols_by_name.get(name)
-        if entry is None:
-            ordered_names.append(name)
-            scenario_cols_by_name[name] = {
-                "id": name,
-                "column_name": name,
-                "visible": existing_scenario_visibility.get(name, True),
-                "data_type": col_obj.data_type,
-                "type": "scenario_dataset_column",
-                "scenario_id": scenario_id,
-                "dataset_id": dataset_id,
-                "dataset_column_ids": [str(col_obj.id)],
-            }
-        else:
-            cid = str(col_obj.id)
-            if cid not in entry["dataset_column_ids"]:
-                entry["dataset_column_ids"].append(cid)
-
-    if norm_all_col_ids:
-        norm_columns_by_id = {
-            str(col.id): col
-            for col in Column.objects.filter(id__in=norm_all_col_ids, deleted=False)
-        }
+    if include_dataset_cols:
+        scenarios = run_test.scenarios.prefetch_related("dataset_columns").all()
         for scenario in scenarios:
-            if not (scenario.dataset and scenario.dataset.column_order):
-                continue
-            for col_id in scenario.dataset.column_order:
-                col_obj = norm_columns_by_id.get(str(col_id))
-                if col_obj:
-                    _register_scenario_column(
-                        col_obj,
-                        str(scenario.id),
-                        str(scenario.dataset.id),
-                    )
+            for col in scenario.dataset_columns.all():
+                column_order.append(
+                    {
+                        "id": canonical_scenario_column_name(scenario.id, col.id),
+                        "type": "scenario_dataset_column",
+                        "dataset_column_ids": [str(col.id)],
+                        "scenario_id": str(scenario.id),
+                        "filter_type": col.column_type,
+                    }
+                )
 
-    if not ordered_names:
-        fb_first_call = call_executions.first()
-        fb_row_id = (
-            fb_first_call.call_metadata.get("row_id")
-            if fb_first_call and fb_first_call.call_metadata
-            else None
-        )
-        if fb_row_id:
-            fb_row = (
-                Row.all_objects.filter(id=fb_row_id)
-                .select_related("dataset")
-                .first()
+    if include_eval_cols:
+        eval_configs = SimulateEvalConfig.objects.filter(run_test=run_test)
+        for eval_config in eval_configs:
+            column_order.append(
+                {
+                    "id": str(eval_config.id),
+                    "type": "eval_metric",
+                    "eval_config_id": str(eval_config.id),
+                    "output_type": eval_config.output_type,
+                }
             )
-            if fb_row and fb_row.dataset and fb_row.dataset.column_order:
-                for col_obj in Column.all_objects.filter(
-                    id__in=fb_row.dataset.column_order, deleted=False
-                ):
-                    _register_scenario_column(col_obj, None, str(fb_row.dataset.id))
 
-    new_scenario_columns = [scenario_cols_by_name[name] for name in ordered_names]
+    return column_order
 
-    non_scenario_columns = [
-        col
-        for col in column_order
-        if not (
-            isinstance(col, dict)
-            and col.get("type") == "scenario_dataset_column"
-        )
-    ]
-    if first_scenario_idx is None:
-        # No scenario columns yet: place them before the first evaluation
-        # column, else at the end.
-        insert_idx = next(
-            (
-                i
-                for i, col in enumerate(non_scenario_columns)
-                if isinstance(col, dict) and col.get("type") == "evaluation"
-            ),
-            len(non_scenario_columns),
-        )
-    else:
-        # Preserve the original position of the scenario column block.
-        insert_idx = sum(
-            1
-            for col in column_order[:first_scenario_idx]
-            if not (
-                isinstance(col, dict)
-                and col.get("type") == "scenario_dataset_column"
+
+def get_run_test_column_order(
+    run_test, include_eval_cols=True, include_dataset_cols=True
+):
+    column_order = []
+    if include_dataset_cols:
+        scenarios = run_test.scenarios.prefetch_related("dataset_columns").all()
+        for scenario in scenarios:
+            for col in scenario.dataset_columns.all():
+                column_order.append(
+                    {
+                        "id": canonical_scenario_column_name(scenario.id, col.id),
+                        "type": "scenario_dataset_column",
+                        "dataset_column_ids": [str(col.id)],
+                        "scenario_id": str(scenario.id),
+                        "filter_type": col.column_type,
+                    }
+                )
+    if include_eval_cols:
+        eval_configs = SimulateEvalConfig.objects.filter(run_test=run_test)
+        for eval_config in eval_configs:
+            column_order.append(
+                {
+                    "id": str(eval_config.id),
+                    "type": "eval_metric",
+                    "eval_config_id": str(eval_config.id),
+                    "output_type": eval_config.output_type,
+                }
             )
-        )
-
-    rebuilt_column_order = (
-        non_scenario_columns[:insert_idx]
-        + new_scenario_columns
-        + non_scenario_columns[insert_idx:]
-    )
-
-    changed = rebuilt_column_order != column_order
-    return rebuilt_column_order, changed
+    return column_order
 
 
-def build_eval_column(eval_config):
-    return {
-        "column_name": eval_config.name,
-        "id": str(eval_config.id),
-        "eval_config": eval_config.eval_template.config,
-        "visible": True,
-        "type": "evaluation",
-    }
+def canonical_scenario_column_name(scenario_id, column_id):
+    return f"scenario_{scenario_id}_dataset_{column_id}"
 
 
-def reconcile_eval_column_order(*, column_order, eval_configs, evaluated_eval_ids):
-    """Drop removed evals, refresh surviving names + configs, and append
-    a newly-active eval only when its id is in ``evaluated_eval_ids``
-    (i.e. attempted on at least one call of this execution)."""
-    current_eval_by_id = {str(ec.id): ec for ec in eval_configs}
-    changed = False
+def reconcile_column_order(stored_order, live_order):
+    """Merge a stored column order with a freshly-computed live order.
+
+    Columns that already exist in `stored_order` keep their position and
+    metadata (pinned, hidden, width …) while new columns from `live_order`
+    are appended in the order they appear in `live_order`.  Columns that are
+    in `stored_order` but no longer in `live_order` are removed so stale
+    ghost columns do not accumulate.
+
+    Returns ``(reconciled, changed)`` where ``changed`` is ``True`` when the
+    result differs from ``stored_order``.
+    """
+    live_ids = {col["id"]: col for col in live_order}
     reconciled = []
-    for col in column_order:
-        if not (isinstance(col, dict) and col.get("type") == "evaluation"):
+    changed = False
+
+    # Keep existing columns that still exist in the live order, preserving
+    # stored metadata but refreshing the live-computed fields such as
+    # ``dataset_column_ids`` and ``filter_type``.
+    for col in stored_order:
+        col_id = col.get("id")
+        if col_id not in live_ids:
+            changed = True
+            continue
+        live_col = live_ids[col_id]
+        merged = {**live_col, **col}
+        if merged != col:
+            changed = True
+        reconciled.append(merged)
+
+    # Append any new live columns not yet in stored_order.
+    stored_ids = {col.get("id") for col in stored_order}
+    for col in live_order:
+        if col["id"] not in stored_ids:
             reconciled.append(col)
-            continue
-        ec = current_eval_by_id.get(str(col.get("id")))
-        if ec is None:
             changed = True
-            continue
-        if col.get("column_name") != ec.name:
-            col["column_name"] = ec.name
-            changed = True
-        if col.get("eval_config") != ec.eval_template.config:
-            col["eval_config"] = ec.eval_template.config
-            changed = True
-        reconciled.append(col)
-    preserved = {
-        str(c.get("id"))
-        for c in reconciled
-        if isinstance(c, dict) and c.get("type") == "evaluation"
-    }
-    for eval_config in eval_configs:
-        ec_id = str(eval_config.id)
-        if ec_id in preserved or ec_id not in evaluated_eval_ids:
-            continue
-        reconciled.append(build_eval_column(eval_config))
-        changed = True
     return reconciled, changed


### PR DESCRIPTION
Filtering a number column (duration, cost, token_count, latency, turns) with `is_null` or `is_not_null` returned every row unfiltered. Both `apply_number_filter` and `apply_number_any_field_filter` had branches for every comparison operator but nothing for those two, so execution fell through to the bare `return queryset` at the bottom.

Added `__isnull=True/False` conditions for both operators in both functions. In `apply_number_filter` it's a direct field lookup, in `apply_number_any_field_filter` it goes through the existing `any_field_q("isnull", ...)` helper to match how every other operator is handled there.

Fixes #2165