### PR TITLE
fix(collector): bound OTLP admission and durable acks

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -55,6 +55,13 @@ RECAPTCHA_ENABLED=false
 FUTURE_AGI_CLOUD_API_KEY=
 OSS_RETURN_PASSWORD_RESET_LINK=true
 
+# fi-collector bounded admission. Limits include queued and ClickHouse
+# in-flight canonical span batches; reduce them for memory-constrained hosts.
+FI_MAX_PENDING_REQUESTS=1000
+FI_MAX_PENDING_ROWS=20000
+FI_MAX_PENDING_MIB=64
+FI_MAX_CONCURRENT_REQUESTS=32
+
 
 SYSTEM_VOICE_PROVIDER=
 VAPI_API_KEY=

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -476,6 +476,10 @@ services:
       # collector with an external HTTP gateway that strips OTLP at the edge.
       FI_HTTP_ADDR: ":4318"
       FI_ADMIN_ADDR: ":9464"
+      FI_MAX_PENDING_REQUESTS: ${FI_MAX_PENDING_REQUESTS:-1000}
+      FI_MAX_PENDING_ROWS: ${FI_MAX_PENDING_ROWS:-20000}
+      FI_MAX_PENDING_MIB: ${FI_MAX_PENDING_MIB:-64}
+      FI_MAX_CONCURRENT_REQUESTS: ${FI_MAX_CONCURRENT_REQUESTS:-32}
       FI_DEAD_LETTER_FILE: /var/lib/fi-collector/dead_letter.jsonl
     volumes:
       - fi-collector-data:/var/lib/fi-collector
@@ -485,6 +489,7 @@ services:
       redis:
         condition: service_healthy
     restart: unless-stopped
+    stop_grace_period: 600s
 
   redis:
     image: redis:7-alpine

--- a/fi-collector/EMBEDDED.md
+++ b/fi-collector/EMBEDDED.md
@@ -68,7 +68,7 @@ spec:
             requests:
               cpu: 100m
               memory: 64Mi
-           limits:
+            limits:
               cpu: 1
               memory: 512Mi
           # The dead-letter file must survive pod restarts. The bounded

--- a/fi-collector/EMBEDDED.md
+++ b/fi-collector/EMBEDDED.md
@@ -51,6 +51,14 @@ spec:
               value: ":4317"
             - name: FI_ADMIN_ADDR
               value: ":9464"
+            - name: FI_MAX_PENDING_REQUESTS
+              value: "1000"
+            - name: FI_MAX_PENDING_ROWS
+              value: "20000"
+            - name: FI_MAX_PENDING_MIB
+              value: "64"
+            - name: FI_MAX_CONCURRENT_REQUESTS
+              value: "32"
           ports:
             - containerPort: 4317
               name: otlp
@@ -60,10 +68,11 @@ spec:
             requests:
               cpu: 100m
               memory: 64Mi
-            limits:
+           limits:
               cpu: 1
               memory: 512Mi
-          # The dead-letter queue must survive pod restarts. Use an
+          # The dead-letter file must survive pod restarts. The bounded
+          # in-memory queue is intentionally not persistent. Use an
           # emptyDir for ephemeral durability or a persistent volume
           # for stronger guarantees.
           volumeMounts:
@@ -72,6 +81,7 @@ spec:
       volumes:
         - name: fi-collector-dl
           emptyDir: { sizeLimit: 1Gi }
+      terminationGracePeriodSeconds: 600
 ```
 
 Pros: same lifecycle, localhost-loopback latency, single deploy unit. Cons: scaling is coupled (more web pods → more collectors); restarts of either container restart the pod.

--- a/fi-collector/README.md
+++ b/fi-collector/README.md
@@ -8,11 +8,11 @@ mandated to die by `PLAN_V2_NO_CDC.md`.
 ```
 Customer SDK (OTLP / HTTP / gRPC)
     → fi-collector  (this binary)
-       • OTLP receiver
-       • memory_limiter (backpressure)
-       • batch processor (10K spans / 5s)
+       • minimal OTLP receiver
+       • bounded admission (requests + rows + bytes)
+       • batch processor (5K spans / 5s by default)
        • clickhouse25 exporter — splits OTel attrs into typed Maps + typed JSON,
-                                 writes via clickhouse-go native protocol
+                                 writes via HTTP JSONEachRow
     → ClickHouse 25.3 spans table
 ```
 
@@ -54,35 +54,29 @@ Off-the-shelf options considered:
 - **Direct CH writer in Django** — keeps Python in the hot path, which is the
   entire reason for moving off PG-as-write-target. Doesn't scale to 1B/day.
 
-- **Custom Go OTel exporter (this)** — uses the official OTel Collector
-  framework (receivers / processors / exporters / queue / retry / batching
-  all come for free); custom exporter component does ONE thing: take OTLP
-  span pdata and write a row matching `tracer/services/clickhouse/v2/schema/`
-  via the official `clickhouse-go/v2` native driver. Same code path SigNoz,
-  ClickStack, and Uptrace all use.
+- **Minimal Go receiver + custom exporter (this)** — uses the official OTel
+  pdata model but deliberately avoids the full Collector framework. The server
+  owns OTLP decoding, bounded admission and batching; the exporter converts
+  spans to rows matching `tracer/services/clickhouse/v2/schema/`, and the
+  writer sends JSONEachRow over ClickHouse HTTP.
 
 ## Layout
 
 ```
 fi-collector/
-├── cmd/fi-collector/main.go               — ocb-generated entrypoint
+├── cmd/fi-collector/main.go               — config, auth, admin and server entrypoint
 ├── pkg/
 │   ├── adapter/                           — typed-Map split logic
 │   │   ├── adapter.go                     — port of pg_to_ch_adapter.py:split_attributes
 │   │   └── adapter_test.go                — table-driven tests pinning every branch
+│   ├── server/                             — OTLP/gRPC + HTTP, admission and batching
 │   └── chwriter/                          — CH 25.3 writer
-│       ├── writer.go                      — clickhouse-go/v2 batched bulk insert
+│       ├── writer.go                      — HTTP JSONEachRow insert + dead letter
 │       └── writer_test.go
-├── exporter/clickhouse25exporter/         — the OTel Collector component
-│   ├── config.go                          — yaml-config schema
-│   ├── factory.go                         — component registration with otelcol
-│   ├── exporter.go                        — OTLP traces → adapter → chwriter
-│   └── exporter_test.go
+├── exporter/clickhouse25exporter/         — pdata traces → typed CH rows
 ├── config/
-│   ├── fi-collector-local.yaml            — local dev: OTLP → batch → clickhouse25
-│   └── fi-collector-prod.yaml             — prod: + memory_limiter, retry, queue
-├── builder-config.yaml                    — ocb manifest (which components to compile in)
-├── Dockerfile                             — scratch runtime, ~25 MiB image
+│   └── collector.yaml                     — server, writer and auth defaults
+├── Dockerfile                             — distroless nonroot runtime
 ├── docker-compose.standalone.yml          — collector + CH only, for isolated testing
 ├── Makefile                               — build / run / test / docker / bench
 ├── go.mod / go.sum
@@ -99,8 +93,6 @@ make run                 # bin/fi-collector --config config/fi-collector-local.y
 make test                # unit tests
 make bench               # benchmark adapter + writer
 ```
-
-For OCB (the OTel Collector builder): the Makefile installs it if missing.
 
 ## Pricing Configuration
 
@@ -138,18 +130,29 @@ the litellm table nor custom pricing applies, the span's cost is 0.
 
 ```
 SDK   ──HTTP/gRPC──►   fi-collector
-                        ├─ OTLP receiver       (default queue: 1K requests)
-                        ├─ memory_limiter      (hard ceiling — drops if exceeded)
-                        ├─ batch processor     (10K spans / 5s, whichever first)
-                        ├─ retry-on-failure    (exponential, max 5 min)
-                        └─ persistent queue    (disk-backed, survives restart)
-                                ▼
-                        ClickHouse 25.3 (async_insert=1 server-side batching)
+                        ├─ atomic admission    (1K requests / 20K rows / 64 MiB)
+                        ├─ batch processor     (5K spans / 5s, whichever first)
+                        ├─ retry-on-failure    (exponential, 5 retries by default)
+                        └─ fsynced dead letter (terminal CH failures)
+                                 ▼
+                        ClickHouse 25.3 (synchronous HTTP insert by default)
 ```
 
-If ClickHouse is briefly unavailable, the persistent queue absorbs the
-backlog. If memory crosses the limit, the receiver returns 429 and SDKs
-back off — no silent drops, no OOM crashes. Same pattern SigNoz uses.
+The three admission limits cover both queued and canonical-writer in-flight
+work. A shared concurrency gate (32 HTTP/gRPC handlers by default) also bounds
+decoded and converting request memory. A request is admitted in full or rejected in full. Temporary saturation
+returns gRPC `Unavailable` with `RetryInfo`, or HTTP `503` with `Retry-After`,
+so compliant SDKs back off. A request that cannot fit even in an empty queue is
+rejected with gRPC `ResourceExhausted` or HTTP `413` and must be rebatched.
+
+An accepted request is acknowledged only after ClickHouse accepts the batch or
+the terminal failure has been fsynced to the dead-letter file. The in-memory
+queue itself does not survive a process crash; the delayed acknowledgement is
+what lets an SDK retry work that never reached a durable boundary.
+
+Shutdown grace is 600 seconds by default. This covers a canonical batch already
+in flight plus one accepted pending batch exhausting six 30-second attempts and
+capped backoff before their final dead-letter fsyncs.
 
 ## Migration relationship
 

--- a/fi-collector/cmd/fi-collector/main.go
+++ b/fi-collector/cmd/fi-collector/main.go
@@ -42,6 +42,11 @@ type rootConfig struct {
 	Writer chwriter.Config `yaml:"writer"`
 	Server server.Config   `yaml:"server"`
 	Auth   auth.Config     `yaml:"auth"`
+	Admin  adminConfig     `yaml:"admin"`
+}
+
+type adminConfig struct {
+	Addr string `yaml:"addr"`
 }
 
 func main() {
@@ -105,7 +110,11 @@ func main() {
 	srv := server.New(cfg.Server, writer, authenticator, usageEmitter, metering, opts...)
 
 	// Admin HTTP server — internal only, health check endpoint.
-	go runAdmin(":9464", writer, log)
+	adminAddr := cfg.Admin.Addr
+	if adminAddr == "" {
+		adminAddr = ":9464"
+	}
+	go runAdmin(adminAddr, writer, srv, log)
 
 	ctx, cancel := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
 	defer cancel()
@@ -115,7 +124,11 @@ func main() {
 	log.Info("starting",
 		"grpc_addr", cfg.Server.GRPCAddr,
 		"http_addr", cfg.Server.HTTPAddr,
+		"admin_addr", adminAddr,
 		"ch_url", cfg.Writer.URL,
+		"max_pending_requests", srv.QueueSnapshot().MaxPendingRequests,
+		"max_pending_rows", srv.QueueSnapshot().MaxPendingRows,
+		"max_pending_bytes", srv.QueueSnapshot().MaxPendingBytes,
 	)
 	if err := srv.Run(ctx); err != nil && ctx.Err() == nil {
 		log.Error("server exited with error", "err", err)
@@ -208,6 +221,13 @@ func applyEnvOverrides(log *slog.Logger, c *rootConfig) {
 			log.Warn("ignoring invalid FI_GRPC_MAX_RECV_MIB", "value", v)
 		}
 	}
+	applyPositiveIntEnv(log, "FI_MAX_PENDING_REQUESTS", &c.Server.MaxPendingRequests)
+	applyPositiveIntEnv(log, "FI_MAX_PENDING_ROWS", &c.Server.MaxPendingRows)
+	applyPositiveIntEnv(log, "FI_MAX_PENDING_MIB", &c.Server.MaxPendingMiB)
+	applyPositiveIntEnv(log, "FI_MAX_CONCURRENT_REQUESTS", &c.Server.MaxConcurrentRequests)
+	if v := os.Getenv("FI_ADMIN_ADDR"); v != "" {
+		c.Admin.Addr = v
+	}
 	if v := os.Getenv("FI_DEAD_LETTER_FILE"); v != "" {
 		c.Writer.DeadLetterFile = v
 	}
@@ -223,22 +243,46 @@ func applyEnvOverrides(log *slog.Logger, c *rootConfig) {
 	}
 }
 
+func applyPositiveIntEnv(log *slog.Logger, name string, target *int) {
+	v := os.Getenv(name)
+	if v == "" {
+		return
+	}
+	n, err := strconv.Atoi(v)
+	if err != nil || n <= 0 {
+		log.Warn("ignoring invalid positive integer environment variable", "env", name, "value", v)
+		return
+	}
+	*target = n
+}
+
 // runAdmin serves /healthz for container health checks.
-func runAdmin(addr string, w *chwriter.Writer, log *slog.Logger) {
-	mux := http.NewServeMux()
-	mux.HandleFunc("/healthz", func(rw http.ResponseWriter, r *http.Request) {
-		s := w.Snapshot()
-		denom := s.BatchesInserted + s.BatchesFailed
-		if denom > 100 && s.BatchesFailed*2 > denom {
-			rw.WriteHeader(503)
-			_ = json.NewEncoder(rw).Encode(map[string]any{"status": "unhealthy", "stats": s})
-			return
-		}
-		rw.WriteHeader(200)
-		_ = json.NewEncoder(rw).Encode(map[string]any{"status": "ok", "stats": s})
-	})
-	srv := &http.Server{Addr: addr, Handler: mux, ReadHeaderTimeout: 5 * time.Second}
+func runAdmin(addr string, w *chwriter.Writer, collector *server.Server, log *slog.Logger) {
+	srv := &http.Server{Addr: addr, Handler: adminHandler(w, collector), ReadHeaderTimeout: 5 * time.Second}
 	if err := srv.ListenAndServe(); err != nil && err != http.ErrServerClosed {
 		log.Warn("admin server stopped", "err", err)
 	}
+}
+
+func adminHandler(w *chwriter.Writer, collector *server.Server) http.Handler {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/healthz", func(rw http.ResponseWriter, r *http.Request) {
+		s := w.Snapshot()
+		queue := collector.QueueSnapshot()
+		rw.Header().Set("Content-Type", "application/json")
+		if s.BatchesNotDurable > 0 {
+			rw.WriteHeader(503)
+			_ = json.NewEncoder(rw).Encode(map[string]any{"status": "unhealthy", "stats": s, "queue": queue})
+			return
+		}
+		denom := s.BatchesInserted + s.BatchesFailed
+		if denom > 100 && s.BatchesFailed*2 > denom {
+			rw.WriteHeader(503)
+			_ = json.NewEncoder(rw).Encode(map[string]any{"status": "unhealthy", "stats": s, "queue": queue})
+			return
+		}
+		rw.WriteHeader(200)
+		_ = json.NewEncoder(rw).Encode(map[string]any{"status": "ok", "stats": s, "queue": queue})
+	})
+	return mux
 }

--- a/fi-collector/cmd/fi-collector/main_test.go
+++ b/fi-collector/cmd/fi-collector/main_test.go
@@ -4,10 +4,15 @@ import (
 	"bytes"
 	"encoding/json"
 	"log/slog"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/future-agi/future-agi/fi-collector/pkg/chwriter"
+	"github.com/future-agi/future-agi/fi-collector/pkg/server"
 )
 
 // logLines parses newline-delimited slog JSON output into a slice of
@@ -106,5 +111,67 @@ func TestLoadPriceTable_SkippedEntriesWarns(t *testing.T) {
 	}
 	if !sawSkippedWarn {
 		t.Error("want a WARN log reporting the skipped-entry count")
+	}
+}
+
+func TestApplyEnvOverridesPendingLimitsAndAdminAddr(t *testing.T) {
+	t.Setenv("FI_MAX_PENDING_REQUESTS", "17")
+	t.Setenv("FI_MAX_PENDING_ROWS", "23")
+	t.Setenv("FI_MAX_PENDING_MIB", "31")
+	t.Setenv("FI_MAX_CONCURRENT_REQUESTS", "13")
+	t.Setenv("FI_ADMIN_ADDR", "127.0.0.1:9999")
+	cfg := rootConfig{}
+	applyEnvOverrides(slog.Default(), &cfg)
+	if cfg.Server.MaxPendingRequests != 17 || cfg.Server.MaxPendingRows != 23 || cfg.Server.MaxPendingMiB != 31 || cfg.Server.MaxConcurrentRequests != 13 {
+		t.Fatalf("pending overrides not applied: %+v", cfg.Server)
+	}
+	if cfg.Admin.Addr != "127.0.0.1:9999" {
+		t.Fatalf("admin addr=%q", cfg.Admin.Addr)
+	}
+}
+
+func TestApplyEnvOverridesRejectsInvalidPendingLimits(t *testing.T) {
+	t.Setenv("FI_MAX_PENDING_ROWS", "not-a-number")
+	var buf bytes.Buffer
+	log := slog.New(slog.NewJSONHandler(&buf, nil))
+	cfg := rootConfig{Server: server.Config{MaxPendingRows: 99}}
+	applyEnvOverrides(log, &cfg)
+	if cfg.Server.MaxPendingRows != 99 {
+		t.Fatalf("invalid override changed value to %d", cfg.Server.MaxPendingRows)
+	}
+	if !strings.Contains(buf.String(), "FI_MAX_PENDING_ROWS") {
+		t.Fatalf("missing warning log: %s", buf.String())
+	}
+}
+
+func TestAdminHealthIncludesQueueSnapshot(t *testing.T) {
+	ch := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer ch.Close()
+	w, err := chwriter.New(chwriter.Config{URL: ch.URL, DeadLetterFile: filepath.Join(t.TempDir(), "dl.jsonl")})
+	if err != nil {
+		t.Fatal(err)
+	}
+	collector := server.New(server.Config{
+		MaxPendingRequests: 7,
+		MaxPendingRows:     11,
+		MaxPendingMiB:      13,
+	}, w, nil, nil, nil)
+
+	handler := adminHandler(w, collector)
+	rw := httptest.NewRecorder()
+	handler.ServeHTTP(rw, httptest.NewRequest(http.MethodGet, "/healthz", nil))
+	if rw.Code != http.StatusOK {
+		t.Fatalf("status=%d body=%s", rw.Code, rw.Body.String())
+	}
+	var body struct {
+		Queue server.QueueStats `json:"queue"`
+	}
+	if err := json.Unmarshal(rw.Body.Bytes(), &body); err != nil {
+		t.Fatal(err)
+	}
+	if body.Queue.MaxPendingRequests != 7 || body.Queue.MaxPendingRows != 11 || body.Queue.MaxPendingBytes != 13<<20 {
+		t.Fatalf("queue snapshot=%+v", body.Queue)
 	}
 }

--- a/fi-collector/config/collector.yaml
+++ b/fi-collector/config/collector.yaml
@@ -21,8 +21,8 @@ writer:
   # Local path inside the container; bind-mount to /var/lib/fi-collector
   # on the host in compose so a container restart preserves the queue.
   dead_letter_file: /var/lib/fi-collector/dead_letter.jsonl
-  # We default async_insert OFF — our own batching is the primary
-  # backpressure mechanism. Flip on under acute write spikes only.
+  # Must remain false: OTLP success is delayed until the canonical writer
+  # reaches a durable boundary, which wait_for_async_insert=0 cannot prove.
   async_insert: false
 
 server:
@@ -35,6 +35,13 @@ server:
   http_addr: ":4318"
   batch_max_rows: 5000
   batch_max_age: 5s
+  # Hard admission limits across queued plus canonical-writer in-flight work.
+  # Requests are accepted atomically; overload returns retryable OTLP errors.
+  max_pending_requests: 1000
+  max_pending_rows: 20000
+  max_pending_mib: 64
+  # Bounds decoded/converting handler concurrency across HTTP and gRPC.
+  max_concurrent_requests: 32
   # Max gRPC receive message size in MiB (FI_GRPC_MAX_RECV_MIB); 16 matches
   # the OTLP/HTTP body cap.
   grpc_max_recv_mib: 16

--- a/fi-collector/docker-compose.standalone.yml
+++ b/fi-collector/docker-compose.standalone.yml
@@ -65,6 +65,10 @@ services:
       FI_GRPC_ADDR: ":4317"
       FI_HTTP_ADDR: ":4318"
       FI_ADMIN_ADDR: ":9464"
+      FI_MAX_PENDING_REQUESTS: 1000
+      FI_MAX_PENDING_ROWS: 20000
+      FI_MAX_PENDING_MIB: 64
+      FI_MAX_CONCURRENT_REQUESTS: 32
       FI_DEAD_LETTER_FILE: /var/lib/fi-collector/dead_letter.jsonl
     ports:
       - "4317:4317"
@@ -88,6 +92,7 @@ services:
       # health-probe binary. For MVP just rely on the admin /healthz being
       # scraped from the host side.
       disable: true
+    stop_grace_period: 600s
 
 volumes:
   ch-data:

--- a/fi-collector/pkg/auth/auth_test.go
+++ b/fi-collector/pkg/auth/auth_test.go
@@ -933,17 +933,20 @@ func TestUsageEmitterEmitIngestionNil(t *testing.T) {
 }
 
 func TestBillingEventIDDeterministic(t *testing.T) {
-	a := billingEventID("trace-abc")
-	if a != billingEventID("trace-abc") {
+	a := billingEventID("org-1", "trace-abc")
+	if a != billingEventID("org-1", "trace-abc") {
 		t.Error("same dedupKey must yield the same event_id (re-poll must dedup, even across a mode flip)")
 	}
-	if billingEventID("trace-xyz") == a {
+	if billingEventID("org-1", "trace-xyz") == a {
 		t.Error("different dedupKey must yield distinct ids")
+	}
+	if billingEventID("org-2", "trace-abc") == a {
+		t.Error("the same dedupKey in different organizations must yield distinct ids")
 	}
 }
 
 func TestBillingEventIDEmptyKeyIsRandom(t *testing.T) {
-	if billingEventID("") == billingEventID("") {
+	if billingEventID("org-1", "") == billingEventID("org-1", "") {
 		t.Error("empty dedupKey must fall back to a random event_id (SDK batches)")
 	}
 }

--- a/fi-collector/pkg/auth/usage.go
+++ b/fi-collector/pkg/auth/usage.go
@@ -38,14 +38,14 @@ func NewUsageEmitter(rdb *redis.Client, pg *pgxpool.Pool, log *slog.Logger) *Usa
 // Namespace for deterministic billing event_ids (re-poll → same id → consumer dedups).
 var billingDedupNS = uuid.MustParse("a7c3e1f0-5d29-4b6a-8c14-9f2b0e6d3a71")
 
-// billingEventID is deterministic per dedupKey so re-polls dedup to a single
+// billingEventID is deterministic per org+dedupKey so re-polls dedup to a single
 // event even if the org's billing mode flips between polls; empty dedupKey →
 // random id (SDK batches don't re-poll).
-func billingEventID(dedupKey string) string {
+func billingEventID(orgID, dedupKey string) string {
 	if dedupKey == "" {
 		return uuid.New().String()
 	}
-	return uuid.NewSHA1(billingDedupNS, []byte(dedupKey)).String()
+	return uuid.NewSHA1(billingDedupNS, []byte(orgID+":"+dedupKey)).String()
 }
 
 // EmitIngestion records usage for the ONE dimension the org is billed on,
@@ -65,7 +65,7 @@ func (u *UsageEmitter) EmitIngestion(orgID string, numTraces, numSpans int, payl
 	if u.tracingBillingMode(ctx, orgID) == "storage" {
 		if payloadBytes > 0 {
 			u.xadd(ctx, map[string]any{
-				"event_id":   billingEventID(dedupKey),
+				"event_id":   billingEventID(orgID, dedupKey),
 				"org_id":     orgID,
 				"event_type": "observe_add",
 				"timestamp":  now,
@@ -80,7 +80,7 @@ func (u *UsageEmitter) EmitIngestion(orgID string, numTraces, numSpans int, payl
 	tracingUnits := numTraces + numSpans
 	if tracingUnits > 0 {
 		u.xadd(ctx, map[string]any{
-			"event_id":   billingEventID(dedupKey),
+			"event_id":   billingEventID(orgID, dedupKey),
 			"org_id":     orgID,
 			"event_type": "tracing_event",
 			"timestamp":  now,

--- a/fi-collector/pkg/chwriter/writer.go
+++ b/fi-collector/pkg/chwriter/writer.go
@@ -68,11 +68,12 @@ type Config struct {
 // function of curated-RMT outcomes and a curated outage can't trip the span
 // dead-letter alarm.
 type Stats struct {
-	BatchesInserted  uint64
-	RowsInserted     uint64
-	BatchesRetried   uint64
-	RowsDeadLettered uint64
-	BatchesFailed    uint64
+	BatchesInserted   uint64
+	RowsInserted      uint64
+	BatchesRetried    uint64
+	RowsDeadLettered  uint64
+	BatchesFailed     uint64
+	BatchesNotDurable uint64
 
 	// Best-effort curated-dimension path (end_users / trace_sessions).
 	CuratedBatchesInserted uint64
@@ -90,6 +91,16 @@ type Writer struct {
 	stats  Stats
 	rng    *rand.Rand
 	rngMu  sync.Mutex // rng isn't safe for concurrent use
+}
+
+// InsertOutcome describes whether the caller can safely acknowledge a batch.
+// A terminal ClickHouse failure is still durable when every row was fsynced to
+// the dead-letter file; Err remains populated so health and logs retain the
+// original failure signal.
+type InsertOutcome struct {
+	Durable      bool
+	DeadLettered bool
+	Err          error
 }
 
 // New constructs a Writer and validates the config. The file path of the
@@ -143,13 +154,23 @@ func New(cfg Config) (*Writer, error) {
 
 // Insert serialises `rows` to a single JSONEachRow request body and POSTs
 // with retry/backoff into the writer's PINNED table (cfg.Table — `spans`).
-// Returns nil on success (HTTP 200) OR on dead-letter (rows persisted to disk,
-// error returned for the caller's awareness).
+// It preserves the legacy error contract; callers that need to decide when an
+// upstream request is safe to acknowledge should use InsertWithOutcome.
 //
 // Caller owns `rows`. We do NOT mutate the slice; row maps are also not
 // mutated. Returning quickly on transient CH outages with successful
 // dead-letter is preferable to blocking the receiver loop indefinitely.
 func (w *Writer) Insert(ctx context.Context, rows []map[string]any) error {
+	return w.InsertWithOutcome(ctx, rows).Err
+}
+
+// InsertWithOutcome writes a canonical span batch and reports whether it is
+// durable either in ClickHouse or in the fsynced dead-letter file.
+func (w *Writer) InsertWithOutcome(ctx context.Context, rows []map[string]any) InsertOutcome {
+	if w.cfg.AsyncInsert {
+		atomic.AddUint64(&w.stats.BatchesNotDurable, 1)
+		return InsertOutcome{Err: fmt.Errorf("chwriter: async_insert cannot provide durable acknowledgements")}
+	}
 	// Hot path: use the pre-built URL (no per-batch string-concat).
 	return w.insert(ctx, w.url, rows)
 }
@@ -199,14 +220,15 @@ func (w *Writer) InsertBestEffort(ctx context.Context, table string, rows []map[
 // with retry/backoff → dead-letter on exhaustion. `url` selects the target
 // table. The curated path uses InsertBestEffort instead — single POST, no
 // retry, no dead-letter — so it deliberately does NOT share this.
-func (w *Writer) insert(ctx context.Context, url string, rows []map[string]any) error {
+func (w *Writer) insert(ctx context.Context, url string, rows []map[string]any) InsertOutcome {
 	if len(rows) == 0 {
-		return nil
+		return InsertOutcome{Durable: true}
 	}
 
 	body, err := encodeBatch(rows)
 	if err != nil {
-		return fmt.Errorf("chwriter: encode: %w", err)
+		atomic.AddUint64(&w.stats.BatchesNotDurable, 1)
+		return InsertOutcome{Err: fmt.Errorf("chwriter: encode: %w", err)}
 	}
 
 	var lastErr error
@@ -222,7 +244,7 @@ func (w *Writer) insert(ctx context.Context, url string, rows []map[string]any) 
 		if err == nil && status == http.StatusOK {
 			atomic.AddUint64(&w.stats.BatchesInserted, 1)
 			atomic.AddUint64(&w.stats.RowsInserted, uint64(len(rows)))
-			return nil
+			return InsertOutcome{Durable: true}
 		}
 		lastErr = err
 		// 4xx (except 429) is non-retryable — schema or data bug. Dead-letter
@@ -236,11 +258,16 @@ func (w *Writer) insert(ctx context.Context, url string, rows []map[string]any) 
 	// Exhausted retries — persist verbatim and surface error so the caller
 	// (and any /healthz reader) sees the failure.
 	if dlErr := w.appendDeadLetter(rows); dlErr != nil {
-		return fmt.Errorf("chwriter: terminal failure and dead-letter write failed: %v (original: %w)", dlErr, lastErr)
+		atomic.AddUint64(&w.stats.BatchesNotDurable, 1)
+		return InsertOutcome{Err: fmt.Errorf("chwriter: terminal failure and dead-letter write failed: %v (original: %w)", dlErr, lastErr)}
 	}
 	atomic.AddUint64(&w.stats.BatchesFailed, 1)
 	atomic.AddUint64(&w.stats.RowsDeadLettered, uint64(len(rows)))
-	return fmt.Errorf("chwriter: batch dead-lettered after %d attempts: %w", w.cfg.MaxRetries+1, lastErr)
+	return InsertOutcome{
+		Durable:      true,
+		DeadLettered: true,
+		Err:          fmt.Errorf("chwriter: batch dead-lettered after %d attempts: %w", w.cfg.MaxRetries+1, lastErr),
+	}
 }
 
 // insertURL builds an INSERT URL for an arbitrary table, mirroring the
@@ -359,6 +386,7 @@ func (w *Writer) Snapshot() Stats {
 		BatchesRetried:         atomic.LoadUint64(&w.stats.BatchesRetried),
 		RowsDeadLettered:       atomic.LoadUint64(&w.stats.RowsDeadLettered),
 		BatchesFailed:          atomic.LoadUint64(&w.stats.BatchesFailed),
+		BatchesNotDurable:      atomic.LoadUint64(&w.stats.BatchesNotDurable),
 		CuratedBatchesInserted: atomic.LoadUint64(&w.stats.CuratedBatchesInserted),
 		CuratedBatchesFailed:   atomic.LoadUint64(&w.stats.CuratedBatchesFailed),
 	}

--- a/fi-collector/pkg/chwriter/writer_test.go
+++ b/fi-collector/pkg/chwriter/writer_test.go
@@ -132,6 +132,69 @@ func TestInsert4xxDeadLettersWithoutRetry(t *testing.T) {
 	}
 }
 
+func TestInsertWithOutcomeReportsClickHouseDurability(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+	w, _ := New(mkConfig(t, srv.URL))
+	defer w.Close()
+
+	outcome := w.InsertWithOutcome(context.Background(), []map[string]any{{"id": "s1"}})
+	if !outcome.Durable || outcome.DeadLettered || outcome.Err != nil {
+		t.Fatalf("outcome=%+v, want durable ClickHouse success", outcome)
+	}
+}
+
+func TestInsertWithOutcomeReportsDurableDeadLetter(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "bad schema", http.StatusBadRequest)
+	}))
+	defer srv.Close()
+	w, _ := New(mkConfig(t, srv.URL))
+	defer w.Close()
+
+	outcome := w.InsertWithOutcome(context.Background(), []map[string]any{{"id": "s1"}})
+	if !outcome.Durable || !outcome.DeadLettered || outcome.Err == nil {
+		t.Fatalf("outcome=%+v, want durable dead-letter failure", outcome)
+	}
+}
+
+func TestInsertWithOutcomeReportsDeadLetterFailureAsNotDurable(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "bad schema", http.StatusBadRequest)
+	}))
+	defer srv.Close()
+	cfg := mkConfig(t, srv.URL)
+	cfg.DeadLetterFile = t.TempDir() // opening a directory as a file must fail
+	w, _ := New(cfg)
+	defer w.Close()
+
+	outcome := w.InsertWithOutcome(context.Background(), []map[string]any{{"id": "s1"}})
+	if outcome.Durable || outcome.DeadLettered || outcome.Err == nil {
+		t.Fatalf("outcome=%+v, want non-durable dead-letter failure", outcome)
+	}
+	if w.Snapshot().BatchesNotDurable != 1 {
+		t.Fatalf("BatchesNotDurable=%d, want 1", w.Snapshot().BatchesNotDurable)
+	}
+}
+
+func TestInsertWithOutcomeRejectsAsyncInsert(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Error("durable writer must not send wait_for_async_insert=0 requests")
+	}))
+	defer srv.Close()
+	cfg := mkConfig(t, srv.URL)
+	cfg.AsyncInsert = true
+	w, _ := New(cfg)
+	defer w.Close()
+
+	outcome := w.InsertWithOutcome(context.Background(), []map[string]any{{"id": "s1"}})
+	if outcome.Durable || outcome.Err == nil {
+		t.Fatalf("outcome=%+v, want async insert rejection", outcome)
+	}
+}
+
 func TestInsertEmptyBatchNoop(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		t.Error("server should not be called on empty batch")

--- a/fi-collector/pkg/server/server.go
+++ b/fi-collector/pkg/server/server.go
@@ -16,6 +16,7 @@ package server
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"log/slog"
@@ -30,19 +31,79 @@ import (
 	"github.com/future-agi/future-agi/fi-collector/pkg/chwriter"
 	"github.com/future-agi/future-agi/fi-collector/pkg/curatedwriter"
 	"go.opentelemetry.io/collector/pdata/ptrace/ptraceotlp"
+	"google.golang.org/genproto/googleapis/rpc/errdetails"
+	statuspb "google.golang.org/genproto/googleapis/rpc/status"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/stats"
 	"google.golang.org/grpc/status"
+	"google.golang.org/grpc/tap"
+	"google.golang.org/protobuf/encoding/protojson"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/durationpb"
 )
 
 // Config is what main() passes us. Public fields = YAML wire format.
 type Config struct {
-	GRPCAddr       string        `yaml:"grpc_addr"`         // :4317 default
-	HTTPAddr       string        `yaml:"http_addr"`         // :4318 default; empty disables
-	BatchMaxRows   int           `yaml:"batch_max_rows"`    // flush after N rows
-	BatchMaxAge    time.Duration `yaml:"batch_max_age"`     // flush after X time
-	GRPCMaxRecvMiB int           `yaml:"grpc_max_recv_mib"` // max gRPC message size in MiB; default + rationale in New()
+	GRPCAddr              string        `yaml:"grpc_addr"`               // :4317 default
+	HTTPAddr              string        `yaml:"http_addr"`               // :4318 default; empty disables
+	BatchMaxRows          int           `yaml:"batch_max_rows"`          // flush after N rows
+	BatchMaxAge           time.Duration `yaml:"batch_max_age"`           // flush after X time
+	GRPCMaxRecvMiB        int           `yaml:"grpc_max_recv_mib"`       // max gRPC message size in MiB; default + rationale in New()
+	MaxPendingRequests    int           `yaml:"max_pending_requests"`    // queued + canonical-writer in-flight requests
+	MaxPendingRows        int           `yaml:"max_pending_rows"`        // queued + canonical-writer in-flight rows
+	MaxPendingMiB         int           `yaml:"max_pending_mib"`         // queued + canonical-writer in-flight payload MiB
+	MaxConcurrentRequests int           `yaml:"max_concurrent_requests"` // shared HTTP + gRPC handler limit
+}
+
+var (
+	errQueueFull       = errors.New("collector queue is full")
+	errRequestTooLarge = errors.New("request exceeds collector queue capacity")
+	errShuttingDown    = errors.New("collector is shutting down")
+)
+
+const overloadRetryDelay = time.Second
+const otlpTraceExportMethod = "/opentelemetry.proto.collector.trace.v1.TraceService/Export"
+const usageWorkerCount = 16
+
+type pendingRequest struct {
+	rows  int
+	bytes int64
+	usage *usageRecord
+	done  chan chwriter.InsertOutcome
+}
+
+type admissionReservation struct {
+	rows  int
+	bytes int64
+}
+
+type receiverTicket struct {
+	server *Server
+	once   sync.Once
+}
+
+type receiverTicketKey struct{}
+
+// QueueStats is a consistent snapshot of bounded admission state.
+type QueueStats struct {
+	Accepting            bool   `json:"accepting"`
+	PendingRequests      int    `json:"pending_requests"`
+	PendingRows          int    `json:"pending_rows"`
+	PendingBytes         int64  `json:"pending_bytes"`
+	ReservedRequests     int    `json:"reserved_requests"`
+	ReservedRows         int    `json:"reserved_rows"`
+	ReservedBytes        int64  `json:"reserved_bytes"`
+	InFlightRequests     int    `json:"in_flight_requests"`
+	InFlightRows         int    `json:"in_flight_rows"`
+	InFlightBytes        int64  `json:"in_flight_bytes"`
+	MaxPendingRequests   int    `json:"max_pending_requests"`
+	MaxPendingRows       int    `json:"max_pending_rows"`
+	MaxPendingBytes      int64  `json:"max_pending_bytes"`
+	RejectedQueueFull    uint64 `json:"rejected_queue_full"`
+	RejectedTooLarge     uint64 `json:"rejected_too_large"`
+	RejectedShuttingDown uint64 `json:"rejected_shutting_down"`
+	UsageEventsDropped   uint64 `json:"usage_events_dropped"`
 }
 
 // Server owns the gRPC + HTTP OTLP listeners and the batch flusher goroutine.
@@ -52,16 +113,18 @@ type Config struct {
 // the only difference: gRPC uses the generated stub; HTTP accepts
 // `application/x-protobuf` and `application/json` per the OTLP/HTTP spec.
 type Server struct {
-	cfg      Config
-	writer   *chwriter.Writer
-	curated  *curatedwriter.Writer // CH-derived dimensions dual-write (P3b step2 HALF 2)
-	auth     *auth.Authenticator
-	usage    UsageEmitter
-	metering Metering
-	log      *slog.Logger
-	pricer   chexp.Pricer
-	grpc     *grpc.Server
-	httpd    *http.Server
+	cfg         Config
+	writer      *chwriter.Writer
+	curated     *curatedwriter.Writer // CH-derived dimensions dual-write (P3b step2 HALF 2)
+	auth        *auth.Authenticator
+	usage       UsageEmitter
+	metering    Metering
+	log         *slog.Logger
+	pricer      chexp.Pricer
+	grpc        *grpc.Server
+	httpd       *http.Server
+	receiverSem chan struct{}
+	receiverWG  sync.WaitGroup
 
 	// Batching: the receiver handler pushes converted rows onto `pending` and
 	// signals via `pendCh`. A single flusher goroutine drains it on either
@@ -74,13 +137,31 @@ type Server struct {
 	// trace_sessions best-effort insert — bounding the curated latency and
 	// avoiding many tiny RMT parts. It rides the same lock + flush cycle as
 	// `pend` so the curated dual-write flushes with the span batch.
-	pendMu      sync.Mutex
-	pend        []map[string]any
-	pendCurated *curatedwriter.Batch
-	pendCh      chan struct{}
+	pendMu           sync.Mutex
+	drainMu          sync.Mutex
+	accepting        bool
+	pend             []map[string]any
+	pendCurated      *curatedwriter.Batch
+	pendRequests     []pendingRequest
+	pendingRows      int
+	pendingBytes     int64
+	reservedRequests int
+	reservedRows     int
+	reservedBytes    int64
+	inFlightRequests int
+	inFlightRows     int
+	inFlightBytes    int64
+	rejectedFull     uint64
+	rejectedLarge    uint64
+	rejectedStopping uint64
+	usageDropped     uint64
+	pendCh           chan struct{}
 
-	stopCh chan struct{}
-	wg     sync.WaitGroup
+	stopCh        chan struct{}
+	shutdownOnce  sync.Once
+	reservationWG sync.WaitGroup
+	usageCh       chan *usageRecord
+	wg            sync.WaitGroup
 }
 
 // Option configures optional Server dependencies.
@@ -102,6 +183,8 @@ func WithPricer(p chexp.Pricer) Option { return Option{pricer: p} }
 //   - GRPCAddr ":4317" (OTLP gRPC). Set to "" to disable.
 //   - HTTPAddr ":4318" (OTLP/HTTP). Set to "" to disable.
 //   - BatchMaxRows 5000, BatchMaxAge 5s.
+//   - MaxPendingRequests 1000, MaxPendingRows 20000, MaxPendingMiB 64.
+//   - MaxConcurrentRequests 32.
 //
 // At least one of GRPCAddr / HTTPAddr must be non-empty or Run returns an
 // error. We default both ON because every supported SDK picks one of them;
@@ -128,6 +211,24 @@ func New(cfg Config, writer *chwriter.Writer, authenticator *auth.Authenticator,
 	if cfg.GRPCMaxRecvMiB > 1024 {
 		cfg.GRPCMaxRecvMiB = 1024 // keep the <<20 shift well under proto's 2 GiB ceiling
 	}
+	if cfg.MaxPendingRequests <= 0 {
+		cfg.MaxPendingRequests = 1000
+	}
+	if cfg.MaxPendingRows <= 0 {
+		cfg.MaxPendingRows = 20000
+	}
+	if cfg.MaxPendingMiB <= 0 {
+		cfg.MaxPendingMiB = 64
+	}
+	if cfg.MaxPendingMiB > 4096 {
+		cfg.MaxPendingMiB = 4096
+	}
+	if cfg.MaxConcurrentRequests <= 0 {
+		cfg.MaxConcurrentRequests = 32
+	}
+	if cfg.MaxConcurrentRequests > cfg.MaxPendingRequests {
+		cfg.MaxConcurrentRequests = cfg.MaxPendingRequests
+	}
 
 	log := slog.Default()
 	var pricer chexp.Pricer
@@ -153,45 +254,65 @@ func New(cfg Config, writer *chwriter.Writer, authenticator *auth.Authenticator,
 		// single POST, no retry, no dead-letter) so it can't stall the span flush
 		// loop or pollute the span dead-letter. Targets end_users /
 		// trace_sessions, never the pinned span table.
-		curated: curatedwriter.New(writer),
-		pendCh:  make(chan struct{}, 1),
-		stopCh:  make(chan struct{}),
+		curated:     curatedwriter.New(writer),
+		accepting:   true,
+		receiverSem: make(chan struct{}, cfg.MaxConcurrentRequests),
+		usageCh:     make(chan *usageRecord, cfg.MaxPendingRequests),
+		pendCh:      make(chan struct{}, 1),
+		stopCh:      make(chan struct{}),
 	}
 	return s
 }
 
-// Run blocks until ctx is cancelled or a serve error occurs. On shutdown
-// we drain pending rows once before returning so an SIGTERM doesn't lose
-// the in-flight batch (DECISIONS: in-flight loss bounded to last 5 s as
-// the deliberate at-least-once boundary).
+// Run blocks until ctx is cancelled or a serve error occurs. On shutdown it
+// stops admission first, lets active handlers finish, then drains any accepted
+// batch before returning.
 func (s *Server) Run(ctx context.Context) error {
 	if s.cfg.GRPCAddr == "" && s.cfg.HTTPAddr == "" {
 		return fmt.Errorf("at least one of GRPCAddr / HTTPAddr must be set")
 	}
 
-	// One error channel sized for both listeners — first error wins, the
-	// other listener is shut down by the select-case below.
+	// Bind every configured listener before serving any traffic. Otherwise a
+	// successful gRPC bind followed by an HTTP bind failure can accept exports
+	// before the flusher exists and then strand them during startup rollback.
 	serveErr := make(chan error, 2)
+	var grpcLis, httpLis net.Listener
 
 	if s.cfg.GRPCAddr != "" {
 		lis, err := net.Listen("tcp", s.cfg.GRPCAddr)
 		if err != nil {
 			return fmt.Errorf("listen grpc %s: %w", s.cfg.GRPCAddr, err)
 		}
+		grpcLis = lis
+	}
+	if s.cfg.HTTPAddr != "" {
+		lis, err := net.Listen("tcp", s.cfg.HTTPAddr)
+		if err != nil {
+			if grpcLis != nil {
+				_ = grpcLis.Close()
+			}
+			return fmt.Errorf("listen http %s: %w", s.cfg.HTTPAddr, err)
+		}
+		httpLis = lis
+	}
+
+	if grpcLis != nil {
 		s.log.Info("grpc listener", "addr", s.cfg.GRPCAddr, "max_recv_mib", s.cfg.GRPCMaxRecvMiB)
 		grpcOpts := []grpc.ServerOption{
 			grpc.MaxRecvMsgSize(s.cfg.GRPCMaxRecvMiB << 20),
 			grpc.StatsHandler(&grpcErrLogger{log: s.log}),
+			grpc.InTapHandle(s.receiverTap),
 		}
+		interceptors := []grpc.UnaryServerInterceptor{s.receiverInterceptor()}
 		if s.auth != nil {
-			grpcOpts = append(grpcOpts, grpc.UnaryInterceptor(s.auth.GRPCInterceptor()))
+			interceptors = append(interceptors, s.auth.GRPCInterceptor())
 		}
+		grpcOpts = append(grpcOpts, grpc.ChainUnaryInterceptor(interceptors...))
 		s.grpc = grpc.NewServer(grpcOpts...)
 		ptraceotlp.RegisterGRPCServer(s.grpc, &otlpHandler{s: s})
-		go func() { serveErr <- s.grpc.Serve(lis) }()
 	}
 
-	if s.cfg.HTTPAddr != "" {
+	if httpLis != nil {
 		mux := http.NewServeMux()
 		// OTLP/HTTP wire spec: a single endpoint per signal. `/v1/traces` is
 		// the trace signal — POST only, body is a serialised
@@ -210,19 +331,21 @@ func (s *Server) Run(ctx context.Context) error {
 			Addr:              s.cfg.HTTPAddr,
 			Handler:           handler,
 			ReadHeaderTimeout: 10 * time.Second,
+			ReadTimeout:       30 * time.Second,
 		}
-		lis, err := net.Listen("tcp", s.cfg.HTTPAddr)
-		if err != nil {
-			if s.grpc != nil {
-				s.grpc.GracefulStop()
-			}
-			return fmt.Errorf("listen http %s: %w", s.cfg.HTTPAddr, err)
-		}
-		go func() { serveErr <- s.httpd.Serve(lis) }()
 	}
 
-	s.wg.Add(1)
+	s.wg.Add(1 + usageWorkerCount)
 	go s.flushLoop()
+	for i := 0; i < usageWorkerCount; i++ {
+		go s.usageLoop()
+	}
+	if s.grpc != nil {
+		go func() { serveErr <- s.grpc.Serve(grpcLis) }()
+	}
+	if s.httpd != nil {
+		go func() { serveErr <- s.httpd.Serve(httpLis) }()
+	}
 
 	select {
 	case <-ctx.Done():
@@ -237,21 +360,43 @@ func (s *Server) Run(ctx context.Context) error {
 	}
 }
 
-// shutdown stops both listeners, waits for the flusher to exit, drains the
-// in-flight batch. Called once from Run on either ctx cancel or a serve
-// error. Safe to call when one of grpc/httpd is nil.
+// shutdown stops admission, drains accepted work, and is safe to call when one
+// of grpc/httpd is nil. shutdownOnce also makes it safe for repeated callers.
 func (s *Server) shutdown() {
-	if s.grpc != nil {
-		s.grpc.GracefulStop()
-	}
-	if s.httpd != nil {
-		shCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-		defer cancel()
-		_ = s.httpd.Shutdown(shCtx)
-	}
-	close(s.stopCh)
-	s.wg.Wait()
-	s.drainNow(context.Background())
+	s.shutdownOnce.Do(func() {
+		s.pendMu.Lock()
+		s.accepting = false
+		s.pendMu.Unlock()
+		s.kickFlusher()
+
+		var listenerWG sync.WaitGroup
+		if s.grpc != nil {
+			listenerWG.Add(1)
+			go func() {
+				defer listenerWG.Done()
+				s.grpc.GracefulStop()
+			}()
+		}
+		if s.httpd != nil {
+			listenerWG.Add(1)
+			go func() {
+				defer listenerWG.Done()
+				shCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+				defer cancel()
+				if err := s.httpd.Shutdown(shCtx); err != nil {
+					_ = s.httpd.Close()
+				}
+			}()
+		}
+		listenerWG.Wait()
+		s.receiverWG.Wait()
+		s.reservationWG.Wait()
+		s.kickFlusher()
+		close(s.stopCh)
+		s.drainNow(context.Background())
+		close(s.usageCh)
+		s.wg.Wait()
+	})
 }
 
 // grpcErrLogger surfaces transport-level message-size rejections. A message
@@ -284,7 +429,11 @@ func (h *grpcErrLogger) TagRPC(ctx context.Context, info *stats.RPCTagInfo) cont
 
 func (h *grpcErrLogger) HandleRPC(ctx context.Context, s stats.RPCStats) {
 	end, ok := s.(*stats.End)
-	if !ok || end.Error == nil {
+	if !ok {
+		return
+	}
+	releaseReceiverFromContext(ctx)
+	if end.Error == nil {
 		return
 	}
 	st, _ := status.FromError(end.Error)
@@ -330,14 +479,31 @@ func (h *otlpHandler) Export(ctx context.Context, req ptraceotlp.ExportRequest) 
 		}
 	}
 
+	payloadBytes, _ := req.MarshalProto()
+	reservation, err := h.s.reserve(req.Traces().SpanCount(), int64(len(payloadBytes)))
+	if err != nil {
+		return ptraceotlp.NewExportResponse(), grpcAdmissionError(err)
+	}
 	rows, ids, err := chexp.ConvertWithIdentities(ctx, req.Traces(), h.s.pricer)
 	if err != nil {
-		return ptraceotlp.NewExportResponse(), err
+		h.s.releaseReservation(reservation)
+		return ptraceotlp.NewExportResponse(), status.Errorf(codes.InvalidArgument, "convert: %v", err)
 	}
-	h.s.enqueue(rows, ids)
 
-	payloadBytes, _ := req.MarshalProto()
-	h.s.emitUsage(ctx, req.Traces(), int64(len(payloadBytes)))
+	usage := usageFromContext(ctx, req.Traces(), payloadBytes)
+	done, err := h.s.commitReservation(reservation, rows, ids, usage)
+	if err != nil {
+		return ptraceotlp.NewExportResponse(), grpcAdmissionError(err)
+	}
+	releaseReceiverFromContext(ctx)
+	select {
+	case outcome := <-done:
+		if !outcome.Durable {
+			return ptraceotlp.NewExportResponse(), grpcRetryableError("collector could not durably accept batch")
+		}
+	case <-ctx.Done():
+		return ptraceotlp.NewExportResponse(), status.FromContextError(ctx.Err()).Err()
+	}
 
 	return ptraceotlp.NewExportResponse(), nil
 }
@@ -365,7 +531,6 @@ func (s *Server) handleHTTPTraces(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
 		return
 	}
-
 	ct := r.Header.Get("Content-Type")
 	// Strip any `;charset=...` suffix. The spec only mentions the two base
 	// types but charset is allowed and common (esp. from JSON clients).
@@ -373,6 +538,12 @@ func (s *Server) handleHTTPTraces(w http.ResponseWriter, r *http.Request) {
 		ct = ct[:i]
 	}
 	ct = trimSpace(ct)
+	ticket, err := s.tryAcquireReceiver()
+	if err != nil {
+		s.writeHTTPAdmissionError(w, ct, err)
+		return
+	}
+	defer ticket.release()
 
 	body, err := io.ReadAll(io.LimitReader(r.Body, maxOTLPHTTPBodyBytes+1))
 	if err != nil {
@@ -425,15 +596,35 @@ func (s *Server) handleHTTPTraces(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
+	reservation, err := s.reserve(req.Traces().SpanCount(), int64(len(body)))
+	if err != nil {
+		s.writeHTTPAdmissionError(w, ct, err)
+		return
+	}
 	rows, ids, err := chexp.ConvertWithIdentities(r.Context(), req.Traces(), s.pricer)
 	if err != nil {
+		s.releaseReservation(reservation)
 		// 4xx — the SDK shouldn't retry a malformed conversion.
 		http.Error(w, "convert: "+err.Error(), http.StatusBadRequest)
 		return
 	}
-	s.enqueue(rows, ids)
-
-	s.emitUsage(r.Context(), req.Traces(), int64(len(body)))
+	usage := usageFromContext(r.Context(), req.Traces(), body)
+	done, err := s.commitReservation(reservation, rows, ids, usage)
+	if err != nil {
+		s.writeHTTPAdmissionError(w, ct, err)
+		return
+	}
+	ticket.release()
+	select {
+	case outcome := <-done:
+		if !outcome.Durable {
+			w.Header().Set("Retry-After", "1")
+			writeOTLPHTTPError(w, ct, http.StatusServiceUnavailable, codes.Unavailable, "collector could not durably accept batch")
+			return
+		}
+	case <-r.Context().Done():
+		return
+	}
 
 	// Empty ExportTraceServiceResponse — same wire shape, encoded to match
 	// the request's content-type. The spec requires the response media type
@@ -453,6 +644,59 @@ func (s *Server) handleHTTPTraces(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", ct)
 	w.WriteHeader(http.StatusOK)
 	_, _ = w.Write(out)
+}
+
+func (s *Server) tryAcquireReceiver() (*receiverTicket, error) {
+	s.pendMu.Lock()
+	if !s.accepting {
+		s.rejectedStopping++
+		s.pendMu.Unlock()
+		return nil, errShuttingDown
+	}
+	select {
+	case s.receiverSem <- struct{}{}:
+		s.receiverWG.Add(1)
+		s.pendMu.Unlock()
+		return &receiverTicket{server: s}, nil
+	default:
+		s.rejectedFull++
+		s.pendMu.Unlock()
+		return nil, errQueueFull
+	}
+}
+
+func (t *receiverTicket) release() {
+	if t == nil {
+		return
+	}
+	t.once.Do(func() {
+		<-t.server.receiverSem
+		t.server.receiverWG.Done()
+	})
+}
+
+func (s *Server) receiverTap(ctx context.Context, info *tap.Info) (context.Context, error) {
+	if info.FullMethodName != otlpTraceExportMethod {
+		return ctx, nil
+	}
+	ticket, err := s.tryAcquireReceiver()
+	if err != nil {
+		return ctx, grpcAdmissionError(err)
+	}
+	return context.WithValue(ctx, receiverTicketKey{}, ticket), nil
+}
+
+func (s *Server) receiverInterceptor() grpc.UnaryServerInterceptor {
+	return func(ctx context.Context, req any, _ *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (any, error) {
+		ticket, _ := ctx.Value(receiverTicketKey{}).(*receiverTicket)
+		defer ticket.release()
+		return handler(ctx, req)
+	}
+}
+
+func releaseReceiverFromContext(ctx context.Context) {
+	ticket, _ := ctx.Value(receiverTicketKey{}).(*receiverTicket)
+	ticket.release()
 }
 
 // indexByte and trimSpace are lifted here so the file doesn't grow a
@@ -477,32 +721,122 @@ func trimSpace(s string) string {
 	return s
 }
 
-// enqueue parks rows on the pending buffer and signals the flusher.
-// We choose non-blocking signalling: if the channel already holds a tick
-// the flusher will already wake up and see this batch.
+// enqueue is the white-box convenience path for already-converted rows. OTLP
+// handlers reserve capacity before conversion and call commitReservation.
 //
 // `ids` are the CURATED dimension identities collected for this same payload;
 // they ride alongside `rows` so the curated dual-write flushes with the span
 // batch. A nil / empty Batch is skipped (the common no-user/no-session case).
-func (s *Server) enqueue(rows []map[string]any, ids *curatedwriter.Batch) {
-	if len(rows) == 0 {
+func (s *Server) enqueue(rows []map[string]any, ids *curatedwriter.Batch, payloadBytes int64, usage *usageRecord) (<-chan chwriter.InsertOutcome, error) {
+	reservation, err := s.reserve(len(rows), payloadBytes)
+	if err != nil {
+		return nil, err
+	}
+	return s.commitReservation(reservation, rows, ids, usage)
+}
+
+// reserve atomically claims queue capacity before conversion expands pdata
+// into row maps. This bounds the admitted conversion work as well as queued
+// and canonical-writer in-flight batches.
+func (s *Server) reserve(rows int, payloadBytes int64) (*admissionReservation, error) {
+	s.pendMu.Lock()
+	if !s.accepting {
+		s.rejectedStopping++
+		s.pendMu.Unlock()
+		return nil, errShuttingDown
+	}
+	if rows == 0 {
+		s.pendMu.Unlock()
+		return &admissionReservation{}, nil
+	}
+	maxBytes := int64(s.cfg.MaxPendingMiB) << 20
+	if rows > s.cfg.MaxPendingRows || payloadBytes > maxBytes {
+		s.rejectedLarge++
+		s.pendMu.Unlock()
+		return nil, errRequestTooLarge
+	}
+	activeRequests := len(s.pendRequests) + s.reservedRequests + s.inFlightRequests
+	activeRows := s.pendingRows + s.reservedRows + s.inFlightRows
+	activeBytes := s.pendingBytes + s.reservedBytes + s.inFlightBytes
+	if activeRequests >= s.cfg.MaxPendingRequests ||
+		activeRows > s.cfg.MaxPendingRows-rows ||
+		activeBytes > maxBytes-payloadBytes {
+		s.rejectedFull++
+		s.pendMu.Unlock()
+		s.kickFlusher()
+		return nil, errQueueFull
+	}
+	s.reservedRequests++
+	s.reservedRows += rows
+	s.reservedBytes += payloadBytes
+	s.reservationWG.Add(1)
+	s.pendMu.Unlock()
+	return &admissionReservation{rows: rows, bytes: payloadBytes}, nil
+}
+
+func (s *Server) releaseReservation(reservation *admissionReservation) {
+	if reservation == nil || reservation.rows == 0 {
 		return
 	}
 	s.pendMu.Lock()
+	s.reservedRequests--
+	s.reservedRows -= reservation.rows
+	s.reservedBytes -= reservation.bytes
+	s.pendMu.Unlock()
+	s.reservationWG.Done()
+}
+
+func (s *Server) commitReservation(reservation *admissionReservation, rows []map[string]any, ids *curatedwriter.Batch, usage *usageRecord) (<-chan chwriter.InsertOutcome, error) {
+	done := make(chan chwriter.InsertOutcome, 1)
+	if len(rows) == 0 {
+		s.releaseReservation(reservation)
+		done <- chwriter.InsertOutcome{Durable: true}
+		return done, nil
+	}
+	s.pendMu.Lock()
+	if reservation == nil || reservation.rows == 0 {
+		s.pendMu.Unlock()
+		return nil, errors.New("missing queue reservation")
+	}
+	if len(rows) > reservation.rows {
+		// Converter output is expected to be at most one row per input span.
+		// Fail closed rather than let a changed converter violate admission.
+		s.reservedRequests--
+		s.reservedRows -= reservation.rows
+		s.reservedBytes -= reservation.bytes
+		s.rejectedLarge++
+		s.pendMu.Unlock()
+		s.reservationWG.Done()
+		return nil, errRequestTooLarge
+	}
+	s.reservedRequests--
+	s.reservedRows -= reservation.rows
+	s.reservedBytes -= reservation.bytes
 	s.pend = append(s.pend, rows...)
+	s.pendRequests = append(s.pendRequests, pendingRequest{
+		rows: len(rows), bytes: reservation.bytes, usage: usage, done: done,
+	})
+	s.pendingRows += len(rows)
+	s.pendingBytes += reservation.bytes
 	if ids != nil && !ids.Empty() {
 		if s.pendCurated == nil {
 			s.pendCurated = curatedwriter.NewBatch()
 		}
 		s.pendCurated.Merge(ids)
 	}
-	shouldKick := len(s.pend) >= s.cfg.BatchMaxRows
+	shouldKick := len(s.pend) >= s.cfg.BatchMaxRows || !s.accepting
 	s.pendMu.Unlock()
+	s.reservationWG.Done()
 	if shouldKick {
-		select {
-		case s.pendCh <- struct{}{}:
-		default:
-		}
+		s.kickFlusher()
+	}
+	return done, nil
+}
+
+func (s *Server) kickFlusher() {
+	select {
+	case s.pendCh <- struct{}{}:
+	default:
 	}
 }
 
@@ -527,20 +861,63 @@ func (s *Server) flushLoop() {
 // drainNow swaps the pending buffer and flushes it. Uses a fresh slice so
 // the next request can immediately start filling without contending.
 func (s *Server) drainNow(ctx context.Context) {
+	s.drainMu.Lock()
+	defer s.drainMu.Unlock()
+
 	s.pendMu.Lock()
 	batch := s.pend
 	curated := s.pendCurated
+	requests := s.pendRequests
+	batchRows := s.pendingRows
+	batchBytes := s.pendingBytes
 	s.pend = nil
 	s.pendCurated = nil
+	s.pendRequests = nil
+	s.pendingRows = 0
+	s.pendingBytes = 0
+	s.inFlightRequests += len(requests)
+	s.inFlightRows += batchRows
+	s.inFlightBytes += batchBytes
 	s.pendMu.Unlock()
 	if len(batch) == 0 {
 		return
 	}
-	_ = s.writer.Insert(ctx, batch)
-	// Insert returns an error on dead-letter; the writer already persisted
-	// the rows + bumped stats. We swallow here because the flusher's job
-	// is to make progress, not propagate per-batch failures. /healthz
-	// surfaces the writer's failure counter.
+	outcome := s.writer.InsertWithOutcome(ctx, batch)
+	if outcome.Err != nil {
+		level := slog.LevelError
+		if outcome.Durable {
+			level = slog.LevelWarn
+		}
+		s.log.Log(ctx, level, "canonical span batch write failed",
+			"durable", outcome.Durable, "dead_lettered", outcome.DeadLettered, "err", outcome.Err)
+	}
+
+	s.pendMu.Lock()
+	s.inFlightRequests -= len(requests)
+	s.inFlightRows -= batchRows
+	s.inFlightBytes -= batchBytes
+	s.pendMu.Unlock()
+	for _, request := range requests {
+		request.done <- outcome
+	}
+	if outcome.Durable {
+		// Billing is deliberately outside the canonical flusher and request
+		// lifecycle. A client cancellation after durable acceptance must neither
+		// block ingestion nor skip usage; payload-based IDs deduplicate retries.
+		for _, request := range requests {
+			if request.usage == nil {
+				continue
+			}
+			select {
+			case s.usageCh <- request.usage:
+			default:
+				s.pendMu.Lock()
+				s.usageDropped++
+				s.pendMu.Unlock()
+				s.log.Warn("usage queue full; ingestion usage event dropped", "org_id", request.usage.orgID)
+			}
+		}
+	}
 
 	// CH-derived dimensions (P3b step2 HALF 2): BEST-EFFORT mirror the
 	// drain-scoped curated end_users / trace_sessions identities AFTER the span
@@ -550,7 +927,95 @@ func (s *Server) drainNow(ctx context.Context) {
 	// span dead-letter. The result is swallowed — the span insert above already
 	// completed and Django's backfill reconciles any curated gap. One `now`
 	// stamps version/first_seen for every curated row in this drain.
-	if curated != nil && !curated.Empty() {
+	s.pendMu.Lock()
+	accepting := s.accepting
+	s.pendMu.Unlock()
+	if accepting && curated != nil && !curated.Empty() {
 		_ = s.curated.Write(ctx, curated, time.Now().UTC())
 	}
+}
+
+func (s *Server) usageLoop() {
+	defer s.wg.Done()
+	for record := range s.usageCh {
+		s.emitUsage(record)
+	}
+}
+
+// QueueSnapshot returns bounded admission state for health and diagnostics.
+func (s *Server) QueueSnapshot() QueueStats {
+	s.pendMu.Lock()
+	defer s.pendMu.Unlock()
+	return QueueStats{
+		Accepting:            s.accepting,
+		PendingRequests:      len(s.pendRequests),
+		PendingRows:          s.pendingRows,
+		PendingBytes:         s.pendingBytes,
+		ReservedRequests:     s.reservedRequests,
+		ReservedRows:         s.reservedRows,
+		ReservedBytes:        s.reservedBytes,
+		InFlightRequests:     s.inFlightRequests,
+		InFlightRows:         s.inFlightRows,
+		InFlightBytes:        s.inFlightBytes,
+		MaxPendingRequests:   s.cfg.MaxPendingRequests,
+		MaxPendingRows:       s.cfg.MaxPendingRows,
+		MaxPendingBytes:      int64(s.cfg.MaxPendingMiB) << 20,
+		RejectedQueueFull:    s.rejectedFull,
+		RejectedTooLarge:     s.rejectedLarge,
+		RejectedShuttingDown: s.rejectedStopping,
+		UsageEventsDropped:   s.usageDropped,
+	}
+}
+
+func grpcAdmissionError(err error) error {
+	switch {
+	case errors.Is(err, errRequestTooLarge):
+		return status.Error(codes.ResourceExhausted, err.Error())
+	case errors.Is(err, errQueueFull), errors.Is(err, errShuttingDown):
+		return grpcRetryableError(err.Error())
+	default:
+		return status.Error(codes.Internal, err.Error())
+	}
+}
+
+func grpcRetryableError(message string) error {
+	st := status.New(codes.Unavailable, message)
+	withDetails, err := st.WithDetails(&errdetails.RetryInfo{RetryDelay: durationpb.New(overloadRetryDelay)})
+	if err != nil {
+		return st.Err()
+	}
+	return withDetails.Err()
+}
+
+func (s *Server) writeHTTPAdmissionError(w http.ResponseWriter, contentType string, err error) {
+	switch {
+	case errors.Is(err, errRequestTooLarge):
+		writeOTLPHTTPError(w, contentType, http.StatusRequestEntityTooLarge, codes.ResourceExhausted, err.Error())
+	case errors.Is(err, errQueueFull), errors.Is(err, errShuttingDown):
+		w.Header().Set("Retry-After", "1")
+		writeOTLPHTTPError(w, contentType, http.StatusServiceUnavailable, codes.Unavailable, err.Error())
+	default:
+		writeOTLPHTTPError(w, contentType, http.StatusInternalServerError, codes.Internal, err.Error())
+	}
+}
+
+func writeOTLPHTTPError(w http.ResponseWriter, contentType string, httpStatus int, code codes.Code, message string) {
+	body := &statuspb.Status{Code: int32(code), Message: message}
+	var (
+		encoded []byte
+		err     error
+	)
+	if contentType == "application/json" {
+		encoded, err = protojson.Marshal(body)
+	} else {
+		contentType = "application/x-protobuf"
+		encoded, err = proto.Marshal(body)
+	}
+	if err != nil {
+		http.Error(w, message, httpStatus)
+		return
+	}
+	w.Header().Set("Content-Type", contentType)
+	w.WriteHeader(httpStatus)
+	_, _ = w.Write(encoded)
 }

--- a/fi-collector/pkg/server/server_test.go
+++ b/fi-collector/pkg/server/server_test.go
@@ -3,6 +3,8 @@ package server
 import (
 	"bytes"
 	"context"
+	"encoding/json"
+	"errors"
 	"io"
 	"log/slog"
 	"net"
@@ -19,6 +21,7 @@ import (
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/ptrace"
 	"go.opentelemetry.io/collector/pdata/ptrace/ptraceotlp"
+	"google.golang.org/genproto/googleapis/rpc/errdetails"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials/insecure"
@@ -702,9 +705,9 @@ func TestDrainAggregatesCuratedAcrossPayloads(t *testing.T) {
 	r2a, ids2a, _ := chexp.ConvertWithIdentities(context.Background(), makeObserveTraces(proj, org, "userA", "sessX", 0x02), nil) // dup identity
 	r2b, ids2b, _ := chexp.ConvertWithIdentities(context.Background(), makeObserveTraces(proj, org, "userB", "sessY", 0x03), nil)
 
-	s.enqueue(r1, ids1)
-	s.enqueue(r2a, ids2a)
-	s.enqueue(r2b, ids2b)
+	_, _ = s.enqueue(r1, ids1, 1, nil)
+	_, _ = s.enqueue(r2a, ids2a, 1, nil)
+	_, _ = s.enqueue(r2b, ids2b, 1, nil)
 
 	// One drain → one span insert + one end_users + one trace_sessions.
 	s.drainNow(context.Background())
@@ -741,6 +744,344 @@ func TestDrainAggregatesCuratedAcrossPayloads(t *testing.T) {
 	}
 	if sessRows != 2 {
 		t.Errorf("trace_sessions rows: got %d want 2", sessRows)
+	}
+}
+
+func TestEnqueueRejectsAtomicallyAtRowLimit(t *testing.T) {
+	s := &Server{
+		cfg:       Config{MaxPendingRequests: 10, MaxPendingRows: 2, MaxPendingMiB: 1},
+		accepting: true,
+		pendCh:    make(chan struct{}, 1),
+	}
+	first := []map[string]any{{"id": "1"}}
+	second := []map[string]any{{"id": "2"}, {"id": "3"}}
+	if _, err := s.enqueue(first, nil, 10, nil); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := s.enqueue(second, nil, 10, nil); !errors.Is(err, errQueueFull) {
+		t.Fatalf("err=%v, want queue full", err)
+	}
+	stats := s.QueueSnapshot()
+	if stats.PendingRequests != 1 || stats.PendingRows != 1 {
+		t.Fatalf("partial admission: %+v", stats)
+	}
+	if len(s.pend) != 1 || s.pend[0]["id"] != "1" {
+		t.Fatalf("pending rows mutated by rejected request: %#v", s.pend)
+	}
+}
+
+func TestEnqueueRejectsSingleRequestLargerThanCapacity(t *testing.T) {
+	s := &Server{
+		cfg:       Config{MaxPendingRequests: 10, MaxPendingRows: 1, MaxPendingMiB: 1},
+		accepting: true,
+		pendCh:    make(chan struct{}, 1),
+	}
+	if _, err := s.enqueue([]map[string]any{{"id": "1"}, {"id": "2"}}, nil, 10, nil); !errors.Is(err, errRequestTooLarge) {
+		t.Fatalf("row limit err=%v, want request too large", err)
+	}
+	if _, err := s.enqueue([]map[string]any{{"id": "1"}}, nil, (1<<20)+1, nil); !errors.Is(err, errRequestTooLarge) {
+		t.Fatalf("byte limit err=%v, want request too large", err)
+	}
+}
+
+func TestCapacityIncludesInFlightAndReleasesAfterWrite(t *testing.T) {
+	started := make(chan struct{})
+	release := make(chan struct{})
+	chSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if insertTable(r) == "spans" {
+			close(started)
+			<-release
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer chSrv.Close()
+	w, _ := chwriter.New(chwriter.Config{
+		URL: chSrv.URL, Database: "default", Table: "spans", MaxRetries: 1,
+		InitialBackoff: time.Millisecond, MaxBackoff: time.Millisecond,
+		RequestTimeout: 2 * time.Second, DeadLetterFile: t.TempDir() + "/dl.jsonl",
+	})
+	s := New(Config{
+		BatchMaxRows: 100, BatchMaxAge: time.Hour,
+		MaxPendingRequests: 1, MaxPendingRows: 1, MaxPendingMiB: 1,
+	}, w, nil, nil, nil)
+	done, err := s.enqueue([]map[string]any{{"id": "1"}}, nil, 10, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	drained := make(chan struct{})
+	go func() {
+		s.drainNow(context.Background())
+		close(drained)
+	}()
+	<-started
+	if _, err := s.enqueue([]map[string]any{{"id": "2"}}, nil, 10, nil); !errors.Is(err, errQueueFull) {
+		t.Fatalf("in-flight admission err=%v, want queue full", err)
+	}
+	stats := s.QueueSnapshot()
+	if stats.InFlightRequests != 1 || stats.InFlightRows != 1 || stats.PendingRows != 0 {
+		t.Fatalf("bad in-flight accounting: %+v", stats)
+	}
+	close(release)
+	<-drained
+	if outcome := <-done; !outcome.Durable {
+		t.Fatalf("outcome=%+v, want durable", outcome)
+	}
+	if _, err := s.enqueue([]map[string]any{{"id": "2"}}, nil, 10, nil); err != nil {
+		t.Fatalf("capacity not released: %v", err)
+	}
+}
+
+func TestOTLPAcknowledgementWaitsForCanonicalWrite(t *testing.T) {
+	started := make(chan struct{})
+	release := make(chan struct{})
+	chSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if insertTable(r) == "spans" {
+			close(started)
+			<-release
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer chSrv.Close()
+	w, _ := chwriter.New(chwriter.Config{
+		URL: chSrv.URL, Database: "default", Table: "spans", MaxRetries: 1,
+		InitialBackoff: time.Millisecond, MaxBackoff: time.Millisecond,
+		RequestTimeout: 2 * time.Second, DeadLetterFile: t.TempDir() + "/dl.jsonl",
+	})
+	s := New(Config{BatchMaxRows: 1, BatchMaxAge: time.Hour}, w, nil, nil, nil)
+	s.wg.Add(1 + usageWorkerCount)
+	go s.flushLoop()
+	for i := 0; i < usageWorkerCount; i++ {
+		go s.usageLoop()
+	}
+	defer func() {
+		close(s.stopCh)
+		close(s.usageCh)
+		s.wg.Wait()
+	}()
+
+	returned := make(chan error, 1)
+	go func() {
+		req := ptraceotlp.NewExportRequestFromTraces(makeTraces("wait-for-durable", "33333333-3333-4333-8333-333333333333"))
+		_, err := (&otlpHandler{s: s}).Export(context.Background(), req)
+		returned <- err
+	}()
+	<-started
+	select {
+	case err := <-returned:
+		t.Fatalf("Export returned before canonical write completed: %v", err)
+	default:
+	}
+	close(release)
+	if err := <-returned; err != nil {
+		t.Fatalf("Export after durable write: %v", err)
+	}
+}
+
+func TestOTLPReturnsRetryableErrorWhenDeadLetterAlsoFails(t *testing.T) {
+	chSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if insertTable(r) == "spans" {
+			http.Error(w, "bad schema", http.StatusBadRequest)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer chSrv.Close()
+	w, _ := chwriter.New(chwriter.Config{
+		URL: chSrv.URL, Database: "default", Table: "spans", MaxRetries: 1,
+		InitialBackoff: time.Millisecond, MaxBackoff: time.Millisecond,
+		RequestTimeout: 2 * time.Second, DeadLetterFile: t.TempDir(),
+	})
+	s := New(Config{BatchMaxRows: 1, BatchMaxAge: time.Hour}, w, nil, nil, nil)
+	s.wg.Add(1 + usageWorkerCount)
+	go s.flushLoop()
+	for i := 0; i < usageWorkerCount; i++ {
+		go s.usageLoop()
+	}
+	defer func() {
+		close(s.stopCh)
+		close(s.usageCh)
+		s.wg.Wait()
+	}()
+
+	req := ptraceotlp.NewExportRequestFromTraces(makeTraces("not-durable", "33333333-3333-4333-8333-333333333333"))
+	_, err := (&otlpHandler{s: s}).Export(context.Background(), req)
+	if status.Code(err) != codes.Unavailable {
+		t.Fatalf("code=%s err=%v, want retryable Unavailable", status.Code(err), err)
+	}
+}
+
+func TestConcurrentEnqueueNeverExceedsRequestLimit(t *testing.T) {
+	const limit = 20
+	s := &Server{
+		cfg:       Config{MaxPendingRequests: limit, MaxPendingRows: limit, MaxPendingMiB: 1},
+		accepting: true,
+		pendCh:    make(chan struct{}, 1),
+	}
+	var wg sync.WaitGroup
+	for i := 0; i < 200; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			_, _ = s.enqueue([]map[string]any{{"id": i}}, nil, 1, nil)
+		}(i)
+	}
+	wg.Wait()
+	stats := s.QueueSnapshot()
+	if stats.PendingRequests > limit || stats.PendingRows > limit || stats.PendingBytes > limit {
+		t.Fatalf("limits exceeded: %+v", stats)
+	}
+	if stats.RejectedQueueFull != 180 {
+		t.Fatalf("rejected=%d, want 180", stats.RejectedQueueFull)
+	}
+}
+
+func TestConcurrentReservationsBoundConversionWork(t *testing.T) {
+	const limit = 12
+	s := &Server{
+		cfg:       Config{MaxPendingRequests: limit, MaxPendingRows: limit, MaxPendingMiB: 1},
+		accepting: true,
+		pendCh:    make(chan struct{}, 1),
+	}
+	var wg sync.WaitGroup
+	reservations := make(chan *admissionReservation, 100)
+	for i := 0; i < 100; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			reservation, err := s.reserve(1, 1)
+			if err == nil {
+				reservations <- reservation
+			}
+		}()
+	}
+	wg.Wait()
+	close(reservations)
+	stats := s.QueueSnapshot()
+	if stats.ReservedRequests != limit || stats.ReservedRows != limit || stats.ReservedBytes != limit {
+		t.Fatalf("reservation limits not enforced: %+v", stats)
+	}
+	for reservation := range reservations {
+		s.releaseReservation(reservation)
+	}
+	stats = s.QueueSnapshot()
+	if stats.ReservedRequests != 0 || stats.ReservedRows != 0 || stats.ReservedBytes != 0 {
+		t.Fatalf("reservations not released: %+v", stats)
+	}
+}
+
+func TestReceiverConcurrencyLimitBlocksAdditionalHandlers(t *testing.T) {
+	s := New(Config{MaxConcurrentRequests: 2}, nil, nil, nil, nil)
+	first, err := s.tryAcquireReceiver()
+	if err != nil {
+		t.Fatal(err)
+	}
+	second, err := s.tryAcquireReceiver()
+	if err != nil {
+		t.Fatal("failed to acquire configured receiver slots")
+	}
+	if _, err := s.tryAcquireReceiver(); !errors.Is(err, errQueueFull) {
+		t.Fatalf("err=%v, want immediate queue full", err)
+	}
+	first.release()
+	second.release()
+}
+
+func TestShutdownWaitsForReservedConversionAndDrainsIt(t *testing.T) {
+	chSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer chSrv.Close()
+	w, _ := chwriter.New(chwriter.Config{
+		URL: chSrv.URL, Database: "default", Table: "spans", MaxRetries: 1,
+		InitialBackoff: time.Millisecond, MaxBackoff: time.Millisecond,
+		RequestTimeout: 2 * time.Second, DeadLetterFile: t.TempDir() + "/dl.jsonl",
+	})
+	s := New(Config{BatchMaxRows: 100, BatchMaxAge: time.Hour}, w, nil, nil, nil)
+	reservation, err := s.reserve(1, 10)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	shutdownDone := make(chan struct{})
+	go func() {
+		s.shutdown()
+		close(shutdownDone)
+	}()
+	select {
+	case <-shutdownDone:
+		t.Fatal("shutdown returned while an admitted conversion was still reserved")
+	case <-time.After(20 * time.Millisecond):
+	}
+	done, err := s.commitReservation(reservation, []map[string]any{{"id": "1"}}, nil, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	select {
+	case <-shutdownDone:
+	case <-time.After(time.Second):
+		t.Fatal("shutdown did not drain committed reservation")
+	}
+	if outcome := <-done; !outcome.Durable {
+		t.Fatalf("outcome=%+v, want durable", outcome)
+	}
+	if s.QueueSnapshot().Accepting {
+		t.Fatal("shutdown did not close admission")
+	}
+}
+
+func TestGRPCAdmissionErrorsHaveCorrectRetrySemantics(t *testing.T) {
+	retryable := grpcAdmissionError(errQueueFull)
+	st, _ := status.FromError(retryable)
+	if st.Code() != codes.Unavailable {
+		t.Fatalf("queue full code=%s, want Unavailable", st.Code())
+	}
+	var sawRetryInfo bool
+	for _, detail := range st.Details() {
+		if retry, ok := detail.(*errdetails.RetryInfo); ok && retry.RetryDelay.AsDuration() == time.Second {
+			sawRetryInfo = true
+		}
+	}
+	if !sawRetryInfo {
+		t.Fatal("retryable overload missing RetryInfo")
+	}
+	if code := status.Code(grpcAdmissionError(errRequestTooLarge)); code != codes.ResourceExhausted {
+		t.Fatalf("too-large code=%s, want ResourceExhausted", code)
+	}
+}
+
+func TestHTTPAdmissionErrorsHaveCorrectRetrySemantics(t *testing.T) {
+	s := &Server{}
+	rw := httptest.NewRecorder()
+	s.writeHTTPAdmissionError(rw, "application/json", errQueueFull)
+	if rw.Code != http.StatusServiceUnavailable || rw.Header().Get("Retry-After") != "1" {
+		t.Fatalf("queue full response=%d headers=%v", rw.Code, rw.Header())
+	}
+	var rpcStatus map[string]any
+	if err := json.Unmarshal(rw.Body.Bytes(), &rpcStatus); err != nil {
+		t.Fatalf("invalid OTLP JSON error: %v", err)
+	}
+	if rpcStatus["code"] != "14" && rpcStatus["code"] != float64(codes.Unavailable) {
+		t.Fatalf("unexpected status body: %v", rpcStatus)
+	}
+
+	rw = httptest.NewRecorder()
+	s.writeHTTPAdmissionError(rw, "application/x-protobuf", errRequestTooLarge)
+	if rw.Code != http.StatusRequestEntityTooLarge || rw.Header().Get("Retry-After") != "" {
+		t.Fatalf("too-large response=%d headers=%v", rw.Code, rw.Header())
+	}
+}
+
+func TestEnqueueRejectsAfterShutdownBegins(t *testing.T) {
+	s := &Server{
+		cfg:       Config{MaxPendingRequests: 10, MaxPendingRows: 10, MaxPendingMiB: 1},
+		accepting: false,
+		pendCh:    make(chan struct{}, 1),
+	}
+	if _, err := s.enqueue([]map[string]any{{"id": "1"}}, nil, 1, nil); !errors.Is(err, errShuttingDown) {
+		t.Fatalf("err=%v, want shutting down", err)
+	}
+	if s.QueueSnapshot().RejectedShuttingDown != 1 {
+		t.Fatal("shutdown rejection not counted")
 	}
 }
 
@@ -865,9 +1206,21 @@ func TestGRPCOverCapRejectionIsLogged(t *testing.T) {
 	if status.Code(err) != codes.ResourceExhausted {
 		t.Fatalf("want ResourceExhausted, got %v", err)
 	}
+	// InTapHandle runs before size validation. The ticket must still be
+	// released when decoding rejects the RPC before the unary interceptor.
+	deadline := time.Now().Add(time.Second)
+	for time.Now().Before(deadline) {
+		if len(s.receiverSem) == 0 {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	if len(s.receiverSem) != 0 {
+		t.Fatalf("receiver ticket leaked after over-cap rejection: %d", len(s.receiverSem))
+	}
 
 	// stats.End may fire concurrently with the client seeing the status.
-	deadline := time.Now().Add(time.Second)
+	deadline = time.Now().Add(time.Second)
 	for time.Now().Before(deadline) {
 		logMu.Lock()
 		got := logBuf.String()

--- a/fi-collector/pkg/server/usage.go
+++ b/fi-collector/pkg/server/usage.go
@@ -2,25 +2,60 @@ package server
 
 import (
 	"context"
+	"crypto/sha256"
 	"encoding/hex"
 
 	"github.com/future-agi/future-agi/fi-collector/pkg/auth"
 	"go.opentelemetry.io/collector/pdata/ptrace"
 )
 
-func (s *Server) emitUsage(ctx context.Context, traces ptrace.Traces, payloadBytes int64) {
+type usageRecord struct {
+	orgID        string
+	numTraces    int
+	numSpans     int
+	payloadBytes int64
+	dedupKey     string
+}
+
+func usageFromContext(ctx context.Context, traces ptrace.Traces, payload []byte) *usageRecord {
 	result := auth.FromContext(ctx)
 	if result == nil {
+		return nil
+	}
+	// Single-trace exports use the trace id. Multi-trace batches use the wire
+	// payload hash so a timeout/retry after durable acceptance is billed once.
+	ids := distinctTraceIDs(traces)
+	dedupKey := usageDedupKey(ids, payload)
+	return &usageRecord{
+		orgID:        result.OrgID,
+		numTraces:    len(ids),
+		numSpans:     traces.SpanCount(),
+		payloadBytes: int64(len(payload)),
+		dedupKey:     dedupKey,
+	}
+}
+
+func usageDedupKey(ids [][16]byte, payload []byte) string {
+	if len(ids) == 1 {
+		return hex.EncodeToString(ids[0][:])
+	} else if len(payload) > 0 {
+		sum := sha256.Sum256(payload)
+		return hex.EncodeToString(sum[:])
+	}
+	return ""
+}
+
+func (s *Server) emitUsage(record *usageRecord) {
+	if record == nil {
 		return
 	}
-	// Single-trace export = a provider-pull call (deterministic trace id, re-polled):
-	// key billing on it so re-polls bill once. Multi-trace SDK batch → random id.
-	ids := distinctTraceIDs(traces)
-	dedupKey := ""
-	if len(ids) == 1 {
-		dedupKey = hex.EncodeToString(ids[0][:])
-	}
-	s.usage.EmitIngestion(result.OrgID, len(ids), traces.SpanCount(), payloadBytes, dedupKey)
+	s.usage.EmitIngestion(
+		record.orgID,
+		record.numTraces,
+		record.numSpans,
+		record.payloadBytes,
+		record.dedupKey,
+	)
 }
 
 func (s *Server) checkUsage(ctx context.Context) (auth.CheckResult, bool) {

--- a/fi-collector/pkg/server/usage_test.go
+++ b/fi-collector/pkg/server/usage_test.go
@@ -99,13 +99,13 @@ func TestCheckUsageNoAuthContext(t *testing.T) {
 func TestEmitUsageNilUsage(t *testing.T) {
 	s := &Server{usage: nil}
 	// Must not panic
-	s.emitUsage(context.Background(), ptrace.NewTraces(), 1024)
+	s.emitUsage(nil)
 }
 
 func TestEmitUsageNoAuthContext(t *testing.T) {
 	s := &Server{usage: &auth.UsageEmitter{}}
 	// Must not panic — no auth result in context
-	s.emitUsage(context.Background(), ptrace.NewTraces(), 1024)
+	s.emitUsage(usageFromContext(context.Background(), ptrace.NewTraces(), make([]byte, 1024)))
 }
 
 func TestCountDistinctTracesMultipleScopeSpans(t *testing.T) {
@@ -144,6 +144,21 @@ func TestDistinctTraceIDsReturnsSingleID(t *testing.T) {
 	}
 	if ids[0] != tid {
 		t.Errorf("distinct id = %x, want %x", ids[0], tid)
+	}
+}
+
+func TestUsageMultiTraceDedupKeyUsesPayloadHash(t *testing.T) {
+	traces := ptrace.NewTraces()
+	rs := traces.ResourceSpans().AppendEmpty()
+	spans := rs.ScopeSpans().AppendEmpty().Spans()
+	spans.AppendEmpty().SetTraceID(pcommon.TraceID([16]byte{1}))
+	spans.AppendEmpty().SetTraceID(pcommon.TraceID([16]byte{2}))
+	payload := []byte("stable OTLP payload")
+	ids := distinctTraceIDs(traces)
+	first := usageDedupKey(ids, payload)
+	second := usageDedupKey(ids, payload)
+	if first == "" || first != second {
+		t.Fatalf("unstable multi-trace dedup keys: %q %q", first, second)
 	}
 }
 

--- a/futureagi/docker-compose.yml
+++ b/futureagi/docker-compose.yml
@@ -370,6 +370,11 @@ services:
       FI_CH_DATABASE: ${CH25_DATABASE:-futureagi}
       FI_GRPC_ADDR: ":4317"
       FI_HTTP_ADDR: ":4318"
+      FI_ADMIN_ADDR: ":9464"
+      FI_MAX_PENDING_REQUESTS: ${FI_MAX_PENDING_REQUESTS:-1000}
+      FI_MAX_PENDING_ROWS: ${FI_MAX_PENDING_ROWS:-20000}
+      FI_MAX_PENDING_MIB: ${FI_MAX_PENDING_MIB:-64}
+      FI_MAX_CONCURRENT_REQUESTS: ${FI_MAX_CONCURRENT_REQUESTS:-32}
       FI_DEAD_LETTER_FILE: /var/lib/fi-collector/dead_letter.jsonl
       FI_PG_WRITE: postgres://${PG_USER:-user}:${PG_PASSWORD:-password}@db:5432/${PG_DB:-tfc}
       FI_PG_READ: postgres://${PG_USER:-user}:${PG_PASSWORD:-password}@db:5432/${PG_DB:-tfc}
@@ -377,9 +382,11 @@ services:
     ports:
       - "${FI_COLLECTOR_GRPC_PORT:-4317}:4317"
       - "${FI_COLLECTOR_HTTP_PORT:-4318}:4318"
+      - "127.0.0.1:${FI_COLLECTOR_ADMIN_PORT:-9464}:9464"
     volumes:
       - fi-dead-letter:/var/lib/fi-collector
     restart: unless-stopped
+    stop_grace_period: 600s
 
   # ===========================================
   # Message Queue & Cache

--- a/futureagi/tracer/utils/fi_collector_supervisor.py
+++ b/futureagi/tracer/utils/fi_collector_supervisor.py
@@ -116,7 +116,7 @@ def _signal_stop(_signum, _frame) -> None:
 
 
 def stop() -> None:
-    """Send SIGTERM to the collector, wait up to 10 s, then SIGKILL.
+    """Send SIGTERM to the collector, wait up to 600 s, then SIGKILL.
     Safe to call multiple times.
     """
     _stop.set()
@@ -128,7 +128,7 @@ def stop() -> None:
         except ProcessLookupError:
             return
         try:
-            proc.wait(timeout=10)
+            proc.wait(timeout=600)
         except subprocess.TimeoutExpired:
             log.warning("fi-collector did not exit on SIGTERM; SIGKILL")
             try:


### PR DESCRIPTION
## Summary

Bounds fi-collector admission across request count, span rows, payload bytes, and decode/conversion concurrency. OTLP success now waits until the canonical span batch is accepted by ClickHouse or fsynced to the dead-letter file; overload returns protocol-correct retryable backpressure instead of allowing memory to grow without limit.

## Linked issues

Closes #2201
Linear: N/A

## Type of change

- [x] Bug fix
- [x] Performance / reliability improvement

## What changed

**Bounded admission**
- Adds atomic reservations before conversion and accounts for reserved, queued, and canonical-writer in-flight work.
- Defaults: 1,000 requests, 20,000 rows, 64 MiB, and 32 concurrent HTTP/gRPC request decodes.
- Uses a gRPC tap before payload decode to reject overload globally across connections; tickets are released from the interceptor or `stats.End` on pre-interceptor failures.

**Durable acknowledgements**
- Adds `InsertWithOutcome` to distinguish ClickHouse success, durable dead-letter, and total durability failure.
- HTTP/gRPC handlers wait for the canonical outcome before returning success.
- gRPC overload is `Unavailable` with `RetryInfo`; HTTP overload is `503` with `Retry-After`; requests that can never fit receive `ResourceExhausted` / `413`.
- `async_insert` is rejected on the durable path because `wait_for_async_insert=0` cannot prove persistence.

**Lifecycle and operations**
- Binds all listeners before serving, closes admission before shutdown, waits for active conversions, and drains accepted work.
- Adds queue/rejection/non-durable counters to `/healthz`; total durability failures make health fail.
- Moves billing off the canonical flusher into a bounded 16-worker queue and scopes deterministic IDs by organization.
- Wires YAML/env/Compose limits and aligns container/supervisor shutdown grace to 600 seconds.
- Updates the README to describe the implementation that actually ships.

## Tests

**`fi-collector/pkg/server/server_test.go`**
- Atomic row/byte/request rejection and concurrent reservation limits.
- In-flight accounting and capacity release.
- ACK waits for canonical durability; double ClickHouse/dead-letter failure returns retryable error.
- gRPC/HTTP retry semantics and `RetryInfo`/`Retry-After`.
- Receiver concurrency, shutdown reservation drain, and gRPC over-cap ticket release.

**`fi-collector/pkg/chwriter/writer_test.go`**
- ClickHouse durability, durable dead-letter, dead-letter failure, and async-insert rejection.

**`fi-collector/cmd/fi-collector/main_test.go`**
- Environment overrides and queue data in admin health output.

**`fi-collector/pkg/auth/auth_test.go` / `pkg/server/usage_test.go`**
- Retry-stable payload deduplication and organization-isolated billing IDs.

Run results:

```text
go test ./pkg/server ./pkg/chwriter ./cmd/fi-collector ./pkg/auth
PASS

go test -race ./pkg/server ./pkg/chwriter ./cmd/fi-collector ./pkg/auth
PASS

go vet ./...
PASS
```

The full `go test ./...` reaches the pre-existing Python parity helper but cannot complete in this checkout because the host Python environment lacks `structlog`; all Go-only packages and every changed package pass.

## Edge cases

- Admission is all-or-nothing; rejected requests never merge curated identities or consume billing.
- An individual export larger than empty-queue capacity is non-retryable until the SDK rebatches it.
- Client cancellation after commit does not strand capacity; durable billing events use deterministic IDs so retries deduplicate.
- Curated dimension writes remain best effort and are skipped during shutdown so they cannot consume the canonical drain budget.

## Checklist

- [x] Code formatted with `gofmt`
- [x] Regression tests added
- [x] Race tests pass for changed packages
- [x] `go vet ./...` passes
- [x] Documentation and deployment configuration updated
- [x] No hardcoded secrets, URLs, or PII
- [x] PR title follows Conventional Commits
