### PR TITLE
fix: enable column resizing in annotation queue items table

### DIFF
--- a/frontend/src/sections/annotations/queues/items/queue-items-table.jsx
+++ b/frontend/src/sections/annotations/queues/items/queue-items-table.jsx
@@ -634,7 +634,7 @@ export default function QueueItemsTable({
       lockVisible: true,
       filter: false,
       sortable: false,
-      resizable: false,
+      resizable: true,
       suppressHeaderMenuButton: true,
       suppressHeaderContextMenu: true,
     }),


### PR DESCRIPTION
## Summary

Fixes #1966.

The `defaultColDef` in `queue-items-table.jsx` had `resizable: false`, preventing all data columns (including "Item Status") from being resized. Changed to `resizable: true`.

The `actions` column retains its own `resizable: false` override at the column level, keeping it fixed at 60px as intended.

## Test plan

- [x] "Item Status" column header can be dragged to resize
- [x] All other data columns become resizable
- [x] Actions column stays fixed at 60px (per-column override)
- [x] Existing per-column width starting values preserved