### PR TITLE
feat(datasets): show per-column run status indicator in dataset grid header

### DIFF
--- a/frontend/src/sections/common/CustomDevelopDetailColumn.jsx
+++ b/frontend/src/sections/common/CustomDevelopDetailColumn.jsx
@@ -1,8 +1,20 @@
-import { alpha, Box, IconButton, Typography, useTheme } from "@mui/material";
+import {
+  alpha,
+  Box,
+  CircularProgress,
+  IconButton,
+  Tooltip,
+  Typography,
+  useTheme,
+} from "@mui/material";
 import PropTypes from "prop-types";
 import React, { useRef, useEffect } from "react";
 import Iconify from "src/components/iconify";
 import SvgColor from "src/components/svg-color";
+import {
+  RefreshStatus,
+  StatusTypes,
+} from "src/sections/common/DevelopCellRenderer/CellRenderers/cellRendererHelper";
 
 export const CustomDevelopDetailColumn = (props) => {
   const { displayName, showColumnMenu, col, hideMenu, eGridHeader, api } =
@@ -117,6 +129,55 @@ export const CustomDevelopDetailColumn = (props) => {
     }
   };
 
+  const renderStatusIndicator = () => {
+    const status = col?.status;
+    if (!status) return null;
+
+    const isQueued = status === "NotStarted";
+    const isRunning = RefreshStatus.includes(status) && !isQueued;
+    const isError = status?.toLowerCase() === StatusTypes.ERROR;
+
+    if (isQueued) {
+      return (
+        <Box
+          data-testid="column-status-queued"
+          sx={{ display: "flex", alignItems: "center", ml: 0.5 }}
+        >
+          <Iconify
+            icon="material-symbols:schedule"
+            sx={{ width: 16, height: 16, color: "text.disabled" }}
+          />
+        </Box>
+      );
+    }
+    if (isRunning) {
+      return (
+        <Box
+          data-testid="column-status-running"
+          sx={{ display: "flex", alignItems: "center", ml: 0.5 }}
+        >
+          <CircularProgress size={14} sx={{ color: "info.main" }} />
+        </Box>
+      );
+    }
+    if (isError) {
+      return (
+        <Tooltip title="This column failed to run. Open the column menu to retry.">
+          <Box
+            data-testid="column-status-error"
+            sx={{ display: "flex", alignItems: "center", ml: 0.5 }}
+          >
+            <Iconify
+              icon="material-symbols:error-outline"
+              sx={{ width: 16, height: 16, color: "error.main" }}
+            />
+          </Box>
+        </Tooltip>
+      );
+    }
+    return null;
+  };
+
   const getBackgroundColor = (originType) => {
     const isDark = theme.palette.mode === "dark";
     if (
@@ -155,6 +216,7 @@ export const CustomDevelopDetailColumn = (props) => {
         <Typography fontWeight={500} fontSize="14px" color={"text.secondary"}>
           {displayName}
         </Typography>
+        {renderStatusIndicator()}
       </Box>
       {!hideMenu && (
         <IconButton size="small" ref={refButton} onClick={onMenuClicked}>

--- a/frontend/src/sections/common/__tests__/CustomDevelopDetailColumn.test.jsx
+++ b/frontend/src/sections/common/__tests__/CustomDevelopDetailColumn.test.jsx
@@ -1,0 +1,142 @@
+import React from "react";
+import { describe, expect, it, vi } from "vitest";
+import { render, screen } from "src/utils/test-utils";
+import CustomDevelopDetailColumn from "../CustomDevelopDetailColumn";
+
+vi.mock("src/components/iconify", () => ({
+  default: ({ icon, ...props }) => (
+    <span data-testid="iconify" data-icon={icon} {...props} />
+  ),
+}));
+
+vi.mock("src/components/svg-color", () => ({
+  default: (props) => <span data-testid="svg-color" {...props} />,
+}));
+
+const baseProps = {
+  displayName: "My Column",
+  showColumnMenu: () => {},
+  eGridHeader: { style: {} },
+  api: null,
+};
+
+const colWithOrigin = (overrides = {}) => ({
+  id: "col-1",
+  originType: "evaluation",
+  dataType: "text",
+  ...overrides,
+});
+
+describe("CustomDevelopDetailColumn status indicator", () => {
+  it("renders a running spinner when the column status is Running", () => {
+    render(
+      <CustomDevelopDetailColumn
+        {...baseProps}
+        col={colWithOrigin({ status: "Running" })}
+      />,
+    );
+    expect(screen.getByTestId("column-status-running")).toBeInTheDocument();
+    expect(
+      screen.queryByTestId("column-status-queued"),
+    ).not.toBeInTheDocument();
+    expect(screen.queryByTestId("column-status-error")).not.toBeInTheDocument();
+  });
+
+  it("renders a running spinner for other computing statuses", () => {
+    const { rerender } = render(
+      <CustomDevelopDetailColumn
+        {...baseProps}
+        col={colWithOrigin({ status: "Editing" })}
+      />,
+    );
+    expect(screen.getByTestId("column-status-running")).toBeInTheDocument();
+
+    rerender(
+      <CustomDevelopDetailColumn
+        {...baseProps}
+        col={colWithOrigin({ status: "PartialRun" })}
+      />,
+    );
+    expect(screen.getByTestId("column-status-running")).toBeInTheDocument();
+
+    rerender(
+      <CustomDevelopDetailColumn
+        {...baseProps}
+        col={colWithOrigin({ status: "ExperimentEvaluation" })}
+      />,
+    );
+    expect(screen.getByTestId("column-status-running")).toBeInTheDocument();
+  });
+
+  it("renders a queued clock icon when the column status is NotStarted", () => {
+    render(
+      <CustomDevelopDetailColumn
+        {...baseProps}
+        col={colWithOrigin({ status: "NotStarted" })}
+      />,
+    );
+    expect(screen.getByTestId("column-status-queued")).toBeInTheDocument();
+    expect(
+      screen.queryByTestId("column-status-running"),
+    ).not.toBeInTheDocument();
+    expect(screen.queryByTestId("column-status-error")).not.toBeInTheDocument();
+  });
+
+  it("renders an error icon when the column status is error", () => {
+    render(
+      <CustomDevelopDetailColumn
+        {...baseProps}
+        col={colWithOrigin({ status: "error" })}
+      />,
+    );
+    expect(screen.getByTestId("column-status-error")).toBeInTheDocument();
+    expect(
+      screen.queryByTestId("column-status-running"),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByTestId("column-status-queued"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("renders no status indicator when the column is completed", () => {
+    render(
+      <CustomDevelopDetailColumn
+        {...baseProps}
+        col={colWithOrigin({ status: "completed" })}
+      />,
+    );
+    expect(
+      screen.queryByTestId("column-status-running"),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByTestId("column-status-queued"),
+    ).not.toBeInTheDocument();
+    expect(screen.queryByTestId("column-status-error")).not.toBeInTheDocument();
+  });
+
+  it("renders no status indicator when the status is absent", () => {
+    render(
+      <CustomDevelopDetailColumn
+        {...baseProps}
+        col={colWithOrigin({ status: undefined })}
+      />,
+    );
+    expect(
+      screen.queryByTestId("column-status-running"),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByTestId("column-status-queued"),
+    ).not.toBeInTheDocument();
+    expect(screen.queryByTestId("column-status-error")).not.toBeInTheDocument();
+  });
+
+  it("still renders the column display name regardless of status", () => {
+    render(
+      <CustomDevelopDetailColumn
+        {...baseProps}
+        col={colWithOrigin({ status: "Running" })}
+      />,
+    );
+    expect(screen.getByText("My Column")).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary

Adds a live status indicator to the dataset grid column header so users can see at a glance when an eval or prompt column is computing, without refreshing or guessing.

Fixes #578

## What changed

`CustomDevelopDetailColumn` already receives `col.status` via `headerComponentParams` (set in `develop-detail/DataTab/common.js`), but it never rendered it. This PR adds a `renderStatusIndicator` that surfaces that status:

| `col.status` | Indicator |
|---|---|
| `Running`, `Editing`, `PartialRun`, `ExperimentEvaluation` | MUI `CircularProgress` spinner (info color) |
| `NotStarted` | clock icon (queued) |
| `error` | red error-outline icon with tooltip |
| completed / absent | nothing (unchanged) |

The indicator sits right after the column display name, inside the existing header layout. The status values and the polling gate are already defined in `cellRendererHelper.js` (`RefreshStatus`, `StatusTypes`) and `DevelopDataV2.jsx` (`columnConfig?.some(v => RefreshStatus.includes(v?.status))`), so the indicator updates and clears automatically on the existing poll interval — no new data fetching, no new state.

## Acceptance criteria checklist

- [x] When a column run starts, its header shows a `running` indicator (the poll loop feeds `col.status`, the header renders it)
- [x] The indicator clears when the run completes (status leaves `RefreshStatus` / stops being `error`)
- [x] Failed runs show a distinct `failed` state with an error tooltip
- [x] No regression on columns that are not running — no indicator renders, no perf change, no flicker
- [x] The `42 / 100 rows` count is intentionally skipped (no backend column for it yet; flagged as a follow-up in the issue)

## How to verify

1. Open a dataset that has an eval or prompt column
2. Trigger a run on that column
3. The column header shows a spinner within the poll interval
4. When the run finishes, the spinner disappears
5. If the run errors, a red icon with a tooltip appears

## Tests

Added `__tests__/CustomDevelopDetailColumn.test.jsx` (7 tests) covering running, queued, error, completed, absent status, and that the display name still renders. Mocks follow the existing `Iconify` / `SvgColor` pattern used across the repo.

```
✓ src/sections/common/__tests__/CustomDevelopDetailColumn.test.jsx (7 tests)
```

`eslint` and `prettier --check` pass on both files.

## Scope

Frontend-only, single component + test. No backend, schema, or API changes.