### PR TITLE
fix(alerts): parity semantics, content-only filters, date-scoped filter subqueries

### DIFF
--- a/futureagi/tracer/services/clickhouse/query_builders/monitor_metrics.py
+++ b/futureagi/tracer/services/clickhouse/query_builders/monitor_metrics.py
@@ -17,8 +17,9 @@ Supports all metric types defined in ``MonitorMetricTypeChoices``:
 - MONTHLY_TOKENS_SPENT
 - EVALUATION_METRICS
 
-Two main query modes:
+Three query modes:
 - ``build_metric_value_query`` -- returns a single scalar value
+- ``build_historical_stats_query`` -- returns mean/stddev for a window
 - ``build_time_series_query`` -- returns time-bucketed series
 """
 
@@ -27,34 +28,27 @@ from typing import Any, Dict, List, Optional, Tuple
 
 import structlog
 
+from tracer.models.monitor import MonitorMetricTypeChoices
 from tracer.models.observation_span import EvalEntryStatus
 from tracer.services.clickhouse.eval_logger_table import eval_logger_source
 from tracer.services.clickhouse.query_builders.base import BaseQueryBuilder, _parse_dt
 from tracer.services.clickhouse.query_builders.filters import ClickHouseFilterBuilder
+from tracer.services.clickhouse.v2.id_remap_sql import (
+    remap_left_join,
+    resolved_id_expr,
+)
 
 logger = structlog.get_logger(__name__)
 
-# Mirror of MonitorMetricTypeChoices values
-COUNT_OF_ERRORS = "count_of_errors"
-ERROR_RATES_FOR_FUNCTION_CALLING = "error_rates_for_function_calling"
-ERROR_FREE_SESSION_RATES = "error_free_session_rates"
-SERVICE_PROVIDER_ERROR_RATES = "service_provider_error_rates"
-LLM_API_FAILURE_RATES = "llm_api_failure_rates"
-SPAN_RESPONSE_TIME = "span_response_time"
-LLM_RESPONSE_TIME = "llm_response_time"
-TOKEN_USAGE = "token_usage"
-DAILY_TOKENS_SPENT = "daily_tokens_spent"
-MONTHLY_TOKENS_SPENT = "monthly_tokens_spent"
-EVALUATION_METRICS = "evaluation_metrics"
-
 SPANS_TABLE = "spans"
+SESSION_REMAP_TABLE = "trace_session_id_remap"
 
 # Time-series buckets: to epoch seconds, integer-divide by the frequency to
 # floor to the bucket boundary, back to DateTime (300s: 12:07:43 -> 12:05:00).
-# Works for any frequency, unlike toStartOfHour/-FiveMinutes. Both bucket on
-# span ``start_time`` (event time — the user's timeline); the eval table has
-# no span-time column, so its series joins spans (alias ``sp``).
-_SPANS_BUCKET_EXPR = (
+# Both bucket on span ``start_time`` (event time — when it happened in the
+# user's system); the eval table has no span-time column, so its series joins
+# spans (alias ``sp``).
+_TIME_BUCKET_EXPR = (
     "toDateTime(intDiv(toUInt32(start_time), %(freq_seconds)s) * %(freq_seconds)s)"
 )
 _EVAL_SPAN_BUCKET_EXPR = (
@@ -66,6 +60,26 @@ _EVAL_SPAN_BUCKET_EXPR = (
 _EVAL_NON_VALUE_STATUSES = ", ".join(
     f"'{s.value}'" for s in EvalEntryStatus if s is not EvalEntryStatus.COMPLETED
 )
+
+
+
+def _pruned_window(start_param: str, end_param: str) -> str:
+    """Half-open exact start_time window ``[start, end)`` + padded created_at guard.
+
+    Event-time semantics: alerts, graphs and baselines all measure when the
+    activity happened in the user's system (``start_time`` — also the partition
+    key, so the exact window prunes directly), never ingest time. Half-open
+    (``>= start AND < end``) so a span on the boundary is never claimed by two
+    adjacent windows (matters for trailing spend sums; harmless elsewhere).
+    The padded ``created_at`` lower bound only guards against clock-skewed
+    producers reporting future ``start_time``. Blind spot: a span ingested
+    after its window was evaluated is never counted.
+    TODO: offset evaluation windows by ingest lag.
+    """
+    return (
+        f"start_time >= %({start_param})s AND start_time < %({end_param})s "
+        f"AND created_at >= %({start_param})s - INTERVAL 1 DAY"
+    )
 
 
 class MonitorMetricsQueryBuilder(BaseQueryBuilder):
@@ -106,7 +120,7 @@ class MonitorMetricsQueryBuilder(BaseQueryBuilder):
 
     @staticmethod
     def _eval_choice_match_expr(param_name: str = "choice_val") -> str:
-        """Choice membership in the JSON list (choice evals only write output_str_list)."""
+        """Choice membership in the JSON list (PG parity: list containment only)."""
         return f"has(JSONExtract(output_str_list, 'Array(String)'), %({param_name})s)"
 
     def _translate_filters(self) -> None:
@@ -119,10 +133,19 @@ class MonitorMetricsQueryBuilder(BaseQueryBuilder):
             self._filter_params = {}
             return
 
-        # Monitor queries bind start_time/end_time per query method, not
-        # start_date/end_date. Disable score date pruning here so annotation
-        # filters do not emit an unbound ``%(start_date)s`` placeholder.
-        fb = ClickHouseFilterBuilder(table=SPANS_TABLE, score_date_scope=False)
+        # QUERY_MODE_SPAN: attr filters apply to the span row itself (PG
+        # parity; alerts count only matching spans) as inline predicates —
+        # unlike the dashboard's trace-scoped membership subquery. The
+        # date-scope seams stay on for the subqueries some filter types
+        # (end-user, score) still emit; %(start_date)s is bound per build.
+        fb = ClickHouseFilterBuilder(
+            table=SPANS_TABLE,
+            score_date_scope=True,
+            span_date_scope=True,
+            query_mode=ClickHouseFilterBuilder.QUERY_MODE_SPAN,
+            project_id=self.project_id,
+            project_ids=self.project_ids,
+        )
 
         for key, value in self.raw_filters.items():
             if key == "span_attributes_filters" and isinstance(value, list):
@@ -131,59 +154,29 @@ class MonitorMetricsQueryBuilder(BaseQueryBuilder):
                     ch_conditions.append(clause)
                     params.update(p)
             elif key == "observation_type":
-                pname = f"mf_obs_type"
+                pname = "mf_obs_type"
                 if isinstance(value, list):
-                    params[pname] = tuple(value)
-                    ch_conditions.append(f"observation_type IN %({pname})s")
+                    if value:
+                        params[pname] = tuple(value)
+                        ch_conditions.append(f"observation_type IN %({pname})s")
+                    else:
+                        # PG Q(observation_type__in=[]) was always-false.
+                        ch_conditions.append("1 = 0")
                 elif isinstance(value, str):
                     params[pname] = value
                     ch_conditions.append(f"observation_type = %({pname})s")
-            elif key == "session_id" and value:
-                pname = "mf_session_id"
-                params[pname] = str(value)
-                ch_conditions.append(f"trace_session_id = toUUID(%({pname})s)")
-            elif key == "date_range" and isinstance(value, list) and len(value) == 2:
-                params["mf_dr_start"] = _parse_dt(value[0])
-                params["mf_dr_end"] = _parse_dt(value[1])
-                ch_conditions.append(
-                    "start_time BETWEEN %(mf_dr_start)s AND %(mf_dr_end)s "
-                    "AND created_at >= %(mf_dr_start)s - INTERVAL 1 DAY"
-                )
-            elif key == "created_at" and value:
-                params["mf_created_at"] = _parse_dt(value)
-                ch_conditions.append(
-                    "start_time >= %(mf_created_at)s "
-                    "AND created_at >= %(mf_created_at)s - INTERVAL 1 DAY"
-                )
+                else:
+                    raise ValueError(
+                        f"Invalid value for observation_type filter: {value!r}"
+                    )
             elif key == "project_id":
                 # Already handled by project_where()
                 pass
+            else:
+                logger.info("monitor_filter_key_ignored", key=key)
 
         self._filter_clause = " AND ".join(ch_conditions) if ch_conditions else ""
         self._filter_params = params
-
-    def _spans_time_window(self) -> str:
-        """Spans time-window predicate — event-time semantics.
-
-        Deliberate change from pre-CH behavior: windows evaluate on
-        ``start_time`` (event time, the partition key, so CH prunes), not
-        ``created_at`` (ingest time, unindexed, full scan). Blind spot: spans
-        ingested after their window was evaluated are never counted.
-        TODO: offset evaluation windows by ingest lag. The padded
-        ``created_at`` companion only guards against clock-skewed future
-        ``start_time``. Mirrors ``DashboardQueryBuilder``.
-        """
-        return (
-            "start_time BETWEEN %(start_time)s AND %(end_time)s "
-            "AND created_at >= %(start_time)s - INTERVAL 1 DAY"
-        )
-
-    def _spans_time_window_half_open(self) -> str:
-        """Half-open (``>= start AND < end``) variant for daily/monthly sums."""
-        return (
-            "start_time >= %(start_time)s AND start_time < %(end_time)s "
-            "AND created_at >= %(start_time)s - INTERVAL 1 DAY"
-        )
 
     def build(self) -> Tuple[str, Dict[str, Any]]:
         """Not used directly -- use build_metric_value_query or build_time_series_query."""
@@ -211,12 +204,14 @@ class MonitorMetricsQueryBuilder(BaseQueryBuilder):
         params.update(self._filter_params)
         params["start_time"] = _parse_dt(start_time)
         params["end_time"] = _parse_dt(end_time)
+        # Bound for the filter builder's date-scoped subqueries (span/score
+        # membership) — see _translate_filters.
+        params["start_date"] = params["start_time"]
 
         base_where = self._spans_base_where()
-        time_win = f"AND {self._spans_time_window()}"
-        time_win_ho = f"AND {self._spans_time_window_half_open()}"
+        time_win = f"AND {_pruned_window('start_time', 'end_time')}"
 
-        if metric_type == COUNT_OF_ERRORS:
+        if metric_type == MonitorMetricTypeChoices.COUNT_OF_ERRORS:
             query = f"""
                 SELECT count() AS value
                 FROM {SPANS_TABLE}
@@ -225,7 +220,7 @@ class MonitorMetricsQueryBuilder(BaseQueryBuilder):
                   AND status = 'ERROR'
             """
 
-        elif metric_type == ERROR_RATES_FOR_FUNCTION_CALLING:
+        elif metric_type == MonitorMetricTypeChoices.ERROR_RATES_FOR_FUNCTION_CALLING:
             query = f"""
                 SELECT
                     CASE WHEN count() = 0 THEN NULL
@@ -237,7 +232,11 @@ class MonitorMetricsQueryBuilder(BaseQueryBuilder):
                   AND observation_type = 'tool'
             """
 
-        elif metric_type == ERROR_FREE_SESSION_RATES:
+        elif metric_type == MonitorMetricTypeChoices.ERROR_FREE_SESSION_RATES:
+            # Resolve session ids through the remap before grouping so old/new
+            # aliases of one logical session count once (see session_analytics).
+            remap_join = remap_left_join("rs.trace_session_id", SESSION_REMAP_TABLE)
+            resolved_ts = resolved_id_expr("rs.trace_session_id")
             query = f"""
                 SELECT
                     CASE WHEN uniq(trace_session_id) = 0 THEN NULL
@@ -245,17 +244,21 @@ class MonitorMetricsQueryBuilder(BaseQueryBuilder):
                     END AS value
                 FROM (
                     SELECT
-                        trace_session_id,
-                        countIf(status = 'ERROR') AS error_count
-                    FROM {SPANS_TABLE}
-                    {base_where}
-                      {time_win}
-                      AND trace_session_id IS NOT NULL
-                    GROUP BY trace_session_id
+                        {resolved_ts} AS trace_session_id,
+                        countIf(rs.status = 'ERROR') AS error_count
+                    FROM (
+                        SELECT trace_session_id, status
+                        FROM {SPANS_TABLE}
+                        {base_where}
+                          {time_win}
+                          AND trace_session_id IS NOT NULL
+                    ) AS rs
+                    {remap_join}
+                    GROUP BY {resolved_ts}
                 )
             """
 
-        elif metric_type == SERVICE_PROVIDER_ERROR_RATES:
+        elif metric_type == MonitorMetricTypeChoices.SERVICE_PROVIDER_ERROR_RATES:
             query = f"""
                 SELECT
                     CASE WHEN uniq(provider) = 0 THEN NULL
@@ -269,12 +272,11 @@ class MonitorMetricsQueryBuilder(BaseQueryBuilder):
                     {base_where}
                       {time_win}
                       AND provider != ''
-                      AND provider IS NOT NULL
                     GROUP BY provider
                 )
             """
 
-        elif metric_type == LLM_API_FAILURE_RATES:
+        elif metric_type == MonitorMetricTypeChoices.LLM_API_FAILURE_RATES:
             query = f"""
                 SELECT
                     CASE WHEN count() = 0 THEN NULL
@@ -286,54 +288,56 @@ class MonitorMetricsQueryBuilder(BaseQueryBuilder):
                   AND observation_type = 'llm'
             """
 
-        elif metric_type == SPAN_RESPONSE_TIME:
+        elif metric_type == MonitorMetricTypeChoices.SPAN_RESPONSE_TIME:
             query = f"""
-                SELECT avg(latency_ms) AS value
+                SELECT ifNotFinite(avg(latency_ms), NULL) AS value
                 FROM {SPANS_TABLE}
                 {base_where}
                   {time_win}
             """
 
-        elif metric_type == LLM_RESPONSE_TIME:
+        elif metric_type == MonitorMetricTypeChoices.LLM_RESPONSE_TIME:
             query = f"""
-                SELECT avg(latency_ms) AS value
+                SELECT ifNotFinite(avg(latency_ms), NULL) AS value
                 FROM {SPANS_TABLE}
                 {base_where}
                   {time_win}
                   AND observation_type = 'llm'
             """
 
-        elif metric_type == TOKEN_USAGE:
+        elif metric_type in (
+            MonitorMetricTypeChoices.TOKEN_USAGE,
+            MonitorMetricTypeChoices.DAILY_TOKENS_SPENT,
+            MonitorMetricTypeChoices.MONTHLY_TOKENS_SPENT,
+        ):
+            # No token data must yield NULL (PG Sum parity), not 0 — a 0 would
+            # falsely fire LESS_THAN spend monitors. v2 total_tokens is
+            # non-Nullable (PG NULL → 0), so "no data" = no nonzero rows.
+            # DAILY/MONTHLY differ only by the trailing window (ch_start override
+            # in the evaluator), not the SQL.
             query = f"""
-                SELECT sum(total_tokens) AS value
+                SELECT
+                    CASE WHEN countIf(total_tokens != 0) = 0 THEN NULL
+                         ELSE sum(total_tokens)
+                    END AS value
                 FROM {SPANS_TABLE}
                 {base_where}
                   {time_win}
             """
 
-        elif metric_type == DAILY_TOKENS_SPENT:
-            query = f"""
-                SELECT sum(total_tokens) AS value
-                FROM {SPANS_TABLE}
-                {base_where}
-                  {time_win_ho}
-            """
-
-        elif metric_type == MONTHLY_TOKENS_SPENT:
-            query = f"""
-                SELECT sum(total_tokens) AS value
-                FROM {SPANS_TABLE}
-                {base_where}
-                  {time_win_ho}
-            """
-
-        elif metric_type == EVALUATION_METRICS:
+        elif metric_type == MonitorMetricTypeChoices.EVALUATION_METRICS:
             query, params = self._build_eval_metric_value_query(params)
 
         else:
             query = "SELECT NULL AS value"
 
         return query, params
+
+    # Eval SQL reads the eval-logger table AND embeds a spans membership
+    # subquery whose monitor-filter fragment carries v1 map tokens (span_attr_*),
+    # so it must go THROUGH the v2 rewrite; the not-deleted predicate uses the
+    # rewrite-safe (deleted-based) form, so no exclusion is needed. These are
+    # reached via the EVALUATION_METRICS branch of the public build_* dispatch.
 
     def _build_eval_metric_value_query(
         self, params: Dict[str, Any]
@@ -393,9 +397,10 @@ class MonitorMetricsQueryBuilder(BaseQueryBuilder):
     ) -> Tuple[str, Dict[str, Any]]:
         """Build a query that returns mean and stddev for historical analysis.
 
-        For rate-based and latency metrics, computes per-row stats.
-        For aggregated metrics (token usage, error counts), computes
-        stats over time-bucketed values.
+        Per-row stats for rate/latency metrics (population stddev, PG parity);
+        calendar-bucketed stats for count/token metrics (``interval_kind`` =
+        minute/hour/day/month, sample stddev — parity with the old
+        ``Trunc`` + ``statistics.stdev`` path).
 
         Returns:
             A ``(query_string, params_dict)`` tuple with ``mean`` and ``stddev`` columns.
@@ -404,15 +409,18 @@ class MonitorMetricsQueryBuilder(BaseQueryBuilder):
         params.update(self._filter_params)
         params["start_time"] = _parse_dt(start_time)
         params["end_time"] = _parse_dt(end_time)
+        # Bound for the filter builder's date-scoped subqueries (span/score
+        # membership) — see _translate_filters.
+        params["start_date"] = params["start_time"]
 
         base_where = self._spans_base_where()
-        time_win = f"AND {self._spans_time_window()}"
+        time_win = f"AND {_pruned_window('start_time', 'end_time')}"
 
-        if metric_type == ERROR_RATES_FOR_FUNCTION_CALLING:
+        if metric_type == MonitorMetricTypeChoices.ERROR_RATES_FOR_FUNCTION_CALLING:
             query = f"""
                 SELECT
-                    avg(is_error) AS mean,
-                    stddevSamp(is_error) AS stddev
+                    ifNotFinite(avg(is_error), NULL) AS mean,
+                    ifNotFinite(stddevPop(is_error), NULL) AS stddev
                 FROM (
                     SELECT
                         CASE WHEN status = 'ERROR' THEN 1.0 ELSE 0.0 END AS is_error
@@ -423,27 +431,33 @@ class MonitorMetricsQueryBuilder(BaseQueryBuilder):
                 )
             """
 
-        elif metric_type == ERROR_FREE_SESSION_RATES:
+        elif metric_type == MonitorMetricTypeChoices.ERROR_FREE_SESSION_RATES:
+            remap_join = remap_left_join("rs.trace_session_id", SESSION_REMAP_TABLE)
+            resolved_ts = resolved_id_expr("rs.trace_session_id")
             query = f"""
                 SELECT
-                    avg(is_error_free) AS mean,
-                    stddevSamp(is_error_free) AS stddev
+                    ifNotFinite(avg(is_error_free), NULL) AS mean,
+                    ifNotFinite(stddevPop(is_error_free), NULL) AS stddev
                 FROM (
                     SELECT
-                        CASE WHEN countIf(status = 'ERROR') > 0 THEN 0.0 ELSE 1.0 END AS is_error_free
-                    FROM {SPANS_TABLE}
-                    {base_where}
-                      {time_win}
-                      AND trace_session_id IS NOT NULL
-                    GROUP BY trace_session_id
+                        CASE WHEN countIf(rs.status = 'ERROR') > 0 THEN 0.0 ELSE 1.0 END AS is_error_free
+                    FROM (
+                        SELECT trace_session_id, status
+                        FROM {SPANS_TABLE}
+                        {base_where}
+                          {time_win}
+                          AND trace_session_id IS NOT NULL
+                    ) AS rs
+                    {remap_join}
+                    GROUP BY {resolved_ts}
                 )
             """
 
-        elif metric_type == SERVICE_PROVIDER_ERROR_RATES:
+        elif metric_type == MonitorMetricTypeChoices.SERVICE_PROVIDER_ERROR_RATES:
             query = f"""
                 SELECT
-                    avg(is_error_free) AS mean,
-                    stddevSamp(is_error_free) AS stddev
+                    ifNotFinite(avg(is_error_free), NULL) AS mean,
+                    ifNotFinite(stddevPop(is_error_free), NULL) AS stddev
                 FROM (
                     SELECT
                         CASE WHEN countIf(status = 'ERROR') > 0 THEN 0.0 ELSE 1.0 END AS is_error_free
@@ -451,16 +465,15 @@ class MonitorMetricsQueryBuilder(BaseQueryBuilder):
                     {base_where}
                       {time_win}
                       AND provider != ''
-                      AND provider IS NOT NULL
                     GROUP BY provider
                 )
             """
 
-        elif metric_type == LLM_API_FAILURE_RATES:
+        elif metric_type == MonitorMetricTypeChoices.LLM_API_FAILURE_RATES:
             query = f"""
                 SELECT
-                    avg(is_error) AS mean,
-                    stddevSamp(is_error) AS stddev
+                    ifNotFinite(avg(is_error), NULL) AS mean,
+                    ifNotFinite(stddevPop(is_error), NULL) AS stddev
                 FROM (
                     SELECT
                         CASE WHEN status = 'ERROR' THEN 1.0 ELSE 0.0 END AS is_error
@@ -471,46 +484,45 @@ class MonitorMetricsQueryBuilder(BaseQueryBuilder):
                 )
             """
 
-        elif metric_type == SPAN_RESPONSE_TIME:
+        elif metric_type == MonitorMetricTypeChoices.SPAN_RESPONSE_TIME:
             query = f"""
                 SELECT
-                    avg(latency_ms) AS mean,
-                    stddevSamp(latency_ms) AS stddev
+                    ifNotFinite(avg(latency_ms), NULL) AS mean,
+                    ifNotFinite(stddevPop(latency_ms), NULL) AS stddev
                 FROM {SPANS_TABLE}
                 {base_where}
                   {time_win}
             """
 
-        elif metric_type == LLM_RESPONSE_TIME:
+        elif metric_type == MonitorMetricTypeChoices.LLM_RESPONSE_TIME:
             query = f"""
                 SELECT
-                    avg(latency_ms) AS mean,
-                    stddevSamp(latency_ms) AS stddev
+                    ifNotFinite(avg(latency_ms), NULL) AS mean,
+                    ifNotFinite(stddevPop(latency_ms), NULL) AS stddev
                 FROM {SPANS_TABLE}
                 {base_where}
                   {time_win}
                   AND observation_type = 'llm'
             """
 
-        elif metric_type == EVALUATION_METRICS:
+        elif metric_type == MonitorMetricTypeChoices.EVALUATION_METRICS:
             query, params = self._build_eval_stats_query(params)
 
         elif metric_type in (
-            COUNT_OF_ERRORS,
-            TOKEN_USAGE,
-            DAILY_TOKENS_SPENT,
-            MONTHLY_TOKENS_SPENT,
+            MonitorMetricTypeChoices.COUNT_OF_ERRORS,
+            MonitorMetricTypeChoices.TOKEN_USAGE,
+            MonitorMetricTypeChoices.DAILY_TOKENS_SPENT,
+            MonitorMetricTypeChoices.MONTHLY_TOKENS_SPENT,
         ):
             # Stats over calendar-aligned buckets. Empty result collapses to
             # (0, 0), a single bucket to (value, 0), and no-token buckets are
             # skipped via nullIf (v2 total_tokens is non-Nullable) — matching
-            # the old Python path. Buckets are on created_at, so cap it at
-            # end_time: a late-ingested in-window span would otherwise create
-            # a sparse trailing bucket that skews mean/stddev every tick.
+            # the old Python path. Buckets are on start_time (event time), the
+            # same axis as the window — no out-of-window trailing bucket.
             bucket_fn = self.time_bucket_expr(interval_kind or "hour")
             agg = (
                 "countIf(status = 'ERROR')"
-                if metric_type == COUNT_OF_ERRORS
+                if metric_type == MonitorMetricTypeChoices.COUNT_OF_ERRORS
                 else "nullIf(sum(total_tokens), 0)"
             )
             query = f"""
@@ -519,12 +531,11 @@ class MonitorMetricsQueryBuilder(BaseQueryBuilder):
                     coalesce(ifNotFinite(stddevSamp(bucket_value), 0), 0) AS stddev
                 FROM (
                     SELECT
-                        {bucket_fn}(created_at) AS bucket_ts,
+                        {bucket_fn}(start_time) AS bucket_ts,
                         {agg} AS bucket_value
                     FROM {SPANS_TABLE}
                     {base_where}
                       {time_win}
-                      AND created_at <= %(end_time)s
                     GROUP BY bucket_ts
                 )
             """
@@ -537,10 +548,7 @@ class MonitorMetricsQueryBuilder(BaseQueryBuilder):
     def _build_eval_stats_query(
         self, params: Dict[str, Any]
     ) -> Tuple[str, Dict[str, Any]]:
-        """Build eval metric stats (mean/stddev) query.
-
-        ``stddevPop`` matches the pre-migration PG ``StdDev`` default.
-        """
+        """Build eval metric stats (mean/stddev) query."""
         if not self.eval_config_id:
             return "SELECT NULL AS mean, NULL AS stddev", params
 
@@ -612,14 +620,21 @@ class MonitorMetricsQueryBuilder(BaseQueryBuilder):
         params.update(self._filter_params)
         params["start_time"] = _parse_dt(start_time)
         params["end_time"] = _parse_dt(end_time)
+        # Bound for the filter builder's date-scoped subqueries (span/score
+        # membership) — see _translate_filters.
+        params["start_date"] = params["start_time"]
         params["freq_seconds"] = frequency_seconds
 
-        bucket_expr = _SPANS_BUCKET_EXPR
+        bucket_expr = _TIME_BUCKET_EXPR
 
         base_where = self._spans_base_where()
-        time_filter = f"AND {self._spans_time_window()}"
+        time_filter = f"AND {_pruned_window('start_time', 'end_time')}"
 
-        if metric_type in (TOKEN_USAGE, DAILY_TOKENS_SPENT, MONTHLY_TOKENS_SPENT):
+        if metric_type in (
+            MonitorMetricTypeChoices.TOKEN_USAGE,
+            MonitorMetricTypeChoices.DAILY_TOKENS_SPENT,
+            MonitorMetricTypeChoices.MONTHLY_TOKENS_SPENT,
+        ):
             query = f"""
                 SELECT
                     {bucket_expr} AS timestamp,
@@ -631,7 +646,7 @@ class MonitorMetricsQueryBuilder(BaseQueryBuilder):
                 ORDER BY timestamp
             """
 
-        elif metric_type == COUNT_OF_ERRORS:
+        elif metric_type == MonitorMetricTypeChoices.COUNT_OF_ERRORS:
             query = f"""
                 SELECT
                     {bucket_expr} AS timestamp,
@@ -643,7 +658,7 @@ class MonitorMetricsQueryBuilder(BaseQueryBuilder):
                 ORDER BY timestamp
             """
 
-        elif metric_type == SPAN_RESPONSE_TIME:
+        elif metric_type == MonitorMetricTypeChoices.SPAN_RESPONSE_TIME:
             query = f"""
                 SELECT
                     {bucket_expr} AS timestamp,
@@ -655,7 +670,7 @@ class MonitorMetricsQueryBuilder(BaseQueryBuilder):
                 ORDER BY timestamp
             """
 
-        elif metric_type == LLM_RESPONSE_TIME:
+        elif metric_type == MonitorMetricTypeChoices.LLM_RESPONSE_TIME:
             query = f"""
                 SELECT
                     {bucket_expr} AS timestamp,
@@ -668,9 +683,14 @@ class MonitorMetricsQueryBuilder(BaseQueryBuilder):
                 ORDER BY timestamp
             """
 
-        elif metric_type in (ERROR_RATES_FOR_FUNCTION_CALLING, LLM_API_FAILURE_RATES):
+        elif metric_type in (
+            MonitorMetricTypeChoices.ERROR_RATES_FOR_FUNCTION_CALLING,
+            MonitorMetricTypeChoices.LLM_API_FAILURE_RATES,
+        ):
             obs_type = (
-                "tool" if metric_type == ERROR_RATES_FOR_FUNCTION_CALLING else "llm"
+                "tool"
+                if metric_type == MonitorMetricTypeChoices.ERROR_RATES_FOR_FUNCTION_CALLING
+                else "llm"
             )
             params["obs_type_ts"] = obs_type
             query = f"""
@@ -687,7 +707,9 @@ class MonitorMetricsQueryBuilder(BaseQueryBuilder):
                 ORDER BY timestamp
             """
 
-        elif metric_type == ERROR_FREE_SESSION_RATES:
+        elif metric_type == MonitorMetricTypeChoices.ERROR_FREE_SESSION_RATES:
+            remap_join = remap_left_join("rs.trace_session_id", SESSION_REMAP_TABLE)
+            resolved_ts = resolved_id_expr("rs.trace_session_id")
             query = f"""
                 SELECT
                     timestamp,
@@ -697,19 +719,23 @@ class MonitorMetricsQueryBuilder(BaseQueryBuilder):
                 FROM (
                     SELECT
                         {bucket_expr} AS timestamp,
-                        trace_session_id,
-                        countIf(status = 'ERROR') AS error_count
-                    FROM {SPANS_TABLE}
-                    {base_where}
-                      {time_filter}
-                      AND trace_session_id IS NOT NULL
-                    GROUP BY timestamp, trace_session_id
+                        {resolved_ts} AS trace_session_id,
+                        countIf(rs.status = 'ERROR') AS error_count
+                    FROM (
+                        SELECT trace_session_id, status, start_time
+                        FROM {SPANS_TABLE}
+                        {base_where}
+                          {time_filter}
+                          AND trace_session_id IS NOT NULL
+                    ) AS rs
+                    {remap_join}
+                    GROUP BY timestamp, {resolved_ts}
                 )
                 GROUP BY timestamp
                 ORDER BY timestamp
             """
 
-        elif metric_type == SERVICE_PROVIDER_ERROR_RATES:
+        elif metric_type == MonitorMetricTypeChoices.SERVICE_PROVIDER_ERROR_RATES:
             query = f"""
                 SELECT
                     timestamp,
@@ -725,14 +751,13 @@ class MonitorMetricsQueryBuilder(BaseQueryBuilder):
                     {base_where}
                       {time_filter}
                       AND provider != ''
-                      AND provider IS NOT NULL
                     GROUP BY timestamp, provider
                 )
                 GROUP BY timestamp
                 ORDER BY timestamp
             """
 
-        elif metric_type == EVALUATION_METRICS:
+        elif metric_type == MonitorMetricTypeChoices.EVALUATION_METRICS:
             query, params = self._build_eval_time_series_query(params)
 
         else:
@@ -805,11 +830,12 @@ class MonitorMetricsQueryBuilder(BaseQueryBuilder):
         ``not_deleted`` comes from the same ``eval_logger_source()`` call that
         resolved the table, so the pair stays consistent.
 
-        The window lives on the SPAN's ``created_at`` (ingest time — late
-        spans land in the current tick), not the eval row's — evals run async
-        after their spans. A JOIN (vs ``IN``) streams the span set instead of
-        materializing it in memory: a 30-day graph window on a busy project
-        overflows ``max_bytes_in_set`` as an IN-set (~100M ids).
+        The window lives on the SPAN's ``start_time`` (event time — the
+        user's timeline), not the eval row's ``created_at`` — evals run async
+        after their spans (8,577 vs 400 evals for the same busy hour when
+        windowed on eval time). A JOIN (vs ``IN``) streams the span set
+        instead of materializing it in memory (~100M ids overflowed
+        ``max_bytes_in_set`` at prod scale).
         The eval-side ``created_at`` lower bound (1-day skew pad) is
         correctness-neutral but is the eval table's only partition prune
         (toYYYYMM(created_at)); the v2 sort key also prunes granules with it.
@@ -834,8 +860,6 @@ class MonitorMetricsQueryBuilder(BaseQueryBuilder):
             f"SELECT {select_cols} FROM {SPANS_TABLE} "
             f"WHERE {self.project_filter_sql()} "
             f"AND is_deleted = 0 "
-            f"AND created_at >= %(start_time)s AND created_at < %(end_time)s "
-            f"AND start_time >= %(start_time)s - INTERVAL 1 DAY "
-            f"AND start_time < %(end_time)s + INTERVAL 1 DAY"
+            f"AND {_pruned_window('start_time', 'end_time')}"
             f"{filter_extra}"
         )

--- a/futureagi/tracer/tests/test_clickhouse.py
+++ b/futureagi/tracer/tests/test_clickhouse.py
@@ -8300,7 +8300,9 @@ class TestMonitorMetricsQueryBuilder:
             "error_free_session_rates", datetime(2024, 1, 1), datetime(2024, 1, 31)
         )
         assert "trace_session_id" in query
-        assert "GROUP BY trace_session_id" in query
+        # Remap-aware: groups by the survivor-resolved session id.
+        assert "id_remap.survivor_id" in query
+        assert "GROUP BY" in query
 
     def test_service_provider_error_rates_query(self):
         """SERVICE_PROVIDER_ERROR_RATES should group by provider."""
@@ -8467,8 +8469,10 @@ class TestMonitorMetricsQueryBuilder:
         query, _ = builder.build_historical_stats_query(
             "span_response_time", datetime(2024, 1, 1), datetime(2024, 1, 31)
         )
-        assert "avg(latency_ms) AS mean" in query
-        assert "stddevSamp(latency_ms) AS stddev" in query
+        # NaN -> NULL so empty windows suppress alerts instead of firing.
+        assert "ifNotFinite(avg(latency_ms), NULL) AS mean" in query
+        # Population stddev (PG StdDev default) with NaN -> NULL guard.
+        assert "ifNotFinite(stddevPop(latency_ms), NULL) AS stddev" in query
 
     def test_historical_stats_eval_score(self):
         """Historical stats for EVALUATION_METRICS SCORE should use output_float."""
@@ -8617,31 +8621,20 @@ class TestMonitorMetricsQueryBuilder:
         """All metric types should produce valid SQL (not crash)."""
         from datetime import datetime
 
-        from tracer.services.clickhouse.query_builders.monitor_metrics import (
-            COUNT_OF_ERRORS,
-            DAILY_TOKENS_SPENT,
-            ERROR_FREE_SESSION_RATES,
-            ERROR_RATES_FOR_FUNCTION_CALLING,
-            LLM_API_FAILURE_RATES,
-            LLM_RESPONSE_TIME,
-            MONTHLY_TOKENS_SPENT,
-            SERVICE_PROVIDER_ERROR_RATES,
-            SPAN_RESPONSE_TIME,
-            TOKEN_USAGE,
-        )
+        from tracer.models.monitor import MonitorMetricTypeChoices
 
         builder = self._make_builder()
         metric_types = [
-            COUNT_OF_ERRORS,
-            ERROR_RATES_FOR_FUNCTION_CALLING,
-            ERROR_FREE_SESSION_RATES,
-            SERVICE_PROVIDER_ERROR_RATES,
-            LLM_API_FAILURE_RATES,
-            SPAN_RESPONSE_TIME,
-            LLM_RESPONSE_TIME,
-            TOKEN_USAGE,
-            DAILY_TOKENS_SPENT,
-            MONTHLY_TOKENS_SPENT,
+            MonitorMetricTypeChoices.COUNT_OF_ERRORS,
+            MonitorMetricTypeChoices.ERROR_RATES_FOR_FUNCTION_CALLING,
+            MonitorMetricTypeChoices.ERROR_FREE_SESSION_RATES,
+            MonitorMetricTypeChoices.SERVICE_PROVIDER_ERROR_RATES,
+            MonitorMetricTypeChoices.LLM_API_FAILURE_RATES,
+            MonitorMetricTypeChoices.SPAN_RESPONSE_TIME,
+            MonitorMetricTypeChoices.LLM_RESPONSE_TIME,
+            MonitorMetricTypeChoices.TOKEN_USAGE,
+            MonitorMetricTypeChoices.DAILY_TOKENS_SPENT,
+            MonitorMetricTypeChoices.MONTHLY_TOKENS_SPENT,
         ]
         for mt in metric_types:
             query, params = builder.build_metric_value_query(
@@ -8750,7 +8743,9 @@ class TestSessionAnalyticsQueryBuilder:
         builder = self._make_builder()
         query, params = builder.build_session_metrics_query(["sess-1", "sess-2"])
         assert "trace_session_id" in query
-        assert "GROUP BY trace_session_id" in query
+        # Remap-aware: groups by the survivor-resolved session id.
+        assert "id_remap.survivor_id" in query
+        assert "GROUP BY" in query
         assert "count(DISTINCT trace_id)" in query
         assert "sum(total_tokens)" in query
         assert "sum(cost)" in query

--- a/futureagi/tracer/tests/test_monitor_evaluator.py
+++ b/futureagi/tracer/tests/test_monitor_evaluator.py
@@ -234,6 +234,16 @@ def test_invalid_filters_are_non_retryable(user_alert_monitor) -> None:
     assert UserAlertMonitorLog.objects.count() == 0
 
 
+def test_invalid_observation_type_filter_raises_config_error(
+    user_alert_monitor,
+) -> None:
+    # Non-list/non-str observation_type is a permanent misconfig: the builder's
+    # ValueError must surface as MonitorConfigError, not silently drop the filter.
+    user_alert_monitor.filters = {"observation_type": 123}
+    with pytest.raises(MonitorConfigError):
+        build_monitor_ch_builder(user_alert_monitor)
+
+
 def test_deleted_monitor_returns_quietly() -> None:
     task_fn = process_monitor_task._original_func
     with _patch_ch([]):  # no CH call may happen for a missing monitor

--- a/futureagi/tracer/tests/test_monitor_metrics_eval_path.py
+++ b/futureagi/tracer/tests/test_monitor_metrics_eval_path.py
@@ -10,7 +10,7 @@ from datetime import UTC, datetime
 import pytest
 from django.test import override_settings
 
-from tracer.services.clickhouse.query_builders import monitor_metrics as mm
+from tracer.models.monitor import MonitorMetricTypeChoices
 from tracer.services.clickhouse.query_builders.monitor_metrics import (
     MonitorMetricsQueryBuilder,
 )
@@ -58,9 +58,9 @@ def _eval_sqls(
 ) -> list[str]:
     b = _builder(cls, filters=filters)
     return [
-        b.build_metric_value_query(mm.EVALUATION_METRICS, START, END)[0],
-        b.build_historical_stats_query(mm.EVALUATION_METRICS, START, END)[0],
-        b.build_time_series_query(mm.EVALUATION_METRICS, START, END, 3600)[0],
+        b.build_metric_value_query(MonitorMetricTypeChoices.EVALUATION_METRICS, START, END)[0],
+        b.build_historical_stats_query(MonitorMetricTypeChoices.EVALUATION_METRICS, START, END)[0],
+        b.build_time_series_query(MonitorMetricTypeChoices.EVALUATION_METRICS, START, END, 3600)[0],
     ]
 
 
@@ -89,17 +89,16 @@ def test_eval_v2_table_uses_is_deleted() -> None:
 
 def test_eval_membership_is_windowed_span_join() -> None:
     # Membership is a JOIN on a span subquery windowed on the SPAN's
-    # created_at (evals run async after their spans), with the ±1-day
-    # start_time pruning pads. A JOIN streams the span set — the old IN
+    # start_time (event time; evals run async after their spans), with the
+    # created_at skew guard. A JOIN streams the span set — the old IN
     # materialized it in memory (105M ids / 30d at prod scale). The series
     # additionally selects start_time to bucket on.
     value_sql, stats_sql, ts_sql = _eval_sqls()
     for sql in (value_sql, stats_sql, ts_sql):
         subq = sql.split("INNER JOIN (", 1)[1]
         assert "ON observation_span_id = sp.id" in subq
-        assert "created_at >= %(start_time)s AND created_at < %(end_time)s" in subq
-        assert "start_time >= %(start_time)s - INTERVAL 1 DAY" in subq
-        assert "start_time < %(end_time)s + INTERVAL 1 DAY" in subq
+        assert "start_time >= %(start_time)s AND start_time < %(end_time)s" in subq
+        assert "created_at >= %(start_time)s - INTERVAL 1 DAY" in subq
         assert "project_id = %(project_id)s" in subq
         assert "observation_span_id IN" not in sql
         assert "INTERVAL 30 DAY" not in sql
@@ -143,7 +142,7 @@ def test_v1_eval_filter_emits_legacy_span_attr_token() -> None:
     b = _builder(filters=ATTR_FILTER)
     assert b._filter_clause, "attr filter should compile to a clause"
     assert (
-        "span_attr" in b.build_metric_value_query(mm.EVALUATION_METRICS, START, END)[0]
+        "span_attr" in b.build_metric_value_query(MonitorMetricTypeChoices.EVALUATION_METRICS, START, END)[0]
     )
 
 
@@ -169,10 +168,10 @@ def test_eval_empty_window_yields_null_for_all_output_types() -> None:
         )
         assert (
             "ifNotFinite("
-            in b.build_metric_value_query(mm.EVALUATION_METRICS, START, END)[0]
+            in b.build_metric_value_query(MonitorMetricTypeChoices.EVALUATION_METRICS, START, END)[0]
         )
         assert (
-            b.build_historical_stats_query(mm.EVALUATION_METRICS, START, END)[0].count(
+            b.build_historical_stats_query(MonitorMetricTypeChoices.EVALUATION_METRICS, START, END)[0].count(
                 "ifNotFinite("
             )
             >= 2
@@ -187,7 +186,7 @@ def test_all_eval_output_types_build(output_type: str) -> None:
         eval_output_type=output_type,
         threshold_metric_value="Passed" if output_type != "SCORE" else None,
     )
-    sql, _ = b.build_metric_value_query(mm.EVALUATION_METRICS, START, END)
+    sql, _ = b.build_metric_value_query(MonitorMetricTypeChoices.EVALUATION_METRICS, START, END)
     assert "FROM " in sql and "custom_eval_config_id" in sql
 
 
@@ -200,9 +199,9 @@ def test_choices_without_threshold_value_returns_null() -> None:
         eval_output_type="CHOICES",
         threshold_metric_value=None,
     )
-    value_sql, _ = b.build_metric_value_query(mm.EVALUATION_METRICS, START, END)
-    stats_sql, _ = b.build_historical_stats_query(mm.EVALUATION_METRICS, START, END)
-    ts_sql, _ = b.build_time_series_query(mm.EVALUATION_METRICS, START, END, 3600)
+    value_sql, _ = b.build_metric_value_query(MonitorMetricTypeChoices.EVALUATION_METRICS, START, END)
+    stats_sql, _ = b.build_historical_stats_query(MonitorMetricTypeChoices.EVALUATION_METRICS, START, END)
+    ts_sql, _ = b.build_time_series_query(MonitorMetricTypeChoices.EVALUATION_METRICS, START, END, 3600)
     assert "NULL" in value_sql and "output_str_list" not in value_sql
     assert "NULL" in stats_sql and "output_str_list" not in stats_sql
     assert "output_str_list" not in ts_sql
@@ -215,7 +214,7 @@ def test_pass_fail_time_series_shape() -> None:
         eval_output_type="PASS_FAIL",
         threshold_metric_value="Passed",
     )
-    sql, params = b.build_time_series_query(mm.EVALUATION_METRICS, START, END, 3600)
+    sql, params = b.build_time_series_query(MonitorMetricTypeChoices.EVALUATION_METRICS, START, END, 3600)
     assert "output_bool = %(output_bool_val)s" in sql
     assert params["output_bool_val"] == 1
     assert "GROUP BY timestamp" in sql
@@ -228,7 +227,7 @@ def test_choices_time_series_shape() -> None:
         eval_output_type="CHOICES",
         threshold_metric_value="Good",
     )
-    sql, params = b.build_time_series_query(mm.EVALUATION_METRICS, START, END, 3600)
+    sql, params = b.build_time_series_query(MonitorMetricTypeChoices.EVALUATION_METRICS, START, END, 3600)
     assert "has(JSONExtract(output_str_list, 'Array(String)'), %(choice_val)s)" in sql
     assert params["choice_val"] == "Good"
     assert "GROUP BY timestamp" in sql

--- a/futureagi/tracer/tests/test_monitor_metrics_execution_smoke.py
+++ b/futureagi/tracer/tests/test_monitor_metrics_execution_smoke.py
@@ -1,0 +1,410 @@
+"""Execution smoke: monitor metrics SQL runs against the live test ClickHouse.
+
+Every other monitor test asserts on SQL strings or mocks the CH client; the
+generated SQL — notably the session-remap join composition (three-level nested
+subquery + window function + GROUP BY on a full expression) run through the V2
+rewriter, and the eval INNER JOIN membership — was never executed. This suite
+builds the SQL through the production resolver (``get_query_builder_class``)
+and executes it via ``AnalyticsQueryService().execute_ch_query`` — the exact
+path ``tracer/utils/monitor.py`` / ``monitor_graphs.py`` use — against the
+live test CH, on a tiny seeded dataset with known expected values.
+
+Harness: mirrors ``test_span_reader_column_projection.py`` — connect via
+``get_v2_config()``, SKIP when CH is down, seed through ``_ch_seed`` (the
+production ``adapt()`` shape), tear down with synchronous ``ALTER … DELETE``.
+"""
+
+from __future__ import annotations
+
+import math
+import uuid
+from datetime import UTC, datetime
+from typing import Any
+
+import pytest
+from django.conf import settings
+from django.test import override_settings
+
+WINDOW_START = datetime(2026, 8, 10, 10, 0, tzinfo=UTC)
+WINDOW_END = datetime(2026, 8, 10, 11, 0, tzinfo=UTC)
+EMPTY_START = datetime(2026, 1, 1, tzinfo=UTC)
+EMPTY_END = datetime(2026, 1, 2, tzinfo=UTC)
+FREQ_SECONDS = 300
+
+EVAL_CONFIG_ID = str(uuid.uuid4())
+
+SPAN_METRICS = [
+    "count_of_errors",
+    "error_rates_for_function_calling",
+    "error_free_session_rates",
+    "service_provider_error_rates",
+    "llm_api_failure_rates",
+    "span_response_time",
+    "llm_response_time",
+    "token_usage",
+    "daily_tokens_spent",
+    "monthly_tokens_spent",
+]
+
+# (eval_output_type, threshold_metric_value)
+EVAL_VARIANTS = [
+    ("SCORE", None),
+    ("PASS_FAIL", "Passed"),
+    ("CHOICES", "Good"),
+]
+
+# Seed shape (all inside the window, unique per-span times for bucketing):
+#   s1 llm  OK    sess_a     latency 100 tokens 100 provider openai     (eval: 1.0/pass/Good)
+#   s2 tool ERROR sess_a     latency  50 tokens   0 provider openai
+#   s3 llm  OK    strad_old  latency 300 tokens 200 provider anthropic  (eval: 0.5/fail/Bad)
+#   s4 agent OK   strad_new  latency  10 tokens   0 provider ''
+#   s5 llm  ERROR (no sess)  latency 400 tokens  50 provider anthropic
+# Remap strad_old -> strad_new: both alias spans resolve to ONE session, so
+# resolved sessions = {sess_a (has error), straddler (error-free)}.
+EXPECTED_VALUE: dict[str, Any] = {
+    "count_of_errors": 2,
+    "error_rates_for_function_calling": pytest.approx(1.0),
+    "error_free_session_rates": pytest.approx(0.5),
+    "service_provider_error_rates": pytest.approx(0.0),
+    "llm_api_failure_rates": pytest.approx(1 / 3),
+    "span_response_time": pytest.approx(172.0),
+    "llm_response_time": pytest.approx(800 / 3),
+    "token_usage": 350,
+    "daily_tokens_spent": 350,
+    "monthly_tokens_spent": 350,
+}
+EXPECTED_EVAL_VALUE = {
+    "SCORE": pytest.approx(0.75),
+    "PASS_FAIL": pytest.approx(0.5),
+    "CHOICES": pytest.approx(0.5),
+}
+
+
+def _not_nan(v: Any) -> bool:
+    """NULL is fine; a float NaN leaking to the caller is not."""
+    return not (isinstance(v, float) and math.isnan(v))
+
+
+def _builder_cls() -> type:
+    """Resolve the builder exactly the way ``tracer/utils/monitor.py`` does,
+    with monitor_metrics routed to v2 so the rewriter is on the path."""
+    from tracer.services.clickhouse.v2.dispatch import get_query_builder_class
+
+    v2_cfg = {**settings.CLICKHOUSE_V2, "QUERY_TYPES_V2_ONLY": "monitor_metrics"}
+    with override_settings(CLICKHOUSE_V2=v2_cfg):
+        return get_query_builder_class("MONITOR_METRICS")
+
+
+def _make_builder(eval_output_type: str | None = None, threshold: str | None = None):
+    return _builder_cls()(
+        project_id=_PROJECT_ID,
+        eval_config_id=EVAL_CONFIG_ID if eval_output_type else None,
+        eval_output_type=eval_output_type,
+        threshold_metric_value=threshold,
+    )
+
+
+def _execute(sql: str, params: dict[str, Any]):
+    """The production execution path (monitor.py / monitor_graphs.py)."""
+    from tracer.services.clickhouse.query_service import AnalyticsQueryService
+
+    return AnalyticsQueryService().execute_ch_query(sql, params)
+
+
+# One project per module run so seeds never collide with other suites.
+_PROJECT_ID = str(uuid.uuid4())
+
+
+def _span(
+    span_id: str,
+    *,
+    observation_type: str,
+    status: str,
+    start_time: datetime,
+    latency_ms: int,
+    total_tokens: int,
+    provider: str,
+    trace_session_id: str | None,
+) -> dict[str, Any]:
+    return {
+        "id": span_id,
+        "trace_id": str(uuid.uuid4()),
+        "project_id": _PROJECT_ID,
+        "org_id": str(uuid.uuid4()),
+        "parent_span_id": "",
+        "name": f"smoke-{span_id[:8]}",
+        "observation_type": observation_type,
+        "status": status,
+        "start_time": start_time,
+        "end_time": start_time,
+        "created_at": start_time,
+        "latency_ms": latency_ms,
+        "total_tokens": total_tokens,
+        "provider": provider,
+        "trace_session_id": trace_session_id,
+    }
+
+
+def _seed_eval_rows(client: Any, rows: list[dict[str, Any]]) -> str:
+    """Insert eval rows into the table ``eval_logger_source()`` resolves,
+    writing only the columns that table actually carries (v2 vs CDC shape)."""
+    from tracer.services.clickhouse.eval_logger_table import eval_logger_source
+
+    eval_table, _ = eval_logger_source()
+    table_cols = [
+        r[0]
+        for r in client.query(
+            "SELECT name FROM system.columns "
+            "WHERE database = currentDatabase() AND table = %(t)s",
+            parameters={"t": eval_table},
+        ).result_rows
+    ]
+    cols = [c for c in rows[0] if c in table_cols]
+    client.insert(eval_table, [[r[c] for c in cols] for r in rows], column_names=cols)
+    return eval_table
+
+
+def _delete_sync(client: Any, table: str, where: str, params: dict[str, Any]) -> None:
+    """Synchronous ALTER … DELETE (mutations_sync=2) — deterministic teardown."""
+    client.command(
+        f"ALTER TABLE {table} DELETE WHERE {where} SETTINGS mutations_sync=2",
+        parameters=params,
+    )
+
+
+@pytest.fixture(scope="module")
+def seeded():
+    """Seed the tiny dataset; SKIPs when CH is down (either interface)."""
+    import clickhouse_connect
+
+    from tracer.services.clickhouse.v2 import get_v2_config
+    from tracer.tests._ch_seed import seed_ch_spans
+
+    cfg = get_v2_config()
+    try:
+        client = clickhouse_connect.get_client(
+            host=cfg["host"],
+            port=cfg["http_port"],
+            username=cfg["user"],
+            password=cfg["password"] or "",
+            database=cfg["database"],
+        )
+        client.command("SELECT 1")
+    except Exception as exc:  # pragma: no cover - env-dependent
+        pytest.skip(f"CH 25.3 (v2) not reachable ({exc!r}); integration test")
+    try:
+        _execute("SELECT 1", {})
+    except Exception as exc:  # pragma: no cover - env-dependent
+        pytest.skip(f"CH native (query-service) interface not reachable ({exc!r})")
+
+    sess_a = str(uuid.uuid4())
+    strad_old = str(uuid.uuid4())
+    strad_new = str(uuid.uuid4())
+
+    def t(minute: int) -> datetime:
+        return WINDOW_START.replace(minute=minute)
+
+    s1, s2, s3, s4, s5 = (f"smoke-span-{uuid.uuid4().hex[:12]}" for _ in range(5))
+    spans = [
+        _span(s1, observation_type="llm", status="OK", start_time=t(2),
+              latency_ms=100, total_tokens=100, provider="openai",
+              trace_session_id=sess_a),
+        _span(s2, observation_type="tool", status="ERROR", start_time=t(7),
+              latency_ms=50, total_tokens=0, provider="openai",
+              trace_session_id=sess_a),
+        _span(s3, observation_type="llm", status="OK", start_time=t(12),
+              latency_ms=300, total_tokens=200, provider="anthropic",
+              trace_session_id=strad_old),
+        _span(s4, observation_type="agent", status="OK", start_time=t(17),
+              latency_ms=10, total_tokens=0, provider="",
+              trace_session_id=strad_new),
+        _span(s5, observation_type="llm", status="ERROR", start_time=t(22),
+              latency_ms=400, total_tokens=50, provider="anthropic",
+              trace_session_id=None),
+    ]
+    seed_ch_spans(spans, client=client)
+
+    # Straddler bridge: old -> new; survivor is the old id (argMin over strings).
+    client.command(
+        "INSERT INTO trace_session_id_remap (old_id, new_id, version) "
+        "VALUES (%(o)s, %(n)s, %(v)s)",
+        parameters={"o": strad_old, "n": strad_new, "v": WINDOW_START},
+    )
+
+    def eval_row(span_id: str, out_float: float, out_bool: int, choices: str) -> dict:
+        return {
+            "id": str(uuid.uuid4()),
+            "observation_span_id": span_id,
+            "custom_eval_config_id": EVAL_CONFIG_ID,
+            "output_bool": out_bool,
+            "output_float": out_float,
+            "output_str": None,
+            "output_str_list": choices,
+            "status": "completed",
+            "error": 0,
+            "is_deleted": 0,
+            "deleted": 0,
+            "created_at": WINDOW_START,
+            "updated_at": WINDOW_START,
+        }
+
+    eval_table = _seed_eval_rows(
+        client,
+        [
+            eval_row(s1, 1.0, 1, '["Good"]'),
+            eval_row(s3, 0.5, 0, '["Bad"]'),
+        ],
+    )
+
+    try:
+        yield
+    finally:
+        _delete_sync(client, "spans", "project_id = %(p)s", {"p": _PROJECT_ID})
+        _delete_sync(
+            client, "trace_session_id_remap", "old_id = %(o)s", {"o": strad_old}
+        )
+        _delete_sync(
+            client,
+            eval_table,
+            "custom_eval_config_id = %(c)s",
+            {"c": EVAL_CONFIG_ID},
+        )
+        client.close()
+
+
+@pytest.mark.integration
+class TestMonitorMetricsExecutionSmoke:
+    def test_dispatch_resolves_v2_builder(self, seeded):
+        from tracer.services.clickhouse.v2.query_builders.monitor_metrics import (
+            MonitorMetricsQueryBuilderV2,
+        )
+
+        assert _builder_cls() is MonitorMetricsQueryBuilderV2
+
+    # ── metric value (single scalar) ─────────────────────────────────────────
+
+    @pytest.mark.parametrize("metric_type", SPAN_METRICS)
+    def test_metric_value_executes(self, seeded, metric_type: str):
+        sql, params = _make_builder().build_metric_value_query(
+            metric_type, WINDOW_START, WINDOW_END
+        )
+        result = _execute(sql, params)
+        assert result.row_count == 1
+        value = result.data[0]["value"]
+        assert _not_nan(value)
+        assert value == EXPECTED_VALUE[metric_type]
+
+    @pytest.mark.parametrize("eval_output_type,threshold", EVAL_VARIANTS)
+    def test_eval_metric_value_executes(
+        self, seeded, eval_output_type: str, threshold: str | None
+    ):
+        sql, params = _make_builder(
+            eval_output_type, threshold
+        ).build_metric_value_query("evaluation_metrics", WINDOW_START, WINDOW_END)
+        result = _execute(sql, params)
+        assert result.row_count == 1
+        value = result.data[0]["value"]
+        assert _not_nan(value)
+        assert value == EXPECTED_EVAL_VALUE[eval_output_type]
+
+    # ── historical stats (mean + stddev) ─────────────────────────────────────
+
+    @pytest.mark.parametrize("metric_type", SPAN_METRICS)
+    def test_historical_stats_executes(self, seeded, metric_type: str):
+        sql, params = _make_builder().build_historical_stats_query(
+            metric_type, WINDOW_START, WINDOW_END, interval_kind="hour"
+        )
+        result = _execute(sql, params)
+        assert result.row_count == 1
+        row = result.data[0]
+        assert set(row) == {"mean", "stddev"}
+        assert _not_nan(row["mean"]) and _not_nan(row["stddev"])
+        assert row["mean"] is not None  # every metric has data in the window
+
+    def test_historical_stats_known_values(self, seeded):
+        # Per-row stats: mean latency over the 5 seeded spans.
+        sql, params = _make_builder().build_historical_stats_query(
+            "span_response_time", WINDOW_START, WINDOW_END
+        )
+        row = _execute(sql, params).data[0]
+        assert row["mean"] == pytest.approx(172.0)
+        # Calendar-bucketed stats: one hour bucket -> (value, 0).
+        sql, params = _make_builder().build_historical_stats_query(
+            "count_of_errors", WINDOW_START, WINDOW_END, interval_kind="hour"
+        )
+        row = _execute(sql, params).data[0]
+        assert row["mean"] == pytest.approx(2.0)
+        assert row["stddev"] == pytest.approx(0.0)
+
+    @pytest.mark.parametrize("eval_output_type,threshold", EVAL_VARIANTS)
+    def test_eval_historical_stats_executes(
+        self, seeded, eval_output_type: str, threshold: str | None
+    ):
+        sql, params = _make_builder(
+            eval_output_type, threshold
+        ).build_historical_stats_query(
+            "evaluation_metrics", WINDOW_START, WINDOW_END
+        )
+        result = _execute(sql, params)
+        assert result.row_count == 1
+        row = result.data[0]
+        assert row["mean"] == EXPECTED_EVAL_VALUE[eval_output_type]
+        assert _not_nan(row["stddev"])
+
+    # ── time series (timestamp + value rows) ─────────────────────────────────
+
+    @pytest.mark.parametrize("metric_type", SPAN_METRICS)
+    def test_time_series_executes(self, seeded, metric_type: str):
+        sql, params = _make_builder().build_time_series_query(
+            metric_type, WINDOW_START, WINDOW_END, FREQ_SECONDS
+        )
+        result = _execute(sql, params)
+        assert result.row_count >= 1
+        timestamps = []
+        for row in result.data:
+            assert set(row) == {"timestamp", "value"}
+            assert isinstance(row["timestamp"], datetime)
+            assert _not_nan(row["value"])
+            ts = row["timestamp"].replace(tzinfo=UTC)
+            assert WINDOW_START <= ts < WINDOW_END
+            assert ts.timestamp() % FREQ_SECONDS == 0  # bucket-floored
+            timestamps.append(row["timestamp"])
+        assert timestamps == sorted(timestamps)
+
+    @pytest.mark.parametrize("eval_output_type,threshold", EVAL_VARIANTS)
+    def test_eval_time_series_executes(
+        self, seeded, eval_output_type: str, threshold: str | None
+    ):
+        sql, params = _make_builder(
+            eval_output_type, threshold
+        ).build_time_series_query(
+            "evaluation_metrics", WINDOW_START, WINDOW_END, FREQ_SECONDS
+        )
+        result = _execute(sql, params)
+        # Two eval'd spans in different 300s buckets.
+        assert result.row_count == 2
+        for row in result.data:
+            assert isinstance(row["timestamp"], datetime)
+            assert _not_nan(row["value"])
+
+    # ── remap composition + empty window ─────────────────────────────────────
+
+    def test_error_free_session_rate_unifies_straddler(self, seeded):
+        """The remap join collapses the straddler's old+new alias spans into
+        ONE error-free session: 1 error-free of 2 resolved sessions."""
+        sql, params = _make_builder().build_metric_value_query(
+            "error_free_session_rates", WINDOW_START, WINDOW_END
+        )
+        value = _execute(sql, params).data[0]["value"]
+        assert value == pytest.approx(0.5)
+
+    @pytest.mark.parametrize("metric_type", ["token_usage", "span_response_time"])
+    def test_empty_window_value_is_null(self, seeded, metric_type: str):
+        """No data must read as NULL (never 0, never NaN) — a 0/NaN would
+        falsely fire LESS_THAN monitors."""
+        sql, params = _make_builder().build_metric_value_query(
+            metric_type, EMPTY_START, EMPTY_END
+        )
+        result = _execute(sql, params)
+        assert result.row_count == 1
+        assert result.data[0]["value"] is None

--- a/futureagi/tracer/tests/test_monitor_metrics_parity.py
+++ b/futureagi/tracer/tests/test_monitor_metrics_parity.py
@@ -1,5 +1,6 @@
 """Monitor builder parity: calendar-bucketed historical stats for count/token
-metrics (matches the old Python statistics path). Pure SQL-string assertions."""
+metrics, stddevPop vs stddevSamp split, NULL-on-empty token windows, provider
+guard, and eval CHOICES containment. Pure SQL-string assertions."""
 
 from __future__ import annotations
 
@@ -7,25 +8,39 @@ from datetime import UTC, datetime
 
 import pytest
 
-from tracer.services.clickhouse.query_builders import monitor_metrics as mm
+from tracer.models.monitor import MonitorMetricTypeChoices
 from tracer.services.clickhouse.query_builders.monitor_metrics import (
     MonitorMetricsQueryBuilder,
 )
 
 PROJECT_ID = "11111111-1111-1111-1111-111111111111"
+EVAL_CONFIG_ID = "22222222-2222-2222-2222-222222222222"
 START = datetime(2026, 8, 1, tzinfo=UTC)
 END = datetime(2026, 8, 8, tzinfo=UTC)
 
 TIME_AGGREGATED = [
-    mm.COUNT_OF_ERRORS,
-    mm.TOKEN_USAGE,
-    mm.DAILY_TOKENS_SPENT,
-    mm.MONTHLY_TOKENS_SPENT,
+    MonitorMetricTypeChoices.COUNT_OF_ERRORS,
+    MonitorMetricTypeChoices.TOKEN_USAGE,
+    MonitorMetricTypeChoices.DAILY_TOKENS_SPENT,
+    MonitorMetricTypeChoices.MONTHLY_TOKENS_SPENT,
+]
+PER_ROW_HISTORICAL = [
+    MonitorMetricTypeChoices.ERROR_RATES_FOR_FUNCTION_CALLING,
+    MonitorMetricTypeChoices.ERROR_FREE_SESSION_RATES,
+    MonitorMetricTypeChoices.SERVICE_PROVIDER_ERROR_RATES,
+    MonitorMetricTypeChoices.LLM_API_FAILURE_RATES,
+    MonitorMetricTypeChoices.SPAN_RESPONSE_TIME,
+    MonitorMetricTypeChoices.LLM_RESPONSE_TIME,
 ]
 
 
-def _builder() -> MonitorMetricsQueryBuilder:
-    return MonitorMetricsQueryBuilder(project_id=PROJECT_ID)
+def _builder(eval_output_type: str | None = None) -> MonitorMetricsQueryBuilder:
+    return MonitorMetricsQueryBuilder(
+        project_id=PROJECT_ID,
+        eval_config_id=EVAL_CONFIG_ID if eval_output_type else None,
+        eval_output_type=eval_output_type,
+        threshold_metric_value="Good" if eval_output_type == "CHOICES" else None,
+    )
 
 
 # --- Calendar-bucketed historical stats for count/token metrics ---------------
@@ -47,10 +62,8 @@ def test_time_aggregated_historical_buckets_calendar(
     sql, _ = _builder().build_historical_stats_query(
         metric_type, START, END, interval_kind=interval_kind
     )
-    assert f"{bucket_fn}(created_at) AS bucket_ts" in sql
-    # Bucket axis capped at the window end — no sparse trailing bucket from
-    # late-ingested spans deflating the mean / inflating the stddev.
-    assert "created_at <= %(end_time)s" in sql
+    # Event time: buckets share the window's axis, so no out-of-window bucket.
+    assert f"{bucket_fn}(start_time) AS bucket_ts" in sql
     assert "GROUP BY bucket_ts" in sql
     # Sample stddev here (old path used statistics.stdev), collapsed to 0.
     assert "stddevSamp(bucket_value)" in sql
@@ -59,19 +72,80 @@ def test_time_aggregated_historical_buckets_calendar(
 
 def test_time_aggregated_historical_agg_per_metric() -> None:
     sql_err, _ = _builder().build_historical_stats_query(
-        mm.COUNT_OF_ERRORS, START, END, interval_kind="hour"
+        MonitorMetricTypeChoices.COUNT_OF_ERRORS, START, END, interval_kind="hour"
     )
     assert "countIf(status = 'ERROR') AS bucket_value" in sql_err
     sql_tok, _ = _builder().build_historical_stats_query(
-        mm.TOKEN_USAGE, START, END, interval_kind="hour"
+        MonitorMetricTypeChoices.TOKEN_USAGE, START, END, interval_kind="hour"
     )
     # No-token buckets excluded (v2 total_tokens is non-Nullable, PG NULL -> 0).
     assert "nullIf(sum(total_tokens), 0) AS bucket_value" in sql_tok
 
 
 def test_time_aggregated_historical_defaults_to_hour() -> None:
-    sql, _ = _builder().build_historical_stats_query(mm.COUNT_OF_ERRORS, START, END)
-    assert "toStartOfHour(created_at) AS bucket_ts" in sql
+    sql, _ = _builder().build_historical_stats_query(MonitorMetricTypeChoices.COUNT_OF_ERRORS, START, END)
+    assert "toStartOfHour(start_time) AS bucket_ts" in sql
+
+
+# --- stddevPop for per-row + eval stats (PG StdDev is population) -------------
+
+
+@pytest.mark.parametrize("metric_type", PER_ROW_HISTORICAL)
+def test_per_row_historical_uses_population_stddev(metric_type: str) -> None:
+    sql, _ = _builder().build_historical_stats_query(metric_type, START, END)
+    assert "stddevPop(" in sql
+    assert "stddevSamp" not in sql
+
+
+def test_eval_stats_use_population_stddev() -> None:
+    sql, _ = _builder(eval_output_type="SCORE").build_historical_stats_query(
+        MonitorMetricTypeChoices.EVALUATION_METRICS, START, END
+    )
+    assert "stddevPop(" in sql
+    assert "stddevSamp" not in sql
+
+
+# --- No-token window yields NULL, not 0 ---------------------------------------
+
+
+@pytest.mark.parametrize(
+    "metric_type",
+    [MonitorMetricTypeChoices.TOKEN_USAGE, MonitorMetricTypeChoices.DAILY_TOKENS_SPENT, MonitorMetricTypeChoices.MONTHLY_TOKENS_SPENT],
+)
+def test_token_value_null_on_empty_window(metric_type: str) -> None:
+    sql, _ = _builder().build_metric_value_query(metric_type, START, END)
+    assert "CASE WHEN countIf(total_tokens != 0) = 0 THEN NULL" in sql
+    assert "sum(total_tokens)" in sql
+
+
+# --- Provider guard (v2 provider is non-Nullable; '' means no provider) -------
+
+
+def test_provider_guard_excludes_empty_string_only() -> None:
+    for sql, _ in (
+        _builder().build_metric_value_query(
+            MonitorMetricTypeChoices.SERVICE_PROVIDER_ERROR_RATES, START, END
+        ),
+        _builder().build_historical_stats_query(
+            MonitorMetricTypeChoices.SERVICE_PROVIDER_ERROR_RATES, START, END
+        ),
+        _builder().build_time_series_query(
+            MonitorMetricTypeChoices.SERVICE_PROVIDER_ERROR_RATES, START, END, 3600
+        ),
+    ):
+        assert "provider != ''" in sql
+        assert "provider IS NOT NULL" not in sql
+
+
+# --- Eval CHOICES list containment only (PG parity) ---------------------------
+
+
+def test_eval_choices_no_output_str_fallback() -> None:
+    sql, _ = _builder(eval_output_type="CHOICES").build_metric_value_query(
+        MonitorMetricTypeChoices.EVALUATION_METRICS, START, END
+    )
+    assert "has(JSONExtract(output_str_list, 'Array(String)'), %(choice_val)s)" in sql
+    assert "OR output_str" not in sql
 
 
 # --- Evaluator routing: CH serves these metrics, PG is never touched ----------
@@ -85,10 +159,10 @@ class TestHistoricalStatsRouting:
     @pytest.mark.parametrize(
         ("metric_type", "frequency", "bucket_fn"),
         [
-            (mm.COUNT_OF_ERRORS, 60, "toStartOfHour"),
-            (mm.TOKEN_USAGE, 5, "toStartOfMinute"),
-            (mm.DAILY_TOKENS_SPENT, 60, "toStartOfDay"),
-            (mm.MONTHLY_TOKENS_SPENT, 60, "toStartOfMonth"),
+            (MonitorMetricTypeChoices.COUNT_OF_ERRORS, 60, "toStartOfHour"),
+            (MonitorMetricTypeChoices.TOKEN_USAGE, 5, "toStartOfMinute"),
+            (MonitorMetricTypeChoices.DAILY_TOKENS_SPENT, 60, "toStartOfDay"),
+            (MonitorMetricTypeChoices.MONTHLY_TOKENS_SPENT, 60, "toStartOfMonth"),
         ],
     )
     def test_ch_route_passes_interval_kind_and_skips_pg(
@@ -118,7 +192,7 @@ class TestHistoricalStatsRouting:
 
         assert (mean, stddev) == (4.2, 1.1)
         # interval_kind derived from the monitor reaches the bucket function.
-        assert f"{bucket_fn}(created_at)" in captured["query"]
+        assert f"{bucket_fn}(start_time)" in captured["query"]
         # PG path is gone structurally: the module no longer imports the
         # dropped span table at all.
         assert not hasattr(monitor_utils, "ObservationSpan")

--- a/futureagi/tracer/tests/test_monitor_metrics_session_id.py
+++ b/futureagi/tracer/tests/test_monitor_metrics_session_id.py
@@ -1,84 +1,238 @@
-"""
-Pin the monitor builder's session grouping/filter to ``trace_session_id``.
+"""Monitor builder session metrics + monitor filters: trace_session_id column,
+remap-resolved grouping, and the stable content-class filters (observation_type,
+span_attributes_filters). Pure SQL-string assertions, no ClickHouse.
 
-The live v2 spans table has no ``session_id`` column — only
-``trace_session_id`` (Nullable(UUID)) — and the v2 rewriter does not translate
-the name. These tests assert the compiled SQL uses ``trace_session_id``, drops
-the ``!= ''`` guard (invalid on a UUID column), and that the session filter is a
-direct equality (not the old malformed ``trace_id IN (SELECT id ...)`` subquery).
-"""
+Entity/time-scoping filter keys (session_id/trace_id/span_id/date_range/
+created_at) are intentionally not honored on monitors — a continuous alert owns
+its own rolling window, so pinning it to momentary ids or an absolute range would
+make the metric age out and the alert silently go dark."""
 
 from __future__ import annotations
 
 from datetime import datetime, timezone
+from typing import Any, Dict, Optional
+from unittest import mock
 
 import pytest
 
+from tracer.models.monitor import MonitorMetricTypeChoices
 from tracer.services.clickhouse.query_builders import monitor_metrics as mm
 from tracer.services.clickhouse.query_builders.monitor_metrics import (
     MonitorMetricsQueryBuilder,
 )
 
 PROJECT_ID = "11111111-1111-1111-1111-111111111111"
-SESSION_ID = "33333333-3333-3333-3333-333333333333"
 START = datetime(2026, 8, 1, tzinfo=timezone.utc)
 END = datetime(2026, 8, 8, tzinfo=timezone.utc)
 
 
-def _builder(filters=None):
+def _builder(
+    filters: Optional[Dict[str, Any]] = None,
+) -> MonitorMetricsQueryBuilder:
     return MonitorMetricsQueryBuilder(project_id=PROJECT_ID, filters=filters)
 
 
 def _assert_session_ok(sql: str) -> None:
     assert "trace_session_id" in sql
-    # Bare ``session_id`` column must never appear, nor the invalid UUID guard.
-    assert "session_id != ''" not in sql
-    # Catch a bare ``session_id`` not prefixed by ``trace_``.
+    assert "session_id != ''" not in sql, "invalid String guard on a UUID column"
+    # No bare session_id column ref (strip the trace_session_id token first).
     assert " session_id" not in sql.replace("trace_session_id", "")
 
 
-def test_error_free_session_rates_value_uses_trace_session_id():
+def test_session_rates_value_resolves_remap() -> None:
     sql, _ = _builder().build_metric_value_query(
-        mm.ERROR_FREE_SESSION_RATES, START, END
+        MonitorMetricTypeChoices.ERROR_FREE_SESSION_RATES, START, END
     )
     _assert_session_ok(sql)
-    assert "GROUP BY trace_session_id" in sql
+    assert "trace_session_id_remap" in sql, "missing session id remap resolution"
 
 
-def test_error_free_session_rates_historical_uses_trace_session_id():
+def test_session_rates_historical_resolves_remap() -> None:
     sql, _ = _builder().build_historical_stats_query(
-        mm.ERROR_FREE_SESSION_RATES, START, END
+        MonitorMetricTypeChoices.ERROR_FREE_SESSION_RATES, START, END
     )
     _assert_session_ok(sql)
-    assert "GROUP BY trace_session_id" in sql
+    assert "trace_session_id_remap" in sql
 
 
-def test_error_free_session_rates_time_series_uses_trace_session_id():
+def test_session_rates_time_series_resolves_remap() -> None:
     sql, _ = _builder().build_time_series_query(
-        mm.ERROR_FREE_SESSION_RATES, START, END, 3600
+        MonitorMetricTypeChoices.ERROR_FREE_SESSION_RATES, START, END, 3600
     )
     _assert_session_ok(sql)
-    assert "GROUP BY timestamp, trace_session_id" in sql
+    assert "trace_session_id_remap" in sql
+    assert "GROUP BY timestamp, " in sql
 
 
-def test_session_id_filter_is_direct_equality():
-    sql, params = _builder(filters={"session_id": SESSION_ID}).build_metric_value_query(
-        mm.COUNT_OF_ERRORS, START, END
+@pytest.mark.parametrize("key", ["session_id", "trace_id", "span_id", "created_at"])
+def test_entity_and_time_scoping_keys_are_ignored(key: str) -> None:
+    # These keys don't make sense on a continuous alert and must not compile to
+    # any predicate — no id match, no 1 = 0, no created_at bound.
+    sql, params = _builder(filters={key: "irrelevant"}).build_metric_value_query(
+        MonitorMetricTypeChoices.COUNT_OF_ERRORS, START, END
     )
-    assert "trace_session_id = toUUID(%(mf_session_id)s)" in sql
-    assert params["mf_session_id"] == SESSION_ID
-    # The old malformed span-id/trace-id subquery is gone.
-    assert "SELECT DISTINCT id FROM spans" not in sql
+    assert "mf_session_ids" not in sql
+    assert "mf_trace_ids" not in sql
+    assert "mf_span_ids" not in sql
+    assert "mf_created_at" not in sql
+    assert not any(k.startswith("mf_") for k in params)
 
 
-@pytest.mark.parametrize(
-    "metric_type",
-    [mm.COUNT_OF_ERRORS, mm.TOKEN_USAGE, mm.SPAN_RESPONSE_TIME],
-)
-def test_session_filter_does_not_break_other_metrics(metric_type):
-    # A session_id filter is spliced into the shared base WHERE, so it must
-    # compile for every metric type, not just error_free_session_rates.
-    sql, _ = _builder(filters={"session_id": SESSION_ID}).build_metric_value_query(
-        metric_type, START, END
+def test_date_range_filter_is_ignored() -> None:
+    # A stray absolute window (e.g. copied from a dashboard filter) is dropped,
+    # not parsed — so it neither raises nor pins the rolling window.
+    sql, params = _builder(
+        filters={"date_range": ["not-a-date", "2026-08-01"]}
+    ).build_metric_value_query(MonitorMetricTypeChoices.COUNT_OF_ERRORS, START, END)
+    assert "mf_dr_start" not in sql
+    assert not any(k.startswith("mf_") for k in params)
+
+
+def test_ignored_keys_are_logged() -> None:
+    # Each dropped legacy key emits one observability log line; SQL unchanged.
+    with mock.patch.object(mm, "logger") as mock_logger:
+        sql, params = _builder(
+            filters={"session_id": "x", "date_range": ["2026-08-01", "2026-08-08"]}
+        ).build_metric_value_query(MonitorMetricTypeChoices.COUNT_OF_ERRORS, START, END)
+    mock_logger.info.assert_any_call("monitor_filter_key_ignored", key="session_id")
+    mock_logger.info.assert_any_call("monitor_filter_key_ignored", key="date_range")
+    assert mock_logger.info.call_count == 2
+    assert "1 = 0" not in sql
+    assert not any(k.startswith("mf_") for k in params)
+
+
+def test_handled_and_project_id_keys_do_not_log() -> None:
+    with mock.patch.object(mm, "logger") as mock_logger:
+        _builder(
+            filters={"observation_type": ["llm"], "project_id": PROJECT_ID}
+        ).build_metric_value_query(MonitorMetricTypeChoices.COUNT_OF_ERRORS, START, END)
+    mock_logger.info.assert_not_called()
+
+
+def test_empty_observation_type_list_is_always_false() -> None:
+    sql, _ = _builder(filters={"observation_type": []}).build_metric_value_query(
+        MonitorMetricTypeChoices.COUNT_OF_ERRORS, START, END
     )
-    assert "trace_session_id = toUUID(%(mf_session_id)s)" in sql
+    assert "1 = 0" in sql
+    assert "IN %(mf_obs_type)s" not in sql
+
+
+def test_non_list_non_str_observation_type_raises() -> None:
+    # PG raised on bad observation_type values; silently dropping the filter
+    # would broaden the metric instead.
+    with pytest.raises(ValueError, match="observation_type"):
+        _builder(filters={"observation_type": 123})
+
+
+def test_span_attr_filter_is_inline_span_scoped() -> None:
+    filters = {
+        "span_attributes_filters": [
+            {
+                "column_id": "session.id",
+                "filter_config": {
+                    "col_type": "SPAN_ATTRIBUTE",
+                    "filter_type": "text",
+                    "filter_op": "equals",
+                    "filter_value": "x",
+                },
+            }
+        ]
+    }
+    b = _builder(filters=filters)
+    assert b._filter_clause, "attr filter must compile to a non-empty clause"
+    # Span mode (PG parity): a direct predicate on the span row, no
+    # trace-membership subquery.
+    assert "mapContains(span_attr_str, 'session.id')" in b._filter_clause
+    assert "trace_id IN (" not in b._filter_clause
+    sql, _ = b.build_metric_value_query(
+        MonitorMetricTypeChoices.COUNT_OF_ERRORS, START, END
+    )
+    # Predicate rides the tenant-scoped outer scan; no unscoped subquery.
+    assert "WHERE 1 = 1" not in sql
+    assert "trace_id IN (" not in sql
+    assert "mapContains(span_attr_str, 'session.id')" in sql
+
+
+@pytest.mark.parametrize("key", ["session_id", "trace_id", "span_id"])
+def test_empty_ignored_key_does_not_emit_always_false(key: str) -> None:
+    # Removed keys are ignored, so even an empty selection must not inject a
+    # 1 = 0 that would silently zero out the metric.
+    sql, _ = _builder(filters={key: []}).build_metric_value_query(
+        MonitorMetricTypeChoices.COUNT_OF_ERRORS, START, END
+    )
+    assert "1 = 0" not in sql
+
+
+# --- span-attribute filter span scoping -------------------------------------
+
+ATTR_FILTER = {
+    "span_attributes_filters": [
+        {
+            "column_id": "llm.model_name",
+            "filter_config": {
+                "col_type": "SPAN_ATTRIBUTE",
+                "filter_type": "text",
+                "filter_op": "equals",
+                "filter_value": "gpt-4o",
+            },
+        }
+    ]
+}
+
+
+def test_attr_filter_compiles_to_inline_predicate() -> None:
+    # Span mode: the filter is a direct predicate on the (window-pruned)
+    # outer scan — no trace-membership subquery, so no scan of the
+    # project's entire span history.
+    b = _builder(filters=ATTR_FILTER)
+    assert "mapContains(span_attr_str, 'llm.model_name')" in b._filter_clause
+    assert "span_attr_str['llm.model_name']" in b._filter_clause
+    assert "trace_id IN (" not in b._filter_clause
+
+
+@pytest.mark.parametrize("family", ["value", "historical", "time_series"])
+def test_attr_filter_start_date_bound_in_all_families(family: str) -> None:
+    # Every build method still binds %(start_date)s for the date-scoped
+    # subqueries other filter types (scores/evals/end-user) can emit.
+    b = _builder(filters=ATTR_FILTER)
+    if family == "value":
+        sql, params = b.build_metric_value_query(MonitorMetricTypeChoices.COUNT_OF_ERRORS, START, END)
+    elif family == "historical":
+        sql, params = b.build_historical_stats_query(MonitorMetricTypeChoices.COUNT_OF_ERRORS, START, END)
+    else:
+        sql, params = b.build_time_series_query(
+            MonitorMetricTypeChoices.COUNT_OF_ERRORS, START, END, 3600
+        )
+    assert params["start_date"] == params["start_time"]
+
+
+def test_attr_filter_inlined_into_eval_span_subquery() -> None:
+    # Eval monitors splice the same inline predicate into their span
+    # membership subquery — still span-scoped, no trace-membership hop.
+    b = MonitorMetricsQueryBuilder(
+        project_id=PROJECT_ID,
+        filters=ATTR_FILTER,
+        eval_config_id="22222222-2222-2222-2222-222222222222",
+        eval_output_type="SCORE",
+    )
+    sql, params = b.build_metric_value_query(
+        MonitorMetricTypeChoices.EVALUATION_METRICS, START, END
+    )
+    assert "mapContains(span_attr_str, 'llm.model_name')" in sql
+    assert "trace_id IN (" not in sql
+    # The predicate lands inside the bounded spans subquery.
+    spans_subq = sql.split("FROM spans", 1)[1]
+    assert "mapContains(span_attr_str, 'llm.model_name')" in spans_subq
+    assert params["start_date"] == params["start_time"]
+
+
+def test_dashboard_default_stays_unscoped() -> None:
+    # The shared builder must stay byte-identical for callers that don't opt
+    # in (dashboards): no %(start_date)s fragment in membership subqueries.
+    from tracer.services.clickhouse.query_builders.filters import (
+        ClickHouseFilterBuilder,
+    )
+
+    fb = ClickHouseFilterBuilder(table="spans", project_id=PROJECT_ID)
+    clause, _ = fb.translate(ATTR_FILTER["span_attributes_filters"])
+    assert "%(start_date)s" not in clause

--- a/futureagi/tracer/tests/test_monitor_metrics_start_time.py
+++ b/futureagi/tracer/tests/test_monitor_metrics_start_time.py
@@ -1,23 +1,21 @@
-"""
-Pin the monitor builder's time-window predicates to ``start_time``.
+"""Monitor builder time windows — event-time semantics.
 
-The v2 spans table is ``PARTITION BY toDate(start_time)`` with
-``toStartOfHour(start_time)`` in the primary key and no index on
-``created_at``. Filtering ``created_at`` prunes nothing → full-history scans.
-These tests assert the COMPILED SQL filters/buckets spans on ``start_time``
-(with a padded ``created_at`` companion bound); eval-table queries window and
-bucket via their joined span (the eval table has no ``start_time`` column).
-
-No real ClickHouse is hit — only the generated SQL string is asserted.
+Everything (alerts, graphs, baselines) measures when the activity happened in
+the user's system: exact half-open ``start_time`` window (also the partition
+key, so it prunes directly) + a padded ``created_at`` lower guard against
+clock-skewed producers. Buckets are on ``start_time``; eval queries window and
+bucket via their joined span (the eval table has no span-time column).
+Pure SQL-string assertions, no ClickHouse.
 """
 
 from __future__ import annotations
 
 from datetime import UTC, datetime
+from typing import Any
 
 import pytest
 
-from tracer.services.clickhouse.query_builders import monitor_metrics as mm
+from tracer.models.monitor import MonitorMetricTypeChoices
 from tracer.services.clickhouse.query_builders.monitor_metrics import (
     MonitorMetricsQueryBuilder,
 )
@@ -27,35 +25,36 @@ EVAL_CONFIG_ID = "22222222-2222-2222-2222-222222222222"
 START = datetime(2026, 8, 1, tzinfo=UTC)
 END = datetime(2026, 8, 8, tzinfo=UTC)
 
-COMPANION = "created_at >= %(start_time)s - INTERVAL 1 DAY"
-BETWEEN_START = "start_time BETWEEN %(start_time)s AND %(end_time)s"
-HALF_OPEN_START = "start_time >= %(start_time)s AND start_time < %(end_time)s"
+# One unified half-open event-time window for every spans query.
+EXACT_HALF_OPEN = "start_time >= %(start_time)s AND start_time < %(end_time)s"
+SKEW_GUARD = "created_at >= %(start_time)s - INTERVAL 1 DAY"
 
-# Spans metric types whose time window is a BETWEEN on start_time.
-SPANS_BETWEEN = [
-    mm.COUNT_OF_ERRORS,
-    mm.ERROR_RATES_FOR_FUNCTION_CALLING,
-    mm.ERROR_FREE_SESSION_RATES,
-    mm.SERVICE_PROVIDER_ERROR_RATES,
-    mm.LLM_API_FAILURE_RATES,
-    mm.SPAN_RESPONSE_TIME,
-    mm.LLM_RESPONSE_TIME,
-    mm.TOKEN_USAGE,
+SPANS_METRICS = [
+    MonitorMetricTypeChoices.COUNT_OF_ERRORS,
+    MonitorMetricTypeChoices.ERROR_RATES_FOR_FUNCTION_CALLING,
+    MonitorMetricTypeChoices.ERROR_FREE_SESSION_RATES,
+    MonitorMetricTypeChoices.SERVICE_PROVIDER_ERROR_RATES,
+    MonitorMetricTypeChoices.LLM_API_FAILURE_RATES,
+    MonitorMetricTypeChoices.SPAN_RESPONSE_TIME,
+    MonitorMetricTypeChoices.LLM_RESPONSE_TIME,
+    MonitorMetricTypeChoices.TOKEN_USAGE,
+    MonitorMetricTypeChoices.DAILY_TOKENS_SPENT,
+    MonitorMetricTypeChoices.MONTHLY_TOKENS_SPENT,
 ]
-SPANS_HALF_OPEN = [mm.DAILY_TOKENS_SPENT, mm.MONTHLY_TOKENS_SPENT]
-# Per-row metrics that have a historical-stats branch (excludes the
-# time-aggregated ones handled in Python and eval).
 HISTORICAL_SPANS = [
-    mm.ERROR_RATES_FOR_FUNCTION_CALLING,
-    mm.ERROR_FREE_SESSION_RATES,
-    mm.SERVICE_PROVIDER_ERROR_RATES,
-    mm.LLM_API_FAILURE_RATES,
-    mm.SPAN_RESPONSE_TIME,
-    mm.LLM_RESPONSE_TIME,
+    MonitorMetricTypeChoices.ERROR_RATES_FOR_FUNCTION_CALLING,
+    MonitorMetricTypeChoices.ERROR_FREE_SESSION_RATES,
+    MonitorMetricTypeChoices.SERVICE_PROVIDER_ERROR_RATES,
+    MonitorMetricTypeChoices.LLM_API_FAILURE_RATES,
+    MonitorMetricTypeChoices.SPAN_RESPONSE_TIME,
+    MonitorMetricTypeChoices.LLM_RESPONSE_TIME,
 ]
 
 
-def _builder(filters=None, eval_output_type=None):
+def _builder(
+    filters: dict[str, Any] | None = None,
+    eval_output_type: str | None = None,
+) -> MonitorMetricsQueryBuilder:
     return MonitorMetricsQueryBuilder(
         project_id=PROJECT_ID,
         filters=filters,
@@ -65,77 +64,57 @@ def _builder(filters=None, eval_output_type=None):
     )
 
 
-def _assert_spans_pruned(sql: str) -> None:
-    """A spans query must prune on start_time and never bind bare created_at."""
-    assert COMPANION in sql, "missing padded created_at companion bound"
-    assert "created_at BETWEEN" not in sql, "spans query still filters created_at"
+def _assert_event_time_window(sql: str) -> None:
+    assert EXACT_HALF_OPEN in sql, "missing exact start_time window"
+    assert SKEW_GUARD in sql, "missing created_at skew guard"
+    assert "created_at BETWEEN" not in sql
+    assert "created_at >= %(start_time)s AND created_at < %(end_time)s" not in sql
 
 
-@pytest.mark.parametrize("metric_type", SPANS_BETWEEN)
-def test_metric_value_spans_filter_start_time(metric_type):
+@pytest.mark.parametrize("metric_type", SPANS_METRICS)
+def test_metric_value_event_time_window(metric_type: str) -> None:
     sql, _ = _builder().build_metric_value_query(metric_type, START, END)
-    assert BETWEEN_START in sql
-    _assert_spans_pruned(sql)
-
-
-@pytest.mark.parametrize("metric_type", SPANS_HALF_OPEN)
-def test_metric_value_half_open_filters_start_time(metric_type):
-    sql, _ = _builder().build_metric_value_query(metric_type, START, END)
-    assert HALF_OPEN_START in sql
-    _assert_spans_pruned(sql)
+    _assert_event_time_window(sql)
 
 
 @pytest.mark.parametrize("metric_type", HISTORICAL_SPANS)
-def test_historical_stats_filter_start_time(metric_type):
+def test_historical_stats_event_time_window(metric_type: str) -> None:
     sql, _ = _builder().build_historical_stats_query(metric_type, START, END)
-    assert BETWEEN_START in sql
-    _assert_spans_pruned(sql)
+    _assert_event_time_window(sql)
 
 
-@pytest.mark.parametrize("metric_type", SPANS_BETWEEN)
-def test_time_series_buckets_and_filters_start_time(metric_type):
+@pytest.mark.parametrize("metric_type", SPANS_METRICS)
+def test_time_series_buckets_start_time(metric_type: str) -> None:
     sql, _ = _builder().build_time_series_query(metric_type, START, END, 3600)
-    assert "toUInt32(start_time)" in sql, "spans bucket must floor start_time"
+    assert "toUInt32(start_time)" in sql, "series must bucket on event time"
     assert "toUInt32(created_at)" not in sql
-    _assert_spans_pruned(sql)
+    _assert_event_time_window(sql)
 
 
-def test_date_range_and_created_at_filters_use_start_time():
-    filters = {
-        "date_range": [START.isoformat(), END.isoformat()],
-        "created_at": START.isoformat(),
-    }
-    sql, _ = _builder(filters=filters).build_metric_value_query(
-        mm.COUNT_OF_ERRORS, START, END
-    )
-    assert "start_time BETWEEN %(mf_dr_start)s AND %(mf_dr_end)s" in sql
-    assert "start_time >= %(mf_created_at)s" in sql
-    assert "created_at BETWEEN %(mf_dr_start)s" not in sql
+# --- Eval queries window/bucket via the joined span --------------------------
 
 
-# --- Eval-table queries window/bucket via the joined span, not created_at ----
-
-
-def test_eval_value_query_windows_span_time():
+def test_eval_value_query_windows_span_time() -> None:
     # The metric window lives on the SPAN membership join (evals run async
     # after their spans); the eval table keeps only a loose created_at lower
     # bound (its sole partition prune).
     sql, _ = _builder(eval_output_type="SCORE").build_metric_value_query(
-        mm.EVALUATION_METRICS, START, END
+        MonitorMetricTypeChoices.EVALUATION_METRICS, START, END
     )
     subq = sql.split("INNER JOIN (", 1)[1]
-    assert "created_at >= %(start_time)s AND created_at < %(end_time)s" in subq
+    assert EXACT_HALF_OPEN in subq
     guards = sql.split("ON observation_span_id = sp.id", 1)[1]
-    assert "created_at >= %(start_time)s - INTERVAL 1 DAY" in guards
+    assert SKEW_GUARD in guards
     # No bucket expression in a scalar query.
     assert "toUInt32(" not in sql
 
 
-def test_eval_time_series_buckets_span_start_time():
+def test_eval_time_series_buckets_span_start_time() -> None:
     # Eval graphs chart the user's application timeline: buckets come from
     # the joined span's start_time, never the eval row's created_at.
     sql, _ = _builder(eval_output_type="SCORE").build_time_series_query(
-        mm.EVALUATION_METRICS, START, END, 3600
+        MonitorMetricTypeChoices.EVALUATION_METRICS, START, END, 3600
     )
     assert "toUInt32(sp.start_time)" in sql
     assert "toUInt32(created_at)" not in sql
+    assert "INNER JOIN" in sql and "ON observation_span_id = sp.id" in sql


### PR DESCRIPTION
## Summary

With every query running, this PR closes the remaining correctness gaps against pre-migration behavior and finalizes filter semantics: population-vs-sample stddev split, NULL (not 0) on empty token windows, NaN guards, session-alias dedup via the id-remap survivor map, one unified half-open time window, monitors honoring only stable content-class filters, and date-scoped filter membership subqueries. PR 6 of 7.

## Linked issues

Linear: Fixed TH-7538

## Type of change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] 🚀 Performance improvement

---

## 1) What changes were done

**A. Parity semantics**

- Per-row metrics + eval stats use `stddevPop` (PG `StdDev` default); the four bucketed metrics keep `stddevSamp` (old `statistics.stdev`). NaN → NULL via `ifNotFinite` so empty windows suppress alerts instead of firing.
- Token metrics return NULL on no-token windows (`countIf(total_tokens != 0) = 0`) — v2 `total_tokens` is non-Nullable, and a `0` would false-fire `LESS_THAN` spend monitors.
- One unified half-open window `[start, end)` for all spans queries — no boundary double-count in trailing spend sums; the three token metrics collapse into one branch (their trailing window is the evaluator's start override, not SQL).
- **Event-time semantics (review update):** the unified window is exact on **`start_time`** (when it happened in the user's system — also the partition key, so it prunes directly), with `created_at` kept only as a −1d clock-skew guard. Buckets are on `start_time` everywhere (spans series, calendar baselines, eval series via the span join). Alerts, graphs and baselines all measure the user's timeline; the known trade-off is late-ingested spans missing an already-evaluated window (TODO: ingest-lag offset).
- **stddev split is deliberate:** per-row + eval stats use `stddevPop` (PG `StdDev` default); the four bucketed metrics use `stddevSamp` (old `statistics.stdev`). Same data can produce slightly different effective thresholds across metric families — do not "clean up" one into the other.
- `ERROR_FREE_SESSION_RATES` resolves session ids through the `trace_session_id_remap` survivor map before grouping, so old/new aliases of one logical session count once.

**B. Filter semantics + performance**

- Monitors honor only stable content-class filters (`observation_type`, `span_attributes_filters`); entity/time-scoping keys (`session_id`/`trace_id`/`span_id`/`date_range`/`created_at`) are intentionally ignored — a continuous alert owns its rolling window; pinning it to momentary ids makes the metric age out and the alert silently go dark. Ignored keys are logged (`monitor_filter_key_ignored`); a prod audit found **0 of 45** monitors store any of these keys. Invalid `observation_type` values raise `MonitorConfigError` (was: silent drop).
- **Span-scoped attr filters (review update):** monitors pass `query_mode=QUERY_MODE_SPAN`, so a span-attribute filter is an inline predicate on the span row itself — PG parity (`Q(span_attributes__contains=...)`) and an alert counts only matching spans. This deliberately diverges from the dashboard's trace-scoping, and it removes the trace-membership subquery from the monitor path entirely (the `span_date_scope`/`score_date_scope` seams stay on for the subqueries end-user/score filters still emit; `%(start_date)s` bound in all three build methods). **Zero changes to the shared filter builder — dashboard SQL untouched.**
- Metric-type dispatch compares against `MonitorMetricTypeChoices` directly.

## 2) Why the changes were done

- **Product:** semantic drift here shifts thresholds — false positives/negatives even when queries "work".
- **Technical:** each divergence from PG was resolved explicitly: match PG where it's the contract, prefer the v2-faithful form where the schema changed (documented inline).

---

## 3) Tests written + scenarios each covers

**`tracer/tests/test_monitor_metrics_parity.py`** — stddevPop/Samp split per metric, token NULL-on-empty, provider empty-string guard, CHOICES containment-only, eval stats population stddev.
**`tracer/tests/test_monitor_metrics_start_time.py`** — unified half-open window across every spans metric × family; `BETWEEN` absent; pruning pads intact.
**`tracer/tests/test_monitor_metrics_session_id.py`** — remap survivor-map grouping in all three families; ignored filter keys emit no predicate (and no `1 = 0`); attr-filter subquery date-scoped with `start_date` bound in all families and in the eval splice path; dashboard default stays unscoped.

> Run result: full tracer suite green at this commit, including **`tracer/tests/test_monitor_metrics_execution_smoke.py`** — 44 tests that EXECUTE every metric × family through the routed V2 builder against the live test ClickHouse (exact-value assertions incl. the remap straddler and the eval span join, empty-window NULL semantics).

## 4) How to run / test

```bash
cd futureagi
.venv/bin/python -m pytest tracer/tests/test_monitor_metrics_parity.py tracer/tests/test_monitor_metrics_start_time.py tracer/tests/test_monitor_metrics_session_id.py -q
```

---

**Stack:** PR 6/7, on `fix/alerts-remove-pg-fallbacks`.

