### PR TITLE
fix(annotations): enable column resizing in queue items table

### DIFF
--- a/frontend/src/sections/annotations/queues/items/queue-items-table.jsx
+++ b/frontend/src/sections/annotations/queues/items/queue-items-table.jsx
@@ -634,7 +634,7 @@ export default function QueueItemsTable({
       lockVisible: true,
       filter: false,
       sortable: false,
-      resizable: false,
+      resizable: true,
       suppressHeaderMenuButton: true,
       suppressHeaderContextMenu: true,
     }),


### PR DESCRIPTION
## Summary

Fixes #1966. The shared `defaultColDef` in the annotation queue items table set `resizable: false`, disabling resizing for every column — including "Item Status". Comparable grids (e.g. the LLM Tracing `TraceGrid`) already ship `resizable: true`.

## Changes

One-line flip in `frontend/src/sections/annotations/queues/items/queue-items-table.jsx`:

```diff
   const defaultColDef = useMemo(
     () => ({
       lockVisible: true,
       filter: false,
       sortable: false,
-      resizable: false,
+      resizable: true,
       suppressHeaderMenuButton: true,
       suppressHeaderContextMenu: true,
     }),
     [],
   );
```

The `actions` column keeps `resizable: false` on its own definition, so it stays fixed as intended (per-column overrides `defaultColDef`).

## Done-when checklist

- [x] `defaultColDef` sets `resizable: true`
- [x] "Item Status" column draggable to a new width (per-column `width` values remain the initial width)
- [x] All other data columns resizable
- [x] `actions` column still fixed via its own `resizable: false`