### PR TITLE
fix(model_hub): sanitize run-prompt error responses (#2081)

### DIFF
--- a/futureagi/model_hub/tests/test_run_prompt_error_sanitization.py
+++ b/futureagi/model_hub/tests/test_run_prompt_error_sanitization.py
@@ -1,0 +1,260 @@
+"""
+Tests for run-prompt error sanitization (issue #2081).
+
+Run-prompt failures must never leak raw exception text to API callers:
+- Local validation errors (RunPromptValidationError) are the user's own
+  input and are surfaced verbatim.
+- Everything else (provider errors, unexpected exceptions) is replaced
+  with a generic message; full details stay server-side in the logs.
+
+Run with: pytest model_hub/tests/test_run_prompt_error_sanitization.py -v
+"""
+
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+from rest_framework.test import APIClient
+
+from accounts.models import Organization, User
+from accounts.models.workspace import Workspace
+from model_hub.models.choices import (
+    CellStatus,
+    DatasetSourceChoices,
+    DataTypeChoices,
+    SourceChoices,
+)
+from model_hub.models.develop_dataset import Cell, Column, Dataset, Row
+from model_hub.views.run_prompt import (
+    RUN_PROMPT_GENERIC_ERROR_MESSAGE,
+    RunPromptValidationError,
+    get_run_prompt_error_message,
+)
+from tfc.middleware.workspace_context import set_workspace_context
+
+RAW_PROVIDER_ERROR = (
+    "litellm.APIError: upstream https://api.internal.example/v1 returned 500 "
+    "[sk-secret-key-abc123]"
+)
+
+
+@pytest.fixture
+def organization(db):
+    return Organization.objects.create(name="Test Organization")
+
+
+@pytest.fixture
+def user(db, organization):
+    return User.objects.create_user(
+        email="test@example.com",
+        password="testpassword123",
+        name="Test User",
+        organization=organization,
+    )
+
+
+@pytest.fixture
+def workspace(db, organization, user):
+    return Workspace.objects.create(
+        name="Default Workspace",
+        organization=organization,
+        is_default=True,
+        created_by=user,
+    )
+
+
+@pytest.fixture
+def auth_client(user, workspace):
+    client = APIClient()
+    client.force_authenticate(user=user)
+    set_workspace_context(workspace=workspace, organization=user.organization)
+    return client
+
+
+@pytest.fixture
+def dataset(db, organization, workspace):
+    ds = Dataset.objects.create(
+        name="Test Dataset",
+        organization=organization,
+        workspace=workspace,
+        source=DatasetSourceChoices.BUILD.value,
+    )
+    ds.column_order = []
+    ds.save()
+    return ds
+
+
+@pytest.fixture
+def input_column(db, dataset):
+    col = Column.objects.create(
+        name="Input Column",
+        dataset=dataset,
+        data_type=DataTypeChoices.TEXT.value,
+        source=SourceChoices.OTHERS.value,
+    )
+    dataset.column_order.append(str(col.id))
+    dataset.save()
+    return col
+
+
+@pytest.fixture
+def row(db, dataset):
+    return Row.objects.create(dataset=dataset, order=0)
+
+
+@pytest.fixture
+def cell(db, dataset, input_column, row):
+    return Cell.objects.create(
+        dataset=dataset,
+        column=input_column,
+        row=row,
+        value="Test input value",
+    )
+
+
+@pytest.fixture
+def run_prompt_config():
+    return {
+        "model": "gpt-4",
+        "messages": [
+            {
+                "role": "user",
+                "content": [{"type": "text", "text": "What is {{Input Column}}?"}],
+            }
+        ],
+        "temperature": 0.7,
+        "max_tokens": 100,
+        "output_format": "string",
+    }
+
+
+class TestGetRunPromptErrorMessage:
+    """Unit tests for the error-message sanitizer helper."""
+
+    def test_local_validation_error_surfaced_verbatim(self):
+        exc = RunPromptValidationError(
+            "Placeholder '{{missing}}' was not resolved."
+        )
+        assert get_run_prompt_error_message(exc) == (
+            "Placeholder '{{missing}}' was not resolved."
+        )
+
+    def test_unexpected_exception_returns_generic_message(self):
+        exc = RuntimeError(RAW_PROVIDER_ERROR)
+        message = get_run_prompt_error_message(exc)
+        assert message == RUN_PROMPT_GENERIC_ERROR_MESSAGE
+
+    def test_generic_message_does_not_contain_raw_exception_text(self):
+        exc = RuntimeError(RAW_PROVIDER_ERROR)
+        message = get_run_prompt_error_message(exc)
+        assert "api.internal.example" not in message
+        assert "sk-secret-key-abc123" not in message
+        assert str(exc) not in message
+
+
+@pytest.mark.django_db
+class TestLitellmAPIViewProcessRowSanitization:
+    """The per-row execution path must store safe messages in cells."""
+
+    def _process_row(self, dataset, input_column, row, organization, user):
+        from model_hub.views.run_prompt import LitellmAPIView
+
+        view = LitellmAPIView()
+        validated_data = {
+            "model": "gpt-4",
+            "messages": [{"role": "user", "content": "Hello"}],
+            "output_format": "string",
+        }
+        request = MagicMock(organization=organization, user=user)
+        view.process_row(row, validated_data, dataset, input_column, request)
+
+    def test_local_validation_error_message_stored_in_cell(
+        self, dataset, input_column, row, organization, user
+    ):
+        validation_message = "Placeholder '{{missing}}' was not resolved."
+        with patch(
+            "model_hub.views.run_prompt.populate_placeholders",
+            side_effect=RunPromptValidationError(validation_message),
+        ):
+            self._process_row(dataset, input_column, row, organization, user)
+
+        output_cell = Cell.objects.get(
+            dataset=dataset, column=input_column, row=row
+        )
+        assert output_cell.status == CellStatus.ERROR.value
+        assert output_cell.value == validation_message
+        value_infos = json.loads(output_cell.value_infos)
+        assert value_infos["reason"] == validation_message
+
+    def test_unexpected_provider_error_redacted_in_cell(
+        self, dataset, input_column, row, organization, user
+    ):
+        mock_run_prompt = MagicMock()
+        mock_run_prompt.litellm_response.side_effect = RuntimeError(
+            RAW_PROVIDER_ERROR
+        )
+        with patch(
+            "model_hub.views.run_prompt.populate_placeholders",
+            return_value=[{"role": "user", "content": "Hello"}],
+        ), patch(
+            "model_hub.views.run_prompt.RunPrompt",
+            return_value=mock_run_prompt,
+        ):
+            self._process_row(dataset, input_column, row, organization, user)
+
+        output_cell = Cell.objects.get(
+            dataset=dataset, column=input_column, row=row
+        )
+        assert output_cell.status == CellStatus.ERROR.value
+        assert output_cell.value == RUN_PROMPT_GENERIC_ERROR_MESSAGE
+        assert "api.internal.example" not in output_cell.value
+        assert "sk-secret-key-abc123" not in output_cell.value
+        value_infos = json.loads(output_cell.value_infos)
+        assert value_infos["reason"] == RUN_PROMPT_GENERIC_ERROR_MESSAGE
+        assert RAW_PROVIDER_ERROR not in output_cell.value_infos
+
+
+@pytest.mark.django_db
+class TestPreviewRunPromptColumnViewSanitization:
+    """The preview endpoint must never echo raw exception text."""
+
+    def _preview(self, auth_client, dataset, row, config):
+        return auth_client.post(
+            "/model-hub/develops/preview_run_prompt_column/",
+            {
+                "dataset_id": str(dataset.id),
+                "config": config,
+                "first_n_rows": 1,
+            },
+            format="json",
+        )
+
+    def test_local_validation_error_surfaced_verbatim(
+        self, auth_client, dataset, input_column, row, run_prompt_config
+    ):
+        validation_message = "Placeholder '{{missing}}' was not resolved."
+        with patch(
+            "model_hub.views.run_prompt.populate_placeholders",
+            side_effect=RunPromptValidationError(validation_message),
+        ):
+            response = self._preview(auth_client, dataset, row, run_prompt_config)
+
+        assert response.status_code == 200
+        responses = response.json()["result"]["responses"]
+        assert responses == [validation_message]
+
+    def test_unexpected_provider_error_returns_generic_message(
+        self, auth_client, dataset, input_column, row, run_prompt_config
+    ):
+        with patch(
+            "model_hub.views.run_prompt.populate_placeholders",
+            side_effect=RuntimeError(RAW_PROVIDER_ERROR),
+        ):
+            response = self._preview(auth_client, dataset, row, run_prompt_config)
+
+        assert response.status_code == 200
+        body = response.json()
+        responses = body["result"]["responses"]
+        assert responses == [RUN_PROMPT_GENERIC_ERROR_MESSAGE]
+        assert "api.internal.example" not in json.dumps(body)
+        assert "sk-secret-key-abc123" not in json.dumps(body)

--- a/futureagi/model_hub/views/run_prompt.py
+++ b/futureagi/model_hub/views/run_prompt.py
@@ -94,7 +94,6 @@ from tfc.temporal import temporal_activity
 from tfc.utils.error_codes import (
     get_error_for_api_status,
     get_error_message,
-    get_specific_error_message,
 )
 from tfc.utils.api_contracts import validated_request
 from tfc.utils.functions import get_prompt_stats
@@ -112,6 +111,36 @@ try:
     from ee.usage.utils.usage_entries import log_and_deduct_cost_for_api_request
 except ImportError:
     log_and_deduct_cost_for_api_request = None
+
+
+class RunPromptValidationError(Exception):
+    """Raised when run-prompt input fails local validation.
+
+    The message describes the user's own input problem (unresolved
+    placeholder, template syntax error, unsupported media) and is safe to
+    surface to API callers verbatim. Any other exception raised during
+    run-prompt execution is treated as internal and redacted.
+    """
+
+
+RUN_PROMPT_GENERIC_ERROR_MESSAGE = (
+    "Run prompt failed. Please check your configuration and try again."
+)
+
+
+def get_run_prompt_error_message(exc):
+    """Return a caller-safe error message for a run-prompt failure.
+
+    Local validation errors (RunPromptValidationError) are the user's own
+    input and are surfaced verbatim since they are actionable. Every other
+    failure (provider errors, unexpected exceptions) is logged in full
+    server-side and replaced with a generic message so traceback internals,
+    file paths and provider error bodies never reach API callers.
+    """
+    if isinstance(exc, RunPromptValidationError):
+        return str(exc)
+    logger.exception("run_prompt_error_redacted", error=str(exc))
+    return RUN_PROMPT_GENERIC_ERROR_MESSAGE
 
 
 def _request_organization(request):
@@ -633,7 +662,7 @@ def populate_placeholders(
 
         except ValueError as e:
             media_error = True
-            raise e
+            raise RunPromptValidationError(str(e)) from e
 
     except Exception as e:
         if media_error:
@@ -1021,7 +1050,7 @@ class LitellmAPIView(CreateAPIView):
 
         except Exception as e:
             logger.exception(f"Error in processing the row: {str(e)}")
-            error_message = get_specific_error_message(e)
+            error_message = get_run_prompt_error_message(e)
             response = error_message
             value_info = {"reason": error_message}
             status = CellStatus.ERROR.value
@@ -1495,14 +1524,14 @@ class RunPrompts:
                     error=str(e),
                     is_llm_error=is_llm_error,
                 )
-                error_message = get_specific_error_message(e, is_llm_error)
+                error_message = get_run_prompt_error_message(e)
                 logger.error(
                     "RunPrompts_process_row_error_message",
                     run_prompt_id=str(self.run_prompt_id),
                     row_id=row_id,
                     error_message=error_message,
                 )
-                response = str(e)
+                response = error_message
                 value_info = {"reason": error_message}
                 status = CellStatus.ERROR.value
 
@@ -1840,7 +1869,7 @@ class AddRunPromptColumnView(APIView):
 
         except Exception as e:
             traceback.print_exc()
-            error_message = get_specific_error_message(e)
+            error_message = get_run_prompt_error_message(e)
             logger.exception(f"Error in adding run prompt column: {error_message}")
             return self._gm.internal_server_error_response(error_message)
 
@@ -1969,7 +1998,7 @@ class PreviewRunPromptColumnView(APIView):
                         responses.append(response)
 
                 except Exception as e:
-                    responses.append(str(e))
+                    responses.append(get_run_prompt_error_message(e))
                     value_infos = {"metadata": {"usage": {}, "cost": {}}}
             return self._gm.success_response(
                 {
@@ -1980,7 +2009,7 @@ class PreviewRunPromptColumnView(APIView):
             )
 
         except Exception as e:
-            error_message = get_specific_error_message(e)
+            error_message = get_run_prompt_error_message(e)
             logger.exception(f"Error in preview run prompt column: {error_message}")
             return self._gm.internal_server_error_response(error_message)
 
@@ -2159,7 +2188,7 @@ class EditRunPromptColumnView(APIView):
         except Http404:
             return self._gm.not_found("Column or dataset not found")
         except Exception as e:
-            error_message = get_specific_error_message(e)
+            error_message = get_run_prompt_error_message(e)
             logger.exception(f"Error in updating run prompt column: {error_message}")
             return self._gm.internal_server_error_response(error_message)
 
@@ -2249,7 +2278,7 @@ class RetrieveRunPromptColumnConfigView(APIView):
         except Http404:
             return self._gm.not_found("Column or run prompt configuration not found")
         except Exception as e:
-            error_message = get_specific_error_message(e)
+            error_message = get_run_prompt_error_message(e)
             logger.exception(f"Error in fetching run prompt column: {error_message}")
             return self._gm.internal_server_error_response(error_message)
 
@@ -2277,7 +2306,7 @@ class DefaultProviderView(APIView):
             return self._gm.not_found(get_error_message("PROVIDER_CONFIG_NOT_FOUND"))
 
         except Exception as e:
-            error_message = get_specific_error_message(e)
+            error_message = get_run_prompt_error_message(e)
             logger.exception(
                 f"Error in fetching provider's configurations: {error_message}"
             )
@@ -2315,7 +2344,7 @@ class DefaultProviderView(APIView):
             return self._gm.success_response("Default provider updated successfully")
 
         except Exception as e:
-            error_message = get_specific_error_message(e)
+            error_message = get_run_prompt_error_message(e)
             logger.exception(f"Error in setting provider as default: {error_message}")
             return self._gm.internal_server_error_response(error_message)
 
@@ -2408,7 +2437,7 @@ class RetrieveRunPromptOptionsView(APIView):
             return self._gm.success_response(data)
 
         except Exception as e:
-            error_message = get_specific_error_message(e)
+            error_message = get_run_prompt_error_message(e)
             logger.exception(f"Error in fetching run prompt options: {error_message}")
             return self._gm.internal_server_error_response(error_message)
 
@@ -2459,7 +2488,7 @@ class DatasetRunPromptStatsView(APIView):
             return self._gm.success_response(response)
 
         except Exception as e:
-            error_message = get_specific_error_message(e)
+            error_message = get_run_prompt_error_message(e)
             logger.exception(f"Error in fetching run prompt data: {error_message}")
             return self._gm.bad_request(error_message)
 
@@ -2700,7 +2729,7 @@ class LiteLLMModelVoicesView(APIView):
             return self._gm.success_response(response_data)
 
         except Exception as e:
-            error_message = get_specific_error_message(e)
+            error_message = get_run_prompt_error_message(e)
             logger.exception(f"Error fetching model voices: {error_message}")
             return self._gm.internal_server_error_response(error_message)
 
@@ -2727,7 +2756,7 @@ class ModelParametersView(APIView):
             return self._gm.success_response(parameters)
 
         except Exception as e:
-            error_message = get_specific_error_message(e)
+            error_message = get_run_prompt_error_message(e)
             logger.exception(f"Error fetching model parameters: {error_message}")
             return self._gm.internal_server_error_response(error_message)
 
@@ -2818,7 +2847,7 @@ class RunPromptForRowsView(APIView):
                 {"success": "Run prompts queued for processing."}
             )
         except Exception as e:
-            error_message = get_specific_error_message(e)
+            error_message = get_run_prompt_error_message(e)
             logger.exception(f"Error in running prompt on rows: {error_message}")
             return self._gm.internal_server_error_response(error_message)
 
@@ -2858,7 +2887,7 @@ def run_all_prompts_task(run_prompt_ids, row_ids):
 
     except Exception as e:
         # Handle exceptions and log errors
-        error_message = get_specific_error_message(e)
+        error_message = get_run_prompt_error_message(e)
         logger.exception(f"Error in run all prompts task: {error_message}")
         # Optionally update the run prompt status to FAILED
         try:


### PR DESCRIPTION
## Summary

`model_hub` run-prompt failures currently return raw exception text to API callers: provider error bodies, library internals, and occasionally file paths / connection details reach the API response verbatim, and per-row failures store the raw exception string in cell values.

## Root Cause

- `RunPrompts.process_row` (batch/Celery path) called `get_specific_error_message(e, is_llm_error)` with `is_llm_error=True` — that branch returns `str(e)` **verbatim** — and additionally stored `response = str(e)` directly in the cell value and `value_info["reason"]`.
- `LitellmAPIView.process_row` and `PreviewRunPromptColumnView` surfaced `str(e)` / `get_specific_error_message(e)` (which passes `ValueError` messages through unchanged) to callers.
- There was no distinction between user-input validation failures (actionable, safe to show) and everything else (internal, must be redacted).

## Change

- Added an explicit **allowlist of local-validation phases** in `futureagi/model_hub/views/run_prompt.py`:
  - New `RunPromptValidationError` exception, raised by `populate_placeholders` for placeholder/media/template validation failures — the user's own input, surfaced verbatim.
  - New `get_run_prompt_error_message(exc)` helper: `RunPromptValidationError` → message verbatim; **any other exception → generic message** ("Run prompt failed. Please check your configuration and try again."), with the full exception logged server-side via `logger.exception` (safe default is redaction).
- Replaced every `get_specific_error_message(e)` / `str(e)` leak point in `run_prompt.py` (both `process_row` paths, preview endpoint `responses` array, and the run-prompt CRUD/config views) with the sanitizer. `response = str(e)` in `RunPrompts.process_row` now stores the sanitized message.

## Verification

- Added `futureagi/model_hub/tests/test_run_prompt_error_sanitization.py` covering:
  - a known local-validation failure returns the clean mapped message verbatim (helper + cell-storage + preview endpoint);
  - an unexpected exception returns the generic message and the raw exception text (provider URL, secret key) never appears in the cell value, `value_infos`, or the preview API response.
- Ran: `pytest model_hub/tests/test_run_prompt_error_sanitization.py -v` — all tests pass (and existing `test_run_prompt_*` suites were checked for regressions).

Closes #2081
