### PR TITLE
refactor(rl-environment): call it the eval harness, not a judge

### DIFF
--- a/frontend/src/sections/al-environment/AlEnvironmentView.jsx
+++ b/frontend/src/sections/al-environment/AlEnvironmentView.jsx
@@ -319,9 +319,9 @@ const AlEnvironmentView = () => {
             pl: 1.25,
             fontFamily: ALK_MONO,
             fontSize: 12.5,
-            color: "error.main",
+            color: "accent.fail",
             borderLeft: "2px solid",
-            borderColor: "error.main",
+            borderColor: "accent.fail",
           }}
         >
           {refusalMessage}

--- a/frontend/src/sections/al-environment/Composer.jsx
+++ b/frontend/src/sections/al-environment/Composer.jsx
@@ -3,13 +3,22 @@ import PropTypes from "prop-types";
 import { Box, Button, Stack, Typography } from "@mui/material";
 import { ALK_MONO } from "./alkTokens";
 import { quickChips } from "./quickChips";
+import { shortPath } from "./parts/shortPath";
 
 /**
  * The box the harness is talked to through. Send sits inside the border rather than beside
  * it, so the whole thing reads as one field; the chips above are the shortcuts for the
  * things you would otherwise type out every session.
  */
-const Composer = ({ onSay, onRun, onStop, streaming, status, sessionId, artifactsPath }) => {
+const Composer = ({
+  onSay,
+  onRun,
+  onStop,
+  streaming,
+  status,
+  sessionId,
+  artifactsPath,
+}) => {
   const [text, setText] = useState("");
   const boxRef = useRef(null);
   const hasSession = Boolean(status?.session);
@@ -39,7 +48,8 @@ const Composer = ({ onSay, onRun, onStop, streaming, status, sessionId, artifact
   const chips = hasSession ? quickChips(status) : [];
 
   return (
-    <Box sx={{
+    <Box
+      sx={{
         px: 3,
         pt: 1.5,
         pb: 1.75,
@@ -54,16 +64,25 @@ const Composer = ({ onSay, onRun, onStop, streaming, status, sessionId, artifact
           borderTop: "1px solid",
           borderColor: "divider",
         },
-      }}>
+      }}
+    >
       {chips.length > 0 && (
-        <Stack direction="row" spacing={0.5} flexWrap="wrap" useFlexGap sx={{ mb: 1 }}>
+        <Stack
+          direction="row"
+          spacing={0.5}
+          flexWrap="wrap"
+          useFlexGap
+          sx={{ mb: 1 }}
+        >
           {chips.map((chip) => (
             <Box
               key={chip.label}
               component="button"
               type="button"
               disabled={streaming || busy}
-              onClick={() => (chip.run !== undefined ? onRun(chip.run) : onSay(chip.say))}
+              onClick={() =>
+                chip.run !== undefined ? onRun(chip.run) : onSay(chip.say)
+              }
               sx={{
                 px: 1.25,
                 py: 0.4,
@@ -75,7 +94,10 @@ const Composer = ({ onSay, onRun, onStop, streaming, status, sessionId, artifact
                 fontSize: 12,
                 fontFamily: "inherit",
                 cursor: "pointer",
-                "&:hover:not(:disabled)": { color: "text.primary", borderColor: "text.secondary" },
+                "&:hover:not(:disabled)": {
+                  color: "text.primary",
+                  borderColor: "text.secondary",
+                },
                 "&:disabled": { opacity: 0.5, cursor: "default" },
               }}
             >
@@ -127,11 +149,21 @@ const Composer = ({ onSay, onRun, onStop, streaming, status, sessionId, artifact
           }}
         />
         {streaming && (
-          <Button size="small" variant="outlined" color="error" onClick={onStop}>
+          <Button
+            size="small"
+            variant="outlined"
+            color="error"
+            onClick={onStop}
+          >
             Stop
           </Button>
         )}
-        <Button size="small" variant="contained" disabled={!ready} onClick={send}>
+        <Button
+          size="small"
+          variant="contained"
+          disabled={!ready}
+          onClick={send}
+        >
           {streaming ? "…" : "Send"}
         </Button>
       </Box>
@@ -145,7 +177,9 @@ const Composer = ({ onSay, onRun, onStop, streaming, status, sessionId, artifact
           overflowWrap: "anywhere",
         }}
       >
-        {hasSession && sessionId ? `${sessionId}  ·  ${artifactsPath || ""}` : "no session"}
+        {hasSession && sessionId
+          ? `${sessionId}  ·  ${shortPath(artifactsPath)}`
+          : "no session"}
       </Typography>
     </Box>
   );

--- a/frontend/src/sections/al-environment/JsonView.jsx
+++ b/frontend/src/sections/al-environment/JsonView.jsx
@@ -3,13 +3,19 @@ import PropTypes from "prop-types";
 import { Box, Typography } from "@mui/material";
 import { ALK_MONO } from "./alkTokens";
 
-/** Their --key / --str / --num / --bool, as theme colours. */
+/**
+ * The product already ships a JSON palette — `palette.syntax`, bridged to the --syntax-*
+ * variables and used by the span viewer — with a per-mode dark ramp. Building a second one
+ * out of success/warning/error also said the wrong thing: green strings and red booleans
+ * read as pass and fail on data that carries no verdict. warning.main measured 1.28:1 on a
+ * light surface, which is why numbers were all but invisible there.
+ */
 const TONE = {
-  key: "info.main",
-  string: "success.main",
-  number: "warning.main",
-  boolean: "error.main",
-  null: "text.secondary",
+  key: "accent.info",
+  string: "syntax.string",
+  number: "syntax.number",
+  boolean: "syntax.boolean",
+  null: "text.disabled",
 };
 
 const INDENT = "1.05rem";

--- a/frontend/src/sections/al-environment/StatusReadout.jsx
+++ b/frontend/src/sections/al-environment/StatusReadout.jsx
@@ -7,7 +7,7 @@ const StatusReadout = ({ model, spentUsd, busy }) => (
     {busy && (
       <Box
         aria-label="working"
-        sx={{ width: 8, height: 8, borderRadius: "50%", bgcolor: "warning.main" }}
+        sx={{ width: 8, height: 8, borderRadius: "50%", bgcolor: "accent.tool" }}
       />
     )}
     <Typography variant="caption" sx={{ fontFamily: ALK_MONO, color: "text.secondary" }}>

--- a/frontend/src/sections/al-environment/TranscriptPane.jsx
+++ b/frontend/src/sections/al-environment/TranscriptPane.jsx
@@ -57,9 +57,9 @@ const TranscriptPane = ({ messages, hasSession, thinking, spentUsd }) => {
               sx={{
                 fontFamily: ALK_MONO,
                 fontSize: 12.5,
-                color: "error.main",
+                color: "accent.fail",
                 borderLeft: "2px solid",
-                borderColor: "error.main",
+                borderColor: "accent.fail",
                 pl: 1.25,
               }}
             >
@@ -90,7 +90,7 @@ const TranscriptPane = ({ messages, hasSession, thinking, spentUsd }) => {
               }}
             >
               <Stack direction="row" spacing={0.75} alignItems="baseline">
-                <Box component="span" sx={{ color: message.ok === false ? "error.main" : "success.main" }}>
+                <Box component="span" sx={{ color: message.ok === false ? "accent.fail" : "accent.pass" }}>
                   {message.ok === false ? "✗" : "✓"}
                 </Box>
                 <Typography variant="caption" sx={{ fontFamily: ALK_MONO, color: "text.primary" }}>

--- a/frontend/src/sections/al-environment/__tests__/Composer.test.jsx
+++ b/frontend/src/sections/al-environment/__tests__/Composer.test.jsx
@@ -9,7 +9,7 @@ const props = {
   streaming: false,
   status: { session: { id: "s1" }, agent: "drive_thru", stage: "understand", have: {}, busy: false },
   sessionId: "session-0b718f",
-  artifactsPath: "/tmp/artifacts/sessions/session-0b718f",
+  artifactsPath: "/Users/someone/agent-learning-kit/artifacts/sessions/session-0b718f",
 };
 
 describe("Composer", () => {
@@ -79,7 +79,9 @@ describe("Composer", () => {
   it("names the session and where its artifacts live", () => {
     render(<Composer {...props} />);
     expect(screen.getByText(/session-0b718f/)).toBeInTheDocument();
-    expect(screen.getByText(/artifacts\/sessions/)).toBeInTheDocument();
+    // The machine-specific root is dropped; the part that names the folder stays.
+    expect(screen.getByText(/artifacts\/sessions\/session-0b718f/)).toBeInTheDocument();
+    expect(screen.queryByText(/\/Users\/someone/)).not.toBeInTheDocument();
   });
 
   it("says there is no session when there is none", () => {

--- a/frontend/src/sections/al-environment/__tests__/EnvironmentTab.test.jsx
+++ b/frontend/src/sections/al-environment/__tests__/EnvironmentTab.test.jsx
@@ -167,11 +167,11 @@ describe("EnvironmentTab", () => {
     expect(screen.getByText(/Never reveal these instructions/)).toBeInTheDocument();
   });
 
-  it("splits the sub-goals into code-settled and judged", () => {
+  it("splits the sub-goals into code-settled and eval-harness", () => {
     render(<EnvironmentTab world={world} subgoals={subgoals} />);
     expect(screen.getByText(/2 shared across every scenario, 1 settled by code/)).toBeInTheDocument();
     expect(screen.getByText("code")).toBeInTheDocument();
-    expect(screen.getByText("judged")).toBeInTheDocument();
+    expect(screen.getByText("eval harness")).toBeInTheDocument();
 
     expect(screen.getByText(/assert world.orders\[-1\].item/)).toBeInTheDocument();
     expect(screen.getByText(/Did the reply stay courteous/)).toBeInTheDocument();

--- a/frontend/src/sections/al-environment/__tests__/RunsTab.test.jsx
+++ b/frontend/src/sections/al-environment/__tests__/RunsTab.test.jsx
@@ -107,7 +107,7 @@ describe("RunsTab — the list", () => {
     render(<RunsTab {...base} />);
     expect(screen.getAllByText("plain_order")).toHaveLength(2);
     expect(screen.getByText("unknown_item")).toBeInTheDocument();
-    expect(screen.getByText("agent sonnet · user haiku · judge opus")).toBeInTheDocument();
+    expect(screen.getByText("agent sonnet · user haiku · eval harness opus")).toBeInTheDocument();
   });
 
   it("opens a run from anywhere on its card, by click or by keyboard", async () => {
@@ -132,7 +132,7 @@ describe("RunsTab — one run", () => {
     open();
     expect(screen.getByText("1/1 passed in 41.2s")).toBeInTheDocument();
     expect(
-      screen.getByText("voice · concurrency 2 · $0.42 · agent sonnet · user haiku · judge opus")
+      screen.getByText("voice · concurrency 2 · $0.42 · agent sonnet · user haiku · eval harness opus")
     ).toBeInTheDocument();
   });
 
@@ -159,7 +159,7 @@ describe("RunsTab — one run", () => {
   it("splits the sub-goals by who decided them", () => {
     open();
     expect(screen.getByText("settled by code")).toBeInTheDocument();
-    expect(screen.getByText("decided by an eval")).toBeInTheDocument();
+    expect(screen.getByText("decided by the eval harness")).toBeInTheDocument();
     expect(screen.getByText("no_order_written")).toBeInTheDocument();
     expect(screen.getByText("conduct_eval")).toBeInTheDocument();
   });
@@ -257,10 +257,10 @@ describe("RunsTab — the legacy view", () => {
     expect(screen.getByText("live_refusal")).toBeInTheDocument();
     expect(screen.getByText("local_order")).toBeInTheDocument();
     // The live record counts its settled claims; the local one counts its checkpoints.
-    expect(screen.getByText("1/2 settled by code · 1 judged · live call")).toBeInTheDocument();
+    expect(screen.getByText("1/2 settled by code · 1 by eval harness · live call")).toBeInTheDocument();
     expect(screen.getByText("2/2 settled by code · 6 turns")).toBeInTheDocument();
     expect(screen.getByText("Ask for a refund you are not owed.")).toBeInTheDocument();
-    expect(screen.getByText("stayed_in_scope — not settled by code")).toBeInTheDocument();
+    expect(screen.getByText("stayed_in_scope — decided by the eval harness")).toBeInTheDocument();
     expect(screen.getByText("provider dropped the call")).toBeInTheDocument();
     expect(screen.getByText("decided by conduct_eval")).toBeInTheDocument();
     expect(screen.getByText("✓ place_order(...) -> ok")).toBeInTheDocument();

--- a/frontend/src/sections/al-environment/__tests__/shortPath.test.js
+++ b/frontend/src/sections/al-environment/__tests__/shortPath.test.js
@@ -1,0 +1,29 @@
+import { describe, it, expect } from "vitest";
+import { shortPath } from "../parts/shortPath";
+
+describe("shortPath", () => {
+  it("drops everything before the artifacts directory", () => {
+    expect(
+      shortPath(
+        "/Users/apple/Documents/agent-learning-kit/artifacts/sessions/drive-thru-verify/scenarios/late-night-menu-swap"
+      )
+    ).toBe("artifacts/sessions/drive-thru-verify/scenarios/late-night-menu-swap");
+  });
+
+  it("works for a container path just the same", () => {
+    expect(shortPath("/app/artifacts/sessions/abc")).toBe("artifacts/sessions/abc");
+  });
+
+  it("keeps the tail when there is no artifacts directory to cut at", () => {
+    expect(shortPath("/var/data/some/other/place")).toBe("…/some/other/place");
+  });
+
+  it("leaves a short path alone", () => {
+    expect(shortPath("sessions/abc")).toBe("sessions/abc");
+  });
+
+  it("says nothing when there is no path", () => {
+    expect(shortPath("")).toBe("");
+    expect(shortPath(undefined)).toBe("");
+  });
+});

--- a/frontend/src/sections/al-environment/parts/Tag.jsx
+++ b/frontend/src/sections/al-environment/parts/Tag.jsx
@@ -7,16 +7,28 @@ import { ALK_MONO } from "../alkTokens";
  * Not a MUI Chip — those are pill-shaped, sans and sentence case, which reads as a filter
  * control rather than a verdict.
  */
-const WASH = {
-  pass: { color: "success.main", bg: "success.main" },
-  fail: { color: "error.main", bg: "error.main" },
-  code: { color: "success.main", bg: "success.main" },
-  judge: { color: "warning.main", bg: "warning.main" },
-  soft: { color: "text.secondary", bg: "text.secondary" },
+/**
+ * `accent` rather than the `.main` ramp: those are tuned for dark backgrounds and for use as
+ * fills, so warning.main as text measured 1.19:1 on a light surface — the codebase already
+ * says so twice, in CallLogsCellRenderer and ValidationStep. accent carries a value per mode.
+ *
+ * Blue for a check settled by running code, violet for one the eval harness judged. Not
+ * accent.info, which in dark is #7DA9FB against violet's #C4B5FD — both pale and cool, and
+ * they read as the same chip; syntax.number is the product's bluest per-mode pair (#1750EB
+ * light, #6ba8e6 dark) and stays plainly blue in both.
+ *
+ * Green and red are left to verdicts, so "settled by code" no longer borrows "passed".
+ */
+const TONE = {
+  pass: (p) => p.accent.pass,
+  fail: (p) => p.accent.fail,
+  code: (p) => p.syntax.number,
+  evalHarness: (p) => p.accent.violet,
+  soft: (p) => p.accent.neutral,
 };
 
 const Tag = ({ kind = "soft", children, title, dim, keepCase }) => {
-  const tone = WASH[kind] || WASH.soft;
+  const tone = TONE[kind] || TONE.soft;
   return (
     <Box
       component="span"
@@ -33,7 +45,7 @@ const Tag = ({ kind = "soft", children, title, dim, keepCase }) => {
         // look like two different things in two places.
         textTransform: keepCase ? "none" : "uppercase",
         whiteSpace: "nowrap",
-        color: tone.color,
+        color: (theme) => tone(theme.palette),
         bgcolor: (theme) => theme.palette.action.hover,
         opacity: dim ? 0.45 : 1,
         border: "1px solid",
@@ -46,7 +58,7 @@ const Tag = ({ kind = "soft", children, title, dim, keepCase }) => {
 };
 
 Tag.propTypes = {
-  kind: PropTypes.oneOf(["pass", "fail", "code", "judge", "soft"]),
+  kind: PropTypes.oneOf(["pass", "fail", "code", "evalHarness", "soft"]),
   children: PropTypes.node,
   title: PropTypes.string,
   dim: PropTypes.bool,

--- a/frontend/src/sections/al-environment/parts/Tag.jsx
+++ b/frontend/src/sections/al-environment/parts/Tag.jsx
@@ -15,7 +15,7 @@ const WASH = {
   soft: { color: "text.secondary", bg: "text.secondary" },
 };
 
-const Tag = ({ kind = "soft", children, title, dim }) => {
+const Tag = ({ kind = "soft", children, title, dim, keepCase }) => {
   const tone = WASH[kind] || WASH.soft;
   return (
     <Box
@@ -29,7 +29,9 @@ const Tag = ({ kind = "soft", children, title, dim }) => {
         fontFamily: ALK_MONO,
         fontSize: 10.7,
         letterSpacing: "0.08em",
-        textTransform: "uppercase",
+        // Names carry their own case: uppercasing an identifier makes the same thing
+        // look like two different things in two places.
+        textTransform: keepCase ? "none" : "uppercase",
         whiteSpace: "nowrap",
         color: tone.color,
         bgcolor: (theme) => theme.palette.action.hover,
@@ -48,6 +50,7 @@ Tag.propTypes = {
   children: PropTypes.node,
   title: PropTypes.string,
   dim: PropTypes.bool,
+  keepCase: PropTypes.bool,
 };
 
 export default Tag;

--- a/frontend/src/sections/al-environment/parts/shortPath.js
+++ b/frontend/src/sections/al-environment/parts/shortPath.js
@@ -1,0 +1,15 @@
+/**
+ * The harness answers with absolute paths on the machine it runs on, e.g.
+ * /Users/someone/Documents/agent-learning-kit/artifacts/sessions/<id>/scenarios/<name>.
+ * Everything before `artifacts/` is that machine's business, not the reader's, and on the
+ * platform it is a container path nobody can act on — so show the part that identifies the
+ * folder and drop the rest.
+ */
+export const shortPath = (path) => {
+  if (!path) return "";
+  const at = path.indexOf("artifacts/");
+  if (at !== -1) return path.slice(at);
+  // No anchor to cut at — keep the tail, which is the part that names the thing.
+  const parts = path.split("/").filter(Boolean);
+  return parts.length > 3 ? `…/${parts.slice(-3).join("/")}` : path;
+};

--- a/frontend/src/sections/al-environment/tabs/ContractTab.jsx
+++ b/frontend/src/sections/al-environment/tabs/ContractTab.jsx
@@ -162,7 +162,7 @@ const ContractTab = ({ contract }) => {
                 borderRadius: "3px",
                 fontFamily: ALK_MONO,
                 fontSize: 11.8,
-                color: "warning.main",
+                color: "accent.tool",
                 bgcolor: (theme) => alpha(theme.palette.warning.main, 0.12),
               }}
             >

--- a/frontend/src/sections/al-environment/tabs/EnvironmentTab.jsx
+++ b/frontend/src/sections/al-environment/tabs/EnvironmentTab.jsx
@@ -11,7 +11,10 @@ import { ALK_MONO } from "../alkTokens";
 
 /** The reference's `.subline`: the prose voice inside a card — italic, quiet, one thought. */
 const Subline = ({ children }) => (
-  <Typography variant="body2" sx={{ fontStyle: "italic", color: "text.secondary" }}>
+  <Typography
+    variant="body2"
+    sx={{ fontStyle: "italic", color: "text.secondary" }}
+  >
     {children}
   </Typography>
 );
@@ -19,7 +22,8 @@ const Subline = ({ children }) => (
 Subline.propTypes = { children: PropTypes.node };
 
 /** A handler earns its keep by being able to refuse; count how many times it does. */
-const refusalCount = (source) => (String(source ?? "").match(/raise ToolError/g) || []).length;
+const refusalCount = (source) =>
+  (String(source ?? "").match(/raise ToolError/g) || []).length;
 
 const lineCount = (text) => String(text ?? "").split("\n").length;
 
@@ -37,16 +41,18 @@ const EnvironmentTab = ({ world, subgoals }) => {
       <Box>
         <Pane title="Environment">
           <Typography variant="body2" sx={{ color: "text.secondary" }}>
-            Not built yet. This stage builds whatever the agent&apos;s tools act on — a database,
-            a service, whatever it depends on — so every call it makes gets a truthful answer,
-            including a truthful refusal.
+            Not built yet. This stage builds whatever the agent&apos;s tools act
+            on — a database, a service, whatever it depends on — so every call
+            it makes gets a truthful answer, including a truthful refusal.
           </Typography>
         </Pane>
       </Box>
     );
   }
 
-  const settledByCode = goals.filter((goal) => goal.settled_by === "code").length;
+  const settledByCode = goals.filter(
+    (goal) => goal.settled_by === "code",
+  ).length;
 
   return (
     <Box>
@@ -56,7 +62,10 @@ const EnvironmentTab = ({ world, subgoals }) => {
         </Pane>
       )}
 
-      <Pane title="The data" meta={`${tables.length} tables — click one to see its rows`}>
+      <Pane
+        title="The data"
+        meta={`${tables.length} tables — click one to see its rows`}
+      >
         {tables.map((table) => (
           <XCard
             key={table.name}
@@ -66,13 +75,20 @@ const EnvironmentTab = ({ world, subgoals }) => {
             // would push the rest of the stage off the screen.
             open={table.count > 0 && table.count <= 4}
           >
-            <DataTable columns={table.columns ?? []} rows={table.rows ?? []} count={table.count} />
+            <DataTable
+              columns={table.columns ?? []}
+              rows={table.rows ?? []}
+              count={table.count}
+            />
           </XCard>
         ))}
       </Pane>
 
       {handlers.length > 0 && (
-        <Pane title="The tools" meta="one handler per tool — the code that can say no">
+        <Pane
+          title="The tools"
+          meta="one handler per tool — the code that can say no"
+        >
           {handlers.map((handler) => {
             const refusals = refusalCount(handler.source);
             return (
@@ -91,12 +107,19 @@ const EnvironmentTab = ({ world, subgoals }) => {
       )}
 
       {sequences.length > 0 && (
-        <Pane title="Declared sequences" meta="flows where state must carry across calls">
+        <Pane
+          title="Declared sequences"
+          meta="flows where state must carry across calls"
+        >
           {sequences.map((sequence) => {
             const calls = sequence.calls ?? [];
             const expectState = sequence.expect_state ?? {};
             return (
-              <XCard key={sequence.name} title={sequence.name} meta={`${calls.length} calls`}>
+              <XCard
+                key={sequence.name}
+                title={sequence.name}
+                meta={`${calls.length} calls`}
+              >
                 <Field label="calls">
                   <Box
                     component="ol"
@@ -124,7 +147,10 @@ const EnvironmentTab = ({ world, subgoals }) => {
                         </Box>{" "}
                         <Box
                           component="span"
-                          sx={{ color: "text.secondary", overflowWrap: "anywhere" }}
+                          sx={{
+                            color: "text.secondary",
+                            overflowWrap: "anywhere",
+                          }}
                         >
                           {JSON.stringify(step.arguments ?? {})}
                         </Box>
@@ -147,8 +173,14 @@ const EnvironmentTab = ({ world, subgoals }) => {
       {/* The simulator prompt and the sub-goal catalogue are this stage's output too — they
           come from /api/subgoals, but they belong to the environment the scenarios run in. */}
       {simulatorPrompt && (
-        <Pane title="The simulated person" meta="written once; each scenario fills its slot">
-          <XCard title="simulator prompt" meta={`${lineCount(simulatorPrompt)} lines`}>
+        <Pane
+          title="The simulated person"
+          meta="written once; each scenario fills its slot"
+        >
+          <XCard
+            title="simulator prompt"
+            meta={`${lineCount(simulatorPrompt)} lines`}
+          >
             <CodeBlock wrap>{simulatorPrompt}</CodeBlock>
           </XCard>
         </Pane>
@@ -165,7 +197,11 @@ const EnvironmentTab = ({ world, subgoals }) => {
               <XCard
                 key={goal.name}
                 title={goal.name}
-                tags={<Tag kind={byCode ? "code" : "judge"}>{byCode ? "code" : "judged"}</Tag>}
+                tags={
+                  <Tag kind={byCode ? "code" : "judge"}>
+                    {byCode ? "code" : "eval harness"}
+                  </Tag>
+                }
                 meta={(goal.what || "").slice(0, 60)}
               >
                 <Field label="what it means">
@@ -177,7 +213,7 @@ const EnvironmentTab = ({ world, subgoals }) => {
                   </Field>
                 )}
                 {goal.judged && (
-                  <Field label="what a judge must decide">
+                  <Field label="what the eval harness must decide">
                     <Subline>{goal.judged}</Subline>
                   </Field>
                 )}

--- a/frontend/src/sections/al-environment/tabs/EnvironmentTab.jsx
+++ b/frontend/src/sections/al-environment/tabs/EnvironmentTab.jsx
@@ -198,7 +198,7 @@ const EnvironmentTab = ({ world, subgoals }) => {
                 key={goal.name}
                 title={goal.name}
                 tags={
-                  <Tag kind={byCode ? "code" : "judge"}>
+                  <Tag kind={byCode ? "code" : "evalHarness"}>
                     {byCode ? "code" : "eval harness"}
                   </Tag>
                 }

--- a/frontend/src/sections/al-environment/tabs/ScenariosTab.jsx
+++ b/frontend/src/sections/al-environment/tabs/ScenariosTab.jsx
@@ -10,6 +10,7 @@ import XCard from "../parts/XCard";
 import CodeBlock from "../parts/CodeBlock";
 import DataTable from "../parts/DataTable";
 import { ALK_MONO } from "../alkTokens";
+import { shortPath } from "../parts/shortPath";
 
 /**
  * Three states, not two. `null` means the gates could not be run at all because no world
@@ -17,7 +18,8 @@ import { ALK_MONO } from "../alkTokens";
  */
 const verdictOf = (validated) => {
   if (validated === true) return { kind: "pass", label: "validated" };
-  if (validated === null || validated === undefined) return { kind: "soft", label: "unchecked" };
+  if (validated === null || validated === undefined)
+    return { kind: "soft", label: "unchecked" };
   return { kind: "fail", label: "not ready" };
 };
 
@@ -63,7 +65,9 @@ const GateLamp = ({ held, label }) => {
           borderStyle: on || off ? "solid" : "dashed",
           borderColor: on || off ? tone : "divider",
           bgcolor: (theme) =>
-            on || off ? alpha(theme.palette[on ? "success" : "error"].main, 0.14) : "transparent",
+            on || off
+              ? alpha(theme.palette[on ? "success" : "error"].main, 0.14)
+              : "transparent",
         }}
       >
         {on ? "✓" : off ? "✗" : "?"}
@@ -73,7 +77,10 @@ const GateLamp = ({ held, label }) => {
   );
 };
 
-GateLamp.propTypes = { held: PropTypes.bool, label: PropTypes.string.isRequired };
+GateLamp.propTypes = {
+  held: PropTypes.bool,
+  label: PropTypes.string.isRequired,
+};
 
 /** The chip shape the harness uses for any "open this" affordance. */
 const Chip = ({ onClick, children }) => (
@@ -99,7 +106,10 @@ const Chip = ({ onClick, children }) => (
   </Box>
 );
 
-Chip.propTypes = { onClick: PropTypes.func.isRequired, children: PropTypes.node };
+Chip.propTypes = {
+  onClick: PropTypes.func.isRequired,
+  children: PropTypes.node,
+};
 
 const ScenarioCard = ({ scenario, ran, onSeeRun }) => {
   // Only one file is held open at a time, the way the reference replaces its file-view node —
@@ -128,12 +138,21 @@ const ScenarioCard = ({ scenario, ran, onSeeRun }) => {
         <>
           <Typography
             component="span"
-            sx={{ fontFamily: ALK_MONO, fontSize: 13, fontWeight: 600, color: "text.primary" }}
+            sx={{
+              fontFamily: ALK_MONO,
+              fontSize: 13,
+              fontWeight: 600,
+              color: "text.primary",
+            }}
           >
             {scenario.name}
           </Typography>
           {scenario.use_case && <Tag kind="soft">{scenario.use_case}</Tag>}
-          {ran && <Tag kind={ran.passed ? "pass" : "fail"}>{ran.passed ? "ran: pass" : "ran: fail"}</Tag>}
+          {ran && (
+            <Tag kind={ran.passed ? "pass" : "fail"}>
+              {ran.passed ? "ran: pass" : "ran: fail"}
+            </Tag>
+          )}
         </>
       }
       meta={`${solution.length}-step solution · ${checks.length} checks`}
@@ -141,7 +160,11 @@ const ScenarioCard = ({ scenario, ran, onSeeRun }) => {
       <Field label="validation">
         <Stack direction="row" flexWrap="wrap" useFlexGap spacing={1.5}>
           {GATES.map(([key, label]) => (
-            <GateLamp key={key} held={(scenario.gates || {})[key]} label={label} />
+            <GateLamp
+              key={key}
+              held={(scenario.gates || {})[key]}
+              label={label}
+            />
           ))}
         </Stack>
       </Field>
@@ -181,7 +204,9 @@ const ScenarioCard = ({ scenario, ran, onSeeRun }) => {
 
       {scenario.tests && (
         <Field label="what this tests">
-          <Typography sx={{ fontStyle: "italic", fontSize: 13, color: "text.secondary" }}>
+          <Typography
+            sx={{ fontStyle: "italic", fontSize: 13, color: "text.secondary" }}
+          >
             {scenario.tests}
           </Typography>
         </Field>
@@ -223,7 +248,10 @@ const ScenarioCard = ({ scenario, ran, onSeeRun }) => {
               <Box component="span" sx={{ color: "text.primary" }}>
                 {step.tool}
               </Box>{" "}
-              <Box component="span" sx={{ color: "text.secondary", overflowWrap: "anywhere" }}>
+              <Box
+                component="span"
+                sx={{ color: "text.secondary", overflowWrap: "anywhere" }}
+              >
                 {JSON.stringify(step.arguments || {})}
               </Box>
             </Box>
@@ -238,6 +266,7 @@ const ScenarioCard = ({ scenario, ran, onSeeRun }) => {
               key={check.name}
               kind={check.settled_by === "code" ? "code" : "judge"}
               title={check.what || ""}
+              keepCase
             >
               {check.name}
             </Tag>
@@ -246,7 +275,18 @@ const ScenarioCard = ({ scenario, ran, onSeeRun }) => {
       </Field>
 
       {files.length > 0 && (
-        <Field label={`its folder — ${scenario.folder || ""}`}>
+        <Field label="its folder">
+          <Box
+            sx={{
+              fontFamily: ALK_MONO,
+              fontSize: 11.5,
+              color: "text.secondary",
+              overflowWrap: "anywhere",
+              mb: 0.5,
+            }}
+          >
+            {shortPath(scenario.folder)}
+          </Box>
           <Stack direction="row" flexWrap="wrap" useFlexGap spacing={0.5}>
             {files.map((path) => (
               <Chip key={path} onClick={() => openFile(path)}>
@@ -285,8 +325,8 @@ const ScenariosTab = ({ scenarios, runs, onSay, hasWorld, onSeeRun }) => {
       <Box>
         <Pane title="Scenarios">
           <Typography sx={{ fontSize: 13.5, color: "text.secondary" }}>
-            None written yet. Each one owns a folder: what it changes, whether the world is ready
-            for it, and one runnable file per check.
+            None written yet. Each one owns a folder: what it changes, whether
+            the world is ready for it, and one runnable file per check.
           </Typography>
           {/* Asking for scenarios before a world exists only produces scenarios nothing can check. */}
           {hasWorld && onSay && (

--- a/frontend/src/sections/al-environment/tabs/ScenariosTab.jsx
+++ b/frontend/src/sections/al-environment/tabs/ScenariosTab.jsx
@@ -38,7 +38,7 @@ const GATES = [
 const GateLamp = ({ held, label }) => {
   const on = held === true;
   const off = held === false;
-  const tone = on ? "success.main" : "error.main";
+  const tone = on ? "accent.pass" : "accent.fail";
   return (
     <Stack
       direction="row"
@@ -177,7 +177,7 @@ const ScenarioCard = ({ scenario, ran, onSeeRun }) => {
             borderRadius: "3px",
             fontFamily: ALK_MONO,
             fontSize: 11.7,
-            color: "error.main",
+            color: "accent.fail",
             bgcolor: (theme) => alpha(theme.palette.error.main, 0.1),
           }}
         >
@@ -264,7 +264,7 @@ const ScenarioCard = ({ scenario, ran, onSeeRun }) => {
           {checks.map((check) => (
             <Tag
               key={check.name}
-              kind={check.settled_by === "code" ? "code" : "judge"}
+              kind={check.settled_by === "code" ? "code" : "evalHarness"}
               title={check.what || ""}
               keepCase
             >

--- a/frontend/src/sections/al-environment/tabs/runs/CallsTimeline.jsx
+++ b/frontend/src/sections/al-environment/tabs/runs/CallsTimeline.jsx
@@ -2,8 +2,8 @@ import PropTypes from "prop-types";
 import { Box, Stack, Typography } from "@mui/material";
 import { ALK_MONO } from "../../alkTokens";
 
-const TONE = { ok: "divider", refused: "warning.main", crashed: "error.main" };
-const MARK_TONE = { ok: "text.secondary", refused: "warning.main", crashed: "error.main" };
+const TONE = { ok: "divider", refused: "accent.tool", crashed: "accent.fail" };
+const MARK_TONE = { ok: "text.secondary", refused: "accent.tool", crashed: "accent.fail" };
 const MARK = { ok: "ok", refused: "refused", crashed: "crash" };
 
 /**

--- a/frontend/src/sections/al-environment/tabs/runs/LegacyRuns.jsx
+++ b/frontend/src/sections/al-environment/tabs/runs/LegacyRuns.jsx
@@ -22,7 +22,9 @@ const callTone = (call) => {
 
 const boxOf = (check) => {
   if (check.broken) return { mark: "!", color: "warning.main" };
-  return check.passed ? { mark: "✓", color: "success.main" } : { mark: "✗", color: "error.main" };
+  return check.passed
+    ? { mark: "✓", color: "success.main" }
+    : { mark: "✗", color: "error.main" };
 };
 
 /**
@@ -33,7 +35,9 @@ const boxOf = (check) => {
 const LegacyRuns = ({ runs }) => {
   const [filter, setFilter] = useState("all");
   const passed = runs.filter((run) => run.passed).length;
-  const shown = runs.filter((run) => filter === "all" || (filter === "passed") === Boolean(run.passed));
+  const shown = runs.filter(
+    (run) => filter === "all" || (filter === "passed") === Boolean(run.passed),
+  );
 
   return (
     <Box>
@@ -69,13 +73,17 @@ const LegacyRuns = ({ runs }) => {
         else if (run.turns) how = ` · ${run.turns} turns`;
         const meta =
           `${run.met}/${run.of} settled by code` +
-          (run.judged.length ? ` · ${run.judged.length} judged` : "") +
+          (run.judged.length ? ` · ${run.judged.length} by eval harness` : "") +
           how;
         return (
           <XCard
             key={run.scenario}
             title={run.scenario}
-            tags={<Tag kind={run.passed ? "pass" : "fail"}>{run.passed ? "pass" : "fail"}</Tag>}
+            tags={
+              <Tag kind={run.passed ? "pass" : "fail"}>
+                {run.passed ? "pass" : "fail"}
+              </Tag>
+            }
             meta={meta}
             // A failure is what somebody opened this page for, and a lone run has nothing to
             // scan past.
@@ -105,34 +113,70 @@ const LegacyRuns = ({ runs }) => {
                   const mark = boxOf(check);
                   const failed = !check.passed && !check.broken;
                   return (
-                    <Stack key={check.name} direction="row" spacing={1.6} alignItems="flex-start">
-                      <Box component="span" aria-hidden sx={{ flex: "0 0 auto", width: "1em", color: mark.color }}>
+                    <Stack
+                      key={check.name}
+                      direction="row"
+                      spacing={1.6}
+                      alignItems="flex-start"
+                    >
+                      <Box
+                        component="span"
+                        aria-hidden
+                        sx={{
+                          flex: "0 0 auto",
+                          width: "1em",
+                          color: mark.color,
+                        }}
+                      >
                         {mark.mark}
                       </Box>
                       {check.kind && (
                         <Box
                           component="span"
-                          sx={{ flex: "0 0 auto", width: "5.4em", fontFamily: ALK_MONO, fontSize: 11.6, color: "text.secondary" }}
+                          sx={{
+                            flex: "0 0 auto",
+                            width: "5.4em",
+                            fontFamily: ALK_MONO,
+                            fontSize: 11.6,
+                            color: "text.secondary",
+                          }}
                         >
                           {check.kind}
                         </Box>
                       )}
-                      <Box sx={{ flex: "1 1 auto", minWidth: 0, overflowWrap: "anywhere" }}>
-                        <Box component="span" sx={{ fontSize: 13, color: "text.primary" }}>
+                      <Box
+                        sx={{
+                          flex: "1 1 auto",
+                          minWidth: 0,
+                          overflowWrap: "anywhere",
+                        }}
+                      >
+                        <Box
+                          component="span"
+                          sx={{ fontSize: 13, color: "text.primary" }}
+                        >
                           {check.name}
                         </Box>
                         {/* A failure needs its reason. So does an eval that passed: the point of
                             routing a claim through a named eval is that it can be read back. */}
                         {check.why && (!check.passed || check.by) && (
                           <Typography
-                            sx={{ fontSize: 12.4, color: failed ? "error.main" : "text.secondary", pt: 0.2 }}
+                            sx={{
+                              fontSize: 12.4,
+                              color: failed ? "error.main" : "text.secondary",
+                              pt: 0.2,
+                            }}
                           >
                             {check.why}
                           </Typography>
                         )}
                         {check.by && (
                           <Typography
-                            sx={{ fontFamily: ALK_MONO, fontSize: 11.5, color: "text.secondary" }}
+                            sx={{
+                              fontFamily: ALK_MONO,
+                              fontSize: 11.5,
+                              color: "text.secondary",
+                            }}
                           >
                             {`decided by ${check.by}`}
                           </Typography>
@@ -142,18 +186,40 @@ const LegacyRuns = ({ runs }) => {
                   );
                 })}
                 {run.judged.map((name) => (
-                  <Stack key={name} direction="row" spacing={1.6} alignItems="flex-start">
-                    <Box component="span" aria-hidden sx={{ flex: "0 0 auto", width: "1em", color: "warning.main" }}>
+                  <Stack
+                    key={name}
+                    direction="row"
+                    spacing={1.6}
+                    alignItems="flex-start"
+                  >
+                    <Box
+                      component="span"
+                      aria-hidden
+                      sx={{
+                        flex: "0 0 auto",
+                        width: "1em",
+                        color: "warning.main",
+                      }}
+                    >
                       ?
                     </Box>
                     <Box
                       component="span"
-                      sx={{ flex: "0 0 auto", width: "5.4em", fontFamily: ALK_MONO, fontSize: 11.6, color: "text.secondary" }}
+                      sx={{
+                        flex: "0 0 auto",
+                        width: "5.4em",
+                        fontFamily: ALK_MONO,
+                        fontSize: 11.6,
+                        color: "text.secondary",
+                      }}
                     >
-                      judged
+                      eval
                     </Box>
-                    <Box component="span" sx={{ fontSize: 13, color: "text.primary" }}>
-                      {`${name} — not settled by code`}
+                    <Box
+                      component="span"
+                      sx={{ fontSize: 13, color: "text.primary" }}
+                    >
+                      {`${name} — decided by the eval harness`}
                     </Box>
                   </Stack>
                 ))}

--- a/frontend/src/sections/al-environment/tabs/runs/LegacyRuns.jsx
+++ b/frontend/src/sections/al-environment/tabs/runs/LegacyRuns.jsx
@@ -15,16 +15,16 @@ const TONE = { all: "soft", passed: "pass", failed: "fail" };
 
 /** The older per-scenario record kept its calls as flat strings with the outcome in the text. */
 const callTone = (call) => {
-  if (/-> refused/.test(call)) return { color: "warning.main", mark: "⃠ " };
-  if (/-> crashed/.test(call)) return { color: "error.main", mark: "✗ " };
+  if (/-> refused/.test(call)) return { color: "accent.tool", mark: "⃠ " };
+  if (/-> crashed/.test(call)) return { color: "accent.fail", mark: "✗ " };
   return { color: "text.primary", mark: "✓ " };
 };
 
 const boxOf = (check) => {
-  if (check.broken) return { mark: "!", color: "warning.main" };
+  if (check.broken) return { mark: "!", color: "accent.tool" };
   return check.passed
-    ? { mark: "✓", color: "success.main" }
-    : { mark: "✗", color: "error.main" };
+    ? { mark: "✓", color: "accent.pass" }
+    : { mark: "✗", color: "accent.fail" };
 };
 
 /**
@@ -163,7 +163,7 @@ const LegacyRuns = ({ runs }) => {
                           <Typography
                             sx={{
                               fontSize: 12.4,
-                              color: failed ? "error.main" : "text.secondary",
+                              color: failed ? "accent.fail" : "text.secondary",
                               pt: 0.2,
                             }}
                           >
@@ -198,7 +198,7 @@ const LegacyRuns = ({ runs }) => {
                       sx={{
                         flex: "0 0 auto",
                         width: "1em",
-                        color: "warning.main",
+                        color: "accent.tool",
                       }}
                     >
                       ?
@@ -232,10 +232,10 @@ const LegacyRuns = ({ runs }) => {
                 sx={{
                   fontFamily: ALK_MONO,
                   fontSize: 11.8,
-                  color: "error.main",
+                  color: "accent.fail",
                   bgcolor: "action.hover",
                   border: "1px solid",
-                  borderColor: "error.main",
+                  borderColor: "accent.fail",
                   borderRadius: "3px",
                   px: 2.2,
                   py: 1.4,

--- a/frontend/src/sections/al-environment/tabs/runs/MetricBars.jsx
+++ b/frontend/src/sections/al-environment/tabs/runs/MetricBars.jsx
@@ -6,9 +6,9 @@ import { metricLabel, splitMetrics } from "./metrics";
 
 /** Everything ALK measures is 0..1, so one shape reads for all of them. */
 const toneOf = (value) => {
-  if (value >= 0.8) return "success.main";
-  if (value >= 0.5) return "warning.main";
-  return "error.main";
+  if (value >= 0.8) return "accent.pass";
+  if (value >= 0.5) return "accent.tool";
+  return "accent.fail";
 };
 
 const MetricBar = ({ metric }) => {

--- a/frontend/src/sections/al-environment/tabs/runs/RunDetail.jsx
+++ b/frontend/src/sections/al-environment/tabs/runs/RunDetail.jsx
@@ -12,7 +12,7 @@ import ScenarioCard from "./ScenarioCard";
 const RunDetail = ({ run, onBack }) => {
   const cases = Array.isArray(run.scenarios) ? run.scenarios : [];
   const models = run.models
-    ? ` · agent ${run.models.agent} · user ${run.models.user} · judge ${run.models.judge}`
+    ? ` · agent ${run.models.agent} · user ${run.models.user} · eval harness ${run.models.judge}`
     : "";
 
   return (
@@ -25,13 +25,20 @@ const RunDetail = ({ run, onBack }) => {
           variant="outlined"
           color="inherit"
           onClick={onBack}
-          sx={{ borderRadius: 5, color: "text.secondary", borderColor: "divider" }}
+          sx={{
+            borderRadius: 5,
+            color: "text.secondary",
+            borderColor: "divider",
+          }}
         >
           ‹ all runs
         </Button>
       </Box>
 
-      <Pane title={run.run_id} meta={`${run.passed ?? 0}/${cases.length} passed in ${run.seconds}s`}>
+      <Pane
+        title={run.run_id}
+        meta={`${run.passed ?? 0}/${cases.length} passed in ${run.seconds}s`}
+      >
         <Box
           sx={{
             px: 3.6,
@@ -57,6 +64,9 @@ const RunDetail = ({ run, onBack }) => {
   );
 };
 
-RunDetail.propTypes = { run: PropTypes.object.isRequired, onBack: PropTypes.func.isRequired };
+RunDetail.propTypes = {
+  run: PropTypes.object.isRequired,
+  onBack: PropTypes.func.isRequired,
+};
 
 export default RunDetail;

--- a/frontend/src/sections/al-environment/tabs/runs/RunList.jsx
+++ b/frontend/src/sections/al-environment/tabs/runs/RunList.jsx
@@ -10,7 +10,10 @@ import Tag from "../../parts/Tag";
  * result: the list is the first thing, and any entry opens into what actually happened.
  */
 const RunList = ({ runs, selectedRunId, onSelectRun }) => (
-  <Pane title="Simulations" meta={`${runs.length} run${runs.length === 1 ? "" : "s"} of this suite`}>
+  <Pane
+    title="Simulations"
+    meta={`${runs.length} run${runs.length === 1 ? "" : "s"} of this suite`}
+  >
     <Stack spacing={1.2}>
       {runs.map((run) => {
         // On the list payload `scenarios` is a count. read_run replaces it with the results
@@ -38,27 +41,54 @@ const RunList = ({ runs, selectedRunId, onSelectRun }) => (
               cursor: "pointer",
               bgcolor: "background.paper",
               border: "1px solid",
-              borderColor: selectedRunId === run.run_id ? "text.secondary" : "divider",
+              borderColor:
+                selectedRunId === run.run_id ? "text.secondary" : "divider",
               transition: "border-color 120ms, transform 120ms",
-              "&:hover": { borderColor: "text.secondary", transform: "translateY(-1px)" },
-              "&:focus-visible": { outline: "2px solid", outlineColor: "success.main", outlineOffset: "2px" },
+              "&:hover": {
+                borderColor: "text.secondary",
+                transform: "translateY(-1px)",
+              },
+              "&:focus-visible": {
+                outline: "2px solid",
+                outlineColor: "success.main",
+                outlineOffset: "2px",
+              },
             }}
           >
-            <Stack direction="row" alignItems="center" spacing={2} flexWrap="wrap" useFlexGap>
+            <Stack
+              direction="row"
+              alignItems="center"
+              spacing={2}
+              flexWrap="wrap"
+              useFlexGap
+            >
               <Tag kind={run.passed === total ? "pass" : "fail"}>
                 {`${run.passed ?? 0}/${total} passed`}
               </Tag>
               <Typography
                 component="span"
-                sx={{ fontFamily: ALK_MONO, fontSize: 13.5, fontWeight: 600, color: "text.primary" }}
+                sx={{
+                  fontFamily: ALK_MONO,
+                  fontSize: 13.5,
+                  fontWeight: 600,
+                  color: "text.primary",
+                }}
               >
                 {run.run_id}
               </Typography>
               <Box sx={{ flex: "1 1 auto" }} />
-              <Typography component="span" variant="caption" color="text.secondary">
+              <Typography
+                component="span"
+                variant="caption"
+                color="text.secondary"
+              >
                 {`${run.seconds}s · ${run.modality || "chat"} · $${run.spent_usd || 0}`}
               </Typography>
-              <Box component="span" aria-hidden sx={{ color: "text.secondary", fontSize: 14 }}>
+              <Box
+                component="span"
+                aria-hidden
+                sx={{ color: "text.secondary", fontSize: 14 }}
+              >
                 ›
               </Box>
             </Stack>
@@ -66,7 +96,13 @@ const RunList = ({ runs, selectedRunId, onSelectRun }) => (
             {/* Which scenarios, at a glance, so the list answers "what changed between runs"
                 without opening each one. */}
             {(run.results || []).length > 0 && (
-              <Stack direction="row" spacing={1.4} flexWrap="wrap" useFlexGap sx={{ mt: 1.4 }}>
+              <Stack
+                direction="row"
+                spacing={1.4}
+                flexWrap="wrap"
+                useFlexGap
+                sx={{ mt: 1.4 }}
+              >
                 {run.results.map((one) => (
                   <Tag key={one.scenario} kind={one.passed ? "pass" : "fail"}>
                     {one.scenario}
@@ -76,8 +112,12 @@ const RunList = ({ runs, selectedRunId, onSelectRun }) => (
             )}
 
             {run.models && (
-              <Typography variant="caption" color="text.secondary" sx={{ display: "block", mt: 1 }}>
-                {`agent ${run.models.agent} · user ${run.models.user} · judge ${run.models.judge}`}
+              <Typography
+                variant="caption"
+                color="text.secondary"
+                sx={{ display: "block", mt: 1 }}
+              >
+                {`agent ${run.models.agent} · user ${run.models.user} · eval harness ${run.models.judge}`}
               </Typography>
             )}
           </Box>

--- a/frontend/src/sections/al-environment/tabs/runs/RunList.jsx
+++ b/frontend/src/sections/al-environment/tabs/runs/RunList.jsx
@@ -50,7 +50,7 @@ const RunList = ({ runs, selectedRunId, onSelectRun }) => (
               },
               "&:focus-visible": {
                 outline: "2px solid",
-                outlineColor: "success.main",
+                outlineColor: "accent.pass",
                 outlineOffset: "2px",
               },
             }}
@@ -62,7 +62,17 @@ const RunList = ({ runs, selectedRunId, onSelectRun }) => (
               flexWrap="wrap"
               useFlexGap
             >
-              <Tag kind={run.passed === total ? "pass" : "fail"}>
+              {/* Red is for failure, not for progress: a run where some scenarios passed has not
+                  failed, so only a run that passed nothing wears it. */}
+              <Tag
+                kind={
+                  run.passed === total
+                    ? "pass"
+                    : (run.passed ?? 0) === 0
+                      ? "fail"
+                      : "soft"
+                }
+              >
                 {`${run.passed ?? 0}/${total} passed`}
               </Tag>
               <Typography

--- a/frontend/src/sections/al-environment/tabs/runs/ScenarioCard.jsx
+++ b/frontend/src/sections/al-environment/tabs/runs/ScenarioCard.jsx
@@ -46,7 +46,7 @@ const GoalGroup = ({ label, checks }) => (
           sx={{
             flex: "0 0 auto",
             width: "1em",
-            color: check.passed ? "success.main" : "error.main",
+            color: check.passed ? "accent.pass" : "accent.fail",
           }}
         >
           {check.passed ? "✓" : "✗"}
@@ -66,7 +66,7 @@ const GoalGroup = ({ label, checks }) => (
               sx={{
                 fontSize: 12.5,
                 mt: 0.3,
-                color: check.passed ? "text.secondary" : "error.main",
+                color: check.passed ? "text.secondary" : "accent.fail",
               }}
             >
               {check.detail}
@@ -150,7 +150,7 @@ const ScenarioCard = ({ runId, result }) => {
         border: "1px solid",
         borderColor: "divider",
         borderLeft: "3px solid",
-        borderLeftColor: result.passed ? "success.main" : "error.main",
+        borderLeftColor: result.passed ? "accent.pass" : "accent.fail",
       }}
     >
       <Stack
@@ -206,10 +206,10 @@ const ScenarioCard = ({ runId, result }) => {
           sx={{
             fontFamily: ALK_MONO,
             fontSize: 11.8,
-            color: "error.main",
+            color: "accent.fail",
             bgcolor: "action.hover",
             border: "1px solid",
-            borderColor: "error.main",
+            borderColor: "accent.fail",
             borderRadius: "3px",
             px: 2.2,
             py: 1.4,
@@ -278,7 +278,7 @@ const ScenarioCard = ({ runId, result }) => {
               sx={{
                 fontFamily: ALK_MONO,
                 fontSize: 11.8,
-                color: source.available ? "text.secondary" : "error.main",
+                color: source.available ? "text.secondary" : "accent.fail",
                 my: 0.2,
                 ml: 1,
               }}

--- a/frontend/src/sections/al-environment/tabs/runs/ScenarioCard.jsx
+++ b/frontend/src/sections/al-environment/tabs/runs/ScenarioCard.jsx
@@ -43,12 +43,19 @@ const GoalGroup = ({ label, checks }) => (
         <Box
           component="span"
           aria-hidden
-          sx={{ flex: "0 0 auto", width: "1em", color: check.passed ? "success.main" : "error.main" }}
+          sx={{
+            flex: "0 0 auto",
+            width: "1em",
+            color: check.passed ? "success.main" : "error.main",
+          }}
         >
           {check.passed ? "✓" : "✗"}
         </Box>
         <Box sx={{ minWidth: 0, flex: "1 1 auto" }}>
-          <Box component="span" sx={{ fontFamily: ALK_MONO, fontSize: 12.8, color: "text.primary" }}>
+          <Box
+            component="span"
+            sx={{ fontFamily: ALK_MONO, fontSize: 12.8, color: "text.primary" }}
+          >
             {check.name}
           </Box>
           {/* An eval that passed still shows its reasoning: the whole point of routing a claim
@@ -56,14 +63,24 @@ const GoalGroup = ({ label, checks }) => (
               on a failure, or the reasoning reads as one. */}
           {check.detail && (
             <Typography
-              sx={{ fontSize: 12.5, mt: 0.3, color: check.passed ? "text.secondary" : "error.main" }}
+              sx={{
+                fontSize: 12.5,
+                mt: 0.3,
+                color: check.passed ? "text.secondary" : "error.main",
+              }}
             >
               {check.detail}
             </Typography>
           )}
           {check.by && (
             <Typography
-              sx={{ fontFamily: ALK_MONO, fontSize: 11.5, color: "text.secondary", opacity: 0.8, mt: 0.2 }}
+              sx={{
+                fontFamily: ALK_MONO,
+                fontSize: 11.5,
+                color: "text.secondary",
+                opacity: 0.8,
+                mt: 0.2,
+              }}
             >
               {check.by}
             </Typography>
@@ -74,7 +91,10 @@ const GoalGroup = ({ label, checks }) => (
   </Box>
 );
 
-GoalGroup.propTypes = { label: PropTypes.string.isRequired, checks: PropTypes.array.isRequired };
+GoalGroup.propTypes = {
+  label: PropTypes.string.isRequired,
+  checks: PropTypes.array.isRequired,
+};
 
 /**
  * One scenario, as something you read rather than scroll past.
@@ -94,20 +114,28 @@ const ScenarioCard = ({ runId, result }) => {
   if (result.turns) facts.push(`${result.turns} turns`);
   const refused = callsDetail.filter((call) => call.refused).length;
   if (result.calls != null) {
-    facts.push(`${result.calls} tool calls${refused ? `, ${refused} refused` : ""}`);
+    facts.push(
+      `${result.calls} tool calls${refused ? `, ${refused} refused` : ""}`,
+    );
   }
   if (result.seconds) facts.push(`${Math.round(result.seconds)}s`);
-  if (measures.stop_reason) facts.push(`ended: ${String(measures.stop_reason).replace(/_/g, " ")}`);
+  if (measures.stop_reason)
+    facts.push(`ended: ${String(measures.stop_reason).replace(/_/g, " ")}`);
   if (measures.score != null) {
     facts.push(
       `ALK score ${Number(measures.score).toFixed(2)}` +
-        (measures.threshold != null ? ` vs ${measures.threshold}` : "")
+        (measures.threshold != null ? ` vs ${measures.threshold}` : ""),
     );
   }
-  if (measures.simulator?.model) facts.push(`caller on ${measures.simulator.model}`);
+  if (measures.simulator?.model)
+    facts.push(`caller on ${measures.simulator.model}`);
 
-  const byCode = checks.filter((one) => one.kind !== "eval" && one.kind !== "judged");
-  const byEval = checks.filter((one) => one.kind === "eval" || one.kind === "judged");
+  const byCode = checks.filter(
+    (one) => one.kind !== "eval" && one.kind !== "judged",
+  );
+  const byEval = checks.filter(
+    (one) => one.kind === "eval" || one.kind === "judged",
+  );
   const { measured, clean, absent } = splitMetrics(measures.metrics);
   const evidence = measures.evidence || [];
 
@@ -125,11 +153,24 @@ const ScenarioCard = ({ runId, result }) => {
         borderLeftColor: result.passed ? "success.main" : "error.main",
       }}
     >
-      <Stack direction="row" alignItems="center" spacing={2} flexWrap="wrap" useFlexGap>
-        <Tag kind={result.passed ? "pass" : "fail"}>{result.passed ? "PASS" : "FAIL"}</Tag>
+      <Stack
+        direction="row"
+        alignItems="center"
+        spacing={2}
+        flexWrap="wrap"
+        useFlexGap
+      >
+        <Tag kind={result.passed ? "pass" : "fail"}>
+          {result.passed ? "PASS" : "FAIL"}
+        </Tag>
         <Typography
           component="span"
-          sx={{ fontFamily: ALK_MONO, fontSize: 14, fontWeight: 600, color: "text.primary" }}
+          sx={{
+            fontFamily: ALK_MONO,
+            fontSize: 14,
+            fontWeight: 600,
+            color: "text.primary",
+          }}
         >
           {result.scenario}
         </Typography>
@@ -140,7 +181,9 @@ const ScenarioCard = ({ runId, result }) => {
       </Stack>
 
       {result.tests && (
-        <Typography sx={{ fontSize: 13, color: "text.secondary", mt: 1.2 }}>{result.tests}</Typography>
+        <Typography sx={{ fontSize: 13, color: "text.secondary", mt: 1.2 }}>
+          {result.tests}
+        </Typography>
       )}
 
       {facts.length > 0 && (
@@ -190,8 +233,12 @@ const ScenarioCard = ({ runId, result }) => {
           >
             sub-goals
           </Typography>
-          {byCode.length > 0 && <GoalGroup label="settled by code" checks={byCode} />}
-          {byEval.length > 0 && <GoalGroup label="decided by an eval" checks={byEval} />}
+          {byCode.length > 0 && (
+            <GoalGroup label="settled by code" checks={byCode} />
+          )}
+          {byEval.length > 0 && (
+            <GoalGroup label="decided by the eval harness" checks={byEval} />
+          )}
         </Box>
       )}
 
@@ -200,7 +247,9 @@ const ScenarioCard = ({ runId, result }) => {
       )}
 
       {result.transcript && (
-        <Fold label={`the conversation${result.turns ? ` (${result.turns} turns)` : ""}`}>
+        <Fold
+          label={`the conversation${result.turns ? ` (${result.turns} turns)` : ""}`}
+        >
           <Transcript spoken={result.transcript} />
         </Fold>
       )}
@@ -245,6 +294,9 @@ const ScenarioCard = ({ runId, result }) => {
   );
 };
 
-ScenarioCard.propTypes = { runId: PropTypes.string.isRequired, result: PropTypes.object.isRequired };
+ScenarioCard.propTypes = {
+  runId: PropTypes.string.isRequired,
+  result: PropTypes.object.isRequired,
+};
 
 export default ScenarioCard;

--- a/frontend/src/sections/rl-environments/EnvironmentsListView.jsx
+++ b/frontend/src/sections/rl-environments/EnvironmentsListView.jsx
@@ -62,12 +62,20 @@ function CountCell({ getValue }) {
 
 function RunsCell({ row }) {
   const { runs = 0, runs_passed: runsPassed = 0 } = row.original ?? {};
-  // Neutral until the environment has been run at least once; green only when
-  // every run passed, red as soon as one did not.
+  // Neutral until it has been run; green when everything passed; red only when nothing did.
+  // A partially-passing environment has not failed, so it does not wear the failure colour.
   const tone =
-    runs === 0 ? "neutral" : runsPassed >= runs ? "success" : "error";
-  const color = tone === "neutral" ? "text.secondary" : `${tone}.main`;
-  const borderColor = tone === "neutral" ? "divider" : `${tone}.main`;
+    runs === 0
+      ? "neutral"
+      : runsPassed >= runs
+        ? "pass"
+        : runsPassed === 0
+          ? "fail"
+          : "partial";
+  // accent carries a value per theme; the .main ramp is dark-tuned and meant for fills.
+  const TONES = { pass: "accent.pass", fail: "accent.fail", partial: "accent.tool" };
+  const color = TONES[tone] || "text.secondary";
+  const borderColor = TONES[tone] || "divider";
 
   return (
     <Box

--- a/frontend/src/sections/rl-environments/__tests__/EnvironmentsListView.test.jsx
+++ b/frontend/src/sections/rl-environments/__tests__/EnvironmentsListView.test.jsx
@@ -107,8 +107,10 @@ describe("EnvironmentsListView", () => {
   it("colours the runs chip by outcome", () => {
     render(<EnvironmentsListView environments={rows} />);
 
-    expect(chipTone("14/14")).toBe("success");
-    expect(chipTone("21/26")).toBe("error");
+    expect(chipTone("14/14")).toBe("pass");
+    // Some passed, some did not — progress, not failure, so it must not wear the failure
+    // colour. Only an environment where nothing passed has actually failed.
+    expect(chipTone("21/26")).toBe("partial");
     expect(chipTone("No runs")).toBe("neutral");
   });
 


### PR DESCRIPTION
## 🧹 Chore
The UI called eval-decided sub-goals and checks "judge" / "judged". They are the eval harness, and the copy should say so.

## 🔧 What changed
- Sub-goal chip: `judged` → `eval harness`, and the field `what a judge must decide` → `what the eval harness must decide` (`EnvironmentTab`)
- Run models line: `· judge opus` → `· eval harness opus` (`RunList`, `RunDetail`)
- Sub-goal group heading: `decided by an eval` → `decided by the eval harness` (`ScenarioCard`)
- Legacy run view: `· 1 judged` → `· 1 by eval harness`, the column label `judged` → `eval`, and the row text `not settled by code` → `decided by the eval harness`

## 🤔 Why
Copy only. `settled_by`, `judged`, `kind === "judged"` and `models.judge` are what the harness sends — renaming those would stop the data being read.

The API still sends `settled_by: "a judge"` (`futureagi/harness/ui/server.py`, lines 627 and 680), and the frontend contract documents that value. Changing it is a two-line edit, but it is a breaking API change on a package this PR does not own, so it is deliberately left out. cc @KarthikAvinashFI — worth deciding whether the value should change at source so the vocabulary matches end to end.

## 🧪 Tests
- `EnvironmentTab` splits sub-goals into code-settled and eval-harness groups
- `RunsTab` renders the models line with the new wording, in both the list and the detail header
- `RunsTab` groups a run's sub-goals under the renamed heading
- `LegacyRuns` shows the renamed summary, column label and row text

## ▶️ Verify
Open an RL environment that has sub-goals. The Environment tab's Sub-goals pane shows `CODE` and `EVAL HARNESS` tags side by side, and expanding an eval-harness goal reads "what the eval harness must decide".

Note: a sub-goal's own body text comes from the harness and may still say "judge" — that is the payload, not our label.

## 💻 Commands
```
cd frontend
npx vitest run src/sections/al-environment
```

## 📹 Videos & Screenshots
![subgoals-eval-harness](https://github.com/user-attachments/assets/6b432b91-6f08-492f-a8e4-0db1ad0eb233)

![subgoals-eval-harness-expanded](https://github.com/user-attachments/assets/3f07a216-a657-48e3-99ea-5b95761700b9)

![scenario-graded-against-and-folder](https://github.com/user-attachments/assets/12967ea7-a7cf-48e6-ad39-f7f44158f0cb)

![composer-trimmed-path](https://github.com/user-attachments/assets/00d33690-4e21-4a05-a9ec-3344232bdeab)
