### PR TITLE
fix(alerts): CH-native historical stats for count/token metrics

### DIFF
--- a/futureagi/tracer/services/clickhouse/query_builders/base.py
+++ b/futureagi/tracer/services/clickhouse/query_builders/base.py
@@ -138,8 +138,8 @@ class BaseQueryBuilder(ABC):
         """Return the ClickHouse time-bucketing function name for *interval*.
 
         Args:
-            interval: One of ``"hour"``, ``"day"``, ``"week"``, ``"month"``,
-                ``"year"``.
+            interval: One of ``"minute"``, ``"hour"``, ``"day"``, ``"week"``,
+                ``"month"``, ``"year"``.
 
         Returns:
             The ClickHouse function name, e.g. ``"toStartOfHour"``.

--- a/futureagi/tracer/services/clickhouse/query_builders/monitor_metrics.py
+++ b/futureagi/tracer/services/clickhouse/query_builders/monitor_metrics.py
@@ -504,7 +504,9 @@ class MonitorMetricsQueryBuilder(BaseQueryBuilder):
             # Stats over calendar-aligned buckets. Empty result collapses to
             # (0, 0), a single bucket to (value, 0), and no-token buckets are
             # skipped via nullIf (v2 total_tokens is non-Nullable) — matching
-            # the old Python path.
+            # the old Python path. Buckets are on created_at, so cap it at
+            # end_time: a late-ingested in-window span would otherwise create
+            # a sparse trailing bucket that skews mean/stddev every tick.
             bucket_fn = self.time_bucket_expr(interval_kind or "hour")
             agg = (
                 "countIf(status = 'ERROR')"
@@ -522,6 +524,7 @@ class MonitorMetricsQueryBuilder(BaseQueryBuilder):
                     FROM {SPANS_TABLE}
                     {base_where}
                       {time_win}
+                      AND created_at <= %(end_time)s
                     GROUP BY bucket_ts
                 )
             """

--- a/futureagi/tracer/services/clickhouse/query_builders/monitor_metrics.py
+++ b/futureagi/tracer/services/clickhouse/query_builders/monitor_metrics.py
@@ -389,6 +389,7 @@ class MonitorMetricsQueryBuilder(BaseQueryBuilder):
         metric_type: str,
         start_time: datetime,
         end_time: datetime,
+        interval_kind: Optional[str] = None,
     ) -> Tuple[str, Dict[str, Any]]:
         """Build a query that returns mean and stddev for historical analysis.
 
@@ -494,9 +495,38 @@ class MonitorMetricsQueryBuilder(BaseQueryBuilder):
         elif metric_type == EVALUATION_METRICS:
             query, params = self._build_eval_stats_query(params)
 
+        elif metric_type in (
+            COUNT_OF_ERRORS,
+            TOKEN_USAGE,
+            DAILY_TOKENS_SPENT,
+            MONTHLY_TOKENS_SPENT,
+        ):
+            # Stats over calendar-aligned buckets. Empty result collapses to
+            # (0, 0), a single bucket to (value, 0), and no-token buckets are
+            # skipped via nullIf (v2 total_tokens is non-Nullable) — matching
+            # the old Python path.
+            bucket_fn = self.time_bucket_expr(interval_kind or "hour")
+            agg = (
+                "countIf(status = 'ERROR')"
+                if metric_type == COUNT_OF_ERRORS
+                else "nullIf(sum(total_tokens), 0)"
+            )
+            query = f"""
+                SELECT
+                    coalesce(ifNotFinite(avg(bucket_value), 0), 0) AS mean,
+                    coalesce(ifNotFinite(stddevSamp(bucket_value), 0), 0) AS stddev
+                FROM (
+                    SELECT
+                        {bucket_fn}(created_at) AS bucket_ts,
+                        {agg} AS bucket_value
+                    FROM {SPANS_TABLE}
+                    {base_where}
+                      {time_win}
+                    GROUP BY bucket_ts
+                )
+            """
+
         else:
-            # For COUNT_OF_ERRORS, TOKEN_USAGE, DAILY/MONTHLY_TOKENS_SPENT
-            # these are handled via time-series aggregation in Python
             query = "SELECT NULL AS mean, NULL AS stddev"
 
         return query, params

--- a/futureagi/tracer/tests/test_clickhouse.py
+++ b/futureagi/tracer/tests/test_clickhouse.py
@@ -8484,15 +8484,18 @@ class TestMonitorMetricsQueryBuilder:
         assert "avg(output_float)" in query
         assert "stddevPop(output_float)" in query
 
-    def test_historical_stats_aggregated_metrics_return_null(self):
-        """COUNT_OF_ERRORS etc. should return NULL for stats (handled in Python)."""
+    def test_historical_stats_aggregated_metrics_bucket_in_ch(self):
+        """COUNT_OF_ERRORS etc. compute bucketed mean/stddev CH-natively."""
         from datetime import datetime
 
         builder = self._make_builder()
         query, _ = builder.build_historical_stats_query(
             "count_of_errors", datetime(2024, 1, 1), datetime(2024, 1, 31)
         )
-        assert "NULL AS mean" in query
+        assert "avg(bucket_value)" in query
+        assert "stddevSamp(bucket_value)" in query
+        assert "countIf(status = 'ERROR')" in query
+        assert "GROUP BY bucket_ts" in query
 
     # -- Time series queries --
 

--- a/futureagi/tracer/tests/test_monitor_metrics_parity.py
+++ b/futureagi/tracer/tests/test_monitor_metrics_parity.py
@@ -3,8 +3,7 @@ metrics (matches the old Python statistics path). Pure SQL-string assertions."""
 
 from __future__ import annotations
 
-from datetime import datetime, timezone
-from typing import Optional
+from datetime import UTC, datetime
 
 import pytest
 
@@ -14,9 +13,8 @@ from tracer.services.clickhouse.query_builders.monitor_metrics import (
 )
 
 PROJECT_ID = "11111111-1111-1111-1111-111111111111"
-EVAL_CONFIG_ID = "22222222-2222-2222-2222-222222222222"
-START = datetime(2026, 8, 1, tzinfo=timezone.utc)
-END = datetime(2026, 8, 8, tzinfo=timezone.utc)
+START = datetime(2026, 8, 1, tzinfo=UTC)
+END = datetime(2026, 8, 8, tzinfo=UTC)
 
 TIME_AGGREGATED = [
     mm.COUNT_OF_ERRORS,
@@ -26,13 +24,8 @@ TIME_AGGREGATED = [
 ]
 
 
-def _builder(eval_output_type: Optional[str] = None) -> MonitorMetricsQueryBuilder:
-    return MonitorMetricsQueryBuilder(
-        project_id=PROJECT_ID,
-        eval_config_id=EVAL_CONFIG_ID if eval_output_type else None,
-        eval_output_type=eval_output_type,
-        threshold_metric_value="Good" if eval_output_type == "CHOICES" else None,
-    )
+def _builder() -> MonitorMetricsQueryBuilder:
+    return MonitorMetricsQueryBuilder(project_id=PROJECT_ID)
 
 
 # --- Calendar-bucketed historical stats for count/token metrics ---------------
@@ -55,6 +48,9 @@ def test_time_aggregated_historical_buckets_calendar(
         metric_type, START, END, interval_kind=interval_kind
     )
     assert f"{bucket_fn}(created_at) AS bucket_ts" in sql
+    # Bucket axis capped at the window end — no sparse trailing bucket from
+    # late-ingested spans deflating the mean / inflating the stddev.
+    assert "created_at <= %(end_time)s" in sql
     assert "GROUP BY bucket_ts" in sql
     # Sample stddev here (old path used statistics.stdev), collapsed to 0.
     assert "stddevSamp(bucket_value)" in sql
@@ -76,3 +72,54 @@ def test_time_aggregated_historical_agg_per_metric() -> None:
 def test_time_aggregated_historical_defaults_to_hour() -> None:
     sql, _ = _builder().build_historical_stats_query(mm.COUNT_OF_ERRORS, START, END)
     assert "toStartOfHour(created_at) AS bucket_ts" in sql
+
+
+# --- Evaluator routing: CH serves these metrics, PG is never touched ----------
+
+
+class TestHistoricalStatsRouting:
+    """Pin the _get_historical_stats routing hunk: the four time-aggregated
+    metrics are served by the CH builder with the monitor's interval_kind,
+    and ObservationSpan (the dropped span table) is never queried."""
+
+    @pytest.mark.parametrize(
+        ("metric_type", "frequency", "bucket_fn"),
+        [
+            (mm.COUNT_OF_ERRORS, 60, "toStartOfHour"),
+            (mm.TOKEN_USAGE, 5, "toStartOfMinute"),
+            (mm.DAILY_TOKENS_SPENT, 60, "toStartOfDay"),
+            (mm.MONTHLY_TOKENS_SPENT, 60, "toStartOfMonth"),
+        ],
+    )
+    def test_ch_route_passes_interval_kind_and_skips_pg(
+        self, metric_type: str, frequency: int, bucket_fn: str
+    ) -> None:
+        from types import SimpleNamespace
+        from unittest import mock
+
+        from tracer.models.monitor import UserAlertMonitor
+        from tracer.utils import monitor as monitor_utils
+
+        monitor = UserAlertMonitor(
+            project_id=PROJECT_ID,
+            metric_type=metric_type,
+            alert_frequency=frequency,
+            filters={},
+        )
+        captured: dict[str, str] = {}
+
+        class _Svc:
+            def execute_ch_query(self, query, params, timeout_ms=None):
+                captured["query"] = query
+                return SimpleNamespace(data=[{"mean": 4.2, "stddev": 1.1}])
+
+        with (
+            mock.patch.object(monitor_utils, "AnalyticsQueryService", _Svc),
+            mock.patch.object(monitor_utils, "ObservationSpan") as pg_spans,
+        ):
+            mean, stddev = monitor_utils._get_historical_stats(monitor, START, END)
+
+        assert (mean, stddev) == (4.2, 1.1)
+        # interval_kind derived from the monitor reaches the bucket function.
+        assert f"{bucket_fn}(created_at)" in captured["query"]
+        pg_spans.objects.filter.assert_not_called()

--- a/futureagi/tracer/tests/test_monitor_metrics_parity.py
+++ b/futureagi/tracer/tests/test_monitor_metrics_parity.py
@@ -1,0 +1,78 @@
+"""Monitor builder parity: calendar-bucketed historical stats for count/token
+metrics (matches the old Python statistics path). Pure SQL-string assertions."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Optional
+
+import pytest
+
+from tracer.services.clickhouse.query_builders import monitor_metrics as mm
+from tracer.services.clickhouse.query_builders.monitor_metrics import (
+    MonitorMetricsQueryBuilder,
+)
+
+PROJECT_ID = "11111111-1111-1111-1111-111111111111"
+EVAL_CONFIG_ID = "22222222-2222-2222-2222-222222222222"
+START = datetime(2026, 8, 1, tzinfo=timezone.utc)
+END = datetime(2026, 8, 8, tzinfo=timezone.utc)
+
+TIME_AGGREGATED = [
+    mm.COUNT_OF_ERRORS,
+    mm.TOKEN_USAGE,
+    mm.DAILY_TOKENS_SPENT,
+    mm.MONTHLY_TOKENS_SPENT,
+]
+
+
+def _builder(eval_output_type: Optional[str] = None) -> MonitorMetricsQueryBuilder:
+    return MonitorMetricsQueryBuilder(
+        project_id=PROJECT_ID,
+        eval_config_id=EVAL_CONFIG_ID if eval_output_type else None,
+        eval_output_type=eval_output_type,
+        threshold_metric_value="Good" if eval_output_type == "CHOICES" else None,
+    )
+
+
+# --- Calendar-bucketed historical stats for count/token metrics ---------------
+
+
+@pytest.mark.parametrize(
+    "interval_kind,bucket_fn",
+    [
+        ("minute", "toStartOfMinute"),
+        ("hour", "toStartOfHour"),
+        ("day", "toStartOfDay"),
+        ("month", "toStartOfMonth"),
+    ],
+)
+@pytest.mark.parametrize("metric_type", TIME_AGGREGATED)
+def test_time_aggregated_historical_buckets_calendar(
+    metric_type: str, interval_kind: str, bucket_fn: str
+) -> None:
+    sql, _ = _builder().build_historical_stats_query(
+        metric_type, START, END, interval_kind=interval_kind
+    )
+    assert f"{bucket_fn}(created_at) AS bucket_ts" in sql
+    assert "GROUP BY bucket_ts" in sql
+    # Sample stddev here (old path used statistics.stdev), collapsed to 0.
+    assert "stddevSamp(bucket_value)" in sql
+    assert "coalesce(ifNotFinite(avg(bucket_value), 0), 0)" in sql
+
+
+def test_time_aggregated_historical_agg_per_metric() -> None:
+    sql_err, _ = _builder().build_historical_stats_query(
+        mm.COUNT_OF_ERRORS, START, END, interval_kind="hour"
+    )
+    assert "countIf(status = 'ERROR') AS bucket_value" in sql_err
+    sql_tok, _ = _builder().build_historical_stats_query(
+        mm.TOKEN_USAGE, START, END, interval_kind="hour"
+    )
+    # No-token buckets excluded (v2 total_tokens is non-Nullable, PG NULL -> 0).
+    assert "nullIf(sum(total_tokens), 0) AS bucket_value" in sql_tok
+
+
+def test_time_aggregated_historical_defaults_to_hour() -> None:
+    sql, _ = _builder().build_historical_stats_query(mm.COUNT_OF_ERRORS, START, END)
+    assert "toStartOfHour(created_at) AS bucket_ts" in sql

--- a/futureagi/tracer/utils/monitor.py
+++ b/futureagi/tracer/utils/monitor.py
@@ -468,19 +468,10 @@ def _get_time_series_data_for_time_aggregated_metrics(
     Groups spans in certain intervals and returns a dictionary of {timestamp: value}.
     `interval_kind` must be one of 'minute', 'hour', 'day', 'week', 'month', 'year'.
 
-    CH25-TODO(blocked-on-reader-extension): this helper is reached from both
-    the CH primary branch (via _get_stats_for_time_aggregated_metrics, when
-    metric_type is COUNT_OF_ERRORS / TOKEN_USAGE / DAILY_TOKENS_SPENT /
-    MONTHLY_TOKENS_SPENT) and the PG fallback branch. The new
-    time_bucket_aggregate(project_id, interval=, since=, until=,
-    observation_type=) reader covers TOKEN_USAGE but cannot serve
-    COUNT_OF_ERRORS (needs status-stratified count) and cannot consume the
-    full parsing_evaltask_filters Q-object (which can include
-    span_attributes_filters → FilterEngine territory). Migrating requires
-    a new reader signature roughly
-    `time_bucket_aggregate_with_filters(project_id, *, interval, since,
-    until, **parsing_evaltask_filters_for_ch_output)` that also emits a
-    status-stratified count column.
+    Only reached from the PG fallback branch now — the CH primary branch
+    serves COUNT_OF_ERRORS / TOKEN_USAGE / DAILY_TOKENS_SPENT /
+    MONTHLY_TOKENS_SPENT via build_historical_stats_query. Removed along
+    with the PG fallbacks later in the stack.
     """
 
     filters = parsing_monitor_filters(monitor.filters)

--- a/futureagi/tracer/utils/monitor.py
+++ b/futureagi/tracer/utils/monitor.py
@@ -545,18 +545,12 @@ def _get_historical_stats(monitor, start_time, end_time):
     try:
         metric_type = monitor.metric_type
 
-        # For time-aggregated metrics, compute stats from time-series buckets
-        if metric_type in (
-            MonitorMetricTypeChoices.COUNT_OF_ERRORS,
-            MonitorMetricTypeChoices.TOKEN_USAGE,
-            MonitorMetricTypeChoices.DAILY_TOKENS_SPENT,
-            MonitorMetricTypeChoices.MONTHLY_TOKENS_SPENT,
-        ):
-            return _get_stats_for_time_aggregated_metrics(monitor, start_time, end_time)
-
         builder = _build_monitor_ch_builder(monitor)
         query, params = builder.build_historical_stats_query(
-            metric_type, start_time, end_time
+            metric_type,
+            start_time,
+            end_time,
+            interval_kind=_get_interval_kind(monitor),
         )
         result = analytics.execute_ch_query(query, params, timeout_ms=5000)
         if result.data:


### PR DESCRIPTION
## Summary

Percentage-change monitors on `COUNT_OF_ERRORS` / `TOKEN_USAGE` / `DAILY_TOKENS_SPENT` / `MONTHLY_TOKENS_SPENT` crashed every tick: their historical mean/stddev was computed by reading the dropped Postgres span table. This PR computes those stats natively in ClickHouse over calendar-aligned buckets. PR 4 of 7.

## Linked issues

Linear: Fixed TH-7536

## Type of change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

---

## 1) What changes were done

**A. CH-native bucketed historical stats**

- `build_historical_stats_query` gains an `interval_kind` kwarg and a branch for the four time-aggregated metrics: bucket by `toStartOfMinute/Hour/Day/Month(created_at)` (calendar-aligned, matching the old Django `Trunc`), aggregate per bucket (`countIf(status='ERROR')` or `nullIf(sum(total_tokens), 0)`), then `avg` / `stddevSamp` over bucket values.
- `stddevSamp` here is deliberate — the old Python path used `statistics.stdev` (sample). Empty result collapses to `(0, 0)`, matching the old behavior.
- `_get_historical_stats` routes these four metrics to the CH branch (passing `interval_kind` from the monitor's frequency) instead of the Postgres helper.

## 2) Why the changes were done

- **Product:** four metric types could not use percentage-change thresholds at all.
- **Technical:** the PG source table is physically dropped; bucket-level aggregation in CH reproduces the old semantics without a Python round-trip.

---

## 3) Tests written + scenarios each covers

**`tracer/tests/test_monitor_metrics_parity.py`**

- `test_time_aggregated_historical_buckets_calendar` — all 4 metrics × minute/hour/day/month bucket functions, `stddevSamp`, `(0,0)` collapse.
- `test_time_aggregated_historical_agg_per_metric` — `countIf` for errors vs `nullIf(sum(total_tokens), 0)` for tokens.
- `test_time_aggregated_historical_defaults_to_hour` — default bucket.

> Run result: 65 passed across the stack's suites at this commit.

## 4) How to run / test

```bash
cd futureagi
.venv/bin/python -m pytest tracer/tests/test_monitor_metrics_parity.py -q
```

---

**Stack:** PR 4/7, on `fix/alerts-ch-eval-path`.
