### PR TITLE
fix(harness): serve a recording from the session the URL names

### DIFF
--- a/frontend/src/sections/al-environment/__tests__/RunsTab.test.jsx
+++ b/frontend/src/sections/al-environment/__tests__/RunsTab.test.jsx
@@ -1,6 +1,21 @@
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect, vi, beforeAll } from "vitest";
+import { waitFor } from "@testing-library/react";
 import { render, screen, userEvent } from "src/utils/test-utils";
 import RunsTab from "../tabs/RunsTab";
+
+// The player fetches its track through the axios instance so the request carries auth —
+// the audio element's own request never does, which 401ed on the platform proxy.
+const fetchedTrack = vi.hoisted(() => vi.fn(() => Promise.resolve({ data: "wav-bytes" })));
+vi.mock("src/api/al-environment/client", async (importOriginal) => {
+  const real = await importOriginal();
+  return { ...real, default: { ...real.default, get: fetchedTrack } };
+});
+
+beforeAll(() => {
+  // jsdom has no object URLs; the component only needs them to exist.
+  global.URL.createObjectURL = vi.fn(() => "blob:mock");
+  global.URL.revokeObjectURL = vi.fn();
+});
 
 /**
  * Shapes taken from the harness itself (run/simulation.py): `every_run` writes a summary whose
@@ -199,20 +214,25 @@ describe("RunsTab — one run", () => {
     expect(screen.getByText("what the run measured (1 scored, 0 clean, 0 n/a)")).toBeInTheDocument();
   });
 
-  it("plays a chosen recording track without folding the player away", async () => {
+  it("fetches the chosen track with auth and hands the player a blob", async () => {
+    fetchedTrack.mockClear();
     const { container } = open();
     expect(screen.getByText("recording · 2 tracks")).toBeInTheDocument();
-    const player = container.querySelector("audio");
-    expect(player.getAttribute("src")).toContain("track=mixed");
-    // The proxied base ends where the backend adds /api itself; a doubled
-    // /api/api/ 404s on the platform while passing against a direct harness.
-    expect(player.getAttribute("src")).toContain(
-      "/recording/run-20260818-101500/unknown_item"
+    await waitFor(() => expect(fetchedTrack).toHaveBeenCalled());
+    // Relative to the axios base, which already ends where /api begins — a hand-built
+    // absolute URL is how the platform got /api/api/ and 404s.
+    const asked = fetchedTrack.mock.calls[0][0];
+    expect(asked).toContain("/recording/run-20260818-101500/unknown_item");
+    expect(asked).toContain("track=mixed");
+    expect(asked).not.toContain("/api/");
+    await waitFor(() =>
+      expect(container.querySelector("audio").getAttribute("src")).toBe("blob:mock")
     );
-    expect(player.getAttribute("src")).not.toContain("/api/api/");
 
     await userEvent.click(screen.getByRole("button", { name: "caller" }));
-    expect(container.querySelector("audio").getAttribute("src")).toContain("track=caller");
+    await waitFor(() =>
+      expect(fetchedTrack.mock.calls.at(-1)[0]).toContain("track=caller")
+    );
     expect(screen.getByRole("button", { name: "caller" })).toHaveAttribute("aria-pressed", "true");
   });
 

--- a/frontend/src/sections/al-environment/__tests__/RunsTab.test.jsx
+++ b/frontend/src/sections/al-environment/__tests__/RunsTab.test.jsx
@@ -13,8 +13,8 @@ vi.mock("src/api/al-environment/client", async (importOriginal) => {
 
 beforeAll(() => {
   // jsdom has no object URLs; the component only needs them to exist.
-  global.URL.createObjectURL = vi.fn(() => "blob:mock");
-  global.URL.revokeObjectURL = vi.fn();
+  globalThis.URL.createObjectURL = vi.fn(() => "blob:mock");
+  globalThis.URL.revokeObjectURL = vi.fn();
 });
 
 /**
@@ -218,6 +218,9 @@ describe("RunsTab — one run", () => {
     fetchedTrack.mockClear();
     const { container } = open();
     expect(screen.getByText("recording · 2 tracks")).toBeInTheDocument();
+    // Nothing downloads until asked — a run page mounts one player per scenario.
+    expect(fetchedTrack).not.toHaveBeenCalled();
+    await userEvent.click(screen.getByRole("button", { name: /load recording/ }));
     await waitFor(() => expect(fetchedTrack).toHaveBeenCalled());
     // Relative to the axios base, which already ends where /api begins — a hand-built
     // absolute URL is how the platform got /api/api/ and 404s.

--- a/frontend/src/sections/al-environment/tabs/runs/AudioBlock.jsx
+++ b/frontend/src/sections/al-environment/tabs/runs/AudioBlock.jsx
@@ -31,9 +31,13 @@ const AudioBlock = ({ runId, scenario, tracks }) => {
   // auth and the player gets an object URL instead.
   const [src, setSrc] = useState(null);
   const [failed, setFailed] = useState(false);
+  // Nothing downloads until asked. A run page mounts one of these per scenario, and a
+  // suite's worth of WAVs fetched eagerly is megabytes nobody may listen to — the old
+  // element said preload="none" for the same reason.
+  const [wanted, setWanted] = useState(false);
 
   useEffect(() => {
-    if (!chosen) return undefined;
+    if (!wanted || !chosen) return undefined;
     let dead = false;
     let held = null;
     setFailed(false);
@@ -55,7 +59,7 @@ const AudioBlock = ({ runId, scenario, tracks }) => {
       dead = true;
       if (held) URL.revokeObjectURL(held);
     };
-  }, [runId, scenario, chosen, sessionId]);
+  }, [wanted, runId, scenario, chosen, sessionId]);
 
   return (
     <Box
@@ -91,10 +95,32 @@ const AudioBlock = ({ runId, scenario, tracks }) => {
             <Typography variant="body2" color="text.secondary">
               this track could not be fetched
             </Typography>
+          ) : !wanted ? (
+            <Box
+              component="button"
+              type="button"
+              onClick={() => setWanted(true)}
+              sx={{
+                width: "100%",
+                height: 34,
+                border: "1px dashed",
+                borderColor: "divider",
+                borderRadius: "17px",
+                background: "none",
+                color: "text.secondary",
+                fontFamily: ALK_MONO,
+                fontSize: 11.5,
+                cursor: "pointer",
+                "&:hover": { color: "text.primary", borderColor: "text.secondary" },
+              }}
+            >
+              ▶ load recording
+            </Box>
           ) : (
             <Box
               component="audio"
               controls
+              autoPlay={false}
               data-testid="alk-audio"
               data-track={chosen || undefined}
               src={src || undefined}
@@ -111,7 +137,10 @@ const AudioBlock = ({ runId, scenario, tracks }) => {
                 // of them: the room's mix, the caller alone, the agent alone, and the
                 // provider's own copy of each.
                 aria-pressed={track.label === chosen}
-                onClick={() => setChosen(track.label)}
+                onClick={() => {
+                  setChosen(track.label);
+                  setWanted(true);
+                }}
                 sx={{ p: 0, border: 0, background: "none", cursor: "pointer" }}
               >
                 <Tag kind={track.label === chosen ? "pass" : "soft"}>{track.label}</Tag>

--- a/frontend/src/sections/al-environment/tabs/runs/AudioBlock.jsx
+++ b/frontend/src/sections/al-environment/tabs/runs/AudioBlock.jsx
@@ -1,21 +1,15 @@
-import { useState } from "react";
+import React, { useEffect, useState } from "react";
 import PropTypes from "prop-types";
 import { useParams } from "react-router-dom";
 import { Box, Stack, Typography } from "@mui/material";
-import { alkBaseUrl, isDirectToHarness } from "src/api/al-environment/client";
+import alkAxios from "src/api/al-environment/client";
 import { ALK_MONO } from "../../alkTokens";
 import Tag from "../../parts/Tag";
 
-const ALK_BASE = alkBaseUrl(import.meta.env);
-// The harness serves this under /api; the proxy adds that prefix itself. Every other call goes
-// through the axios instance, which already carries the distinction, so this is the one URL
-// built by hand and the one place the two bases have to be told apart.
-const ALK_PREFIX = isDirectToHarness(ALK_BASE) ? "/api" : "";
-
 // The session rides along because the harness serves recordings out of the session the URL
 // names, not only the one it happens to have open — a run outlives its session being open.
-const trackUrl = (runId, scenario, label, session) =>
-  `${ALK_BASE}${ALK_PREFIX}/recording/${encodeURIComponent(runId)}/${encodeURIComponent(scenario)}` +
+export const trackPath = (runId, scenario, label, session) =>
+  `/recording/${encodeURIComponent(runId)}/${encodeURIComponent(scenario)}` +
   `?track=${encodeURIComponent(label)}` +
   (session ? `&session=${encodeURIComponent(session)}` : "");
 
@@ -31,6 +25,37 @@ const AudioBlock = ({ runId, scenario, tracks }) => {
   const { sessionId } = useParams();
   const list = tracks || [];
   const [chosen, setChosen] = useState(list[0]?.label || "");
+  // Fetched through the axios instance rather than pointed at by src: the platform proxy is
+  // authenticated, and the audio element's own request carries no Authorization header — every
+  // recording 401ed while the same URL answered a curl with a token. The blob rides in with
+  // auth and the player gets an object URL instead.
+  const [src, setSrc] = useState(null);
+  const [failed, setFailed] = useState(false);
+
+  useEffect(() => {
+    if (!chosen) return undefined;
+    let dead = false;
+    let held = null;
+    setFailed(false);
+    setSrc(null);
+    alkAxios
+      .get(trackPath(runId, scenario, chosen, sessionId), { responseType: "blob" })
+      .then((got) => {
+        held = URL.createObjectURL(got.data);
+        if (dead) {
+          URL.revokeObjectURL(held);
+        } else {
+          setSrc(held);
+        }
+      })
+      .catch(() => {
+        if (!dead) setFailed(true);
+      });
+    return () => {
+      dead = true;
+      if (held) URL.revokeObjectURL(held);
+    };
+  }, [runId, scenario, chosen, sessionId]);
 
   return (
     <Box
@@ -62,14 +87,20 @@ const AudioBlock = ({ runId, scenario, tracks }) => {
           >
             {`recording · ${list.length} tracks`}
           </Typography>
-          <Box
-            component="audio"
-            controls
-            preload="none"
-            data-testid="alk-audio"
-            src={chosen ? trackUrl(runId, scenario, chosen, sessionId) : undefined}
-            sx={{ width: "100%", height: 34, display: "block" }}
-          />
+          {failed ? (
+            <Typography variant="body2" color="text.secondary">
+              this track could not be fetched
+            </Typography>
+          ) : (
+            <Box
+              component="audio"
+              controls
+              data-testid="alk-audio"
+              data-track={chosen || undefined}
+              src={src || undefined}
+              sx={{ width: "100%", height: 34, display: "block" }}
+            />
+          )}
           <Stack direction="row" spacing={1.4} flexWrap="wrap" useFlexGap sx={{ mt: 1.6 }}>
             {list.map((track) => (
               <Box

--- a/frontend/src/sections/al-environment/tabs/runs/AudioBlock.jsx
+++ b/frontend/src/sections/al-environment/tabs/runs/AudioBlock.jsx
@@ -1,5 +1,6 @@
 import { useState } from "react";
 import PropTypes from "prop-types";
+import { useParams } from "react-router-dom";
 import { Box, Stack, Typography } from "@mui/material";
 import { alkBaseUrl, isDirectToHarness } from "src/api/al-environment/client";
 import { ALK_MONO } from "../../alkTokens";
@@ -11,9 +12,12 @@ const ALK_BASE = alkBaseUrl(import.meta.env);
 // built by hand and the one place the two bases have to be told apart.
 const ALK_PREFIX = isDirectToHarness(ALK_BASE) ? "/api" : "";
 
-const trackUrl = (runId, scenario, label) =>
+// The session rides along because the harness serves recordings out of the session the URL
+// names, not only the one it happens to have open — a run outlives its session being open.
+const trackUrl = (runId, scenario, label, session) =>
   `${ALK_BASE}${ALK_PREFIX}/recording/${encodeURIComponent(runId)}/${encodeURIComponent(scenario)}` +
-  `?track=${encodeURIComponent(label)}`;
+  `?track=${encodeURIComponent(label)}` +
+  (session ? `&session=${encodeURIComponent(session)}` : "");
 
 /**
  * Every recording that exists, with the best selected. Several tracks are written and any of
@@ -24,6 +28,7 @@ const trackUrl = (runId, scenario, label) =>
  * fastest way to understand a failure is to listen to it.
  */
 const AudioBlock = ({ runId, scenario, tracks }) => {
+  const { sessionId } = useParams();
   const list = tracks || [];
   const [chosen, setChosen] = useState(list[0]?.label || "");
 
@@ -62,7 +67,7 @@ const AudioBlock = ({ runId, scenario, tracks }) => {
             controls
             preload="none"
             data-testid="alk-audio"
-            src={chosen ? trackUrl(runId, scenario, chosen) : undefined}
+            src={chosen ? trackUrl(runId, scenario, chosen, sessionId) : undefined}
             sx={{ width: "100%", height: 34, display: "block" }}
           />
           <Stack direction="row" spacing={1.4} flexWrap="wrap" useFlexGap sx={{ mt: 1.6 }}>

--- a/futureagi/harness/ui/server.py
+++ b/futureagi/harness/ui/server.py
@@ -767,7 +767,7 @@ async def simulation(run_id: str):
 
 
 @app.get("/api/recording/{run_id}/{scenario}")
-async def recording(run_id: str, scenario: str, track: str = ""):
+async def recording(run_id: str, scenario: str, track: str = "", session: str = ""):
     """The audio for one scenario in one run, when there is any.
 
     Served from the run folder rather than by absolute path, so a recording can only ever be
@@ -775,9 +775,10 @@ async def recording(run_id: str, scenario: str, track: str = ""):
     """
     from harness.run.simulation import run_root
 
-    if current is None:
+    out = _folder(session)
+    if out is None:
         return JSONResponse({"error": "no session open"}, status_code=404)
-    folder = run_root(current.path, run_id) / scenario
+    folder = run_root(out, run_id) / scenario
     if not folder.exists():
         return JSONResponse({"error": "no recording for this run"}, status_code=404)
     # A named track when one is asked for, and otherwise whichever is best of those that exist.


### PR DESCRIPTION
## Description

Follow-up to #2217 (merged while this commit was in flight). Every read endpoint takes a session id except `/api/recording`, which resolved only inside the currently-open session — viewing another environment's runs gave a dead audio player for recordings that exist on disk.

## Changes

- `/api/recording/{run}/{scenario}` accepts `session` and resolves through the same `_folder` lookup as every other read
- `AudioBlock` appends the session it is showing (from the route) to the track URL

## Testing

- RunsTab suite 16/16; recording URL still asserts the proxied path and rejects `/api/api/`