### PR TITLE
fix(agentcc): point .env.example internal gateway URLs at the container port

### DIFF
--- a/futureagi/.env.example
+++ b/futureagi/.env.example
@@ -525,7 +525,9 @@ GUARDRAILS_TOKEN=your-guardrails-token
 # -----------------------------------------------------------------------------
 AGENTCC_GATEWAY_PORT=8090
 AGENTCC_GATEWAY_PUBLIC_URL=https://your-gateway-domain.com
-AGENTCC_GATEWAY_INTERNAL_URL=http://agentcc-gateway:8090
+# Container-to-container: use the gateway CONTAINER port (8080), not the
+# host-published port (AGENTCC_GATEWAY_PORT). Compose maps 8090:8080.
+AGENTCC_GATEWAY_INTERNAL_URL=http://agentcc-gateway:8080
 AGENTCC_ADMIN_TOKEN=agentcc-admin-secret
 AGENTCC_WEBHOOK_SECRET=test-webhook-secret
 
@@ -534,7 +536,7 @@ AGENTCC_WEBHOOK_SECRET=test-webhook-secret
 # Uses the SAME agentcc-gateway, but with a dedicated API key tagged as "internal".
 # Internal calls bypass user quota but are still cost-tracked.
 # -----------------------------------------------------------------------------
-AGENTCC_INTERNAL_URL=http://agentcc-gateway:8090
+AGENTCC_INTERNAL_URL=http://agentcc-gateway:8080
 AGENTCC_INTERNAL_API_KEY=fi-internal-dev-key-change-in-prod
 
 # -----------------------------------------------------------------------------

--- a/futureagi/agentcc/services/gateway_client.py
+++ b/futureagi/agentcc/services/gateway_client.py
@@ -32,7 +32,8 @@ def resolve_gateway_internal_url():
 
 # Default gateway address — set via env vars in docker-compose / .env
 AGENTCC_GATEWAY_URL = resolve_gateway_public_url()
-# Internal URL for container-to-container communication (e.g. http://agentcc-gateway:8090)
+# Internal URL for container-to-container communication — the gateway
+# CONTAINER port (e.g. http://agentcc-gateway:8080), not the host-published one.
 AGENTCC_GATEWAY_INTERNAL_URL = resolve_gateway_internal_url()
 AGENTCC_ADMIN_TOKEN = os.environ.get("AGENTCC_ADMIN_TOKEN", "")
 if not AGENTCC_ADMIN_TOKEN:

--- a/futureagi/agentcc/tests/test_services.py
+++ b/futureagi/agentcc/tests/test_services.py
@@ -4,6 +4,8 @@ Agentcc Services Tests
 Tests for GatewayClient, auth_bridge, and log_ingestion services.
 """
 
+import re
+from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -423,3 +425,47 @@ class TestWebhookDelivery:
         assert event.status == AgentccWebhookEvent.PENDING
         assert event.attempts == 1
         assert event.next_retry_at is not None
+
+
+class TestEnvExampleGatewayPorts:
+    """`.env.example` must not point container-to-container traffic at the
+    host-published gateway port.
+
+    CONTRIBUTING tells new contributors to `cp futureagi/.env.example
+    futureagi/.env`, and compose loads that file via `env_file`. Because the
+    compose default is `${AGENTCC_GATEWAY_INTERNAL_URL:-http://agentcc-gateway:8080}`,
+    a wrong value in `.env.example` silently *overrides* the correct default
+    for every fresh checkout.
+    """
+
+    REPO_ROOT = Path(__file__).resolve().parents[3]
+    ENV_EXAMPLE = REPO_ROOT / "futureagi" / ".env.example"
+    COMPOSE = REPO_ROOT / "docker-compose.yml"
+
+    def _container_port(self) -> str:
+        """Container side of the agentcc-gateway port mapping in compose."""
+        text = self.COMPOSE.read_text(encoding="utf-8")
+        m = re.search(r'\$\{AGENTCC_GATEWAY_PORT:-\d+\}:(\d+)', text)
+        assert m, "agentcc-gateway port mapping not found in docker-compose.yml"
+        return m.group(1)
+
+    def _env_value(self, key: str) -> str:
+        for line in self.ENV_EXAMPLE.read_text(encoding="utf-8").splitlines():
+            if line.startswith(f"{key}="):
+                return line.split("=", 1)[1].strip()
+        pytest.fail(f"{key} not found in .env.example")
+
+    @pytest.mark.parametrize(
+        "key", ["AGENTCC_GATEWAY_INTERNAL_URL", "AGENTCC_INTERNAL_URL"]
+    )
+    def test_internal_url_uses_container_port(self, key):
+        url = self._env_value(key)
+        expected = self._container_port()
+        assert url.endswith(f":{expected}"), (
+            f"{key}={url} points at the host-published port; "
+            f"container-to-container traffic must use :{expected}"
+        )
+
+    def test_public_gateway_port_still_documented(self):
+        """The host-published port is a separate knob and must stay as-is."""
+        assert self._env_value("AGENTCC_GATEWAY_PORT") == "8090"


### PR DESCRIPTION
## Summary

Fixes #1058.

`futureagi/.env.example` pointed both container-to-container gateway URLs at `http://agentcc-gateway:8090`. `8090` is the **host-published** port — compose maps `${AGENTCC_GATEWAY_PORT:-8090}:8080`, so on the compose network the gateway only answers on **8080**.

## Why this bites every new contributor

`CONTRIBUTING.md` says:

```bash
cp futureagi/.env.example futureagi/.env
docker compose up -d
```

The backend services load that file with `env_file: .env`. The compose defaults are already **correct**:

```yaml
AGENTCC_GATEWAY_INTERNAL_URL: ${AGENTCC_GATEWAY_INTERNAL_URL:-http://agentcc-gateway:8080}
```

So the copied `.env` doesn't leave a gap — it *silently overrides a working default with a dead port*. A stack brought up by following CONTRIBUTING has backend→gateway calls pointed at a port nothing listens on inside the network.

## A note on the issue title

The issue is filed as "docker-compose.yml uses wrong internal port". Both compose files are actually correct (`docker-compose.yml:51`, `futureagi/docker-compose.yml:63`). The wrong values are in `futureagi/.env.example` (lines 528 and 537), which is what overrides them. I've fixed the real source rather than the file named in the title.

## Change

- `futureagi/.env.example` — `AGENTCC_GATEWAY_INTERNAL_URL` and `AGENTCC_INTERNAL_URL` now use `8080`, with a comment explaining the host/container split. `AGENTCC_GATEWAY_PORT` stays `8090`: that one *is* the host-published port and is correct.
- `futureagi/agentcc/services/gateway_client.py` — corrected the misleading `e.g. http://agentcc-gateway:8090` in the module comment, which is presumably where the wrong value was copied from.
- `futureagi/agentcc/tests/test_services.py` — added `TestEnvExampleGatewayPorts`. It parses the container port out of `docker-compose.yml` rather than hardcoding `8080`, then asserts both internal URLs match it. If the port mapping ever changes, the test moves with it; if `.env.example` drifts again, it fails.

## Verification

- New test asserted against the **pre-fix** `.env.example`: both parametrised cases **fail** (`:8090` vs expected `:8080`), so it is a real regression guard and not a tautology.
- Against the fixed tree: all cases pass.
- `python -m py_compile` clean on the modified test module.

## Deliberately out of scope

- `futureagi/tfc/settings/settings.py:524` defaults to `http://agentcc-internal:8090`. `agentcc-internal` is not a service in either compose file, so that default looks dead for a different reason — worth its own issue rather than folding a guess into this PR.
- Several `:8090` references under `futureagi/ee/`. That tree is under `LICENSE-EE`, so I left it alone.
- `test_internal_url_supports_legacy_env_name` uses `:8090` as an arbitrary value while exercising env-name fallback. The port is incidental there, so I didn't churn it.
