### PR TITLE
fix: debounce dashboard time filter to prevent redundant widget refetches

### DIFF
--- a/frontend/src/sections/dashboards/DashboardDetailView.jsx
+++ b/frontend/src/sections/dashboards/DashboardDetailView.jsx
@@ -69,6 +69,8 @@ import {
   useDroppable,
 } from "@dnd-kit/core";
 
+const DASHBOARD_FILTER_DEBOUNCE_MS = 400;
+
 /** Group a flat sorted widget list into rows based on cumulative widths.
  *  Widgets in each row are normalized so their widths sum to exactly 12. */
 function computeRows(widgets) {
@@ -667,7 +669,7 @@ export default function DashboardDetailView() {
     () => resolveGlobalDateRange(datePreset, customDateRange),
     [datePreset, customDateRange],
   );
-  const debouncedGlobalDateRange = useDebounce(globalDateRange, 400);
+  const debouncedGlobalDateRange = useDebounce(globalDateRange, DASHBOARD_FILTER_DEBOUNCE_MS);
 
   // Widget context menu
   const [menuAnchor, setMenuAnchor] = useState(null);

--- a/frontend/src/sections/dashboards/DashboardDetailView.jsx
+++ b/frontend/src/sections/dashboards/DashboardDetailView.jsx
@@ -7,6 +7,7 @@ import React, {
   useRef,
   useState,
 } from "react";
+import { useDebounce } from "src/hooks/use-debounce";
 import {
   Box,
   Breadcrumbs,
@@ -573,10 +574,10 @@ function DraggableWidgetCard({
           {/* Chart */}
           <Box sx={{ flex: 1, minHeight: 0, overflow: "hidden" }}>
             <WidgetChart
-              key={`${widget.id}:${datePreset || "default"}${
+              key={`${widget.id}${
                 globalDateRange
                   ? `:${globalDateRange.start}:${globalDateRange.end}`
-                  : ""
+                  : ":default"
               }`}
               widget={widget}
               globalDateRange={globalDateRange}
@@ -666,6 +667,7 @@ export default function DashboardDetailView() {
     () => resolveGlobalDateRange(datePreset, customDateRange),
     [datePreset, customDateRange],
   );
+  const debouncedGlobalDateRange = useDebounce(globalDateRange, 400);
 
   // Widget context menu
   const [menuAnchor, setMenuAnchor] = useState(null);
@@ -1367,7 +1369,7 @@ export default function DashboardDetailView() {
                               dashboardId={dashboardId}
                               navigate={navigate}
                               onMenuOpen={handleWidgetMenuOpen}
-                              globalDateRange={globalDateRange}
+                              globalDateRange={debouncedGlobalDateRange}
                               isDragActive={!!activeWidget}
                               rowHeight={rowHeight}
                               datePreset={datePreset}


### PR DESCRIPTION
## Summary
- Debounce `globalDateRange` (400ms) before passing to widget cards, so rapid preset clicks settle into a single fetch instead of firing one per click
- Chip active state still updates instantly — only the value driving widget refetches is debounced
- Removed redundant `datePreset` from widget key since the date range already encodes the time info

## How it works
1. `useDebounce(globalDateRange, 400)` creates a debounced version in the parent `DashboardDetailView`
2. `DraggableWidgetCard` receives `debouncedGlobalDateRange` as its `globalDateRange` prop
3. `WidgetChart` key and props use the debounced range — remount and refetch only happen once the user stops clicking
4. Raw `datePreset` stays in the chip UI for instant visual feedback

Fixes #1968