### PR TITLE
fix(dataset): use snake_case key for column_config in cache read/write

### DIFF
--- a/frontend/src/sections/develop-detail/DevelopBarRightSection/DevelopBarLeftSection.jsx
+++ b/frontend/src/sections/develop-detail/DevelopBarRightSection/DevelopBarLeftSection.jsx
@@ -144,7 +144,7 @@ const DevelopBarLeftSection = ({
     queryClient.setQueryData(
       getDatasetQueryKey(dataset, 0, [], [], ""),
       (oldData) => {
-        const existingColumnOrder = oldData?.data?.result?.columnConfig;
+        const existingColumnOrder = oldData?.data?.result?.column_config;
 
         const newColumnOrder = existingColumnOrder.map((col) => {
           columnOrder.push(col.id);
@@ -155,10 +155,6 @@ const DevelopBarLeftSection = ({
             is_visible: nextVisible,
             is_frozen: col.pinned,
           };
-          // Update BOTH snake_case (canonical) and camelCase (alias) keys
-          // so downstream reads of either form stay in sync. Without this,
-          // `col.is_visible` would remain stale and downstream code using
-          // `col?.is_visible ?? col?.isVisible` would read the old value.
           return col.id === columnId
             ? { ...col, is_visible: nextVisible, isVisible: nextVisible }
             : col;
@@ -170,7 +166,7 @@ const DevelopBarLeftSection = ({
             ...oldData.data,
             result: {
               ...oldData.data.result,
-              columnConfig: newColumnOrder,
+              column_config: newColumnOrder,
             },
           },
         };
@@ -191,7 +187,7 @@ const DevelopBarLeftSection = ({
     queryClient.setQueryData(
       getDatasetQueryKey(dataset, 0, [], [], ""),
       (oldData) => {
-        const existingColumnOrder = oldData?.data?.result?.columnConfig;
+        const existingColumnOrder = oldData?.data?.result?.column_config;
         const colDefMap = existingColumnOrder.reduce((acc, col) => {
           acc[col.id] = col;
           return acc;
@@ -212,7 +208,7 @@ const DevelopBarLeftSection = ({
             ...oldData.data,
             result: {
               ...oldData.data.result,
-              columnConfig: newColumnOrder,
+              column_config: newColumnOrder,
             },
           },
         };


### PR DESCRIPTION
## Summary

The column reorder and column hide features on the dataset detail page were completely broken — clicking the Columns button and dragging to reorder or toggling visibility did nothing because no backend request was ever made. The root cause is that `onColumnVisibilityChange` and `onColumnOrderChange` in `DevelopBarLeftSection.jsx` read and write the React Query cache using `columnConfig` (camelCase), but the API response stores the data under `column_config` (snake_case). This caused `.map()` / `.reduce()` to be called on `undefined`, throwing a TypeError before `updateDataset()` could fire. The AG Grid native `onColumnChanged` handler in `DevelopDataV2.jsx` already uses the correct snake_case key via `getResultColumnConfig()` — this fix aligns the dropdown-based handlers to match.

Closes TH-7611

## Test plan

- [ ] Open a dataset detail page
- [ ] Click the Columns button to open the column dropdown
- [ ] Drag a column to reorder — verify the grid reflects the new order and a PUT request is made to `/model-hub/develops/{id}/edit_dataset_behavior/`
- [ ] Toggle a column's visibility checkbox — verify the column hides/shows and a PUT request is made
- [ ] Refresh the page — verify the reorder/visibility changes persisted
- [ ] Drag columns directly in the AG Grid header — verify this still works (regression check)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have verified that the AG Grid handler (`DevelopDataV2.jsx`) is unaffected