### PR TITLE
refactor(gateway): share the metadata parser and the org redactor cache

### DIFF
--- a/agentcc-gateway/cmd/agentcc/main.go
+++ b/agentcc-gateway/cmd/agentcc/main.go
@@ -582,6 +582,8 @@ func main() {
 		slog.Info("alerting enabled", "rules", alertManager.RuleCount())
 	}
 
+	// The logging plugin is deliberately absent here: its redactor cache moved
+	// onto tenantStore, which invalidates itself on every config change.
 	if onOrgConfigChange != nil {
 		prev := onOrgConfigChange
 		onOrgConfigChange = func(orgID string) {
@@ -589,17 +591,11 @@ func main() {
 			if alertingPlugin != nil {
 				alertingPlugin.InvalidateOrg(orgID)
 			}
-			if loggingPlugin != nil {
-				loggingPlugin.InvalidateOrg(orgID)
-			}
 		}
-	} else if alertingPlugin != nil || loggingPlugin != nil || ipaclPlugin != nil {
+	} else if alertingPlugin != nil || ipaclPlugin != nil {
 		onOrgConfigChange = func(orgID string) {
 			if alertingPlugin != nil {
 				alertingPlugin.InvalidateOrg(orgID)
-			}
-			if loggingPlugin != nil {
-				loggingPlugin.InvalidateOrg(orgID)
 			}
 			if ipaclPlugin != nil {
 				ipaclPlugin.InvalidateOrg(orgID)

--- a/agentcc-gateway/internal/models/context.go
+++ b/agentcc-gateway/internal/models/context.go
@@ -102,6 +102,12 @@ type RequestContext struct {
 
 	// Per-org model fallback chains: model → ordered fallback models.
 	OrgModelFallbacks map[string][]string
+
+	// CustomMetadataKeys lists the Metadata keys that came from the caller's
+	// x-agentcc-metadata header. Metadata also holds ~120 internal keys written
+	// by plugins, so this is the only reliable way to tell caller-supplied
+	// dimensions apart from gateway internals when exporting telemetry.
+	CustomMetadataKeys []string
 }
 
 type RequestFlags struct {
@@ -164,6 +170,7 @@ func (rc *RequestContext) Release() {
 	rc.OrgModelFallbacks = nil
 	rc.GuardrailResults = rc.GuardrailResults[:0]
 	rc.RequestHeaders = nil
+	rc.CustomMetadataKeys = rc.CustomMetadataKeys[:0]
 
 	// Reuse maps by clearing them (keeps allocated memory).
 	for k := range rc.Metadata {

--- a/agentcc-gateway/internal/plugins/logging/logging.go
+++ b/agentcc-gateway/internal/plugins/logging/logging.go
@@ -3,7 +3,6 @@ package logging
 import (
 	"context"
 	"log/slog"
-	"sync"
 
 	"github.com/futureagi/agentcc-gateway/internal/config"
 	"github.com/futureagi/agentcc-gateway/internal/models"
@@ -14,12 +13,11 @@ import (
 
 // Plugin is a post-response pipeline plugin that asynchronously logs trace records.
 type Plugin struct {
-	emitter      *TraceEmitter
-	flusher      *LogFlusher
-	cfg          config.RequestLoggingConfig
-	redactor     *privacy.Redactor
-	tenantStore  *tenant.Store
-	orgRedactors sync.Map
+	emitter     *TraceEmitter
+	flusher     *LogFlusher
+	cfg         config.RequestLoggingConfig
+	redactor    *privacy.Redactor
+	tenantStore *tenant.Store
 }
 
 // New creates a new logging plugin.
@@ -81,7 +79,7 @@ func (p *Plugin) ProcessResponse(_ context.Context, rc *models.RequestContext) p
 	}
 
 	// Check per-org privacy config from tenant store for richer redaction (custom patterns).
-	orgRedactor := p.getOrgRedactor(rc)
+	orgRedactor := p.tenantStore.Redactor(rc.Metadata[tenant.MetadataKeyOrgID])
 
 	// Apply redaction: org redactor (with org patterns) takes priority over global.
 	// The flag goes on the record, not on rc: this runs inside the parallel
@@ -111,53 +109,6 @@ func markRedacted(record *TraceRecord) {
 		record.Metadata = make(map[string]string, 1)
 	}
 	record.Metadata["privacy_redacted"] = "true"
-}
-
-// getOrgRedactor returns a per-org privacy redactor if the org has privacy config.
-func (p *Plugin) getOrgRedactor(rc *models.RequestContext) *privacy.Redactor {
-	if p.tenantStore == nil {
-		return nil
-	}
-	orgID := rc.Metadata[tenant.MetadataKeyOrgID]
-	if orgID == "" {
-		return nil
-	}
-	orgCfg := p.tenantStore.Get(orgID)
-	if orgCfg == nil || orgCfg.Privacy == nil || !orgCfg.Privacy.Enabled {
-		return nil
-	}
-
-	// Check cache first.
-	if v, ok := p.orgRedactors.Load(orgID); ok {
-		return v.(*privacy.Redactor)
-	}
-
-	// Build redactor from org patterns.
-	patterns := make([]privacy.PatternConfig, 0, len(orgCfg.Privacy.Patterns))
-	for _, pat := range orgCfg.Privacy.Patterns {
-		if pat != nil && pat.Pattern != "" {
-			patterns = append(patterns, privacy.PatternConfig{
-				Name:    pat.Name,
-				Pattern: pat.Pattern,
-			})
-		}
-	}
-
-	mode := orgCfg.Privacy.Mode
-	if mode == "" {
-		mode = privacy.ModePatterns
-	}
-	redactor := privacy.New(mode, patterns)
-	p.orgRedactors.Store(orgID, redactor)
-	return redactor
-}
-
-// InvalidateOrg removes the cached per-org redactor so updated privacy config is rebuilt.
-func (p *Plugin) InvalidateOrg(orgID string) {
-	if p == nil || orgID == "" {
-		return
-	}
-	p.orgRedactors.Delete(orgID)
 }
 
 // Close drains buffered trace records and stops workers.

--- a/agentcc-gateway/internal/server/handlers.go
+++ b/agentcc-gateway/internal/server/handlers.go
@@ -866,15 +866,7 @@ func (h *Handlers) ChatCompletion(w http.ResponseWriter, r *http.Request) {
 
 	// Extract Agentcc metadata from headers (with security key blocklist).
 	if meta := r.Header.Get("x-agentcc-metadata"); meta != "" {
-		var m map[string]string
-		if err := json.Unmarshal([]byte(meta), &m); err == nil {
-			for k, v := range m {
-				if isBlockedMetadataKey(k) {
-					continue
-				}
-				rc.Metadata[k] = v
-			}
-		}
+		parseMetadataHeader(meta, rc)
 	}
 	if sid := r.Header.Get("x-agentcc-session-id"); sid != "" {
 		if len(sid) > maxSessionIDLen {
@@ -1877,6 +1869,24 @@ func splitCSV(s string) []string {
 		}
 	}
 	return result
+}
+
+// parseMetadataHeader parses the x-agentcc-metadata JSON header into the request
+// context. Security-sensitive keys are blocked to prevent client-side injection.
+// Accepted keys are recorded on the context so telemetry can distinguish them
+// from the metadata plugins write themselves.
+func parseMetadataHeader(meta string, rc *models.RequestContext) {
+	var m map[string]string
+	if err := json.Unmarshal([]byte(meta), &m); err != nil {
+		return
+	}
+	for k, v := range m {
+		if isBlockedMetadataKey(k) {
+			continue
+		}
+		rc.Metadata[k] = v
+		rc.CustomMetadataKeys = append(rc.CustomMetadataKeys, k)
+	}
 }
 
 // isBlockedMetadataKey returns true for metadata keys that must not be

--- a/agentcc-gateway/internal/server/handlers_anthropic.go
+++ b/agentcc-gateway/internal/server/handlers_anthropic.go
@@ -72,15 +72,7 @@ func (h *Handlers) AnthropicMessages(w http.ResponseWriter, r *http.Request) {
 	// Extract headers.
 	setAuthMetadataFromRequest(rc, r)
 	if meta := r.Header.Get("x-agentcc-metadata"); meta != "" {
-		var m map[string]string
-		if err := json.Unmarshal([]byte(meta), &m); err == nil {
-			for k, v := range m {
-				if isBlockedMetadataKey(k) {
-					continue
-				}
-				rc.Metadata[k] = v
-			}
-		}
+		parseMetadataHeader(meta, rc)
 	}
 
 	// Resolve timeout and context.

--- a/agentcc-gateway/internal/server/handlers_assistants.go
+++ b/agentcc-gateway/internal/server/handlers_assistants.go
@@ -3,7 +3,6 @@ package server
 import (
 	"bufio"
 	"context"
-	"encoding/json"
 	"fmt"
 	"io"
 	"log/slog"
@@ -60,15 +59,7 @@ func (h *Handlers) setupAssistantsRC(r *http.Request, operation string) *models.
 
 	setAuthMetadataFromRequest(rc, r)
 	if meta := r.Header.Get("x-agentcc-metadata"); meta != "" {
-		var m map[string]string
-		if err := json.Unmarshal([]byte(meta), &m); err == nil {
-			for k, v := range m {
-				if isBlockedMetadataKey(k) {
-					continue
-				}
-				rc.Metadata[k] = v
-			}
-		}
+		parseMetadataHeader(meta, rc)
 	}
 
 	// Peek key org_id before resolving org config (same as ChatCompletion).

--- a/agentcc-gateway/internal/server/handlers_completion.go
+++ b/agentcc-gateway/internal/server/handlers_completion.go
@@ -75,15 +75,7 @@ func (h *Handlers) TextCompletion(w http.ResponseWriter, r *http.Request) {
 
 	// Extract Agentcc metadata from headers (with security key blocklist).
 	if meta := r.Header.Get("x-agentcc-metadata"); meta != "" {
-		var m map[string]string
-		if err := json.Unmarshal([]byte(meta), &m); err == nil {
-			for k, v := range m {
-				if isBlockedMetadataKey(k) {
-					continue
-				}
-				rc.Metadata[k] = v
-			}
-		}
+		parseMetadataHeader(meta, rc)
 	}
 	if sid := r.Header.Get("x-agentcc-session-id"); sid != "" {
 		if len(sid) > maxSessionIDLen {

--- a/agentcc-gateway/internal/server/handlers_genai.go
+++ b/agentcc-gateway/internal/server/handlers_genai.go
@@ -2,7 +2,6 @@ package server
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -469,20 +468,6 @@ func (h *Handlers) handleGenAIStreamViaCanonical(
 
 		if eventCh == nil && errCh == nil && translatorErrCh == nil {
 			return
-		}
-	}
-}
-
-// parseMetadataHeader parses the x-agentcc-metadata JSON header into the request context.
-// Security-sensitive keys are blocked to prevent client-side injection.
-func parseMetadataHeader(meta string, rc *models.RequestContext) {
-	var m map[string]string
-	if err := json.Unmarshal([]byte(meta), &m); err == nil {
-		for k, v := range m {
-			if isBlockedMetadataKey(k) {
-				continue
-			}
-			rc.Metadata[k] = v
 		}
 	}
 }

--- a/agentcc-gateway/internal/server/handlers_responses.go
+++ b/agentcc-gateway/internal/server/handlers_responses.go
@@ -61,15 +61,7 @@ func (h *Handlers) CreateResponse(w http.ResponseWriter, r *http.Request) {
 
 	// Extract Agentcc metadata (with security key blocklist).
 	if meta := r.Header.Get("x-agentcc-metadata"); meta != "" {
-		var m map[string]string
-		if err := json.Unmarshal([]byte(meta), &m); err == nil {
-			for k, v := range m {
-				if isBlockedMetadataKey(k) {
-					continue
-				}
-				rc.Metadata[k] = v
-			}
-		}
+		parseMetadataHeader(meta, rc)
 	}
 
 	// Resolve timeout.

--- a/agentcc-gateway/internal/server/metadata_header_test.go
+++ b/agentcc-gateway/internal/server/metadata_header_test.go
@@ -1,0 +1,84 @@
+package server
+
+import (
+	"sort"
+	"testing"
+
+	"github.com/futureagi/agentcc-gateway/internal/models"
+)
+
+func TestParseMetadataHeader(t *testing.T) {
+	tests := []struct {
+		name       string
+		header     string
+		wantMeta   map[string]string
+		wantCustom []string
+	}{
+		{
+			name:       "caller keys are stored and recorded",
+			header:     `{"profile_id":"milestone-p1","business_id":"biz-42"}`,
+			wantMeta:   map[string]string{"profile_id": "milestone-p1", "business_id": "biz-42"},
+			wantCustom: []string{"business_id", "profile_id"},
+		},
+		{
+			name:       "reserved keys are rejected, not recorded",
+			header:     `{"cost":"0","org_id":"evil","auth_key_id":"evil","client_ip":"1.2.3.4","tenant":"ok"}`,
+			wantMeta:   map[string]string{"tenant": "ok"},
+			wantCustom: []string{"tenant"},
+		},
+		{
+			name:       "malformed json is ignored",
+			header:     `not json`,
+			wantMeta:   map[string]string{},
+			wantCustom: nil,
+		},
+		{
+			name:       "non-string values are ignored",
+			header:     `{"depth":3}`,
+			wantMeta:   map[string]string{},
+			wantCustom: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rc := &models.RequestContext{Metadata: map[string]string{}}
+			parseMetadataHeader(tt.header, rc)
+
+			if len(rc.Metadata) != len(tt.wantMeta) {
+				t.Fatalf("Metadata = %v, want %v", rc.Metadata, tt.wantMeta)
+			}
+			for k, v := range tt.wantMeta {
+				if rc.Metadata[k] != v {
+					t.Errorf("Metadata[%q] = %q, want %q", k, rc.Metadata[k], v)
+				}
+			}
+
+			got := append([]string(nil), rc.CustomMetadataKeys...)
+			sort.Strings(got)
+			if len(got) != len(tt.wantCustom) {
+				t.Fatalf("CustomMetadataKeys = %v, want %v", got, tt.wantCustom)
+			}
+			for i, k := range tt.wantCustom {
+				if got[i] != k {
+					t.Errorf("CustomMetadataKeys[%d] = %q, want %q", i, got[i], k)
+				}
+			}
+		})
+	}
+}
+
+// A blocked key must not become a telemetry dimension either — CustomMetadataKeys
+// is what the OTel plugin exports, so recording one would re-open the injection
+// the blocklist exists to prevent.
+func TestParseMetadataHeaderDoesNotRecordBlockedKeys(t *testing.T) {
+	rc := &models.RequestContext{Metadata: map[string]string{"cost": "0.5"}}
+	parseMetadataHeader(`{"cost":"0.0"}`, rc)
+
+	if rc.Metadata["cost"] != "0.5" {
+		t.Errorf("caller overwrote a plugin-owned key: cost = %q", rc.Metadata["cost"])
+	}
+	if len(rc.CustomMetadataKeys) != 0 {
+		t.Errorf("CustomMetadataKeys = %v, want empty", rc.CustomMetadataKeys)
+	}
+}

--- a/agentcc-gateway/internal/tenant/store.go
+++ b/agentcc-gateway/internal/tenant/store.go
@@ -24,7 +24,11 @@ type Store struct {
 	// path which changes a config also drops the stale redactor — a missed
 	// invalidation would mean redacting with an org's previous patterns
 	// after it tightened them.
-	redactors sync.Map // orgID -> *privacy.Redactor
+	//
+	// Guarded by mu, like configs. A separately synchronized cache is not
+	// enough: a build that reads a config, loses the CPU, and stores after an
+	// invalidation has already run caches a redactor older than the store.
+	redactors map[string]*privacy.Redactor
 }
 
 // NewStore creates a new empty tenant config store.
@@ -32,6 +36,7 @@ func NewStore() *Store {
 	return &Store{
 		configs:    make(map[string]*OrgConfig),
 		configHash: make(map[string][32]byte),
+		redactors:  make(map[string]*privacy.Redactor),
 	}
 }
 
@@ -57,8 +62,8 @@ func (s *Store) Set(orgID string, cfg *OrgConfig) {
 	s.mu.Lock()
 	s.configs[orgID] = cfg
 	s.configHash[orgID] = hashConfig(cfg)
+	delete(s.redactors, orgID)
 	s.mu.Unlock()
-	s.redactors.Delete(orgID)
 }
 
 // Delete removes the org config for the given org ID.
@@ -66,8 +71,8 @@ func (s *Store) Delete(orgID string) {
 	s.mu.Lock()
 	delete(s.configs, orgID)
 	delete(s.configHash, orgID)
+	delete(s.redactors, orgID)
 	s.mu.Unlock()
-	s.redactors.Delete(orgID)
 }
 
 // GetAll returns a copy of all org configs.
@@ -99,7 +104,7 @@ func (s *Store) LoadBulk(configs map[string]*OrgConfig) {
 	}
 	// LoadBulk replaces every config and deliberately fires no onChange, so
 	// nothing downstream would otherwise learn these redactors are stale.
-	s.redactors.Clear()
+	clear(s.redactors)
 }
 
 // MergeBulk merges successfully parsed org configs into the store.
@@ -136,12 +141,12 @@ func (s *Store) MergeBulk(parsedConfigs map[string]*OrgConfig, allOrgIDs map[str
 		s.configHash[orgID] = newHash
 	}
 
+	for _, orgID := range changed {
+		delete(s.redactors, orgID)
+	}
+
 	cb := s.onChange
 	s.mu.Unlock()
-
-	for _, orgID := range changed {
-		s.redactors.Delete(orgID)
-	}
 
 	// Fire onChange outside the lock to avoid deadlocks with downstream caches.
 	if cb != nil {
@@ -162,14 +167,29 @@ func (s *Store) Redactor(orgID string) *privacy.Redactor {
 	if s == nil || orgID == "" {
 		return nil
 	}
-	if v, ok := s.redactors.Load(orgID); ok {
-		r, _ := v.(*privacy.Redactor)
-		return r
+	s.mu.RLock()
+	cached, hit := s.redactors[orgID]
+	enabled := redactionEnabled(s.configs[orgID])
+	s.mu.RUnlock()
+	if hit {
+		return cached
+	}
+	// Nothing to build, so nothing to cache either — orgs without privacy
+	// stay off the write lock entirely.
+	if !enabled {
+		return nil
 	}
 
-	cfg := s.Get(orgID)
-	if cfg == nil || cfg.Privacy == nil || !cfg.Privacy.Enabled {
-		return nil
+	// The build holds the write lock: releasing it to compile the patterns is
+	// what lets an invalidation slip in front of the store below.
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if r, ok := s.redactors[orgID]; ok {
+		return r
+	}
+	cfg := s.configs[orgID]
+	if !redactionEnabled(cfg) {
+		return nil // disabled while this call was waiting for the lock
 	}
 
 	patterns := make([]privacy.PatternConfig, 0, len(cfg.Privacy.Patterns))
@@ -184,12 +204,13 @@ func (s *Store) Redactor(orgID string) *privacy.Redactor {
 		mode = privacy.ModePatterns
 	}
 	redactor := privacy.New(mode, patterns)
+	s.redactors[orgID] = redactor
+	return redactor
+}
 
-	// LoadOrStore, not Store: a concurrent invalidation between Get and here
-	// would otherwise be overwritten by this now-stale build.
-	actual, _ := s.redactors.LoadOrStore(orgID, redactor)
-	r, _ := actual.(*privacy.Redactor)
-	return r
+// redactionEnabled reports whether a config asks for any redaction at all.
+func redactionEnabled(cfg *OrgConfig) bool {
+	return cfg != nil && cfg.Privacy != nil && cfg.Privacy.Enabled
 }
 
 // hashConfig returns a SHA-256 hash of the JSON-serialized config.

--- a/agentcc-gateway/internal/tenant/store.go
+++ b/agentcc-gateway/internal/tenant/store.go
@@ -6,16 +6,25 @@ import (
 	"fmt"
 	"sync"
 	"time"
+
+	"github.com/futureagi/agentcc-gateway/internal/privacy"
 )
 
 // Store is a thread-safe in-memory store for per-org gateway configurations.
 // It maps organization IDs to their merged OrgConfig. All methods are safe
 // for concurrent use.
 type Store struct {
-	mu          sync.RWMutex
-	configs     map[string]*OrgConfig
-	configHash  map[string][32]byte      // SHA-256 of serialized config per org
-	onChange    func(orgID string)        // optional callback fired when an org config changes
+	mu         sync.RWMutex
+	configs    map[string]*OrgConfig
+	configHash map[string][32]byte // SHA-256 of serialized config per org
+	onChange   func(orgID string)  // optional callback fired when an org config changes
+
+	// redactors caches the per-org privacy.Redactor built from configs.
+	// It lives here rather than in the plugins that use it so that every
+	// path which changes a config also drops the stale redactor — a missed
+	// invalidation would mean redacting with an org's previous patterns
+	// after it tightened them.
+	redactors sync.Map // orgID -> *privacy.Redactor
 }
 
 // NewStore creates a new empty tenant config store.
@@ -49,6 +58,7 @@ func (s *Store) Set(orgID string, cfg *OrgConfig) {
 	s.configs[orgID] = cfg
 	s.configHash[orgID] = hashConfig(cfg)
 	s.mu.Unlock()
+	s.redactors.Delete(orgID)
 }
 
 // Delete removes the org config for the given org ID.
@@ -57,6 +67,7 @@ func (s *Store) Delete(orgID string) {
 	delete(s.configs, orgID)
 	delete(s.configHash, orgID)
 	s.mu.Unlock()
+	s.redactors.Delete(orgID)
 }
 
 // GetAll returns a copy of all org configs.
@@ -86,14 +97,18 @@ func (s *Store) LoadBulk(configs map[string]*OrgConfig) {
 	for k, v := range configs {
 		s.configs[k] = v
 	}
+	// LoadBulk replaces every config and deliberately fires no onChange, so
+	// nothing downstream would otherwise learn these redactors are stale.
+	s.redactors.Clear()
 }
 
 // MergeBulk merges successfully parsed org configs into the store.
-// - Orgs in parsedConfigs are added or updated.
-// - Orgs present in the control plane response (allOrgIDs) but NOT in
-//   parsedConfigs failed to parse — their existing store entries are preserved.
-// - Orgs in the store that are NOT in allOrgIDs were removed from the control
-//   plane — they are deleted from the store.
+//   - Orgs in parsedConfigs are added or updated.
+//   - Orgs present in the control plane response (allOrgIDs) but NOT in
+//     parsedConfigs failed to parse — their existing store entries are preserved.
+//   - Orgs in the store that are NOT in allOrgIDs were removed from the control
+//     plane — they are deleted from the store.
+//
 // Fires the onChange callback for each org that was added, updated, or removed.
 func (s *Store) MergeBulk(parsedConfigs map[string]*OrgConfig, allOrgIDs map[string]struct{}) {
 	s.mu.Lock()
@@ -124,12 +139,57 @@ func (s *Store) MergeBulk(parsedConfigs map[string]*OrgConfig, allOrgIDs map[str
 	cb := s.onChange
 	s.mu.Unlock()
 
+	for _, orgID := range changed {
+		s.redactors.Delete(orgID)
+	}
+
 	// Fire onChange outside the lock to avoid deadlocks with downstream caches.
 	if cb != nil {
 		for _, orgID := range changed {
 			cb(orgID)
 		}
 	}
+}
+
+// Redactor returns the privacy redactor for an org, or nil when the org has no
+// privacy config or none is enabled. Built on first use and cached until the
+// org's config changes.
+//
+// Every sink that exports request or response content must redact through this
+// — the request-log webhook and exported trace spans alike — or one of them
+// becomes a way around a privacy policy the operator configured.
+func (s *Store) Redactor(orgID string) *privacy.Redactor {
+	if s == nil || orgID == "" {
+		return nil
+	}
+	if v, ok := s.redactors.Load(orgID); ok {
+		r, _ := v.(*privacy.Redactor)
+		return r
+	}
+
+	cfg := s.Get(orgID)
+	if cfg == nil || cfg.Privacy == nil || !cfg.Privacy.Enabled {
+		return nil
+	}
+
+	patterns := make([]privacy.PatternConfig, 0, len(cfg.Privacy.Patterns))
+	for _, pat := range cfg.Privacy.Patterns {
+		if pat != nil && pat.Pattern != "" {
+			patterns = append(patterns, privacy.PatternConfig{Name: pat.Name, Pattern: pat.Pattern})
+		}
+	}
+
+	mode := cfg.Privacy.Mode
+	if mode == "" {
+		mode = privacy.ModePatterns
+	}
+	redactor := privacy.New(mode, patterns)
+
+	// LoadOrStore, not Store: a concurrent invalidation between Get and here
+	// would otherwise be overwritten by this now-stale build.
+	actual, _ := s.redactors.LoadOrStore(orgID, redactor)
+	r, _ := actual.(*privacy.Redactor)
+	return r
 }
 
 // hashConfig returns a SHA-256 hash of the JSON-serialized config.

--- a/agentcc-gateway/internal/tenant/store_test.go
+++ b/agentcc-gateway/internal/tenant/store_test.go
@@ -125,3 +125,91 @@ func TestStoreConcurrency(t *testing.T) {
 
 	// Should not panic or race (run with -race flag)
 }
+
+func privacyConfig(pattern string) *OrgConfig {
+	return &OrgConfig{Privacy: &PrivacyConfig{
+		Enabled:  true,
+		Mode:     "patterns",
+		Patterns: []*RedactPatternConfig{{Name: "test", Pattern: pattern}},
+	}}
+}
+
+// The redactor cache lives on the store so that no config-change path can
+// forget to drop it. A stale redactor means content is exported using an org's
+// previous patterns after it tightened them, which is a privacy failure rather
+// than a staleness annoyance — so every mutator is covered here.
+func TestStoreRedactorInvalidatedOnEveryConfigChange(t *testing.T) {
+	const orgID = "org-1"
+
+	redactsWith := func(t *testing.T, s *Store, secret string) bool {
+		t.Helper()
+		r := s.Redactor(orgID)
+		if r == nil {
+			t.Fatal("no redactor for an org with privacy enabled")
+		}
+		return r.Redact("value "+secret) != "value "+secret
+	}
+
+	t.Run("Set", func(t *testing.T) {
+		s := NewStore()
+		s.Set(orgID, privacyConfig("alpha"))
+		if !redactsWith(t, s, "alpha") {
+			t.Fatal("initial pattern not applied")
+		}
+		s.Set(orgID, privacyConfig("beta"))
+		if !redactsWith(t, s, "beta") {
+			t.Error("Set did not drop the stale redactor")
+		}
+	})
+
+	t.Run("MergeBulk", func(t *testing.T) {
+		s := NewStore()
+		s.Set(orgID, privacyConfig("alpha"))
+		_ = redactsWith(t, s, "alpha") // prime the cache
+		s.MergeBulk(map[string]*OrgConfig{orgID: privacyConfig("beta")},
+			map[string]struct{}{orgID: {}})
+		if !redactsWith(t, s, "beta") {
+			t.Error("MergeBulk did not drop the stale redactor")
+		}
+	})
+
+	// LoadBulk replaces every config and fires no onChange, so a cache living
+	// in a plugin behind that callback would never hear about this one.
+	t.Run("LoadBulk", func(t *testing.T) {
+		s := NewStore()
+		s.Set(orgID, privacyConfig("alpha"))
+		_ = redactsWith(t, s, "alpha")
+		s.LoadBulk(map[string]*OrgConfig{orgID: privacyConfig("beta")})
+		if !redactsWith(t, s, "beta") {
+			t.Error("LoadBulk did not drop the stale redactor")
+		}
+	})
+
+	t.Run("Delete", func(t *testing.T) {
+		s := NewStore()
+		s.Set(orgID, privacyConfig("alpha"))
+		_ = redactsWith(t, s, "alpha")
+		s.Delete(orgID)
+		if r := s.Redactor(orgID); r != nil {
+			t.Error("redactor survived the org being deleted")
+		}
+	})
+}
+
+func TestStoreRedactorAbsentWithoutPrivacyConfig(t *testing.T) {
+	s := NewStore()
+	if r := s.Redactor("unknown-org"); r != nil {
+		t.Error("unknown org should have no redactor")
+	}
+	s.Set("org-2", &OrgConfig{})
+	if r := s.Redactor("org-2"); r != nil {
+		t.Error("org without privacy config should have no redactor")
+	}
+	s.Set("org-3", &OrgConfig{Privacy: &PrivacyConfig{Enabled: false}})
+	if r := s.Redactor("org-3"); r != nil {
+		t.Error("org with privacy disabled should have no redactor")
+	}
+	if r := s.Redactor(""); r != nil {
+		t.Error("empty org id should have no redactor")
+	}
+}

--- a/agentcc-gateway/internal/tenant/store_test.go
+++ b/agentcc-gateway/internal/tenant/store_test.go
@@ -1,8 +1,10 @@
 package tenant
 
 import (
+	"fmt"
 	"sync"
 	"testing"
+	"time"
 )
 
 func TestStoreGetSetDelete(t *testing.T) {
@@ -194,6 +196,47 @@ func TestStoreRedactorInvalidatedOnEveryConfigChange(t *testing.T) {
 			t.Error("redactor survived the org being deleted")
 		}
 	})
+}
+
+// A redactor built from a config the store has already replaced must never
+// reach the cache. Invalidation cannot fix this after the fact: the delete runs
+// while nothing is cached, so it hits nothing, and the stale build lands after
+// it and stays until some unrelated write to the same org.
+//
+// The many-pattern config is the point — it makes the build slow enough that
+// Set reliably lands inside the window a released lock would open. -race does
+// not flag this: both the configs map and the cache are synchronized, it is the
+// gap between them that is wrong.
+func TestStoreRedactorNeverCachesAConfigTheStoreHasReplaced(t *testing.T) {
+	const orgID = "org-1"
+
+	slow := &OrgConfig{Privacy: &PrivacyConfig{Enabled: true, Mode: "patterns"}}
+	for i := 0; i < 400; i++ {
+		slow.Privacy.Patterns = append(slow.Privacy.Patterns,
+			&RedactPatternConfig{Name: fmt.Sprintf("p%d", i), Pattern: fmt.Sprintf("alpha%d[0-9a-f]+", i)})
+	}
+
+	s := NewStore()
+	s.Set(orgID, slow)
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		s.Redactor(orgID) // reads the config, then compiles 400 patterns
+	}()
+
+	time.Sleep(2 * time.Millisecond) // let the build get past reading the config
+	s.Set(orgID, privacyConfig("beta"))
+	wg.Wait()
+
+	r := s.Redactor(orgID)
+	if r == nil {
+		t.Fatal("no redactor after the config was replaced")
+	}
+	if got := r.Redact("value beta"); got == "value beta" {
+		t.Errorf("cached a redactor built from the replaced config: %q left unredacted", got)
+	}
 }
 
 func TestStoreRedactorAbsentWithoutPrivacyConfig(t *testing.T) {


### PR DESCRIPTION
Split out of #2183 — **PR 2 of 4**. Based on the race fix (#2186), so review the top two commits only; it retargets to `dev` and rebases once that merges.

Two refactors the OTLP exporter needs. Neither changes behaviour, and both are worth having on their own.

**Share one `x-agentcc-metadata` parser.** Five handlers carried their own copy of the same parse-and-blocklist loop while the GenAI path already had a helper doing exactly that. They now all call it: 32 lines less of a security check that only stays correct as long as five copies stay identical — the blocklist is what stops a caller writing `cost` or `org_id` straight into the request context.

The helper also records which keys the caller actually supplied, on `RequestContext.CustomMetadataKeys`. `Metadata` picks up ~120 more keys from plugins as the request flows through, so without that list there is no way to tell caller-supplied dimensions from gateway bookkeeping. Nothing reads it yet — the exporter stacked above does.

**Hoist the per-org redactor cache onto the tenant store.** Two sinks now need per-org redaction. Copying the cache into the second one means threading `InvalidateOrg` through a three-branch callback chain where a missed branch does not produce staleness — it produces content exported under an org's *previous* redaction patterns. The store self-invalidates instead, and the logging plugin gets 61 lines shorter. `LoadBulk` is the branch that mattered: it replaces every config and fires no `onChange`, so a plugin-side cache would never have heard about it.

## Tests

- `metadata_header_test.go` — blocked keys dropped, malformed JSON is a no-op that keeps the request, accepted keys land in `CustomMetadataKeys`
- `tenant/store_test.go` — a second call returns the cached redactor, and `Set` / `Delete` / `MergeBulk` / `LoadBulk` each invalidate it

Part of TH-6826.
