### PR TITLE
fix(alerts): use trace_session_id for CH session metrics

### DIFF
--- a/futureagi/tracer/services/clickhouse/query_builders/monitor_metrics.py
+++ b/futureagi/tracer/services/clickhouse/query_builders/monitor_metrics.py
@@ -137,13 +137,7 @@ class MonitorMetricsQueryBuilder(BaseQueryBuilder):
             elif key == "session_id" and value:
                 pname = "mf_session_id"
                 params[pname] = str(value)
-                ch_conditions.append(
-                    f"trace_id IN ("
-                    f"SELECT DISTINCT id FROM spans "
-                    f"WHERE session_id = %({pname})s "
-                    f"AND is_deleted = 0"
-                    f")"
-                )
+                ch_conditions.append(f"trace_session_id = toUUID(%({pname})s)")
             elif key == "date_range" and isinstance(value, list) and len(value) == 2:
                 params["mf_dr_start"] = _parse_dt(value[0])
                 params["mf_dr_end"] = _parse_dt(value[1])
@@ -242,19 +236,18 @@ class MonitorMetricsQueryBuilder(BaseQueryBuilder):
         elif metric_type == ERROR_FREE_SESSION_RATES:
             query = f"""
                 SELECT
-                    CASE WHEN uniq(session_id) = 0 THEN NULL
-                         ELSE uniqIf(session_id, error_count = 0) / uniq(session_id)
+                    CASE WHEN uniq(trace_session_id) = 0 THEN NULL
+                         ELSE uniqIf(trace_session_id, error_count = 0) / uniq(trace_session_id)
                     END AS value
                 FROM (
                     SELECT
-                        session_id,
+                        trace_session_id,
                         countIf(status = 'ERROR') AS error_count
                     FROM {SPANS_TABLE}
                     {base_where}
                       {time_win}
-                      AND session_id != ''
-                      AND session_id IS NOT NULL
-                    GROUP BY session_id
+                      AND trace_session_id IS NOT NULL
+                    GROUP BY trace_session_id
                 )
             """
 
@@ -438,9 +431,8 @@ class MonitorMetricsQueryBuilder(BaseQueryBuilder):
                     FROM {SPANS_TABLE}
                     {base_where}
                       {time_win}
-                      AND session_id != ''
-                      AND session_id IS NOT NULL
-                    GROUP BY session_id
+                      AND trace_session_id IS NOT NULL
+                    GROUP BY trace_session_id
                 )
             """
 
@@ -663,20 +655,19 @@ class MonitorMetricsQueryBuilder(BaseQueryBuilder):
             query = f"""
                 SELECT
                     timestamp,
-                    CASE WHEN uniq(session_id) = 0 THEN 0
-                         ELSE uniqIf(session_id, error_count = 0) / uniq(session_id)
+                    CASE WHEN uniq(trace_session_id) = 0 THEN 0
+                         ELSE uniqIf(trace_session_id, error_count = 0) / uniq(trace_session_id)
                     END AS value
                 FROM (
                     SELECT
                         {bucket_expr} AS timestamp,
-                        session_id,
+                        trace_session_id,
                         countIf(status = 'ERROR') AS error_count
                     FROM {SPANS_TABLE}
                     {base_where}
                       {time_filter}
-                      AND session_id != ''
-                      AND session_id IS NOT NULL
-                    GROUP BY timestamp, session_id
+                      AND trace_session_id IS NOT NULL
+                    GROUP BY timestamp, trace_session_id
                 )
                 GROUP BY timestamp
                 ORDER BY timestamp

--- a/futureagi/tracer/tests/test_clickhouse.py
+++ b/futureagi/tracer/tests/test_clickhouse.py
@@ -8292,15 +8292,15 @@ class TestMonitorMetricsQueryBuilder:
         assert "countIf(status = 'ERROR')" in query
 
     def test_error_free_session_rates_query(self):
-        """ERROR_FREE_SESSION_RATES should group by session_id."""
+        """ERROR_FREE_SESSION_RATES should group by trace_session_id."""
         from datetime import datetime
 
         builder = self._make_builder()
         query, _ = builder.build_metric_value_query(
             "error_free_session_rates", datetime(2024, 1, 1), datetime(2024, 1, 31)
         )
-        assert "session_id" in query
-        assert "GROUP BY session_id" in query
+        assert "trace_session_id" in query
+        assert "GROUP BY trace_session_id" in query
 
     def test_service_provider_error_rates_query(self):
         """SERVICE_PROVIDER_ERROR_RATES should group by provider."""

--- a/futureagi/tracer/tests/test_monitor_metrics_session_id.py
+++ b/futureagi/tracer/tests/test_monitor_metrics_session_id.py
@@ -1,0 +1,84 @@
+"""
+Pin the monitor builder's session grouping/filter to ``trace_session_id``.
+
+The live v2 spans table has no ``session_id`` column — only
+``trace_session_id`` (Nullable(UUID)) — and the v2 rewriter does not translate
+the name. These tests assert the compiled SQL uses ``trace_session_id``, drops
+the ``!= ''`` guard (invalid on a UUID column), and that the session filter is a
+direct equality (not the old malformed ``trace_id IN (SELECT id ...)`` subquery).
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+import pytest
+
+from tracer.services.clickhouse.query_builders import monitor_metrics as mm
+from tracer.services.clickhouse.query_builders.monitor_metrics import (
+    MonitorMetricsQueryBuilder,
+)
+
+PROJECT_ID = "11111111-1111-1111-1111-111111111111"
+SESSION_ID = "33333333-3333-3333-3333-333333333333"
+START = datetime(2026, 8, 1, tzinfo=timezone.utc)
+END = datetime(2026, 8, 8, tzinfo=timezone.utc)
+
+
+def _builder(filters=None):
+    return MonitorMetricsQueryBuilder(project_id=PROJECT_ID, filters=filters)
+
+
+def _assert_session_ok(sql: str) -> None:
+    assert "trace_session_id" in sql
+    # Bare ``session_id`` column must never appear, nor the invalid UUID guard.
+    assert "session_id != ''" not in sql
+    # Catch a bare ``session_id`` not prefixed by ``trace_``.
+    assert " session_id" not in sql.replace("trace_session_id", "")
+
+
+def test_error_free_session_rates_value_uses_trace_session_id():
+    sql, _ = _builder().build_metric_value_query(
+        mm.ERROR_FREE_SESSION_RATES, START, END
+    )
+    _assert_session_ok(sql)
+    assert "GROUP BY trace_session_id" in sql
+
+
+def test_error_free_session_rates_historical_uses_trace_session_id():
+    sql, _ = _builder().build_historical_stats_query(
+        mm.ERROR_FREE_SESSION_RATES, START, END
+    )
+    _assert_session_ok(sql)
+    assert "GROUP BY trace_session_id" in sql
+
+
+def test_error_free_session_rates_time_series_uses_trace_session_id():
+    sql, _ = _builder().build_time_series_query(
+        mm.ERROR_FREE_SESSION_RATES, START, END, 3600
+    )
+    _assert_session_ok(sql)
+    assert "GROUP BY timestamp, trace_session_id" in sql
+
+
+def test_session_id_filter_is_direct_equality():
+    sql, params = _builder(filters={"session_id": SESSION_ID}).build_metric_value_query(
+        mm.COUNT_OF_ERRORS, START, END
+    )
+    assert "trace_session_id = toUUID(%(mf_session_id)s)" in sql
+    assert params["mf_session_id"] == SESSION_ID
+    # The old malformed span-id/trace-id subquery is gone.
+    assert "SELECT DISTINCT id FROM spans" not in sql
+
+
+@pytest.mark.parametrize(
+    "metric_type",
+    [mm.COUNT_OF_ERRORS, mm.TOKEN_USAGE, mm.SPAN_RESPONSE_TIME],
+)
+def test_session_filter_does_not_break_other_metrics(metric_type):
+    # A session_id filter is spliced into the shared base WHERE, so it must
+    # compile for every metric type, not just error_free_session_rates.
+    sql, _ = _builder(filters={"session_id": SESSION_ID}).build_metric_value_query(
+        metric_type, START, END
+    )
+    assert "trace_session_id = toUUID(%(mf_session_id)s)" in sql


### PR DESCRIPTION
## Summary

`ERROR_FREE_SESSION_RATES` (and any session-filtered monitor) threw on every run: the builder referenced a bare `session_id`, but the live v2 spans table only has `trace_session_id` (a `Nullable(UUID)`, so the old `!= ''` guard also throws). PR 2 of 7 in the alerts-restore stack.

## Linked issues

Linear: Fixed TH-7534

## Type of change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

---

## 1) What changes were done

**A. Schema-correct session metrics**

- `session_id` → `trace_session_id` in the three `ERROR_FREE_SESSION_RATES` branches (value / historical / time series).
- Guard replaced with `trace_session_id IS NOT NULL` (UUID column; `!= ''` is a type error).
- The malformed session filter (`trace_id IN (SELECT DISTINCT id …)` — compared span-ids to trace-ids, matched nothing) replaced with a direct `trace_session_id` predicate. (Filter semantics are finalized later in the stack — PR 6 removes entity-scoping filter keys entirely.)

## 2) Why the changes were done

- **Technical:** the v2 rewriter's rename map doesn't translate `session_id`, so this could only be fixed at the source. Session-remap-aware grouping (alias dedup) lands in PR 6 with the other correctness work.

---

## 3) Tests written + scenarios each covers

**`tracer/tests/test_monitor_metrics_session_id.py`** — asserts `trace_session_id` everywhere, no bare `session_id` emitted, no String guards on the UUID column, across all three query families.

## 4) How to run / test

```bash
cd futureagi
.venv/bin/python -m pytest tracer/tests/test_monitor_metrics_session_id.py -q
```

---

**Stack:** PR 2/7, on `fix/alerts-ch-start-time-pruning`.
