### PR TITLE
fix(simulate): support null filters for number columns

### DIFF
--- a/futureagi/model_hub/tests/test_dataset_bulk_add_items_filter.py
+++ b/futureagi/model_hub/tests/test_dataset_bulk_add_items_filter.py
@@ -19,9 +19,8 @@ from structlog.testing import capture_logs
 from model_hub.models.ai_model import AIModel
 from model_hub.models.annotation_queues import AnnotationQueue, QueueItem
 from tracer.models.observation_span import ObservationSpan
-from tracer.models.project import Project, ProjectSourceChoices
+from tracer.models.project import Project
 from tracer.models.trace import Trace
-from tracer.models.trace_session import TraceSession
 from tracer.tests._ch_seed import seed_ch_span
 
 # --------------------------------------------------------------------------
@@ -79,6 +78,16 @@ def _api_filter(column_id, filter_type, filter_op, filter_value):
             "filter_type": filter_type,
             "filter_op": filter_op,
             "filter_value": filter_value,
+        },
+    }
+
+
+def _api_number_null_filter(column_id, filter_op):
+    return {
+        "column_id": column_id,
+        "filter_config": {
+            "filter_type": "number",
+            "filter_op": filter_op,
         },
     }
 
@@ -159,7 +168,8 @@ class TestAddItemsEnumeratedRegression:
     ):
         """A repeated (source_type, id) in ONE payload creates a single row — the batch
         resolve-then-create path dedupes within the payload (the old per-item .exists()
-        only caught ids already committed, so two copies in one request slipped through)."""
+        only caught ids already committed, so two copies in one request slipped through).
+        """
         t = Trace.objects.create(project=observe_project, name="t-dedupe")
         _seed_ch_trace_root(t)
         resp = auth_client.post(
@@ -371,9 +381,7 @@ class TestAddItemsFilterMode:
     ):
         """Filter-mode add stamps project_id from the selection too, so every path
         that fills a queue leaves items scope-able by the render read."""
-        _seed_ch_trace_root(
-            Trace.objects.create(project=observe_project, name="t-fp")
-        )
+        _seed_ch_trace_root(Trace.objects.create(project=observe_project, name="t-fp"))
         resp = auth_client.post(
             _add_items_url(active_queue.id),
             {
@@ -874,6 +882,8 @@ def seeded_mixed_call_executions(db, organization, workspace):
         status="completed",
         duration_seconds=10,
         cost_cents=12,
+        avg_agent_latency_ms=250,
+        response_time_ms=1250,
         row_id=high_priority_row.id,
         call_metadata={
             "row_data": {
@@ -915,7 +925,8 @@ def seeded_mixed_call_executions(db, organization, workspace):
         scenario=scen,
         status="failed",
         duration_seconds=30,
-        cost_cents=56,
+        avg_agent_latency_ms=500,
+        response_time_ms=2750,
         row_id=failed_row.id,
         call_metadata={
             "row_data": {
@@ -944,6 +955,42 @@ def seeded_mixed_call_executions(db, organization, workspace):
 
 @pytest.mark.django_db
 class TestAddItemsFilterModeCallExecutionRichFilters:
+    _NUMBER_NULL_FILTER_CASES = [
+        (
+            "overall_score_is_null_matches_all_rows",
+            "overall_score",
+            "is_null",
+            (0, 1, 2),
+        ),
+        (
+            "overall_score_is_not_null_matches_no_rows",
+            "overall_score",
+            "is_not_null",
+            (),
+        ),
+        ("agent_latency_is_null", "avg_agent_latency_ms", "is_null", (1,)),
+        (
+            "agent_latency_is_not_null",
+            "avg_agent_latency_ms",
+            "is_not_null",
+            (0, 2),
+        ),
+        ("cost_is_null_when_both_fields_are_null", "cost_cents", "is_null", (2,)),
+        (
+            "cost_is_not_null_when_either_field_is_set",
+            "cost_cents",
+            "is_not_null",
+            (0, 1),
+        ),
+        ("response_time_is_null", "responseTime", "is_null", (1,)),
+        (
+            "response_time_is_not_null",
+            "responseTime",
+            "is_not_null",
+            (0, 2),
+        ),
+    ]
+
     def test_simulation_add_items_grid_endpoint_applies_rules_style_filters(
         self, auth_client, seeded_mixed_call_executions
     ):
@@ -1072,6 +1119,38 @@ class TestAddItemsFilterModeCallExecutionRichFilters:
         assert resp.status_code == 200, resp.data
         assert resp.data["count"] == 1
         assert [row["id"] for row in resp.data["results"]] == [str(completed_short.id)]
+
+    @pytest.mark.parametrize(
+        "column_id,filter_op,expected_call_indices",
+        [case[1:] for case in _NUMBER_NULL_FILTER_CASES],
+        ids=[case[0] for case in _NUMBER_NULL_FILTER_CASES],
+    )
+    def test_simulation_add_items_grid_endpoint_filters_number_null_values(
+        self,
+        auth_client,
+        seeded_mixed_call_executions,
+        column_id,
+        filter_op,
+        expected_call_indices,
+    ):
+        _, test_execution, *call_executions, _, _ = seeded_mixed_call_executions
+        expected_ids = {
+            str(call_executions[index].id) for index in expected_call_indices
+        }
+
+        resp = auth_client.get(
+            f"/simulate/test-executions/{test_execution.id}/",
+            {
+                "filters": json.dumps([_api_number_null_filter(column_id, filter_op)]),
+                "page": 1,
+                "limit": 20,
+            },
+        )
+
+        assert resp.status_code == 200, resp.data
+        assert resp.data["count"] == len(expected_ids)
+        assert {row["id"] for row in resp.data["results"]} == expected_ids
+        assert resp.data["error_messages"] == []
 
     def test_simulation_add_items_grid_endpoint_filters_persona_fields(
         self, auth_client, seeded_mixed_call_executions

--- a/futureagi/simulate/utils/test_execution_utils.py
+++ b/futureagi/simulate/utils/test_execution_utils.py
@@ -78,6 +78,11 @@ class TestExecutionUtils:
             return queryset
 
         def apply_number_filter(queryset, field, op, value, transform=lambda v: v):
+            if op == "is_null":
+                return queryset.filter(**{f"{field}__isnull": True})
+            if op == "is_not_null":
+                return queryset.filter(**{f"{field}__isnull": False})
+
             values = as_list(value)
             if op == "equals":
                 return queryset.filter(**{field: transform(values[0])})
@@ -109,8 +114,6 @@ class TestExecutionUtils:
         def apply_number_any_field_filter(
             queryset, fields, op, value, transform=lambda v: v
         ):
-            values = as_list(value)
-
             def q_for(field, lookup, val):
                 key = field if lookup is None else f"{field}__{lookup}"
                 return models.Q(**{key: val})
@@ -121,6 +124,18 @@ class TestExecutionUtils:
                     condition |= q_for(field, lookup, val)
                 return condition
 
+            def all_fields_q(lookup, val):
+                condition = models.Q()
+                for field in fields:
+                    condition &= q_for(field, lookup, val)
+                return condition
+
+            if op == "is_null":
+                return queryset.filter(all_fields_q("isnull", True))
+            if op == "is_not_null":
+                return queryset.filter(any_field_q("isnull", False))
+
+            values = as_list(value)
             if op == "equals":
                 return queryset.filter(any_field_q(None, transform(values[0])))
             if op == "not_equals":
@@ -411,29 +426,38 @@ class TestExecutionUtils:
                 elif column_id in ["responseTime", "response_time"]:
                     # Filter by response time (convert to milliseconds for database comparison)
                     if filter_type == "number":
-                        filter_value = float(filter_value)
-                        # Convert seconds to milliseconds for database comparison
-                        filter_value_ms = filter_value * 1000
-                        if filter_op == "greater_than":
+                        if filter_op == "is_null":
                             call_executions = call_executions.filter(
-                                response_time_ms__gt=filter_value_ms
+                                response_time_ms__isnull=True
                             )
-                        elif filter_op == "less_than":
+                        elif filter_op == "is_not_null":
                             call_executions = call_executions.filter(
-                                response_time_ms__lt=filter_value_ms
+                                response_time_ms__isnull=False
                             )
-                        elif filter_op == "equals":
-                            call_executions = call_executions.filter(
-                                response_time_ms=filter_value_ms
-                            )
-                        elif filter_op == "greater_than_or_equal":
-                            call_executions = call_executions.filter(
-                                response_time_ms__gte=filter_value_ms
-                            )
-                        elif filter_op == "less_than_or_equal":
-                            call_executions = call_executions.filter(
-                                response_time_ms__lte=filter_value_ms
-                            )
+                        else:
+                            filter_value = float(filter_value)
+                            # Convert seconds to milliseconds for database comparison
+                            filter_value_ms = filter_value * 1000
+                            if filter_op == "greater_than":
+                                call_executions = call_executions.filter(
+                                    response_time_ms__gt=filter_value_ms
+                                )
+                            elif filter_op == "less_than":
+                                call_executions = call_executions.filter(
+                                    response_time_ms__lt=filter_value_ms
+                                )
+                            elif filter_op == "equals":
+                                call_executions = call_executions.filter(
+                                    response_time_ms=filter_value_ms
+                                )
+                            elif filter_op == "greater_than_or_equal":
+                                call_executions = call_executions.filter(
+                                    response_time_ms__gte=filter_value_ms
+                                )
+                            elif filter_op == "less_than_or_equal":
+                                call_executions = call_executions.filter(
+                                    response_time_ms__lte=filter_value_ms
+                                )
 
                 elif column_id == "status":
                     # Filter by status
@@ -1389,9 +1413,7 @@ def reconcile_scenario_column_order(*, scenarios, call_executions, column_order)
         )
         if fb_row_id:
             fb_row = (
-                Row.all_objects.filter(id=fb_row_id)
-                .select_related("dataset")
-                .first()
+                Row.all_objects.filter(id=fb_row_id).select_related("dataset").first()
             )
             if fb_row and fb_row.dataset and fb_row.dataset.column_order:
                 for col_obj in Column.all_objects.filter(
@@ -1404,10 +1426,7 @@ def reconcile_scenario_column_order(*, scenarios, call_executions, column_order)
     non_scenario_columns = [
         col
         for col in column_order
-        if not (
-            isinstance(col, dict)
-            and col.get("type") == "scenario_dataset_column"
-        )
+        if not (isinstance(col, dict) and col.get("type") == "scenario_dataset_column")
     ]
     if first_scenario_idx is None:
         # No scenario columns yet: place them before the first evaluation
@@ -1426,8 +1445,7 @@ def reconcile_scenario_column_order(*, scenarios, call_executions, column_order)
             1
             for col in column_order[:first_scenario_idx]
             if not (
-                isinstance(col, dict)
-                and col.get("type") == "scenario_dataset_column"
+                isinstance(col, dict) and col.get("type") == "scenario_dataset_column"
             )
         )
 


### PR DESCRIPTION
Fixes #2165

## Summary

- Add `is_null` and `is_not_null` support to single-field number filters.
- Treat multi-field cost filters as null only when all backing fields are null.
- Handle both null operators for `responseTime` before value conversion.
- Add endpoint regression coverage for all-null and mixed-value datasets.

Null checks run before parsing `filter_value`, since these operators are sent without a value.

## Validation

- `bin/test --no-services model_hub/tests/test_dataset_bulk_add_items_filter.py` — 42 passed
- Black, isort, Ruff, and `git diff --check` — passed