### PR TITLE
fix(gateway): propagate post-response guardrail errors as 403 (#2028)

### DIFF
--- a/agentcc-gateway/internal/guardrails/engine_test.go
+++ b/agentcc-gateway/internal/guardrails/engine_test.go
@@ -3,6 +3,8 @@ package guardrails
 import (
 	"context"
 	"encoding/json"
+	"errors"
+	"net/http"
 	"strings"
 	"sync/atomic"
 	"testing"
@@ -1361,5 +1363,72 @@ func TestPlugin_InvalidRequestPolicy(t *testing.T) {
 	result := plug.ProcessRequest(context.Background(), rc)
 	if result.Error == nil {
 		t.Fatal("expected error for invalid policy value")
+	}
+}
+
+// TestGuardrailPostBlockPropagatesThroughPipeline is the end-to-end regression
+// test for issue #2028: a blocking post-stage guardrail must propagate its
+// models.ErrGuardrailBlocked out of pipeline.Engine.Process so handlers return
+// 403 content_blocked instead of a generic 500 "no response from provider".
+func TestGuardrailPostBlockPropagatesThroughPipeline(t *testing.T) {
+	registry := map[string]Guardrail{
+		"toxicity": &mockGuardrail{
+			name:  "toxicity",
+			stage: StagePost,
+			result: &CheckResult{
+				Pass:    false,
+				Score:   0.92,
+				Action:  ActionBlock,
+				Message: "toxic response",
+			},
+		},
+	}
+	cfg := config.GuardrailsConfig{
+		Enabled:        true,
+		FailOpen:       true,
+		DefaultTimeout: 5 * time.Second,
+		Rules: []config.GuardrailRuleConfig{
+			{Name: "toxicity", Stage: "post", Mode: "sync", Action: "block", Threshold: 0.7},
+		},
+	}
+	guardrailEngine := NewEngine(cfg, registry)
+	plugin := NewPlugin(guardrailEngine, nil, nil, nil, nil)
+
+	pipelineEngine := pipeline.NewEngine(plugin)
+
+	rc := models.AcquireRequestContext()
+	defer rc.Release()
+	rc.Request = &models.ChatCompletionRequest{Model: "gpt-4o"}
+	rc.Model = "gpt-4o"
+
+	err := pipelineEngine.Process(context.Background(), rc, func(ctx context.Context, rc *models.RequestContext) error {
+		rc.Response = &models.ChatCompletionResponse{ID: "provider-resp"}
+		return nil
+	})
+
+	if err == nil {
+		t.Fatal("pipeline.Process should return the guardrail block error")
+	}
+	var apiErr *models.APIError
+	if !errors.As(err, &apiErr) {
+		t.Fatalf("expected *APIError, got %T", err)
+	}
+	if apiErr.Status != http.StatusForbidden {
+		t.Errorf("status = %d, want 403", apiErr.Status)
+	}
+	if apiErr.Code != "content_blocked" {
+		t.Errorf("code = %q, want content_blocked", apiErr.Code)
+	}
+	if apiErr.Type != models.ErrTypeGuardrail {
+		t.Errorf("type = %q, want %q", apiErr.Type, models.ErrTypeGuardrail)
+	}
+	if rc.Response != nil {
+		t.Error("blocked provider response must not escape the pipeline")
+	}
+	if !rc.Flags.GuardrailTriggered {
+		t.Error("GuardrailTriggered flag should be set")
+	}
+	if rc.Metadata["guardrail_action"] != "blocked" {
+		t.Errorf("guardrail_action = %q, want 'blocked'", rc.Metadata["guardrail_action"])
 	}
 }

--- a/agentcc-gateway/internal/pipeline/engine.go
+++ b/agentcc-gateway/internal/pipeline/engine.go
@@ -100,8 +100,7 @@ func (e *Engine) Process(ctx context.Context, rc *models.RequestContext, provide
 			if result.Response != nil {
 				rc.Response = result.Response
 			}
-			e.RunPostPlugins(ctx, rc)
-			return nil
+			return e.RunPostPlugins(ctx, rc)
 		}
 	}
 
@@ -132,7 +131,7 @@ func (e *Engine) Process(ctx context.Context, rc *models.RequestContext, provide
 	// Post-plugins — skip for streaming requests; the stream handler
 	// will call RunPostPlugins after the stream completes with final usage.
 	if !rc.IsStream {
-		e.RunPostPlugins(ctx, rc)
+		return e.RunPostPlugins(ctx, rc)
 	}
 	return nil
 }
@@ -142,10 +141,20 @@ func (e *Engine) Process(ctx context.Context, rc *models.RequestContext, provide
 //  2. Parallel-safe plugins run concurrently after sequential ones complete.
 //  3. Plugins implementing SkipOnCacheHit are skipped on cache hits.
 //
+// All post-plugins always run: a sequential plugin error does not stop the
+// remaining sequential or parallel (observer) plugins, so logging, audit, and
+// metrics are preserved. The first sequential post-plugin error is recorded on
+// the request context (rc.Errors) and returned once the whole post pipeline has
+// completed, so callers can propagate intentional short-circuits such as
+// guardrail blocks (models.ErrGuardrailBlocked -> 403 content_blocked).
+// Parallel observer-plugin failures remain non-fatal and are only logged.
+//
 // Exported so that streaming handlers can call it after the stream completes,
 // when rc.Response and usage data are populated.
-func (e *Engine) RunPostPlugins(ctx context.Context, rc *models.RequestContext) {
+func (e *Engine) RunPostPlugins(ctx context.Context, rc *models.RequestContext) error {
 	isCacheHit := rc.Flags.ShortCircuited && rc.Metadata["cache_status"] == "hit_exact"
+
+	var firstPostErr error
 
 	// Phase 1: Sequential post-plugins (e.g., cost → credits dependency chain).
 	for _, p := range e.postSequential {
@@ -165,6 +174,12 @@ func (e *Engine) RunPostPlugins(ctx context.Context, rc *models.RequestContext) 
 				"error", result.Error.Message,
 				"request_id", rc.RequestID,
 			)
+			// Record the error before observer plugins run and retain the first
+			// one so Engine.Process can propagate it to the handler.
+			rc.AddError(result.Error)
+			if firstPostErr == nil {
+				firstPostErr = result.Error
+			}
 		}
 	}
 
@@ -179,7 +194,7 @@ func (e *Engine) RunPostPlugins(ctx context.Context, rc *models.RequestContext) 
 	// mutex. So each goroutine times itself into its own slot, and the timings
 	// are recorded once the window has closed and execution is serial again.
 	if len(e.postParallel) == 0 {
-		return
+		return firstPostErr
 	}
 
 	toRun := e.postParallel
@@ -218,6 +233,8 @@ func (e *Engine) RunPostPlugins(ctx context.Context, rc *models.RequestContext) 
 	for i, p := range toRun {
 		rc.RecordTiming("post_"+p.Name(), durations[i])
 	}
+
+	return firstPostErr
 }
 
 // PluginCount returns the number of registered plugins.

--- a/agentcc-gateway/internal/pipeline/engine_test.go
+++ b/agentcc-gateway/internal/pipeline/engine_test.go
@@ -2,6 +2,8 @@ package pipeline
 
 import (
 	"context"
+	"errors"
+	"net/http"
 	"testing"
 	"time"
 
@@ -10,14 +12,16 @@ import (
 
 // mockPlugin is a test plugin.
 type mockPlugin struct {
-	name     string
-	priority int
-	onReq    func(ctx context.Context, rc *models.RequestContext) PluginResult
-	onResp   func(ctx context.Context, rc *models.RequestContext) PluginResult
+	name           string
+	priority       int
+	onReq          func(ctx context.Context, rc *models.RequestContext) PluginResult
+	onResp         func(ctx context.Context, rc *models.RequestContext) PluginResult
+	isPostParallel bool
 }
 
-func (m *mockPlugin) Name() string  { return m.name }
-func (m *mockPlugin) Priority() int { return m.priority }
+func (m *mockPlugin) Name() string         { return m.name }
+func (m *mockPlugin) Priority() int        { return m.priority }
+func (m *mockPlugin) IsPostParallel() bool { return m.isPostParallel }
 func (m *mockPlugin) ProcessRequest(ctx context.Context, rc *models.RequestContext) PluginResult {
 	if m.onReq != nil {
 		return m.onReq(ctx, rc)
@@ -328,3 +332,161 @@ func TestRunPostPluginsSkipOnCacheHitTimings(t *testing.T) {
 type skipOnCacheHitPostPlugin struct{ readOnlyPostPlugin }
 
 func (skipOnCacheHitPostPlugin) ShouldSkipOnCacheHit() bool { return true }
+
+// TestEnginePostPluginErrorPropagates pins the core contract of issue #2028:
+// a blocking post-response plugin (e.g. a guardrail) must propagate its error
+// out of Engine.Process so the handler can return 403 content_blocked instead
+// of falling through to the nil-response check and emitting a generic 500.
+// The remaining sequential and parallel post-plugins must still run so
+// logging, audit, and metrics are preserved.
+func TestEnginePostPluginErrorPropagates(t *testing.T) {
+	blockingErr := models.ErrGuardrailBlocked("content_blocked", "blocked by guardrail")
+
+	var postOrder []string
+	guardrailPlugin := &mockPlugin{
+		name:     "guardrails",
+		priority: 50,
+		onResp: func(ctx context.Context, rc *models.RequestContext) PluginResult {
+			postOrder = append(postOrder, "guardrails")
+			// Guardrail clears the provider response and returns the block error.
+			rc.Response = nil
+			rc.Flags.GuardrailTriggered = true
+			return ResultError(blockingErr)
+		},
+	}
+	costPlugin := &mockPlugin{
+		name:     "cost",
+		priority: 60,
+		onResp: func(ctx context.Context, rc *models.RequestContext) PluginResult {
+			postOrder = append(postOrder, "cost")
+			return ResultContinue()
+		},
+	}
+	observerPlugin := &mockPlugin{
+		name:           "observer",
+		priority:       900,
+		isPostParallel: true,
+		onResp: func(ctx context.Context, rc *models.RequestContext) PluginResult {
+			postOrder = append(postOrder, "observer")
+			return ResultContinue()
+		},
+	}
+
+	engine := NewEngine(guardrailPlugin, costPlugin, observerPlugin)
+
+	rc := models.AcquireRequestContext()
+	defer rc.Release()
+
+	err := engine.Process(context.Background(), rc, func(ctx context.Context, rc *models.RequestContext) error {
+		rc.Response = &models.ChatCompletionResponse{ID: "provider-resp"}
+		return nil
+	})
+
+	if err == nil {
+		t.Fatal("Process should return the post-plugin error")
+	}
+	var apiErr *models.APIError
+	if !errors.As(err, &apiErr) {
+		t.Fatalf("error should be *APIError, got %T", err)
+	}
+	if apiErr.Status != http.StatusForbidden {
+		t.Errorf("status = %d, want 403", apiErr.Status)
+	}
+	if apiErr.Code != "content_blocked" {
+		t.Errorf("code = %q, want content_blocked", apiErr.Code)
+	}
+	if apiErr.Type != models.ErrTypeGuardrail {
+		t.Errorf("type = %q, want %q", apiErr.Type, models.ErrTypeGuardrail)
+	}
+	if rc.Response != nil {
+		t.Error("blocked provider response must not escape the pipeline")
+	}
+	wantOrder := []string{"guardrails", "cost", "observer"}
+	if len(postOrder) != len(wantOrder) {
+		t.Fatalf("post plugins run = %v, want %v (all must run after an error)", postOrder, wantOrder)
+	}
+	for i, v := range wantOrder {
+		if postOrder[i] != v {
+			t.Errorf("post order[%d] = %q, want %q", i, postOrder[i], v)
+		}
+	}
+	if len(rc.Errors) == 0 {
+		t.Error("post-plugin error should be recorded on the request context")
+	}
+}
+
+// TestEngineShortCircuitPropagatesPostError covers the cache-short-circuit
+// path: a pre-plugin short-circuits with a cached response, then a blocking
+// post-plugin errors. Engine.Process must still propagate that error.
+func TestEngineShortCircuitPropagatesPostError(t *testing.T) {
+	cachePlugin := &mockPlugin{
+		name:     "cache",
+		priority: 1,
+		onReq: func(ctx context.Context, rc *models.RequestContext) PluginResult {
+			return ResultShortCircuit(&models.ChatCompletionResponse{ID: "cached"})
+		},
+	}
+	guardrailPlugin := &mockPlugin{
+		name:     "guardrails",
+		priority: 50,
+		onResp: func(ctx context.Context, rc *models.RequestContext) PluginResult {
+			rc.Response = nil
+			return ResultError(models.ErrGuardrailBlocked("content_blocked", "cached response blocked"))
+		},
+	}
+
+	engine := NewEngine(cachePlugin, guardrailPlugin)
+
+	rc := models.AcquireRequestContext()
+	defer rc.Release()
+
+	providerCalled := false
+	err := engine.Process(context.Background(), rc, func(ctx context.Context, rc *models.RequestContext) error {
+		providerCalled = true
+		return nil
+	})
+
+	if providerCalled {
+		t.Error("provider should NOT have been called (short-circuited)")
+	}
+	if err == nil {
+		t.Fatal("Process should return the post-plugin error on the short-circuit path")
+	}
+	var apiErr *models.APIError
+	if !errors.As(err, &apiErr) {
+		t.Fatalf("error should be *APIError, got %T", err)
+	}
+	if apiErr.Status != http.StatusForbidden || apiErr.Code != "content_blocked" {
+		t.Errorf("expected 403 content_blocked, got status=%d code=%q", apiErr.Status, apiErr.Code)
+	}
+}
+
+// TestEngineParallelObserverErrorNotFatal pins the other half of the contract:
+// a failing parallel observer plugin is logged but does not fail the request.
+func TestEngineParallelObserverErrorNotFatal(t *testing.T) {
+	observerPlugin := &mockPlugin{
+		name:           "observer",
+		priority:       900,
+		isPostParallel: true,
+		onResp: func(ctx context.Context, rc *models.RequestContext) PluginResult {
+			return ResultError(models.ErrInternal("observer failed"))
+		},
+	}
+
+	engine := NewEngine(observerPlugin)
+
+	rc := models.AcquireRequestContext()
+	defer rc.Release()
+
+	err := engine.Process(context.Background(), rc, func(ctx context.Context, rc *models.RequestContext) error {
+		rc.Response = &models.ChatCompletionResponse{ID: "ok"}
+		return nil
+	})
+
+	if err != nil {
+		t.Fatalf("Process should not fail on a parallel observer error, got %v", err)
+	}
+	if rc.Response == nil {
+		t.Error("response should survive an observer failure")
+	}
+}


### PR DESCRIPTION
## Summary

Fixes #2028 — a blocking post-response guardrail currently surfaces as a generic `500 no response from provider` instead of the intentional `403 content_blocked` policy response.

## Root Cause

`GuardrailPlugin.ProcessResponse` correctly detects a block, clears `rc.Response`, and returns `models.ErrGuardrailBlocked("content_blocked", ...)`, but `pipeline.Engine.RunPostPlugins` only logged post-plugin errors and discarded them. `Engine.Process` then returned `nil`, and non-streaming handlers fell through to their `rc.Response == nil` check, emitting `500 internal_error: no response from provider` — turning a policy decision into a server failure.

## Change

- `RunPostPlugins` now retains the **first sequential post-plugin error**, records it on the request context (`rc.Errors`) before observer plugins run, and returns it **after the entire post pipeline completes** — remaining sequential plugins and parallel observers (logging, audit, metrics) still run, per the issue's expected behavior. Parallel observer-plugin failures remain non-fatal (logged only).
- `Engine.Process` propagates that error from the **successful provider path** and the **cache/short-circuit path**. Pre-plugin error, timeout, and provider-error paths keep returning their primary error (post errors are still recorded on the context).
- Streaming is unaffected: streaming handlers write data before their final post-plugin pass and already call `RunPostPlugins` themselves (they discard the returned error, preserving current streaming semantics — post-response buffering is out of scope per the issue).

With the error propagating, existing handlers that call `h.engine.Process(...)` and write `models.WriteErrorFromError(w, err)` automatically return `403 content_blocked` with `error.type = guardrail_error` — no handler changes needed.

## Verification

- `go test ./internal/pipeline/... ./internal/guardrails/...` — all pass.
- New tests (also run under `-race`):
  - `TestEnginePostPluginErrorPropagates` — a blocking post-plugin error propagates out of `Engine.Process` as `*APIError` (403 / `content_blocked` / `guardrail_error`), the blocked response does not escape, remaining sequential + parallel post-plugins still run, and the error is recorded on `rc.Errors`.
  - `TestEngineShortCircuitPropagatesPostError` — the cache-short-circuit path propagates the post-plugin error.
  - `TestEngineParallelObserverErrorNotFatal` — a failing parallel observer does not fail the request.
  - `TestGuardrailPostBlockPropagatesThroughPipeline` (guardrails) — end-to-end: a real blocking post-stage guardrail through `pipeline.Engine.Process` yields 403 `content_blocked`, clears `rc.Response`, and sets `GuardrailTriggered`.

Closes #2028
