### PR TITLE
feat: use disposable-email-domains package in the signup gate

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,19 +1,5 @@
 FROM futureagi/future-agi-base:v1.0.1
 
-# future-agi-base is published from main, so it lags requirements added on a
-# feature branch. Install those here until the dependency lands on main and
-# the base is republished.
-COPY futureagi/requirements.txt /tmp/requirements.txt
-RUN uv pip install --system -r /tmp/requirements.txt --no-cache --only-binary av
-
-# AnnotationCorpusBuilder (model_hub/utils/utils.py) calls nltk.download() at
-# module import, so a missing corpus blocks Django startup until
-# raw.githubusercontent.com responds — minutes on a slow link, and repeated on
-# every container recreate because ~/nltk_data is not persisted. Bake them in.
-ENV NLTK_DATA=/usr/local/share/nltk_data
-RUN python -m nltk.downloader -d $NLTK_DATA \
-    punkt averaged_perceptron_tagger wordnet omw-1.4 stopwords
-
 COPY futureagi/ .
 
 # Install Node.js for sandboxed JavaScript eval execution

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,18 @@
-FROM futureagi/future-agi-base:v1.0.0
+FROM futureagi/future-agi-base:v1.0.1
+
+# future-agi-base is published from main, so it lags requirements added on a
+# feature branch. Install those here until the dependency lands on main and
+# the base is republished.
+COPY futureagi/requirements.txt /tmp/requirements.txt
+RUN uv pip install --system -r /tmp/requirements.txt --no-cache --only-binary av
+
+# AnnotationCorpusBuilder (model_hub/utils/utils.py) calls nltk.download() at
+# module import, so a missing corpus blocks Django startup until
+# raw.githubusercontent.com responds — minutes on a slow link, and repeated on
+# every container recreate because ~/nltk_data is not persisted. Bake them in.
+ENV NLTK_DATA=/usr/local/share/nltk_data
+RUN python -m nltk.downloader -d $NLTK_DATA \
+    punkt averaged_perceptron_tagger wordnet omw-1.4 stopwords
 
 COPY futureagi/ .
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM futureagi/future-agi-base:v1.0.1
+FROM futureagi/future-agi-base:v1.0.2
 
 COPY futureagi/ .
 

--- a/futureagi/Dockerfile
+++ b/futureagi/Dockerfile
@@ -1,4 +1,4 @@
-FROM futureagi/future-agi-base:v1.0.1
+FROM futureagi/future-agi-base:v1.0.2
 
 COPY . .
 

--- a/futureagi/Dockerfile
+++ b/futureagi/Dockerfile
@@ -1,4 +1,4 @@
-FROM futureagi/future-agi-base:v1.0.0
+FROM futureagi/future-agi-base:v1.0.1
 
 COPY . .
 

--- a/futureagi/accounts/tests/test_signup.py
+++ b/futureagi/accounts/tests/test_signup.py
@@ -2120,6 +2120,47 @@ class TestWorkEmailGate:
 
 
 @pytest.mark.unit
+class TestDisposableEmailDomains:
+    """The packaged blocklist and the hand-maintained free-provider set cover
+    different things, so the gate has to consult both."""
+
+    def test_a_listed_throwaway_provider_is_disposable(self):
+        from accounts.utils import is_disposable_email_domain
+
+        assert is_disposable_email_domain("mailinator.com")
+
+    def test_subdomains_of_a_listed_provider_are_disposable(self):
+        """Mailinator hands out `anything.mailinator.com`; matching the exact
+        domain alone would let every one of those through."""
+        from accounts.utils import is_disposable_email_domain
+
+        assert is_disposable_email_domain("inbox.mailinator.com")
+        assert is_disposable_email_domain("deep.nested.mailinator.com")
+
+    def test_a_company_domain_is_not_disposable(self):
+        from accounts.utils import is_disposable_email_domain
+
+        assert not is_disposable_email_domain("futureagi.com")
+        assert not is_disposable_email_domain("mail.futureagi.com")
+
+    def test_the_bare_tld_is_never_matched(self):
+        """The walk stops before the last label, so a stray `.com` in the
+        blocklist could not take out every commercial domain."""
+        from accounts.utils import is_disposable_email_domain
+
+        assert not is_disposable_email_domain("com")
+
+    def test_free_providers_are_absent_from_the_package_list(self):
+        """gmail and friends are permanent mailboxes, not throwaways, so the
+        package does not list them. Dropping the hand-maintained set in favour
+        of the package alone would silently reopen the gate to them."""
+        from accounts.utils import DISPOSABLE_EMAIL_DOMAINS
+
+        assert "gmail.com" not in DISPOSABLE_EMAIL_DOMAINS
+        assert "yahoo.com" not in DISPOSABLE_EMAIL_DOMAINS
+
+
+@pytest.mark.unit
 class TestAuthLinkBuilders:
     def test_reset_link_uses_the_uid_and_token_it_is_given(self):
         """The caller has already minted the AuthToken the token encodes;

--- a/futureagi/accounts/utils.py
+++ b/futureagi/accounts/utils.py
@@ -5,6 +5,7 @@ import string
 
 import requests
 import structlog
+from disposable_email_domains import blocklist as DISPOSABLE_EMAIL_DOMAINS
 from django.conf import settings
 from django.contrib.auth.tokens import default_token_generator
 from django.db import close_old_connections, transaction
@@ -164,6 +165,20 @@ class WorkEmailRequired(Exception):
         super().__init__(message)
 
 
+def is_disposable_email_domain(domain):
+    """True if the domain, or any parent of it, is a known throwaway provider.
+
+    Walks the suffixes so a single blocklist entry also covers a provider's
+    subdomains -- Mailinator hands out `anything.mailinator.com`, and an exact
+    match on `mailinator.com` would miss every one of them. The bare TLD is
+    never tested, so a stray entry there can't take out a whole namespace.
+    """
+    parts = domain.split(".")
+    return any(
+        ".".join(parts[i:]) in DISPOSABLE_EMAIL_DOMAINS for i in range(len(parts) - 1)
+    )
+
+
 def is_work_email(email):
     """
     Returns True if the email appears to be a work email,
@@ -221,8 +236,14 @@ def is_work_email(email):
     # Extract the domain part from the email
     domain = email.split("@")[-1]
 
-    # Return False if the domain is in the free domains list
-    return domain not in free_domains
+    if domain in free_domains:
+        return False
+
+    # The set above covers the mainstream free providers (gmail, yahoo, ...),
+    # which are real mailboxes rather than throwaway ones and so are absent
+    # from the package list. The two are complementary; a domain has to clear
+    # both to count as a work address.
+    return not is_disposable_email_domain(domain)
 
 
 def first_signup(data, mode=None):

--- a/futureagi/accounts/utils.py
+++ b/futureagi/accounts/utils.py
@@ -173,10 +173,11 @@ def is_disposable_email_domain(domain):
     match on `mailinator.com` would miss every one of them. The bare TLD is
     never tested, so a stray entry there can't take out a whole namespace.
     """
-    parts = domain.split(".")
-    return any(
-        ".".join(parts[i:]) in DISPOSABLE_EMAIL_DOMAINS for i in range(len(parts) - 1)
-    )
+    domain_parts = domain.split(".")
+    for i in range(len(domain_parts) - 1):
+        if ".".join(domain_parts[i:]) in DISPOSABLE_EMAIL_DOMAINS:
+            return True
+    return False
 
 
 def is_work_email(email):

--- a/futureagi/accounts/utils.py
+++ b/futureagi/accounts/utils.py
@@ -239,10 +239,6 @@ def is_work_email(email):
     if domain in free_domains:
         return False
 
-    # The set above covers the mainstream free providers (gmail, yahoo, ...),
-    # which are real mailboxes rather than throwaway ones and so are absent
-    # from the package list. The two are complementary; a domain has to clear
-    # both to count as a work address.
     return not is_disposable_email_domain(domain)
 
 

--- a/futureagi/pyproject.toml
+++ b/futureagi/pyproject.toml
@@ -43,7 +43,7 @@ dependencies = [
     "stripe",
     # Community-maintained set of throwaway-inbox domains, used by
     # accounts.utils.is_work_email to reject disposable signups.
-    "disposable-email-domains",
+    "disposable-email-domains==0.0.239",
     # OpenTelemetry core
     "opentelemetry-api>=1.20.0",
     "opentelemetry-sdk>=1.20.0",

--- a/futureagi/pyproject.toml
+++ b/futureagi/pyproject.toml
@@ -41,6 +41,9 @@ dependencies = [
     "qdrant-client",
     "weaviate-client",
     "stripe",
+    # Community-maintained set of throwaway-inbox domains, used by
+    # accounts.utils.is_work_email to reject disposable signups.
+    "disposable-email-domains",
     # OpenTelemetry core
     "opentelemetry-api>=1.20.0",
     "opentelemetry-sdk>=1.20.0",

--- a/futureagi/requirements.txt
+++ b/futureagi/requirements.txt
@@ -199,6 +199,8 @@ dill==0.3.8
     # via
     #   datasets
     #   multiprocess
+disposable-email-domains==0.0.239
+    # via core-backend (pyproject.toml)
 distro==1.9.0
     # via
     #   anthropic

--- a/futureagi/uv.lock
+++ b/futureagi/uv.lock
@@ -1147,6 +1147,7 @@ dependencies = [
     { name = "clickhouse-connect" },
     { name = "clickhouse-driver" },
     { name = "datasets" },
+    { name = "disposable-email-domains" },
     { name = "django" },
     { name = "django-anymail" },
     { name = "django-celery-beat" },
@@ -1314,6 +1315,7 @@ requires-dist = [
     { name = "clickhouse-connect" },
     { name = "clickhouse-driver" },
     { name = "datasets" },
+    { name = "disposable-email-domains", specifier = "==0.0.239" },
     { name = "django", specifier = "==5.1.8" },
     { name = "django-anymail" },
     { name = "django-celery-beat" },
@@ -1838,6 +1840,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/12/80/630b4b88364e9a8c8c5797f4602d0f76ef820909ee32f0bacb9f90654042/dill-0.4.0.tar.gz", hash = "sha256:0633f1d2df477324f53a895b02c901fb961bdbf65a17122586ea7019292cbcf0", size = 186976, upload-time = "2025-04-16T00:41:48.867Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/50/3d/9373ad9c56321fdab5b41197068e1d8c25883b3fea29dd361f9b55116869/dill-0.4.0-py3-none-any.whl", hash = "sha256:44f54bf6412c2c8464c14e8243eb163690a9800dbe2c367330883b19c7561049", size = 119668, upload-time = "2025-04-16T00:41:47.671Z" },
+]
+
+[[package]]
+name = "disposable-email-domains"
+version = "0.0.239"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/6b/96/d9cbcb9f6a7228c961fbdfcf1e537a240d3135fb2fcd73fefcbc25678019/disposable_email_domains-0.0.239.tar.gz", hash = "sha256:b32dcfc839a0851d8cdba7117aec0e72c569344de186deb4462c69cfbec5f16f", size = 101343, upload-time = "2026-08-19T01:47:29.608Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/43/b2a2af68bd2b06bd8e01a6a52d97529df54ac4ceff435a7abaf8a5f4143f/disposable_email_domains-0.0.239-py3-none-any.whl", hash = "sha256:8b33f253eb3c1fcb260cc036000c755acbbc0115541f38b8a6a149712fc0a601", size = 52073, upload-time = "2026-08-19T01:47:28.196Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
The signup gate currently matches against a hand-maintained set of 29 domains in `is_work_email()`. Every newly-spotted throwaway domain needs a code change and a deploy, so we are permanently a step behind. This swaps the throwaway half of that job onto a maintained package.

## What changed

- **`disposable-email-domains`** added to `pyproject.toml` and `requirements.txt` (MIT, pure data, no transitive deps). Release 0.0.239 ships 8,310 domains as a plain `set`.
- **`is_disposable_email_domain()`** in `accounts/utils.py` — checks the domain and each of its parent domains against that set.
- **`is_work_email()`** now has to clear both lists.

## The two lists are complementary, not redundant

The package covers *throwaway inboxes*. It deliberately does **not** list `gmail.com`, `yahoo.com`, `outlook.com` — those are permanent mailboxes, not disposable ones. Deleting the hand-maintained set in favour of the package alone would silently reopen the gate to every personal Gmail. There is a test pinning this so nobody removes it later.

## Why the suffix walk

Mailinator hands out `anything.mailinator.com`, all landing in a public inbox. The current flat `domain not in free_domains` check matches `mailinator.com` and misses every subdomain of it. Walking the suffixes means one blocklist entry covers a provider's whole subdomain tree. The walk stops before the final label, so a stray `com` entry upstream could not take out every commercial domain.

## Scope

Backend only. The frontend list in `workEmail.js` stays as-is — it drives the inline validation message, and shipping 8,310 domains into the JS bundle to improve a client-side hint is not a trade worth making. The gate that matters is server-side, and every signup path (password, Google, GitHub, Microsoft) funnels through `first_signup`.

This only runs at signup, not login, so existing accounts are unaffected even if the package lists a domain one of them uses.

## Testing

Five unit tests in `TestDisposableEmailDomains`: a listed provider, subdomains of a listed provider, a real company domain, the bare-TLD guard, and the free-providers-absent-from-the-package assertion.

I could not run the suite locally — there is no backend venv on this machine and the suite needs a database. I compiled both changed files and exercised the helper verbatim against the real package data, which passed, but **the pytest run itself is unverified — please confirm in CI.**

## Needs a second pair of eyes

**`requirements.txt` was hand-edited, not recompiled.** Running `uv pip compile` on macOS dropped the Linux-only CUDA wheels (`cuda-bindings`, `cuda-pathfinder`), added a macOS-only `audioop-lts`, and overwrote the hand-written comment on `clickhouse-connect` — 64 deletions that would likely break the Docker build. I inserted the single pinned entry in its correct alphabetical position instead. **Worth recompiling on Linux before this merges.**

## Follow-ups this does not do

The package is reactive — a domain registered this morning will not be in it. The durable fixes are an MX-host check (one entry kills a provider's whole future domain set) and a domain-age check via RDAP. Also worth an allowlist table checked first, as an escape hatch if the upstream list ever includes a real customer's domain.

Depends on #2228 only by overlap: that PR adds `guerrillamailblock.com`, which this package already covers, and `example.net`, which it does not. They merge cleanly in either order.