### PR TITLE
fix(alerts): prune ClickHouse monitor queries on start_time

### DIFF
--- a/futureagi/tracer/services/clickhouse/query_builders/monitor_metrics.py
+++ b/futureagi/tracer/services/clickhouse/query_builders/monitor_metrics.py
@@ -48,6 +48,16 @@ EVALUATION_METRICS = "evaluation_metrics"
 SPANS_TABLE = "spans"
 EVAL_TABLE = "tracer_eval_logger"
 
+# Time-series bucket expressions: floor the time column to the frequency window.
+# Spans are partitioned/keyed on ``start_time``; the eval table has no
+# ``start_time`` column, so it must bucket on ``created_at``.
+_SPANS_BUCKET_EXPR = (
+    "toDateTime(intDiv(toUInt32(start_time), %(freq_seconds)s) * %(freq_seconds)s)"
+)
+_EVAL_BUCKET_EXPR = (
+    "toDateTime(intDiv(toUInt32(created_at), %(freq_seconds)s) * %(freq_seconds)s)"
+)
+
 
 class MonitorMetricsQueryBuilder(BaseQueryBuilder):
     """Build ClickHouse queries for monitor metric evaluation and graphing.
@@ -137,17 +147,42 @@ class MonitorMetricsQueryBuilder(BaseQueryBuilder):
                 params["mf_dr_start"] = _parse_dt(value[0])
                 params["mf_dr_end"] = _parse_dt(value[1])
                 ch_conditions.append(
-                    "created_at BETWEEN %(mf_dr_start)s AND %(mf_dr_end)s"
+                    "start_time BETWEEN %(mf_dr_start)s AND %(mf_dr_end)s "
+                    "AND created_at >= %(mf_dr_start)s - INTERVAL 1 DAY"
                 )
             elif key == "created_at" and value:
                 params["mf_created_at"] = _parse_dt(value)
-                ch_conditions.append("created_at >= %(mf_created_at)s")
+                ch_conditions.append(
+                    "start_time >= %(mf_created_at)s "
+                    "AND created_at >= %(mf_created_at)s - INTERVAL 1 DAY"
+                )
             elif key == "project_id":
                 # Already handled by project_where()
                 pass
 
         self._filter_clause = " AND ".join(ch_conditions) if ch_conditions else ""
         self._filter_params = params
+
+    def _spans_time_window(self) -> str:
+        """Spans time-window predicate.
+
+        Filters on ``start_time`` (the partition + primary-key column) so CH
+        prunes partitions, plus a padded ``created_at`` companion lower bound.
+        A ``created_at``-only filter prunes nothing on the v2 spans table
+        (``PARTITION BY toDate(start_time)``, no ``created_at`` index). Mirrors
+        ``DashboardQueryBuilder._build_where_clauses``.
+        """
+        return (
+            "start_time BETWEEN %(start_time)s AND %(end_time)s "
+            "AND created_at >= %(start_time)s - INTERVAL 1 DAY"
+        )
+
+    def _spans_time_window_half_open(self) -> str:
+        """Half-open (``>= start AND < end``) variant for daily/monthly sums."""
+        return (
+            "start_time >= %(start_time)s AND start_time < %(end_time)s "
+            "AND created_at >= %(start_time)s - INTERVAL 1 DAY"
+        )
 
     def build(self) -> Tuple[str, Dict[str, Any]]:
         """Not used directly -- use build_metric_value_query or build_time_series_query."""
@@ -177,13 +212,15 @@ class MonitorMetricsQueryBuilder(BaseQueryBuilder):
         params["end_time"] = _parse_dt(end_time)
 
         base_where = self._spans_base_where()
+        time_win = f"AND {self._spans_time_window()}"
+        time_win_ho = f"AND {self._spans_time_window_half_open()}"
 
         if metric_type == COUNT_OF_ERRORS:
             query = f"""
                 SELECT count() AS value
                 FROM {SPANS_TABLE}
                 {base_where}
-                  AND created_at BETWEEN %(start_time)s AND %(end_time)s
+                  {time_win}
                   AND status = 'ERROR'
             """
 
@@ -195,7 +232,7 @@ class MonitorMetricsQueryBuilder(BaseQueryBuilder):
                     END AS value
                 FROM {SPANS_TABLE}
                 {base_where}
-                  AND created_at BETWEEN %(start_time)s AND %(end_time)s
+                  {time_win}
                   AND observation_type = 'tool'
             """
 
@@ -211,7 +248,7 @@ class MonitorMetricsQueryBuilder(BaseQueryBuilder):
                         countIf(status = 'ERROR') AS error_count
                     FROM {SPANS_TABLE}
                     {base_where}
-                      AND created_at BETWEEN %(start_time)s AND %(end_time)s
+                      {time_win}
                       AND session_id != ''
                       AND session_id IS NOT NULL
                     GROUP BY session_id
@@ -230,7 +267,7 @@ class MonitorMetricsQueryBuilder(BaseQueryBuilder):
                         countIf(status = 'ERROR') AS error_count
                     FROM {SPANS_TABLE}
                     {base_where}
-                      AND created_at BETWEEN %(start_time)s AND %(end_time)s
+                      {time_win}
                       AND provider != ''
                       AND provider IS NOT NULL
                     GROUP BY provider
@@ -245,7 +282,7 @@ class MonitorMetricsQueryBuilder(BaseQueryBuilder):
                     END AS value
                 FROM {SPANS_TABLE}
                 {base_where}
-                  AND created_at BETWEEN %(start_time)s AND %(end_time)s
+                  {time_win}
                   AND observation_type = 'llm'
             """
 
@@ -254,7 +291,7 @@ class MonitorMetricsQueryBuilder(BaseQueryBuilder):
                 SELECT avg(latency_ms) AS value
                 FROM {SPANS_TABLE}
                 {base_where}
-                  AND created_at BETWEEN %(start_time)s AND %(end_time)s
+                  {time_win}
             """
 
         elif metric_type == LLM_RESPONSE_TIME:
@@ -262,7 +299,7 @@ class MonitorMetricsQueryBuilder(BaseQueryBuilder):
                 SELECT avg(latency_ms) AS value
                 FROM {SPANS_TABLE}
                 {base_where}
-                  AND created_at BETWEEN %(start_time)s AND %(end_time)s
+                  {time_win}
                   AND observation_type = 'llm'
             """
 
@@ -271,7 +308,7 @@ class MonitorMetricsQueryBuilder(BaseQueryBuilder):
                 SELECT sum(total_tokens) AS value
                 FROM {SPANS_TABLE}
                 {base_where}
-                  AND created_at BETWEEN %(start_time)s AND %(end_time)s
+                  {time_win}
             """
 
         elif metric_type == DAILY_TOKENS_SPENT:
@@ -279,8 +316,7 @@ class MonitorMetricsQueryBuilder(BaseQueryBuilder):
                 SELECT sum(total_tokens) AS value
                 FROM {SPANS_TABLE}
                 {base_where}
-                  AND created_at >= %(start_time)s
-                  AND created_at < %(end_time)s
+                  {time_win_ho}
             """
 
         elif metric_type == MONTHLY_TOKENS_SPENT:
@@ -288,8 +324,7 @@ class MonitorMetricsQueryBuilder(BaseQueryBuilder):
                 SELECT sum(total_tokens) AS value
                 FROM {SPANS_TABLE}
                 {base_where}
-                  AND created_at >= %(start_time)s
-                  AND created_at < %(end_time)s
+                  {time_win_ho}
             """
 
         elif metric_type == EVALUATION_METRICS:
@@ -372,6 +407,7 @@ class MonitorMetricsQueryBuilder(BaseQueryBuilder):
         params["end_time"] = _parse_dt(end_time)
 
         base_where = self._spans_base_where()
+        time_win = f"AND {self._spans_time_window()}"
 
         if metric_type == ERROR_RATES_FOR_FUNCTION_CALLING:
             query = f"""
@@ -383,7 +419,7 @@ class MonitorMetricsQueryBuilder(BaseQueryBuilder):
                         CASE WHEN status = 'ERROR' THEN 1.0 ELSE 0.0 END AS is_error
                     FROM {SPANS_TABLE}
                     {base_where}
-                      AND created_at BETWEEN %(start_time)s AND %(end_time)s
+                      {time_win}
                       AND observation_type = 'tool'
                 )
             """
@@ -398,7 +434,7 @@ class MonitorMetricsQueryBuilder(BaseQueryBuilder):
                         CASE WHEN countIf(status = 'ERROR') > 0 THEN 0.0 ELSE 1.0 END AS is_error_free
                     FROM {SPANS_TABLE}
                     {base_where}
-                      AND created_at BETWEEN %(start_time)s AND %(end_time)s
+                      {time_win}
                       AND session_id != ''
                       AND session_id IS NOT NULL
                     GROUP BY session_id
@@ -415,7 +451,7 @@ class MonitorMetricsQueryBuilder(BaseQueryBuilder):
                         CASE WHEN countIf(status = 'ERROR') > 0 THEN 0.0 ELSE 1.0 END AS is_error_free
                     FROM {SPANS_TABLE}
                     {base_where}
-                      AND created_at BETWEEN %(start_time)s AND %(end_time)s
+                      {time_win}
                       AND provider != ''
                       AND provider IS NOT NULL
                     GROUP BY provider
@@ -432,7 +468,7 @@ class MonitorMetricsQueryBuilder(BaseQueryBuilder):
                         CASE WHEN status = 'ERROR' THEN 1.0 ELSE 0.0 END AS is_error
                     FROM {SPANS_TABLE}
                     {base_where}
-                      AND created_at BETWEEN %(start_time)s AND %(end_time)s
+                      {time_win}
                       AND observation_type = 'llm'
                 )
             """
@@ -444,7 +480,7 @@ class MonitorMetricsQueryBuilder(BaseQueryBuilder):
                     stddevSamp(latency_ms) AS stddev
                 FROM {SPANS_TABLE}
                 {base_where}
-                  AND created_at BETWEEN %(start_time)s AND %(end_time)s
+                  {time_win}
             """
 
         elif metric_type == LLM_RESPONSE_TIME:
@@ -454,7 +490,7 @@ class MonitorMetricsQueryBuilder(BaseQueryBuilder):
                     stddevSamp(latency_ms) AS stddev
                 FROM {SPANS_TABLE}
                 {base_where}
-                  AND created_at BETWEEN %(start_time)s AND %(end_time)s
+                  {time_win}
                   AND observation_type = 'llm'
             """
 
@@ -547,10 +583,10 @@ class MonitorMetricsQueryBuilder(BaseQueryBuilder):
         params["end_time"] = _parse_dt(end_time)
         params["freq_seconds"] = frequency_seconds
 
-        bucket_expr = "toDateTime(intDiv(toUInt32(created_at), %(freq_seconds)s) * %(freq_seconds)s)"
+        bucket_expr = _SPANS_BUCKET_EXPR
 
         base_where = self._spans_base_where()
-        time_filter = "AND created_at BETWEEN %(start_time)s AND %(end_time)s"
+        time_filter = f"AND {self._spans_time_window()}"
 
         if metric_type in (TOKEN_USAGE, DAILY_TOKENS_SPENT, MONTHLY_TOKENS_SPENT):
             query = f"""
@@ -667,7 +703,7 @@ class MonitorMetricsQueryBuilder(BaseQueryBuilder):
             """
 
         elif metric_type == EVALUATION_METRICS:
-            query, params = self._build_eval_time_series_query(params, bucket_expr)
+            query, params = self._build_eval_time_series_query(params)
 
         else:
             query = "SELECT NULL AS timestamp, NULL AS value WHERE 1 = 0"
@@ -677,14 +713,17 @@ class MonitorMetricsQueryBuilder(BaseQueryBuilder):
     def _build_eval_time_series_query(
         self,
         params: Dict[str, Any],
-        bucket_expr: str,
     ) -> Tuple[str, Dict[str, Any]]:
-        """Build eval metric time-series query."""
+        """Build eval metric time-series query.
+
+        Buckets on ``created_at``: the eval table has no ``start_time`` column.
+        """
         if not self.eval_config_id:
             return "SELECT NULL AS timestamp, NULL AS value WHERE 1 = 0", params
 
         params["eval_config_id"] = self.eval_config_id
         eval_where = self._eval_base_where()
+        bucket_expr = _EVAL_BUCKET_EXPR
         time_filter = "AND created_at BETWEEN %(start_time)s AND %(end_time)s"
 
         if self.eval_output_type == "SCORE":

--- a/futureagi/tracer/services/clickhouse/query_builders/monitor_metrics.py
+++ b/futureagi/tracer/services/clickhouse/query_builders/monitor_metrics.py
@@ -48,9 +48,10 @@ EVALUATION_METRICS = "evaluation_metrics"
 SPANS_TABLE = "spans"
 EVAL_TABLE = "tracer_eval_logger"
 
-# Time-series bucket expressions: floor the time column to the frequency window.
-# Spans are partitioned/keyed on ``start_time``; the eval table has no
-# ``start_time`` column, so it must bucket on ``created_at``.
+# Time-series buckets: to epoch seconds, integer-divide by the frequency to
+# floor to the bucket boundary, back to DateTime (300s: 12:07:43 -> 12:05:00).
+# Works for any frequency, unlike toStartOfHour/-FiveMinutes. Spans bucket on
+# ``start_time`` (event time); the eval table has none, so ``created_at``.
 _SPANS_BUCKET_EXPR = (
     "toDateTime(intDiv(toUInt32(start_time), %(freq_seconds)s) * %(freq_seconds)s)"
 )
@@ -164,13 +165,15 @@ class MonitorMetricsQueryBuilder(BaseQueryBuilder):
         self._filter_params = params
 
     def _spans_time_window(self) -> str:
-        """Spans time-window predicate.
+        """Spans time-window predicate — event-time semantics.
 
-        Filters on ``start_time`` (the partition + primary-key column) so CH
-        prunes partitions, plus a padded ``created_at`` companion lower bound.
-        A ``created_at``-only filter prunes nothing on the v2 spans table
-        (``PARTITION BY toDate(start_time)``, no ``created_at`` index). Mirrors
-        ``DashboardQueryBuilder._build_where_clauses``.
+        Deliberate change from pre-CH behavior: windows evaluate on
+        ``start_time`` (event time, the partition key, so CH prunes), not
+        ``created_at`` (ingest time, unindexed, full scan). Blind spot: spans
+        ingested after their window was evaluated are never counted.
+        TODO: offset evaluation windows by ingest lag. The padded
+        ``created_at`` companion only guards against clock-skewed future
+        ``start_time``. Mirrors ``DashboardQueryBuilder``.
         """
         return (
             "start_time BETWEEN %(start_time)s AND %(end_time)s "

--- a/futureagi/tracer/tests/test_monitor_metrics_start_time.py
+++ b/futureagi/tracer/tests/test_monitor_metrics_start_time.py
@@ -100,7 +100,7 @@ def test_time_series_buckets_and_filters_start_time(metric_type):
     _assert_spans_pruned(sql)
 
 
-def test_session_and_date_range_filters_use_start_time():
+def test_date_range_and_created_at_filters_use_start_time():
     filters = {
         "date_range": [START.isoformat(), END.isoformat()],
         "created_at": START.isoformat(),

--- a/futureagi/tracer/tests/test_monitor_metrics_start_time.py
+++ b/futureagi/tracer/tests/test_monitor_metrics_start_time.py
@@ -1,0 +1,135 @@
+"""
+Pin the monitor builder's time-window predicates to ``start_time``.
+
+The v2 spans table is ``PARTITION BY toDate(start_time)`` with
+``toStartOfHour(start_time)`` in the primary key and no index on
+``created_at``. Filtering ``created_at`` prunes nothing → full-history scans.
+These tests assert the COMPILED SQL filters/buckets spans on ``start_time``
+(with a padded ``created_at`` companion bound), while the eval-table queries
+stay on ``created_at`` (that table has no ``start_time`` column).
+
+No real ClickHouse is hit — only the generated SQL string is asserted.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+import pytest
+
+from tracer.services.clickhouse.query_builders import monitor_metrics as mm
+from tracer.services.clickhouse.query_builders.monitor_metrics import (
+    MonitorMetricsQueryBuilder,
+)
+
+PROJECT_ID = "11111111-1111-1111-1111-111111111111"
+EVAL_CONFIG_ID = "22222222-2222-2222-2222-222222222222"
+START = datetime(2026, 8, 1, tzinfo=timezone.utc)
+END = datetime(2026, 8, 8, tzinfo=timezone.utc)
+
+COMPANION = "created_at >= %(start_time)s - INTERVAL 1 DAY"
+BETWEEN_START = "start_time BETWEEN %(start_time)s AND %(end_time)s"
+HALF_OPEN_START = "start_time >= %(start_time)s AND start_time < %(end_time)s"
+
+# Spans metric types whose time window is a BETWEEN on start_time.
+SPANS_BETWEEN = [
+    mm.COUNT_OF_ERRORS,
+    mm.ERROR_RATES_FOR_FUNCTION_CALLING,
+    mm.ERROR_FREE_SESSION_RATES,
+    mm.SERVICE_PROVIDER_ERROR_RATES,
+    mm.LLM_API_FAILURE_RATES,
+    mm.SPAN_RESPONSE_TIME,
+    mm.LLM_RESPONSE_TIME,
+    mm.TOKEN_USAGE,
+]
+SPANS_HALF_OPEN = [mm.DAILY_TOKENS_SPENT, mm.MONTHLY_TOKENS_SPENT]
+# Per-row metrics that have a historical-stats branch (excludes the
+# time-aggregated ones handled in Python and eval).
+HISTORICAL_SPANS = [
+    mm.ERROR_RATES_FOR_FUNCTION_CALLING,
+    mm.ERROR_FREE_SESSION_RATES,
+    mm.SERVICE_PROVIDER_ERROR_RATES,
+    mm.LLM_API_FAILURE_RATES,
+    mm.SPAN_RESPONSE_TIME,
+    mm.LLM_RESPONSE_TIME,
+]
+
+
+def _builder(filters=None, eval_output_type=None):
+    return MonitorMetricsQueryBuilder(
+        project_id=PROJECT_ID,
+        filters=filters,
+        eval_config_id=EVAL_CONFIG_ID if eval_output_type else None,
+        eval_output_type=eval_output_type,
+        threshold_metric_value="Passed" if eval_output_type == "PASS_FAIL" else None,
+    )
+
+
+def _assert_spans_pruned(sql: str) -> None:
+    """A spans query must prune on start_time and never bind bare created_at."""
+    assert COMPANION in sql, "missing padded created_at companion bound"
+    assert "created_at BETWEEN" not in sql, "spans query still filters created_at"
+
+
+@pytest.mark.parametrize("metric_type", SPANS_BETWEEN)
+def test_metric_value_spans_filter_start_time(metric_type):
+    sql, _ = _builder().build_metric_value_query(metric_type, START, END)
+    assert BETWEEN_START in sql
+    _assert_spans_pruned(sql)
+
+
+@pytest.mark.parametrize("metric_type", SPANS_HALF_OPEN)
+def test_metric_value_half_open_filters_start_time(metric_type):
+    sql, _ = _builder().build_metric_value_query(metric_type, START, END)
+    assert HALF_OPEN_START in sql
+    _assert_spans_pruned(sql)
+
+
+@pytest.mark.parametrize("metric_type", HISTORICAL_SPANS)
+def test_historical_stats_filter_start_time(metric_type):
+    sql, _ = _builder().build_historical_stats_query(metric_type, START, END)
+    assert BETWEEN_START in sql
+    _assert_spans_pruned(sql)
+
+
+@pytest.mark.parametrize("metric_type", SPANS_BETWEEN)
+def test_time_series_buckets_and_filters_start_time(metric_type):
+    sql, _ = _builder().build_time_series_query(metric_type, START, END, 3600)
+    assert "toUInt32(start_time)" in sql, "spans bucket must floor start_time"
+    assert "toUInt32(created_at)" not in sql
+    _assert_spans_pruned(sql)
+
+
+def test_session_and_date_range_filters_use_start_time():
+    filters = {
+        "date_range": [START.isoformat(), END.isoformat()],
+        "created_at": START.isoformat(),
+    }
+    sql, _ = _builder(filters=filters).build_metric_value_query(
+        mm.COUNT_OF_ERRORS, START, END
+    )
+    assert "start_time BETWEEN %(mf_dr_start)s AND %(mf_dr_end)s" in sql
+    assert "start_time >= %(mf_created_at)s" in sql
+    assert "created_at BETWEEN %(mf_dr_start)s" not in sql
+
+
+# --- Eval-table queries must stay on created_at (no start_time column) --------
+
+
+def test_eval_value_query_keeps_created_at():
+    sql, _ = _builder(eval_output_type="SCORE").build_metric_value_query(
+        mm.EVALUATION_METRICS, START, END
+    )
+    assert "created_at BETWEEN %(start_time)s AND %(end_time)s" in sql
+    # ``start_time`` is only ever a param name here, never a column reference —
+    # the eval table has no start_time column.
+    for col_use in ("start_time BETWEEN", "start_time >=", "toUInt32(start_time)"):
+        assert col_use not in sql, f"eval query references start_time column: {col_use}"
+
+
+def test_eval_time_series_buckets_created_at():
+    sql, _ = _builder(eval_output_type="SCORE").build_time_series_query(
+        mm.EVALUATION_METRICS, START, END, 3600
+    )
+    assert "toUInt32(created_at)" in sql
+    assert "toUInt32(start_time)" not in sql


### PR DESCRIPTION
## Summary

Alerting has been non-functional at production scale since the PG→CH span migration: monitor queries filter `created_at`, but the v2 `spans` table is `PARTITION BY toDate(start_time)` with no `created_at` index — so every evaluation full-scans the project's entire history and times out on large projects. This PR makes every directly windowed monitor spans query prunable — the foundation of the alerts-restore stack (PR 1 of 7). Two pre-existing unbounded subqueries remain and are fixed later in the stack (see below).

## Linked issues

Linear: Fixed TH-7533

## Type of change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] 🚀 Performance improvement

---

## 1) What changes were done

**A. Event-time windows on every monitor spans query (semantics change)**

- All three query families (metric value / historical stats / time series) now evaluate the metric window on `start_time` (event time — when the span happened), not `created_at` (ingest time). This is a deliberate semantics change, and `start_time` is the partition key, so ClickHouse prunes partitions instead of scanning all history.
- A padded `created_at >= start − 1 DAY` companion guards against clock-skewed producers reporting future `start_time`; it is a hygiene guard, not the window.
- Time-series buckets are on `start_time` as well, so buckets and windows agree.
- Stored monitor filters (`date_range`, `created_at`) are translated to the same event-time shape.
- Eval-table queries are untouched here (no `start_time` column on `tracer_eval_logger`); the eval path is reworked in PR #2172.

**Known limitation (event-time blind spot):** a span ingested after its window was already evaluated is counted by no evaluation. The standard mitigation — an ingest-lag offset on the evaluation window (`[start − lag, end − lag)`) — is not in this stack; it is called out as a TODO in `_spans_time_window()` and will be a follow-up.

**Not covered by this PR (fixed later in the stack):**
- `_eval_base_where()`'s span-membership subquery is unbounded here; PR #2172 adds the time window + project filter to it.
- The `session_id` filter's unbounded cross-tenant subquery is removed in PR #2171 (replaced by `trace_session_id = toUUID(...)`).

## 2) Why the changes were done

- **Product:** monitors on any project with meaningful history silently timed out every tick — alerts never fired.
- **Technical:** partition pruning needs a predicate on the partition key. Event-time is also the semantics we want: windows describe when activity happened, not when it was ingested. Mirrors the dashboard builder's window pattern.

---

## 3) Tests written + scenarios each covers

**`tracer/tests/test_monitor_metrics_start_time.py`** — SQL-shape assertions for the window across all spans metrics × all three query families: exact `start_time` window present, `created_at` companion present, buckets on `start_time`, eval table exempt from spans-style windows.

> Run result: suite passes at this commit. Later PRs in the stack extend these tests as query shapes evolve.

## 4) How to run / test

```bash
cd futureagi
.venv/bin/python -m pytest tracer/tests/test_monitor_metrics_start_time.py -q
```

---

**Stack:** PR 1/7 (base). Reviewed bottom-up; merge order 1→7.
