### PR TITLE
feat(gateway): attach request and response bodies to exported spans

### DIFF
--- a/agentcc-gateway/cmd/agentcc/main.go
+++ b/agentcc-gateway/cmd/agentcc/main.go
@@ -535,15 +535,17 @@ func main() {
 	// Create logging plugin.
 	loggingPlugin := loggingplugin.New(cfg.Logging.RequestLogging, tenantStore)
 
-	// Attach privacy redactor if enabled.
+	// Attach privacy redactor if enabled. Kept in scope because every sink
+	// that exports request or response content redacts through it.
+	var globalRedactor *privacy.Redactor
 	if cfg.Privacy.Enabled {
 		patterns := make([]privacy.PatternConfig, len(cfg.Privacy.Patterns))
 		for i, p := range cfg.Privacy.Patterns {
 			patterns[i] = privacy.PatternConfig{Name: p.Name, Pattern: p.Pattern}
 		}
-		redactor := privacy.New(cfg.Privacy.Mode, patterns)
-		loggingPlugin.SetRedactor(redactor)
-		slog.Info("privacy mode enabled", "mode", cfg.Privacy.Mode, "patterns", redactor.PatternCount())
+		globalRedactor = privacy.New(cfg.Privacy.Mode, patterns)
+		loggingPlugin.SetRedactor(globalRedactor)
+		slog.Info("privacy mode enabled", "mode", cfg.Privacy.Mode, "patterns", globalRedactor.PatternCount())
 	}
 
 	plugins = append(plugins, loggingPlugin)
@@ -615,6 +617,8 @@ func main() {
 	var otelPlugin *otelplugin.Plugin
 	if cfg.OTel.Enabled {
 		otelPlugin = otelplugin.New(cfg.OTel)
+		otelPlugin.SetTenantStore(tenantStore)
+		otelPlugin.SetRedactor(globalRedactor)
 		plugins = append(plugins, otelPlugin)
 		slog.Info("otel enabled", "exporter", cfg.OTel.Exporter, "sample_rate", cfg.OTel.SampleRate)
 	}

--- a/agentcc-gateway/config.example.yaml
+++ b/agentcc-gateway/config.example.yaml
@@ -475,6 +475,11 @@ logging:
 #   headers:                           # hosted collectors authenticate here;
 #     X-Api-Key: "${FI_API_KEY}"       # keep credentials in the environment,
 #     X-Secret-Key: "${FI_SECRET_KEY}" # not in this file
+#   include_bodies: false              # attach prompt + completion to each span
+#                                      # (input.value / output.value). Off by
+#                                      # default: it sends user content to the
+#                                      # collector. Redacted with the same
+#                                      # privacy config as the request log.
 #   sample_rate: 0.1                   # 10% of requests
 #   attributes:                        # emitted as OTLP resource attributes
 #     environment: "production"

--- a/agentcc-gateway/internal/config/config.go
+++ b/agentcc-gateway/internal/config/config.go
@@ -775,6 +775,13 @@ type OTelConfig struct {
 	// this way, so write credentials as ${VAR} and keep them in the
 	// environment rather than in this file.
 	Headers map[string]string `yaml:"headers" json:"-"`
+
+	// IncludeBodies attaches the prompt and completion to each span. Off by
+	// default: it sends user content to the collector, and it is a separate
+	// decision from logging.request_logging.include_bodies because the two
+	// go to different places and are signed off separately. Content is
+	// redacted with the org's privacy config exactly as the request log is.
+	IncludeBodies bool `yaml:"include_bodies" json:"include_bodies"`
 }
 
 // PrometheusConfig controls the Prometheus metrics endpoint.

--- a/agentcc-gateway/internal/otel/otlp.go
+++ b/agentcc-gateway/internal/otel/otlp.go
@@ -322,16 +322,28 @@ func (e *OTLPExporter) retry(spans []*Span, reason string, attr slog.Attr) {
 			"reason", reason, "dropped", len(spans))
 		return
 	}
-	dropped := 0
-	if len(spans) > room {
-		dropped = len(spans) - room
+	total := len(spans)
+	if total > room {
 		spans = spans[:room]
 	}
+	// The byte ceiling binds on re-enqueue as well. Export enforces it on the
+	// way in, so a failed batch coming back is the one path that could push the
+	// queue past the memory bound it exists to hold.
+	kept, keptBytes := 0, 0
+	for _, s := range spans {
+		size := spanSize(s)
+		if e.bufferBytes+keptBytes+size > otlpMaxQueueBytes {
+			break
+		}
+		keptBytes += size
+		kept++
+	}
+	spans = spans[:kept]
+	dropped := total - kept
+
 	// Failed spans go to the front so the oldest telemetry still leaves first.
 	e.buffer = append(spans, e.buffer...)
-	for _, s := range spans {
-		e.bufferBytes += spanSize(s)
-	}
+	e.bufferBytes += keptBytes
 	e.mu.Unlock()
 
 	if dropped > 0 {

--- a/agentcc-gateway/internal/otel/otlp.go
+++ b/agentcc-gateway/internal/otel/otlp.go
@@ -29,6 +29,10 @@ const (
 	// scopeName identifies the instrumentation that produced these spans.
 	scopeName = "github.com/futureagi/agentcc-gateway"
 
+	// spanSizeOverhead approximates the fixed cost of a span (ids, name,
+	// timestamps, status) when estimating payload size.
+	spanSizeOverhead = 256
+
 	// resourceAttrPrefix marks span attributes that are really resource-level.
 	// They are emitted on the OTLP Resource instead and skipped on the span.
 	resourceAttrPrefix = "resource."
@@ -38,6 +42,16 @@ const (
 	otlpMaxQueue      = 4096             // hard ceiling; spans past it are dropped
 	otlpHTTPTimeout   = 10 * time.Second // per-request budget for the collector
 	otlpMaxRetries    = 3                // consecutive failures before dropping a batch
+
+	// Spans carrying prompts and completions are unbounded in a way ordinary
+	// telemetry is not — a single one can be megabytes — so the queue and the
+	// batch are bounded by bytes as well as by count. Without this, 4096
+	// queued spans of a few hundred KB each is close to a gigabyte of heap
+	// while a collector is unreachable, and one flush is far past any
+	// collector's request limit.
+	otlpMaxBatchBytes = 4 << 20  // flush once the buffer is roughly this big
+	otlpMaxQueueBytes = 64 << 20 // hard ceiling on queued span content
+	otlpMaxBodyBytes  = 8 << 20  // split a marshalled batch above this
 )
 
 // OTLPExporter ships spans to an OpenTelemetry collector over OTLP/HTTP with
@@ -56,6 +70,7 @@ type OTLPExporter struct {
 
 	mu               sync.Mutex
 	buffer           []*Span
+	bufferBytes      int
 	consecutiveFails int
 
 	dropped atomic.Int64
@@ -139,23 +154,31 @@ func (e *OTLPExporter) Export(spans []*Span) error {
 	}
 
 	e.mu.Lock()
-	room := otlpMaxQueue - len(e.buffer)
-	if room <= 0 {
-		e.mu.Unlock()
-		total := e.dropped.Add(int64(len(spans)))
+	var accepted, acceptedBytes, dropped int
+	for _, s := range spans {
+		size := spanSize(s)
+		if len(e.buffer)+accepted >= otlpMaxQueue || e.bufferBytes+acceptedBytes+size > otlpMaxQueueBytes {
+			dropped = len(spans) - accepted
+			break
+		}
+		accepted++
+		acceptedBytes += size
+	}
+	e.buffer = append(e.buffer, spans[:accepted]...)
+	e.bufferBytes += acceptedBytes
+	full := len(e.buffer) >= otlpBatchSize || e.bufferBytes >= otlpMaxBatchBytes
+	queuedBytes := e.bufferBytes
+	e.mu.Unlock()
+
+	if dropped > 0 {
+		total := e.dropped.Add(int64(dropped))
 		slog.Warn("otlp exporter: queue full, dropping spans",
-			"dropped", len(spans), "dropped_total", total)
+			"dropped", dropped, "queued", accepted,
+			"queued_bytes", queuedBytes, "dropped_total", total)
+	}
+	if accepted == 0 {
 		return nil
 	}
-	if len(spans) > room {
-		total := e.dropped.Add(int64(len(spans) - room))
-		slog.Warn("otlp exporter: queue full, dropping excess spans",
-			"queued", room, "dropped", len(spans)-room, "dropped_total", total)
-		spans = spans[:room]
-	}
-	e.buffer = append(e.buffer, spans...)
-	full := len(e.buffer) >= otlpBatchSize
-	e.mu.Unlock()
 
 	if full {
 		go e.flush()
@@ -193,14 +216,36 @@ func (e *OTLPExporter) flush() {
 	}
 	spans := e.buffer
 	e.buffer = make([]*Span, 0, otlpBatchSize)
+	e.bufferBytes = 0
 	e.mu.Unlock()
 
+	e.send(spans)
+}
+
+// send marshals and posts one batch, halving it if the encoded payload is over
+// otlpMaxBodyBytes. Splitting locally beats learning the same thing from a 413:
+// it costs no round trip and does not depend on the collector reporting the
+// limit correctly.
+func (e *OTLPExporter) send(spans []*Span) {
 	body, err := proto.Marshal(e.encode(spans))
 	if err != nil {
 		// The batch is gone: count it, or the one drop path that takes out
 		// spans which were themselves fine stays invisible to Dropped().
 		e.dropped.Add(int64(len(spans)))
 		slog.Error("otlp exporter: marshal failed, dropping batch", "error", err, "count", len(spans))
+		return
+	}
+
+	if len(body) > otlpMaxBodyBytes {
+		if len(spans) == 1 {
+			e.dropped.Add(1)
+			slog.Error("otlp exporter: single span exceeds the payload limit, dropping",
+				"bytes", len(body), "limit", otlpMaxBodyBytes)
+			return
+		}
+		mid := len(spans) / 2
+		e.send(spans[:mid])
+		e.send(spans[mid:])
 		return
 	}
 
@@ -284,6 +329,9 @@ func (e *OTLPExporter) retry(spans []*Span, reason string, attr slog.Attr) {
 	}
 	// Failed spans go to the front so the oldest telemetry still leaves first.
 	e.buffer = append(spans, e.buffer...)
+	for _, s := range spans {
+		e.bufferBytes += spanSize(s)
+	}
 	e.mu.Unlock()
 
 	if dropped > 0 {
@@ -367,6 +415,25 @@ func encodeSpan(s *Span) *tracepb.Span {
 	}
 
 	return pb
+}
+
+// spanSize estimates a span's contribution to the encoded payload. Only the
+// attribute values can be large, so a rough sum of those plus a fixed overhead
+// is enough to keep the queue and the batch bounded.
+func spanSize(s *Span) int {
+	if s == nil {
+		return 0
+	}
+	size := spanSizeOverhead
+	for k, v := range s.Attributes {
+		size += len(k)
+		if str, ok := v.(string); ok {
+			size += len(str)
+		} else {
+			size += 8
+		}
+	}
+	return size
 }
 
 // normalizeID turns an arbitrary identifier into the fixed-width byte ID that

--- a/agentcc-gateway/internal/otel/otlp_test.go
+++ b/agentcc-gateway/internal/otel/otlp_test.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -668,4 +669,102 @@ func TestHeaderNamesExcludesValues(t *testing.T) {
 			t.Fatal("headerNames leaked a credential value")
 		}
 	}
+}
+
+func spanWithBody(bytes int) *Span {
+	s := testSpan()
+	s.SetAttribute("input.value", strings.Repeat("x", bytes))
+	return s
+}
+
+// Spans carrying prompts are orders of magnitude larger than ordinary ones, so
+// a count-only ceiling lets the queue grow to hundreds of megabytes while a
+// collector is unreachable.
+func TestOTLPExporterQueueBoundedByBytes(t *testing.T) {
+	e, err := NewOTLPExporter(OTLPOptions{Endpoint: "http://127.0.0.1:1/v1/traces", ServiceName: "svc"})
+	if err != nil {
+		t.Fatalf("NewOTLPExporter: %v", err)
+	}
+	defer e.Shutdown()
+
+	// Well under the span-count ceiling, well over the byte ceiling.
+	const each = 1 << 20
+	spans := make([]*Span, 0, 128)
+	for i := 0; i < 128; i++ {
+		spans = append(spans, spanWithBody(each))
+	}
+	if err := e.Export(spans); err != nil {
+		t.Fatalf("Export: %v", err)
+	}
+
+	e.mu.Lock()
+	queued, queuedBytes := len(e.buffer), e.bufferBytes
+	e.mu.Unlock()
+
+	if queued == len(spans) {
+		t.Error("byte ceiling never applied — the whole batch was queued")
+	}
+	if queuedBytes > otlpMaxQueueBytes {
+		t.Errorf("queued %d bytes, over the %d ceiling", queuedBytes, otlpMaxQueueBytes)
+	}
+	if e.Dropped() == 0 {
+		t.Error("dropped spans not counted")
+	}
+}
+
+// An oversized batch is split locally rather than posted and rejected: a 413
+// costs a round trip to learn something the exporter can measure itself.
+func TestOTLPExporterSplitsOversizedPayload(t *testing.T) {
+	c := newCollector(t, nil)
+	e, err := NewOTLPExporter(OTLPOptions{Endpoint: c.URL, ServiceName: "svc"})
+	if err != nil {
+		t.Fatalf("NewOTLPExporter: %v", err)
+	}
+
+	// Four spans of 3 MiB: one batch would exceed the 8 MiB payload limit.
+	spans := []*Span{spanWithBody(3 << 20), spanWithBody(3 << 20), spanWithBody(3 << 20), spanWithBody(3 << 20)}
+	e.mu.Lock()
+	e.buffer = append(e.buffer, spans...)
+	e.mu.Unlock()
+	e.flush()
+
+	if got := c.requestCount(); got < 2 {
+		t.Fatalf("collector saw %d requests, want the batch split across at least 2", got)
+	}
+	if got := len(c.allSpans()); got != len(spans) {
+		t.Errorf("collector received %d spans, want all %d", got, len(spans))
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	for i, h := range c.headers {
+		if h.Get("Content-Type") != otlpContentType {
+			t.Errorf("split request %d lost its content type", i)
+		}
+	}
+	if e.Dropped() != 0 {
+		t.Errorf("splitting dropped %d spans", e.Dropped())
+	}
+	_ = e.Shutdown()
+}
+
+// A body large enough to make one span unsendable is dropped alone, not
+// retried forever and not taking a batch with it.
+func TestOTLPExporterDropsSingleOversizedSpan(t *testing.T) {
+	c := newCollector(t, nil)
+	e, err := NewOTLPExporter(OTLPOptions{Endpoint: c.URL, ServiceName: "svc"})
+	if err != nil {
+		t.Fatalf("NewOTLPExporter: %v", err)
+	}
+	e.mu.Lock()
+	e.buffer = append(e.buffer, spanWithBody(otlpMaxBodyBytes+(1<<20)))
+	e.mu.Unlock()
+	e.flush()
+
+	if got := c.requestCount(); got != 0 {
+		t.Errorf("posted %d oversized requests, want 0", got)
+	}
+	if e.Dropped() != 1 {
+		t.Errorf("Dropped() = %d, want 1", e.Dropped())
+	}
+	_ = e.Shutdown()
 }

--- a/agentcc-gateway/internal/otel/otlp_test.go
+++ b/agentcc-gateway/internal/otel/otlp_test.go
@@ -3,6 +3,7 @@ package otel
 import (
 	"encoding/hex"
 	"io"
+	"log/slog"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -545,6 +546,46 @@ func TestOTLPExporterCountsABatchLostToEncoding(t *testing.T) {
 		t.Fatalf("Dropped() = %d, want 2 — the whole batch was lost", e.Dropped())
 	}
 	_ = e.Shutdown()
+}
+
+// A batch coming back from a failed send is the one path into the queue that
+// does not go through Export, so the byte ceiling has to be enforced here too
+// or a retry can push the queue past the bound that caps its memory.
+func TestOTLPExporterRetryHoldsTheByteCeiling(t *testing.T) {
+	c := newCollector(t, func(int) int { return http.StatusOK })
+	e, err := NewOTLPExporter(OTLPOptions{Endpoint: c.URL, ServiceName: "svc", Resource: nil})
+	if err != nil {
+		t.Fatalf("NewOTLPExporter: %v", err)
+	}
+	defer func() { _ = e.Shutdown() }()
+
+	big := func() *Span {
+		s := NewSpan("chat_completion", "svc")
+		s.SetAttribute("input.value", strings.Repeat("x", 4096))
+		s.End()
+		return s
+	}
+
+	// Park the queue just under the ceiling, with room for one of these spans.
+	e.mu.Lock()
+	e.bufferBytes = otlpMaxQueueBytes - spanSize(big())
+	e.mu.Unlock()
+
+	e.retry([]*Span{big(), big(), big()}, "test", slog.String("k", "v"))
+
+	e.mu.Lock()
+	queued, bytes := len(e.buffer), e.bufferBytes
+	e.mu.Unlock()
+
+	if bytes > otlpMaxQueueBytes {
+		t.Errorf("bufferBytes = %d, over the %d ceiling", bytes, otlpMaxQueueBytes)
+	}
+	if queued != 1 {
+		t.Errorf("re-enqueued %d spans, want the 1 that fits", queued)
+	}
+	if e.Dropped() != 2 {
+		t.Errorf("Dropped() = %d, want the 2 that did not fit", e.Dropped())
+	}
 }
 
 func TestOTLPExporterShutdownIsIdempotent(t *testing.T) {

--- a/agentcc-gateway/internal/payloads/payloads.go
+++ b/agentcc-gateway/internal/payloads/payloads.go
@@ -1,0 +1,225 @@
+// Package payloads renders a request context's request and response into JSON
+// for the sinks that record content — the request-log webhook and exported
+// trace spans.
+//
+// It exists so those two agree. They are different destinations but the same
+// question: what does this request actually look like? Answering it twice
+// invites them to drift, and a trace whose body disagrees with the log of the
+// same request is worse than either alone.
+//
+// Large binary payloads are summarized rather than carried. A base64 image or
+// an embedding vector is megabytes that no reviewer reads and no evaluator
+// scores, and including it would crowd out the prompt text that is the point.
+// What replaces it says how big it was, so nothing looks silently absent.
+package payloads
+
+import (
+	"encoding/json"
+	"regexp"
+	"strconv"
+	"strings"
+
+	"github.com/futureagi/agentcc-gateway/internal/models"
+)
+
+// ForEndpoint returns the request and response payloads for a non-chat
+// endpoint. Chat-shaped traffic returns nil, nil: rc.Request and rc.Response
+// already describe it, and callers marshal those directly.
+func ForEndpoint(rc *models.RequestContext) (request, response json.RawMessage) {
+	switch rc.EndpointType {
+	case "embedding", "genai_embed":
+		return marshalPtr(rc.EmbeddingRequest), marshal(embeddingResponse(rc.EmbeddingResponse))
+
+	case "image":
+		return marshalPtr(rc.ImageRequest), marshal(imageResponse(rc.ImageResponse))
+
+	case "speech", "speech_stream":
+		if rc.SpeechRequest == nil {
+			return nil, nil
+		}
+		resp := map[string]any{
+			"binary":       true,
+			"content_type": rc.Metadata["response_content_type"],
+		}
+		if size := rc.Metadata["response_size_bytes"]; size != "" {
+			resp["size_bytes"] = size
+		}
+		return marshalPtr(rc.SpeechRequest), marshal(resp)
+
+	case "transcription":
+		if rc.TranscriptionReq == nil {
+			return nil, marshalPtr(rc.TranscriptionResp)
+		}
+		req := map[string]any{
+			"model":           rc.TranscriptionReq.Model,
+			"file_name":       rc.TranscriptionReq.FileName,
+			"file_size_bytes": len(rc.TranscriptionReq.FileData),
+			"language":        rc.TranscriptionReq.Language,
+			"response_format": rc.TranscriptionReq.ResponseFormat,
+		}
+		if rc.TranscriptionReq.Temperature != nil {
+			req["temperature"] = *rc.TranscriptionReq.Temperature
+		}
+		if audioSeconds := rc.Metadata["audio_seconds"]; audioSeconds != "" {
+			req["audio_seconds"] = audioSeconds
+		}
+		return marshal(req), marshalPtr(rc.TranscriptionResp)
+
+	case "translation":
+		if rc.TranslationReq == nil {
+			return nil, marshalPtr(rc.TranslationResp)
+		}
+		req := map[string]any{
+			"model":           rc.TranslationReq.Model,
+			"file_name":       rc.TranslationReq.FileName,
+			"file_size_bytes": len(rc.TranslationReq.FileData),
+			"prompt":          rc.TranslationReq.Prompt,
+			"response_format": rc.TranslationReq.ResponseFormat,
+		}
+		if rc.TranslationReq.Temperature != nil {
+			req["temperature"] = *rc.TranslationReq.Temperature
+		}
+		return marshal(req), marshalPtr(rc.TranslationResp)
+
+	case "rerank":
+		// Query and documents are the whole content; the size cap handles bulk.
+		return marshalPtr(rc.RerankRequest), marshalPtr(rc.RerankResponse)
+
+	case "search":
+		return marshalPtr(rc.SearchRequest), marshalPtr(rc.SearchResponse)
+
+	case "ocr":
+		return marshalPtr(rc.OCRRequest), marshal(ocrResponse(rc.OCRResponse))
+
+	default:
+		return nil, nil
+	}
+}
+
+// embeddingResponse keeps the shape and the usage but drops the vectors. The
+// numbers are the one part of an embedding response nobody reads back.
+func embeddingResponse(resp *models.EmbeddingResponse) any {
+	if resp == nil {
+		return nil
+	}
+	data := make([]map[string]any, 0, len(resp.Data))
+	for _, d := range resp.Data {
+		data = append(data, map[string]any{
+			"object":          d.Object,
+			"index":           d.Index,
+			"embedding_bytes": len(d.Embedding),
+		})
+	}
+	return map[string]any{
+		"object": resp.Object,
+		"model":  resp.Model,
+		"usage":  resp.Usage,
+		"data":   data,
+	}
+}
+
+// imageResponse keeps URLs and revised prompts — both worth reading — and
+// replaces inline base64 images with their size.
+func imageResponse(resp *models.ImageResponse) any {
+	if resp == nil {
+		return nil
+	}
+	data := make([]map[string]any, 0, len(resp.Data))
+	for _, d := range resp.Data {
+		entry := map[string]any{}
+		if d.URL != "" {
+			entry["url"] = d.URL
+		}
+		if d.RevisedPrompt != "" {
+			entry["revised_prompt"] = d.RevisedPrompt
+		}
+		if d.B64JSON != "" {
+			entry["b64_json_bytes"] = len(d.B64JSON)
+		}
+		data = append(data, entry)
+	}
+	return map[string]any{"created": resp.Created, "data": data}
+}
+
+// ocrResponse keeps the extracted markdown, which is the result, and drops the
+// base64 page images, which are the input rendered back.
+func ocrResponse(resp *models.OCRResponse) any {
+	if resp == nil {
+		return nil
+	}
+	pages := make([]map[string]any, 0, len(resp.Pages))
+	for _, p := range resp.Pages {
+		page := map[string]any{
+			"index":    p.Index,
+			"markdown": p.Markdown,
+		}
+		if p.Dimensions != nil {
+			page["dimensions"] = p.Dimensions
+		}
+		if len(p.Images) > 0 {
+			images := make([]map[string]any, 0, len(p.Images))
+			for _, img := range p.Images {
+				entry := map[string]any{"image_base64_bytes": len(img.ImageBase64)}
+				if img.BBox != nil {
+					entry["bbox"] = img.BBox
+				}
+				images = append(images, entry)
+			}
+			page["images"] = images
+		}
+		pages = append(pages, page)
+	}
+	return map[string]any{
+		"object":     resp.Object,
+		"model":      resp.Model,
+		"pages":      pages,
+		"usage_info": resp.UsageInfo,
+	}
+}
+
+// marshalPtr exists because a nil pointer inside an `any` is not `== nil`:
+// passing one to marshal would emit the JSON literal `null` rather than
+// omitting the field, so an absent payload would read as a present empty one.
+func marshalPtr[T any](v *T) json.RawMessage {
+	if v == nil {
+		return nil
+	}
+	return marshal(v)
+}
+
+func marshal(v any) json.RawMessage {
+	if v == nil {
+		return nil
+	}
+	b, err := json.Marshal(v)
+	if err != nil {
+		return nil
+	}
+	return b
+}
+
+// dataURI matches an inline base64 data URI, the way images and audio arrive
+// inside chat message content.
+var dataURI = regexp.MustCompile(`data:([a-zA-Z0-9.+/-]+);base64,([A-Za-z0-9+/=]{256,})`)
+
+// ElideInlineData replaces inline base64 data URIs with a note of their type
+// and size.
+//
+// Vision and audio requests carry the payload inside the message content, so
+// unlike the multimodal endpoints there is no separate field to leave behind.
+// Carried through, one image is megabytes: it would blow the per-attribute cap
+// and truncate the surrounding JSON into something unparseable, losing the
+// prompt as well as the image. The mime type and size are what a reviewer can
+// actually use.
+func ElideInlineData(s string) string {
+	if !strings.Contains(s, ";base64,") {
+		return s
+	}
+	return dataURI.ReplaceAllStringFunc(s, func(match string) string {
+		parts := dataURI.FindStringSubmatch(match)
+		if len(parts) != 3 {
+			return match
+		}
+		return "data:" + parts[1] + ";base64,<elided " + strconv.Itoa(len(parts[2])) + " bytes>"
+	})
+}

--- a/agentcc-gateway/internal/payloads/payloads_test.go
+++ b/agentcc-gateway/internal/payloads/payloads_test.go
@@ -1,0 +1,138 @@
+package payloads
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/futureagi/agentcc-gateway/internal/models"
+)
+
+// An absent payload must be absent, not the literal null — a nil pointer in an
+// `any` is not == nil, so this is easy to get wrong and invisible once wrong.
+func TestAbsentPayloadsAreOmitted(t *testing.T) {
+	for _, endpoint := range []string{"embedding", "image", "rerank", "search", "ocr", "transcription", "translation"} {
+		rc := &models.RequestContext{EndpointType: endpoint, Metadata: map[string]string{}}
+		req, resp := ForEndpoint(rc)
+		if string(req) == "null" || string(resp) == "null" {
+			t.Errorf("%s: emitted a null literal instead of omitting (req=%q resp=%q)", endpoint, req, resp)
+		}
+	}
+}
+
+func TestChatFallsThrough(t *testing.T) {
+	rc := &models.RequestContext{EndpointType: "chat", Metadata: map[string]string{}}
+	req, resp := ForEndpoint(rc)
+	if req != nil || resp != nil {
+		t.Error("chat should be left to the caller's own marshalling")
+	}
+}
+
+// The prompt is the point of an image request; the base64 result is megabytes
+// nobody reads. Keep the first, summarize the second.
+func TestImageKeepsPromptAndElidesBase64(t *testing.T) {
+	big := strings.Repeat("A", 400000)
+	rc := &models.RequestContext{
+		EndpointType:  "image",
+		Metadata:      map[string]string{},
+		ImageRequest:  &models.ImageRequest{Model: "dall-e-3", Prompt: "a red bicycle"},
+		ImageResponse: &models.ImageResponse{Data: []models.ImageData{{B64JSON: big, RevisedPrompt: "a red racing bicycle"}}},
+	}
+	req, resp := ForEndpoint(rc)
+
+	if !strings.Contains(string(req), "a red bicycle") {
+		t.Errorf("prompt missing from request payload: %s", req)
+	}
+	if strings.Contains(string(resp), big) {
+		t.Error("base64 image carried into the payload")
+	}
+	if len(resp) > 1000 {
+		t.Errorf("response payload is %d bytes; the image was not elided", len(resp))
+	}
+	if !strings.Contains(string(resp), "b64_json_bytes") {
+		t.Error("elided image should record its size")
+	}
+	if !strings.Contains(string(resp), "a red racing bicycle") {
+		t.Error("revised prompt should survive — it is model output")
+	}
+}
+
+// Vectors are the one part of an embedding response nobody reads back, and the
+// largest. The input text is what matters.
+func TestEmbeddingKeepsInputAndElidesVectors(t *testing.T) {
+	vec, _ := json.Marshal(make([]float64, 3072))
+	rc := &models.RequestContext{
+		EndpointType:     "embedding",
+		Metadata:         map[string]string{},
+		EmbeddingRequest: &models.EmbeddingRequest{Model: "text-embedding-3-large", Input: json.RawMessage(`"embed this sentence"`)},
+		EmbeddingResponse: &models.EmbeddingResponse{
+			Object: "list", Model: "text-embedding-3-large",
+			Data: []models.EmbeddingData{{Object: "embedding", Index: 0, Embedding: vec}},
+		},
+	}
+	req, resp := ForEndpoint(rc)
+
+	if !strings.Contains(string(req), "embed this sentence") {
+		t.Errorf("input text missing: %s", req)
+	}
+	if strings.Contains(string(resp), "0,0,0,0") {
+		t.Error("embedding vector carried into the payload")
+	}
+	if !strings.Contains(string(resp), "embedding_bytes") {
+		t.Error("elided vector should record its size")
+	}
+}
+
+// OCR's result is the extracted markdown; the page images are the input
+// rendered back and can be large.
+func TestOCRKeepsMarkdownAndElidesPageImages(t *testing.T) {
+	big := strings.Repeat("B", 300000)
+	rc := &models.RequestContext{
+		EndpointType: "ocr",
+		Metadata:     map[string]string{},
+		OCRRequest:   &models.OCRRequest{Model: "ocr-1", Document: models.OCRDocument{Type: "document_url", DocumentURL: "https://x/y.pdf"}},
+		OCRResponse: &models.OCRResponse{Pages: []models.OCRPage{
+			{Index: 0, Markdown: "# Invoice\ntotal 42", Images: []models.OCRImage{{ImageBase64: big}}},
+		}},
+	}
+	req, resp := ForEndpoint(rc)
+
+	if !strings.Contains(string(req), "y.pdf") {
+		t.Errorf("document reference missing: %s", req)
+	}
+	if strings.Contains(string(resp), big) {
+		t.Error("page image carried into the payload")
+	}
+	if !strings.Contains(string(resp), "total 42") {
+		t.Error("extracted markdown missing — that is the OCR result")
+	}
+}
+
+// Rerank and search are text end to end; nothing to elide.
+func TestTextEndpointsCarryContent(t *testing.T) {
+	rc := &models.RequestContext{
+		EndpointType:  "rerank",
+		Metadata:      map[string]string{},
+		RerankRequest: &models.RerankRequest{Model: "rerank-1", Query: "best bicycle", Documents: []string{"a doc"}},
+	}
+	req, _ := ForEndpoint(rc)
+	if !strings.Contains(string(req), "best bicycle") || !strings.Contains(string(req), "a doc") {
+		t.Errorf("rerank query/documents missing: %s", req)
+	}
+}
+
+// Audio bytes never travel; the request is described by size instead.
+func TestTranscriptionDescribesAudioWithoutCarryingIt(t *testing.T) {
+	rc := &models.RequestContext{
+		EndpointType:     "transcription",
+		Metadata:         map[string]string{},
+		TranscriptionReq: &models.TranscriptionRequest{Model: "whisper-1", FileName: "call.mp3", FileData: make([]byte, 5000)},
+	}
+	req, _ := ForEndpoint(rc)
+	if strings.Contains(string(req), "file_data") {
+		t.Error("audio bytes carried into the payload")
+	}
+	if !strings.Contains(string(req), "file_size_bytes") || !strings.Contains(string(req), "call.mp3") {
+		t.Errorf("audio not described: %s", req)
+	}
+}

--- a/agentcc-gateway/internal/plugins/logging/record.go
+++ b/agentcc-gateway/internal/plugins/logging/record.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/futureagi/agentcc-gateway/internal/config"
 	"github.com/futureagi/agentcc-gateway/internal/models"
+	"github.com/futureagi/agentcc-gateway/internal/payloads"
 	"github.com/futureagi/agentcc-gateway/internal/privacy"
 )
 
@@ -197,76 +198,13 @@ func buildRecord(rc *models.RequestContext, cfg config.RequestLoggingConfig) Tra
 	if cfg.IncludeBodies {
 		rec.RequestBody = rc.Request
 		rec.ResponseBody = rc.Response
-		rec.RequestBodyJSON, rec.ResponseBodyJSON = buildEndpointBodyJSON(rc)
+		rec.RequestBodyJSON, rec.ResponseBodyJSON = payloads.ForEndpoint(rc)
 		if rc.RequestHeaders != nil {
 			rec.RequestHeaders = sanitizeHeaders(rc.RequestHeaders)
 		}
 	}
 
 	return rec
-}
-
-func buildEndpointBodyJSON(rc *models.RequestContext) (json.RawMessage, json.RawMessage) {
-	marshal := func(v any) json.RawMessage {
-		if v == nil {
-			return nil
-		}
-		b, err := json.Marshal(v)
-		if err != nil {
-			return nil
-		}
-		return b
-	}
-
-	switch rc.EndpointType {
-	case "speech", "speech_stream":
-		if rc.SpeechRequest == nil {
-			return nil, nil
-		}
-		resp := map[string]any{
-			"binary":       true,
-			"content_type": rc.Metadata["response_content_type"],
-		}
-		if size := rc.Metadata["response_size_bytes"]; size != "" {
-			resp["size_bytes"] = size
-		}
-		return marshal(rc.SpeechRequest), marshal(resp)
-	case "transcription":
-		if rc.TranscriptionReq == nil {
-			return nil, marshal(rc.TranscriptionResp)
-		}
-		req := map[string]any{
-			"model":           rc.TranscriptionReq.Model,
-			"file_name":       rc.TranscriptionReq.FileName,
-			"file_size_bytes": len(rc.TranscriptionReq.FileData),
-			"language":        rc.TranscriptionReq.Language,
-			"response_format": rc.TranscriptionReq.ResponseFormat,
-		}
-		if rc.TranscriptionReq.Temperature != nil {
-			req["temperature"] = *rc.TranscriptionReq.Temperature
-		}
-		if audioSeconds := rc.Metadata["audio_seconds"]; audioSeconds != "" {
-			req["audio_seconds"] = audioSeconds
-		}
-		return marshal(req), marshal(rc.TranscriptionResp)
-	case "translation":
-		if rc.TranslationReq == nil {
-			return nil, marshal(rc.TranslationResp)
-		}
-		req := map[string]any{
-			"model":           rc.TranslationReq.Model,
-			"file_name":       rc.TranslationReq.FileName,
-			"file_size_bytes": len(rc.TranslationReq.FileData),
-			"prompt":          rc.TranslationReq.Prompt,
-			"response_format": rc.TranslationReq.ResponseFormat,
-		}
-		if rc.TranslationReq.Temperature != nil {
-			req["temperature"] = *rc.TranslationReq.Temperature
-		}
-		return marshal(req), marshal(rc.TranslationResp)
-	default:
-		return nil, nil
-	}
 }
 
 // redactRecord applies privacy redaction to message content in the trace record.

--- a/agentcc-gateway/internal/plugins/otel/bodies.go
+++ b/agentcc-gateway/internal/plugins/otel/bodies.go
@@ -3,6 +3,7 @@ package otel
 import (
 	"encoding/json"
 	"log/slog"
+	"unicode/utf8"
 
 	"github.com/futureagi/agentcc-gateway/internal/models"
 	otelpkg "github.com/futureagi/agentcc-gateway/internal/otel"
@@ -88,7 +89,16 @@ func prepareBody(v string, r *privacy.Redactor, mode string) preparedBody {
 	if len(v) <= maxBodyAttrBytes {
 		return preparedBody{value: v}
 	}
-	return preparedBody{value: v[:maxBodyAttrBytes], originalBytes: len(v), truncated: true}
+	// Walk back to a rune boundary. Slicing by byte index can end the string
+	// mid-rune, and an OTLP attribute is a proto string: proto.Marshal rejects
+	// the whole message rather than the offending field, so a single body cut
+	// through a multi-byte character would take its entire batch of unrelated
+	// spans with it. Non-ASCII prompts are not an edge case.
+	cut := maxBodyAttrBytes
+	for cut > 0 && !utf8.RuneStart(v[cut]) {
+		cut--
+	}
+	return preparedBody{value: v[:cut], originalBytes: len(v), truncated: true}
 }
 
 // redactorFor prefers the org's redactor over the gateway-wide one, matching

--- a/agentcc-gateway/internal/plugins/otel/bodies.go
+++ b/agentcc-gateway/internal/plugins/otel/bodies.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/futureagi/agentcc-gateway/internal/models"
 	otelpkg "github.com/futureagi/agentcc-gateway/internal/otel"
+	"github.com/futureagi/agentcc-gateway/internal/payloads"
 	"github.com/futureagi/agentcc-gateway/internal/privacy"
 	"github.com/futureagi/agentcc-gateway/internal/tenant"
 )
@@ -29,18 +30,37 @@ func (p *Plugin) attachBodies(span *otelpkg.Span, rc *models.RequestContext) {
 		mode = orgMode
 	}
 
+	in, out := bodyJSON(rc)
+	if in != "" {
+		setBodyAttr(span, "input", prepareBody(in, redactor, mode))
+	}
+	if out != "" {
+		setBodyAttr(span, "output", prepareBody(out, redactor, mode))
+	}
+}
+
+// bodyJSON renders whatever this request was — chat, embedding, image, audio,
+// OCR, rerank, search — into request and response JSON. Non-chat endpoints go
+// through the same builder the request log uses, so a span and a log row of
+// the same request never disagree about what was sent.
+func bodyJSON(rc *models.RequestContext) (in, out string) {
+	if req, resp := payloads.ForEndpoint(rc); req != nil || resp != nil {
+		return string(req), string(resp)
+	}
+
 	if rc.Request != nil {
 		if v, ok := encodeBody(rc.Request); ok {
-			setBodyAttr(span, "input", prepareBody(v, redactor, mode))
+			in = v
 		}
 	}
 	// A streamed response with no choices is the pre-assembly husk; exporting
 	// it would claim an empty completion rather than an absent one.
 	if resp := rc.Response; resp != nil && len(resp.Choices) > 0 {
 		if v, ok := encodeBody(resp); ok {
-			setBodyAttr(span, "output", prepareBody(v, redactor, mode))
+			out = v
 		}
 	}
+	return in, out
 }
 
 // preparedBody is a body ready to go on a span.
@@ -58,6 +78,9 @@ type preparedBody struct {
 // exported. Redacting the complete text first means a match is replaced whole,
 // and truncation only ever removes already-safe content.
 func prepareBody(v string, r *privacy.Redactor, mode string) preparedBody {
+	// Inline images and audio go first: removing them outright is safer than
+	// redacting them, and it leaves far less text for the patterns to scan.
+	v = payloads.ElideInlineData(v)
 	v = redact(v, r, mode)
 
 	if len(v) <= maxBodyAttrBytes {

--- a/agentcc-gateway/internal/plugins/otel/bodies.go
+++ b/agentcc-gateway/internal/plugins/otel/bodies.go
@@ -30,6 +30,8 @@ func (p *Plugin) attachBodies(span *otelpkg.Span, rc *models.RequestContext) {
 		mode = orgMode
 	}
 
+	p.attachMessages(span, rc, redactor, mode)
+
 	in, out := bodyJSON(rc)
 	if in != "" {
 		setBodyAttr(span, "input", prepareBody(in, redactor, mode))

--- a/agentcc-gateway/internal/plugins/otel/bodies.go
+++ b/agentcc-gateway/internal/plugins/otel/bodies.go
@@ -1,0 +1,110 @@
+package otel
+
+import (
+	"encoding/json"
+	"log/slog"
+
+	"github.com/futureagi/agentcc-gateway/internal/models"
+	otelpkg "github.com/futureagi/agentcc-gateway/internal/otel"
+	"github.com/futureagi/agentcc-gateway/internal/privacy"
+	"github.com/futureagi/agentcc-gateway/internal/tenant"
+)
+
+// maxBodyAttrBytes caps a single prompt or completion attribute. Observed
+// production prompts run to a few hundred KB with outliers in the megabytes;
+// this passes the ordinary ones intact and truncates only the extremes, which
+// keeps one span from dominating a batch.
+const maxBodyAttrBytes = 1 << 20
+
+// attachBodies puts the request and response on the span as input.value and
+// output.value — the keys the platform lifts into its input/output columns.
+//
+// Content is redacted before it is truncated. The other order can cut through
+// the middle of a match and export the leading half of the very thing the
+// pattern exists to remove.
+func (p *Plugin) attachBodies(span *otelpkg.Span, rc *models.RequestContext) {
+	redactor := p.redactorFor(rc)
+	mode := rc.Metadata["privacy_mode"]
+	if orgMode := rc.Metadata["org_privacy_mode"]; orgMode != "" {
+		mode = orgMode
+	}
+
+	if rc.Request != nil {
+		if v, ok := encodeBody(rc.Request); ok {
+			setBodyAttr(span, "input", prepareBody(v, redactor, mode))
+		}
+	}
+	// A streamed response with no choices is the pre-assembly husk; exporting
+	// it would claim an empty completion rather than an absent one.
+	if resp := rc.Response; resp != nil && len(resp.Choices) > 0 {
+		if v, ok := encodeBody(resp); ok {
+			setBodyAttr(span, "output", prepareBody(v, redactor, mode))
+		}
+	}
+}
+
+// preparedBody is a body ready to go on a span.
+type preparedBody struct {
+	value         string
+	originalBytes int
+	truncated     bool
+}
+
+// prepareBody redacts and then truncates, in that order.
+//
+// The order is the whole point of this function existing. Truncating first can
+// cut through the middle of a match — the tail that made it recognisable is
+// gone, the pattern no longer fires, and the leading half of the secret is
+// exported. Redacting the complete text first means a match is replaced whole,
+// and truncation only ever removes already-safe content.
+func prepareBody(v string, r *privacy.Redactor, mode string) preparedBody {
+	v = redact(v, r, mode)
+
+	if len(v) <= maxBodyAttrBytes {
+		return preparedBody{value: v}
+	}
+	return preparedBody{value: v[:maxBodyAttrBytes], originalBytes: len(v), truncated: true}
+}
+
+// redactorFor prefers the org's redactor over the gateway-wide one, matching
+// how the request log resolves it.
+func (p *Plugin) redactorFor(rc *models.RequestContext) *privacy.Redactor {
+	if p.tenantStore != nil {
+		if r := p.tenantStore.Redactor(rc.Metadata[tenant.MetadataKeyOrgID]); r != nil {
+			return r
+		}
+	}
+	return p.redactor
+}
+
+func redact(content string, r *privacy.Redactor, mode string) string {
+	if r == nil || !r.ShouldRedact() {
+		return content
+	}
+	if mode != "" {
+		return r.RedactForMode(content, mode)
+	}
+	return r.Redact(content)
+}
+
+func encodeBody(v any) (string, bool) {
+	b, err := json.Marshal(v)
+	if err != nil {
+		slog.Debug("otel: body not serializable, omitted from span", "error", err)
+		return "", false
+	}
+	return string(b), true
+}
+
+// setBodyAttr writes the value plus its mime type, and — when the value had to
+// be cut — flags it so a consumer does not try to parse a truncated document
+// as JSON.
+func setBodyAttr(span *otelpkg.Span, kind string, b preparedBody) {
+	if b.truncated {
+		span.SetAttribute("agentcc."+kind+"_original_bytes", b.originalBytes)
+		span.SetAttribute("agentcc."+kind+"_truncated", true)
+	} else {
+		span.SetAttribute(kind+".mime_type", "application/json")
+	}
+	span.SetAttribute(kind+".value", b.value)
+}

--- a/agentcc-gateway/internal/plugins/otel/bodies_test.go
+++ b/agentcc-gateway/internal/plugins/otel/bodies_test.go
@@ -391,3 +391,116 @@ func min(a, b int) int {
 	}
 	return b
 }
+
+// The trace viewer renders a conversation from these flattened keys, not from
+// input.value. Without them a vision request displays as text with the image
+// silently missing.
+func TestMessageAttributesRenderable(t *testing.T) {
+	p, _ := bodyPlugin(t, true)
+	rc := newTestRC()
+	content, _ := json.Marshal([]map[string]any{
+		{"type": "text", "text": "what colour is this?"},
+		{"type": "image_url", "image_url": map[string]string{"url": "https://img/bike.png"}},
+	})
+	rc.Request.Messages = []models.Message{{Role: "user", Content: content}}
+	out, _ := json.Marshal("it is red")
+	rc.Response.Choices = []models.Choice{{Message: models.Message{Role: "assistant", Content: out}}}
+
+	attrs := runOnce(p, rc)
+	want := map[string]interface{}{
+		"llm.input_messages.0.message.role":                                 "user",
+		"llm.input_messages.0.message.contents.0.message_content.type":      "text",
+		"llm.input_messages.0.message.contents.0.message_content.text":      "what colour is this?",
+		"llm.input_messages.0.message.contents.1.message_content.type":      "image_url",
+		"llm.input_messages.0.message.contents.1.message_content.image.url": "https://img/bike.png",
+		"llm.output_messages.0.message.role":                                "assistant",
+		"llm.output_messages.0.message.content":                             "it is red",
+	}
+	for k, v := range want {
+		if got := attrs[k]; got != v {
+			t.Errorf("%s = %v, want %v", k, got, v)
+		}
+	}
+}
+
+// A plain text message emits flat content, which is what the viewer expects
+// for the common case.
+func TestMessageAttributesFlatForPlainText(t *testing.T) {
+	p, _ := bodyPlugin(t, true)
+	rc := newTestRC()
+	c, _ := json.Marshal("just text")
+	rc.Request.Messages = []models.Message{{Role: "user", Content: c}}
+	rc.Response = nil
+
+	attrs := runOnce(p, rc)
+	if attrs["llm.input_messages.0.message.content"] != "just text" {
+		t.Errorf("flat content = %v", attrs["llm.input_messages.0.message.content"])
+	}
+	if _, ok := attrs["llm.input_messages.0.message.contents.0.message_content.text"]; ok {
+		t.Error("emitted structured parts for plain text; the viewer would ignore them anyway")
+	}
+}
+
+// An image too large to carry is described rather than dropped, and only the
+// flat summary is emitted — the viewer prefers it over structured parts, so
+// sending both would hide the parts and risk the crash that shape once caused.
+func TestMessageAttributesMaskOversizedImage(t *testing.T) {
+	p, _ := bodyPlugin(t, true)
+	rc := newTestRC()
+	huge := "data:image/png;base64," + strings.Repeat("A", maxInlineImageBytes+1000)
+	content, _ := json.Marshal([]map[string]any{
+		{"type": "text", "text": "describe this"},
+		{"type": "image_url", "image_url": map[string]string{"url": huge}},
+	})
+	rc.Request.Messages = []models.Message{{Role: "user", Content: content}}
+	rc.Response = nil
+
+	attrs := runOnce(p, rc)
+	flat, _ := attrs["llm.input_messages.0.message.content"].(string)
+	if !strings.Contains(flat, "describe this") {
+		t.Errorf("prompt lost from the masked summary: %q", flat)
+	}
+	if !strings.Contains(flat, "[image: image/png") {
+		t.Errorf("image not described: %q", flat)
+	}
+	if strings.Contains(flat, strings.Repeat("A", 100)) {
+		t.Error("oversized image carried anyway")
+	}
+	if v, ok := attrs["llm.input_messages.0.message.contents.1.message_content.image.url"]; ok {
+		t.Errorf("structured part emitted alongside the flat summary: %v", v)
+	}
+}
+
+// These attributes carry the same user content input.value does, so they must
+// go through the same redaction — otherwise they are a way around it.
+func TestMessageAttributesRedacted(t *testing.T) {
+	p, _ := bodyPlugin(t, true)
+	p.SetRedactor(privacy.New("patterns", []privacy.PatternConfig{{Name: "pw", Pattern: "hunter2"}}))
+
+	rc := newTestRC()
+	c, _ := json.Marshal("my password is hunter2")
+	rc.Request.Messages = []models.Message{{Role: "user", Content: c}}
+	out, _ := json.Marshal("your password is hunter2")
+	rc.Response.Choices = []models.Choice{{Message: models.Message{Role: "assistant", Content: out}}}
+
+	attrs := runOnce(p, rc)
+	if in, _ := attrs["llm.input_messages.0.message.content"].(string); strings.Contains(in, "hunter2") {
+		t.Errorf("input message not redacted: %q", in)
+	}
+	if o, _ := attrs["llm.output_messages.0.message.content"].(string); strings.Contains(o, "hunter2") {
+		t.Errorf("output message not redacted: %q", o)
+	}
+}
+
+func TestMessageAttributesAbsentUnlessEnabled(t *testing.T) {
+	p, _ := bodyPlugin(t, false)
+	rc := newTestRC()
+	c, _ := json.Marshal("just text")
+	rc.Request.Messages = []models.Message{{Role: "user", Content: c}}
+
+	for k := range runOnce(p, rc) {
+		if strings.HasPrefix(k, "llm.input_messages") || strings.HasPrefix(k, "llm.output_messages") {
+			t.Errorf("message attribute %q emitted with include_bodies off", k)
+		}
+	}
+}

--- a/agentcc-gateway/internal/plugins/otel/bodies_test.go
+++ b/agentcc-gateway/internal/plugins/otel/bodies_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"strings"
 	"testing"
+	"unicode/utf8"
 
 	"github.com/futureagi/agentcc-gateway/internal/config"
 	"github.com/futureagi/agentcc-gateway/internal/models"
@@ -126,6 +127,30 @@ func TestBodiesRedactBeforeTruncate(t *testing.T) {
 	}
 	if len(got.value) > maxBodyAttrBytes {
 		t.Errorf("value length %d exceeds the cap %d", len(got.value), maxBodyAttrBytes)
+	}
+}
+
+// Truncation cuts by byte index, so on a non-ASCII body the cap can land in
+// the middle of a character. An OTLP attribute is a proto string and
+// proto.Marshal fails the whole message on invalid UTF-8, so that one body
+// would take its entire batch of unrelated spans with it. The other truncation
+// tests use ASCII filler, which is exactly why they cannot see this.
+func TestBodiesTruncateOnARuneBoundary(t *testing.T) {
+	// Shift the content by one byte at a time: one of these puts a multi-byte
+	// character across the cap no matter where the cap happens to sit.
+	for pad := 0; pad < 3; pad++ {
+		body := strings.Repeat("a", pad) + strings.Repeat("héllo wörld ☃", maxBodyAttrBytes)
+		got := prepareBody(body, nil, "")
+
+		if !got.truncated {
+			t.Fatalf("pad=%d: body of %d bytes was not truncated", pad, len(body))
+		}
+		if len(got.value) > maxBodyAttrBytes {
+			t.Errorf("pad=%d: value length %d exceeds the cap %d", pad, len(got.value), maxBodyAttrBytes)
+		}
+		if !utf8.ValidString(got.value) {
+			t.Errorf("pad=%d: truncation left invalid UTF-8; the batch this span joins cannot be marshalled", pad)
+		}
 	}
 }
 

--- a/agentcc-gateway/internal/plugins/otel/bodies_test.go
+++ b/agentcc-gateway/internal/plugins/otel/bodies_test.go
@@ -1,0 +1,170 @@
+package otel
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/futureagi/agentcc-gateway/internal/config"
+	"github.com/futureagi/agentcc-gateway/internal/models"
+	"github.com/futureagi/agentcc-gateway/internal/privacy"
+	"github.com/futureagi/agentcc-gateway/internal/tenant"
+)
+
+func bodyPlugin(t *testing.T, include bool) (*Plugin, *captureExporter) {
+	t.Helper()
+	exp := &captureExporter{}
+	p := New(config.OTelConfig{Enabled: true, Exporter: "stdout", IncludeBodies: include})
+	p.exporter = exp
+	return p, exp
+}
+
+func runOnce(p *Plugin, rc *models.RequestContext) map[string]interface{} {
+	ctx := context.Background()
+	p.ProcessRequest(ctx, rc)
+	p.ProcessResponse(ctx, rc)
+	return p.exporter.(*captureExporter).Spans()[0].Attributes
+}
+
+func rcWithBodies() *models.RequestContext {
+	rc := newTestRC()
+	content := json.RawMessage(`"my password is hunter2"`)
+	rc.Request.Messages = []models.Message{{Role: "user", Content: content}}
+	out := json.RawMessage(`"the password is hunter2"`)
+	rc.Response.Choices = []models.Choice{{Index: 0, Message: models.Message{Role: "assistant", Content: out}}}
+	return rc
+}
+
+// input.value / output.value are the keys the platform lifts into its input and
+// output columns. A rename here shows up as blank columns, not an error.
+func TestBodiesUseTheConventionalKeys(t *testing.T) {
+	p, _ := bodyPlugin(t, true)
+	attrs := runOnce(p, rcWithBodies())
+
+	in, ok := attrs["input.value"].(string)
+	if !ok || !strings.Contains(in, "hunter2") {
+		t.Fatalf("input.value = %v", attrs["input.value"])
+	}
+	if !json.Valid([]byte(in)) {
+		t.Error("input.value is not valid JSON")
+	}
+	out, ok := attrs["output.value"].(string)
+	if !ok || !strings.Contains(out, "hunter2") {
+		t.Fatalf("output.value = %v", attrs["output.value"])
+	}
+	if attrs["input.mime_type"] != "application/json" || attrs["output.mime_type"] != "application/json" {
+		t.Error("mime types not set")
+	}
+}
+
+// The knob is the whole privacy contract: off means no content leaves.
+func TestBodiesAbsentUnlessEnabled(t *testing.T) {
+	p, _ := bodyPlugin(t, false)
+	attrs := runOnce(p, rcWithBodies())
+
+	for _, k := range []string{"input.value", "output.value", "input.mime_type", "output.mime_type"} {
+		if v, ok := attrs[k]; ok {
+			t.Errorf("%s present with include_bodies off: %v", k, v)
+		}
+	}
+}
+
+// Redaction must apply to spans exactly as it applies to the request log,
+// otherwise trace export is a way around a configured privacy policy.
+func TestBodiesRedactedWithOrgPatterns(t *testing.T) {
+	store := tenant.NewStore()
+	store.Set("org-1", &tenant.OrgConfig{Privacy: &tenant.PrivacyConfig{
+		Enabled:  true,
+		Mode:     "patterns",
+		Patterns: []*tenant.RedactPatternConfig{{Name: "pw", Pattern: "hunter2"}},
+	}})
+
+	p, _ := bodyPlugin(t, true)
+	p.SetTenantStore(store)
+
+	rc := rcWithBodies()
+	rc.Metadata[tenant.MetadataKeyOrgID] = "org-1"
+	attrs := runOnce(p, rc)
+
+	if in := attrs["input.value"].(string); strings.Contains(in, "hunter2") {
+		t.Errorf("org pattern not applied to input.value: %s", in)
+	}
+	if out := attrs["output.value"].(string); strings.Contains(out, "hunter2") {
+		t.Errorf("org pattern not applied to output.value: %s", out)
+	}
+}
+
+// With no org config, the gateway-wide redactor still applies.
+func TestBodiesRedactedWithGlobalRedactor(t *testing.T) {
+	p, _ := bodyPlugin(t, true)
+	p.SetRedactor(privacy.New("patterns", []privacy.PatternConfig{{Name: "pw", Pattern: "hunter2"}}))
+
+	attrs := runOnce(p, rcWithBodies())
+	if in := attrs["input.value"].(string); strings.Contains(in, "hunter2") {
+		t.Errorf("global redactor not applied: %s", in)
+	}
+}
+
+// Truncation happens after redaction, and the cap is what makes the order
+// observable: a secret straddling the boundary is cut in half by
+// truncate-first, stops matching the pattern, and its leading half is
+// exported. Redact-first replaces the whole match before any cutting.
+func TestBodiesRedactBeforeTruncate(t *testing.T) {
+	const secret = "SECRET-1234567890"
+	r := privacy.New("patterns", []privacy.PatternConfig{{Name: "s", Pattern: "SECRET-[0-9]{10}"}})
+
+	// Position the secret so the cap falls 12 characters into it.
+	filler := strings.Repeat("x", maxBodyAttrBytes-12)
+	got := prepareBody(filler+secret, r, "patterns")
+
+	if strings.Contains(got.value, "SECRET-12345") {
+		t.Errorf("leading half of the secret survived — truncation ran before redaction")
+	}
+	if strings.Contains(got.value, secret) {
+		t.Error("secret not redacted at all")
+	}
+	if len(got.value) > maxBodyAttrBytes {
+		t.Errorf("value length %d exceeds the cap %d", len(got.value), maxBodyAttrBytes)
+	}
+}
+
+func TestBodiesTruncatedAndFlagged(t *testing.T) {
+	p, _ := bodyPlugin(t, true)
+	rc := newTestRC()
+	huge, _ := json.Marshal(strings.Repeat("x", maxBodyAttrBytes+5000))
+	rc.Request.Messages = []models.Message{{Role: "user", Content: json.RawMessage(huge)}}
+	rc.Response = nil
+
+	attrs := runOnce(p, rc)
+	in := attrs["input.value"].(string)
+	if len(in) != maxBodyAttrBytes {
+		t.Fatalf("input.value length = %d, want the cap %d", len(in), maxBodyAttrBytes)
+	}
+	if attrs["agentcc.input_truncated"] != true {
+		t.Error("truncation not flagged")
+	}
+	if attrs["agentcc.input_original_bytes"] == nil {
+		t.Error("original size not recorded")
+	}
+	// Truncated JSON is not parseable; saying so is what stops a consumer trying.
+	if _, ok := attrs["input.mime_type"]; ok {
+		t.Error("truncated value must not claim to be application/json")
+	}
+}
+
+// The streaming husk — a response with usage but no choices — must not be
+// exported as an empty completion.
+func TestBodiesSkipEmptyStreamingResponse(t *testing.T) {
+	p, _ := bodyPlugin(t, true)
+	rc := rcWithBodies()
+	rc.Response = &models.ChatCompletionResponse{Model: "gpt-4o"}
+
+	attrs := runOnce(p, rc)
+	if v, ok := attrs["output.value"]; ok {
+		t.Errorf("exported an output for a response with no choices: %v", v)
+	}
+	if _, ok := attrs["input.value"]; !ok {
+		t.Error("input should still be captured")
+	}
+}

--- a/agentcc-gateway/internal/plugins/otel/bodies_test.go
+++ b/agentcc-gateway/internal/plugins/otel/bodies_test.go
@@ -168,3 +168,226 @@ func TestBodiesSkipEmptyStreamingResponse(t *testing.T) {
 		t.Error("input should still be captured")
 	}
 }
+
+// Multimodal endpoints must carry content too. An image span with no prompt is
+// exactly as useless as a chat span with no prompt.
+func TestBodiesCoverMultimodalEndpoints(t *testing.T) {
+	tests := []struct {
+		endpoint string
+		setup    func(*models.RequestContext)
+		wantIn   string
+		wantOut  string
+	}{
+		{
+			endpoint: "image",
+			setup: func(rc *models.RequestContext) {
+				rc.ImageRequest = &models.ImageRequest{Model: "dall-e-3", Prompt: "a red bicycle"}
+				rc.ImageResponse = &models.ImageResponse{Data: []models.ImageData{{URL: "https://img/1.png"}}}
+			},
+			wantIn:  "a red bicycle",
+			wantOut: "https://img/1.png",
+		},
+		{
+			endpoint: "embedding",
+			setup: func(rc *models.RequestContext) {
+				rc.EmbeddingRequest = &models.EmbeddingRequest{Model: "te-3", Input: json.RawMessage(`"embed me"`)}
+				rc.EmbeddingResponse = &models.EmbeddingResponse{Object: "list", Model: "te-3"}
+			},
+			wantIn:  "embed me",
+			wantOut: "list",
+		},
+		{
+			endpoint: "rerank",
+			setup: func(rc *models.RequestContext) {
+				rc.RerankRequest = &models.RerankRequest{Query: "best bicycle", Documents: []string{"doc"}}
+			},
+			wantIn: "best bicycle",
+		},
+		{
+			endpoint: "ocr",
+			setup: func(rc *models.RequestContext) {
+				rc.OCRResponse = &models.OCRResponse{Pages: []models.OCRPage{{Markdown: "# Invoice"}}}
+			},
+			wantOut: "# Invoice",
+		},
+		{
+			endpoint: "speech",
+			setup: func(rc *models.RequestContext) {
+				rc.SpeechRequest = &models.SpeechRequest{Model: "tts-1", Input: "read this aloud", Voice: "alloy"}
+			},
+			wantIn:  "read this aloud",
+			wantOut: "binary",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.endpoint, func(t *testing.T) {
+			p, _ := bodyPlugin(t, true)
+			rc := newTestRC()
+			rc.EndpointType = tt.endpoint
+			rc.Request, rc.Response = nil, nil
+			tt.setup(rc)
+
+			attrs := runOnce(p, rc)
+			if tt.wantIn != "" {
+				in, _ := attrs["input.value"].(string)
+				if !strings.Contains(in, tt.wantIn) {
+					t.Errorf("input.value = %q, want it to contain %q", in, tt.wantIn)
+				}
+			}
+			if tt.wantOut != "" {
+				out, _ := attrs["output.value"].(string)
+				if !strings.Contains(out, tt.wantOut) {
+					t.Errorf("output.value = %q, want it to contain %q", out, tt.wantOut)
+				}
+			}
+		})
+	}
+}
+
+// Binary payloads must be described, never carried: one base64 image would
+// blow the per-attribute cap on its own and tell a reviewer nothing.
+func TestBodiesElideBinaryPayloads(t *testing.T) {
+	big := strings.Repeat("A", 500000)
+	p, _ := bodyPlugin(t, true)
+	rc := newTestRC()
+	rc.EndpointType = "image"
+	rc.Request, rc.Response = nil, nil
+	rc.ImageRequest = &models.ImageRequest{Prompt: "a cat"}
+	rc.ImageResponse = &models.ImageResponse{Data: []models.ImageData{{B64JSON: big}}}
+
+	attrs := runOnce(p, rc)
+	out, _ := attrs["output.value"].(string)
+	if strings.Contains(out, big) {
+		t.Fatal("base64 image was exported on the span")
+	}
+	if !strings.Contains(out, "b64_json_bytes") {
+		t.Error("elided image should still report its size")
+	}
+	if attrs["agentcc.output_truncated"] == true {
+		t.Error("eliding should have kept the payload well under the cap")
+	}
+}
+
+// The convention has first-class attributes for these endpoints. Emitting them
+// is what makes an image or audio span filterable by prompt, size or transcript
+// instead of only greppable inside input.value.
+func TestEndpointAttributesUseTheConvention(t *testing.T) {
+	n := 2
+	dims := 1536
+	topN := 5
+
+	tests := []struct {
+		name     string
+		setup    func(*models.RequestContext)
+		endpoint string
+		want     map[string]interface{}
+	}{
+		{
+			name:     "image",
+			endpoint: "image",
+			setup: func(rc *models.RequestContext) {
+				rc.ImageRequest = &models.ImageRequest{
+					Prompt: "a red bicycle", Size: "1024x1024", Quality: "hd", Style: "vivid",
+					ResponseFormat: "url", N: &n,
+				}
+				rc.ImageResponse = &models.ImageResponse{Data: []models.ImageData{
+					{URL: "https://img/1.png", RevisedPrompt: "a red racing bicycle"},
+					{URL: "https://img/2.png"},
+				}}
+			},
+			want: map[string]interface{}{
+				"gen_ai.image.prompt":         "a red bicycle",
+				"gen_ai.image.size":           "1024x1024",
+				"gen_ai.image.quality":        "hd",
+				"gen_ai.image.style":          "vivid",
+				"gen_ai.image.count":          2,
+				"gen_ai.image.output_urls":    "https://img/1.png,https://img/2.png",
+				"gen_ai.image.revised_prompt": "a red racing bicycle",
+			},
+		},
+		{
+			name:     "embedding",
+			endpoint: "embedding",
+			setup: func(rc *models.RequestContext) {
+				rc.EmbeddingRequest = &models.EmbeddingRequest{Dimensions: &dims}
+			},
+			want: map[string]interface{}{"gen_ai.embeddings.dimension.count": 1536},
+		},
+		{
+			name:     "rerank",
+			endpoint: "rerank",
+			setup: func(rc *models.RequestContext) {
+				rc.RerankRequest = &models.RerankRequest{Query: "best bicycle", Model: "rerank-1", TopN: &topN}
+			},
+			want: map[string]interface{}{
+				"gen_ai.reranker.query": "best bicycle",
+				"gen_ai.reranker.model": "rerank-1",
+				"gen_ai.reranker.top_n": 5,
+			},
+		},
+		{
+			name:     "speech",
+			endpoint: "speech",
+			setup: func(rc *models.RequestContext) {
+				rc.SpeechRequest = &models.SpeechRequest{Input: "read this aloud", Voice: "alloy"}
+			},
+			want: map[string]interface{}{"gen_ai.audio.transcript": "read this aloud"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Not gated on include_bodies: these are dimensions, not content.
+			p, _ := bodyPlugin(t, false)
+			rc := newTestRC()
+			rc.EndpointType = tt.endpoint
+			rc.Request, rc.Response = nil, nil
+			tt.setup(rc)
+
+			attrs := runOnce(p, rc)
+			for k, want := range tt.want {
+				if got := attrs[k]; got != want {
+					t.Errorf("%s = %v (%T), want %v", k, got, got, want)
+				}
+			}
+		})
+	}
+}
+
+// Inline base64 in chat content is the vision case: there is no separate field
+// to leave it in, so carrying it would truncate the prompt away with it.
+func TestInlineImageDataElidedFromChat(t *testing.T) {
+	b64 := strings.Repeat("QUJD", 100000) // ~400 KB
+	p, _ := bodyPlugin(t, true)
+	rc := newTestRC()
+	content, _ := json.Marshal([]map[string]any{
+		{"type": "text", "text": "what is in this picture?"},
+		{"type": "image_url", "image_url": map[string]string{"url": "data:image/png;base64," + b64}},
+	})
+	rc.Request.Messages = []models.Message{{Role: "user", Content: content}}
+	rc.Response = nil
+
+	attrs := runOnce(p, rc)
+	in, _ := attrs["input.value"].(string)
+
+	if strings.Contains(in, b64) {
+		t.Fatal("base64 image carried into the span")
+	}
+	if !strings.Contains(in, "what is in this picture?") {
+		t.Error("the prompt was lost — elision should protect it, not replace it")
+	}
+	if !strings.Contains(in, "data:image/png;base64,<elided") {
+		t.Errorf("elision marker missing: %s", in[:min(len(in), 300)])
+	}
+	if attrs["agentcc.input_truncated"] == true {
+		t.Error("eliding should have kept the body under the cap")
+	}
+}
+
+func min(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}

--- a/agentcc-gateway/internal/plugins/otel/endpoints.go
+++ b/agentcc-gateway/internal/plugins/otel/endpoints.go
@@ -1,0 +1,98 @@
+package otel
+
+import (
+	"strconv"
+	"strings"
+
+	"github.com/futureagi/agentcc-gateway/internal/models"
+	otelpkg "github.com/futureagi/agentcc-gateway/internal/otel"
+)
+
+// attachEndpointAttributes sets the convention's own attributes for non-chat
+// endpoints, so an image or audio span is queryable by prompt, size or
+// transcript rather than only as a blob of JSON in input.value.
+//
+// These are dimensions, not payloads: everything here is small and worth
+// filtering or grouping by. The full record still goes in input.value /
+// output.value when body capture is on, and the bulk — base64 images, audio
+// bytes, embedding vectors — is never carried by either.
+func (p *Plugin) attachEndpointAttributes(span *otelpkg.Span, rc *models.RequestContext) {
+	switch rc.EndpointType {
+	case "image":
+		if req := rc.ImageRequest; req != nil {
+			setIfNotEmpty(span, "gen_ai.image.prompt", req.Prompt)
+			setIfNotEmpty(span, "gen_ai.image.size", req.Size)
+			setIfNotEmpty(span, "gen_ai.image.quality", req.Quality)
+			setIfNotEmpty(span, "gen_ai.image.style", req.Style)
+			setIfNotEmpty(span, "gen_ai.image.format", req.ResponseFormat)
+			if req.N != nil {
+				span.SetAttribute("gen_ai.image.count", *req.N)
+			}
+		}
+		if resp := rc.ImageResponse; resp != nil {
+			var urls []string
+			for _, d := range resp.Data {
+				if d.URL != "" {
+					urls = append(urls, d.URL)
+				}
+				setIfNotEmpty(span, "gen_ai.image.revised_prompt", d.RevisedPrompt)
+			}
+			if len(urls) > 0 {
+				span.SetAttribute("gen_ai.image.output_urls", strings.Join(urls, ","))
+			}
+		}
+
+	case "transcription":
+		if req := rc.TranscriptionReq; req != nil {
+			setIfNotEmpty(span, "gen_ai.audio.language", req.Language)
+		}
+		if secs := rc.Metadata["audio_seconds"]; secs != "" {
+			if v, err := strconv.ParseFloat(secs, 64); err == nil {
+				span.SetAttribute("gen_ai.audio.duration_secs", v)
+			}
+		}
+		if resp := rc.TranscriptionResp; resp != nil {
+			setIfNotEmpty(span, "gen_ai.audio.transcript", resp.Text)
+		}
+
+	case "translation":
+		if resp := rc.TranslationResp; resp != nil {
+			setIfNotEmpty(span, "gen_ai.audio.transcript", resp.Text)
+		}
+
+	case "speech", "speech_stream":
+		if req := rc.SpeechRequest; req != nil {
+			// The text being spoken is the prompt for a TTS call.
+			setIfNotEmpty(span, "gen_ai.audio.transcript", req.Input)
+			setIfNotEmpty(span, "gen_ai.audio.mime_type", rc.Metadata["response_content_type"])
+		}
+
+	case "embedding", "genai_embed":
+		if req := rc.EmbeddingRequest; req != nil && req.Dimensions != nil {
+			span.SetAttribute("gen_ai.embeddings.dimension.count", *req.Dimensions)
+		}
+
+	case "rerank":
+		if req := rc.RerankRequest; req != nil {
+			setIfNotEmpty(span, "gen_ai.reranker.query", req.Query)
+			setIfNotEmpty(span, "gen_ai.reranker.model", req.Model)
+			if req.TopN != nil {
+				span.SetAttribute("gen_ai.reranker.top_n", *req.TopN)
+			}
+		}
+
+	case "search":
+		if req := rc.SearchRequest; req != nil {
+			setIfNotEmpty(span, "gen_ai.retrieval.query", string(req.QueryRaw))
+			if req.MaxResults > 0 {
+				span.SetAttribute("gen_ai.retrieval.top_k", req.MaxResults)
+			}
+		}
+	}
+}
+
+func setIfNotEmpty(span *otelpkg.Span, key, value string) {
+	if value != "" {
+		span.SetAttribute(key, value)
+	}
+}

--- a/agentcc-gateway/internal/plugins/otel/messages.go
+++ b/agentcc-gateway/internal/plugins/otel/messages.go
@@ -1,0 +1,148 @@
+package otel
+
+import (
+	"encoding/json"
+	"strconv"
+
+	"github.com/futureagi/agentcc-gateway/internal/models"
+	otelpkg "github.com/futureagi/agentcc-gateway/internal/otel"
+	"github.com/futureagi/agentcc-gateway/internal/payloads"
+	"github.com/futureagi/agentcc-gateway/internal/privacy"
+)
+
+// maxInlineImageBytes bounds an inline image carried on a span. Under it the
+// data URI travels and the platform renders the picture; over it the message
+// is masked to a description instead. Whole photos are megabytes and would
+// dominate a batch for one thumbnail's worth of value.
+const maxInlineImageBytes = 64 << 10
+
+// attachMessages emits the flattened message attributes the platform reads to
+// render a conversation:
+//
+//	llm.input_messages.0.message.role
+//	llm.input_messages.0.message.content
+//	llm.input_messages.0.message.contents.0.message_content.type
+//	llm.input_messages.0.message.contents.0.message_content.image.url
+//
+// input.value carries the same request as one JSON document, which is what an
+// evaluator consumes; this is what the trace viewer draws. Without it a vision
+// request shows as text with the image silently missing.
+// The redactor is threaded through because these attributes carry the same
+// user content input.value does. Emitting them unredacted would be a way
+// around the org's privacy config that the JSON body already respects.
+func (p *Plugin) attachMessages(span *otelpkg.Span, rc *models.RequestContext, r *privacy.Redactor, mode string) {
+	scrub := func(s string) string { return redact(payloads.ElideInlineData(s), r, mode) }
+
+	if rc.Request != nil {
+		for i, msg := range rc.Request.Messages {
+			p.attachMessage(span, "llm.input_messages."+strconv.Itoa(i), msg, scrub)
+		}
+	}
+	if rc.Response != nil {
+		for i, choice := range rc.Response.Choices {
+			p.attachMessage(span, "llm.output_messages."+strconv.Itoa(i), choice.Message, scrub)
+		}
+	}
+}
+
+func (p *Plugin) attachMessage(span *otelpkg.Span, prefix string, msg models.Message, scrub func(string) string) {
+	if msg.Role != "" {
+		span.SetAttribute(prefix+".message.role", msg.Role)
+	}
+	if len(msg.Content) == 0 {
+		return
+	}
+
+	// Plain string content: the common case, emitted flat.
+	var text string
+	if err := json.Unmarshal(msg.Content, &text); err == nil {
+		span.SetAttribute(prefix+".message.content", scrub(text))
+		return
+	}
+
+	var parts []messagePart
+	if err := json.Unmarshal(msg.Content, &parts); err != nil {
+		// Some other shape — hand it over as-is rather than dropping it.
+		span.SetAttribute(prefix+".message.content", scrub(string(msg.Content)))
+		return
+	}
+
+	// A masked message keeps only the flat summary. The viewer prefers a flat
+	// string over structured parts for the same message, so emitting both
+	// would hide the parts anyway.
+	if summary, masked := maskOversizedParts(parts); masked {
+		span.SetAttribute(prefix+".message.content", scrub(summary))
+		return
+	}
+
+	for j, part := range parts {
+		base := prefix + ".message.contents." + strconv.Itoa(j) + ".message_content"
+		if part.Type != "" {
+			span.SetAttribute(base+".type", part.Type)
+		}
+		if part.Text != "" {
+			span.SetAttribute(base+".text", scrub(part.Text))
+		}
+		// The URL is left intact: under the size bound it is either a link or
+		// a small data URI the viewer renders, and scrubbing would break both.
+		if part.ImageURL != nil && part.ImageURL.URL != "" {
+			span.SetAttribute(base+".image.url", part.ImageURL.URL)
+		}
+	}
+}
+
+type messagePart struct {
+	Type     string `json:"type"`
+	Text     string `json:"text,omitempty"`
+	ImageURL *struct {
+		URL    string `json:"url"`
+		Detail string `json:"detail,omitempty"`
+	} `json:"image_url,omitempty"`
+}
+
+// maskOversizedParts reports whether any inline image is too large to carry,
+// and if so returns a description of the whole message to send instead.
+func maskOversizedParts(parts []messagePart) (string, bool) {
+	oversized := false
+	for _, part := range parts {
+		if part.ImageURL != nil && len(part.ImageURL.URL) > maxInlineImageBytes {
+			oversized = true
+			break
+		}
+	}
+	if !oversized {
+		return "", false
+	}
+
+	summary := ""
+	for _, part := range parts {
+		if summary != "" {
+			summary += " "
+		}
+		switch {
+		case part.Text != "":
+			summary += part.Text
+		case part.ImageURL != nil:
+			summary += "[image: " + describeImageURL(part.ImageURL.URL) + "]"
+		}
+	}
+	return summary, true
+}
+
+// describeImageURL names an image that is not being carried, so the trace says
+// what was sent rather than leaving a hole.
+func describeImageURL(url string) string {
+	if len(url) <= maxInlineImageBytes {
+		return url
+	}
+	mime := "inline"
+	if len(url) > 5 && url[:5] == "data:" {
+		for i := 5; i < len(url) && i < 64; i++ {
+			if url[i] == ';' {
+				mime = url[5:i]
+				break
+			}
+		}
+	}
+	return mime + ", " + strconv.Itoa(len(url)) + " bytes"
+}

--- a/agentcc-gateway/internal/plugins/otel/otel.go
+++ b/agentcc-gateway/internal/plugins/otel/otel.go
@@ -14,6 +14,8 @@ import (
 	"github.com/futureagi/agentcc-gateway/internal/models"
 	otelpkg "github.com/futureagi/agentcc-gateway/internal/otel"
 	"github.com/futureagi/agentcc-gateway/internal/pipeline"
+	"github.com/futureagi/agentcc-gateway/internal/privacy"
+	"github.com/futureagi/agentcc-gateway/internal/tenant"
 )
 
 // Plugin is a pipeline plugin that creates OTel-compatible trace spans and records metrics.
@@ -24,6 +26,12 @@ type Plugin struct {
 	enabled     bool
 	serviceName string
 	attributes  map[string]string
+
+	// Body capture: off unless configured, and redacted through the same
+	// per-org privacy config the request log uses.
+	includeBodies bool
+	redactor      *privacy.Redactor
+	tenantStore   *tenant.Store
 
 	// spans stores in-flight spans keyed by request ID.
 	spans sync.Map
@@ -68,15 +76,27 @@ func New(cfg config.OTelConfig) *Plugin {
 		serviceName = "agentcc-gateway"
 	}
 
+	if cfg.Enabled && cfg.IncludeBodies {
+		slog.Warn("otel body capture is enabled — prompts and completions will be sent to the trace collector")
+	}
+
 	return &Plugin{
-		exporter:    exp,
-		metrics:     &otelpkg.Metrics{},
-		sampleRate:  sampleRate,
-		enabled:     cfg.Enabled,
-		serviceName: serviceName,
-		attributes:  cfg.Attributes,
+		exporter:      exp,
+		metrics:       &otelpkg.Metrics{},
+		sampleRate:    sampleRate,
+		enabled:       cfg.Enabled,
+		serviceName:   serviceName,
+		attributes:    cfg.Attributes,
+		includeBodies: cfg.Enabled && cfg.IncludeBodies,
 	}
 }
+
+// SetRedactor sets the gateway-wide redactor, used when an org has no privacy
+// config of its own.
+func (p *Plugin) SetRedactor(r *privacy.Redactor) { p.redactor = r }
+
+// SetTenantStore supplies per-org privacy configuration.
+func (p *Plugin) SetTenantStore(s *tenant.Store) { p.tenantStore = s }
 
 // NewWithExporter creates a plugin with a specific exporter (for testing).
 func NewWithExporter(exp otelpkg.SpanExporter, sampleRate float64, enabled bool) *Plugin {
@@ -242,6 +262,10 @@ func (p *Plugin) ProcessResponse(_ context.Context, rc *models.RequestContext) p
 	if len(rc.Errors) > 0 {
 		span.SetError(rc.Errors[0].Error())
 		p.metrics.ErrorCount.Add(1)
+	}
+
+	if p.includeBodies {
+		p.attachBodies(span, rc)
 	}
 
 	span.End()

--- a/agentcc-gateway/internal/plugins/otel/otel.go
+++ b/agentcc-gateway/internal/plugins/otel/otel.go
@@ -264,6 +264,11 @@ func (p *Plugin) ProcessResponse(_ context.Context, rc *models.RequestContext) p
 		p.metrics.ErrorCount.Add(1)
 	}
 
+	// Dimensions for non-chat endpoints. Unlike bodies these are small and
+	// carry no user content beyond what the request already declares, so they
+	// are not gated on include_bodies.
+	p.attachEndpointAttributes(span, rc)
+
 	if p.includeBodies {
 		p.attachBodies(span, rc)
 	}

--- a/agentcc-gateway/internal/server/handlers.go
+++ b/agentcc-gateway/internal/server/handlers.go
@@ -44,6 +44,10 @@ type Handlers struct {
 	maxBodySize    int64
 	defaultTimeout time.Duration
 
+	// captureStreamContent reassembles streamed completions so post-plugins
+	// see the text. Set when a sink is configured to record bodies.
+	captureStreamContent bool
+
 	// Streaming guardrail support.
 	guardrailEngine    *guardrails.Engine
 	policyStore        *policy.Store
@@ -201,6 +205,10 @@ func (h *Handlers) resolveProviderWithOrgFallback(ctx context.Context, rc *model
 	}
 	return provider, nil
 }
+
+// SetCaptureStreamContent enables reassembly of streamed completions. Off by
+// default: without a sink that records bodies, the assembly is wasted work.
+func (h *Handlers) SetCaptureStreamContent(v bool) { h.captureStreamContent = v }
 
 // NewHandlers creates a Handlers instance.
 func NewHandlers(registry *providers.Registry, engine *pipeline.Engine, maxBodySize int64, defaultTimeout time.Duration, failover *routing.Failover, modelFallbacks *routing.ModelFallbacks, conditionalRouter *routing.ConditionalRouter, healthMonitor *routing.HealthMonitor, modelTimeouts map[string]time.Duration, mirror *routing.Mirror, guardrailEngine *guardrails.Engine, policyStore *policy.Store, streamGuardrailCfg config.StreamingGuardrailConfig, mdbPtr *atomic.Pointer[modeldb.ModelDB], tenantStore *tenant.Store, orgProviderCache *providers.OrgProviderCache, keyStore *authpkg.KeyStore) *Handlers {
@@ -1560,6 +1568,7 @@ func (h *Handlers) handleStream(ctx context.Context, w http.ResponseWriter, rc *
 	var lastUsage *models.Usage
 	var streamID string
 	var streamCreated int64
+	capture := newStreamCapture(h.captureStreamContent)
 
 	// finalizeStream populates rc.Response with accumulated usage and runs
 	// post-plugins (cost, credits, logging, otel, prometheus). Must be called
@@ -1567,9 +1576,13 @@ func (h *Handlers) handleStream(ctx context.Context, w http.ResponseWriter, rc *
 	// a background context so post-plugins run even after client disconnect.
 	finalizeStream := func(detach bool) *models.StreamChunk {
 		rc.Response = &models.ChatCompletionResponse{
-			Model: rc.ResolvedModel,
-			Usage: lastUsage, // nil is OK — means provider didn't send usage
+			ID:      streamID,
+			Object:  "chat.completion",
+			Created: streamCreated,
+			Model:   rc.ResolvedModel,
+			Usage:   lastUsage, // nil is OK — means provider didn't send usage
 		}
+		capture.applyTo(rc.Response)
 		pluginCtx := ctx
 		if detach {
 			pluginCtx = context.Background()
@@ -1616,6 +1629,7 @@ func (h *Handlers) handleStream(ctx context.Context, w http.ResponseWriter, rc *
 			if chunk.Usage != nil {
 				lastUsage = chunk.Usage
 			}
+			capture.observe(chunk)
 
 			if streamChecker != nil {
 				if res := streamChecker.ProcessChunk(streamCtx, chunk); res.Blocked {
@@ -1678,6 +1692,7 @@ func (h *Handlers) handleStream(ctx context.Context, w http.ResponseWriter, rc *
 			if chunk.Usage != nil {
 				lastUsage = chunk.Usage
 			}
+			capture.observe(chunk)
 
 			// Run streaming guardrail check.
 			if streamChecker != nil {

--- a/agentcc-gateway/internal/server/handlers_completion.go
+++ b/agentcc-gateway/internal/server/handlers_completion.go
@@ -355,14 +355,17 @@ func (h *Handlers) handleCompletionStream(ctx context.Context, w http.ResponseWr
 
 	// Track last usage from stream chunks for post-plugin cost/credits tracking.
 	var lastUsage *models.Usage
+	capture := newStreamCapture(h.captureStreamContent)
 
 	// finalizeStream populates rc.Response with accumulated usage and runs
 	// post-plugins (cost, credits, logging). Must be called before every return.
 	finalizeStream := func(detach bool) {
 		rc.Response = &models.ChatCompletionResponse{
-			Model: rc.ResolvedModel,
-			Usage: lastUsage,
+			Object: "chat.completion",
+			Model:  rc.ResolvedModel,
+			Usage:  lastUsage,
 		}
+		capture.applyTo(rc.Response)
 		pluginCtx := ctx
 		if detach {
 			pluginCtx = context.Background()
@@ -384,6 +387,7 @@ func (h *Handlers) handleCompletionStream(ctx context.Context, w http.ResponseWr
 			if chunk.Usage != nil {
 				lastUsage = chunk.Usage
 			}
+			capture.observe(chunk)
 
 			// Convert chat chunk to legacy completion chunk.
 			completionChunk := models.CompletionStreamChunkFromChat(chunk)

--- a/agentcc-gateway/internal/server/server.go
+++ b/agentcc-gateway/internal/server/server.go
@@ -200,6 +200,9 @@ func New(cfg *config.Config, configPath string, registry *providers.Registry, en
 	}
 
 	handlers := NewHandlers(registry, engine, cfg.Server.MaxRequestBodySize, cfg.Server.DefaultRequestTimeout, failover, modelFallbacks, condRouter, healthMonitor, cfg.Routing.ModelTimeouts, mirror, guardrailEngine, policyStore, cfg.Guardrails.Streaming, modelDBPtr, tenantStore, orgProviderCache, authKeyStore)
+	// A streamed completion exists nowhere else — it has to be assembled while
+	// the chunks go past, and only if something is going to record it.
+	handlers.SetCaptureStreamContent(cfg.Logging.RequestLogging.IncludeBodies || (cfg.OTel.Enabled && cfg.OTel.IncludeBodies))
 	s.handlers = handlers
 
 	// Set up Files API store.

--- a/agentcc-gateway/internal/server/stream_capture.go
+++ b/agentcc-gateway/internal/server/stream_capture.go
@@ -1,0 +1,78 @@
+package server
+
+import (
+	"encoding/json"
+	"strings"
+
+	"github.com/futureagi/agentcc-gateway/internal/models"
+)
+
+// maxStreamCaptureBytes bounds the assembled completion. Past it the tail is
+// dropped rather than growing without limit on a runaway generation.
+const maxStreamCaptureBytes = 2 << 20
+
+// streamCapture reassembles a streamed completion so post-plugins can see what
+// was actually returned.
+//
+// Nothing else in the gateway keeps this: finalizeStream builds rc.Response
+// from the usage totals alone, so without this a streamed request reaches the
+// request log and the trace exporter with no completion text at all. Only
+// switched on when a sink is configured to record bodies — otherwise the
+// assembly is pure cost.
+//
+// Content deltas only. Tool-call deltas are not assembled; a partial arguments
+// string is worse than an absent one.
+type streamCapture struct {
+	content      strings.Builder
+	finishReason string
+	truncated    bool
+}
+
+func newStreamCapture(enabled bool) *streamCapture {
+	if !enabled {
+		return nil
+	}
+	return &streamCapture{}
+}
+
+// observe accumulates one chunk. Safe on a nil receiver so call sites stay
+// free of enabled-checks.
+func (c *streamCapture) observe(chunk models.StreamChunk) {
+	if c == nil {
+		return
+	}
+	for _, choice := range chunk.Choices {
+		if choice.Delta.Content != nil && !c.truncated {
+			if c.content.Len()+len(*choice.Delta.Content) > maxStreamCaptureBytes {
+				c.truncated = true
+			} else {
+				c.content.WriteString(*choice.Delta.Content)
+			}
+		}
+		if choice.FinishReason != nil && *choice.FinishReason != "" {
+			c.finishReason = *choice.FinishReason
+		}
+	}
+}
+
+// applyTo fills in the response choices from what was captured. Called from
+// finalizeStream, before post-plugins run, so writing to rc is still legal.
+func (c *streamCapture) applyTo(resp *models.ChatCompletionResponse) {
+	if c == nil || resp == nil {
+		return
+	}
+	if c.content.Len() == 0 && c.finishReason == "" {
+		return
+	}
+	// Message.Content is raw JSON, so the assembled text is marshalled as a
+	// JSON string rather than assigned directly.
+	content, err := json.Marshal(c.content.String())
+	if err != nil {
+		return
+	}
+	resp.Choices = []models.Choice{{
+		Index:        0,
+		Message:      models.Message{Role: "assistant", Content: content},
+		FinishReason: c.finishReason,
+	}}
+}

--- a/agentcc-gateway/internal/server/stream_capture_test.go
+++ b/agentcc-gateway/internal/server/stream_capture_test.go
@@ -1,0 +1,113 @@
+package server
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/futureagi/agentcc-gateway/internal/models"
+)
+
+func chunk(content string, finish string) models.StreamChunk {
+	c := models.StreamChoice{Index: 0}
+	if content != "" {
+		c.Delta.Content = &content
+	}
+	if finish != "" {
+		c.FinishReason = &finish
+	}
+	return models.StreamChunk{Choices: []models.StreamChoice{c}}
+}
+
+// finalizeStream builds rc.Response from usage alone, so without this assembly
+// a streamed request reaches every post-plugin with no completion at all.
+func TestStreamCaptureAssemblesCompletion(t *testing.T) {
+	c := newStreamCapture(true)
+	c.observe(chunk("Hel", ""))
+	c.observe(chunk("lo ", ""))
+	c.observe(chunk("world", ""))
+	c.observe(chunk("", "stop"))
+
+	resp := &models.ChatCompletionResponse{}
+	c.applyTo(resp)
+
+	if len(resp.Choices) != 1 {
+		t.Fatalf("got %d choices, want 1", len(resp.Choices))
+	}
+	var got string
+	if err := json.Unmarshal(resp.Choices[0].Message.Content, &got); err != nil {
+		t.Fatalf("content is not a JSON string: %v", err)
+	}
+	if got != "Hello world" {
+		t.Errorf("content = %q, want %q", got, "Hello world")
+	}
+	if resp.Choices[0].FinishReason != "stop" {
+		t.Errorf("finish_reason = %q", resp.Choices[0].FinishReason)
+	}
+	if resp.Choices[0].Message.Role != "assistant" {
+		t.Errorf("role = %q", resp.Choices[0].Message.Role)
+	}
+}
+
+// Disabled must cost nothing and leave the response exactly as it was.
+func TestStreamCaptureDisabledIsInert(t *testing.T) {
+	c := newStreamCapture(false)
+	c.observe(chunk("ignored", "stop")) // must not panic on nil
+	resp := &models.ChatCompletionResponse{}
+	c.applyTo(resp)
+	if resp.Choices != nil {
+		t.Errorf("disabled capture wrote choices: %v", resp.Choices)
+	}
+}
+
+// A stream that produced nothing must not be reported as an empty completion —
+// absent and empty mean different things to whatever reads the span.
+func TestStreamCaptureNoContentLeavesResponseAlone(t *testing.T) {
+	c := newStreamCapture(true)
+	resp := &models.ChatCompletionResponse{}
+	c.applyTo(resp)
+	if resp.Choices != nil {
+		t.Errorf("wrote choices for a stream with no deltas: %v", resp.Choices)
+	}
+}
+
+func TestStreamCaptureBounded(t *testing.T) {
+	c := newStreamCapture(true)
+	big := strings.Repeat("x", 1<<20)
+	for i := 0; i < 4; i++ {
+		c.observe(chunk(big, ""))
+	}
+	c.observe(chunk("", "length"))
+
+	resp := &models.ChatCompletionResponse{}
+	c.applyTo(resp)
+	var got string
+	_ = json.Unmarshal(resp.Choices[0].Message.Content, &got)
+	if len(got) > maxStreamCaptureBytes {
+		t.Errorf("captured %d bytes, over the %d cap", len(got), maxStreamCaptureBytes)
+	}
+	if !c.truncated {
+		t.Error("truncation not recorded")
+	}
+	// The finish reason still lands even after content stopped accumulating.
+	if resp.Choices[0].FinishReason != "length" {
+		t.Errorf("finish_reason = %q", resp.Choices[0].FinishReason)
+	}
+}
+
+// Tool-call deltas are deliberately not assembled; a half-built arguments
+// string would be worse than none.
+func TestStreamCaptureIgnoresToolCallDeltas(t *testing.T) {
+	c := newStreamCapture(true)
+	ch := models.StreamChunk{Choices: []models.StreamChoice{{
+		Index: 0,
+		Delta: models.Delta{ToolCalls: []models.ToolCallDelta{{Index: 0, ID: "call_1"}}},
+	}}}
+	c.observe(ch)
+
+	resp := &models.ChatCompletionResponse{}
+	c.applyTo(resp)
+	if resp.Choices != nil {
+		t.Errorf("assembled a completion from tool-call deltas alone: %v", resp.Choices)
+	}
+}


### PR DESCRIPTION
**PR 4 of 4** — the last of the #2183 split: race fix (#2186) → refactors (#2187) → exporter (#2183) → **bodies**. Based on #2183; retargets to `dev` and rebases as the ones below merge.

The exporter shipped spans with no content on them. Empty `input`/`output` columns on an eval platform is a defect, not a missing nicety — this fills them, for every endpoint the gateway serves.

Gated on `otel.include_bodies`, deliberately **not** reusing `logging.request_logging.include_bodies`: that knob already means "bodies to the log webhook" in live deployments, and reusing it would silently start sending prompts to whatever `otel.endpoint` points at.

## Redaction and size

Content is redacted through the org's privacy config exactly as the request log is, and redaction runs **before** truncation. The other order cuts through a match, the pattern stops firing, and the leading half of the secret is exported. `prepareBody` makes the order explicit and a test fails if it is swapped.

Bodies also broke the exporter's own assumptions. Real prompts on our gateway run to a few hundred KB with megabyte outliers, against a 512-span batch and a collector that refuses bodies over 16 MB — the first flush would have been rejected and, per the 4xx path, dropped. Queue and batch are now bounded by bytes as well as by count, a single attribute caps at 1 MiB and is flagged when it is cut, and an oversized encoded batch splits locally rather than posting to find out.

## Streaming

`finalizeStream` built `rc.Response` from usage totals alone, so a streamed completion did not exist anywhere in the gateway — not in this exporter, not in the request log. The chunk loops now assemble content deltas into a capped buffer and `finalizeStream` fills in the choices. Tool-call deltas are deliberately not assembled: a half-built arguments string is worse than none.

## Every endpoint, not just chat

`buildEndpointBodyJSON` handled speech, transcription and translation and returned nothing for image, embedding, rerank, search and OCR — so those bodies have never been recorded anywhere, the request log included. Both sinks now render through `internal/payloads`.

Bulk is described, never carried, and the platform does not do it for us: fi-collector special-cases none of these keys and `gen_ai.input.images` is not in its overflow prefixes, so a base64 image sent there lands in the typed attribute map that overflow exists to keep bounded. Base64 images become `b64_json_bytes`, embedding vectors `embedding_bytes`, OCR page images `image_base64_bytes`, audio `file_size_bytes`. Extracted markdown, revised prompts, URLs and transcripts survive — those are model output.

Alongside the bodies, each endpoint gets its conventional dimensions (`gen_ai.image.*`, `gen_ai.audio.*`, `gen_ai.embeddings.dimension.count`, `gen_ai.reranker.*`, `gen_ai.retrieval.*`), which are not gated on `include_bodies`.

## Making traces actually render

`input.value` is what an evaluator consumes; the trace viewer does not read it. `getSpanData.js` builds its conversation from `llm.input_messages.<i>.message.contents.<j>.message_content.image.url` and friends, so vision requests were arriving with the image nowhere on screen.

Images up to 64 KB travel as their data URI and render; larger ones mask the message to `[image: image/png, 66536 bytes]` — the same shape the viewer's own test fixture pins. Plain text emits flat content, structured emits parts, never both: attaching sub-properties to a flat string is what caused the crash the viewer's code still carries a comment about.

## Verification

On `api.futureagi.com`, from a dev gateway:

- prompts and completions land on both streamed and non-streamed requests
- an error span carries the prompt with no completion
- a vision request whose image was 36,800 base64 characters produced a 232-character `input.value`, still valid JSON, prompt intact
- a 1-pixel PNG under the 64 KB bound rendered in the viewer, and the model answered "red"
- `include_bodies: false` produces spans with no content attributes at all

## Note for the reviewer

`gen_ai.image.*` / `gen_ai.audio.*` are emitted as queryable dimensions but nothing renders from them yet — the `llm.*` message path is the one with a consumer.

Part of TH-6826.
