### PR TITLE
fix(accounts): add optional expiry for org API keys

### DIFF
--- a/api_contracts/openapi/swagger.json
+++ b/api_contracts/openapi/swagger.json
@@ -73836,6 +73836,12 @@
                     "type": "string",
                     "maxLength": 100,
                     "minLength": 1
+                },
+                "expires_at": {
+                    "title": "Expires at",
+                    "type": "string",
+                    "format": "date-time",
+                    "x-nullable": true
                 }
             }
         },
@@ -73968,6 +73974,12 @@
                     "title": "Created at",
                     "type": "string",
                     "format": "date-time"
+                },
+                "expires_at": {
+                    "title": "Expires at",
+                    "type": "string",
+                    "format": "date-time",
+                    "x-nullable": true
                 },
                 "enabled": {
                     "title": "Enabled",

--- a/frontend/src/api/contracts/openapi-contract.generated.js
+++ b/frontend/src/api/contracts/openapi-contract.generated.js
@@ -50440,6 +50440,12 @@ export const OPENAPI_CONTRACT = Object.freeze({
           "type": "string",
           "maxLength": 100,
           "minLength": 1
+        },
+        "expires_at": {
+          "title": "Expires at",
+          "type": "string",
+          "format": "date-time",
+          "x-nullable": true
         }
       }
     },
@@ -98716,6 +98722,12 @@ export const OPENAPI_CONTRACT = Object.freeze({
           "title": "Created at",
           "type": "string",
           "format": "date-time"
+        },
+        "expires_at": {
+          "title": "Expires at",
+          "type": "string",
+          "format": "date-time",
+          "x-nullable": true
         },
         "enabled": {
           "title": "Enabled",

--- a/frontend/src/generated/api-contracts/api.schemas.ts
+++ b/frontend/src/generated/api-contracts/api.schemas.ts
@@ -452,6 +452,7 @@ export interface CreateSecretKeyApi {
      * @maxLength 100
      */
   key_name: string;
+  expires_at?: string | null;
 }
 
 export interface SecretKeyCreateResultApi {
@@ -490,6 +491,7 @@ export interface SecretKeyListItemApi {
   /** @minLength 1 */
   created_by: string;
   created_at: string;
+  expires_at?: string | null;
   enabled: boolean;
   /** @minLength 1 */
   type: string;

--- a/frontend/src/generated/api-contracts/api.zod.ts
+++ b/frontend/src/generated/api-contracts/api.zod.ts
@@ -647,7 +647,8 @@ export const accountsKeyGenerateSecretKeyBodyKeyNameMax = 100;
 
 
 export const AccountsKeyGenerateSecretKeyBody = zod.object({
-  "key_name": zod.string().min(1).max(accountsKeyGenerateSecretKeyBodyKeyNameMax)
+  "key_name": zod.string().min(1).max(accountsKeyGenerateSecretKeyBodyKeyNameMax),
+  "expires_at": zod.string().datetime({"offset":true}).nullish()
 })
 
 
@@ -692,6 +693,7 @@ export const AccountsKeyGetSecretKeysResponse = zod.object({
   "secret_key": zod.string().min(1),
   "created_by": zod.string().min(1),
   "created_at": zod.string().datetime({"offset":true}),
+  "expires_at": zod.string().datetime({"offset":true}).nullish(),
   "enabled": zod.boolean(),
   "type": zod.string().min(1)
 }))

--- a/frontend/src/sections/keys/view/CreateApiKey.jsx
+++ b/frontend/src/sections/keys/view/CreateApiKey.jsx
@@ -23,10 +23,12 @@ import SvgColor from "src/components/svg-color";
 
 const CreateApiKey = ({ open, onClose, refreshGrid }) => {
   const [keyName, setKeyName] = useState("");
+  const [expiresAt, setExpiresAt] = useState("");
   const [showKeys, setShowKeys] = useState(false);
 
   const handleClose = () => {
     setKeyName("");
+    setExpiresAt("");
     setShowKeys(false);
     reset();
     onClose();
@@ -38,10 +40,13 @@ const CreateApiKey = ({ open, onClose, refreshGrid }) => {
     isPending: loading,
     reset,
   } = useMutation({
-    mutationFn: () =>
-      axios.post(endpoints.keys.generateSecretKey, {
-        key_name: keyName,
-      }),
+    mutationFn: () => {
+      const payload = { key_name: keyName };
+      if (expiresAt) {
+        payload.expires_at = new Date(expiresAt).toISOString();
+      }
+      return axios.post(endpoints.keys.generateSecretKey, payload);
+    },
     onSuccess: () => {
       setShowKeys(true);
       // trackEvent(Events.saveApiClicked, { [PropertyName.click]: true });
@@ -97,7 +102,14 @@ const CreateApiKey = ({ open, onClose, refreshGrid }) => {
 
         <DialogContent sx={{ padding: 0, margin: 0 }}>
           <ShowComponent condition={!isSecretKey}>
-            <Box sx={{ marginTop: 2 }}>
+            <Box
+              sx={{
+                marginTop: 2,
+                display: "flex",
+                flexDirection: "column",
+                gap: 2,
+              }}
+            >
               <TextField
                 label={"Key name"}
                 value={keyName}
@@ -113,6 +125,17 @@ const CreateApiKey = ({ open, onClose, refreshGrid }) => {
                 variant="outlined"
                 required
                 size="small"
+              />
+              <TextField
+                label="Expires (optional)"
+                type="datetime-local"
+                value={expiresAt}
+                onChange={(e) => setExpiresAt(e.target.value)}
+                fullWidth
+                variant="outlined"
+                size="small"
+                InputLabelProps={{ shrink: true }}
+                helperText="Leave blank for a key that never expires"
               />
             </Box>
           </ShowComponent>

--- a/frontend/src/sections/keys/view/__tests__/CreateApiKey.test.jsx
+++ b/frontend/src/sections/keys/view/__tests__/CreateApiKey.test.jsx
@@ -1,0 +1,79 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, waitFor, fireEvent } from "src/utils/test-utils";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import userEvent from "@testing-library/user-event";
+
+const { postMock } = vi.hoisted(() => ({
+  postMock: vi.fn(),
+}));
+
+vi.mock("src/utils/axios", () => ({
+  default: { post: (...args) => postMock(...args) },
+  endpoints: {
+    keys: { generateSecretKey: "/accounts/key/generate_secret_key/" },
+  },
+}));
+
+vi.mock("notistack", () => ({
+  enqueueSnackbar: vi.fn(),
+}));
+
+import CreateApiKey from "../CreateApiKey";
+
+const renderDialog = () => {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <CreateApiKey open onClose={vi.fn()} refreshGrid={vi.fn()} />
+    </QueryClientProvider>,
+  );
+};
+
+describe("CreateApiKey expiry payload", () => {
+  beforeEach(() => {
+    postMock.mockReset();
+    postMock.mockResolvedValue({
+      data: { result: { api_key: "a", secret_key: "s" } },
+    });
+  });
+
+  it("omits expires_at when no expiry is chosen", async () => {
+    const user = userEvent.setup();
+    renderDialog();
+
+    await user.type(
+      screen.getByPlaceholderText("Enter your key name"),
+      "my-key",
+    );
+    await user.click(screen.getByRole("button", { name: /next/i }));
+
+    await waitFor(() => expect(postMock).toHaveBeenCalledTimes(1));
+    expect(postMock).toHaveBeenCalledWith(
+      "/accounts/key/generate_secret_key/",
+      {
+        key_name: "my-key",
+      },
+    );
+  });
+
+  it("sends expires_at as ISO when a date is chosen", async () => {
+    const user = userEvent.setup();
+    renderDialog();
+
+    await user.type(
+      screen.getByPlaceholderText("Enter your key name"),
+      "temp-key",
+    );
+    fireEvent.change(screen.getByLabelText("Expires (optional)"), {
+      target: { value: "2026-12-01T15:30" },
+    });
+    await user.click(screen.getByRole("button", { name: /next/i }));
+
+    await waitFor(() => expect(postMock).toHaveBeenCalledTimes(1));
+    const payload = postMock.mock.calls[0][1];
+    expect(payload.key_name).toBe("temp-key");
+    expect(payload.expires_at).toBe(new Date("2026-12-01T15:30").toISOString());
+  });
+});

--- a/frontend/src/sections/keys/view/__tests__/keyExpiry.test.js
+++ b/frontend/src/sections/keys/view/__tests__/keyExpiry.test.js
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vitest";
+import { formatApiKeyExpiry, isOrgApiKeyExpired } from "../keyExpiry";
+
+describe("isOrgApiKeyExpired", () => {
+  it("treats a null expiry as never expired", () => {
+    expect(isOrgApiKeyExpired(null, Date.parse("2026-08-18T12:00:00Z"))).toBe(
+      false,
+    );
+  });
+
+  it("treats a future expiry as active", () => {
+    expect(
+      isOrgApiKeyExpired(
+        "2026-12-01T00:00:00Z",
+        Date.parse("2026-08-18T12:00:00Z"),
+      ),
+    ).toBe(false);
+  });
+
+  it("treats a past expiry as expired", () => {
+    expect(
+      isOrgApiKeyExpired(
+        "2026-01-01T00:00:00Z",
+        Date.parse("2026-08-18T12:00:00Z"),
+      ),
+    ).toBe(true);
+  });
+});
+
+describe("formatApiKeyExpiry", () => {
+  it("renders Never when expiry is missing", () => {
+    expect(formatApiKeyExpiry(null)).toBe("Never");
+    expect(formatApiKeyExpiry("")).toBe("Never");
+  });
+
+  it("formats a real expiry date", () => {
+    expect(formatApiKeyExpiry("2026-12-01T15:30:00Z")).toBe("12-01-2026");
+  });
+});

--- a/frontend/src/sections/keys/view/dev-keys-view.jsx
+++ b/frontend/src/sections/keys/view/dev-keys-view.jsx
@@ -11,6 +11,7 @@ import CreateApiKey from "./CreateApiKey";
 import ActionMenu from "./ActionMenu";
 import SecretKeyRenderer from "./SecretKeyRenderer";
 import stringAvatar from "src/utils/stringAvatar";
+import { formatApiKeyExpiry, isOrgApiKeyExpired } from "./keyExpiry";
 
 export default function DevKeysView() {
   const queryClient = useQueryClient();
@@ -84,7 +85,20 @@ export default function DevKeysView() {
             >
               {getValue()}
             </Typography>
-            {!row.original.enabled && (
+            {isOrgApiKeyExpired(row.original.expires_at) ? (
+              <Chip
+                label="Expired"
+                sx={{
+                  ml: 1,
+                  flexShrink: 0,
+                  height: 22,
+                  fontSize: 11,
+                  borderRadius: "4px",
+                  color: "warning.darker",
+                  bgcolor: "warning.lighter",
+                }}
+              />
+            ) : !row.original.enabled ? (
               <Chip
                 label="Disabled"
                 sx={{
@@ -97,7 +111,7 @@ export default function DevKeysView() {
                   bgcolor: "background.neutral",
                 }}
               />
-            )}
+            ) : null}
           </Box>
         ),
       },
@@ -160,6 +174,17 @@ export default function DevKeysView() {
             </Typography>
           );
         },
+      },
+      {
+        id: "expires_at",
+        accessorKey: "expires_at",
+        header: "Expires",
+        meta: { flex: 1 },
+        cell: ({ getValue }) => (
+          <Typography variant="body2" noWrap sx={{ fontSize: 13 }}>
+            {formatApiKeyExpiry(getValue())}
+          </Typography>
+        ),
       },
       {
         id: "actions",

--- a/frontend/src/sections/keys/view/keyExpiry.js
+++ b/frontend/src/sections/keys/view/keyExpiry.js
@@ -1,0 +1,20 @@
+import { format } from "date-fns";
+
+export function isOrgApiKeyExpired(expiresAt, now = Date.now()) {
+  if (!expiresAt) {
+    return false;
+  }
+  const ms = new Date(expiresAt).getTime();
+  return Number.isFinite(ms) && ms <= now;
+}
+
+export function formatApiKeyExpiry(expiresAt) {
+  if (!expiresAt) {
+    return "Never";
+  }
+  const date = new Date(expiresAt);
+  if (Number.isNaN(date.getTime())) {
+    return "Never";
+  }
+  return format(date, "MM-dd-yyyy");
+}

--- a/futureagi/accounts/admin.py
+++ b/futureagi/accounts/admin.py
@@ -211,6 +211,7 @@ class OrgApiKeyAdmin(admin.ModelAdmin):
         "organization",
         "type",
         "enabled",
+        "expires_at",
         "user",
         "workspace",
         "created_at",
@@ -223,7 +224,7 @@ class OrgApiKeyAdmin(admin.ModelAdmin):
     fieldsets = (
         (None, {"fields": ("name", "organization", "type")}),
         ("Access Control", {"fields": ("user", "workspace")}),
-        ("Status", {"fields": ("enabled",)}),
+        ("Status", {"fields": ("enabled", "expires_at")}),
         ("Keys", {"fields": ("api_key", "secret_key")}),
         ("Metadata", {"fields": ("id", "created_at")}),
     )

--- a/futureagi/accounts/authentication.py
+++ b/futureagi/accounts/authentication.py
@@ -167,7 +167,6 @@ class APIKeyAuthentication(BaseAuthentication):
             ).get(
                 api_key=api_key,
                 secret_key=secret_key,
-                enabled=True,
                 deleted=False,
             )
 
@@ -175,9 +174,7 @@ class APIKeyAuthentication(BaseAuthentication):
             if not org_api_key.organization:
                 raise AuthenticationFailed("API key has no organization")
 
-            # Validate that the API key is enabled
-            if not org_api_key.enabled:
-                raise AuthenticationFailed("API key is disabled")
+            self._enforce_org_api_key_access(org_api_key)
 
             # Get or create a system user for this organization
             if org_api_key.type == "system":
@@ -201,6 +198,23 @@ class APIKeyAuthentication(BaseAuthentication):
             return user, None
         except OrgApiKey.DoesNotExist as e:
             raise AuthenticationFailed("Invalid API key or secret key") from e
+
+    def _enforce_org_api_key_access(self, org_api_key):
+        """Reject expired keys first, then disabled keys.
+
+        The lookup must not filter on ``enabled=True``. An expired key is
+        auto-disabled, and a subsequent request has to keep matching so the
+        caller still sees "API key has expired" rather than a generic invalid
+        key error.
+        """
+        expires_at = org_api_key.expires_at
+        if expires_at is not None and expires_at <= timezone.now():
+            if org_api_key.enabled:
+                org_api_key.enabled = False
+                org_api_key.save(update_fields=["enabled"])
+            raise AuthenticationFailed("API key has expired")
+        if not org_api_key.enabled:
+            raise AuthenticationFailed("API key is disabled")
 
     def _set_workspace_context(self, request, user):
         """Set workspace context after successful authentication.
@@ -579,7 +593,6 @@ class LangfuseBasicAuthentication(APIKeyAuthentication):
             ).get(
                 api_key=public_key,
                 secret_key=secret_key,
-                enabled=True,
                 deleted=False,
             )
         except OrgApiKey.DoesNotExist as e:
@@ -587,6 +600,8 @@ class LangfuseBasicAuthentication(APIKeyAuthentication):
 
         if not org_api_key.organization:
             raise AuthenticationFailed("API key has no organization")
+
+        self._enforce_org_api_key_access(org_api_key)
 
         # Resolve user (same logic as parent class)
         if org_api_key.type == "system":

--- a/futureagi/accounts/migrations/0025_orgapikey_expires_at.py
+++ b/futureagi/accounts/migrations/0025_orgapikey_expires_at.py
@@ -1,0 +1,20 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("accounts", "0024_sosloginproxy"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="orgapikey",
+            name="expires_at",
+            field=models.DateTimeField(
+                blank=True,
+                help_text="When this key stops authenticating. Null means it never expires.",
+                null=True,
+            ),
+        ),
+    ]

--- a/futureagi/accounts/models/user.py
+++ b/futureagi/accounts/models/user.py
@@ -314,6 +314,11 @@ class OrgApiKey(BaseModel):
         choices=[("system", "System"), ("user", "User"), ("mcp", "MCP")],
     )
     enabled = models.BooleanField(default=True)
+    expires_at = models.DateTimeField(
+        null=True,
+        blank=True,
+        help_text="When this key stops authenticating. Null means it never expires.",
+    )
     user = models.ForeignKey(
         User,
         on_delete=models.CASCADE,

--- a/futureagi/accounts/serializers/contracts.py
+++ b/futureagi/accounts/serializers/contracts.py
@@ -602,6 +602,7 @@ class SecretKeyListItemSerializer(serializers.Serializer):
     secret_key = serializers.CharField()
     created_by = serializers.CharField(allow_null=True)
     created_at = serializers.DateTimeField()
+    expires_at = serializers.DateTimeField(required=False, allow_null=True)
     enabled = serializers.BooleanField()
     type = serializers.CharField()
 

--- a/futureagi/accounts/serializers/org_api_key.py
+++ b/futureagi/accounts/serializers/org_api_key.py
@@ -19,3 +19,4 @@ class UserSecretKeySerializer(serializers.Serializer):
 
 class CreateSecretKeySerializer(serializers.Serializer):
     key_name = serializers.CharField(max_length=100, required=True)
+    expires_at = serializers.DateTimeField(required=False, allow_null=True)

--- a/futureagi/accounts/tests/test_keys.py
+++ b/futureagi/accounts/tests/test_keys.py
@@ -610,6 +610,7 @@ class TestGetSecretKeysRowContent:
             "secret_key",
             "created_by",
             "created_at",
+            "expires_at",
             "enabled",
             "type",
         }
@@ -870,3 +871,65 @@ class TestGetKeysViewResponse:
         # Should have created a system key
         data = response.json()
         assert data.get("data") is not None
+
+
+@pytest.mark.integration
+@pytest.mark.api
+class TestApiKeyExpiry:
+    """Optional expires_at on create and list. Null means the key never expires."""
+
+    def test_generate_without_expiry_stores_null(self, auth_client):
+        response = auth_client.post(
+            "/accounts/key/generate_secret_key/",
+            {"key_name": "Never Expires Key"},
+            format="json",
+        )
+        assert response.status_code == status.HTTP_200_OK
+        key_id = response.json()["result"]["key_id"]
+
+        from accounts.models.user import OrgApiKey
+
+        key = OrgApiKey.all_objects.get(id=key_id)
+        assert key.expires_at is None
+
+        listed = auth_client.get(f"{SECRET_KEYS_URL}?search=Never Expires")
+        assert listed.status_code == status.HTTP_200_OK
+        row = _rows(listed)[0]
+        assert row["expires_at"] is None
+
+    def test_generate_with_expiry_persists_and_lists_it(self, auth_client):
+        expires_at = timezone.now() + timedelta(days=7)
+        response = auth_client.post(
+            "/accounts/key/generate_secret_key/",
+            {
+                "key_name": "Temporary Key",
+                "expires_at": expires_at.isoformat(),
+            },
+            format="json",
+        )
+        assert response.status_code == status.HTTP_200_OK
+        key_id = response.json()["result"]["key_id"]
+
+        from accounts.models.user import OrgApiKey
+
+        key = OrgApiKey.all_objects.get(id=key_id)
+        assert key.expires_at is not None
+        assert abs((key.expires_at - expires_at).total_seconds()) < 1
+
+        listed = auth_client.get(f"{SECRET_KEYS_URL}?search=Temporary Key")
+        assert listed.status_code == status.HTTP_200_OK
+        row = _rows(listed)[0]
+        assert row["expires_at"] is not None
+
+    def test_generate_with_null_expiry_is_the_same_as_omitting_it(self, auth_client):
+        response = auth_client.post(
+            "/accounts/key/generate_secret_key/",
+            {"key_name": "Explicit Null Expiry", "expires_at": None},
+            format="json",
+        )
+        assert response.status_code == status.HTTP_200_OK
+
+        from accounts.models.user import OrgApiKey
+
+        key = OrgApiKey.all_objects.get(id=response.json()["result"]["key_id"])
+        assert key.expires_at is None

--- a/futureagi/accounts/tests/test_multi_org_auth.py
+++ b/futureagi/accounts/tests/test_multi_org_auth.py
@@ -12,9 +12,11 @@ These are integration tests that hit the actual auth layer.
 """
 
 import base64
+from datetime import timedelta
 from unittest.mock import MagicMock, patch
 
 import pytest
+from django.utils import timezone
 from rest_framework.exceptions import AuthenticationFailed
 
 from accounts.authentication import APIKeyAuthentication, LangfuseBasicAuthentication
@@ -192,6 +194,125 @@ class TestAPIKeyAuthentication:
 
         with pytest.raises(AuthenticationFailed):
             LangfuseBasicAuthentication().authenticate(request)
+
+    def test_expired_api_key_is_rejected_and_stays_expired(
+        self, auth_instance, auth_user, org_primary
+    ):
+        key = OrgApiKey.no_workspace_objects.create(
+            name="Expired API auth key",
+            organization=org_primary,
+            type="user",
+            user=auth_user,
+            expires_at=timezone.now() - timedelta(minutes=1),
+        )
+        request = _make_request(
+            headers={
+                "X-Api-Key": key.api_key,
+                "X-Secret-Key": key.secret_key,
+            }
+        )
+
+        with pytest.raises(AuthenticationFailed, match="API key has expired"):
+            auth_instance.authenticate(request)
+        key.refresh_from_db()
+        assert key.enabled is False
+
+        with pytest.raises(AuthenticationFailed, match="API key has expired"):
+            auth_instance.authenticate(request)
+
+    def test_expired_basic_api_key_is_rejected(self, auth_user, org_primary):
+        key = OrgApiKey.no_workspace_objects.create(
+            name="Expired basic auth key",
+            organization=org_primary,
+            type="user",
+            user=auth_user,
+            expires_at=timezone.now() - timedelta(minutes=1),
+        )
+        encoded = base64.b64encode(
+            f"{key.api_key}:{key.secret_key}".encode("utf-8")
+        ).decode("ascii")
+        request = _make_request()
+        request.META = {"HTTP_AUTHORIZATION": f"Basic {encoded}"}
+
+        with pytest.raises(AuthenticationFailed, match="API key has expired"):
+            LangfuseBasicAuthentication().authenticate(request)
+        key.refresh_from_db()
+        assert key.enabled is False
+
+        with pytest.raises(AuthenticationFailed, match="API key has expired"):
+            LangfuseBasicAuthentication().authenticate(request)
+
+    def test_null_expiry_does_not_block_api_key_auth(
+        self, auth_instance, auth_user, org_primary
+    ):
+        key = OrgApiKey.no_workspace_objects.create(
+            name="Never-expires API auth key",
+            organization=org_primary,
+            type="user",
+            user=auth_user,
+            expires_at=None,
+        )
+        request = _make_request(
+            headers={
+                "X-Api-Key": key.api_key,
+                "X-Secret-Key": key.secret_key,
+            }
+        )
+
+        with patch.object(APIKeyAuthentication, "_set_workspace_context"):
+            user, _token = auth_instance.authenticate(request)
+        assert user == auth_user
+        key.refresh_from_db()
+        assert key.enabled is True
+
+    def test_future_expiry_does_not_block_api_key_auth(
+        self, auth_instance, auth_user, org_primary
+    ):
+        key = OrgApiKey.no_workspace_objects.create(
+            name="Future-dated API auth key",
+            organization=org_primary,
+            type="user",
+            user=auth_user,
+            expires_at=timezone.now() + timedelta(days=7),
+        )
+        request = _make_request(
+            headers={
+                "X-Api-Key": key.api_key,
+                "X-Secret-Key": key.secret_key,
+            }
+        )
+
+        with patch.object(APIKeyAuthentication, "_set_workspace_context"):
+            user, _token = auth_instance.authenticate(request)
+        assert user == auth_user
+
+    def test_disabled_non_expired_key_is_rejected_on_both_paths(
+        self, auth_instance, auth_user, org_primary
+    ):
+        key = OrgApiKey.no_workspace_objects.create(
+            name="Manually disabled API auth key",
+            organization=org_primary,
+            type="user",
+            user=auth_user,
+            enabled=False,
+            expires_at=None,
+        )
+        header_request = _make_request(
+            headers={
+                "X-Api-Key": key.api_key,
+                "X-Secret-Key": key.secret_key,
+            }
+        )
+        with pytest.raises(AuthenticationFailed, match="API key is disabled"):
+            auth_instance.authenticate(header_request)
+
+        encoded = base64.b64encode(
+            f"{key.api_key}:{key.secret_key}".encode("utf-8")
+        ).decode("ascii")
+        basic_request = _make_request()
+        basic_request.META = {"HTTP_AUTHORIZATION": f"Basic {encoded}"}
+        with pytest.raises(AuthenticationFailed, match="API key is disabled"):
+            LangfuseBasicAuthentication().authenticate(basic_request)
 
 
 # ---------------------------------------------------------------------------

--- a/futureagi/accounts/views/keys.py
+++ b/futureagi/accounts/views/keys.py
@@ -32,6 +32,7 @@ def _publish_key_revocation(api_key: str, secret_key: str) -> None:
     except Exception:
         logger.warning("fi_auth_revoke_publish_failed", exc_info=True)
 
+
 from accounts.models import OrgApiKey
 from accounts.serializers.contracts import (
     ACCOUNTS_ERROR_RESPONSES,
@@ -105,6 +106,8 @@ class SecretKeyAPIViewSet(ViewSet):
         "created_at": "created_at",
         "createdBy": "user__name",
         "created_by": "user__name",
+        "expiresAt": "expires_at",
+        "expires_at": "expires_at",
         "enabled": "enabled",
         "type": "type",
     }
@@ -174,6 +177,7 @@ class SecretKeyAPIViewSet(ViewSet):
                     "secret_key": mask_key(key.secret_key),
                     "created_by": key.user.name if key.user else None,
                     "created_at": key.created_at,
+                    "expires_at": key.expires_at,
                     "enabled": key.enabled,
                     "type": key.type,
                 }
@@ -273,6 +277,7 @@ class SecretKeyAPIViewSet(ViewSet):
     def generate_secret_key(self, request, *args, **kwargs):
         try:
             key_name = request.validated_data.get("key_name")
+            expires_at = request.validated_data.get("expires_at")
 
             if OrgApiKey.objects.filter(
                 name=key_name,
@@ -288,6 +293,7 @@ class SecretKeyAPIViewSet(ViewSet):
                 or request.user.organization,
                 type="user",
                 user=request.user,
+                expires_at=expires_at,
             )
             response = {
                 "key_id": org_key.id,


### PR DESCRIPTION
## Summary

Org API keys had no expiry: they could not be set to expire, the keys list never showed one, and authentication never rejected a key for being past date. This adds optional `expires_at` (null means never expires), enforces it on both auth paths, and surfaces it in the Keys UI.

## Linked issues

Closes #1458
Linear:

## Type of change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📖 Documentation only
- [ ] 🧹 Chore / refactor (no user-visible change)
- [ ] 🚀 Performance improvement
- [ ] 🧪 Test-only change

---

## 1) What changes were done

**A. Backend: persist and enforce optional expiry**

- Added nullable `expires_at` on `OrgApiKey` (migration `0025_orgapikey_expires_at`; `0024` is already taken on current `dev`).
- `CreateSecretKeySerializer` accepts optional `expires_at`. Omitting it or sending `null` still creates a key that never expires.
- `SecretKeyListItemSerializer` and `get_secret_keys` return `expires_at`.
- `APIKeyAuthentication` and `LangfuseBasicAuthentication` look up keys without `enabled=True`, then reject expired keys with `"API key has expired"` before disabled keys with `"API key is disabled"`. An expired key is auto-disabled so it stays visible in the list, and the expired message is returned on every subsequent request.

**B. Frontend: set and display expiry**

- Create-key dialog has an optional datetime control. The existing one-field flow is unchanged when it is left blank.
- Keys list has an **Expires** column (`Never` vs formatted date).
- A key whose `expires_at` is in the past shows an **Expired** chip, distinct from a manually **Disabled** key.

**C. Relationship to #1474**

- #1474 already implements Part 1 (auth rejection + model field) and is still open. This PR is self-contained so Part 2 can be reviewed against current `dev`.
- If #1474 merges first, I will rebase and drop the overlapping model/auth/migration bits.

---

## 2) Why the changes were done

- **Product/UX:** a contractor, demo, or CI key can now be created with an end date, and the list distinguishes expired from admin-disabled.
- **Technical:** null expiry is already the gateway-key convention (`AgentccAPIKey` / Go `IsExpired`). Copying that keeps org keys and gateway keys consistent.
- **Architecture:** one `_enforce_org_api_key_access` helper is shared by both authenticators so the lookup/message behaviour cannot drift.

---

## 3) Tests written + scenarios each covers

**`accounts/tests/test_multi_org_auth.py`** — auth enforcement

- `test_expired_api_key_is_rejected_and_stays_expired` — header path returns `"API key has expired"` on the first request and after auto-disable.
- `test_expired_basic_api_key_is_rejected` — same for Basic auth.
- `test_null_expiry_does_not_block_api_key_auth` — `expires_at=None` still authenticates.
- `test_future_expiry_does_not_block_api_key_auth` — a future date still authenticates.
- `test_disabled_non_expired_key_is_rejected_on_both_paths` — manually disabled keys get `"API key is disabled"`.

**`accounts/tests/test_keys.py`** — create/list contract

- `test_generate_without_expiry_stores_null` — omitting the field stores null and the list shows null.
- `test_generate_with_expiry_persists_and_lists_it` — a provided date is saved and returned on list.
- `test_generate_with_null_expiry_is_the_same_as_omitting_it` — explicit `null` does not wipe or invent an expiry.
- `test_row_exposes_expected_fields_only` — updated to include `expires_at`.

**`frontend/src/sections/keys/view/__tests__/keyExpiry.test.js`**

- null / future / past expiry classification, and `Never` vs formatted date.

**`frontend/src/sections/keys/view/__tests__/CreateApiKey.test.jsx`**

- POST body omits `expires_at` when the control is empty.
- POST body sends ISO `expires_at` when a date is chosen.

> Run result: frontend **7 passed**. Backend suites were not run here (no local test Postgres). `black`/`isort` applied to the new Python.

---

## 4) How to run / test

### Backend tests

```bash
cd futureagi
bin/test accounts/tests/test_multi_org_auth.py accounts/tests/test_keys.py -k "expir or TestAPIKeyAuthentication or TestApiKeyExpiry or TestGetSecretKeysRowContent" -v
```

### Frontend tests

```bash
cd frontend
yarn test:run src/sections/keys/view/__tests__/keyExpiry.test.js src/sections/keys/view/__tests__/CreateApiKey.test.jsx
```

### UI steps (manual)

1. Open **Keys** and click **Add API Key**.
2. Create a key with only a name — it should authenticate indefinitely and show **Never** under Expires.
3. Create a key with an expiry date — the list should show that date without a reload.
4. Backdate `expires_at` (admin/shell) and call an authenticated endpoint — expect `401 API key has expired` on every request, and an **Expired** chip in the list (not **Disabled**).

---

## 6) Edge cases & considerations

- Existing keys have `expires_at=NULL` and keep working forever.
- No default TTL is introduced.
- Editing expiry on an existing key is out of scope, per the issue.
- `AgentccAPIKey` / Go gateway expiry is unchanged.

---

## 8) Architectural / important decisions

- **Lookup does not filter `enabled=True`:** otherwise the accurate expired message would degrade to `"Invalid API key or secret key"` after the first request auto-disables the key.
- **Expiry before enabled:** so an expired-and-disabled key stays labelled expired.
- **Migration `0025`:** #1474 used `0024_orgapikey_expires_at`, which conflicts with `0024_sosloginproxy` already on `dev`.

---

## Checklist

- [x] My code follows the [style guide](../CONTRIBUTING.md#code-style)
- [x] I've added tests that prove my fix is effective or that my feature works
- [ ] `bin/test` passes locally (backend)
- [x] `yarn test:run` passes locally (frontend — the new key expiry tests)
- [x] OpenAPI + generated frontend contracts updated for `expires_at`
- [x] No hardcoded secrets, URLs, or PII
- [ ] I've signed the [CLA](../CONTRIBUTING.md#contributor-license-agreement-cla)
- [x] PR title follows Conventional Commits
- [ ] Linear issue is linked and updated with status

