### PR TITLE
feat: color bar/line series by breakdown value (hue) and metric (shade)

### DIFF
--- a/frontend/src/sections/dashboards/WidgetChart.jsx
+++ b/frontend/src/sections/dashboards/WidgetChart.jsx
@@ -23,52 +23,13 @@ import {
 import WidgetPieCharts from "./WidgetPieCharts";
 import { toTimeRangePayload } from "./dashboardDateRange";
 import { NO_DATA_FOR_RANGE_MESSAGE } from "./constants";
+import {
+  buildBreakdownColorMap,
+  buildSeriesColorMap,
+  getSeriesColorFromMap,
+} from "./seriesColors";
 
 const CHART_HEIGHT_FALLBACK = 280;
-const COLORS = [
-  "#7B56DB", // purple (primary)
-  "#1ABCFE", // cyan
-  "#FF6B6B", // coral red
-  "#2ECB71", // emerald green
-  "#F7B731", // amber
-  "#E84393", // magenta pink
-  "#0984E3", // ocean blue
-  "#FD7E14", // tangerine orange
-  "#00CEC9", // teal
-  "#A29BFE", // lavender
-];
-
-const hashSeriesName = (name) => {
-  const s = String(name || "");
-  let h = 0;
-  for (let i = 0; i < s.length; i += 1) {
-    h = (h * 31 + s.charCodeAt(i)) | 0;
-  }
-  return Math.abs(h);
-};
-// Name-hash gives cross-reload stability, but a bare hash % palette collides ~50%
-// at 4 series. Walk each name once and, on a taken slot, advance to the next
-// free one — distinct up to palette size, stable for the common non-colliding case.
-const buildSeriesColorMap = (names) => {
-  const map = {};
-  const used = new Set();
-  (names || []).forEach((name) => {
-    const start = hashSeriesName(name) % COLORS.length;
-    let picked = start;
-    for (let i = 0; i < COLORS.length; i += 1) {
-      const candidate = (start + i) % COLORS.length;
-      if (!used.has(candidate)) {
-        picked = candidate;
-        break;
-      }
-    }
-    used.add(picked);
-    map[name] = COLORS[picked];
-  });
-  return map;
-};
-const getSeriesColorFromMap = (map, name) =>
-  (map && map[name]) || COLORS[hashSeriesName(name) % COLORS.length];
 
 function getApexType(chartType) {
   const map = {
@@ -220,9 +181,14 @@ export default function WidgetChart({ widget, globalDateRange }) {
 
   // Build from the full `series` list (not filtered chartSeries) so a
   // hidden series keeps its slot and its color stays put when unhidden.
+  // Bar/Line/Stacked color each series by its breakdown value (a stable base
+  // hue) plus its metric (a nearby shade); `total` falls back to legacy colors.
   const seriesColorMap = useMemo(
-    () => buildSeriesColorMap(series.map((s) => s.name)),
-    [series],
+    () =>
+      buildBreakdownColorMap(series, {
+        isDark: theme.palette.mode === "dark",
+      }),
+    [series, theme.palette.mode],
   );
   const colorFor = (name) => getSeriesColorFromMap(seriesColorMap, name);
 
@@ -1148,7 +1114,7 @@ export default function WidgetChart({ widget, globalDateRange }) {
       {legendNames.length > 1 && (
         <ChartLegend
           items={legendNames}
-          colors={COLORS}
+          colors={legendNames.map((name) => colorFor(name))}
           onHoverSeries={handleLegendHover}
           onLeaveSeries={handleLegendLeave}
         />

--- a/frontend/src/sections/dashboards/WidgetEditorView.jsx
+++ b/frontend/src/sections/dashboards/WidgetEditorView.jsx
@@ -92,6 +92,11 @@ import {
   toAxisConfigPayload,
 } from "./widgetUtils";
 import {
+  buildBreakdownColorMap,
+  buildSeriesColorMap,
+  getSeriesColorFromMap,
+} from "./seriesColors";
+import {
   AGGREGATION_OPTIONS,
   ALL_AGGREGATIONS,
   PERCENTILE_OPTIONS,
@@ -340,48 +345,9 @@ const METRIC_TYPE_ICONS = {
   custom_column: "mdi:table-column",
 };
 
-const SERIES_COLORS = [
-  "#7B56DB", // purple (primary)
-  "#1ABCFE", // cyan
-  "#FF6B6B", // coral red
-  "#2ECB71", // emerald green
-  "#F7B731", // amber
-  "#E84393", // magenta pink
-  "#0984E3", // ocean blue
-  "#FD7E14", // tangerine orange
-  "#00CEC9", // teal
-  "#A29BFE", // lavender
-];
-
-const hashSeriesName = (name) => {
-  const s = String(name || "");
-  let h = 0;
-  for (let i = 0; i < s.length; i += 1) {
-    h = (h * 31 + s.charCodeAt(i)) | 0;
-  }
-  return Math.abs(h);
-};
-const buildSeriesColorMap = (names) => {
-  const map = {};
-  const used = new Set();
-  (names || []).forEach((name) => {
-    const start = hashSeriesName(name) % SERIES_COLORS.length;
-    let picked = start;
-    for (let i = 0; i < SERIES_COLORS.length; i += 1) {
-      const candidate = (start + i) % SERIES_COLORS.length;
-      if (!used.has(candidate)) {
-        picked = candidate;
-        break;
-      }
-    }
-    used.add(picked);
-    map[name] = SERIES_COLORS[picked];
-  });
-  return map;
-};
-const getSeriesColor = (name, map) =>
-  (map && map[name]) ||
-  SERIES_COLORS[hashSeriesName(name) % SERIES_COLORS.length];
+// Thin alias over the shared seriesColors resolver, preserving the existing
+// `(name, map)` argument order used throughout this file.
+const getSeriesColor = (name, map) => getSeriesColorFromMap(map, name);
 
 const LETTER_LABELS = "ABCDEFGHIJKLMNOPQRSTUVWXYZ";
 
@@ -2291,8 +2257,11 @@ export default function WidgetEditorView() {
   // share a color inside one widget. Built from previewSeries so hidden
   // series keep their color when re-checked.
   const seriesColorMap = useMemo(
-    () => buildSeriesColorMap(previewSeries.map((s) => s.name)),
-    [previewSeries],
+    () =>
+      buildBreakdownColorMap(previewSeries, {
+        isDark: theme.palette.mode === "dark",
+      }),
+    [previewSeries, theme.palette.mode],
   );
   const chartColors = useMemo(
     () => chartSeries.map((s) => getSeriesColor(s.name, seriesColorMap)),

--- a/frontend/src/sections/dashboards/__tests__/WidgetChart.test.jsx
+++ b/frontend/src/sections/dashboards/__tests__/WidgetChart.test.jsx
@@ -4,6 +4,7 @@ import { render, screen } from "src/utils/test-utils";
 import WidgetChart from "../WidgetChart";
 import WidgetPieCharts from "../WidgetPieCharts";
 import { NO_DATA_FOR_RANGE_MESSAGE } from "../constants";
+import { buildBreakdownColorMap } from "../seriesColors";
 
 const h = vi.hoisted(() => ({
   query: { data: null, isPending: false, isError: false, mutate: vi.fn() },
@@ -19,6 +20,17 @@ vi.mock("react-apexcharts", () => ({
       data-testid={`apex-${props.type}`}
       data-series={JSON.stringify(props.series)}
       data-labels={JSON.stringify(props.options?.labels ?? null)}
+      data-colors={JSON.stringify(props.options?.colors ?? null)}
+    />
+  ),
+}));
+
+vi.mock("../ChartLegend", () => ({
+  default: (props) => (
+    <div
+      data-testid="chart-legend"
+      data-items={JSON.stringify(props.items ?? [])}
+      data-colors={JSON.stringify(props.colors ?? [])}
     />
   ),
 }));
@@ -389,5 +401,84 @@ describe("WidgetPieCharts — nothing to draw in any metric", () => {
     expect(
       screen.getByText(/Nothing to chart for this metric/),
     ).toBeInTheDocument();
+  });
+});
+
+describe("WidgetChart — breakdown colors reach Apex and the legend", () => {
+  const pt = (value, hour = 0) => ({
+    timestamp: `2026-07-09T0${hour}:00:00Z`,
+    value,
+  });
+
+  const lineWidget = {
+    id: "w-line",
+    query_config: {
+      metrics: [
+        { name: "Requests", aggregation: "avg" },
+        { name: "Errors", aggregation: "avg" },
+      ],
+      breakdowns: [{ name: "service" }],
+    },
+    chart_config: { chart_type: "line" },
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    h.query.isPending = false;
+    h.query.isError = false;
+    h.query.data = {
+      data: {
+        result: {
+          metrics: [
+            {
+              name: "Requests",
+              aggregation: "avg",
+              series: [
+                { name: "api-gateway", data: [pt(10), pt(20, 1)] },
+                { name: "web-frontend", data: [pt(30), pt(40, 1)] },
+              ],
+            },
+            {
+              name: "Errors",
+              aggregation: "avg",
+              series: [
+                { name: "api-gateway", data: [pt(1), pt(2, 1)] },
+                { name: "web-frontend", data: [pt(3), pt(4, 1)] },
+              ],
+            },
+          ],
+        },
+      },
+    };
+  });
+
+  it("feeds Apex and ChartLegend the same breakdown-aware colors", () => {
+    render(<WidgetChart widget={lineWidget} globalDateRange={null} />);
+
+    const names = [
+      "Requests / api-gateway (avg)",
+      "Requests / web-frontend (avg)",
+      "Errors / api-gateway (avg)",
+      "Errors / web-frontend (avg)",
+    ];
+    const expected = buildBreakdownColorMap(
+      [
+        { name: names[0], breakdownName: "api-gateway", metricIndex: 0 },
+        { name: names[1], breakdownName: "web-frontend", metricIndex: 0 },
+        { name: names[2], breakdownName: "api-gateway", metricIndex: 1 },
+        { name: names[3], breakdownName: "web-frontend", metricIndex: 1 },
+      ],
+      { isDark: false },
+    );
+    const expectedColors = names.map((name) => expected[name]);
+
+    const apexColors = JSON.parse(
+      screen.getByTestId("apex-line").getAttribute("data-colors"),
+    );
+    expect(apexColors).toEqual(expectedColors);
+
+    const legend = screen.getByTestId("chart-legend");
+    expect(JSON.parse(legend.getAttribute("data-items"))).toEqual(names);
+    expect(JSON.parse(legend.getAttribute("data-colors"))).toEqual(apexColors);
   });
 });

--- a/frontend/src/sections/dashboards/__tests__/seriesColors.test.js
+++ b/frontend/src/sections/dashboards/__tests__/seriesColors.test.js
@@ -1,0 +1,144 @@
+import {
+  buildBreakdownColorMap,
+  buildSeriesColorMap,
+} from "../seriesColors";
+
+const hexToHsl = (hex) => {
+  const clean = hex.replace("#", "");
+  const n = parseInt(clean, 16);
+  const r = ((n >> 16) & 255) / 255;
+  const g = ((n >> 8) & 255) / 255;
+  const b = (n & 255) / 255;
+  const max = Math.max(r, g, b);
+  const min = Math.min(r, g, b);
+  const l = (max + min) / 2;
+  if (max === min) return { h: 0, s: 0, l };
+  const d = max - min;
+  const s = l > 0.5 ? d / (2 - max - min) : d / (max + min);
+  let h;
+  switch (max) {
+    case r:
+      h = (g - b) / d + (g < b ? 6 : 0);
+      break;
+    case g:
+      h = (b - r) / d + 2;
+      break;
+    default:
+      h = (r - g) / d + 4;
+      break;
+  }
+  return { h: h * 60, s, l };
+};
+
+const series = (name, breakdownName, metricIndex) => ({
+  name,
+  breakdownName,
+  metricIndex,
+});
+
+describe("buildBreakdownColorMap", () => {
+  it("falls back to legacy composite-label colors when there is no breakdown", () => {
+    const rows = [
+      series("requests (avg)", "total", 0),
+      series("errors (avg)", "total", 1),
+    ];
+    const map = buildBreakdownColorMap(rows, { isDark: false });
+    expect(map).toEqual(buildSeriesColorMap(rows.map((s) => s.name)));
+  });
+
+  it("gives one breakdown value the same base hue across metrics", () => {
+    const rows = [
+      series("requests / api-gateway (avg)", "api-gateway", 0),
+      series("errors / api-gateway (avg)", "api-gateway", 1),
+      series("requests / web-frontend (avg)", "web-frontend", 0),
+      series("errors / web-frontend (avg)", "web-frontend", 1),
+    ];
+    const map = buildBreakdownColorMap(rows, { isDark: false });
+    const hueA0 = hexToHsl(map["requests / api-gateway (avg)"]).h;
+    const hueA1 = hexToHsl(map["errors / api-gateway (avg)"]).h;
+    const hueB0 = hexToHsl(map["requests / web-frontend (avg)"]).h;
+    const hueB1 = hexToHsl(map["errors / web-frontend (avg)"]).h;
+    // Same breakdown -> same hue (the metric only shifts lightness).
+    expect(Math.abs(hueA0 - hueA1)).toBeLessThan(4);
+    expect(Math.abs(hueB0 - hueB1)).toBeLessThan(4);
+    // Different breakdowns -> different base hues (321 vs 205).
+    expect(Math.abs(hueA0 - hueB0)).toBeGreaterThan(2);
+  });
+
+  it("maps each metric to a distinct shade within one breakdown value", () => {
+    const rows = [
+      series("requests / project-a (avg)", "project-a", 0),
+      series("errors / project-a (avg)", "project-a", 1),
+      series("latency / project-a (avg)", "project-a", 2),
+    ];
+    const map = buildBreakdownColorMap(rows, { isDark: false });
+    const colors = rows.map((s) => map[s.name]);
+    expect(new Set(colors).size).toBe(rows.length);
+  });
+
+  it("applies the same shade step per metric across every breakdown value", () => {
+    const rows = [
+      series("requests / project-a (avg)", "project-a", 0),
+      series("errors / project-a (avg)", "project-a", 1),
+      series("requests / project-b (avg)", "project-b", 0),
+      series("errors / project-b (avg)", "project-b", 1),
+    ];
+    const map = buildBreakdownColorMap(rows, { isDark: false });
+    const deltaA =
+      hexToHsl(map["requests / project-a (avg)"]).l -
+      hexToHsl(map["errors / project-a (avg)"]).l;
+    const deltaB =
+      hexToHsl(map["requests / project-b (avg)"]).l -
+      hexToHsl(map["errors / project-b (avg)"]).l;
+    // metricIndex 1 is the same shade level regardless of the breakdown. Hex
+    // output quantizes to 8-bit channels, so allow ~0.05 lightness tolerance.
+    expect(deltaA).toBeCloseTo(deltaB, 1);
+  });
+
+  it("darkens shades in the light theme and lightens them in the dark theme", () => {
+    const rows = [
+      series("requests / project-a (avg)", "project-a", 0),
+      series("errors / project-a (avg)", "project-a", 1),
+    ];
+    const light = buildBreakdownColorMap(rows, { isDark: false });
+    const dark = buildBreakdownColorMap(rows, { isDark: true });
+    const base = hexToHsl(light["requests / project-a (avg)"]).l;
+    const lightShade = hexToHsl(light["errors / project-a (avg)"]).l;
+    const darkShade = hexToHsl(dark["errors / project-a (avg)"]).l;
+    expect(lightShade).toBeLessThan(base);
+    expect(darkShade).toBeGreaterThan(base);
+  });
+
+  it("is stable across repeated calls (reload / re-query)", () => {
+    const rows = [
+      series("requests / project-a (avg)", "project-a", 0),
+      series("errors / project-b (avg)", "project-b", 1),
+    ];
+    const first = buildBreakdownColorMap(rows, { isDark: false });
+    const second = buildBreakdownColorMap([...rows], { isDark: false });
+    expect(second).toEqual(first);
+  });
+
+  it("keeps a breakdown value's hue when other values appear", () => {
+    const a = series("requests / project-a (avg)", "project-a", 0);
+    const b = series("errors / project-b (avg)", "project-b", 0);
+    const c = series("latency / project-c (avg)", "project-c", 0);
+    const alone = buildBreakdownColorMap([a], { isDark: false });
+    const withOthers = buildBreakdownColorMap([a, b, c], { isDark: false });
+    expect(withOthers[a.name]).toBe(alone[a.name]);
+  });
+
+  it("uses metricIndex directly for the shade level", () => {
+    const m2 = series("requests / project-a (avg)", "project-a", 2);
+    const full = buildBreakdownColorMap(
+      [
+        series("requests / project-a (avg)", "project-a", 0),
+        series("errors / project-a (avg)", "project-a", 1),
+        m2,
+      ],
+      { isDark: false },
+    );
+    const sparse = buildBreakdownColorMap([m2], { isDark: false });
+    expect(sparse[m2.name]).toBe(full[m2.name]);
+  });
+});

--- a/frontend/src/sections/dashboards/seriesColors.js
+++ b/frontend/src/sections/dashboards/seriesColors.js
@@ -1,0 +1,168 @@
+// Shared dashboard series color logic.
+//
+// Bar, Stacked Bar and Line color each series by its breakdown value (one
+// stable base hue) plus its metric (a nearby shade). Pie and the no-breakdown
+// (`total`) case keep the legacy composite-label coloring.
+
+export const CHART_COLORS = [
+  "#7B56DB", // purple (primary)
+  "#1ABCFE", // cyan
+  "#FF6B6B", // coral red
+  "#2ECB71", // emerald green
+  "#F7B731", // amber
+  "#E84393", // magenta pink
+  "#0984E3", // ocean blue
+  "#FD7E14", // tangerine orange
+  "#00CEC9", // teal
+  "#A29BFE", // lavender
+];
+
+export const hashSeriesName = (name) => {
+  const s = String(name || "");
+  let h = 0;
+  for (let i = 0; i < s.length; i += 1) {
+    h = (h * 31 + s.charCodeAt(i)) | 0;
+  }
+  return Math.abs(h);
+};
+
+// Name-hash gives cross-reload stability, but a bare hash % palette collides
+// ~50% at 4 series. Walk each name once and, on a taken slot, advance to the
+// next free one: distinct up to palette size, stable for the common case.
+export const buildSeriesColorMap = (names) => {
+  const map = {};
+  const used = new Set();
+  (names || []).forEach((name) => {
+    const start = hashSeriesName(name) % CHART_COLORS.length;
+    let picked = start;
+    for (let i = 0; i < CHART_COLORS.length; i += 1) {
+      const candidate = (start + i) % CHART_COLORS.length;
+      if (!used.has(candidate)) {
+        picked = candidate;
+        break;
+      }
+    }
+    used.add(picked);
+    map[name] = CHART_COLORS[picked];
+  });
+  return map;
+};
+
+export const getSeriesColorFromMap = (map, name) =>
+  (map && map[name]) || CHART_COLORS[hashSeriesName(name) % CHART_COLORS.length];
+
+// Lightness delta (in HSL, 0..1) between adjacent metric shades.
+const SHADE_STEP = 0.09;
+// Keep shades off the extreme ends so they stay distinguishable from the chart
+// background in both themes.
+const MIN_LIGHTNESS = 0.18;
+const MAX_LIGHTNESS = 0.85;
+
+function hexToRgb(hex) {
+  const clean = String(hex).replace("#", "");
+  const n = parseInt(clean, 16);
+  return { r: (n >> 16) & 255, g: (n >> 8) & 255, b: n & 255 };
+}
+
+function rgbToHsl({ r, g, b }) {
+  const rn = r / 255;
+  const gn = g / 255;
+  const bn = b / 255;
+  const max = Math.max(rn, gn, bn);
+  const min = Math.min(rn, gn, bn);
+  const l = (max + min) / 2;
+  let h = 0;
+  let s = 0;
+  if (max !== min) {
+    const d = max - min;
+    s = l > 0.5 ? d / (2 - max - min) : d / (max + min);
+    switch (max) {
+      case rn:
+        h = (gn - bn) / d + (gn < bn ? 6 : 0);
+        break;
+      case gn:
+        h = (bn - rn) / d + 2;
+        break;
+      default:
+        h = (rn - gn) / d + 4;
+        break;
+    }
+    h /= 6;
+  }
+  return { h: h * 360, s, l };
+}
+
+function hslToRgb(h, s, l) {
+  const hn = ((((h % 360) + 360) % 360) / 360);
+  const hue2rgb = (p, q, t) => {
+    let tn = t;
+    if (tn < 0) tn += 1;
+    if (tn > 1) tn -= 1;
+    if (tn < 1 / 6) return p + (q - p) * 6 * tn;
+    if (tn < 1 / 2) return q;
+    if (tn < 2 / 3) return p + (q - p) * (2 / 3 - tn) * 6;
+    return p;
+  };
+  let r;
+  let g;
+  let b;
+  if (s === 0) {
+    r = g = b = l;
+  } else {
+    const q = l < 0.5 ? l * (1 + s) : l + s - l * s;
+    const p = 2 * l - q;
+    r = hue2rgb(p, q, hn + 1 / 3);
+    g = hue2rgb(p, q, hn);
+    b = hue2rgb(p, q, hn - 1 / 3);
+  }
+  return { r: Math.round(r * 255), g: Math.round(g * 255), b: Math.round(b * 255) };
+}
+
+function rgbToHex({ r, g, b }) {
+  const clamp = (v) => Math.max(0, Math.min(255, Math.round(v)));
+  const to2 = (v) => clamp(v).toString(16).padStart(2, "0");
+  return `#${to2(r)}${to2(g)}${to2(b)}`.toUpperCase();
+}
+
+// One stable base hue per breakdown value, spread across the full hue wheel.
+// Derived from the name hash alone, so a value keeps its hue regardless of
+// which other breakdown values are present.
+const breakdownBaseHex = (breakdownName) => {
+  const hue = hashSeriesName(breakdownName) % 360;
+  return rgbToHex(hslToRgb(hue, 0.65, 0.52));
+};
+
+// Shift a base hue's lightness by the metric's shade position. In the light
+// theme shades darken away from the light background; in the dark theme they
+// lighten away from the dark background.
+const shadeBaseColor = (baseHex, pos, isDark) => {
+  const { r, g, b } = hexToRgb(baseHex);
+  const { h, s, l } = rgbToHsl({ r, g, b });
+  const delta = pos * SHADE_STEP;
+  const lightness = isDark
+    ? Math.min(MAX_LIGHTNESS, l + delta)
+    : Math.max(MIN_LIGHTNESS, l - delta);
+  return rgbToHex(hslToRgb(h, s, lightness));
+};
+
+// Build a `seriesName -> color` map (same shape as `buildSeriesColorMap`) so
+// callers can drop it in without changing their lookup. Each breakdown value
+// gets one stable base hue; each metric shifts that hue by a fixed lightness
+// step, so a metric is always the same shade level across every breakdown.
+export const buildBreakdownColorMap = (series = [], { isDark = false } = {}) => {
+  const hasBreakdown = series.some((s) => s?.breakdownName !== "total");
+  if (!hasBreakdown) {
+    // No breakdown: keep the legacy composite-label coloring so `total` and
+    // single-metric widgets render exactly as they do today.
+    return buildSeriesColorMap(series.map((s) => s.name));
+  }
+
+  const map = {};
+  for (const s of series) {
+    const base = breakdownBaseHex(s.breakdownName);
+    // metricIndex is already a stable shade key; using it directly keeps a
+    // metric's shade level fixed even when another metric is hidden or absent.
+    map[s.name] = shadeBaseColor(base, s.metricIndex ?? 0, isDark);
+  }
+  return map;
+};


### PR DESCRIPTION
Closes #2166

Bar, stacked bar and line widgets color each series by its composite label
(`<metric> / <breakdown> (<aggregation>)`), so the same breakdown value ends up
with a different color under every metric. That means the breakdown value carries
no color at all. Pie charts already key colors by the raw breakdown value; this
change brings bar and line in line with that.

What changed:

- Added `frontend/src/sections/dashboards/seriesColors.js`. It keeps the existing
  10-color palette and the hash/collision-walk map, and adds
  `buildBreakdownColorMap(series, { isDark })`. That assigns one base hue per
  breakdown value and shifts lightness per metric, so a metric is always the same
  shade level. Widgets with no breakdown (`breakdownName === "total"`) keep the
  old coloring.
- Removed the duplicated palette/hash/map helpers from `WidgetChart.jsx` and
  `WidgetEditorView.jsx`; both now import from the shared module.
- The line-chart legend now gets the resolved per-series colors instead of the
  raw palette, so swatches match the chart.

Tests: added `seriesColors.test.js` covering hue stability, per-metric shade,
shade-step consistency across breakdown values, light/dark direction, the
`total` fallback and determinism. Verified in the sandbox together with the
existing `WidgetChart` and `widgetUtils` suites: 76 passing.
