### PR TITLE
fix(annotations): enable annotation queue item column resizing

### DIFF
--- a/frontend/src/sections/annotations/queues/__tests__/items.test.jsx
+++ b/frontend/src/sections/annotations/queues/__tests__/items.test.jsx
@@ -36,13 +36,20 @@ function MockAgGridReact({
   noRowsOverlayComponent: NoRowsOverlay,
   rowSelection,
   selectionColumnDef,
+  defaultColDef,
   onSelectionChanged,
 }) {
   if (!rowData || rowData.length === 0) {
     return NoRowsOverlay ? <NoRowsOverlay /> : null;
   }
   return (
-    <div data-testid="ag-grid">
+    <div
+      data-testid="ag-grid"
+      data-default-columns-resizable={defaultColDef?.resizable}
+      data-actions-column-resizable={
+        columnDefs.find((column) => column.field === "actions")?.resizable
+      }
+    >
       {rowSelection && selectionColumnDef && (
         <div
           data-testid="selection-column-def"
@@ -108,6 +115,7 @@ MockAgGridReact.propTypes = {
   noRowsOverlayComponent: PropTypes.elementType,
   rowSelection: PropTypes.object,
   selectionColumnDef: PropTypes.object,
+  defaultColDef: PropTypes.object,
   onSelectionChanged: PropTypes.func,
 };
 
@@ -239,6 +247,19 @@ const tableProps = {
 };
 
 describe("QueueItemsTable", () => {
+  it("allows resizing data columns while keeping fixed columns opt-out", () => {
+    render(<QueueItemsTable {...tableProps} />);
+
+    expect(screen.getByTestId("ag-grid")).toHaveAttribute(
+      "data-default-columns-resizable",
+      "true",
+    );
+    expect(screen.getByTestId("ag-grid")).toHaveAttribute(
+      "data-actions-column-resizable",
+      "false",
+    );
+  });
+
   it("renders table headers", () => {
     render(<QueueItemsTable {...tableProps} />);
     expect(screen.getByText("Source")).toBeInTheDocument();

--- a/frontend/src/sections/annotations/queues/items/queue-items-table.jsx
+++ b/frontend/src/sections/annotations/queues/items/queue-items-table.jsx
@@ -634,7 +634,7 @@ export default function QueueItemsTable({
       lockVisible: true,
       filter: false,
       sortable: false,
-      resizable: false,
+      resizable: true,
       suppressHeaderMenuButton: true,
       suppressHeaderContextMenu: true,
     }),


### PR DESCRIPTION
Fixes #1966

## Summary

Enable resizing for data columns in the annotation queue items table.

The table-wide column defaults now allow resizing, while the Actions column remains explicitly fixed at its existing 60px width.

## Tests

- Add regression coverage that verifies:
  - data columns receive `resizable: true`
  - the Actions column remains `resizable: false`
- `npx vitest run src/sections/annotations/queues/__tests__/items.test.jsx`
- `npx eslint src/sections/annotations/queues/items/queue-items-table.jsx src/sections/annotations/queues/__tests__/items.test.jsx`