### PR TITLE
fix(alerts): eval metrics via eval_logger_source, windowed on span time

### DIFF
--- a/futureagi/tracer/services/clickhouse/query_builders/monitor_metrics.py
+++ b/futureagi/tracer/services/clickhouse/query_builders/monitor_metrics.py
@@ -27,6 +27,7 @@ from typing import Any, Dict, List, Optional, Tuple
 
 import structlog
 
+from tracer.models.observation_span import EvalEntryStatus
 from tracer.services.clickhouse.eval_logger_table import eval_logger_source
 from tracer.services.clickhouse.query_builders.base import BaseQueryBuilder, _parse_dt
 from tracer.services.clickhouse.query_builders.filters import ClickHouseFilterBuilder
@@ -57,6 +58,12 @@ _SPANS_BUCKET_EXPR = (
 )
 _EVAL_BUCKET_EXPR = (
     "toDateTime(intDiv(toUInt32(created_at), %(freq_seconds)s) * %(freq_seconds)s)"
+)
+
+# Statuses whose rows carry no real value (NULL outputs). NOT IN keeps legacy
+# empty/NULL-status rows counted as completed (mirrors span_list.py).
+_EVAL_NON_VALUE_STATUSES = ", ".join(
+    f"'{s.value}'" for s in EvalEntryStatus if s is not EvalEntryStatus.COMPLETED
 )
 
 
@@ -709,8 +716,8 @@ class MonitorMetricsQueryBuilder(BaseQueryBuilder):
         column). Window membership comes from the span subquery, so a
         late-computed eval for an in-window span lands in the bucket of its
         computation time.
-        # TODO: bucket by span time (needs a spans join) for graph fidelity.
         """
+        # TODO: bucket by span time (needs a spans join) for graph fidelity.
         if not self.eval_config_id:
             return "SELECT NULL AS timestamp, NULL AS value WHERE 1 = 0", params
 
@@ -765,21 +772,14 @@ class MonitorMetricsQueryBuilder(BaseQueryBuilder):
         ``not_deleted`` comes from the same ``eval_logger_source()`` call that
         resolved the table, so the pair stays consistent.
 
-        The metric window is applied to the SPAN's ``created_at`` (when the
-        activity happened), NOT the eval row's ``created_at`` (when the score
-        was computed) — evals run asynchronously after their spans, so a
-        window on eval time measures the wrong thing. Windowing the span
-        subquery also keeps the IN-set a window's worth of ids instead of the
-        whole project (an unbounded set explodes on busy projects).
-
-        The eval-side ``created_at`` keeps only a loose lower bound: an eval
-        row is written after its span, so eval time >= span time >= window
-        start (1-day pad for skew). It is correctness-neutral (the span
-        subquery alone determines the result) but it is the eval table's ONLY
-        prune — the table is PARTITION BY toYYYYMM(created_at) with sort key
-        (trace_id, config_id, id), so without it every tick full-scans all
-        partitions + FINAL-merges them. Drop it only if evals are ever
-        backfilled with created_at stamps predating their spans by >1 day.
+        The window lives on the SPAN's ``created_at`` (ingest time — late
+        spans land in the current tick), not the eval row's — evals run async
+        after their spans, and the bounded subquery keeps the IN-set small.
+        The eval-side ``created_at`` lower bound (1-day skew pad) is
+        correctness-neutral but is the eval table's only partition prune
+        (toYYYYMM(created_at)); the v2 sort key also prunes granules with it.
+        Only completed, non-errored rows count — pending/errored rows carry
+        NULL outputs that would read as failures.
         """
         filter_extra = ""
         if self._filter_clause:
@@ -788,6 +788,9 @@ class MonitorMetricsQueryBuilder(BaseQueryBuilder):
         return (
             f"WHERE custom_eval_config_id = toUUID(%(eval_config_id)s) "
             f"AND {not_deleted} "
+            f"AND error = 0 "
+            f"AND ifNull(output_str, '') != 'ERROR' "
+            f"AND status NOT IN ({_EVAL_NON_VALUE_STATUSES}) "
             f"AND created_at >= %(start_time)s - INTERVAL 1 DAY "
             f"AND observation_span_id IN ("
             f"  SELECT id FROM {SPANS_TABLE} "

--- a/futureagi/tracer/services/clickhouse/query_builders/monitor_metrics.py
+++ b/futureagi/tracer/services/clickhouse/query_builders/monitor_metrics.py
@@ -27,6 +27,7 @@ from typing import Any, Dict, List, Optional, Tuple
 
 import structlog
 
+from tracer.services.clickhouse.eval_logger_table import eval_logger_source
 from tracer.services.clickhouse.query_builders.base import BaseQueryBuilder, _parse_dt
 from tracer.services.clickhouse.query_builders.filters import ClickHouseFilterBuilder
 
@@ -46,7 +47,6 @@ MONTHLY_TOKENS_SPENT = "monthly_tokens_spent"
 EVALUATION_METRICS = "evaluation_metrics"
 
 SPANS_TABLE = "spans"
-EVAL_TABLE = "tracer_eval_logger"
 
 # Time-series buckets: to epoch seconds, integer-divide by the frequency to
 # floor to the bucket boundary, back to DateTime (300s: 12:07:43 -> 12:05:00).
@@ -98,12 +98,8 @@ class MonitorMetricsQueryBuilder(BaseQueryBuilder):
 
     @staticmethod
     def _eval_choice_match_expr(param_name: str = "choice_val") -> str:
-        """Return exact choice membership against CH's JSON-string list column."""
-        choice_array = "JSONExtract(output_str_list, 'Array(String)')"
-        return (
-            f"(has({choice_array}, %({param_name})s) "
-            f"OR output_str = %({param_name})s)"
-        )
+        """Choice membership in the JSON list (choice evals only write output_str_list)."""
+        return f"has(JSONExtract(output_str_list, 'Array(String)'), %({param_name})s)"
 
     def _translate_filters(self) -> None:
         """Translate raw monitor filter JSON into CH WHERE clause fragments."""
@@ -334,31 +330,30 @@ class MonitorMetricsQueryBuilder(BaseQueryBuilder):
     def _build_eval_metric_value_query(
         self, params: Dict[str, Any]
     ) -> Tuple[str, Dict[str, Any]]:
-        """Build the eval metric value query against tracer_eval_logger."""
+        """Build the eval metric value query against the configured eval-logger table."""
         if not self.eval_config_id:
             return "SELECT NULL AS value", params
 
         params["eval_config_id"] = self.eval_config_id
 
-        eval_where = self._eval_base_where()
+        eval_table, eval_nd = eval_logger_source()
+        eval_where = self._eval_base_where(eval_nd)
 
         if self.eval_output_type == "SCORE":
             query = f"""
                 SELECT ifNotFinite(avg(output_float), NULL) AS value
-                FROM {EVAL_TABLE} FINAL
+                FROM {eval_table} FINAL
                 {eval_where}
-                  AND created_at BETWEEN %(start_time)s AND %(end_time)s
             """
         elif self.eval_output_type == "PASS_FAIL":
             output_bool_val = 1 if self.threshold_metric_value == "Passed" else 0
             params["output_bool_val"] = output_bool_val
             query = f"""
-                SELECT avg(
+                SELECT ifNotFinite(avg(
                     CASE WHEN output_bool = %(output_bool_val)s THEN 1.0 ELSE 0.0 END
-                ) AS value
-                FROM {EVAL_TABLE} FINAL
+                ), NULL) AS value
+                FROM {eval_table} FINAL
                 {eval_where}
-                  AND created_at BETWEEN %(start_time)s AND %(end_time)s
             """
         elif self.eval_output_type == "CHOICES":
             if not self.threshold_metric_value:
@@ -366,12 +361,11 @@ class MonitorMetricsQueryBuilder(BaseQueryBuilder):
             params["choice_val"] = self.threshold_metric_value
             choice_match = self._eval_choice_match_expr()
             query = f"""
-                SELECT avg(
+                SELECT ifNotFinite(avg(
                     CASE WHEN {choice_match} THEN 1.0 ELSE 0.0 END
-                ) AS value
-                FROM {EVAL_TABLE} FINAL
+                ), NULL) AS value
+                FROM {eval_table} FINAL
                 {eval_where}
-                  AND created_at BETWEEN %(start_time)s AND %(end_time)s
             """
         else:
             query = "SELECT NULL AS value"
@@ -502,35 +496,37 @@ class MonitorMetricsQueryBuilder(BaseQueryBuilder):
     def _build_eval_stats_query(
         self, params: Dict[str, Any]
     ) -> Tuple[str, Dict[str, Any]]:
-        """Build eval metric stats (mean/stddev) query."""
+        """Build eval metric stats (mean/stddev) query.
+
+        ``stddevPop`` matches the pre-migration PG ``StdDev`` default.
+        """
         if not self.eval_config_id:
             return "SELECT NULL AS mean, NULL AS stddev", params
 
         params["eval_config_id"] = self.eval_config_id
-        eval_where = self._eval_base_where()
+        eval_table, eval_nd = eval_logger_source()
+        eval_where = self._eval_base_where(eval_nd)
 
         if self.eval_output_type == "SCORE":
             query = f"""
                 SELECT
                     ifNotFinite(avg(output_float), NULL) AS mean,
-                    ifNotFinite(stddevSamp(output_float), NULL) AS stddev
-                FROM {EVAL_TABLE} FINAL
+                    ifNotFinite(stddevPop(output_float), NULL) AS stddev
+                FROM {eval_table} FINAL
                 {eval_where}
-                  AND created_at BETWEEN %(start_time)s AND %(end_time)s
             """
         elif self.eval_output_type == "PASS_FAIL":
             output_bool_val = 1 if self.threshold_metric_value == "Passed" else 0
             params["output_bool_val"] = output_bool_val
             query = f"""
                 SELECT
-                    avg(pass_value) AS mean,
-                    stddevSamp(pass_value) AS stddev
+                    ifNotFinite(avg(pass_value), NULL) AS mean,
+                    ifNotFinite(stddevPop(pass_value), NULL) AS stddev
                 FROM (
                     SELECT
                         CASE WHEN output_bool = %(output_bool_val)s THEN 1.0 ELSE 0.0 END AS pass_value
-                    FROM {EVAL_TABLE} FINAL
+                    FROM {eval_table} FINAL
                     {eval_where}
-                      AND created_at BETWEEN %(start_time)s AND %(end_time)s
                 )
             """
         elif self.eval_output_type == "CHOICES":
@@ -540,14 +536,13 @@ class MonitorMetricsQueryBuilder(BaseQueryBuilder):
             choice_match = self._eval_choice_match_expr()
             query = f"""
                 SELECT
-                    avg(choice_value) AS mean,
-                    stddevSamp(choice_value) AS stddev
+                    ifNotFinite(avg(choice_value), NULL) AS mean,
+                    ifNotFinite(stddevPop(choice_value), NULL) AS stddev
                 FROM (
                     SELECT
                         CASE WHEN {choice_match} THEN 1.0 ELSE 0.0 END AS choice_value
-                    FROM {EVAL_TABLE} FINAL
+                    FROM {eval_table} FINAL
                     {eval_where}
-                      AND created_at BETWEEN %(start_time)s AND %(end_time)s
                 )
             """
         else:
@@ -710,15 +705,19 @@ class MonitorMetricsQueryBuilder(BaseQueryBuilder):
     ) -> Tuple[str, Dict[str, Any]]:
         """Build eval metric time-series query.
 
-        Buckets on ``created_at``: the eval table has no ``start_time`` column.
+        Buckets on the eval row's ``created_at`` (the table has no span-time
+        column). Window membership comes from the span subquery, so a
+        late-computed eval for an in-window span lands in the bucket of its
+        computation time.
+        # TODO: bucket by span time (needs a spans join) for graph fidelity.
         """
         if not self.eval_config_id:
             return "SELECT NULL AS timestamp, NULL AS value WHERE 1 = 0", params
 
         params["eval_config_id"] = self.eval_config_id
-        eval_where = self._eval_base_where()
+        eval_table, eval_nd = eval_logger_source()
+        eval_where = self._eval_base_where(eval_nd)
         bucket_expr = _EVAL_BUCKET_EXPR
-        time_filter = "AND created_at BETWEEN %(start_time)s AND %(end_time)s"
 
         if self.eval_output_type == "SCORE":
             agg = "avg(output_float)"
@@ -741,9 +740,8 @@ class MonitorMetricsQueryBuilder(BaseQueryBuilder):
             SELECT
                 {bucket_expr} AS timestamp,
                 ifNotFinite({agg}, NULL) AS value
-            FROM {EVAL_TABLE} FINAL
+            FROM {eval_table} FINAL
             {eval_where}
-              {time_filter}
             GROUP BY timestamp
             ORDER BY timestamp
         """
@@ -761,11 +759,27 @@ class MonitorMetricsQueryBuilder(BaseQueryBuilder):
             clause += f" AND {self._filter_clause}"
         return clause
 
-    def _eval_base_where(self) -> str:
-        """Return the base WHERE clause for eval_logger table queries.
+    def _eval_base_where(self, not_deleted: str) -> str:
+        """Eval-config scope + span-time window via bounded span membership.
 
-        Scopes to the eval config and ensures the observation_span belongs
-        to the project via a subquery on spans.
+        ``not_deleted`` comes from the same ``eval_logger_source()`` call that
+        resolved the table, so the pair stays consistent.
+
+        The metric window is applied to the SPAN's ``created_at`` (when the
+        activity happened), NOT the eval row's ``created_at`` (when the score
+        was computed) — evals run asynchronously after their spans, so a
+        window on eval time measures the wrong thing. Windowing the span
+        subquery also keeps the IN-set a window's worth of ids instead of the
+        whole project (an unbounded set explodes on busy projects).
+
+        The eval-side ``created_at`` keeps only a loose lower bound: an eval
+        row is written after its span, so eval time >= span time >= window
+        start (1-day pad for skew). It is correctness-neutral (the span
+        subquery alone determines the result) but it is the eval table's ONLY
+        prune — the table is PARTITION BY toYYYYMM(created_at) with sort key
+        (trace_id, config_id, id), so without it every tick full-scans all
+        partitions + FINAL-merges them. Drop it only if evals are ever
+        backfilled with created_at stamps predating their spans by >1 day.
         """
         filter_extra = ""
         if self._filter_clause:
@@ -773,11 +787,15 @@ class MonitorMetricsQueryBuilder(BaseQueryBuilder):
 
         return (
             f"WHERE custom_eval_config_id = toUUID(%(eval_config_id)s) "
-            f"AND is_deleted = 0 "
+            f"AND {not_deleted} "
+            f"AND created_at >= %(start_time)s - INTERVAL 1 DAY "
             f"AND observation_span_id IN ("
             f"  SELECT id FROM {SPANS_TABLE} "
-            f"  WHERE project_id = %(project_id)s "
-            f"  AND is_deleted = 0"
+            f"  WHERE {self.project_filter_sql()} "
+            f"  AND is_deleted = 0 "
+            f"  AND created_at >= %(start_time)s AND created_at < %(end_time)s "
+            f"  AND start_time >= %(start_time)s - INTERVAL 1 DAY "
+            f"  AND start_time < %(end_time)s + INTERVAL 1 DAY"
             f"  {filter_extra}"
             f")"
         )

--- a/futureagi/tracer/services/clickhouse/query_builders/monitor_metrics.py
+++ b/futureagi/tracer/services/clickhouse/query_builders/monitor_metrics.py
@@ -51,13 +51,14 @@ SPANS_TABLE = "spans"
 
 # Time-series buckets: to epoch seconds, integer-divide by the frequency to
 # floor to the bucket boundary, back to DateTime (300s: 12:07:43 -> 12:05:00).
-# Works for any frequency, unlike toStartOfHour/-FiveMinutes. Spans bucket on
-# ``start_time`` (event time); the eval table has none, so ``created_at``.
+# Works for any frequency, unlike toStartOfHour/-FiveMinutes. Both bucket on
+# span ``start_time`` (event time — the user's timeline); the eval table has
+# no span-time column, so its series joins spans (alias ``sp``).
 _SPANS_BUCKET_EXPR = (
     "toDateTime(intDiv(toUInt32(start_time), %(freq_seconds)s) * %(freq_seconds)s)"
 )
-_EVAL_BUCKET_EXPR = (
-    "toDateTime(intDiv(toUInt32(created_at), %(freq_seconds)s) * %(freq_seconds)s)"
+_EVAL_SPAN_BUCKET_EXPR = (
+    "toDateTime(intDiv(toUInt32(sp.start_time), %(freq_seconds)s) * %(freq_seconds)s)"
 )
 
 # Statuses whose rows carry no real value (NULL outputs). NOT IN keeps legacy
@@ -344,7 +345,7 @@ class MonitorMetricsQueryBuilder(BaseQueryBuilder):
         params["eval_config_id"] = self.eval_config_id
 
         eval_table, eval_nd = eval_logger_source()
-        eval_where = self._eval_base_where(eval_nd)
+        eval_where = self._eval_membership(eval_nd)
 
         if self.eval_output_type == "SCORE":
             query = f"""
@@ -512,7 +513,7 @@ class MonitorMetricsQueryBuilder(BaseQueryBuilder):
 
         params["eval_config_id"] = self.eval_config_id
         eval_table, eval_nd = eval_logger_source()
-        eval_where = self._eval_base_where(eval_nd)
+        eval_where = self._eval_membership(eval_nd)
 
         if self.eval_output_type == "SCORE":
             query = f"""
@@ -712,19 +713,18 @@ class MonitorMetricsQueryBuilder(BaseQueryBuilder):
     ) -> Tuple[str, Dict[str, Any]]:
         """Build eval metric time-series query.
 
-        Buckets on the eval row's ``created_at`` (the table has no span-time
-        column). Window membership comes from the span subquery, so a
-        late-computed eval for an in-window span lands in the bucket of its
-        computation time.
+        Buckets on the joined SPAN's ``start_time`` (the user's application
+        timeline): a low score must chart when the activity happened, not
+        when the eval was computed — and late-computed evals must not emit
+        buckets past the requested window.
         """
-        # TODO: bucket by span time (needs a spans join) for graph fidelity.
         if not self.eval_config_id:
             return "SELECT NULL AS timestamp, NULL AS value WHERE 1 = 0", params
 
         params["eval_config_id"] = self.eval_config_id
         eval_table, eval_nd = eval_logger_source()
-        eval_where = self._eval_base_where(eval_nd)
-        bucket_expr = _EVAL_BUCKET_EXPR
+        eval_where = self._eval_membership(eval_nd, "id, start_time")
+        bucket_expr = _EVAL_SPAN_BUCKET_EXPR
 
         if self.eval_output_type == "SCORE":
             agg = "avg(output_float)"
@@ -766,39 +766,43 @@ class MonitorMetricsQueryBuilder(BaseQueryBuilder):
             clause += f" AND {self._filter_clause}"
         return clause
 
-    def _eval_base_where(self, not_deleted: str) -> str:
-        """Eval-config scope + span-time window via bounded span membership.
+    def _eval_membership(self, not_deleted: str, span_cols: str = "id") -> str:
+        """Span-windowed membership (JOIN) + eval-row guards.
 
         ``not_deleted`` comes from the same ``eval_logger_source()`` call that
         resolved the table, so the pair stays consistent.
 
         The window lives on the SPAN's ``created_at`` (ingest time — late
         spans land in the current tick), not the eval row's — evals run async
-        after their spans, and the bounded subquery keeps the IN-set small.
+        after their spans. A JOIN (vs ``IN``) streams the span set instead of
+        materializing it in memory: a 30-day graph window on a busy project
+        overflows ``max_bytes_in_set`` as an IN-set (~100M ids).
         The eval-side ``created_at`` lower bound (1-day skew pad) is
         correctness-neutral but is the eval table's only partition prune
         (toYYYYMM(created_at)); the v2 sort key also prunes granules with it.
         Only completed, non-errored rows count — pending/errored rows carry
         NULL outputs that would read as failures.
         """
-        filter_extra = ""
-        if self._filter_clause:
-            filter_extra = f" AND {self._filter_clause}"
-
         return (
+            f"INNER JOIN ({self._bounded_spans_subquery(span_cols)}) AS sp "
+            f"ON observation_span_id = sp.id "
             f"WHERE custom_eval_config_id = toUUID(%(eval_config_id)s) "
             f"AND {not_deleted} "
             f"AND error = 0 "
             f"AND ifNull(output_str, '') != 'ERROR' "
             f"AND status NOT IN ({_EVAL_NON_VALUE_STATUSES}) "
-            f"AND created_at >= %(start_time)s - INTERVAL 1 DAY "
-            f"AND observation_span_id IN ("
-            f"  SELECT id FROM {SPANS_TABLE} "
-            f"  WHERE {self.project_filter_sql()} "
-            f"  AND is_deleted = 0 "
-            f"  AND created_at >= %(start_time)s AND created_at < %(end_time)s "
-            f"  AND start_time >= %(start_time)s - INTERVAL 1 DAY "
-            f"  AND start_time < %(end_time)s + INTERVAL 1 DAY"
-            f"  {filter_extra}"
-            f")"
+            f"AND created_at >= %(start_time)s - INTERVAL 1 DAY"
+        )
+
+    def _bounded_spans_subquery(self, select_cols: str = "id") -> str:
+        """Metric-window-bounded spans subquery for eval membership."""
+        filter_extra = f" AND {self._filter_clause}" if self._filter_clause else ""
+        return (
+            f"SELECT {select_cols} FROM {SPANS_TABLE} "
+            f"WHERE {self.project_filter_sql()} "
+            f"AND is_deleted = 0 "
+            f"AND created_at >= %(start_time)s AND created_at < %(end_time)s "
+            f"AND start_time >= %(start_time)s - INTERVAL 1 DAY "
+            f"AND start_time < %(end_time)s + INTERVAL 1 DAY"
+            f"{filter_extra}"
         )

--- a/futureagi/tracer/services/clickhouse/v2/query_builders/monitor_metrics.py
+++ b/futureagi/tracer/services/clickhouse/v2/query_builders/monitor_metrics.py
@@ -17,7 +17,13 @@ from tracer.services.clickhouse.v2.query_builders._rewrite import V2RewriteMixin
 
 
 class MonitorMetricsQueryBuilderV2(V2RewriteMixin, MonitorMetricsQueryBuilder):
-    """Drop-in v2 MonitorMetrics builder."""
+    """Drop-in v2 MonitorMetrics builder.
+
+    Every build method (spans and eval) goes through the rewrite: the eval
+    queries embed a spans membership subquery whose filter fragment carries v1
+    map tokens that must be translated, and the eval not-deleted predicate uses
+    the rewrite-safe ``deleted``-based form, so nothing needs excluding.
+    """
 
 
 __all__ = ["MonitorMetricsQueryBuilderV2"]

--- a/futureagi/tracer/tests/test_clickhouse.py
+++ b/futureagi/tracer/tests/test_clickhouse.py
@@ -8419,7 +8419,8 @@ class TestMonitorMetricsQueryBuilder:
             "evaluation_metrics", datetime(2024, 1, 1), datetime(2024, 1, 31)
         )
         assert "JSONExtract(output_str_list, 'Array(String)')" in query
-        assert "OR output_str =" in query
+        # List-containment only: choice evals write output_str_list exclusively.
+        assert "OR output_str =" not in query
         assert params["choice_val"] == "Good"
 
     def test_evaluation_metrics_no_config_returns_null(self):
@@ -8481,7 +8482,7 @@ class TestMonitorMetricsQueryBuilder:
             "evaluation_metrics", datetime(2024, 1, 1), datetime(2024, 1, 31)
         )
         assert "avg(output_float)" in query
-        assert "stddevSamp(output_float)" in query
+        assert "stddevPop(output_float)" in query
 
     def test_historical_stats_aggregated_metrics_return_null(self):
         """COUNT_OF_ERRORS etc. should return NULL for stats (handled in Python)."""

--- a/futureagi/tracer/tests/test_monitor_metrics_eval_path.py
+++ b/futureagi/tracer/tests/test_monitor_metrics_eval_path.py
@@ -5,8 +5,7 @@ Pure SQL-string assertions, no ClickHouse."""
 
 from __future__ import annotations
 
-from datetime import datetime, timezone
-from typing import List, Type
+from datetime import UTC, datetime
 
 import pytest
 from django.test import override_settings
@@ -21,8 +20,8 @@ from tracer.services.clickhouse.v2.query_builders.monitor_metrics import (
 
 PROJECT_ID = "11111111-1111-1111-1111-111111111111"
 EVAL_CONFIG_ID = "22222222-2222-2222-2222-222222222222"
-START = datetime(2026, 8, 1, tzinfo=timezone.utc)
-END = datetime(2026, 8, 8, tzinfo=timezone.utc)
+START = datetime(2026, 8, 1, tzinfo=UTC)
+END = datetime(2026, 8, 8, tzinfo=UTC)
 
 LEGACY_ND = "(deleted = 0 OR deleted IS NULL)"
 ATTR_FILTER = {
@@ -41,7 +40,7 @@ ATTR_FILTER = {
 
 
 def _builder(
-    cls: Type[MonitorMetricsQueryBuilder] = MonitorMetricsQueryBuilder,
+    cls: type[MonitorMetricsQueryBuilder] = MonitorMetricsQueryBuilder,
     output_type: str = "SCORE",
     filters=None,
 ) -> MonitorMetricsQueryBuilder:
@@ -54,9 +53,9 @@ def _builder(
 
 
 def _eval_sqls(
-    cls: Type[MonitorMetricsQueryBuilder] = MonitorMetricsQueryBuilder,
+    cls: type[MonitorMetricsQueryBuilder] = MonitorMetricsQueryBuilder,
     filters=None,
-) -> List[str]:
+) -> list[str]:
     b = _builder(cls, filters=filters)
     return [
         b.build_metric_value_query(mm.EVALUATION_METRICS, START, END)[0],
@@ -116,11 +115,26 @@ def test_eval_table_window_is_loose_lower_bound_only() -> None:
         assert "created_at BETWEEN" not in sql
 
 
+def test_eval_rows_exclude_non_completed_statuses() -> None:
+    # Pending/running/skipped/errored work items carry NULL outputs that
+    # would read as failures (a burst of newly-enqueued evals must not
+    # depress the pass rate). Mirrors span_list.py / filters.py.
+    for sql in _eval_sqls():
+        head = sql.split("observation_span_id IN (", 1)[0]
+        assert "error = 0" in head
+        assert "ifNull(output_str, '') != 'ERROR'" in head
+        for status in ("pending", "running", "skipped", "errored"):
+            assert status in head
+        assert "'completed'" not in head  # NOT-IN keeps empty/NULL status rows
+
+
 def test_v1_eval_filter_emits_legacy_span_attr_token() -> None:
     # Sanity: the spliced filter fragment uses v1 map columns pre-rewrite.
     b = _builder(filters=ATTR_FILTER)
     assert b._filter_clause, "attr filter should compile to a clause"
-    assert "span_attr" in b.build_metric_value_query(mm.EVALUATION_METRICS, START, END)[0]
+    assert (
+        "span_attr" in b.build_metric_value_query(mm.EVALUATION_METRICS, START, END)[0]
+    )
 
 
 def test_v2_eval_filter_fragment_is_rewritten() -> None:
@@ -143,10 +157,16 @@ def test_eval_empty_window_yields_null_for_all_output_types() -> None:
             eval_output_type=output_type,
             threshold_metric_value="Passed" if output_type != "SCORE" else None,
         )
-        assert "ifNotFinite(" in b.build_metric_value_query(mm.EVALUATION_METRICS, START, END)[0]
-        assert b.build_historical_stats_query(mm.EVALUATION_METRICS, START, END)[0].count(
+        assert (
             "ifNotFinite("
-        ) >= 2
+            in b.build_metric_value_query(mm.EVALUATION_METRICS, START, END)[0]
+        )
+        assert (
+            b.build_historical_stats_query(mm.EVALUATION_METRICS, START, END)[0].count(
+                "ifNotFinite("
+            )
+            >= 2
+        )
 
 
 @pytest.mark.parametrize("output_type", ["SCORE", "PASS_FAIL", "CHOICES"])

--- a/futureagi/tracer/tests/test_monitor_metrics_eval_path.py
+++ b/futureagi/tracer/tests/test_monitor_metrics_eval_path.py
@@ -1,0 +1,204 @@
+"""Monitor builder EVALUATION_METRICS: table + not-deleted predicate from
+eval_logger_source(); span membership bounded; the eval SQL goes THROUGH the v2
+rewrite so a spliced span-attribute filter fragment is translated to v2 columns.
+Pure SQL-string assertions, no ClickHouse."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import List, Type
+
+import pytest
+from django.test import override_settings
+
+from tracer.services.clickhouse.query_builders import monitor_metrics as mm
+from tracer.services.clickhouse.query_builders.monitor_metrics import (
+    MonitorMetricsQueryBuilder,
+)
+from tracer.services.clickhouse.v2.query_builders.monitor_metrics import (
+    MonitorMetricsQueryBuilderV2,
+)
+
+PROJECT_ID = "11111111-1111-1111-1111-111111111111"
+EVAL_CONFIG_ID = "22222222-2222-2222-2222-222222222222"
+START = datetime(2026, 8, 1, tzinfo=timezone.utc)
+END = datetime(2026, 8, 8, tzinfo=timezone.utc)
+
+LEGACY_ND = "(deleted = 0 OR deleted IS NULL)"
+ATTR_FILTER = {
+    "span_attributes_filters": [
+        {
+            "column_id": "my.attr",
+            "filter_config": {
+                "col_type": "SPAN_ATTRIBUTE",
+                "filter_type": "text",
+                "filter_op": "equals",
+                "filter_value": "x",
+            },
+        }
+    ]
+}
+
+
+def _builder(
+    cls: Type[MonitorMetricsQueryBuilder] = MonitorMetricsQueryBuilder,
+    output_type: str = "SCORE",
+    filters=None,
+) -> MonitorMetricsQueryBuilder:
+    return cls(
+        project_id=PROJECT_ID,
+        eval_config_id=EVAL_CONFIG_ID,
+        eval_output_type=output_type,
+        filters=filters,
+    )
+
+
+def _eval_sqls(
+    cls: Type[MonitorMetricsQueryBuilder] = MonitorMetricsQueryBuilder,
+    filters=None,
+) -> List[str]:
+    b = _builder(cls, filters=filters)
+    return [
+        b.build_metric_value_query(mm.EVALUATION_METRICS, START, END)[0],
+        b.build_historical_stats_query(mm.EVALUATION_METRICS, START, END)[0],
+        b.build_time_series_query(mm.EVALUATION_METRICS, START, END, 3600)[0],
+    ]
+
+
+def test_eval_legacy_table_default_predicate() -> None:
+    with override_settings(CH25_EVAL_LOGGER_TABLE="tracer_eval_logger"):
+        for sql in _eval_sqls():
+            assert "FROM tracer_eval_logger FINAL" in sql
+            assert "tracer_eval_logger_v2" not in sql
+            assert (
+                f"custom_eval_config_id = toUUID(%(eval_config_id)s) AND {LEGACY_ND}"
+                in sql
+            )
+            # Rewrite-safe: no _peerdb token that the v2 rewriter would mangle.
+            assert "_peerdb" not in sql
+
+
+def test_eval_v2_table_uses_is_deleted() -> None:
+    with override_settings(CH25_EVAL_LOGGER_TABLE="tracer_eval_logger_v2"):
+        for sql in _eval_sqls():
+            assert "FROM tracer_eval_logger_v2 FINAL" in sql
+            assert (
+                "custom_eval_config_id = toUUID(%(eval_config_id)s) AND is_deleted = 0"
+                in sql
+            )
+
+
+def test_eval_span_subquery_windowed_on_span_time() -> None:
+    # The metric window lives on the SPAN's created_at inside the membership
+    # subquery (evals run async after their spans), with the same ±1-day
+    # start_time pruning pads as every other spans query. An unbounded (or
+    # 30-day) span set exploded to 105M ids at prod scale.
+    for sql in _eval_sqls():
+        subq = sql.split("observation_span_id IN (", 1)[1]
+        assert "SELECT id FROM spans" in subq
+        assert "created_at >= %(start_time)s AND created_at < %(end_time)s" in subq
+        assert "start_time >= %(start_time)s - INTERVAL 1 DAY" in subq
+        assert "start_time < %(end_time)s + INTERVAL 1 DAY" in subq
+        assert "project_id = %(project_id)s" in subq
+        assert "INTERVAL 30 DAY" not in sql
+
+
+def test_eval_table_window_is_loose_lower_bound_only() -> None:
+    # The eval row's own created_at gets only a skew-padded lower bound
+    # (eval time >= span time >= window start): prunes the eval table
+    # without dropping late-computed evals for in-window spans. No exact or
+    # upper eval-time window — that measured "evals computed recently", not
+    # "quality of recent activity" (8,577 vs 400 evals for the same hour).
+    for sql in _eval_sqls():
+        head = sql.split("observation_span_id IN (", 1)[0]
+        assert "created_at >= %(start_time)s - INTERVAL 1 DAY" in head
+        assert "created_at < %(end_time)s" not in head
+        assert "created_at BETWEEN" not in sql
+
+
+def test_v1_eval_filter_emits_legacy_span_attr_token() -> None:
+    # Sanity: the spliced filter fragment uses v1 map columns pre-rewrite.
+    b = _builder(filters=ATTR_FILTER)
+    assert b._filter_clause, "attr filter should compile to a clause"
+    assert "span_attr" in b.build_metric_value_query(mm.EVALUATION_METRICS, START, END)[0]
+
+
+def test_v2_eval_filter_fragment_is_rewritten() -> None:
+    # The regression: eval SQL must pass through the v2 rewrite so the spliced
+    # span-attribute filter tokens become v2 columns (no CH Code 47).
+    for sql in _eval_sqls(MonitorMetricsQueryBuilderV2, filters=ATTR_FILTER):
+        assert "span_attr_str" not in sql
+        assert "span_attr_num" not in sql
+        assert "span_attr_bool" not in sql
+        assert "attrs_" in sql
+
+
+def test_eval_empty_window_yields_null_for_all_output_types() -> None:
+    # avg over zero rows is NaN in CH; every output type must collapse to NULL
+    # so the evaluator's no-data skip works.
+    for output_type in ("SCORE", "PASS_FAIL", "CHOICES"):
+        b = MonitorMetricsQueryBuilder(
+            project_id=PROJECT_ID,
+            eval_config_id=EVAL_CONFIG_ID,
+            eval_output_type=output_type,
+            threshold_metric_value="Passed" if output_type != "SCORE" else None,
+        )
+        assert "ifNotFinite(" in b.build_metric_value_query(mm.EVALUATION_METRICS, START, END)[0]
+        assert b.build_historical_stats_query(mm.EVALUATION_METRICS, START, END)[0].count(
+            "ifNotFinite("
+        ) >= 2
+
+
+@pytest.mark.parametrize("output_type", ["SCORE", "PASS_FAIL", "CHOICES"])
+def test_all_eval_output_types_build(output_type: str) -> None:
+    b = MonitorMetricsQueryBuilder(
+        project_id=PROJECT_ID,
+        eval_config_id=EVAL_CONFIG_ID,
+        eval_output_type=output_type,
+        threshold_metric_value="Passed" if output_type != "SCORE" else None,
+    )
+    sql, _ = b.build_metric_value_query(mm.EVALUATION_METRICS, START, END)
+    assert "FROM " in sql and "custom_eval_config_id" in sql
+
+
+def test_choices_without_threshold_value_returns_null() -> None:
+    # A CHOICES monitor with no selected choice can't compute anything — all
+    # three query families must return the NULL/no-data shape, not broken SQL.
+    b = MonitorMetricsQueryBuilder(
+        project_id=PROJECT_ID,
+        eval_config_id=EVAL_CONFIG_ID,
+        eval_output_type="CHOICES",
+        threshold_metric_value=None,
+    )
+    value_sql, _ = b.build_metric_value_query(mm.EVALUATION_METRICS, START, END)
+    stats_sql, _ = b.build_historical_stats_query(mm.EVALUATION_METRICS, START, END)
+    ts_sql, _ = b.build_time_series_query(mm.EVALUATION_METRICS, START, END, 3600)
+    assert "NULL" in value_sql and "output_str_list" not in value_sql
+    assert "NULL" in stats_sql and "output_str_list" not in stats_sql
+    assert "output_str_list" not in ts_sql
+
+
+def test_pass_fail_time_series_shape() -> None:
+    b = MonitorMetricsQueryBuilder(
+        project_id=PROJECT_ID,
+        eval_config_id=EVAL_CONFIG_ID,
+        eval_output_type="PASS_FAIL",
+        threshold_metric_value="Passed",
+    )
+    sql, params = b.build_time_series_query(mm.EVALUATION_METRICS, START, END, 3600)
+    assert "output_bool = %(output_bool_val)s" in sql
+    assert params["output_bool_val"] == 1
+    assert "GROUP BY timestamp" in sql
+
+
+def test_choices_time_series_shape() -> None:
+    b = MonitorMetricsQueryBuilder(
+        project_id=PROJECT_ID,
+        eval_config_id=EVAL_CONFIG_ID,
+        eval_output_type="CHOICES",
+        threshold_metric_value="Good",
+    )
+    sql, params = b.build_time_series_query(mm.EVALUATION_METRICS, START, END, 3600)
+    assert "has(JSONExtract(output_str_list, 'Array(String)'), %(choice_val)s)" in sql
+    assert params["choice_val"] == "Good"
+    assert "GROUP BY timestamp" in sql

--- a/futureagi/tracer/tests/test_monitor_metrics_eval_path.py
+++ b/futureagi/tracer/tests/test_monitor_metrics_eval_path.py
@@ -87,19 +87,29 @@ def test_eval_v2_table_uses_is_deleted() -> None:
             )
 
 
-def test_eval_span_subquery_windowed_on_span_time() -> None:
-    # The metric window lives on the SPAN's created_at inside the membership
-    # subquery (evals run async after their spans), with the same ±1-day
-    # start_time pruning pads as every other spans query. An unbounded (or
-    # 30-day) span set exploded to 105M ids at prod scale.
-    for sql in _eval_sqls():
-        subq = sql.split("observation_span_id IN (", 1)[1]
-        assert "SELECT id FROM spans" in subq
+def test_eval_membership_is_windowed_span_join() -> None:
+    # Membership is a JOIN on a span subquery windowed on the SPAN's
+    # created_at (evals run async after their spans), with the ±1-day
+    # start_time pruning pads. A JOIN streams the span set — the old IN
+    # materialized it in memory (105M ids / 30d at prod scale). The series
+    # additionally selects start_time to bucket on.
+    value_sql, stats_sql, ts_sql = _eval_sqls()
+    for sql in (value_sql, stats_sql, ts_sql):
+        subq = sql.split("INNER JOIN (", 1)[1]
+        assert "ON observation_span_id = sp.id" in subq
         assert "created_at >= %(start_time)s AND created_at < %(end_time)s" in subq
         assert "start_time >= %(start_time)s - INTERVAL 1 DAY" in subq
         assert "start_time < %(end_time)s + INTERVAL 1 DAY" in subq
         assert "project_id = %(project_id)s" in subq
+        assert "observation_span_id IN" not in sql
         assert "INTERVAL 30 DAY" not in sql
+    assert "SELECT id FROM spans" in value_sql
+    assert "SELECT id, start_time FROM spans" in ts_sql
+
+
+def _eval_guards(sql: str) -> str:
+    # Eval-row conditions live in the WHERE after the membership join.
+    return sql.split("ON observation_span_id = sp.id", 1)[1]
 
 
 def test_eval_table_window_is_loose_lower_bound_only() -> None:
@@ -109,9 +119,9 @@ def test_eval_table_window_is_loose_lower_bound_only() -> None:
     # upper eval-time window — that measured "evals computed recently", not
     # "quality of recent activity" (8,577 vs 400 evals for the same hour).
     for sql in _eval_sqls():
-        head = sql.split("observation_span_id IN (", 1)[0]
-        assert "created_at >= %(start_time)s - INTERVAL 1 DAY" in head
-        assert "created_at < %(end_time)s" not in head
+        guards = _eval_guards(sql)
+        assert "created_at >= %(start_time)s - INTERVAL 1 DAY" in guards
+        assert "created_at < %(end_time)s" not in guards
         assert "created_at BETWEEN" not in sql
 
 
@@ -120,12 +130,12 @@ def test_eval_rows_exclude_non_completed_statuses() -> None:
     # would read as failures (a burst of newly-enqueued evals must not
     # depress the pass rate). Mirrors span_list.py / filters.py.
     for sql in _eval_sqls():
-        head = sql.split("observation_span_id IN (", 1)[0]
-        assert "error = 0" in head
-        assert "ifNull(output_str, '') != 'ERROR'" in head
+        guards = _eval_guards(sql)
+        assert "error = 0" in guards
+        assert "ifNull(output_str, '') != 'ERROR'" in guards
         for status in ("pending", "running", "skipped", "errored"):
-            assert status in head
-        assert "'completed'" not in head  # NOT-IN keeps empty/NULL status rows
+            assert status in guards
+        assert "'completed'" not in guards  # NOT-IN keeps empty/NULL rows
 
 
 def test_v1_eval_filter_emits_legacy_span_attr_token() -> None:

--- a/futureagi/tracer/tests/test_monitor_metrics_start_time.py
+++ b/futureagi/tracer/tests/test_monitor_metrics_start_time.py
@@ -5,8 +5,8 @@ The v2 spans table is ``PARTITION BY toDate(start_time)`` with
 ``toStartOfHour(start_time)`` in the primary key and no index on
 ``created_at``. Filtering ``created_at`` prunes nothing → full-history scans.
 These tests assert the COMPILED SQL filters/buckets spans on ``start_time``
-(with a padded ``created_at`` companion bound), while the eval-table queries
-stay on ``created_at`` (that table has no ``start_time`` column).
+(with a padded ``created_at`` companion bound); eval-table queries window and
+bucket via their joined span (the eval table has no ``start_time`` column).
 
 No real ClickHouse is hit — only the generated SQL string is asserted.
 """
@@ -113,28 +113,29 @@ def test_date_range_and_created_at_filters_use_start_time():
     assert "created_at BETWEEN %(mf_dr_start)s" not in sql
 
 
-# --- Eval-table queries must stay on created_at (no start_time column) --------
+# --- Eval-table queries window/bucket via the joined span, not created_at ----
 
 
 def test_eval_value_query_windows_span_time():
-    # The metric window lives on the SPAN membership subquery (evals run async
+    # The metric window lives on the SPAN membership join (evals run async
     # after their spans); the eval table keeps only a loose created_at lower
     # bound (its sole partition prune).
     sql, _ = _builder(eval_output_type="SCORE").build_metric_value_query(
         mm.EVALUATION_METRICS, START, END
     )
-    subq = sql.split("observation_span_id IN (", 1)[1]
+    subq = sql.split("INNER JOIN (", 1)[1]
     assert "created_at >= %(start_time)s AND created_at < %(end_time)s" in subq
-    assert "start_time >= %(start_time)s - INTERVAL 1 DAY" in subq
-    head = sql.split("observation_span_id IN (", 1)[0]
-    assert "created_at >= %(start_time)s - INTERVAL 1 DAY" in head
-    # No spans-style bucket on the eval table itself.
-    assert "toUInt32(start_time)" not in sql
+    guards = sql.split("ON observation_span_id = sp.id", 1)[1]
+    assert "created_at >= %(start_time)s - INTERVAL 1 DAY" in guards
+    # No bucket expression in a scalar query.
+    assert "toUInt32(" not in sql
 
 
-def test_eval_time_series_buckets_created_at():
+def test_eval_time_series_buckets_span_start_time():
+    # Eval graphs chart the user's application timeline: buckets come from
+    # the joined span's start_time, never the eval row's created_at.
     sql, _ = _builder(eval_output_type="SCORE").build_time_series_query(
         mm.EVALUATION_METRICS, START, END, 3600
     )
-    assert "toUInt32(created_at)" in sql
-    assert "toUInt32(start_time)" not in sql
+    assert "toUInt32(sp.start_time)" in sql
+    assert "toUInt32(created_at)" not in sql

--- a/futureagi/tracer/tests/test_monitor_metrics_start_time.py
+++ b/futureagi/tracer/tests/test_monitor_metrics_start_time.py
@@ -13,7 +13,7 @@ No real ClickHouse is hit — only the generated SQL string is asserted.
 
 from __future__ import annotations
 
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 
 import pytest
 
@@ -24,8 +24,8 @@ from tracer.services.clickhouse.query_builders.monitor_metrics import (
 
 PROJECT_ID = "11111111-1111-1111-1111-111111111111"
 EVAL_CONFIG_ID = "22222222-2222-2222-2222-222222222222"
-START = datetime(2026, 8, 1, tzinfo=timezone.utc)
-END = datetime(2026, 8, 8, tzinfo=timezone.utc)
+START = datetime(2026, 8, 1, tzinfo=UTC)
+END = datetime(2026, 8, 8, tzinfo=UTC)
 
 COMPANION = "created_at >= %(start_time)s - INTERVAL 1 DAY"
 BETWEEN_START = "start_time BETWEEN %(start_time)s AND %(end_time)s"

--- a/futureagi/tracer/tests/test_monitor_metrics_start_time.py
+++ b/futureagi/tracer/tests/test_monitor_metrics_start_time.py
@@ -116,15 +116,20 @@ def test_date_range_and_created_at_filters_use_start_time():
 # --- Eval-table queries must stay on created_at (no start_time column) --------
 
 
-def test_eval_value_query_keeps_created_at():
+def test_eval_value_query_windows_span_time():
+    # The metric window lives on the SPAN membership subquery (evals run async
+    # after their spans); the eval table keeps only a loose created_at lower
+    # bound (its sole partition prune).
     sql, _ = _builder(eval_output_type="SCORE").build_metric_value_query(
         mm.EVALUATION_METRICS, START, END
     )
-    assert "created_at BETWEEN %(start_time)s AND %(end_time)s" in sql
-    # ``start_time`` is only ever a param name here, never a column reference —
-    # the eval table has no start_time column.
-    for col_use in ("start_time BETWEEN", "start_time >=", "toUInt32(start_time)"):
-        assert col_use not in sql, f"eval query references start_time column: {col_use}"
+    subq = sql.split("observation_span_id IN (", 1)[1]
+    assert "created_at >= %(start_time)s AND created_at < %(end_time)s" in subq
+    assert "start_time >= %(start_time)s - INTERVAL 1 DAY" in subq
+    head = sql.split("observation_span_id IN (", 1)[0]
+    assert "created_at >= %(start_time)s - INTERVAL 1 DAY" in head
+    # No spans-style bucket on the eval table itself.
+    assert "toUInt32(start_time)" not in sql
 
 
 def test_eval_time_series_buckets_created_at():


### PR DESCRIPTION
## Summary

`EVALUATION_METRICS` monitors failed 100% of the time: the eval path hardcoded `tracer_eval_logger` with a literal `is_deleted = 0` (the legacy table has no such column), and scoped evals to a project through an **unbounded** span-membership `IN` subquery that explodes on busy projects (`SET_SIZE_LIMIT_EXCEEDED`). It also windowed on the **eval row's** `created_at` — but evals run asynchronously days after their spans, so that measures "evals computed recently", not "quality of recent activity". This PR lands the corrected eval design. PR 3 of 7.

## Linked issues

Linear: Fixed TH-7535

## Type of change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] 🚀 Performance improvement

---

## 1) What changes were done

**A. Table + predicate via `eval_logger_source()`**

- The eval table name and its not-deleted predicate come from `eval_logger_source()` as a consistent pair (legacy `deleted`-based form vs `_v2` `is_deleted`), with `FINAL` applied unconditionally — matching the display path.

**B. Window on span time, membership via JOIN (review update)**

- The metric window lives on the **span's** `created_at` inside the membership subquery (+ the standard ±1-day `start_time` pruning pads). This fixes both the semantics (a monitor window means spans that ran in it) and the set size.
- Membership is an **`INNER JOIN`** on that bounded subquery for all three query families (was `IN`): a join streams the span set instead of materializing it, so `max_bytes_in_set` no longer governs any eval query — including the 7-day percentage-change historical window and the 7/30-day graph windows. Prod-validated on a 241M-span project with `max_bytes_in_set=500MB`: 30-day value 3.5s @ 32 MiB (was ERROR 191), 1-yr hourly series 6.7s (was timeout 159).
- **Time-series buckets on the joined span's `start_time`** (the user's application timeline): a low score charts when the activity happened, not when the eval was computed, and late-computed evals cannot emit buckets past the requested window.
- The eval table keeps only a loose skew-padded `created_at` lower bound — correctness-neutral, but it is that table's only partition prune (`PARTITION BY toYYYYMM(created_at)`; on v2 the sort key prunes granules with it too).
- **Only completed, non-errored eval rows count** (`error = 0`, `output_str != 'ERROR'`, `status NOT IN` non-value states, built from `EvalEntryStatus`) — pending/errored work items carry NULL outputs that would otherwise read as failures and could fire false PASS_FAIL/CHOICES alerts. Mirrors span_list/trace_list.

**C. v2 rewrite**

- The eval SQL goes **through** the v2 rewrite (no exclusions): the spliced span-attribute filter fragment carries v1 map tokens that must be translated; the `deleted`-based tombstone is rewrite-safe.
- CHOICES matcher is list-containment only (`has(JSONExtract(output_str_list, …))`) — choice evals write `output_str_list` exclusively.

## 2) Why the changes were done

- **Product:** eval monitors either errored every tick or, once merely "fixed", would have counted the wrong evals. Windowing on span time returns the full eval set for a window; windowing on eval time returns a fraction of it whenever evals lag.
- **Technical:** an uncorrelated `IN (subquery)` materializes its full result before the outer filter applies — bounding the subquery is the only shape that scales.

---

## 3) Tests written + scenarios each covers

**`tracer/tests/test_monitor_metrics_eval_path.py`**

- `test_eval_legacy_table_default_predicate` / `test_eval_v2_table_uses_is_deleted` — table/predicate pair per settings, no `_peerdb` tokens.
- `test_eval_span_subquery_windowed_on_span_time` — span-time window + pruning pads inside the membership subquery; no 30-day lookback.
- `test_eval_table_window_is_loose_lower_bound_only` — no exact/upper eval-time window.
- `test_v1_eval_filter_emits_legacy_span_attr_token` / `test_v2_eval_filter_fragment_is_rewritten` — filter fragment translated by the v2 rewrite (regression: CH Code 47).
- `test_eval_empty_window_yields_null_for_all_output_types`, `test_all_eval_output_types_build`, `test_choices_without_threshold_value_returns_null`, PASS_FAIL/CHOICES time-series shapes.

> Run result: 47 passed across the stack's suites at this commit.

## 4) How to run / test

```bash
cd futureagi
.venv/bin/python -m pytest tracer/tests/test_monitor_metrics_eval_path.py -q
```

---

**Stack:** PR 3/7, on `fix/alerts-ch-session-id`.

