### PR TITLE
fix: make link evaluators reliable for real HTTP servers

### DIFF
--- a/futureagi/agentic_eval/core_evals/fi_evals/function/functions.py
+++ b/futureagi/agentic_eval/core_evals/fi_evals/function/functions.py
@@ -40,6 +40,14 @@ def _standardize_url(url):
         return "http://" + url
 
 
+def _is_valid_link(url):
+    """Check a URL with bounded, redirect-aware HTTP requests."""
+    response = requests.head(url, timeout=5, allow_redirects=True)
+    if response.status_code in (403, 405):
+        response = requests.get(url, timeout=5, allow_redirects=True, stream=True)
+    return response.status_code < 400
+
+
 def _preprocess_strings(keywords, text, case_sensitive):
     """
     Preprocess the keywords based on the case_sensitive flag.
@@ -1333,8 +1341,7 @@ def contains_valid_link(text, **kwargs):
         if matched_url:
             standardized_url = _standardize_url(matched_url)
             try:
-                text = requests.head(standardized_url)
-                if text.status_code == 200:
+                if _is_valid_link(standardized_url):
                     return {
                         "result": True,
                         "reason": f"link {matched_url} found in output and is valid",
@@ -1344,7 +1351,7 @@ def contains_valid_link(text, **kwargs):
                         "result": False,
                         "reason": f"link {matched_url} found in output but is invalid",
                     }
-            except:
+            except requests.RequestException:
                 return {
                     "result": False,
                     "reason": f"link {matched_url} found in output but is invalid",
@@ -1369,8 +1376,7 @@ def no_invalid_links(text, **kwargs):
         if matched_url:
             standardized_url = _standardize_url(matched_url)
             try:
-                text = requests.head(standardized_url)
-                if text.status_code == 200:
+                if _is_valid_link(standardized_url):
                     return {
                         "result": True,
                         "reason": f"link {matched_url} found in output and is valid",
@@ -1380,7 +1386,7 @@ def no_invalid_links(text, **kwargs):
                         "result": False,
                         "reason": f"link {matched_url} found in output but is invalid",
                     }
-            except:
+            except requests.RequestException:
                 return {
                     "result": False,
                     "reason": f"link {matched_url} found in output but is invalid",

--- a/futureagi/agentic_eval/core_evals/fi_evals/function/tests/test_link_evaluators.py
+++ b/futureagi/agentic_eval/core_evals/fi_evals/function/tests/test_link_evaluators.py
@@ -1,0 +1,71 @@
+from unittest.mock import Mock, patch
+
+import pytest
+import requests
+
+from agentic_eval.core_evals.fi_evals.function.functions import (
+    contains_valid_link,
+    no_invalid_links,
+)
+
+
+@pytest.mark.parametrize("evaluator", [contains_valid_link, no_invalid_links])
+def test_link_evaluator_accepts_redirecting_links(evaluator):
+    response = Mock(status_code=200)
+
+    with patch(
+        "agentic_eval.core_evals.fi_evals.function.functions.requests.head",
+        return_value=response,
+    ) as head:
+        result = evaluator("Read more at http://example.com")
+
+    assert result["result"] is True
+    head.assert_called_once_with(
+        "http://example.com", timeout=5, allow_redirects=True
+    )
+
+
+@pytest.mark.parametrize("evaluator", [contains_valid_link, no_invalid_links])
+def test_link_evaluator_falls_back_to_get_when_head_is_not_supported(evaluator):
+    head_response = Mock(status_code=405)
+    get_response = Mock(status_code=200)
+
+    with (
+        patch(
+            "agentic_eval.core_evals.fi_evals.function.functions.requests.head",
+            return_value=head_response,
+        ) as head,
+        patch(
+            "agentic_eval.core_evals.fi_evals.function.functions.requests.get",
+            return_value=get_response,
+        ) as get,
+    ):
+        result = evaluator("Read more at http://example.com")
+
+    assert result["result"] is True
+    head.assert_called_once_with(
+        "http://example.com", timeout=5, allow_redirects=True
+    )
+    get.assert_called_once_with(
+        "http://example.com", timeout=5, allow_redirects=True, stream=True
+    )
+
+
+@pytest.mark.parametrize("evaluator", [contains_valid_link, no_invalid_links])
+def test_link_evaluator_returns_false_on_request_timeout(evaluator):
+    with patch(
+        "agentic_eval.core_evals.fi_evals.function.functions.requests.head",
+        side_effect=requests.Timeout,
+    ):
+        result = evaluator("Read more at http://example.com")
+
+    assert result["result"] is False
+
+
+def test_link_evaluator_does_not_swallow_unexpected_exceptions():
+    with patch(
+        "agentic_eval.core_evals.fi_evals.function.functions.requests.head",
+        side_effect=RuntimeError("unexpected bug"),
+    ):
+        with pytest.raises(RuntimeError, match="unexpected bug"):
+            contains_valid_link("Read more at http://example.com")


### PR DESCRIPTION
## Summary

- add a bounded 5-second timeout and redirect following to link checks
- fall back to a streamed GET when a server rejects HEAD with 403 or 405
- treat any final HTTP status below 400 as valid
- catch only requests.RequestException so unexpected errors are not hidden
- add mocked regression coverage for both affected evaluators

Fixes #1945.

## Validation

- isolated mocked link-evaluator checks passed
- python -m compileall -q core_evals/fi_evals/function/functions.py

AI assistance was used during implementation; the changes were reviewed before submission.