### PR TITLE
feat(simulate): allow selecting which evals to run

### DIFF
--- a/frontend/src/sections/common/EvaluationDrawer/SavedEvalsList.jsx
+++ b/frontend/src/sections/common/EvaluationDrawer/SavedEvalsList.jsx
@@ -1,5 +1,5 @@
 /* eslint-disable react/prop-types */
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 import {
   Box,
   Button,
@@ -84,6 +84,7 @@ const EvalRow = ({
   onEdit,
   onDelete,
   showRun,
+  showCheckbox,
   hideStatus,
   isProjectEvals,
   allColumns,
@@ -150,7 +151,7 @@ const EvalRow = ({
           cursor: "pointer",
         }}
       >
-        {showRun && !isProjectEvals && (
+        {showCheckbox && !isProjectEvals && (
           <Checkbox
             size="small"
             checked={selected}
@@ -738,6 +739,8 @@ const SavedEvalsList = ({
   onAddClick,
   isProjectEvals = false,
   showRun = true,
+  showSelection = false,
+  onSelectionChange,
   hideStatus = false,
   hideHeader = false,
   allColumns,
@@ -756,6 +759,12 @@ const SavedEvalsList = ({
   };
   const [sel, setSel] = useState(new Set());
   const [confirmBulkDelete, setConfirmBulkDelete] = useState(false);
+  const showCheckbox = (showRun || showSelection) && !isProjectEvals;
+
+  useEffect(() => {
+    onSelectionChange?.(sel);
+  }, [sel, onSelectionChange]);
+
   const toggle = (item) =>
     setSel((p) => {
       const n = new Set(p);
@@ -799,7 +808,7 @@ const SavedEvalsList = ({
             gap: 0.75,
           }}
         >
-          {showRun && !isProjectEvals && evals.length > 0 && (
+          {showCheckbox && evals.length > 0 && (
             <Checkbox
               size="small"
               checked={sel.size === evals.length && evals.length > 0}
@@ -856,6 +865,7 @@ const SavedEvalsList = ({
             onEdit={onEditEvalClick}
             onDelete={onDeleteEvalClick}
             showRun={showRun}
+            showCheckbox={showCheckbox}
             hideStatus={hideStatus}
             isProjectEvals={isProjectEvals}
             allColumns={allColumns}
@@ -959,6 +969,8 @@ SavedEvalsList.propTypes = {
   onAddClick: PropTypes.func,
   isProjectEvals: PropTypes.bool,
   showRun: PropTypes.bool,
+  showSelection: PropTypes.bool,
+  onSelectionChange: PropTypes.func,
   hideStatus: PropTypes.bool,
   hideHeader: PropTypes.bool,
   allColumns: PropTypes.array,

--- a/frontend/src/sections/workbench/createPrompt/Simulate/SimulationDetailView/SimulationEvaluationPage.jsx
+++ b/frontend/src/sections/workbench/createPrompt/Simulate/SimulationDetailView/SimulationEvaluationPage.jsx
@@ -22,6 +22,7 @@ import { enqueueSnackbar } from "src/components/snackbar";
 import { useSimulationDetailContext } from "./context/SimulationDetailContext";
 import { useSimulationExecutionsGridStoreShallow } from "./states";
 import CustomTooltip from "src/components/tooltip";
+import { resolveEvalsToRun } from "./evalRunSelection";
 
 const SimulationEvaluationPage = ({
   onClose,
@@ -48,6 +49,7 @@ const SimulationEvaluationPage = ({
   const [openConfirmDialog, setOpenConfirmDialog] = useState(false);
   const [openConfirmRunEvaluations, setOpenConfirmRunEvaluations] =
     useState(false);
+  const [selectedEvalIds, setSelectedEvalIds] = useState(() => new Set());
 
   const { mutate: deleteEval, isPending: isDeleting } = useMutation({
     mutationFn: (evalId) =>
@@ -112,6 +114,11 @@ const SimulationEvaluationPage = ({
         selected: true,
       })),
     [simulation],
+  );
+
+  const evalsForConfirm = useMemo(
+    () => resolveEvalsToRun(evals, selectedEvalIds),
+    [evals, selectedEvalIds],
   );
 
   const handleDeleteEval = (evalId) => {
@@ -215,6 +222,8 @@ const SimulationEvaluationPage = ({
             onEditEvalClick={(evalItem) => onEditEvaluation?.(evalItem)}
             onDeleteEvalClick={(evalItem) => handleDeleteEval(evalItem.id)}
             showRun={false}
+            showSelection
+            onSelectionChange={setSelectedEvalIds}
           />
         </ShowComponent>
       </Box>
@@ -312,7 +321,7 @@ const SimulationEvaluationPage = ({
       <ConfirmRunEvaluations
         open={openConfirmRunEvaluations}
         onClose={() => setOpenConfirmRunEvaluations(false)}
-        selectedUserEvalList={evals}
+        selectedUserEvalList={evalsForConfirm}
         loading={isRunningEvals}
         onConfirm={(evalsToRun) => {
           runEvals({

--- a/frontend/src/sections/workbench/createPrompt/Simulate/SimulationDetailView/__tests__/evalRunSelection.test.js
+++ b/frontend/src/sections/workbench/createPrompt/Simulate/SimulationDetailView/__tests__/evalRunSelection.test.js
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest";
+import { resolveEvalsToRun } from "../evalRunSelection";
+
+const evals = [{ id: "a" }, { id: "b" }, { id: "c" }];
+
+describe("resolveEvalsToRun", () => {
+  it("runs every configured eval when nothing is checked", () => {
+    expect(resolveEvalsToRun(evals, new Set())).toEqual(evals);
+    expect(resolveEvalsToRun(evals, null)).toEqual(evals);
+    expect(resolveEvalsToRun(evals)).toEqual(evals);
+  });
+
+  it("runs only the checked subset", () => {
+    expect(resolveEvalsToRun(evals, new Set(["a", "c"]))).toEqual([
+      { id: "a" },
+      { id: "c" },
+    ]);
+  });
+
+  it("falls back to every configured eval when the selection is stale", () => {
+    expect(resolveEvalsToRun(evals, new Set(["gone"]))).toEqual(evals);
+  });
+
+  it("returns an empty list when there are no configured evals", () => {
+    expect(resolveEvalsToRun([], new Set(["a"]))).toEqual([]);
+  });
+});

--- a/frontend/src/sections/workbench/createPrompt/Simulate/SimulationDetailView/evalRunSelection.js
+++ b/frontend/src/sections/workbench/createPrompt/Simulate/SimulationDetailView/evalRunSelection.js
@@ -1,0 +1,7 @@
+export function resolveEvalsToRun(evals = [], selectedIds) {
+  if (!selectedIds || selectedIds.size === 0) {
+    return evals;
+  }
+  const chosen = evals.filter((item) => selectedIds.has(item.id));
+  return chosen.length > 0 ? chosen : evals;
+}


### PR DESCRIPTION
## Summary

Simulation's evaluation list used the same shared component as Datasets, but passed `showRun={false}`, which hid the per-eval checkboxes. Every configured eval always ran together. This adds checkboxes on that list and wires the selection into the existing Run Evaluation confirm dialog, without adding a second run button.

## Linked issues

Closes #1666
Linear:

## Type of change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📖 Documentation only
- [ ] 🧹 Chore / refactor (no user-visible change)
- [ ] 🚀 Performance improvement
- [ ] 🧪 Test-only change

---

## 1) What changes were done

**A. SavedEvalsList selection can be used without its own Run footer**

- New `showSelection` prop shows per-eval checkboxes even when `showRun` is false
- New `onSelectionChange` callback reports the current Set of eval ids to the parent
- Inline Run/Stop actions and the "Run Selected / Run All" footer still only appear when `showRun` is true, so Datasets is unchanged

**B. Simulation Run Evaluation uses the checked subset**

- SimulationEvaluationPage enables `showSelection` and tracks selected ids
- ConfirmRunEvaluations is seeded with the checked evals
- Nothing checked still runs every configured eval, matching today's behavior
- `runEvals` already accepted `eval_config_ids`; no API change

## 2) Why the changes were done

- **Product/UX:** Simulation should let you run a subset of evals the same way Datasets already does
- **Technical:** Turning on `showRun` would have added a second, conflicting run button. Checkboxes plus `onSelectionChange` reuse Simulation's existing footer and confirm dialog

## 3) Tests written + scenarios each covers

**`frontend/src/sections/workbench/createPrompt/Simulate/SimulationDetailView/__tests__/evalRunSelection.test.js`** — which evals Simulation should run

- `runs every configured eval when nothing is checked`
- `runs only the checked subset`
- `falls back to every configured eval when the selection is stale`
- `returns an empty list when there are no configured evals`

> Run result: **4 passed**.

## 4) How to run / test

### Frontend tests

```bash
cd frontend
yarn --ignore-engines test:run src/sections/workbench/createPrompt/Simulate/SimulationDetailView/__tests__/evalRunSelection.test.js
```

### UI steps (manual)

1. Open a simulation with more than one evaluation configured.
2. Confirm each eval in All Evaluations has a checkbox.
3. Check a subset, click Run Evaluation, and confirm the dialog lists only those evals.
4. Clear the selection, click Run Evaluation, and confirm the dialog lists every configured eval.
5. Open a Dataset evaluation list and confirm checkboxes plus Run Selected / Run All still work as before.

## 5) Screenshots / recordings

### Test output

4 passed (`evalRunSelection.test.js`).

### UI testing

Not captured in this environment (no running frontend stack).

## 6) Edge cases & considerations

- Nothing checked: run all (same as before)
- Stale ids (eval deleted after it was selected): fall back to all configured evals
- Datasets: `showRun` default remains true; `showSelection` default remains false
- Simulation keeps a single Run Evaluation button; SavedEvalsList's footer is still hidden

## 8) Architectural / important decisions

- **`showSelection` instead of `showRun={true}`:** Simulation already has its own run flow. Reusing the list's run footer would add a second button that is not wired to `runEvals`.
- **Helper `resolveEvalsToRun`:** keeps the empty-selection fallback out of the page component so it can be unit-tested without mounting the drawer.

## Checklist

- [x] My code follows the style guide
- [x] I've added tests that prove my fix is effective or that my feature works
- [ ] `bin/test` passes locally (backend)
- [x] `yarn test:run` passes locally (frontend, targeted suite)
- [ ] `yarn contracts:check` passes if API surface changed
- [ ] I've updated the documentation where relevant
- [x] No hardcoded secrets, URLs, or PII
- [ ] I've signed the CLA
- [x] PR title follows Conventional Commits
- [ ] Linear issue is linked and updated with status