### PR TITLE
fix(simulate): bind graph-scenario locals and import ExtractIntentsInput

### DIFF
--- a/futureagi/tfc/temporal/simulate/activities.py
+++ b/futureagi/tfc/temporal/simulate/activities.py
@@ -2429,6 +2429,10 @@ def _create_graph_scenario_sync(
         except Exception:
             logger.warning("usage_precheck_failed", exc_info=True)
 
+        agent_definition_id = validated_data.get("agent_definition_id")
+        source_type = validated_data.get("source_type", "agent_definition")
+        generate_graph = validated_data.get("generate_graph", False)
+        graph_data = validated_data.get("graph")
         no_of_rows = validated_data.get("no_of_rows", 20)
         persona_ids = validated_data.get("personas", [])
         custom_columns = validated_data.get("custom_columns", [])

--- a/futureagi/tfc/temporal/simulate/tests/test_activities.py
+++ b/futureagi/tfc/temporal/simulate/tests/test_activities.py
@@ -4,11 +4,17 @@ Tests for Temporal simulate activities.
 Run with: pytest tfc/temporal/simulate/tests/test_activities.py -v
 """
 
+import ast
 import asyncio
+import builtins
+import pathlib
+import symtable
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pandas as pd
 import pytest
+
+SIMULATE_PKG = pathlib.Path(__file__).resolve().parents[1]
 
 
 def run_async(coro):
@@ -318,3 +324,125 @@ class TestResolveScenarioAgent:
         )
         result = _resolve_scenario_agent(scenario, "prompt")
         assert result.description == "Template-level description"
+
+
+class TestGraphScenarioNameBinding:
+    """Regression tests for two `NameError`s in the graph-scenario path.
+
+    Both bugs are of the same shape: a name is read but never bound, so the
+    code path dies with `NameError` the first time it runs. Neither is
+    reachable from a new workflow — `CreateGraphScenarioWorkflow.run` sends
+    new executions down the v3 branch — but both are live for in-flight and
+    replaying workflows that were started on the older branches.
+
+    These checks are static because the alternative is a Temporal worker.
+    This module's own docstring already records why that is avoided:
+    "running actual Temporal activities requires a Temporal worker
+    environment". A missing local and a missing import are fully decidable
+    from the source, so a static check loses nothing here.
+    """
+
+    GRAPH_ROUTING_KEYS = {
+        "source_type",
+        "agent_definition_id",
+        "generate_graph",
+        "graph_data",
+    }
+
+    @staticmethod
+    def _function_table(module_table, name):
+        """Depth-first lookup of a function's symbol table by name."""
+        for child in module_table.get_children():
+            if child.get_name() == name and child.get_type() == "function":
+                return child
+            found = TestGraphScenarioNameBinding._function_table(child, name)
+            if found is not None:
+                return found
+        return None
+
+    @staticmethod
+    def _unbound_names(source, filename, func_name):
+        """Names a function reads that resolve to neither a local, a module
+        global, nor a builtin — i.e. guaranteed `NameError` at runtime."""
+        module_table = symtable.symtable(source, filename, "exec")
+        module_names = {s.get_name() for s in module_table.get_symbols()}
+        func_table = TestGraphScenarioNameBinding._function_table(
+            module_table, func_name
+        )
+        assert func_table is not None, f"{func_name} not found in {filename}"
+        return sorted(
+            s.get_name()
+            for s in func_table.get_symbols()
+            if s.is_global()
+            and s.get_name() not in module_names
+            and not hasattr(builtins, s.get_name())
+        )
+
+    def test_create_graph_scenario_sync_binds_graph_routing_keys(self):
+        """`_create_graph_scenario_sync` must read its four routing keys.
+
+        A refactor extracted the v3 setup activity and took these four
+        `validated_data.get(...)` assignments with it, leaving the v1 body
+        reading names that no longer existed. The very next statement,
+        `if source_type == "prompt"`, raised `NameError` on every call.
+        """
+        source = (SIMULATE_PKG / "activities.py").read_text()
+        tree = ast.parse(source)
+        func = next(
+            node
+            for node in ast.walk(tree)
+            if isinstance(node, ast.FunctionDef)
+            and node.name == "_create_graph_scenario_sync"
+        )
+        assigned = {
+            target.id
+            for node in ast.walk(func)
+            if isinstance(node, ast.Assign)
+            for target in node.targets
+            if isinstance(target, ast.Name)
+        }
+        missing = sorted(self.GRAPH_ROUTING_KEYS - assigned)
+        msg = f"_create_graph_scenario_sync reads {missing} without binding them"
+        assert not missing, msg
+
+    @pytest.mark.parametrize(
+        "func_name",
+        ["_create_graph_scenario_sync", "_setup_graph_scenario_sync"],
+    )
+    def test_graph_scenario_helpers_have_no_unbound_names(self, func_name):
+        """Neither the v1 nor the v3 graph-scenario helper may read a name
+        that is not a local, a module global, or a builtin."""
+        source = (SIMULATE_PKG / "activities.py").read_text()
+        unbound = self._unbound_names(source, "activities.py", func_name)
+        assert not unbound, f"{func_name} reads unbound names: {unbound}"
+
+    def test_workflows_import_every_activity_input_type(self):
+        """Every `*Input` / `*Output` dataclass the workflows construct must
+        be imported.
+
+        `ExtractIntentsInput` was used in `_run_v2_multi_activity` but was
+        missing from the otherwise-alphabetical import block, so the v2
+        branch raised `NameError` at step 2 — after setup had already run
+        and written a graph.
+        """
+        tree = ast.parse((SIMULATE_PKG / "workflows.py").read_text())
+        available = {
+            alias.asname or alias.name
+            for node in ast.walk(tree)
+            if isinstance(node, (ast.Import, ast.ImportFrom))
+            for alias in node.names
+        }
+        available |= {
+            node.name
+            for node in tree.body
+            if isinstance(node, (ast.ClassDef, ast.FunctionDef))
+        }
+        constructed = {
+            node.func.id
+            for node in ast.walk(tree)
+            if isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Name)
+            and node.func.id.endswith(("Input", "Output"))
+        }
+        missing = sorted(constructed - available)
+        assert not missing, f"workflows.py constructs but never imports: {missing}"

--- a/futureagi/tfc/temporal/simulate/workflows.py
+++ b/futureagi/tfc/temporal/simulate/workflows.py
@@ -39,6 +39,7 @@ with workflow.unsafe.imports_passed_through():
         CreateScenarioDatasetInput,
         CreateScriptScenarioWorkflowInput,
         CreateScriptScenarioWorkflowOutput,
+        ExtractIntentsInput,
         FinalizeGraphScenarioInput,
         GenerateCasesForIntentInput,
         GenerateColumnDataInput,


### PR DESCRIPTION
## Summary

Two `NameError`s in the graph-scenario path, both of the same shape: a name is read but never bound, so the code path dies the first time it runs.

`_create_graph_scenario_sync` reads `source_type`, `agent_definition_id`, `generate_graph` and `graph_data`, none of which are assigned anywhere in the function. `workflows.py` constructs `ExtractIntentsInput` without importing it. Neither path is reachable from a *new* workflow — `CreateGraphScenarioWorkflow.run` sends new executions down the v3 branch — but both are live for in-flight and replaying workflows started on the older branches, which is exactly what `workflow.patched()` exists to keep working.

Found by static analysis (pyflakes `F821`); both files are now `F821`-clean.

## Linked issues

No existing issue — happy to open one first if you'd prefer that order.

Closes #
Linear:

## Type of change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📖 Documentation only
- [ ] 🧹 Chore / refactor (no user-visible change)
- [ ] 🚀 Performance improvement
- [ ] 🧪 Test-only change

---

## 1) What changes were done

**A. `tfc/temporal/simulate/activities.py` — restore four unbound locals in `_create_graph_scenario_sync`**

- Added the four `validated_data.get(...)` assignments the function already depends on, immediately before the existing `no_of_rows` block.
- The values and defaults are copied verbatim from `_setup_graph_scenario_sync` (the v3 twin, `activities.py:2845-2848`), so v1 and v3 now read `validated_data` identically:
  ```python
  agent_definition_id = validated_data.get("agent_definition_id")
  source_type = validated_data.get("source_type", "agent_definition")
  generate_graph = validated_data.get("generate_graph", False)
  graph_data = validated_data.get("graph")
  ```
- No behaviour change for anything that was already working — the function could not previously get past the very next statement, `if source_type == "prompt"`.

**B. `tfc/temporal/simulate/workflows.py` — import `ExtractIntentsInput`**

- One name added to the existing `types` import block, in its alphabetical slot between `CreateScriptScenarioWorkflowOutput` and `FinalizeGraphScenarioInput`.
- `_run_v2_multi_activity` previously raised `NameError` at step 2, *after* `setup_graph_scenario_activity` had already run and written a `ScenarioGraph` row — so the failure left a partially-created scenario behind.

**C. `tfc/temporal/simulate/tests/test_activities.py` — regression tests**

- New `TestGraphScenarioNameBinding` class, four tests. No new dependencies (`ast`, `builtins`, `pathlib`, `symtable` are stdlib).

No API, serializer, model or storage changes.

---

## 2) Why the changes were done

- **Product/UX:** a customer whose graph-scenario workflow was in flight across the v1→v2→v3 migration gets a hard failure instead of a scenario. The v2 case is the worse of the two because it fails *after* persisting a graph.
- **Technical:** the v1 body is a direct ancestor of `_setup_graph_scenario_sync`; the extraction took the four assignments with it and left the reads behind. Copying the v3 values back is the smallest change that makes the two agree, and it keeps the defaults identical so the branches cannot drift silently again.
- **Architecture:** deliberately *not* refactored. `_resolve_scenario_agent` looks like a drop-in for the duplicated adapter block in `_create_graph_scenario_sync`, but it is not — it returns `scenario.agent_definition`, whereas the graph path looks up `AgentDefinition.no_workspace_objects.get(id=agent_definition_id)` from `validated_data`. Collapsing the three copies is a real cleanup but a behavioural change that deserves its own PR and its own review.

---

## 3) Tests written + scenarios each covers

**`tfc/temporal/simulate/tests/test_activities.py`** — `TestGraphScenarioNameBinding`, regression cover for both `NameError`s

- `test_create_graph_scenario_sync_binds_graph_routing_keys` — parses the function and asserts all four routing names are assigned inside it. Pins the exact regression.
- `test_graph_scenario_helpers_have_no_unbound_names[_create_graph_scenario_sync]` — asserts the function reads no name that is neither a local, a module global, nor a builtin. Guards the whole class of bug, not just these four names.
- `test_graph_scenario_helpers_have_no_unbound_names[_setup_graph_scenario_sync]` — same check on the v3 twin, so the branch that is live today is covered too.
- `test_workflows_import_every_activity_input_type` — asserts every `*Input` / `*Output` dataclass the workflow module constructs is actually imported. Catches the next missing import, not just this one.

> Run result: **4 passed**, 0.10s. Verified against the pre-fix tree as well: **3 failed, 1 passed** — each failure naming the exact missing symbol.

The checks are static because the alternative is a running Temporal worker. This module's own docstring already records that trade-off — *"running actual Temporal activities requires a Temporal worker environment"* — and both defects are fully decidable from source, so nothing is lost by checking them statically.

---

## 4) How to run / test

### Backend tests

```bash
cd futureagi

uv venv --python 3.11
source .venv/bin/activate
uv pip install -r requirements-test.txt

# The new tests:
bin/test tfc/temporal/simulate/tests/test_activities.py -k TestGraphScenarioNameBinding -v

# The whole file, to confirm nothing else moved:
bin/test tfc/temporal/simulate/tests/test_activities.py -v
```

### Confirming the tests actually catch the bug

```bash
git stash -- tfc/temporal/simulate/activities.py tfc/temporal/simulate/workflows.py
bin/test tfc/temporal/simulate/tests/test_activities.py -k TestGraphScenarioNameBinding -v   # 3 failed
git stash pop
```

### Static check

```bash
ruff check --select F821 tfc/temporal/simulate/activities.py tfc/temporal/simulate/workflows.py
# before: 6 errors  →  after: All checks passed!
```

### Contract verification

Not applicable — no API surface changed.

### UI steps (manual)

Not reachable from the UI on a current build: `workflow.patched("v3-granular-activities")` routes every new execution to v3. To exercise v1/v2 you need a workflow that was started before those patches and is replaying, which is the condition this PR is about.

---

## 5) Screenshots / recordings

### Test output

```
tfc/temporal/simulate/tests/test_activities.py::TestGraphScenarioNameBinding::test_create_graph_scenario_sync_binds_graph_routing_keys PASSED
tfc/temporal/simulate/tests/test_activities.py::TestGraphScenarioNameBinding::test_graph_scenario_helpers_have_no_unbound_names[_create_graph_scenario_sync] PASSED
tfc/temporal/simulate/tests/test_activities.py::TestGraphScenarioNameBinding::test_graph_scenario_helpers_have_no_unbound_names[_setup_graph_scenario_sync] PASSED
tfc/temporal/simulate/tests/test_activities.py::TestGraphScenarioNameBinding::test_workflows_import_every_activity_input_type PASSED

4 passed in 0.10s
```

### UI testing

N/A — see above.

---

## 6) Edge cases & considerations

- **`source_type` default:** `"agent_definition"`, matching v3. Any caller that omits the key keeps the pre-refactor behaviour of going down the `AgentDefinition` lookup branch.
- **`graph_data` key name:** v1 reads `validated_data["graph"]` into a local named `graph_data`, exactly as v3 does. The mismatch between key and local name is intentional and preserved.
- **`agent_definition_version_id`:** v3 reads one key v1 does not. That key post-dates v1 and v1 has no code that uses it, so it is deliberately not added — this PR restores v1, it does not port v3 features backwards.
- **v1 still calls a None-valued EE symbol** on OSS builds (`check_usage` at `activities.py:2419`), but that call is already wrapped in its own `try/except Exception` that logs and continues, so it degrades rather than fails. Same class as #2033; out of scope here.
- **Replay safety:** both changes are inside activity/workflow *bodies* that previously could not complete at all. No new activity call, no new signal, no change to any workflow's command sequence, so nothing is non-deterministic for a replaying history.

---

## 7) Pre-existing issues (NOT introduced by this PR)

- `black --check tfc/temporal/simulate/activities.py` fails on `main` already (verified against the unmodified file). The four added lines are black-clean; the file has not been reformatted, to keep the diff reviewable.
- `ruff check` reports pre-existing findings in both touched files — unused `typing.List` and three unused `types` imports in `workflows.py`, `F841` on unused `except ... as e` bindings, and `UP006`/`UP045` annotation modernisation in `activities.py`. None are in the changed lines and none are fixed here.
- Four `I001` import-sort findings in `test_activities.py` are in the pre-existing `TestResolveScenarioAgent` class, not the new one.

---

## 8) Architectural / important decisions

- **Copied v3's values rather than inventing defaults:** the two branches must agree on how `validated_data` is read, and v3 is the branch in production, so it is the correct reference.
- **Static tests rather than a Temporal worker:** a missing local and a missing import are decidable from source; spinning a worker to prove it would add a heavy dependency for no extra signal. The `symtable` check generalises past these two names.
- **Fixed, did not refactor:** the duplicated agent-definition adapter block now exists in three places, but `_resolve_scenario_agent` is not behaviour-equivalent to the graph-path lookup, so unifying them is a separate change.

---

## Checklist

- [x] My code follows the [style guide](../CONTRIBUTING.md#code-style)
- [x] I've added tests that prove my fix is effective or that my feature works
- [ ] `bin/test` passes locally (backend) — *tick before opening; the new tests are verified, the full suite still needs a run against the docker services*
- [ ] `yarn test:run` passes locally (frontend) — N/A, no frontend change
- [ ] `yarn contracts:check` passes if API surface changed — N/A, no API change
- [x] I've updated the documentation where relevant — N/A, no user-facing behaviour change
- [x] No hardcoded secrets, URLs, or PII
- [ ] I've signed the [CLA](../CONTRIBUTING.md#contributor-license-agreement-cla) — *happy to sign; I didn't see a CLA bot or a link, so point me at it and I'll do it right away*
- [x] PR title follows Conventional Commits
- [ ] Linear issue is linked and updated with status — N/A, external contributor
