### PR TITLE
fix(gateway): preserve async A2A terminal states

### DIFF
--- a/agentcc-gateway/internal/a2a/server.go
+++ b/agentcc-gateway/internal/a2a/server.go
@@ -207,8 +207,8 @@ func (s *Server) handleMessageSend(w http.ResponseWriter, r *http.Request, msg *
 		return
 	}
 
-	// If pipeline is wired, route through the full plugin pipeline.
-	if s.engine != nil && s.providerRegistry != nil {
+	// Route through the configured execution backend when one is available.
+	if s.chatExecutor != nil || (s.engine != nil && s.providerRegistry != nil) {
 		if params.Configuration != nil && params.Configuration.ReturnImmediately {
 			s.tasks.Store(task)
 			ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
@@ -286,6 +286,12 @@ func (s *Server) runMessageSendWithPipeline(ctx context.Context, authHeader stri
 			s.tasks.Store(task)
 			return
 		}
+		if ctx.Err() != nil {
+			task.Status.State = TaskStatusCanceled
+			task.Status.Message = []MessagePart{{Type: "text", Text: "Task canceled"}}
+			s.tasks.Store(task)
+			return
+		}
 		s.finishTaskFromResponse(task, resp)
 		s.tasks.Store(task)
 		return
@@ -340,6 +346,12 @@ func (s *Server) runMessageSendWithPipeline(ctx context.Context, authHeader stri
 		task.Status.Message = []MessagePart{{Type: "text", Text: fmt.Sprintf("Pipeline error: %s", err.Error())}}
 		s.tasks.Store(task)
 		slog.Warn("a2a: pipeline error", "task_id", task.ID, "error", err)
+		return
+	}
+	if ctx.Err() != nil {
+		task.Status.State = TaskStatusCanceled
+		task.Status.Message = []MessagePart{{Type: "text", Text: "Task canceled"}}
+		s.tasks.Store(task)
 		return
 	}
 

--- a/agentcc-gateway/internal/a2a/server.go
+++ b/agentcc-gateway/internal/a2a/server.go
@@ -286,10 +286,7 @@ func (s *Server) runMessageSendWithPipeline(ctx context.Context, authHeader stri
 			s.tasks.Store(task)
 			return
 		}
-		if ctx.Err() != nil {
-			task.Status.State = TaskStatusCanceled
-			task.Status.Message = []MessagePart{{Type: "text", Text: "Task canceled"}}
-			s.tasks.Store(task)
+		if s.storeTaskContextError(ctx, task) {
 			return
 		}
 		s.finishTaskFromResponse(task, resp)
@@ -348,10 +345,7 @@ func (s *Server) runMessageSendWithPipeline(ctx context.Context, authHeader stri
 		slog.Warn("a2a: pipeline error", "task_id", task.ID, "error", err)
 		return
 	}
-	if ctx.Err() != nil {
-		task.Status.State = TaskStatusCanceled
-		task.Status.Message = []MessagePart{{Type: "text", Text: "Task canceled"}}
-		s.tasks.Store(task)
+	if s.storeTaskContextError(ctx, task) {
 		return
 	}
 
@@ -359,6 +353,23 @@ func (s *Server) runMessageSendWithPipeline(ctx context.Context, authHeader stri
 
 	s.tasks.Store(task)
 	slog.Info("a2a task completed (pipeline)", "task_id", task.ID, "model", model, "provider", rc.Provider)
+}
+
+func (s *Server) storeTaskContextError(ctx context.Context, task *Task) bool {
+	err := ctx.Err()
+	if err == nil {
+		return false
+	}
+
+	if errors.Is(err, context.Canceled) {
+		task.Status.State = TaskStatusCanceled
+		task.Status.Message = []MessagePart{{Type: "text", Text: "Task canceled"}}
+	} else {
+		task.Status.State = TaskStatusFailed
+		task.Status.Message = []MessagePart{{Type: "text", Text: fmt.Sprintf("Pipeline error: %s", err.Error())}}
+	}
+	s.tasks.Store(task)
+	return true
 }
 
 func (s *Server) finishTaskFromResponse(task *Task, resp *models.ChatCompletionResponse) {

--- a/agentcc-gateway/internal/a2a/server.go
+++ b/agentcc-gateway/internal/a2a/server.go
@@ -44,8 +44,15 @@ func newSyncTaskStore() *syncTaskStore {
 
 func (s *syncTaskStore) Store(task *Task) {
 	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	// Cancellation is terminal. A worker can finish concurrently with a
+	// tasks/cancel request, but its stale result must not revive the task.
+	if current, ok := s.store.Get(task.ID); ok &&
+		current.Status.State == TaskStatusCanceled && task.Status.State != TaskStatusCanceled {
+		return
+	}
 	s.store.Store(task)
-	s.mu.Unlock()
 }
 
 func (s *syncTaskStore) Get(id string) (*Task, bool) {
@@ -213,7 +220,7 @@ func (s *Server) handleMessageSend(w http.ResponseWriter, r *http.Request, msg *
 			s.tasks.Store(task)
 			ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
 			s.taskCancels.Store(task.ID, cancel)
-			go s.runMessageSendWithPipeline(ctx, r.Header.Get("Authorization"), task, inputText, params)
+			go s.runMessageSendWithPipeline(ctx, r.Header.Get("Authorization"), cloneTask(task), inputText, params)
 			writeA2AResult(w, msg.ID, task)
 			return
 		}

--- a/agentcc-gateway/internal/a2a/server_test.go
+++ b/agentcc-gateway/internal/a2a/server_test.go
@@ -376,3 +376,39 @@ func TestAsyncCancelCannotBeOverwrittenByLateSuccess(t *testing.T) {
 	}
 	t.Fatal("async task did not finish")
 }
+
+func TestDeadlineCannotBeOverwrittenByLateSuccess(t *testing.T) {
+	executor := func(ctx context.Context, _ string, _ *models.ChatCompletionRequest) (*models.ChatCompletionResponse, error) {
+		<-ctx.Done()
+		return &models.ChatCompletionResponse{
+			Model: "test-model",
+			Choices: []models.Choice{{
+				Message: models.Message{Content: json.RawMessage(`"late success"`)},
+			}},
+		}, nil
+	}
+	s := NewServer(
+		CardConfig{Name: "test-agentcc"},
+		NewRegistry(nil),
+		WithChatCompletionExecutor(executor),
+	)
+	defer s.Close()
+
+	task := &Task{ID: "deadline-task", Status: TaskStatus{State: TaskStatusWorking}}
+	ctx, cancel := context.WithTimeout(context.Background(), time.Millisecond)
+	defer cancel()
+	s.runMessageSendWithPipeline(ctx, "", task, "slow request", MessageSendParams{
+		Metadata: json.RawMessage(`{"model":"test-model"}`),
+	})
+
+	stored, ok := s.tasks.Get(task.ID)
+	if !ok {
+		t.Fatal("expected timed-out task to remain stored")
+	}
+	if stored.Status.State != TaskStatusFailed {
+		t.Fatalf("late success overwrote deadline failure: %s", stored.Status.State)
+	}
+	if len(stored.Status.Message) != 1 || stored.Status.Message[0].Text != "Pipeline error: context deadline exceeded" {
+		t.Fatalf("unexpected deadline error: %#v", stored.Status.Message)
+	}
+}

--- a/agentcc-gateway/internal/a2a/server_test.go
+++ b/agentcc-gateway/internal/a2a/server_test.go
@@ -2,12 +2,15 @@ package a2a
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	"github.com/futureagi/agentcc-gateway/internal/mcp"
+	"github.com/futureagi/agentcc-gateway/internal/models"
 )
 
 func newTestA2AServer() *Server {
@@ -298,4 +301,78 @@ func TestTasksCancel(t *testing.T) {
 	if task.Status.State != TaskStatusCanceled {
 		t.Fatalf("expected canceled, got %s", task.Status.State)
 	}
+}
+
+func TestAsyncCancelCannotBeOverwrittenByLateSuccess(t *testing.T) {
+	started := make(chan struct{})
+	release := make(chan struct{})
+	executor := func(context.Context, string, *models.ChatCompletionRequest) (*models.ChatCompletionResponse, error) {
+		close(started)
+		<-release
+		return &models.ChatCompletionResponse{
+			Model: "test-model",
+			Choices: []models.Choice{{
+				Message: models.Message{Content: json.RawMessage(`"late success"`)},
+			}},
+		}, nil
+	}
+	s := NewServer(
+		CardConfig{Name: "test-agentcc"},
+		NewRegistry(nil),
+		WithChatCompletionExecutor(executor),
+	)
+	defer s.Close()
+
+	params := MessageSendParams{
+		Message: Message{
+			Role:  "user",
+			Parts: []MessagePart{{Type: "text", Text: "slow request"}},
+		},
+		Metadata: json.RawMessage(`{"model":"test-model"}`),
+		Configuration: &MessageSendConfiguration{
+			ReturnImmediately: true,
+		},
+	}
+	paramsData, _ := json.Marshal(params)
+	w := postA2A(t, s, &mcp.Message{
+		JSONRPC: "2.0",
+		ID:      json.RawMessage(`1`),
+		Method:  MethodMessageSend,
+		Params:  paramsData,
+	})
+	var task Task
+	if err := json.Unmarshal(decodeA2AResponse(t, w).Result, &task); err != nil {
+		t.Fatal(err)
+	}
+
+	select {
+	case <-started:
+	case <-time.After(time.Second):
+		t.Fatal("executor did not start")
+	}
+
+	cancelData, _ := json.Marshal(TaskCancelParams{TaskID: task.ID})
+	postA2A(t, s, &mcp.Message{
+		JSONRPC: "2.0",
+		ID:      json.RawMessage(`2`),
+		Method:  MethodTasksCancel,
+		Params:  cancelData,
+	})
+	close(release)
+
+	deadline := time.Now().Add(time.Second)
+	for time.Now().Before(deadline) {
+		if _, running := s.taskCancels.Load(task.ID); !running {
+			stored, ok := s.tasks.Get(task.ID)
+			if !ok {
+				t.Fatal("expected async task to remain stored")
+			}
+			if stored.Status.State != TaskStatusCanceled {
+				t.Fatalf("late success overwrote cancellation: %s", stored.Status.State)
+			}
+			return
+		}
+		time.Sleep(time.Millisecond)
+	}
+	t.Fatal("async task did not finish")
 }

--- a/agentcc-gateway/internal/a2a/server_test.go
+++ b/agentcc-gateway/internal/a2a/server_test.go
@@ -303,6 +303,35 @@ func TestTasksCancel(t *testing.T) {
 	}
 }
 
+func TestSyncTaskStoreDoesNotOverwriteCanceledTaskWithStaleResult(t *testing.T) {
+	tasks := newSyncTaskStore()
+	tasks.Store(&Task{ID: "task-1", Status: TaskStatus{State: TaskStatusWorking}})
+
+	canceled, ok := tasks.Get("task-1")
+	if !ok {
+		t.Fatal("expected stored task")
+	}
+	canceled.Status.State = TaskStatusCanceled
+	tasks.Store(canceled)
+
+	tasks.Store(&Task{
+		ID:        "task-1",
+		Status:    TaskStatus{State: TaskStatusCompleted},
+		Artifacts: []Artifact{{Name: "stale result"}},
+	})
+
+	got, ok := tasks.Get("task-1")
+	if !ok {
+		t.Fatal("expected stored task")
+	}
+	if got.Status.State != TaskStatusCanceled {
+		t.Fatalf("task status = %q, want %q", got.Status.State, TaskStatusCanceled)
+	}
+	if len(got.Artifacts) != 0 {
+		t.Fatalf("canceled task contains stale artifacts: %#v", got.Artifacts)
+	}
+}
+
 func TestAsyncCancelCannotBeOverwrittenByLateSuccess(t *testing.T) {
 	started := make(chan struct{})
 	release := make(chan struct{})

--- a/agentcc-gateway/internal/a2a/types.go
+++ b/agentcc-gateway/internal/a2a/types.go
@@ -163,9 +163,66 @@ func NewTaskStore() *TaskStore {
 	}
 }
 
+func cloneRawMessage(value json.RawMessage) json.RawMessage {
+	if value == nil {
+		return nil
+	}
+	return append(json.RawMessage(nil), value...)
+}
+
+func cloneMessageParts(parts []MessagePart) []MessagePart {
+	if parts == nil {
+		return nil
+	}
+	cloned := make([]MessagePart, len(parts))
+	copy(cloned, parts)
+	for i := range cloned {
+		cloned[i].Data = cloneRawMessage(parts[i].Data)
+	}
+	return cloned
+}
+
+func cloneMessages(messages []Message) []Message {
+	if messages == nil {
+		return nil
+	}
+	cloned := make([]Message, len(messages))
+	copy(cloned, messages)
+	for i := range cloned {
+		cloned[i].Parts = cloneMessageParts(messages[i].Parts)
+		cloned[i].Metadata = cloneRawMessage(messages[i].Metadata)
+	}
+	return cloned
+}
+
+func cloneArtifacts(artifacts []Artifact) []Artifact {
+	if artifacts == nil {
+		return nil
+	}
+	cloned := make([]Artifact, len(artifacts))
+	copy(cloned, artifacts)
+	for i := range cloned {
+		cloned[i].Parts = cloneMessageParts(artifacts[i].Parts)
+		cloned[i].Metadata = cloneRawMessage(artifacts[i].Metadata)
+	}
+	return cloned
+}
+
+func cloneTask(task *Task) *Task {
+	if task == nil {
+		return nil
+	}
+	cloned := *task
+	cloned.Status.Message = cloneMessageParts(task.Status.Message)
+	cloned.Artifacts = cloneArtifacts(task.Artifacts)
+	cloned.History = cloneMessages(task.History)
+	cloned.Metadata = cloneRawMessage(task.Metadata)
+	return &cloned
+}
+
 // Store saves a task.
 func (ts *TaskStore) Store(task *Task) {
-	ts.tasks[task.ID] = &taskEntry{task: task, createdAt: time.Now()}
+	ts.tasks[task.ID] = &taskEntry{task: cloneTask(task), createdAt: time.Now()}
 }
 
 // Get retrieves a task by ID.
@@ -174,14 +231,14 @@ func (ts *TaskStore) Get(id string) (*Task, bool) {
 	if !ok {
 		return nil, false
 	}
-	return e.task, true
+	return cloneTask(e.task), true
 }
 
 // Cleanup removes tasks older than the given duration.
 func (ts *TaskStore) Cleanup(maxAge time.Duration) {
 	cutoff := time.Now().Add(-maxAge)
 	for id, e := range ts.tasks {
-		if e.createdAt.Before(cutoff) {
+		if !e.createdAt.After(cutoff) {
 			delete(ts.tasks, id)
 		}
 	}

--- a/agentcc-gateway/internal/a2a/types_test.go
+++ b/agentcc-gateway/internal/a2a/types_test.go
@@ -152,6 +152,70 @@ func TestTaskStore(t *testing.T) {
 	}
 }
 
+func TestTaskStoreSnapshotsTasks(t *testing.T) {
+	ts := NewTaskStore()
+	task := &Task{
+		ID: "task-1",
+		Status: TaskStatus{
+			State:   TaskStatusWorking,
+			Message: []MessagePart{{Type: "data", Data: json.RawMessage(`{"step":1}`)}},
+		},
+		Artifacts: []Artifact{{
+			Name:     "result",
+			Parts:    []MessagePart{{Type: "text", Text: "original"}},
+			Metadata: json.RawMessage(`{"source":"worker"}`),
+		}},
+		History: []Message{{
+			Role:     "user",
+			Parts:    []MessagePart{{Type: "text", Text: "hello"}},
+			Metadata: json.RawMessage(`{"turn":1}`),
+		}},
+		Metadata: json.RawMessage(`{"model":"test"}`),
+	}
+
+	ts.Store(task)
+	task.Status.State = TaskStatusCompleted
+	task.Status.Message[0].Data[8] = '9'
+	task.Artifacts[0].Parts[0].Text = "changed"
+	task.Artifacts[0].Metadata[11] = 'X'
+	task.History[0].Parts[0].Text = "changed"
+	task.History[0].Metadata[8] = '9'
+	task.Metadata[10] = 'X'
+
+	stored, ok := ts.Get(task.ID)
+	if !ok {
+		t.Fatal("expected stored task")
+	}
+	if stored.Status.State != TaskStatusWorking {
+		t.Fatalf("stored task changed through caller pointer: %s", stored.Status.State)
+	}
+	if string(stored.Status.Message[0].Data) != `{"step":1}` {
+		t.Fatalf("stored status data changed: %s", stored.Status.Message[0].Data)
+	}
+	if stored.Artifacts[0].Parts[0].Text != "original" {
+		t.Fatalf("stored artifact changed: %s", stored.Artifacts[0].Parts[0].Text)
+	}
+	if string(stored.Artifacts[0].Metadata) != `{"source":"worker"}` {
+		t.Fatalf("stored artifact metadata changed: %s", stored.Artifacts[0].Metadata)
+	}
+	if stored.History[0].Parts[0].Text != "hello" {
+		t.Fatalf("stored history changed: %s", stored.History[0].Parts[0].Text)
+	}
+	if string(stored.History[0].Metadata) != `{"turn":1}` {
+		t.Fatalf("stored history metadata changed: %s", stored.History[0].Metadata)
+	}
+	if string(stored.Metadata) != `{"model":"test"}` {
+		t.Fatalf("stored metadata changed: %s", stored.Metadata)
+	}
+
+	stored.Status.State = TaskStatusFailed
+	stored.Artifacts[0].Parts[0].Text = "changed again"
+	again, _ := ts.Get(task.ID)
+	if again.Status.State != TaskStatusWorking || again.Artifacts[0].Parts[0].Text != "original" {
+		t.Fatal("Get returned mutable task-store state")
+	}
+}
+
 func TestTaskStoreCleanup(t *testing.T) {
 	ts := NewTaskStore()
 


### PR DESCRIPTION
## Summary

- isolate A2A task-store snapshots so request handlers and async workers never share mutable task state
- keep cancellation terminal even when a stale worker completion is stored after `tasks/cancel`
- preserve terminal context outcomes when an executor returns successfully after cancellation or deadline expiry
- allow `WithChatCompletionExecutor` to activate A2A execution without requiring otherwise-unused pipeline internals
- make the zero-age cleanup boundary deterministic across clock resolutions

## Root cause

`syncTaskStore` protected access to its map, but `TaskStore.Store` retained the caller's `*Task` and `Get` returned that same pointer. The lock therefore stopped protecting the state as soon as either method returned. Async workers, `tasks/get`, `tasks/cancel`, and JSON response encoding could read or mutate the same task and nested slices concurrently.

Two additional orderings mattered:

1. The `returnImmediately` path handed the same `*Task` to the worker that it serialized in the initial response.
2. A cancellation could land after the worker's context check but before its final store, allowing a stale completion to overwrite the acknowledged canceled state.

Terminal context state was also inferred only from executor errors. If an executor ignored a canceled or expired context and returned a successful response, the worker converted that response into `completed`. Deadline expiry must produce a failed task with the timeout error, while explicit cancellation must remain canceled.

Finally, `WithChatCompletionExecutor` was documented as an execution backend but the request path entered execution only when both the pipeline engine and provider registry were non-nil.

## Changes

- deep-copy task status messages, artifacts, history, and raw JSON metadata at both task-store boundaries
- pass an independent `cloneTask(task)` snapshot to the async worker
- make `canceled` terminal in `syncTaskStore.Store`, rejecting stale non-canceled updates
- re-check the context before committing successful executor or pipeline results
- preserve explicit cancellation as `canceled` and classify deadline expiry as `failed`
- treat a configured chat executor as a valid execution backend
- cover caller/getter mutation isolation, both cancel/store orderings, late success after cancellation, and late success after deadline expiry with regression tests

## Validation

After rebasing onto the latest `dev`:

- `go vet ./internal/a2a ./internal/server`
- `go test ./internal/a2a -count=20`
- `go test ./internal/server -run TestA2AReturnImmediatelyAndCancelUnderV1WithAuth -count=20`
- `go test ./... -count=1` (entire AgentCC gateway)

All checks above passed.
