### PR TITLE
fix(frontend): correct invalid CSS width value 20ox to 20px in Add Filter icon

### DIFF
--- a/frontend/src/sections/develop-detail/DataTab/DevelopFilters/DevelopFilterRow.jsx
+++ b/frontend/src/sections/develop-detail/DataTab/DevelopFilters/DevelopFilterRow.jsx
@@ -108,7 +108,7 @@ const DevelopFilterRow = ({
               <SvgColor
                 src="/assets/icons/ic_add.svg"
                 sx={{
-                  width: "20ox !important",
+                  width: "20px !important",
                   height: "20px !important",
                   color: "primary.main",
                 }}

--- a/frontend/src/sections/evals/DevelopFilters/DevelopFilterRow.jsx
+++ b/frontend/src/sections/evals/DevelopFilters/DevelopFilterRow.jsx
@@ -76,7 +76,7 @@ const DevelopFilterRow = ({
               <SvgColor
                 src="/assets/icons/ic_add.svg"
                 sx={{
-                  width: "20ox !important",
+                  width: "20px !important",
                   height: "20px !important",
                   color: "primary.main",
                 }}


### PR DESCRIPTION
## Summary

Fixes the CSS typo reported in #1967: the Add Filter button icon used an invalid width value `20ox` instead of `20px`, so the icon fell back to its intrinsic size and rendered inconsistently.

## Changes

Single-token fix in both affected files:

- `frontend/src/sections/develop-detail/DataTab/DevelopFilters/DevelopFilterRow.jsx` (line 111)
- `frontend/src/sections/evals/DevelopFilters/DevelopFilterRow.jsx` (line 79)

`width: "20ox !important"` → `width: "20px !important"`

## Testing

- Searched the repo for other occurrences of `20ox` — these two were the only ones
- No logic changes; icon now renders at the intended 20px, matching the sibling `height: 20px` on the next line

Fixes #1967