### PR TITLE
chore: block guerrillamailblock.com and example.net signups

### DIFF
--- a/frontend/src/utils/workEmail.js
+++ b/frontend/src/utils/workEmail.js
@@ -24,8 +24,10 @@ export const NON_WORK_EMAIL_DOMAINS = [
   "yandex.ru",
   "mailinator.com",
   "yopmail.com",
+  "guerrillamailblock.com",
   "web-library.net",
   "example.com",
+  "example.net",
   "noreply.github.com",
   "github.com",
 ];

--- a/futureagi/accounts/utils.py
+++ b/futureagi/accounts/utils.py
@@ -201,8 +201,10 @@ def is_work_email(email):
         "yandex.ru",
         "mailinator.com",
         "yopmail.com",
+        "guerrillamailblock.com",
         "web-library.net",
         "example.com",
+        "example.net",
         "noreply.github.com",  # GitHub's no-reply emails
         "github.com",  # In case GitHub emails are used
     }


### PR DESCRIPTION
Adds two domains to the non-work email denylist after seeing signups come through on them.

- `guerrillamailblock.com` — one of GuerrillaMail's rotating throwaway domains. We already block `mailinator.com` and `yopmail.com`; this is the same class of provider.
- `example.net` — reserved documentation domain (RFC 2606), same reasoning as the `example.com` entry already on the list.

Updated in both places the list currently lives:
- `futureagi/accounts/utils.py` → `is_work_email()`, the actual signup gate. Every path (password, Google, GitHub, Microsoft) funnels through `first_signup`, so this covers all of them.
- `frontend/src/utils/workEmail.js` → `NON_WORK_EMAIL_DOMAINS`, the client-side validation message. Kept in sync so the form rejects before the round trip.

`tfc/constants/email.py` deliberately untouched — that list drives org-name derivation, not access, and these domains never reach it once the gate rejects them.

Verified both lists are still identical (29 entries each, no duplicates). Frontend tests pass; the suite iterates `NON_WORK_EMAIL_DOMAINS`, so the new entries are asserted automatically.

## Note

This is a stopgap. A hand-maintained denylist needs a deploy per domain and is always behind — anyone can register a fresh domain and be through in minutes. Worth following up with an MX-host check plus a domain-age check, and moving the list into data so it's editable without a release.