### PR TITLE
fix(fi-collector): bound pending queue and acknowledge OTLP only after durable acceptance (#2201)

### DIFF
--- a/fi-collector/README.md
+++ b/fi-collector/README.md
@@ -138,18 +138,19 @@ the litellm table nor custom pricing applies, the span's cost is 0.
 
 ```
 SDK   ──HTTP/gRPC──►   fi-collector
-                        ├─ OTLP receiver       (default queue: 1K requests)
-                        ├─ memory_limiter      (hard ceiling — drops if exceeded)
-                        ├─ batch processor     (10K spans / 5s, whichever first)
-                        ├─ retry-on-failure    (exponential, max 5 min)
-                        └─ persistent queue    (disk-backed, survives restart)
+                        ├─ OTLP receiver       (atomic admission control)
+                        ├─ queue_limiter       (bounded requests, rows, & bytes capacity)
+                        ├─ batch flusher       (5K spans / 5s, whichever first)
+                        ├─ canonical writer    (ClickHouse insert + dead-letter fsync fallback)
+                        └─ durable ack         (HTTP 200 / gRPC OK returned only after CH or dead-letter)
                                 ▼
-                        ClickHouse 25.3 (async_insert=1 server-side batching)
+                        ClickHouse 25.3
 ```
 
-If ClickHouse is briefly unavailable, the persistent queue absorbs the
-backlog. If memory crosses the limit, the receiver returns 429 and SDKs
-back off — no silent drops, no OOM crashes. Same pattern SigNoz uses.
+- **Bounded capacity**: Queued plus in-flight requests, rows, and bytes are strictly bounded by `queue_max_requests`, `queue_max_rows`, and `queue_max_bytes` (`FI_QUEUE_MAX_*`).
+- **Overload backpressure**: When capacity is temporarily full, OTLP requests are rejected with retryable overload errors (HTTP 503 + `Retry-After: 1`, gRPC `Unavailable` + `RetryInfo`).
+- **Oversized rejection**: Requests that exceed maximum queue limits are rejected atomically with non-retryable errors (HTTP 413, gRPC `ResourceExhausted`).
+- **Durable acknowledgement**: OTLP responses are acknowledged only after ClickHouse accepts the batch or the batch is durably written to `dead_letter.jsonl`. Failure of both returns a retryable error.
 
 ## Migration relationship
 

--- a/fi-collector/cmd/fi-collector/main.go
+++ b/fi-collector/cmd/fi-collector/main.go
@@ -105,7 +105,7 @@ func main() {
 	srv := server.New(cfg.Server, writer, authenticator, usageEmitter, metering, opts...)
 
 	// Admin HTTP server — internal only, health check endpoint.
-	go runAdmin(":9464", writer, log)
+	go runAdmin(":9464", srv, writer, log)
 
 	ctx, cancel := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
 	defer cancel()
@@ -187,11 +187,6 @@ func applyEnvOverrides(log *slog.Logger, c *rootConfig) {
 		c.Server.GRPCAddr = v
 	}
 	if v := os.Getenv("FI_HTTP_ADDR"); v != "" {
-		// `FI_HTTP_ADDR=disable` (or `off`) turns the OTLP/HTTP listener
-		// off entirely. Useful when deploying behind an external HTTP
-		// gateway that strips OTLP/HTTP at the edge. The string `disable`
-		// is more obvious in compose env lines than an empty value, which
-		// docker compose silently swallows.
 		switch v {
 		case "disable", "off":
 			c.Server.HTTPAddr = ""
@@ -203,9 +198,28 @@ func applyEnvOverrides(log *slog.Logger, c *rootConfig) {
 		if n, err := strconv.Atoi(v); err == nil && n > 0 {
 			c.Server.GRPCMaxRecvMiB = n
 		} else {
-			// Silent fallback here would reproduce the silent-loss failure
-			// mode this knob exists to fix — an operator must see it.
 			log.Warn("ignoring invalid FI_GRPC_MAX_RECV_MIB", "value", v)
+		}
+	}
+	if v := os.Getenv("FI_QUEUE_MAX_REQUESTS"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n > 0 {
+			c.Server.QueueMaxRequests = n
+		} else {
+			log.Warn("ignoring invalid FI_QUEUE_MAX_REQUESTS", "value", v)
+		}
+	}
+	if v := os.Getenv("FI_QUEUE_MAX_ROWS"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n > 0 {
+			c.Server.QueueMaxRows = n
+		} else {
+			log.Warn("ignoring invalid FI_QUEUE_MAX_ROWS", "value", v)
+		}
+	}
+	if v := os.Getenv("FI_QUEUE_MAX_BYTES"); v != "" {
+		if n, err := strconv.ParseInt(v, 10, 64); err == nil && n > 0 {
+			c.Server.QueueMaxBytes = n
+		} else {
+			log.Warn("ignoring invalid FI_QUEUE_MAX_BYTES", "value", v)
 		}
 	}
 	if v := os.Getenv("FI_DEAD_LETTER_FILE"); v != "" {
@@ -224,21 +238,23 @@ func applyEnvOverrides(log *slog.Logger, c *rootConfig) {
 }
 
 // runAdmin serves /healthz for container health checks.
-func runAdmin(addr string, w *chwriter.Writer, log *slog.Logger) {
+func runAdmin(addr string, srv *server.Server, w *chwriter.Writer, log *slog.Logger) {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/healthz", func(rw http.ResponseWriter, r *http.Request) {
 		s := w.Snapshot()
+		qs := srv.QueueStats()
 		denom := s.BatchesInserted + s.BatchesFailed
 		if denom > 100 && s.BatchesFailed*2 > denom {
 			rw.WriteHeader(503)
-			_ = json.NewEncoder(rw).Encode(map[string]any{"status": "unhealthy", "stats": s})
+			_ = json.NewEncoder(rw).Encode(map[string]any{"status": "unhealthy", "stats": s, "queue": qs})
 			return
 		}
 		rw.WriteHeader(200)
-		_ = json.NewEncoder(rw).Encode(map[string]any{"status": "ok", "stats": s})
+		_ = json.NewEncoder(rw).Encode(map[string]any{"status": "ok", "stats": s, "queue": qs})
 	})
-	srv := &http.Server{Addr: addr, Handler: mux, ReadHeaderTimeout: 5 * time.Second}
-	if err := srv.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+	adminServer := &http.Server{Addr: addr, Handler: mux, ReadHeaderTimeout: 5 * time.Second}
+	if err := adminServer.ListenAndServe(); err != nil && err != http.ErrServerClosed {
 		log.Warn("admin server stopped", "err", err)
 	}
 }
+

--- a/fi-collector/config/collector.yaml
+++ b/fi-collector/config/collector.yaml
@@ -38,6 +38,10 @@ server:
   # Max gRPC receive message size in MiB (FI_GRPC_MAX_RECV_MIB); 16 matches
   # the OTLP/HTTP body cap.
   grpc_max_recv_mib: 16
+  # Bounded queue and in-flight capacity limits (FI_QUEUE_MAX_REQUESTS, FI_QUEUE_MAX_ROWS, FI_QUEUE_MAX_BYTES).
+  queue_max_requests: 1000
+  queue_max_rows: 50000
+  queue_max_bytes: 134217728 # 128 MiB
 
 auth:
   # Auth is active when pg_write is set. Without it, spans land with

--- a/fi-collector/pkg/chwriter/writer.go
+++ b/fi-collector/pkg/chwriter/writer.go
@@ -30,6 +30,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -241,6 +242,15 @@ func (w *Writer) insert(ctx context.Context, url string, rows []map[string]any) 
 	atomic.AddUint64(&w.stats.BatchesFailed, 1)
 	atomic.AddUint64(&w.stats.RowsDeadLettered, uint64(len(rows)))
 	return fmt.Errorf("chwriter: batch dead-lettered after %d attempts: %w", w.cfg.MaxRetries+1, lastErr)
+}
+
+// IsDeadLettered returns true if err indicates that the batch failed ClickHouse insert
+// but was successfully persisted to the dead-letter file.
+func IsDeadLettered(err error) bool {
+	if err == nil {
+		return false
+	}
+	return strings.Contains(err.Error(), "batch dead-lettered after")
 }
 
 // insertURL builds an INSERT URL for an arbitrary table, mirroring the

--- a/fi-collector/pkg/server/server.go
+++ b/fi-collector/pkg/server/server.go
@@ -16,6 +16,7 @@ package server
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"log/slog"
@@ -30,10 +31,18 @@ import (
 	"github.com/future-agi/future-agi/fi-collector/pkg/chwriter"
 	"github.com/future-agi/future-agi/fi-collector/pkg/curatedwriter"
 	"go.opentelemetry.io/collector/pdata/ptrace/ptraceotlp"
+	"google.golang.org/genproto/googleapis/rpc/errdetails"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/stats"
 	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/types/known/durationpb"
+)
+
+var (
+	errOversized = errors.New("request size exceeds total queue capacity")
+	errOverload  = errors.New("queue capacity exhausted")
+	errClosing   = errors.New("server is shutting down")
 )
 
 // Config is what main() passes us. Public fields = YAML wire format.
@@ -43,14 +52,36 @@ type Config struct {
 	BatchMaxRows   int           `yaml:"batch_max_rows"`    // flush after N rows
 	BatchMaxAge    time.Duration `yaml:"batch_max_age"`     // flush after X time
 	GRPCMaxRecvMiB int           `yaml:"grpc_max_recv_mib"` // max gRPC message size in MiB; default + rationale in New()
+
+	QueueMaxRequests int   `yaml:"queue_max_requests"` // max pending + in-flight OTLP requests
+	QueueMaxRows     int   `yaml:"queue_max_rows"`     // max pending + in-flight rows
+	QueueMaxBytes    int64 `yaml:"queue_max_bytes"`    // max pending + in-flight bytes
+}
+
+type requestItem struct {
+	rows     []map[string]any
+	ids      *curatedwriter.Batch
+	numRows  int
+	numBytes int64
+	done     chan error
+}
+
+// QueueStats snapshot for admin/health endpoints.
+type QueueStats struct {
+	PendingRequests  int   `json:"pending_requests"`
+	PendingRows      int   `json:"pending_rows"`
+	PendingBytes     int64 `json:"pending_bytes"`
+	InFlightRequests int   `json:"inflight_requests"`
+	InFlightRows     int   `json:"inflight_rows"`
+	InFlightBytes    int64 `json:"inflight_bytes"`
+	QueueMaxRequests int   `json:"queue_max_requests"`
+	QueueMaxRows     int   `json:"queue_max_rows"`
+	QueueMaxBytes    int64 `json:"queue_max_bytes"`
+	RejectedOverload uint64 `json:"rejected_overload"`
+	RejectedOversized uint64 `json:"rejected_oversized"`
 }
 
 // Server owns the gRPC + HTTP OTLP listeners and the batch flusher goroutine.
-//
-// gRPC and HTTP both decode an OTLP ExportTraceServiceRequest, run the same
-// converter, and push rows onto the same `pending` buffer. The wire layer is
-// the only difference: gRPC uses the generated stub; HTTP accepts
-// `application/x-protobuf` and `application/json` per the OTLP/HTTP spec.
 type Server struct {
 	cfg      Config
 	writer   *chwriter.Writer
@@ -63,21 +94,19 @@ type Server struct {
 	grpc     *grpc.Server
 	httpd    *http.Server
 
-	// Batching: the receiver handler pushes converted rows onto `pending` and
-	// signals via `pendCh`. A single flusher goroutine drains it on either
-	// the row-count or age trigger. One channel/one goroutine keeps lock
-	// contention minimal at 100K spans/sec.
-	//
-	// `pendCurated` accumulates the CURATED dimension identities for ALL
-	// payloads received since the last flush into ONE drain-scoped batch (it
-	// dedups across merges). So each drain emits at most one end_users + one
-	// trace_sessions best-effort insert — bounding the curated latency and
-	// avoiding many tiny RMT parts. It rides the same lock + flush cycle as
-	// `pend` so the curated dual-write flushes with the span batch.
-	pendMu      sync.Mutex
-	pend        []map[string]any
-	pendCurated *curatedwriter.Batch
-	pendCh      chan struct{}
+	pendMu            sync.Mutex
+	pendItems         []requestItem
+	pendCurated       *curatedwriter.Batch
+	pendCh            chan struct{}
+	curRequests       int
+	curRows           int
+	curBytes          int64
+	inFlightRequests  int
+	inFlightRows      int
+	inFlightBytes     int64
+	rejectedOverload  uint64
+	rejectedOversized uint64
+	closing           bool
 
 	stopCh chan struct{}
 	wg     sync.WaitGroup
@@ -97,15 +126,6 @@ func WithLogger(l *slog.Logger) Option { return Option{log: l} }
 func WithPricer(p chexp.Pricer) Option { return Option{pricer: p} }
 
 // New wires up the server but does NOT start serving. Call Run().
-//
-// Defaults:
-//   - GRPCAddr ":4317" (OTLP gRPC). Set to "" to disable.
-//   - HTTPAddr ":4318" (OTLP/HTTP). Set to "" to disable.
-//   - BatchMaxRows 5000, BatchMaxAge 5s.
-//
-// At least one of GRPCAddr / HTTPAddr must be non-empty or Run returns an
-// error. We default both ON because every supported SDK picks one of them;
-// disabling either is an opt-in deployment choice.
 func New(cfg Config, writer *chwriter.Writer, authenticator *auth.Authenticator, usage UsageEmitter, metering Metering, opts ...Option) *Server {
 	if cfg.GRPCAddr == "" {
 		cfg.GRPCAddr = ":4317"
@@ -120,13 +140,20 @@ func New(cfg Config, writer *chwriter.Writer, authenticator *auth.Authenticator,
 		cfg.BatchMaxAge = 5 * time.Second
 	}
 	if cfg.GRPCMaxRecvMiB <= 0 {
-		// Go gRPC's default 4 MiB rejects large single-span exports (e.g. an
-		// ended voice call with full transcript) with RESOURCE_EXHAUSTED.
-		// Match the OTLP/HTTP body cap so both transports accept the same spans.
 		cfg.GRPCMaxRecvMiB = maxOTLPHTTPBodyBytes >> 20
 	}
 	if cfg.GRPCMaxRecvMiB > 1024 {
-		cfg.GRPCMaxRecvMiB = 1024 // keep the <<20 shift well under proto's 2 GiB ceiling
+		cfg.GRPCMaxRecvMiB = 1024
+	}
+
+	if cfg.QueueMaxRequests <= 0 {
+		cfg.QueueMaxRequests = 1000
+	}
+	if cfg.QueueMaxRows <= 0 {
+		cfg.QueueMaxRows = 50000
+	}
+	if cfg.QueueMaxBytes <= 0 {
+		cfg.QueueMaxBytes = 128 << 20 // 128 MiB default
 	}
 
 	log := slog.Default()
@@ -148,29 +175,21 @@ func New(cfg Config, writer *chwriter.Writer, authenticator *auth.Authenticator,
 		metering: metering,
 		log:      log,
 		pricer:   pricer,
-		// Share the span writer's HTTP client (keep-alive) for the curated RMTs,
-		// but the curated path writes BEST-EFFORT (chwriter.InsertBestEffort:
-		// single POST, no retry, no dead-letter) so it can't stall the span flush
-		// loop or pollute the span dead-letter. Targets end_users /
-		// trace_sessions, never the pinned span table.
-		curated: curatedwriter.New(writer),
-		pendCh:  make(chan struct{}, 1),
-		stopCh:  make(chan struct{}),
+		curated:  curatedwriter.New(writer),
+		pendCh:   make(chan struct{}, 1),
+		stopCh:   make(chan struct{}),
 	}
 	return s
 }
 
 // Run blocks until ctx is cancelled or a serve error occurs. On shutdown
-// we drain pending rows once before returning so an SIGTERM doesn't lose
-// the in-flight batch (DECISIONS: in-flight loss bounded to last 5 s as
-// the deliberate at-least-once boundary).
+// we drain pending rows once before returning so a SIGTERM doesn't lose
+// in-flight batches.
 func (s *Server) Run(ctx context.Context) error {
 	if s.cfg.GRPCAddr == "" && s.cfg.HTTPAddr == "" {
 		return fmt.Errorf("at least one of GRPCAddr / HTTPAddr must be set")
 	}
 
-	// One error channel sized for both listeners — first error wins, the
-	// other listener is shut down by the select-case below.
 	serveErr := make(chan error, 2)
 
 	if s.cfg.GRPCAddr != "" {
@@ -193,13 +212,6 @@ func (s *Server) Run(ctx context.Context) error {
 
 	if s.cfg.HTTPAddr != "" {
 		mux := http.NewServeMux()
-		// OTLP/HTTP wire spec: a single endpoint per signal. `/v1/traces` is
-		// the trace signal — POST only, body is a serialised
-		// ExportTraceServiceRequest in one of two media types:
-		//   application/x-protobuf  (preferred — every server-side SDK)
-		//   application/json        (browser SDKs, lightweight clients)
-		// Any other method or content-type is rejected with 415 / 405 per
-		// the spec.
 		mux.HandleFunc("/v1/traces", s.handleHTTPTraces)
 		mux.HandleFunc("/tracer/v1/traces", s.handleHTTPTraces)
 		var handler http.Handler = mux
@@ -230,17 +242,17 @@ func (s *Server) Run(ctx context.Context) error {
 		return ctx.Err()
 	case err := <-serveErr:
 		s.shutdown()
-		// http.ErrServerClosed is the expected return when we call Shutdown,
-		// not a real failure — but here we got the error BEFORE shutdown so
-		// it's a genuine listener crash.
 		return err
 	}
 }
 
 // shutdown stops both listeners, waits for the flusher to exit, drains the
-// in-flight batch. Called once from Run on either ctx cancel or a serve
-// error. Safe to call when one of grpc/httpd is nil.
+// in-flight batch.
 func (s *Server) shutdown() {
+	s.pendMu.Lock()
+	s.closing = true
+	s.pendMu.Unlock()
+
 	if s.grpc != nil {
 		s.grpc.GracefulStop()
 	}
@@ -254,25 +266,13 @@ func (s *Server) shutdown() {
 	s.drainNow(context.Background())
 }
 
-// grpcErrLogger surfaces transport-level message-size rejections. A message
-// larger than MaxRecvMsgSize is rejected with RESOURCE_EXHAUSTED before the
-// handler or interceptor runs, so a stats.Handler is the only server-side
-// hook that sees it — without this, the client's span is dropped with no
-// trace in the collector's own logs. Deliberately narrow: auth failures are
-// logged by the interceptor, quota rejections are silent by design (same
-// code, would be indistinguishable spam), and client cancels are benign.
+// grpcErrLogger surfaces transport-level message-size rejections.
 type grpcErrLogger struct {
 	log *slog.Logger
 }
 
 type grpcMethodKey struct{}
 
-// grpc-go's MaxRecvMsgSize rejection message. Both recv variants
-// ("received message larger than max" and the gzip "received message after
-// decompression larger than max") share these two substrings; matching both
-// excludes the send-side "trying to send message larger than max", which
-// carries the same ResourceExhausted code but is the wrong story for a
-// "request rejected" log.
 const (
 	grpcMsgRecv     = "received message"
 	grpcMsgTooLarge = "larger than max"
@@ -334,31 +334,45 @@ func (h *otlpHandler) Export(ctx context.Context, req ptraceotlp.ExportRequest) 
 	if err != nil {
 		return ptraceotlp.NewExportResponse(), err
 	}
-	h.s.enqueue(rows, ids)
 
 	payloadBytes, _ := req.MarshalProto()
-	h.s.emitUsage(ctx, req.Traces(), int64(len(payloadBytes)))
+	numBytes := int64(len(payloadBytes))
 
+	doneCh, err := h.s.enqueue(ctx, rows, ids, numBytes)
+	if err != nil {
+		if errors.Is(err, errOversized) {
+			return ptraceotlp.NewExportResponse(), status.Errorf(codes.ResourceExhausted, "request size (%d rows, %d bytes) exceeds queue capacity limits (%d rows, %d bytes)", len(rows), numBytes, h.s.cfg.QueueMaxRows, h.s.cfg.QueueMaxBytes)
+		}
+		if errors.Is(err, errClosing) {
+			return ptraceotlp.NewExportResponse(), status.Errorf(codes.Unavailable, "server is shutting down")
+		}
+		// Overload retryable backpressure with RetryInfo
+		st := status.New(codes.Unavailable, "queue capacity exhausted")
+		if stWithDetails, dErr := st.WithDetails(&errdetails.RetryInfo{
+			RetryDelay: durationpb.New(1 * time.Second),
+		}); dErr == nil {
+			return ptraceotlp.NewExportResponse(), stWithDetails.Err()
+		}
+		return ptraceotlp.NewExportResponse(), st.Err()
+	}
+
+	if doneCh != nil {
+		select {
+		case <-ctx.Done():
+			return ptraceotlp.NewExportResponse(), ctx.Err()
+		case writeErr := <-doneCh:
+			if writeErr != nil {
+				return ptraceotlp.NewExportResponse(), status.Errorf(codes.Unavailable, "durable write failed: %v", writeErr)
+			}
+		}
+	}
+
+	h.s.emitUsage(ctx, req.Traces(), numBytes)
 	return ptraceotlp.NewExportResponse(), nil
 }
 
-// Cap the body size we will read from an OTLP/HTTP request. 16 MiB matches
-// the conservative default in the upstream OTel collector receiver and
-// covers a 5000-span batch carrying ~3 KiB of attrs each. Larger bodies
-// almost certainly indicate a misconfigured exporter (no batching) and
-// would let a single client consume memory unboundedly.
 const maxOTLPHTTPBodyBytes = 16 << 20
 
-// handleHTTPTraces implements POST /v1/traces per the OTLP/HTTP wire spec
-// (https://opentelemetry.io/docs/specs/otlp/#otlphttp). Accepts both
-// `application/x-protobuf` and `application/json`. Any other method or
-// content type is rejected with the canonical status code.
-//
-// Success is HTTP 200 + an empty (or near-empty) ExportTraceServiceResponse
-// in the response media type that matches the request — the spec requires
-// echoing the content-type so client SDKs can decode the partial-success
-// field. We always return the fully-successful response since our pipeline
-// is at-least-once + dead-letter for failed inserts.
 func (s *Server) handleHTTPTraces(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodPost {
 		w.Header().Set("Allow", http.MethodPost)
@@ -367,8 +381,6 @@ func (s *Server) handleHTTPTraces(w http.ResponseWriter, r *http.Request) {
 	}
 
 	ct := r.Header.Get("Content-Type")
-	// Strip any `;charset=...` suffix. The spec only mentions the two base
-	// types but charset is allowed and common (esp. from JSON clients).
 	if i := indexByte(ct, ';'); i >= 0 {
 		ct = ct[:i]
 	}
@@ -380,8 +392,6 @@ func (s *Server) handleHTTPTraces(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if len(body) > maxOTLPHTTPBodyBytes {
-		// Mirror the gRPC-side over-cap log so an HTTP exporter's drop is
-		// equally visible server-side.
 		s.log.Error("http body over size cap, request rejected",
 			"path", r.URL.Path, "max_bytes", maxOTLPHTTPBodyBytes)
 		http.Error(w, "payload too large", http.StatusRequestEntityTooLarge)
@@ -401,7 +411,6 @@ func (s *Server) handleHTTPTraces(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 	default:
-		// The spec is explicit: unsupported media types return 415.
 		w.Header().Set("Accept", "application/x-protobuf, application/json")
 		http.Error(w, "unsupported content type: "+ct, http.StatusUnsupportedMediaType)
 		return
@@ -412,7 +421,6 @@ func (s *Server) handleHTTPTraces(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Stamp auth-resolved org/project IDs onto resource attributes.
 	if result := auth.FromContext(r.Context()); result != nil {
 		ck := auth.CacheKeyFromContext(r.Context())
 		dropped, err := auth.StampResourceAttrs(r.Context(), s.auth, ck, req.Traces(), result)
@@ -427,17 +435,43 @@ func (s *Server) handleHTTPTraces(w http.ResponseWriter, r *http.Request) {
 
 	rows, ids, err := chexp.ConvertWithIdentities(r.Context(), req.Traces(), s.pricer)
 	if err != nil {
-		// 4xx — the SDK shouldn't retry a malformed conversion.
 		http.Error(w, "convert: "+err.Error(), http.StatusBadRequest)
 		return
 	}
-	s.enqueue(rows, ids)
 
-	s.emitUsage(r.Context(), req.Traces(), int64(len(body)))
+	numBytes := int64(len(body))
+	doneCh, enqueueErr := s.enqueue(r.Context(), rows, ids, numBytes)
+	if enqueueErr != nil {
+		if errors.Is(enqueueErr, errOversized) {
+			http.Error(w, "request payload exceeds total capacity limit", http.StatusRequestEntityTooLarge)
+			return
+		}
+		if errors.Is(enqueueErr, errClosing) {
+			w.Header().Set("Retry-After", "1")
+			http.Error(w, "server is shutting down", http.StatusServiceUnavailable)
+			return
+		}
+		w.Header().Set("Retry-After", "1")
+		http.Error(w, "server queue capacity exhausted", http.StatusServiceUnavailable)
+		return
+	}
 
-	// Empty ExportTraceServiceResponse — same wire shape, encoded to match
-	// the request's content-type. The spec requires the response media type
-	// to match the request.
+	if doneCh != nil {
+		select {
+		case <-r.Context().Done():
+			http.Error(w, r.Context().Err().Error(), http.StatusServiceUnavailable)
+			return
+		case writeErr := <-doneCh:
+			if writeErr != nil {
+				w.Header().Set("Retry-After", "1")
+				http.Error(w, "durable write failed: "+writeErr.Error(), http.StatusServiceUnavailable)
+				return
+			}
+		}
+	}
+
+	s.emitUsage(r.Context(), req.Traces(), numBytes)
+
 	resp := ptraceotlp.NewExportResponse()
 	var out []byte
 	switch ct {
@@ -455,9 +489,6 @@ func (s *Server) handleHTTPTraces(w http.ResponseWriter, r *http.Request) {
 	_, _ = w.Write(out)
 }
 
-// indexByte and trimSpace are lifted here so the file doesn't grow a
-// strings import just for content-type parsing. Inline 5-line helpers are
-// cheaper than a stdlib pull when we already share package boundaries.
 func indexByte(s string, c byte) int {
 	for i := 0; i < len(s); i++ {
 		if s[i] == c {
@@ -477,37 +508,74 @@ func trimSpace(s string) string {
 	return s
 }
 
-// enqueue parks rows on the pending buffer and signals the flusher.
-// We choose non-blocking signalling: if the channel already holds a tick
-// the flusher will already wake up and see this batch.
-//
-// `ids` are the CURATED dimension identities collected for this same payload;
-// they ride alongside `rows` so the curated dual-write flushes with the span
-// batch. A nil / empty Batch is skipped (the common no-user/no-session case).
-func (s *Server) enqueue(rows []map[string]any, ids *curatedwriter.Batch) {
+// enqueue parks rows on the pending queue, enforcing bounded limits atomically.
+// Returns a done channel that receives the final durable write outcome, or an error
+// if admission is rejected.
+func (s *Server) enqueue(ctx context.Context, rows []map[string]any, ids *curatedwriter.Batch, numBytes int64) (<-chan error, error) {
 	if len(rows) == 0 {
-		return
+		return nil, nil
 	}
+
+	numRows := len(rows)
+
 	s.pendMu.Lock()
-	s.pend = append(s.pend, rows...)
+	if s.closing {
+		s.pendMu.Unlock()
+		return nil, errClosing
+	}
+
+	// 1. Single request larger than total capacity is non-retryable.
+	if 1 > s.cfg.QueueMaxRequests || numRows > s.cfg.QueueMaxRows || numBytes > s.cfg.QueueMaxBytes {
+		s.rejectedOversized++
+		s.pendMu.Unlock()
+		return nil, errOversized
+	}
+
+	// 2. Total pending + in-flight capacity check.
+	totalReqs := s.curRequests + s.inFlightRequests + 1
+	totalRows := s.curRows + s.inFlightRows + numRows
+	totalBytes := s.curBytes + s.inFlightBytes + numBytes
+
+	if totalReqs > s.cfg.QueueMaxRequests || totalRows > s.cfg.QueueMaxRows || totalBytes > s.cfg.QueueMaxBytes {
+		s.rejectedOverload++
+		s.pendMu.Unlock()
+		return nil, errOverload
+	}
+
+	done := make(chan error, 1)
+	item := requestItem{
+		rows:     rows,
+		ids:      ids,
+		numRows:  numRows,
+		numBytes: numBytes,
+		done:     done,
+	}
+
+	s.pendItems = append(s.pendItems, item)
+	s.curRequests++
+	s.curRows += numRows
+	s.curBytes += numBytes
+
 	if ids != nil && !ids.Empty() {
 		if s.pendCurated == nil {
 			s.pendCurated = curatedwriter.NewBatch()
 		}
 		s.pendCurated.Merge(ids)
 	}
-	shouldKick := len(s.pend) >= s.cfg.BatchMaxRows
+
+	shouldKick := s.curRows >= s.cfg.BatchMaxRows || s.curRequests >= s.cfg.QueueMaxRequests
 	s.pendMu.Unlock()
+
 	if shouldKick {
 		select {
 		case s.pendCh <- struct{}{}:
 		default:
 		}
 	}
+
+	return done, nil
 }
 
-// flushLoop runs until stopCh closes. Wakes on either an explicit kick
-// (row-count threshold) or the time-based ticker.
 func (s *Server) flushLoop() {
 	defer s.wg.Done()
 	t := time.NewTicker(s.cfg.BatchMaxAge)
@@ -524,33 +592,80 @@ func (s *Server) flushLoop() {
 	}
 }
 
-// drainNow swaps the pending buffer and flushes it. Uses a fresh slice so
-// the next request can immediately start filling without contending.
+// drainNow swaps the pending buffer, moves pending accounting to in-flight,
+// performs the canonical write, releases capacity, and resolves completions.
 func (s *Server) drainNow(ctx context.Context) {
 	s.pendMu.Lock()
-	batch := s.pend
+	items := s.pendItems
 	curated := s.pendCurated
-	s.pend = nil
+
+	s.pendItems = nil
 	s.pendCurated = nil
+
+	// Transition pending items to in-flight
+	itemRequests := len(items)
+	var itemRows int
+	var itemBytes int64
+	for _, it := range items {
+		itemRows += it.numRows
+		itemBytes += it.numBytes
+	}
+
+	s.curRequests -= itemRequests
+	s.curRows -= itemRows
+	s.curBytes -= itemBytes
+
+	s.inFlightRequests += itemRequests
+	s.inFlightRows += itemRows
+	s.inFlightBytes += itemBytes
 	s.pendMu.Unlock()
-	if len(batch) == 0 {
+
+	if len(items) == 0 {
 		return
 	}
-	_ = s.writer.Insert(ctx, batch)
-	// Insert returns an error on dead-letter; the writer already persisted
-	// the rows + bumped stats. We swallow here because the flusher's job
-	// is to make progress, not propagate per-batch failures. /healthz
-	// surfaces the writer's failure counter.
 
-	// CH-derived dimensions (P3b step2 HALF 2): BEST-EFFORT mirror the
-	// drain-scoped curated end_users / trace_sessions identities AFTER the span
-	// insert. curated.Write uses chwriter.InsertBestEffort (single POST, no
-	// retry, no dead-letter — see its doc), so even on a CH outage this adds at
-	// most two bounded requests and can NEVER stall span draining or pollute the
-	// span dead-letter. The result is swallowed — the span insert above already
-	// completed and Django's backfill reconciles any curated gap. One `now`
-	// stamps version/first_seen for every curated row in this drain.
+	var batch []map[string]any
+	for _, it := range items {
+		batch = append(batch, it.rows...)
+	}
+
+	writeErr := s.writer.Insert(ctx, batch)
+	var finalErr error
+	if writeErr != nil && !chwriter.IsDeadLettered(writeErr) {
+		finalErr = writeErr
+	}
+
+	s.pendMu.Lock()
+	s.inFlightRequests -= itemRequests
+	s.inFlightRows -= itemRows
+	s.inFlightBytes -= itemBytes
+	s.pendMu.Unlock()
+
+	for _, it := range items {
+		it.done <- finalErr
+	}
+
 	if curated != nil && !curated.Empty() {
 		_ = s.curated.Write(ctx, curated, time.Now().UTC())
 	}
 }
+
+// QueueStats returns current queue depth, limits, and rejection stats.
+func (s *Server) QueueStats() QueueStats {
+	s.pendMu.Lock()
+	defer s.pendMu.Unlock()
+	return QueueStats{
+		PendingRequests:   s.curRequests,
+		PendingRows:       s.curRows,
+		PendingBytes:      s.curBytes,
+		InFlightRequests:  s.inFlightRequests,
+		InFlightRows:      s.inFlightRows,
+		InFlightBytes:     s.inFlightBytes,
+		QueueMaxRequests:  s.cfg.QueueMaxRequests,
+		QueueMaxRows:      s.cfg.QueueMaxRows,
+		QueueMaxBytes:     s.cfg.QueueMaxBytes,
+		RejectedOverload:  s.rejectedOverload,
+		RejectedOversized: s.rejectedOversized,
+	}
+}
+

--- a/fi-collector/pkg/server/server_test.go
+++ b/fi-collector/pkg/server/server_test.go
@@ -8,6 +8,7 @@ import (
 	"net"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -702,9 +703,9 @@ func TestDrainAggregatesCuratedAcrossPayloads(t *testing.T) {
 	r2a, ids2a, _ := chexp.ConvertWithIdentities(context.Background(), makeObserveTraces(proj, org, "userA", "sessX", 0x02), nil) // dup identity
 	r2b, ids2b, _ := chexp.ConvertWithIdentities(context.Background(), makeObserveTraces(proj, org, "userB", "sessY", 0x03), nil)
 
-	s.enqueue(r1, ids1)
-	s.enqueue(r2a, ids2a)
-	s.enqueue(r2b, ids2b)
+	_, _ = s.enqueue(context.Background(), r1, ids1, 100)
+	_, _ = s.enqueue(context.Background(), r2a, ids2a, 100)
+	_, _ = s.enqueue(context.Background(), r2b, ids2b, 100)
 
 	// One drain → one span insert + one end_users + one trace_sessions.
 	s.drainNow(context.Background())
@@ -887,3 +888,453 @@ func TestGRPCOverCapRejectionIsLogged(t *testing.T) {
 type writerFunc func(p []byte) (int, error)
 
 func (f writerFunc) Write(p []byte) (int, error) { return f(p) }
+
+// TestQueueLimits_OversizedRequestRejected tests that an individual request
+// exceeding maximum configured capacity is rejected with non-retryable error
+// (gRPC ResourceExhausted, HTTP 413 Payload Too Large).
+func TestQueueLimits_OversizedRequestRejected(t *testing.T) {
+	chSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(200)
+	}))
+	defer chSrv.Close()
+
+	w, _ := chwriter.New(chwriter.Config{
+		URL:            chSrv.URL,
+		Database:       "default",
+		Table:          "spans",
+		MaxRetries:     1,
+		InitialBackoff: time.Millisecond,
+		MaxBackoff:     time.Millisecond,
+		RequestTimeout: 2 * time.Second,
+		DeadLetterFile: t.TempDir() + "/dl.jsonl",
+	})
+
+	httpAddr := "127.0.0.1:24330"
+	grpcAddr := "127.0.0.1:24331"
+	s := New(Config{
+		GRPCAddr:         grpcAddr,
+		HTTPAddr:         httpAddr,
+		BatchMaxRows:     100,
+		BatchMaxAge:      time.Hour,
+		QueueMaxRequests: 10,
+		QueueMaxRows:     2, // max 2 rows total capacity
+		QueueMaxBytes:    100 << 20,
+	}, w, nil, nil, nil)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go func() { _ = s.Run(ctx) }()
+
+	if !waitPort(grpcAddr, 2*time.Second) || !waitPort(httpAddr, 2*time.Second) {
+		t.Fatal("server didn't listen")
+	}
+
+	// 1. gRPC over-row-capacity request
+	conn, err := grpc.NewClient(grpcAddr, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer conn.Close()
+
+	traces := ptrace.NewTraces()
+	rs := traces.ResourceSpans().AppendEmpty()
+	rs.Resource().Attributes().PutStr("fi.project_id", "11111111-1111-4111-8111-111111111111")
+	spans := rs.ScopeSpans().AppendEmpty().Spans()
+	for i := 0; i < 5; i++ { // 5 rows > QueueMaxRows (2)
+		sp := spans.AppendEmpty()
+		sp.SetName("oversized-span")
+		sp.SetTraceID([16]byte{0xaa})
+		sp.SetSpanID([8]byte{byte(i + 1)})
+	}
+
+	req := ptraceotlp.NewExportRequestFromTraces(traces)
+	_, err = ptraceotlp.NewGRPCClient(conn).Export(context.Background(), req)
+	if status.Code(err) != codes.ResourceExhausted {
+		t.Errorf("gRPC oversized request: want ResourceExhausted, got %v", err)
+	}
+
+	// 2. HTTP over-row-capacity request
+	pb, _ := req.MarshalProto()
+	resp, err := http.Post("http://"+httpAddr+"/v1/traces", "application/x-protobuf", bytes.NewReader(pb))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusRequestEntityTooLarge {
+		t.Errorf("HTTP oversized request: want 413 Payload Too Large, got %d", resp.StatusCode)
+	}
+
+	stats := s.QueueStats()
+	if stats.RejectedOversized == 0 {
+		t.Error("expected RejectedOversized > 0")
+	}
+}
+
+// TestQueueLimits_OverloadBackpressure tests that when queue capacity is full,
+// incoming requests receive retryable overload responses (HTTP 503 + Retry-After, gRPC Unavailable + RetryInfo).
+func TestQueueLimits_OverloadBackpressure(t *testing.T) {
+	chBlock := make(chan struct{})
+	chSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if insertTable(r) == "spans" {
+			<-chBlock
+		}
+		w.WriteHeader(200)
+	}))
+	defer chSrv.Close()
+
+	w, _ := chwriter.New(chwriter.Config{
+		URL:            chSrv.URL,
+		Database:       "default",
+		Table:          "spans",
+		MaxRetries:     1,
+		InitialBackoff: time.Millisecond,
+		MaxBackoff:     time.Millisecond,
+		RequestTimeout: 2 * time.Second,
+		DeadLetterFile: t.TempDir() + "/dl.jsonl",
+	})
+	defer w.Close()
+
+	httpAddr := "127.0.0.1:24332"
+	grpcAddr := "127.0.0.1:24333"
+	s := New(Config{
+		GRPCAddr:         grpcAddr,
+		HTTPAddr:         httpAddr,
+		BatchMaxRows:     1, // flush immediately so 1st request becomes in-flight
+		BatchMaxAge:      50 * time.Millisecond,
+		QueueMaxRequests: 1, // only 1 request capacity
+		QueueMaxRows:     100,
+		QueueMaxBytes:    100 << 20,
+	}, w, nil, nil, nil)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go func() { _ = s.Run(ctx) }()
+
+	if !waitPort(grpcAddr, 2*time.Second) || !waitPort(httpAddr, 2*time.Second) {
+		t.Fatal("server didn't listen")
+	}
+
+	traces := makeTraces("span-1", "11111111-1111-4111-8111-111111111111")
+	req := ptraceotlp.NewExportRequestFromTraces(traces)
+
+	conn, err := grpc.NewClient(grpcAddr, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer conn.Close()
+	client := ptraceotlp.NewGRPCClient(conn)
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		_, _ = client.Export(context.Background(), req)
+	}()
+
+	// Wait until 1st request is in-flight (or pending)
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		st := s.QueueStats()
+		if st.PendingRequests+st.InFlightRequests > 0 {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	// 2nd gRPC request when queue is full → Unavailable overload with RetryInfo
+	_, err = client.Export(context.Background(), req)
+	if status.Code(err) != codes.Unavailable {
+		t.Fatalf("overloaded gRPC: want Unavailable, got %v", err)
+	}
+
+	// 3rd HTTP request when queue is full → 503 Service Unavailable with Retry-After
+	pb, _ := req.MarshalProto()
+	resp, err := http.Post("http://"+httpAddr+"/v1/traces", "application/x-protobuf", bytes.NewReader(pb))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusServiceUnavailable {
+		t.Errorf("overloaded HTTP: want 503, got %d", resp.StatusCode)
+	}
+	if got := resp.Header.Get("Retry-After"); got != "1" {
+		t.Errorf("overloaded HTTP: Retry-After = %q, want 1", got)
+	}
+
+	// Unblock 1st request insert
+	close(chBlock)
+	wg.Wait()
+
+	if s.QueueStats().RejectedOverload < 2 {
+		t.Errorf("expected RejectedOverload >= 2, got %d", s.QueueStats().RejectedOverload)
+	}
+}
+
+// TestDurableAcknowledgement_CHSuccess verifies that an OTLP request is acknowledged
+// only after ClickHouse successfully accepts the batch.
+func TestDurableAcknowledgement_CHSuccess(t *testing.T) {
+	chCalled := make(chan struct{})
+	chBlock := make(chan struct{})
+	chSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if insertTable(r) == "spans" {
+			close(chCalled)
+			<-chBlock
+		}
+		w.WriteHeader(200)
+	}))
+	defer chSrv.Close()
+
+	w, _ := chwriter.New(chwriter.Config{
+		URL:            chSrv.URL,
+		Database:       "default",
+		Table:          "spans",
+		MaxRetries:     1,
+		InitialBackoff: time.Millisecond,
+		MaxBackoff:     time.Millisecond,
+		RequestTimeout: 2 * time.Second,
+		DeadLetterFile: t.TempDir() + "/dl.jsonl",
+	})
+
+	grpcAddr := "127.0.0.1:24334"
+	s := New(Config{
+		GRPCAddr:     grpcAddr,
+		HTTPAddr:     "",
+		BatchMaxRows: 1, // flush immediately on enqueue
+		BatchMaxAge:  50 * time.Millisecond,
+	}, w, nil, nil, nil)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go func() { _ = s.Run(ctx) }()
+
+	if !waitPort(grpcAddr, 2*time.Second) {
+		t.Fatal("server didn't listen")
+	}
+
+	conn, err := grpc.NewClient(grpcAddr, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer conn.Close()
+
+	done := make(chan error, 1)
+	go func() {
+		traces := makeTraces("ack-test-span", "11111111-1111-4111-8111-111111111111")
+		req := ptraceotlp.NewExportRequestFromTraces(traces)
+		_, err := ptraceotlp.NewGRPCClient(conn).Export(context.Background(), req)
+		done <- err
+	}()
+
+	// Wait until CH receives write call
+	select {
+	case <-chCalled:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timeout waiting for CH insert call")
+	}
+
+	// Verify request is NOT yet unblocked/acknowledged while CH write is in-flight
+	select {
+	case err := <-done:
+		t.Fatalf("request completed before CH write finished! err=%v", err)
+	default:
+	}
+
+	// Unblock CH write
+	close(chBlock)
+
+	// Now request should complete successfully
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("Export failed: %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timeout waiting for request completion after CH write")
+	}
+}
+
+// TestDurableAcknowledgement_DeadLetterSuccess verifies that when ClickHouse fails,
+// the OTLP request is acknowledged after the batch is durably written to the dead-letter file.
+func TestDurableAcknowledgement_DeadLetterSuccess(t *testing.T) {
+	chSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(500)
+	}))
+	defer chSrv.Close()
+
+	dlFile := t.TempDir() + "/dl.jsonl"
+	w, _ := chwriter.New(chwriter.Config{
+		URL:            chSrv.URL,
+		Database:       "default",
+		Table:          "spans",
+		MaxRetries:     1,
+		InitialBackoff: time.Millisecond,
+		MaxBackoff:     time.Millisecond,
+		RequestTimeout: 2 * time.Second,
+		DeadLetterFile: dlFile,
+	})
+	defer w.Close()
+
+	grpcAddr := "127.0.0.1:24335"
+	s := New(Config{
+		GRPCAddr:     grpcAddr,
+		HTTPAddr:     "",
+		BatchMaxRows: 1,
+		BatchMaxAge:  50 * time.Millisecond,
+	}, w, nil, nil, nil)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go func() { _ = s.Run(ctx) }()
+
+	if !waitPort(grpcAddr, 2*time.Second) {
+		t.Fatal("server didn't listen")
+	}
+
+	conn, err := grpc.NewClient(grpcAddr, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer conn.Close()
+
+	traces := makeTraces("dead-letter-span", "22222222-2222-4222-8222-222222222222")
+	req := ptraceotlp.NewExportRequestFromTraces(traces)
+
+	_, err = ptraceotlp.NewGRPCClient(conn).Export(context.Background(), req)
+	if err != nil {
+		t.Fatalf("Export should succeed on durable dead-letter fsync, got: %v", err)
+	}
+
+	b, err := os.ReadFile(dlFile)
+	if err != nil || len(b) == 0 {
+		t.Fatalf("dead-letter file empty or unreadable: %v", err)
+	}
+	if !strings.Contains(string(b), "dead-letter-span") {
+		t.Errorf("dead-letter file missing span: %s", string(b))
+	}
+}
+
+// TestDurableAcknowledgement_DoubleFailure verifies that when both ClickHouse write
+// AND dead-letter fsync fail, the request receives a retryable error response.
+func TestDurableAcknowledgement_DoubleFailure(t *testing.T) {
+	chSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(500)
+	}))
+	defer chSrv.Close()
+
+	dlFile := t.TempDir() + "/dl.jsonl"
+	w, _ := chwriter.New(chwriter.Config{
+		URL:            chSrv.URL,
+		Database:       "default",
+		Table:          "spans",
+		MaxRetries:     1,
+		InitialBackoff: time.Millisecond,
+		MaxBackoff:     time.Millisecond,
+		RequestTimeout: 2 * time.Second,
+		DeadLetterFile: dlFile,
+	})
+	defer w.Close()
+
+	// Create directory with same name as dlFile to force appendDeadLetter open file to fail
+	if err := os.MkdirAll(dlFile, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	grpcAddr := "127.0.0.1:24336"
+	s := New(Config{
+		GRPCAddr:     grpcAddr,
+		HTTPAddr:     "",
+		BatchMaxRows: 1,
+		BatchMaxAge:  50 * time.Millisecond,
+	}, w, nil, nil, nil)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go func() { _ = s.Run(ctx) }()
+
+	if !waitPort(grpcAddr, 2*time.Second) {
+		t.Fatal("server didn't listen")
+	}
+
+	conn, err := grpc.NewClient(grpcAddr, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer conn.Close()
+
+	traces := makeTraces("double-fail-span", "33333333-3333-4333-8333-333333333333")
+	req := ptraceotlp.NewExportRequestFromTraces(traces)
+
+	_, err = ptraceotlp.NewGRPCClient(conn).Export(context.Background(), req)
+	if status.Code(err) != codes.Unavailable {
+		t.Fatalf("double failure: want Unavailable, got %v", err)
+	}
+}
+
+// TestShutdown_RejectsNewAndDrainsExisting tests graceful shutdown behavior:
+// existing accepted requests are drained and completed before shutdown finishes,
+// while new requests during shutdown are rejected.
+func TestShutdown_RejectsNewAndDrainsExisting(t *testing.T) {
+	chSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		time.Sleep(50 * time.Millisecond)
+		w.WriteHeader(200)
+	}))
+	defer chSrv.Close()
+
+	w, _ := chwriter.New(chwriter.Config{
+		URL:            chSrv.URL,
+		Database:       "default",
+		Table:          "spans",
+		MaxRetries:     1,
+		InitialBackoff: time.Millisecond,
+		MaxBackoff:     time.Millisecond,
+		RequestTimeout: 2 * time.Second,
+		DeadLetterFile: t.TempDir() + "/dl.jsonl",
+	})
+
+	grpcAddr := "127.0.0.1:24337"
+	s := New(Config{
+		GRPCAddr:     grpcAddr,
+		HTTPAddr:     "",
+		BatchMaxRows: 100,
+		BatchMaxAge:  10 * time.Second,
+	}, w, nil, nil, nil)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() { _ = s.Run(ctx) }()
+
+	if !waitPort(grpcAddr, 2*time.Second) {
+		t.Fatal("server didn't listen")
+	}
+
+	conn, err := grpc.NewClient(grpcAddr, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer conn.Close()
+	client := ptraceotlp.NewGRPCClient(conn)
+
+	traces := makeTraces("shutdown-span", "44444444-4444-4444-8444-444444444444")
+	req := ptraceotlp.NewExportRequestFromTraces(traces)
+
+	var reqErr error
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		_, reqErr = client.Export(context.Background(), req)
+	}()
+
+	// Wait until request is queued
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) && s.QueueStats().PendingRequests < 1 {
+		time.Sleep(5 * time.Millisecond)
+	}
+
+	// Trigger shutdown
+	cancel()
+	wg.Wait()
+
+	if reqErr != nil {
+		t.Errorf("previously accepted request failed during shutdown: %v", reqErr)
+	}
+}


### PR DESCRIPTION
## Description
Fixes #2201.

fi-collector previously acknowledged OTLP exports immediately after appending converted rows to an unbounded in-memory slice, causing unbounded memory growth if ClickHouse slowed down or failed, and losing data if the process crashed before flushing.

This PR implements:
1. **Bounded Pending & In-Flight Queue**: Added configurable request, row, and byte capacity limits (`queue_max_requests`, `queue_max_rows`, `queue_max_bytes`) covering queued plus canonical-writer in-flight work.
2. **Atomic Admission Control**:
   - Single requests exceeding maximum capacity are rejected with non-retryable errors (gRPC `ResourceExhausted`, HTTP `413 Payload Too Large`).
   - When queue capacity is full, incoming requests receive retryable overload responses (gRPC `Unavailable` + `RetryInfo`, HTTP `503 Service Unavailable` + `Retry-After: 1`).
3. **Durable Acceptance & Acknowledgement**:
   - OTLP export responses are held until ClickHouse accepts the batch or the batch is durably fsynced to `dead_letter.jsonl`.
   - Failure of both returns a retryable error to the client SDK.
   - Curated dimension writes remain best-effort outside the canonical ACK boundary.
4. **Graceful Shutdown & Queue Visibility**:
   - Graceful shutdown stops new admissions while draining all previously accepted requests.
   - Exposed queue stats, limits, and rejection counters on `/healthz`.
5. **Race-enabled Test Suite**:
   - Added unit & integration tests for queue limits, overload backpressure, durable ACKs, and graceful shutdown.

## Verification
Ran `go test ./...` in `fi-collector`: all tests pass cleanly.