### PR TITLE
fix(error-feed): render the Overview fix as markdown, not as its own source

### DIFF
--- a/frontend/src/pages/dashboard/error-feed/components/AnalyzeMarkdown.jsx
+++ b/frontend/src/pages/dashboard/error-feed/components/AnalyzeMarkdown.jsx
@@ -1,0 +1,119 @@
+import { Box, alpha } from "@mui/material";
+import PropTypes from "prop-types";
+import ReactMarkdown from "react-markdown";
+import remarkGfm from "remark-gfm";
+import { purple } from "src/theme/palette";
+
+const ACCENT = purple[500];
+
+// Compact markdown renderer for agent prose (reasoning, synthesis). The model
+// emits real markdown — bold, `code`, headings, lists — so render it instead of
+// dumping the raw `**`/backtick syntax. Styling inherits the caller's font via
+// sx; element margins are tightened to chat density.
+function AnalyzeMarkdown({
+  text,
+  fontSize = "12px",
+  color = "text.secondary",
+  italic = false,
+  sx,
+}) {
+  return (
+    <Box
+      sx={{
+        fontSize,
+        color,
+        lineHeight: 1.6,
+        fontStyle: italic ? "italic" : "normal",
+        wordBreak: "break-word",
+        "& > :first-of-type": { mt: 0 },
+        "& > :last-child": { mb: 0 },
+        "& p": { m: 0, mb: 0.75 },
+        "& strong": { fontWeight: 700, color: "text.primary" },
+        "& em": { fontStyle: "italic" },
+        "& a": { color: ACCENT, textDecoration: "underline" },
+        "& ul, & ol": { m: 0, mb: 0.75, pl: 2.25 },
+        "& li": { mb: 0.2 },
+        "& h1, & h2, & h3, & h4, & h5, & h6": {
+          fontSize: "1.05em",
+          fontWeight: 700,
+          color: "text.primary",
+          m: 0,
+          mb: 0.4,
+        },
+        "& code": {
+          fontFamily: "ui-monospace, SFMono-Regular, monospace",
+          fontSize: "0.9em",
+          fontStyle: "normal",
+          px: 0.5,
+          py: "1px",
+          borderRadius: "3px",
+          bgcolor: (theme) =>
+            theme.palette.mode === "dark"
+              ? alpha("#fff", 0.08)
+              : alpha("#000", 0.05),
+        },
+        "& pre": {
+          m: 0,
+          mb: 0.75,
+          p: 1,
+          borderRadius: "6px",
+          overflowX: "auto",
+          bgcolor: (theme) =>
+            theme.palette.mode === "dark"
+              ? alpha("#fff", 0.05)
+              : alpha("#000", 0.04),
+        },
+        "& pre code": { bgcolor: "transparent", p: 0, fontSize: "11px" },
+        "& blockquote": {
+          m: 0,
+          mb: 0.75,
+          pl: 1,
+          borderLeft: "2px solid",
+          borderColor: "divider",
+          color: "text.secondary",
+        },
+        "& table": {
+          borderCollapse: "collapse",
+          width: "auto",
+          my: 0.75,
+          fontSize: "0.95em",
+          display: "block",
+          overflowX: "auto",
+        },
+        "& th, & td": {
+          border: "1px solid",
+          borderColor: "divider",
+          px: 1,
+          py: 0.5,
+          textAlign: "left",
+        },
+        "& th": {
+          fontWeight: 700,
+          color: "text.primary",
+          bgcolor: (theme) =>
+            theme.palette.mode === "dark"
+              ? alpha("#fff", 0.04)
+              : alpha("#000", 0.03),
+        },
+        "& hr": {
+          border: "none",
+          borderTop: "1px solid",
+          borderColor: "divider",
+          my: 1,
+        },
+        ...sx,
+      }}
+    >
+      <ReactMarkdown remarkPlugins={[remarkGfm]}>{text || ""}</ReactMarkdown>
+    </Box>
+  );
+}
+AnalyzeMarkdown.propTypes = {
+  text: PropTypes.string,
+  fontSize: PropTypes.string,
+  color: PropTypes.string,
+  italic: PropTypes.bool,
+  sx: PropTypes.object,
+};
+
+export default AnalyzeMarkdown;

--- a/frontend/src/pages/dashboard/error-feed/components/AnalyzeTab.jsx
+++ b/frontend/src/pages/dashboard/error-feed/components/AnalyzeTab.jsx
@@ -19,9 +19,8 @@ import {
   useTheme,
 } from "@mui/material";
 import PropTypes from "prop-types";
-import ReactMarkdown from "react-markdown";
-import remarkGfm from "remark-gfm";
 import Iconify from "src/components/iconify";
+import AnalyzeMarkdown from "./AnalyzeMarkdown";
 import { purple } from "src/theme/palette";
 import { useErrorFeedStore } from "../store";
 import { useFollowUpRunner } from "../useAnalyzeRunner";
@@ -69,116 +68,6 @@ function StreamCursor({ color = ACCENT }) {
   );
 }
 StreamCursor.propTypes = { color: PropTypes.string };
-
-// Compact markdown renderer for agent prose (reasoning, synthesis). The model
-// emits real markdown — bold, `code`, headings, lists — so render it instead of
-// dumping the raw `**`/backtick syntax. Styling inherits the caller's font via
-// sx; element margins are tightened to chat density.
-function AnalyzeMarkdown({
-  text,
-  fontSize = "12px",
-  color = "text.secondary",
-  italic = false,
-  sx,
-}) {
-  return (
-    <Box
-      sx={{
-        fontSize,
-        color,
-        lineHeight: 1.6,
-        fontStyle: italic ? "italic" : "normal",
-        wordBreak: "break-word",
-        "& > :first-of-type": { mt: 0 },
-        "& > :last-child": { mb: 0 },
-        "& p": { m: 0, mb: 0.75 },
-        "& strong": { fontWeight: 700, color: "text.primary" },
-        "& em": { fontStyle: "italic" },
-        "& a": { color: ACCENT, textDecoration: "underline" },
-        "& ul, & ol": { m: 0, mb: 0.75, pl: 2.25 },
-        "& li": { mb: 0.2 },
-        "& h1, & h2, & h3, & h4, & h5, & h6": {
-          fontSize: "1.05em",
-          fontWeight: 700,
-          color: "text.primary",
-          m: 0,
-          mb: 0.4,
-        },
-        "& code": {
-          fontFamily: "ui-monospace, SFMono-Regular, monospace",
-          fontSize: "0.9em",
-          fontStyle: "normal",
-          px: 0.5,
-          py: "1px",
-          borderRadius: "3px",
-          bgcolor: (theme) =>
-            theme.palette.mode === "dark"
-              ? alpha("#fff", 0.08)
-              : alpha("#000", 0.05),
-        },
-        "& pre": {
-          m: 0,
-          mb: 0.75,
-          p: 1,
-          borderRadius: "6px",
-          overflowX: "auto",
-          bgcolor: (theme) =>
-            theme.palette.mode === "dark"
-              ? alpha("#fff", 0.05)
-              : alpha("#000", 0.04),
-        },
-        "& pre code": { bgcolor: "transparent", p: 0, fontSize: "11px" },
-        "& blockquote": {
-          m: 0,
-          mb: 0.75,
-          pl: 1,
-          borderLeft: "2px solid",
-          borderColor: "divider",
-          color: "text.secondary",
-        },
-        "& table": {
-          borderCollapse: "collapse",
-          width: "auto",
-          my: 0.75,
-          fontSize: "0.95em",
-          display: "block",
-          overflowX: "auto",
-        },
-        "& th, & td": {
-          border: "1px solid",
-          borderColor: "divider",
-          px: 1,
-          py: 0.5,
-          textAlign: "left",
-        },
-        "& th": {
-          fontWeight: 700,
-          color: "text.primary",
-          bgcolor: (theme) =>
-            theme.palette.mode === "dark"
-              ? alpha("#fff", 0.04)
-              : alpha("#000", 0.03),
-        },
-        "& hr": {
-          border: "none",
-          borderTop: "1px solid",
-          borderColor: "divider",
-          my: 1,
-        },
-        ...sx,
-      }}
-    >
-      <ReactMarkdown remarkPlugins={[remarkGfm]}>{text || ""}</ReactMarkdown>
-    </Box>
-  );
-}
-AnalyzeMarkdown.propTypes = {
-  text: PropTypes.string,
-  fontSize: PropTypes.string,
-  color: PropTypes.string,
-  italic: PropTypes.bool,
-  sx: PropTypes.object,
-};
 
 // Drop-in replacement for <Typography>{text}</Typography> that streams the
 // text in when `instant` is false. When `instant` is true (e.g., the user

--- a/frontend/src/pages/dashboard/error-feed/components/ClusterHeadlineCard.jsx
+++ b/frontend/src/pages/dashboard/error-feed/components/ClusterHeadlineCard.jsx
@@ -11,6 +11,7 @@ import {
 import PropTypes from "prop-types";
 import { formatDistanceToNowStrict } from "date-fns";
 import Iconify from "src/components/iconify";
+import AnalyzeMarkdown from "./AnalyzeMarkdown";
 import CustomTooltip from "src/components/tooltip/CustomTooltip";
 import { purple } from "src/theme/palette";
 import openExternal from "../openExternal";
@@ -224,6 +225,11 @@ function AnalyzedState({ data, linkedIssue, onCreateLinear, onOpenAnalyze }) {
         {data.synthesis}
       </Typography>
 
+      {/* Laid out exactly as the Fix tab's synthesis card does it: no container of its own,
+          because the analysis card around it already is one — a second box inside it reads as
+          a box within a box. The fix is markdown (a file reference, a fenced diff, then prose),
+          so it goes through the same renderer as that tab; as a plain Typography the backticks
+          and asterisks arrived on screen verbatim. */}
       <Stack direction="row" gap={1} alignItems="flex-start">
         <Typography
           fontSize="10px"
@@ -242,13 +248,16 @@ function AnalyzedState({ data, linkedIssue, onCreateLinear, onOpenAnalyze }) {
         >
           Fix
         </Typography>
-        <Typography
-          fontSize="12.5px"
-          color="text.secondary"
-          sx={{ lineHeight: 1.65, flex: 1 }}
-        >
-          {data.fix}
-        </Typography>
+        {/* minWidth: 0 so a long unbroken line in the diff scrolls inside its own <pre>
+            instead of stretching the flex row and the whole card with it. */}
+        <Box sx={{ flex: 1, minWidth: 0 }}>
+          <AnalyzeMarkdown
+            text={data.fix}
+            fontSize="12.5px"
+            color="text.secondary"
+            sx={{ lineHeight: 1.6 }}
+          />
+        </Box>
       </Stack>
 
       <Stack


### PR DESCRIPTION
## 🐛 Bug

The cluster analysis card on the **Overview** tab printed the fix as its own source. `data.fix` went through a bare `<Typography>`, so the model's markdown arrived on screen verbatim — backticks, `**` and the diff's `+` markers run together in a single paragraph.

The **Fix** tab renders the same string properly, so one fix looked like two different things depending on which tab you were on.

## 🔧 What changed

- `ClusterHeadlineCard.jsx` — render `data.fix` through `AnalyzeMarkdown` instead of `<Typography>`.
- `AnalyzeMarkdown.jsx` *(new)* — lifted out of `AnalyzeTab.jsx` so both tabs share one renderer.
- `AnalyzeTab.jsx` — imports it instead of defining it locally (−113 lines, no behaviour change).

## 🤔 Why

Extracted rather than duplicated: a second renderer would drift from the first, which is the exact failure this PR is fixing.

**No container of its own.** The analysis card around it already is one, and the Fix tab lays it out the same way — only the diff gets a box, from the renderer's `& pre` styling. An extra box inside the card reads as a box within a box. Props match `AnalyzeTab.jsx:792` exactly (`fontSize="12.5px"`, `color="text.secondary"`, `lineHeight: 1.6`) so the two tabs cannot drift apart visually.

One deliberate difference from the Fix tab: `minWidth: 0` on the markdown column, so a long unbroken diff line scrolls inside its own `<pre>` rather than widening the whole card. The Fix tab likely has the same latent issue — not touched here.

cc @karthik-avinash — this is the error-feed cluster analysis card.

## 🧪 Tests

No new tests. This is a rendering change with no logic; the existing error-feed suite (5 tests, `store` + `useStreamingText`) covers what logic there is and still passes. `AnalyzeMarkdown` moved verbatim, so the Fix tab is unchanged by construction.

## ▶️ How to verify

1. Open any cluster with a completed analysis: `/dashboard/error-feed/<CLUSTER_ID>`.
2. **Overview** tab → the FIX row: the file reference is inline code and the patch is a real diff block.
3. **Fix** tab → the same fix renders identically. Before this change, only the Fix tab did.

## 💻 Commands

```bash
cd frontend
npx vitest run src/pages/dashboard/error-feed
npx eslint src/pages/dashboard/error-feed/components
```

## 📹 Videos & Screenshots

**After — Overview tab**

![Screenshot-2026-08-19-at-6.26.59PM](https://github.com/user-attachments/assets/cbcf30a4-8117-4f2a-ac9d-b7acf6ef62a7)
