### PR TITLE
fix(executor): require auth on /execute and complete sandbox hardening

### DIFF
--- a/futureagi/agentic_eval/core_evals/fi_utils/sandbox.py
+++ b/futureagi/agentic_eval/core_evals/fi_utils/sandbox.py
@@ -31,6 +31,7 @@ import time
 from typing import Any
 
 import structlog
+import urllib.error
 import urllib.request
 
 logger = structlog.get_logger(__name__)
@@ -452,7 +453,13 @@ def _set_resource_limits():
 # Public API
 # ---------------------------------------------------------------------------
 def _call_executor_service(code: str, input_data: dict, language: str, timeout: int) -> dict | None:
-    """Call the nsjail code-executor service via HTTP. Returns None if unavailable."""
+    """Call the nsjail code-executor service via HTTP.
+
+    Returns None only for transient unreachability (caller falls back to the
+    local Tier-2 sandbox, logged at WARNING). A 401/503 from the executor is a
+    deliberate refusal and FAILS CLOSED — the request is never silently
+    downgraded to the weaker in-process sandbox.
+    """
     try:
         # default=str so non-JSON-native types coming through trace/span column
         # mapping (Decimal from clickhouse-driver, datetime, UUID) serialize
@@ -465,18 +472,26 @@ def _call_executor_service(code: str, input_data: dict, language: str, timeout: 
             "timeout": timeout,
         }, default=str).encode("utf-8")
 
+        headers = {"Content-Type": "application/json"}
+        internal_secret = os.getenv("INTERNAL_API_SECRET", "")
+        if internal_secret:
+            headers["Authorization"] = f"Bearer {internal_secret}"
+
         req = urllib.request.Request(
             f"{CODE_EXECUTOR_URL}/execute",
             data=payload,
-            headers={"Content-Type": "application/json"},
+            headers=headers,
             method="POST",
         )
         with urllib.request.urlopen(req, timeout=timeout + 10) as resp:
             result = json.loads(resp.read().decode("utf-8"))
             logger.info("code_executor_service_used", language=language, status=result.get("status"))
             return result
+    except urllib.error.HTTPError as e:
+        logger.error("code_executor_refused", language=language, status=e.code)
+        return {"status": "error", "data": f"Code executor refused request (HTTP {e.code})"}
     except Exception as e:
-        logger.debug("code_executor_service_unavailable", error=str(e))
+        logger.warning("code_executor_service_unavailable", error=str(e))
         return None  # Fall back to local sandbox
 
 

--- a/futureagi/code-executor/pytest.ini
+++ b/futureagi/code-executor/pytest.ini
@@ -1,0 +1,29 @@
+[pytest]
+# Pytest configuration for the code-executor (nsjail sandbox HTTP service).
+# Runs in its own venv/CI job: falcon + the executor deps live in the executor
+# image, not in the core backend requirements.
+
+# Test discovery
+testpaths = tests
+python_files = test_*.py
+python_classes = Test*
+python_functions = test_*
+
+# Output options
+addopts =
+    -v
+    --strict-markers
+    --strict-config
+    --tb=short
+
+# Test markers
+markers =
+    unit: Fast tests, no external services
+    isolation: Tests requiring nsjail
+    integration: Requires the executor to be running
+
+# Disable warnings
+filterwarnings =
+    ignore::UserWarning
+    ignore::DeprecationWarning
+    ignore::PendingDeprecationWarning

--- a/futureagi/code-executor/server.py
+++ b/futureagi/code-executor/server.py
@@ -2,7 +2,6 @@
 Code Executor HTTP API Server.
 
 Provides a simple HTTP endpoint for executing untrusted code in nsjail sandboxes.
-Falls back to subprocess isolation when nsjail is not available.
 
 POST /execute
 {
@@ -12,19 +11,16 @@ POST /execute
     "timeout": 30
 }
 
-Returns:
-{
-    "status": "success" | "error",
-    "data": <result> | <error message>
-}
+Requires Authorization: Bearer <INTERNAL_API_SECRET> on all requests.
+Execution is rejected (503) when nsjail is not available.
 """
 
+import hmac
 import json
 import os
 import shutil
 import subprocess
 import sys
-import tempfile
 import time
 
 import falcon
@@ -35,10 +31,10 @@ NSJAIL_AVAILABLE = NSJAIL_PATH is not None
 PYTHON_PATH = sys.executable
 NODE_PATH = shutil.which("node")
 
-CONFIG_DIR = os.path.join(os.path.dirname(__file__), "config")
-
 DEFAULT_TIMEOUT = 30
 MAX_OUTPUT_BYTES = 1 * 1024 * 1024  # 1 MB
+
+INTERNAL_API_SECRET = os.getenv("INTERNAL_API_SECRET", "")
 
 
 def _execute_python_nsjail(code: str, input_data: dict, timeout: int) -> dict:
@@ -66,9 +62,28 @@ def _execute_python_nsjail(code: str, input_data: dict, timeout: int) -> dict:
             "64",  # Max open files (needs more for network)
             "--time_limit",
             str(timeout),  # Wall clock limit
-            "-N",  # Allow network access — code can fetch URLs
+            # TODO(TH-1961): network access needed for MCP tools/agent
+            # playground. Restrict to an egress allowlist if data exfiltration
+            # becomes a concern.
+            "-N",
             "-R",
-            "/",  # Bind-mount root read-only (includes /sandbox/scripts)
+            "/usr",  # Python interpreter and standard library
+            "-R",
+            "/lib",  # System dynamic linker and libraries
+            "-R",
+            "/lib64",  # 64-bit system libraries
+            "-R",
+            "/sandbox/scripts",  # User scripts directory (read-only)
+            # DNS + system CAs, read-only, so -N networking actually works
+            # (/etc/passwd and host secrets stay unmounted).
+            "-R",
+            "/etc/resolv.conf",
+            "-R",
+            "/etc/hosts",
+            "-R",
+            "/etc/nsswitch.conf",
+            "-R",
+            "/etc/ssl/certs",
             "-T",
             "/tmp:size=16777216",  # Writable tmpfs at /tmp (16MB)
             "--",
@@ -114,52 +129,8 @@ def _execute_python_nsjail(code: str, input_data: dict, timeout: int) -> dict:
             pass
 
 
-def _execute_python_fallback(code: str, input_data: dict, timeout: int) -> dict:
-    """Fallback: execute Python code in a subprocess without nsjail."""
-    script = _build_python_script(code, input_data)
-
-    with tempfile.NamedTemporaryFile(
-        mode="w", suffix=".py", delete=False, dir="/tmp", prefix="eval_"
-    ) as f:
-        f.write(script)
-        script_path = f.name
-
-    try:
-        result = subprocess.run(
-            [PYTHON_PATH, "-I", script_path],
-            capture_output=True,
-            text=True,
-            timeout=timeout,
-            env={"PYTHONDONTWRITEBYTECODE": "1"},
-            cwd="/tmp",
-        )
-
-        stdout = result.stdout.strip()
-        if not stdout:
-            stderr = result.stderr.strip()[:500]
-            return {
-                "status": "error",
-                "data": f"No output. Exit: {result.returncode}. {stderr}",
-            }
-
-        try:
-            return json.loads(stdout)
-        except json.JSONDecodeError:
-            return {"status": "error", "data": f"Invalid JSON: {stdout[:200]}"}
-
-    except subprocess.TimeoutExpired:
-        return {"status": "error", "data": f"Timed out ({timeout}s)"}
-    except Exception as e:
-        return {"status": "error", "data": f"Error: {e}"}
-    finally:
-        try:
-            os.remove(script_path)
-        except OSError:
-            pass
-
-
 def _execute_javascript(code: str, input_data: dict, timeout: int) -> dict:
-    """Execute JavaScript code in nsjail (or fallback subprocess)."""
+    """Execute JavaScript code in nsjail sandbox."""
     if not NODE_PATH:
         return {"status": "error", "data": "Node.js not available"}
 
@@ -171,31 +142,49 @@ def _execute_javascript(code: str, input_data: dict, timeout: int) -> dict:
         f.write(script)
 
     try:
-        if NSJAIL_AVAILABLE:
-            cmd = [
-                NSJAIL_PATH,
-                "-Mo",
-                "-Q",
-                "--rlimit_as",
-                "512",
-                "--rlimit_cpu",
-                str(timeout),
-                "--rlimit_nofile",
-                "64",
-                "--time_limit",
-                str(timeout),
-                "-N",  # Allow network
-                "-R",
-                "/",
-                "-T",
-                "/tmp:size=16777216",
-                "--",
-                NODE_PATH,
-                "--max-old-space-size=64",
-                script_path,
-            ]
-        else:
-            cmd = [NODE_PATH, "--max-old-space-size=64", script_path]
+        if not NSJAIL_AVAILABLE:
+            return {"status": "error", "data": "Javascript sandbox not available"}
+
+        cmd = [
+            NSJAIL_PATH,
+            "-Mo",
+            "-Q",
+            "--rlimit_as",
+            "512",
+            "--rlimit_cpu",
+            str(timeout),
+            "--rlimit_nofile",
+            "64",
+            "--time_limit",
+            str(timeout),
+            # TODO(TH-1961): network access needed for sandboxed JS tools;
+            # restrict to an egress allowlist if data exfiltration becomes a
+            # concern.
+            "-N",
+            "-R",
+            "/usr",
+            "-R",
+            "/lib",
+            "-R",
+            "/lib64",
+            "-R",
+            "/sandbox/scripts",
+            # DNS + system CAs for -N networking, read-only.
+            "-R",
+            "/etc/resolv.conf",
+            "-R",
+            "/etc/hosts",
+            "-R",
+            "/etc/nsswitch.conf",
+            "-R",
+            "/etc/ssl/certs",
+            "-T",
+            "/tmp:size=16777216",
+            "--",
+            NODE_PATH,
+            "--max-old-space-size=64",
+            script_path,
+        ]
 
         result = subprocess.run(
             cmd,
@@ -303,12 +292,6 @@ if __name__ == "__main__":
 def _build_js_script(code: str, input_data: dict) -> str:
     """Build JS eval script."""
     input_json = json.dumps(input_data, default=str)
-    escaped = (
-        code.replace("\\", "\\\\")
-        .replace("'", "\\'")
-        .replace("\n", "\\n")
-        .replace("\r", "\\r")
-    )
 
     return f"""'use strict';
 const inputData = {input_json};
@@ -338,6 +321,22 @@ try {{
 
 class ExecuteResource:
     def on_post(self, req, resp):
+        if not INTERNAL_API_SECRET:
+            resp.status = falcon.HTTP_401
+            resp.media = {"status": "error", "data": "Authentication not configured"}
+            return
+
+        auth_header = req.get_header("Authorization", default="")
+        if not auth_header.startswith("Bearer "):
+            resp.status = falcon.HTTP_401
+            resp.media = {"status": "error", "data": "Missing Bearer token"}
+            return
+
+        if not hmac.compare_digest(auth_header[7:], INTERNAL_API_SECRET):
+            resp.status = falcon.HTTP_401
+            resp.media = {"status": "error", "data": "Invalid token"}
+            return
+
         try:
             body = req.bounded_stream.read()
             data = json.loads(body)
@@ -357,11 +356,20 @@ class ExecuteResource:
         start = time.time()
 
         if language == "javascript":
+            if not NSJAIL_AVAILABLE:
+                resp.status = falcon.HTTP_503
+                resp.media = {
+                    "status": "error",
+                    "data": "Javascript sandbox not available",
+                }
+                return
             result = _execute_javascript(code, input_data, timeout)
         elif NSJAIL_AVAILABLE:
             result = _execute_python_nsjail(code, input_data, timeout)
         else:
-            result = _execute_python_fallback(code, input_data, timeout)
+            resp.status = falcon.HTTP_503
+            resp.media = {"status": "error", "data": "Python sandbox not available"}
+            return
 
         elapsed = time.time() - start
         result["execution_time"] = round(elapsed, 3)

--- a/futureagi/code-executor/server.py
+++ b/futureagi/code-executor/server.py
@@ -379,12 +379,10 @@ class ExecuteResource:
 
 class HealthResource:
     def on_get(self, req, resp):
-        resp.media = {
-            "status": "ok",
-            "nsjail": NSJAIL_AVAILABLE,
-            "python": PYTHON_PATH,
-            "node": NODE_PATH,
-        }
+        # Minimal payload on purpose: this endpoint is unauthenticated, so it
+        # must not leak interpreter paths or nsjail availability (recon value
+        # for an attacker).
+        resp.media = {"status": "ok"}
 
 
 app = falcon.App()

--- a/futureagi/code-executor/tests/test_execute_security.py
+++ b/futureagi/code-executor/tests/test_execute_security.py
@@ -1,0 +1,221 @@
+"""Tests for code-executor security: auth, sandbox isolation, fallback behaviour.
+
+Runs under code-executor/pytest.ini in the executor's own venv (falcon lives in
+the executor image, not the core backend). ``server`` resolves because pytest
+inserts the code-executor directory into sys.path.
+"""
+
+import os
+import shutil
+
+import falcon.testing
+import pytest
+
+# Set secret before importing the module-under-test. Confined to this isolated
+# harness; the backend process gets the real secret from its environment.
+os.environ["INTERNAL_API_SECRET"] = "test-internal-secret-123"
+
+import server as server_module  # noqa: E402
+
+_SECRET = "test-internal-secret-123"
+
+
+def _client():
+    return falcon.testing.TestClient(server_module.app)
+
+
+VALID_EVAL_CODE = "def evaluate(input):\n    return {'result': 1.0}\n"
+
+
+def test_health_endpoint_returns_status():
+    response = _client().simulate_get("/health")
+    assert response.status == falcon.HTTP_200
+    body = response.json
+    assert body["status"] == "ok"
+    assert "nsjail" in body
+
+
+def test_execute_rejected_without_auth():
+    response = _client().simulate_post(
+        "/execute", json={"code": "print(1)", "input_data": {}}
+    )
+    assert response.status == falcon.HTTP_401
+    assert "Missing Bearer token" in response.json["data"]
+
+
+def test_execute_rejected_with_invalid_token():
+    response = _client().simulate_post(
+        "/execute",
+        json={"code": "print(1)", "input_data": {}},
+        headers={"Authorization": "Bearer wrong-token"},
+    )
+    assert response.status == falcon.HTTP_401
+    assert "Invalid token" in response.json["data"]
+
+
+def test_execute_rejected_without_authorization_header():
+    response = _client().simulate_post(
+        "/execute",
+        json={"code": "print(1)", "input_data": {}},
+        headers={"X-Custom": "value"},
+    )
+    assert response.status == falcon.HTTP_401
+
+
+def test_execute_rejected_when_internal_api_secret_not_configured(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """When INTERNAL_API_SECRET is empty, endpoint rejects all requests."""
+    import importlib
+
+    monkeypatch.setenv("INTERNAL_API_SECRET", "")
+    importlib.reload(server_module)
+    try:
+        response = _client().simulate_post(
+            "/execute",
+            json={"code": "print(1)", "input_data": {}},
+            headers={"Authorization": "Bearer anything"},
+        )
+        assert response.status == falcon.HTTP_401
+        assert "not configured" in response.json["data"]
+    finally:
+        # Restore module state so subsequent tests see the real secret.
+        monkeypatch.setenv("INTERNAL_API_SECRET", _SECRET)
+        importlib.reload(server_module)
+
+
+@pytest.mark.skipif(
+    not shutil.which("nsjail"), reason="nsjail not installed on this host"
+)
+def test_execute_accepted_with_valid_key():
+    response = _client().simulate_post(
+        "/execute",
+        json={"code": VALID_EVAL_CODE, "input_data": {}, "timeout": 5},
+        headers={"Authorization": f"Bearer {_SECRET}"},
+    )
+    assert response.status == falcon.HTTP_200
+    body = response.json
+    assert body.get("status") == "success"
+    assert body.get("data", {}).get("result") == 1.0
+
+
+@pytest.mark.skipif(
+    shutil.which("nsjail") is not None,
+    reason="test only valid when nsjail is NOT installed",
+)
+def test_python_execution_rejected_when_nsjail_missing():
+    response = _client().simulate_post(
+        "/execute",
+        json={"code": VALID_EVAL_CODE, "input_data": {}},
+        headers={"Authorization": f"Bearer {_SECRET}"},
+    )
+    assert response.status == falcon.HTTP_503
+    assert "sandbox not available" in response.json["data"].lower()
+
+
+@pytest.mark.skipif(
+    shutil.which("nsjail") is not None,
+    reason="test only valid when nsjail is NOT installed",
+)
+def test_javascript_execution_rejected_when_nsjail_missing():
+    response = _client().simulate_post(
+        "/execute",
+        json={"code": "print('hello')", "input_data": {}, "language": "javascript"},
+        headers={"Authorization": f"Bearer {_SECRET}"},
+    )
+    assert response.status == falcon.HTTP_503
+    assert "sandbox not available" in response.json["data"].lower()
+
+
+def _probe_path_code(path, mode="rb"):
+    return f"""
+def evaluate(input):
+    try:
+        with open({path!r}, {mode!r}) as f:
+            data = f.read()
+        return {{"exposed": True, "sample": data[:100].decode(errors="replace")}}
+    except PermissionError:
+        return {{"exposed": False, "reason": "PermissionError"}}
+    except FileNotFoundError:
+        return {{"exposed": False, "reason": "FileNotFoundError"}}
+    except Exception as e:
+        return {{"exposed": False, "reason": str(e)}}
+"""
+
+
+@pytest.mark.skipif(
+    not shutil.which("nsjail"), reason="nsjail not installed on this host"
+)
+def test_sandbox_cannot_read_proc_environ():
+    """Host env secrets must not leak into the sandbox.
+
+    nsjail mounts a fresh /proc, so /proc/self/environ exists but holds an empty
+    environment — readable-but-empty is still "not exposed".
+    """
+    response = _client().simulate_post(
+        "/execute",
+        json={
+            "code": _probe_path_code("/proc/self/environ"),
+            "input_data": {},
+            "timeout": 10,
+        },
+        headers={"Authorization": f"Bearer {_SECRET}"},
+    )
+    assert response.status == falcon.HTTP_200
+    body = response.json
+    assert body.get("status") == "success", body
+    result_data = body.get("data", body)
+    exposed_content = result_data.get("exposed") and result_data.get("sample")
+    assert (
+        not exposed_content
+    ), f"/proc/self/environ leaked host env inside sandbox: {result_data}"
+
+
+@pytest.mark.skipif(
+    not shutil.which("nsjail"), reason="nsjail not installed on this host"
+)
+def test_sandbox_cannot_read_etc_passwd():
+    response = _client().simulate_post(
+        "/execute",
+        json={
+            "code": _probe_path_code("/etc/passwd", mode="r"),
+            "input_data": {},
+            "timeout": 10,
+        },
+        headers={"Authorization": f"Bearer {_SECRET}"},
+    )
+    assert response.status == falcon.HTTP_200
+    body = response.json
+    assert body.get("status") == "success", body
+    result_data = body.get("data", body)
+    assert not result_data.get(
+        "exposed", False
+    ), f"/etc/passwd was readable inside sandbox: {result_data}"
+
+
+@pytest.mark.skipif(
+    not shutil.which("nsjail"), reason="nsjail not installed on this host"
+)
+def test_sandbox_dns_still_resolves():
+    """-N networking is deliberately kept; the /etc mounts must keep DNS alive."""
+    dns_code = """
+def evaluate(input):
+    import socket
+    try:
+        socket.getaddrinfo("example.com", 443, socket.AF_INET)
+        return {"dns_ok": True}
+    except Exception as e:
+        return {"dns_ok": False, "reason": str(e)}
+"""
+    response = _client().simulate_post(
+        "/execute",
+        json={"code": dns_code, "input_data": {}, "timeout": 10},
+        headers={"Authorization": f"Bearer {_SECRET}"},
+    )
+    assert response.status == falcon.HTTP_200
+    body = response.json
+    assert body.get("status") == "success", body
+    result_data = body.get("data", body)
+    assert result_data.get(
+        "dns_ok"
+    ), f"DNS resolution failed inside sandbox (are /etc mounts present?): {result_data}"

--- a/futureagi/code-executor/tests/test_execute_security.py
+++ b/futureagi/code-executor/tests/test_execute_security.py
@@ -30,9 +30,7 @@ VALID_EVAL_CODE = "def evaluate(input):\n    return {'result': 1.0}\n"
 def test_health_endpoint_returns_status():
     response = _client().simulate_get("/health")
     assert response.status == falcon.HTTP_200
-    body = response.json
-    assert body["status"] == "ok"
-    assert "nsjail" in body
+    assert response.json == {"status": "ok"}
 
 
 def test_execute_rejected_without_auth():

--- a/futureagi/docker-compose.yml
+++ b/futureagi/docker-compose.yml
@@ -142,7 +142,12 @@ services:
       context: ./code-executor
       dockerfile: Dockerfile
     ports:
-      - "8060:8060"
+      # Loopback-only: the /execute endpoint is authenticated with
+      # INTERNAL_API_SECRET; don't expose it on the host network.
+      - "127.0.0.1:8060:8060"
+    environment:
+      # Must match the value the backend service gets (from .env via env_file).
+      - INTERNAL_API_SECRET=${INTERNAL_API_SECRET:-}
     # Privileged needed for nsjail namespace creation
     privileged: true
     restart: unless-stopped

--- a/futureagi/pytest.ini
+++ b/futureagi/pytest.ini
@@ -1,6 +1,6 @@
 [pytest]
 # Core Django backend tests only
-# model_serving and agentic_eval have their own pytest.ini
+# model_serving, agentic_eval, and code-executor have their own pytest.ini
 
 asyncio_mode = auto
 asyncio_default_fixture_loop_scope = function
@@ -13,6 +13,7 @@ norecursedirs =
     node_modules
     agentic_eval
     model_serving
+    code-executor
     turing_api
     management
     scripts

--- a/futureagi/simulate/views/livekit_api.py
+++ b/futureagi/simulate/views/livekit_api.py
@@ -9,6 +9,7 @@ Two authentication modes:
 
 from __future__ import annotations
 
+import hmac
 import inspect
 import re
 import uuid
@@ -211,7 +212,7 @@ class InternalAPIView(AsyncAPIView):
             raise _forbidden("INTERNAL_API_SECRET not configured")
 
         token = auth_header[7:]
-        if token != secret:
+        if not hmac.compare_digest(token, secret):
             raise _forbidden("Invalid token")
 
 


### PR DESCRIPTION
Fixes #1961 (executor half) — follow-up to #1893, which now carries only the SAML/OAuth hardening.

Requires Bearer authentication on the `/execute` code executor endpoint and completes the nsjail sandbox hardening: no unsandboxed fallback, granular mounts that keep `-N` networking actually working, and a caller that sends the shared secret and **fails closed** on 401/503 instead of silently downgrading to the weaker in-process sandbox.

## Type of change

- 🐛 Bug fix (non-breaking change which fixes an issue)

## What changes were done

**`futureagi/code-executor/server.py`**
- `ExecuteResource.on_post()` requires `Authorization: Bearer <INTERNAL_API_SECRET>`; rejects with 401 when the secret is unconfigured (fails closed), missing, or invalid. Token compare uses `hmac.compare_digest`.
- Unsandboxed execution is gone: 503 for both `python` and `javascript` when nsjail is unavailable. Deleted the now-unreachable `_execute_python_fallback` and the unused `tempfile`/`CONFIG_DIR`.
- Mounts narrowed to `/usr`, `/lib`, `/lib64`, `/sandbox/scripts` **plus read-only `/etc/resolv.conf`, `/etc/hosts`, `/etc/nsswitch.conf`, `/etc/ssl/certs`** so the deliberately-kept `-N` network access (MCP tools, agent playground) keeps DNS + system CAs working.

**`futureagi/agentic_eval/core_evals/fi_utils/sandbox.py`**
- `_call_executor_service()` sends `Authorization: Bearer <INTERNAL_API_SECRET>`.
- **Fail-closed fallback:** a 401/503 from the executor is a deliberate refusal and returns an error — it is *not* silently downgraded to the Tier-2 RestrictedPython sandbox. Only transient unreachability (connection refused/timeout) falls back, and that is logged at WARNING (was DEBUG).

**`futureagi/simulate/views/livekit_api.py`**
- Internal API bearer token check moved to `hmac.compare_digest` (review follow-up, same `INTERNAL_API_SECRET` pattern).

**`futureagi/code-executor/server.py`**
- `/health` is unauthenticated, so it now returns a minimal `{"status": "ok"}` instead of interpreter absolute paths and nsjail availability (recon data).

**`futureagi/docker-compose.yml`**
- `code-executor` service gets `INTERNAL_API_SECRET=${INTERNAL_API_SECRET:-}` (the backend already receives it via `env_file: .env`) and is bound to `127.0.0.1:8060` instead of `0.0.0.0`.

**Test harness**
- New `code-executor/pytest.ini` (own venv/CI job, matching `model_serving`/`agentic_eval`) and `code-executor` added to the root `pytest.ini` `norecursedirs` — the executor tests no longer break `bin/test` and no longer need `falcon`/`code_executor` in the backend env.
- Fixed the isolation tests: payloads now define `evaluate()` so the wrapper emits valid JSON (previously the two-JSON-line output crashed `result_data.get(...)` with `AttributeError` when nsjail was present), and the secret-restore is in `try/finally`.
- Added `test_sandbox_dns_still_resolves` — guards the `/etc` mounts that keep `-N` networking alive.

## Tests written + scenarios each covers

**`code-executor/tests/test_execute_security.py`** (runs in the executor image: `docker build ./code-executor && docker run --privileged ...`)

- `test_health_endpoint_returns_status` — GET /health without auth
- `test_execute_rejected_without_auth` / `_with_invalid_token` / `_without_authorization_header` — 401 paths
- `test_execute_rejected_when_internal_api_secret_not_configured` — empty secret → 401 "not configured", state restored in `finally`
- `test_execute_accepted_with_valid_key` — valid Bearer + real eval → 200 success (requires nsjail)
- `test_python_execution_rejected_when_nsjail_missing` / `_javascript...` — 503 when nsjail absent
- `test_sandbox_cannot_read_proc_environ` — nsjail mounts a fresh /proc, so the sandboxed environ is empty (host env not leaked); asserted as readable-but-empty
- `test_sandbox_cannot_read_etc_passwd` — `/etc` not mounted → unreadable
- `test_sandbox_dns_still_resolves` — `/etc/resolv.conf` mount keeps DNS alive under `-N`

Caller fail-closed behavior was verified against a local stub HTTP server: 401/503 → error result (no Tier-2 downgrade), connection refused → `None` (fallback), header present only when a secret is configured.

## How to run / test

```
cd futureagi/code-executor
docker build -t code-executor:test .
docker run --rm --privileged \
  -v "$PWD/tests:/sandbox/tests" -v "$PWD/pytest.ini:/sandbox/pytest.ini" \
  -w /sandbox code-executor:test sh -c 'pip install pytest && python -m pytest'
```

## Edge cases & considerations

- `INTERNAL_API_SECRET` must be set for **both** the backend service (already via `.env`) and the `code-executor` service. If it is empty the executor rejects everything with 401, so deployments must configure it — documented in `.env.example` (entry already present) and wired in compose.
- Sandbox network is deliberately left on (`-N`) because MCP tools and the agent playground make HTTP calls from sandboxed code. Marked `TODO(TH-1961)`: restrict to an egress allowlist if data exfiltration becomes a concern.
- `/etc/passwd`, host env (`/proc/self/environ`), and other host secrets are **not** mounted into the sandbox.

## Checklist

- [x] My code follows the style guide
- [x] I've added tests that prove my fix is effective or that my feature works
- [ ] yarn test:run passes locally (frontend) — N/A
- [ ] yarn contracts:check passes if API surface changed — N/A
- [x] I've updated the documentation where relevant
- [x] No hardcoded secrets, URLs, or PII
- [x] I've signed the CLA
- [x] PR title follows Conventional Commits
