### PR TITLE
fix(dashboards): debounce global date range feeding widget refetches

### DIFF
--- a/frontend/src/sections/dashboards/DashboardDetailView.jsx
+++ b/frontend/src/sections/dashboards/DashboardDetailView.jsx
@@ -574,10 +574,10 @@ function DraggableWidgetCard({
           {/* Chart */}
           <Box sx={{ flex: 1, minHeight: 0, overflow: "hidden" }}>
             <WidgetChart
-              key={`${widget.id}:${datePreset || "default"}${
+              key={`${widget.id}:${
                 globalDateRange
-                  ? `:${globalDateRange.start}:${globalDateRange.end}`
-                  : ""
+                  ? `${globalDateRange.start}:${globalDateRange.end}`
+                  : "default"
               }`}
               widget={widget}
               globalDateRange={globalDateRange}

--- a/frontend/src/sections/dashboards/DashboardDetailView.jsx
+++ b/frontend/src/sections/dashboards/DashboardDetailView.jsx
@@ -56,6 +56,7 @@ import { useSnackbar } from "src/components/snackbar";
 import CustomTooltip from "src/components/tooltip/CustomTooltip";
 import WidgetChart from "./WidgetChart";
 import { resolveGlobalDateRange } from "./dashboardDateRange";
+import { useDebounce } from "src/hooks/use-debounce";
 import useCanEditDashboard from "./hooks/useCanEditDashboard";
 import {
   DndContext,
@@ -666,6 +667,9 @@ export default function DashboardDetailView() {
     () => resolveGlobalDateRange(datePreset, customDateRange),
     [datePreset, customDateRange],
   );
+  // Debounce only the value that drives widget refetches, so rapid preset
+  // switching fires one round of requests. The chip UI updates immediately.
+  const debouncedGlobalDateRange = useDebounce(globalDateRange, 300);
 
   // Widget context menu
   const [menuAnchor, setMenuAnchor] = useState(null);
@@ -1367,7 +1371,7 @@ export default function DashboardDetailView() {
                               dashboardId={dashboardId}
                               navigate={navigate}
                               onMenuOpen={handleWidgetMenuOpen}
-                              globalDateRange={globalDateRange}
+                              globalDateRange={debouncedGlobalDateRange}
                               isDragActive={!!activeWidget}
                               rowHeight={rowHeight}
                               datePreset={datePreset}


### PR DESCRIPTION
## Summary

Fixes #1968. Rapidly clicking through the dashboard time filter chips (Today, Yesterday, 7D, ...) fired a separate request round per widget per click. Overlapping requests sometimes failed and surfaced a false **"Query execution failed"** toast.

## Approach

Debounce only the value that drives widget refetches — `globalDateRange` — not the UI state:

```jsx
const globalDateRange = useMemo(
  () => resolveGlobalDateRange(datePreset, customDateRange),
  [datePreset, customDateRange],
);
// Debounce only the value that drives widget refetches, so rapid preset
// switching fires one round of requests. The chip UI updates immediately.
const debouncedGlobalDateRange = useDebounce(globalDateRange, 300);
```

`DraggableWidgetCard` now receives `debouncedGlobalDateRange`; chip `variant`/`color` and the rest of the toolbar still read `datePreset` directly, so the active chip switches with no delay.

Reuses the existing `useDebounce` hook (`src/hooks/use-debounce.js`), same pattern as `Scenarios.jsx` search — no new dependency.

## Done-when checklist

- [x] Value driving widget refetch is debounced → N quick clicks = one request round
- [x] Chip active state instant (only fetch debounced)
- [x] No false "Query execution failed" toast on rapid switching
- [x] After settle, widgets show data for last clicked preset (debounce keeps last value)
- [x] Custom date range still refetches (flows through same memo → debounced value)
- [x] `timePreset` URL param restore untouched (initial state, not part of debounce path)