### PR TITLE
feat(gateway): export caller metadata, body fields and headers as span attributes

### DIFF
--- a/agentcc-gateway/config.example.yaml
+++ b/agentcc-gateway/config.example.yaml
@@ -481,6 +481,60 @@ logging:
 #                                      # collector. Redacted with the same
 #                                      # privacy config as the request log.
 #   sample_rate: 0.1                   # 10% of requests
+#   trace_propagation: false           # honour an inbound W3C `traceparent`:
+#                                      # adopt its trace id and nest this span
+#                                      # under the caller's span instead of
+#                                      # starting a second root in the trace.
+#                                      # Only parents a caller that marks itself
+#                                      # sampled — an unsampled caller never
+#                                      # exports the span we would point at.
+#                                      # Leave off unless the caller ships its
+#                                      # spans to the same destination as this
+#                                      # gateway: a trace whose root lives in
+#                                      # another backend has no root here, and
+#                                      # consumers that key on the root span
+#                                      # will not list it. The caller-supplied
+#                                      # trace id is trusted input, so enable it
+#                                      # deliberately.
+#   metadata_attributes: true          # default. Also emit each caller metadata
+#                                      # key as agentcc.metadata.<key>, next to
+#                                      # the `metadata` JSON object that is
+#                                      # always written. The flat copies are
+#                                      # what a backend can filter and group on;
+#                                      # the JSON object is one opaque string.
+#                                      # Capped at 16 pairs / 64-char keys /
+#                                      # 512-char values, matching OpenAI's own
+#                                      # metadata limits. Keys past the cap are
+#                                      # dropped in sorted order and counted in
+#                                      # agentcc.metadata_dropped.
+#   body_attributes: true              # default. Emit the request body's unknown
+#                                      # top-level fields as agentcc.body.<key>
+#                                      # — an SDK's extra_body, and every
+#                                      # OpenAI parameter newer than the field
+#                                      # list the request struct knows about
+#                                      # (reasoning_effort, parallel_tool_calls,
+#                                      # store...). Scalars only: a nested
+#                                      # object is not filterable, and objects
+#                                      # are the shape credentials arrive in.
+#                                      # Numbers stay numbers, so range filters
+#                                      # work. Values are redacted with the
+#                                      # privacy config; the caps and the
+#                                      # agentcc.body_dropped counter mirror
+#                                      # metadata's.
+#   capture_headers:                   # request headers to copy onto the span
+#     - "x-acme-*"                     # as http.request.header.<name>. Empty by
+#     - "x-request-source"             # default. Trailing * is a prefix
+#                                      # wildcard; matching is case-insensitive.
+#                                      # An allowlist, never a blocklist:
+#                                      # request headers carry credentials, and
+#                                      # a trace goes somewhere wider than a log
+#                                      # does. Authorization, x-api-key, cookie
+#                                      # and friends stay denied even when a
+#                                      # wildcard — or an exact entry — names
+#                                      # them. Values are redacted with the
+#                                      # privacy config; metadata values are not,
+#                                      # because they are dimensions the caller
+#                                      # chose to group by.
 #   attributes:                        # emitted as OTLP resource attributes
 #     environment: "production"
 #     region: "us-east-1"
@@ -496,6 +550,24 @@ logging:
 # as the agentcc.trace_id span attribute, so a span can be matched to its
 # request-log row; agentcc.request_id and agentcc.is_stream are likewise
 # gateway facts with no conventional equivalent.
+#
+# Adding your own attributes: the gateway's stand-in for span.SetAttribute() is
+# caller metadata, and it has two channels. Send x-agentcc-metadata with a JSON
+# object, or set the OpenAI-spec `metadata` field in the request body — both
+# land as agentcc.metadata.<key> on the span and in the request log. The header
+# wins if the same key comes through both, because infrastructure tagging should
+# not be overridable by the payload it forwards. Values are strings; keys under
+# auth_, key_, org_, budget_, ratelimit_, cost, cache_, guardrail_ and credit_
+# are reserved for the gateway's own plugins and are silently dropped. There is
+# deliberately no un-prefixed passthrough: a bare key could shadow a gen_ai.*
+# convention the backend reads.
+#
+# Anything else you put in the body is exported too, as agentcc.body.<key>, so
+# an SDK's extra_body needs no gateway-side configuration to show up. The
+# difference between the two is the promise, not the plumbing: metadata is
+# curated, exported verbatim so grouping keys survive, and works on every
+# endpoint through the header. Body fields are whatever the payload carried —
+# scalars only, redacted, and only on endpoints whose body the gateway parses.
 
 # Prometheus metrics endpoint.
 # prometheus:

--- a/agentcc-gateway/internal/config/config.go
+++ b/agentcc-gateway/internal/config/config.go
@@ -776,12 +776,53 @@ type OTelConfig struct {
 	// environment rather than in this file.
 	Headers map[string]string `yaml:"headers" json:"-"`
 
+	// TracePropagation makes the gateway honour an inbound W3C `traceparent`
+	// header: its trace id is adopted and its span id becomes this span's
+	// parent, so the gateway span nests under the caller's span instead of
+	// standing alone as a second root.
+	//
+	// Off by default, and deliberately so. A trace whose root span lives in a
+	// different backend has no root here, and consumers that key a trace off
+	// its root span will not list it. Enable when the caller exports its spans
+	// to the same destination as this gateway.
+	TracePropagation bool `yaml:"trace_propagation" json:"trace_propagation"`
+
 	// IncludeBodies attaches the prompt and completion to each span. Off by
 	// default: it sends user content to the collector, and it is a separate
 	// decision from logging.request_logging.include_bodies because the two
 	// go to different places and are signed off separately. Content is
 	// redacted with the org's privacy config exactly as the request log is.
 	IncludeBodies bool `yaml:"include_bodies" json:"include_bodies"`
+
+	// MetadataAttributes additionally emits every caller-supplied metadata key
+	// as its own `agentcc.metadata.<key>` span attribute, next to the `metadata`
+	// JSON object that is always written. Flat attributes are what a trace
+	// backend can filter and group on; the JSON object is one opaque string.
+	// nil = default true.
+	MetadataAttributes *bool `yaml:"metadata_attributes" json:"metadata_attributes"`
+
+	// CaptureHeaders lists request headers to copy onto the span as
+	// `http.request.header.<name>`. Names are matched case-insensitively and a
+	// trailing `*` is a prefix wildcard, so "x-acme-*" takes a whole namespace.
+	//
+	// Empty by default, and an allowlist rather than a blocklist on purpose.
+	// Request headers carry credentials — the gateway itself copies x-api-key
+	// into Authorization before a span exists — and a trace goes somewhere
+	// wider than a log does. A blocklist is a list you can only be wrong about
+	// once. Credential headers stay denied even when a wildcard matches them.
+	CaptureHeaders []string `yaml:"capture_headers" json:"capture_headers"`
+
+	// BodyAttributes emits the request body's unknown top-level fields as
+	// `agentcc.body.<key>` — an SDK's extra_body, and every OpenAI parameter
+	// newer than the field list the request struct knows about
+	// (reasoning_effort, parallel_tool_calls, store...). On by default: those
+	// are ordinary request knobs, and a span that cannot be filtered by them is
+	// missing something the caller assumes is recorded.
+	//
+	// Scalars only, so a nested object — the shape credentials arrive in when
+	// someone passes service-account JSON through extra_body — is never
+	// exported. Values are redacted with the privacy config. nil = default true.
+	BodyAttributes *bool `yaml:"body_attributes" json:"body_attributes"`
 }
 
 // PrometheusConfig controls the Prometheus metrics endpoint.

--- a/agentcc-gateway/internal/models/context.go
+++ b/agentcc-gateway/internal/models/context.go
@@ -108,6 +108,18 @@ type RequestContext struct {
 	// by plugins, so this is the only reliable way to tell caller-supplied
 	// dimensions apart from gateway internals when exporting telemetry.
 	CustomMetadataKeys []string
+
+	// CallerExtras holds the body's unknown top-level fields (extra_body, plus
+	// every OpenAI param newer than UnmarshalJSON's `known` map). Scalars only.
+	//
+	// Snapshotted in the handler, not read from Request.Extra at export time:
+	// the translation layer writes its own state into that same map, so
+	// provenance is what keeps gateway internals out.
+	CallerExtras map[string]any
+
+	// CallerExtrasDropped counts fields left out — non-scalars and
+	// credential-shaped key names.
+	CallerExtrasDropped int
 }
 
 type RequestFlags struct {
@@ -171,6 +183,8 @@ func (rc *RequestContext) Release() {
 	rc.GuardrailResults = rc.GuardrailResults[:0]
 	rc.RequestHeaders = nil
 	rc.CustomMetadataKeys = rc.CustomMetadataKeys[:0]
+	rc.CallerExtras = nil
+	rc.CallerExtrasDropped = 0
 
 	// Reuse maps by clearing them (keeps allocated memory).
 	for k := range rc.Metadata {

--- a/agentcc-gateway/internal/models/fields.go
+++ b/agentcc-gateway/internal/models/fields.go
@@ -1,0 +1,50 @@
+package models
+
+import (
+	"reflect"
+	"strings"
+)
+
+// JSONFieldNames returns the JSON keys a struct defines, for telling a
+// dialect's own request fields apart from a caller's additions. Derived from
+// the struct so a hand-written list cannot go stale against it.
+//
+// Accepts a struct or pointer; walks embedded structs; skips `json:"-"`.
+func JSONFieldNames(v any) map[string]struct{} {
+	names := make(map[string]struct{})
+	collectJSONFieldNames(reflect.TypeOf(v), names)
+	return names
+}
+
+func collectJSONFieldNames(t reflect.Type, names map[string]struct{}) {
+	for t != nil && t.Kind() == reflect.Pointer {
+		t = t.Elem()
+	}
+	if t == nil || t.Kind() != reflect.Struct {
+		return
+	}
+	for i := 0; i < t.NumField(); i++ {
+		f := t.Field(i)
+		if f.PkgPath != "" && !f.Anonymous {
+			continue // unexported, never serialised
+		}
+		tag, name := f.Tag.Get("json"), ""
+		if comma := strings.IndexByte(tag, ','); comma >= 0 {
+			name = tag[:comma]
+		} else {
+			name = tag
+		}
+		if name == "-" {
+			continue
+		}
+		// Embedded with no name of its own flattens into the parent.
+		if f.Anonymous && name == "" {
+			collectJSONFieldNames(f.Type, names)
+			continue
+		}
+		if name == "" {
+			name = f.Name
+		}
+		names[name] = struct{}{}
+	}
+}

--- a/agentcc-gateway/internal/otel/otlp.go
+++ b/agentcc-gateway/internal/otel/otlp.go
@@ -398,7 +398,11 @@ func encodeSpan(s *Span) *tracepb.Span {
 	// The gateway's own trace ID is what appears in response headers and in the
 	// request-log table. Carry it verbatim so a span can be tied back to a log
 	// row even though the OTLP trace ID is a hash of it.
-	if s.TraceID != "" {
+	// Skip when the span already carries one: with trace propagation the
+	// gateway id is set explicitly as an attribute while s.TraceID holds the
+	// caller's. Appending here too would emit the key twice, which OTLP
+	// disallows and backends resolve inconsistently.
+	if _, ok := s.Attributes["agentcc.trace_id"]; !ok && s.TraceID != "" {
 		attrs = append(attrs, keyValue("agentcc.trace_id", s.TraceID))
 	}
 

--- a/agentcc-gateway/internal/plugins/otel/attributes.go
+++ b/agentcc-gateway/internal/plugins/otel/attributes.go
@@ -1,0 +1,225 @@
+package otel
+
+import (
+	"encoding/json"
+	"sort"
+	"strings"
+
+	"github.com/futureagi/agentcc-gateway/internal/models"
+	otelpkg "github.com/futureagi/agentcc-gateway/internal/otel"
+)
+
+// Mirrors OpenAI's own metadata limits. Applied at export, not at parse: the
+// request log keeps everything the caller sent.
+const (
+	maxMetadataPairs    = 16
+	maxMetadataKeyLen   = 64
+	maxMetadataValueLen = 512
+)
+
+// Namespaced so a caller key cannot shadow a gen_ai.* convention.
+const metadataAttrPrefix = "agentcc.metadata."
+
+// Counts keys the caps removed. Outside the namespace so it cannot collide
+// with a caller key; absent when nothing was dropped.
+const metadataDroppedAttr = "agentcc.metadata_dropped"
+
+// attachMetadata emits caller dimensions twice: the `metadata` object platform
+// ingest parses, and flattened copies that are queryable. Not redacted — these
+// are grouping keys.
+func (p *Plugin) attachMetadata(span *otelpkg.Span, rc *models.RequestContext) {
+	if len(rc.CustomMetadataKeys) == 0 {
+		return
+	}
+
+	// Sorted: ranging the map would make truncation follow randomised hash
+	// order, so a dimension would appear and vanish between identical requests.
+	keys := append([]string(nil), rc.CustomMetadataKeys...)
+	sort.Strings(keys)
+
+	custom := make(map[string]string, len(keys))
+	dropped := 0
+	for _, k := range keys {
+		v, ok := rc.Metadata[k]
+		if !ok {
+			continue
+		}
+		if _, seen := custom[k]; seen {
+			continue
+		}
+		// A truncated key is a different key, not a shorter one — drop it.
+		if len(k) > maxMetadataKeyLen || len(custom) >= maxMetadataPairs {
+			dropped++
+			continue
+		}
+		custom[k] = truncateAtRune(v, maxMetadataValueLen)
+	}
+	if len(custom) == 0 {
+		return
+	}
+
+	if encoded, err := json.Marshal(custom); err == nil {
+		span.SetAttribute("metadata", string(encoded))
+	}
+	if dropped > 0 {
+		span.SetAttribute(metadataDroppedAttr, dropped)
+	}
+	if !p.metadataAttributes {
+		return
+	}
+	for k, v := range custom {
+		span.SetAttribute(metadataAttrPrefix+k, v)
+	}
+}
+
+// A wildcard is written once and then matches whatever a proxy adds upstream,
+// so the count is bounded too.
+const (
+	maxCapturedHeaders   = 24
+	maxHeaderValueLen    = 512
+	headerAttrPrefix     = "http.request.header."
+	headerValueSeparator = ","
+)
+
+// Never exported, whatever the allowlist says. cloneRequestHeaders copies
+// x-api-key into Authorization, so a live credential is always present and a
+// pattern as ordinary as "x-*" would ship it to the trace backend.
+var headerDenylist = map[string]struct{}{
+	"authorization":        {},
+	"proxy-authorization":  {},
+	"www-authenticate":     {},
+	"cookie":               {},
+	"set-cookie":           {},
+	"api-key":              {},
+	"x-api-key":            {},
+	"x-goog-api-key":       {},
+	"x-amz-security-token": {},
+}
+
+// Allowlist only: a blocklist complete enough for the alternative is one you
+// can only be wrong about once.
+type headerMatcher struct {
+	exact  map[string]struct{}
+	prefix []string
+}
+
+// newHeaderMatcher returns nil when nothing usable was configured, which is
+// the capture-nothing default.
+func newHeaderMatcher(patterns []string) *headerMatcher {
+	m := &headerMatcher{exact: make(map[string]struct{}, len(patterns))}
+	for _, pat := range patterns {
+		pat = strings.ToLower(strings.TrimSpace(pat))
+		if pat == "" {
+			continue
+		}
+		if strings.HasSuffix(pat, "*") {
+			m.prefix = append(m.prefix, strings.TrimSuffix(pat, "*"))
+			continue
+		}
+		m.exact[pat] = struct{}{}
+	}
+	if len(m.exact) == 0 && len(m.prefix) == 0 {
+		return nil
+	}
+	return m
+}
+
+// match reports whether a lower-cased header name may be exported.
+func (m *headerMatcher) match(name string) bool {
+	if _, denied := headerDenylist[name]; denied {
+		return false
+	}
+	if _, ok := m.exact[name]; ok {
+		return true
+	}
+	for _, pre := range m.prefix {
+		if strings.HasPrefix(name, pre) {
+			return true
+		}
+	}
+	return false
+}
+
+// attachRequestHeaders copies allowlisted headers as http.request.header.<name>.
+// Joined string, not semconv's array: arrays land in the non-queryable
+// attributes_extra. Redacted, unlike metadata.
+func (p *Plugin) attachRequestHeaders(span *otelpkg.Span, rc *models.RequestContext) {
+	if p.captureHeaders == nil || len(rc.RequestHeaders) == 0 {
+		return
+	}
+
+	names := make([]string, 0, len(rc.RequestHeaders))
+	for name := range rc.RequestHeaders {
+		lower := strings.ToLower(name)
+		if p.captureHeaders.match(lower) {
+			names = append(names, lower)
+		}
+	}
+	if len(names) == 0 {
+		return
+	}
+	sort.Strings(names)
+	if len(names) > maxCapturedHeaders {
+		names = names[:maxCapturedHeaders]
+	}
+
+	redactor := p.redactorFor(rc)
+	mode := privacyMode(rc)
+	for _, name := range names {
+		v := strings.Join(rc.RequestHeaders.Values(name), headerValueSeparator)
+		if v == "" {
+			continue
+		}
+		// Redact before truncating: cutting first can sever the tail that made
+		// a secret recognisable.
+		span.SetAttribute(headerAttrPrefix+name, truncateAtRune(redact(v, redactor, mode), maxHeaderValueLen))
+	}
+}
+
+// Not "extra_body": that is a Python-SDK keyword, not a wire concept.
+const bodyAttrPrefix = "agentcc.body."
+
+// Counts fields left out: non-scalars, credential-shaped names, and the caps.
+const bodyDroppedAttr = "agentcc.body_dropped"
+
+// attachBodyExtras emits the body's unknown top-level fields — extra_body, plus
+// every OpenAI param newer than UnmarshalJSON's fixed list, which is why it
+// defaults on. Already provenance-filtered upstream; this caps and redacts.
+func (p *Plugin) attachBodyExtras(span *otelpkg.Span, rc *models.RequestContext) {
+	if !p.bodyAttributes {
+		return
+	}
+	dropped := rc.CallerExtrasDropped
+	if len(rc.CallerExtras) == 0 {
+		if dropped > 0 {
+			span.SetAttribute(bodyDroppedAttr, dropped)
+		}
+		return
+	}
+
+	// Sorted, for the same reason as metadata.
+	keys := make([]string, 0, len(rc.CallerExtras))
+	for k := range rc.CallerExtras {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	redactor := p.redactorFor(rc)
+	mode := privacyMode(rc)
+	kept := 0
+	for _, k := range keys {
+		if len(k) > maxMetadataKeyLen || kept >= maxMetadataPairs {
+			dropped++
+			continue
+		}
+		v := rc.CallerExtras[k]
+		if sv, ok := v.(string); ok {
+			v = truncateAtRune(redact(sv, redactor, mode), maxMetadataValueLen)
+		}
+		span.SetAttribute(bodyAttrPrefix+k, v)
+		kept++
+	}
+	if dropped > 0 {
+		span.SetAttribute(bodyDroppedAttr, dropped)
+	}
+}

--- a/agentcc-gateway/internal/plugins/otel/attributes_test.go
+++ b/agentcc-gateway/internal/plugins/otel/attributes_test.go
@@ -1,0 +1,464 @@
+package otel
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/futureagi/agentcc-gateway/internal/models"
+	otelpkg "github.com/futureagi/agentcc-gateway/internal/otel"
+	"github.com/futureagi/agentcc-gateway/internal/privacy"
+)
+
+// rcWithMetadata builds a request context carrying caller-supplied dimensions.
+func rcWithMetadata(kv map[string]string) *models.RequestContext {
+	rc := &models.RequestContext{
+		RequestID:      "req-1",
+		Model:          "gpt-4o",
+		Metadata:       map[string]string{},
+		RequestHeaders: http.Header{},
+	}
+	for k, v := range kv {
+		rc.Metadata[k] = v
+		rc.CustomMetadataKeys = append(rc.CustomMetadataKeys, k)
+	}
+	return rc
+}
+
+func attrString(t *testing.T, span *otelpkg.Span, key string) string {
+	t.Helper()
+	v, ok := span.Attributes[key]
+	if !ok {
+		t.Fatalf("attribute %q missing; have %v", key, attrKeys(span))
+	}
+	s, ok := v.(string)
+	if !ok {
+		t.Fatalf("attribute %q = %T, want string", key, v)
+	}
+	return s
+}
+
+func attrKeys(span *otelpkg.Span) []string {
+	keys := make([]string, 0, len(span.Attributes))
+	for k := range span.Attributes {
+		keys = append(keys, k)
+	}
+	return keys
+}
+
+// The JSON object is what the platform parses, so flattening must never
+// replace it.
+func TestAttachMetadata_EmitsBlobAndFlattenedKeys(t *testing.T) {
+	p := NewWithExporter(otelpkg.NoopExporter{}, 1.0, true)
+	rc := rcWithMetadata(map[string]string{"customer_id": "cust-4711", "module": "reviews"})
+
+	span := spanFor(t, p, rc)
+
+	var blob map[string]string
+	if err := json.Unmarshal([]byte(attrString(t, span, "metadata")), &blob); err != nil {
+		t.Fatalf("metadata blob is not a JSON object: %v", err)
+	}
+	if blob["customer_id"] != "cust-4711" || blob["module"] != "reviews" {
+		t.Errorf("blob = %v, want both caller keys", blob)
+	}
+
+	if got := attrString(t, span, "agentcc.metadata.customer_id"); got != "cust-4711" {
+		t.Errorf("flattened customer_id = %q, want %q", got, "cust-4711")
+	}
+	if got := attrString(t, span, "agentcc.metadata.module"); got != "reviews" {
+		t.Errorf("flattened module = %q, want %q", got, "reviews")
+	}
+}
+
+// Turning flattening off must leave the blob — it is the channel the platform
+// reads, not an extra.
+func TestAttachMetadata_DisabledKeepsBlob(t *testing.T) {
+	p := NewWithExporter(otelpkg.NoopExporter{}, 1.0, true)
+	p.metadataAttributes = false
+	rc := rcWithMetadata(map[string]string{"customer_id": "cust-4711"})
+
+	span := spanFor(t, p, rc)
+
+	if _, ok := span.Attributes["metadata"]; !ok {
+		t.Error("metadata blob dropped when flattening is disabled")
+	}
+	if _, ok := span.Attributes["agentcc.metadata.customer_id"]; ok {
+		t.Error("flattened key emitted while flattening is disabled")
+	}
+}
+
+// Go randomises map iteration; without the sort, which keys survive the cap
+// would differ between two identical requests.
+func TestAttachMetadata_CapIsDeterministicAndCounted(t *testing.T) {
+	kv := make(map[string]string, maxMetadataPairs*2)
+	for i := 0; i < maxMetadataPairs*2; i++ {
+		kv[fmt.Sprintf("k%02d", i)] = "v"
+	}
+
+	var first []string
+	for run := 0; run < 5; run++ {
+		p := NewWithExporter(otelpkg.NoopExporter{}, 1.0, true)
+		rc := rcWithMetadata(kv)
+		rc.RequestID = fmt.Sprintf("req-%d", run)
+		span := spanFor(t, p, rc)
+
+		var blob map[string]string
+		if err := json.Unmarshal([]byte(attrString(t, span, "metadata")), &blob); err != nil {
+			t.Fatal(err)
+		}
+		if len(blob) != maxMetadataPairs {
+			t.Fatalf("kept %d pairs, want %d", len(blob), maxMetadataPairs)
+		}
+		if got := span.Attributes[metadataDroppedAttr]; got != maxMetadataPairs {
+			t.Errorf("%s = %v, want %d", metadataDroppedAttr, got, maxMetadataPairs)
+		}
+
+		keys := make([]string, 0, len(blob))
+		for k := range blob {
+			keys = append(keys, k)
+		}
+		if first == nil {
+			first = keys
+			continue
+		}
+		if len(first) != len(keys) {
+			t.Fatalf("run %d kept a different number of keys", run)
+		}
+		for _, k := range first {
+			if _, ok := blob[k]; !ok {
+				t.Fatalf("run %d dropped %q that run 0 kept — truncation is not deterministic", run, k)
+			}
+		}
+	}
+	// Sorted truncation keeps the lowest keys.
+	for _, k := range first {
+		if k >= fmt.Sprintf("k%02d", maxMetadataPairs) {
+			t.Errorf("kept %q, want the first %d sorted keys", k, maxMetadataPairs)
+		}
+	}
+}
+
+// Nothing was dropped, so the counter must be absent rather than zero.
+func TestAttachMetadata_NoDroppedAttributeWhenNothingDropped(t *testing.T) {
+	p := NewWithExporter(otelpkg.NoopExporter{}, 1.0, true)
+	span := spanFor(t, p, rcWithMetadata(map[string]string{"a": "1"}))
+
+	if _, ok := span.Attributes[metadataDroppedAttr]; ok {
+		t.Errorf("%s present with nothing dropped", metadataDroppedAttr)
+	}
+}
+
+func TestAttachMetadata_OversizeKeyDroppedValueTruncated(t *testing.T) {
+	longKey := strings.Repeat("k", maxMetadataKeyLen+1)
+	longValue := strings.Repeat("v", maxMetadataValueLen+50)
+
+	p := NewWithExporter(otelpkg.NoopExporter{}, 1.0, true)
+	span := spanFor(t, p, rcWithMetadata(map[string]string{longKey: "x", "ok": longValue}))
+
+	if _, ok := span.Attributes[metadataAttrPrefix+longKey]; ok {
+		t.Error("oversize key was exported; a shortened key would be a different key")
+	}
+	if got := attrString(t, span, metadataAttrPrefix+"ok"); len(got) != maxMetadataValueLen {
+		t.Errorf("value length = %d, want %d", len(got), maxMetadataValueLen)
+	}
+}
+
+// A value cut mid-rune makes proto.Marshal reject the whole batch.
+func TestAttachMetadata_ValueTruncatesOnRuneBoundary(t *testing.T) {
+	p := NewWithExporter(otelpkg.NoopExporter{}, 1.0, true)
+	// 3 bytes per rune, so the byte cap lands mid-rune.
+	span := spanFor(t, p, rcWithMetadata(map[string]string{"k": strings.Repeat("界", maxMetadataValueLen)}))
+
+	got := attrString(t, span, metadataAttrPrefix+"k")
+	if len(got)%3 != 0 {
+		t.Errorf("value truncated mid-rune: %d bytes", len(got))
+	}
+}
+
+func TestAttachMetadata_NoAttributesWhenNoCallerKeys(t *testing.T) {
+	p := NewWithExporter(otelpkg.NoopExporter{}, 1.0, true)
+	span := spanFor(t, p, rcWithMetadata(nil))
+
+	if _, ok := span.Attributes["metadata"]; ok {
+		t.Error("metadata attribute emitted for a request with no caller dimensions")
+	}
+}
+
+func TestNewHeaderMatcher(t *testing.T) {
+	tests := []struct {
+		name     string
+		patterns []string
+		header   string
+		want     bool
+	}{
+		{name: "no patterns captures nothing", patterns: nil, header: "x-acme-tenant"},
+		{name: "exact match", patterns: []string{"x-acme-tenant"}, header: "x-acme-tenant", want: true},
+		{name: "exact match is case-insensitive", patterns: []string{"X-Acme-Tenant"}, header: "x-acme-tenant", want: true},
+		{name: "exact miss", patterns: []string{"x-acme-tenant"}, header: "x-acme-region"},
+		{name: "prefix wildcard", patterns: []string{"x-acme-*"}, header: "x-acme-region", want: true},
+		{name: "prefix wildcard does not match outside namespace", patterns: []string{"x-acme-*"}, header: "x-other-region"},
+		{name: "bare star matches everything", patterns: []string{"*"}, header: "x-acme-region", want: true},
+		{name: "whitespace trimmed", patterns: []string{"  x-acme-tenant  "}, header: "x-acme-tenant", want: true},
+		{name: "empty pattern ignored", patterns: []string{"", "   "}, header: "x-acme-tenant"},
+
+		// The denylist wins over any allowlist, wildcard or exact.
+		{name: "wildcard cannot reach authorization", patterns: []string{"*"}, header: "authorization"},
+		{name: "x-star cannot reach x-api-key", patterns: []string{"x-*"}, header: "x-api-key"},
+		{name: "x-star cannot reach x-goog-api-key", patterns: []string{"x-*"}, header: "x-goog-api-key"},
+		{name: "naming a credential exactly still denies it", patterns: []string{"authorization"}, header: "authorization"},
+		{name: "cookie denied", patterns: []string{"*"}, header: "cookie"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := newHeaderMatcher(tt.patterns)
+			if m == nil {
+				if tt.want {
+					t.Fatal("matcher is nil but a match was expected")
+				}
+				return
+			}
+			if got := m.match(tt.header); got != tt.want {
+				t.Errorf("match(%q) = %v, want %v", tt.header, got, tt.want)
+			}
+		})
+	}
+}
+
+// The load-bearing case: cloneRequestHeaders copies x-api-key into
+// Authorization, so a live credential is always present on the context.
+func TestAttachRequestHeaders_WildcardNeverExportsCredentials(t *testing.T) {
+	p := NewWithExporter(otelpkg.NoopExporter{}, 1.0, true)
+	p.captureHeaders = newHeaderMatcher([]string{"*"})
+
+	rc := rcWithMetadata(nil)
+	rc.RequestHeaders.Set("Authorization", "Bearer sk-live-secret")
+	rc.RequestHeaders.Set("X-Api-Key", "sk-live-secret")
+	rc.RequestHeaders.Set("Cookie", "session=abc")
+	rc.RequestHeaders.Set("X-Acme-Tenant", "acme-eu")
+
+	span := spanFor(t, p, rc)
+
+	for _, denied := range []string{"authorization", "x-api-key", "cookie"} {
+		if _, ok := span.Attributes[headerAttrPrefix+denied]; ok {
+			t.Errorf("credential header %q reached the span", denied)
+		}
+	}
+	for k, v := range span.Attributes {
+		if s, ok := v.(string); ok && strings.Contains(s, "sk-live-secret") {
+			t.Errorf("attribute %q leaked the credential value", k)
+		}
+	}
+	if got := attrString(t, span, headerAttrPrefix+"x-acme-tenant"); got != "acme-eu" {
+		t.Errorf("x-acme-tenant = %q, want %q", got, "acme-eu")
+	}
+}
+
+func TestAttachRequestHeaders_DisabledByDefault(t *testing.T) {
+	p := NewWithExporter(otelpkg.NoopExporter{}, 1.0, true)
+
+	rc := rcWithMetadata(nil)
+	rc.RequestHeaders.Set("X-Acme-Tenant", "acme-eu")
+
+	span := spanFor(t, p, rc)
+
+	for k := range span.Attributes {
+		if strings.HasPrefix(k, headerAttrPrefix) {
+			t.Errorf("header %q captured with no capture_headers configured", k)
+		}
+	}
+}
+
+// semconv says string array; Split would route that to attributes_extra, which
+// is not queryable — so repeated values are joined instead.
+func TestAttachRequestHeaders_RepeatedValuesJoinAsOneString(t *testing.T) {
+	p := NewWithExporter(otelpkg.NoopExporter{}, 1.0, true)
+	p.captureHeaders = newHeaderMatcher([]string{"x-acme-*"})
+
+	rc := rcWithMetadata(nil)
+	rc.RequestHeaders.Add("X-Acme-Tag", "a")
+	rc.RequestHeaders.Add("X-Acme-Tag", "b")
+
+	span := spanFor(t, p, rc)
+
+	if got := attrString(t, span, headerAttrPrefix+"x-acme-tag"); got != "a,b" {
+		t.Errorf("x-acme-tag = %q, want %q", got, "a,b")
+	}
+}
+
+func TestAttachRequestHeaders_ValuesAreRedacted(t *testing.T) {
+	p := NewWithExporter(otelpkg.NoopExporter{}, 1.0, true)
+	p.captureHeaders = newHeaderMatcher([]string{"x-acme-*"})
+	p.SetRedactor(privacy.New("patterns", []privacy.PatternConfig{
+		{Name: "email", Pattern: `[\w.]+@[\w.]+`},
+	}))
+
+	rc := rcWithMetadata(nil)
+	rc.RequestHeaders.Set("X-Acme-Operator", "ops@milestone.com")
+
+	span := spanFor(t, p, rc)
+
+	if got := attrString(t, span, headerAttrPrefix+"x-acme-operator"); strings.Contains(got, "ops@milestone.com") {
+		t.Errorf("header value was exported unredacted: %q", got)
+	}
+}
+
+// Metadata is dimensional data the caller grouped by; redacting an id that
+// merely looks like an email would silently break their grouping.
+func TestAttachMetadata_ValuesAreNotRedacted(t *testing.T) {
+	p := NewWithExporter(otelpkg.NoopExporter{}, 1.0, true)
+	p.SetRedactor(privacy.New("patterns", []privacy.PatternConfig{
+		{Name: "email", Pattern: `[\w.]+@[\w.]+`},
+	}))
+
+	span := spanFor(t, p, rcWithMetadata(map[string]string{"tenant": "ops@milestone.com"}))
+
+	if got := attrString(t, span, metadataAttrPrefix+"tenant"); got != "ops@milestone.com" {
+		t.Errorf("tenant = %q, want the value the caller sent", got)
+	}
+}
+
+// rcWithExtras builds a request context carrying already-snapshotted body
+// fields, as applyCallerExtras would have left them.
+func rcWithExtras(kv map[string]any) *models.RequestContext {
+	rc := rcWithMetadata(nil)
+	rc.CallerExtras = kv
+	return rc
+}
+
+// The headline case: standard OpenAI parameters the request struct has no field
+// for arrive as body extras, and must be filterable.
+func TestAttachBodyExtras_ExportsModernOpenAIParams(t *testing.T) {
+	p := NewWithExporter(otelpkg.NoopExporter{}, 1.0, true)
+	span := spanFor(t, p, rcWithExtras(map[string]any{
+		"reasoning_effort":    "high",
+		"parallel_tool_calls": true,
+		"store":               false,
+	}))
+
+	if got := attrString(t, span, bodyAttrPrefix+"reasoning_effort"); got != "high" {
+		t.Errorf("reasoning_effort = %q, want %q", got, "high")
+	}
+	if got := span.Attributes[bodyAttrPrefix+"parallel_tool_calls"]; got != true {
+		t.Errorf("parallel_tool_calls = %v, want true", got)
+	}
+	if got, ok := span.Attributes[bodyAttrPrefix+"store"]; !ok || got != false {
+		t.Errorf("store = %v (present %v), want false", got, ok)
+	}
+}
+
+// Numbers must stay numbers: the platform routes numeric attributes into a
+// column a range filter can use, and a stringified one is dead weight there.
+func TestAttachBodyExtras_NumbersKeepTheirType(t *testing.T) {
+	p := NewWithExporter(otelpkg.NoopExporter{}, 1.0, true)
+	span := spanFor(t, p, rcWithExtras(map[string]any{
+		"routing_weight": int64(3),
+		"threshold":      0.75,
+	}))
+
+	if got := span.Attributes[bodyAttrPrefix+"routing_weight"]; got != int64(3) {
+		t.Errorf("routing_weight = %#v, want int64(3)", got)
+	}
+	if got := span.Attributes[bodyAttrPrefix+"threshold"]; got != 0.75 {
+		t.Errorf("threshold = %#v, want 0.75", got)
+	}
+}
+
+func TestAttachBodyExtras_DisabledExportsNothing(t *testing.T) {
+	p := NewWithExporter(otelpkg.NoopExporter{}, 1.0, true)
+	p.bodyAttributes = false
+	span := spanFor(t, p, rcWithExtras(map[string]any{"reasoning_effort": "high"}))
+
+	for k := range span.Attributes {
+		if strings.HasPrefix(k, bodyAttrPrefix) || k == bodyDroppedAttr {
+			t.Errorf("attribute %q emitted while body attributes are disabled", k)
+		}
+	}
+}
+
+// Fields the handler refused still have to be visible as a count, or a silent
+// drop reads as "the caller sent nothing".
+func TestAttachBodyExtras_HandlerDropsAreCounted(t *testing.T) {
+	p := NewWithExporter(otelpkg.NoopExporter{}, 1.0, true)
+	rc := rcWithExtras(map[string]any{"reasoning_effort": "high"})
+	rc.CallerExtrasDropped = 2
+
+	span := spanFor(t, p, rc)
+
+	if got := span.Attributes[bodyDroppedAttr]; got != 2 {
+		t.Errorf("%s = %v, want 2", bodyDroppedAttr, got)
+	}
+}
+
+func TestAttachBodyExtras_CapIsDeterministicAndCounted(t *testing.T) {
+	kv := make(map[string]any, maxMetadataPairs*2)
+	for i := 0; i < maxMetadataPairs*2; i++ {
+		kv[fmt.Sprintf("f%02d", i)] = "v"
+	}
+
+	p := NewWithExporter(otelpkg.NoopExporter{}, 1.0, true)
+	span := spanFor(t, p, rcWithExtras(kv))
+
+	kept := 0
+	for k := range span.Attributes {
+		if strings.HasPrefix(k, bodyAttrPrefix) {
+			kept++
+		}
+	}
+	if kept != maxMetadataPairs {
+		t.Fatalf("kept %d fields, want %d", kept, maxMetadataPairs)
+	}
+	if got := span.Attributes[bodyDroppedAttr]; got != maxMetadataPairs {
+		t.Errorf("%s = %v, want %d", bodyDroppedAttr, got, maxMetadataPairs)
+	}
+	// Sorted truncation keeps the lowest keys.
+	for i := maxMetadataPairs; i < maxMetadataPairs*2; i++ {
+		if _, ok := span.Attributes[bodyAttrPrefix+fmt.Sprintf("f%02d", i)]; ok {
+			t.Errorf("kept f%02d, want only the first %d sorted keys", i, maxMetadataPairs)
+		}
+	}
+}
+
+// Unlike metadata, body extras are arbitrary payload rather than a dimension
+// the caller picked, so the privacy config applies.
+func TestAttachBodyExtras_StringValuesAreRedacted(t *testing.T) {
+	p := NewWithExporter(otelpkg.NoopExporter{}, 1.0, true)
+	p.SetRedactor(privacy.New("patterns", []privacy.PatternConfig{
+		{Name: "key", Pattern: `sk-[A-Za-z0-9]+`},
+	}))
+
+	span := spanFor(t, p, rcWithExtras(map[string]any{"upstream_hint": "use sk-live1234abcd now"}))
+
+	if got := attrString(t, span, bodyAttrPrefix+"upstream_hint"); strings.Contains(got, "sk-live1234abcd") {
+		t.Errorf("body value exported unredacted: %q", got)
+	}
+}
+
+// The provenance guarantee, pinned. The translation layer writes its own state
+// into the canonical request's Extra map (tool_name_mapping and friends), and
+// the exporter must read the handler's snapshot instead — so gateway internals
+// are excluded by where the data came from, not by a list of our key names that
+// someone has to remember to update.
+func TestAttachBodyExtras_NeverReadsRequestExtra(t *testing.T) {
+	p := NewWithExporter(otelpkg.NoopExporter{}, 1.0, true)
+
+	rc := rcWithExtras(nil)
+	rc.Request = &models.ChatCompletionRequest{
+		Model: "gpt-4o",
+		Extra: map[string]json.RawMessage{
+			"tool_name_mapping":         json.RawMessage(`{"a":"b"}`),
+			"anthropic_thinking_config": json.RawMessage(`{"type":"enabled"}`),
+			"gemini_tool_call_id_map":   json.RawMessage(`{"c":"d"}`),
+		},
+	}
+
+	span := spanFor(t, p, rc)
+
+	for k := range span.Attributes {
+		if strings.HasPrefix(k, bodyAttrPrefix) {
+			t.Errorf("gateway-internal key %q leaked from Request.Extra onto the span", k)
+		}
+	}
+}

--- a/agentcc-gateway/internal/plugins/otel/bodies.go
+++ b/agentcc-gateway/internal/plugins/otel/bodies.go
@@ -26,10 +26,7 @@ const maxBodyAttrBytes = 1 << 20
 // pattern exists to remove.
 func (p *Plugin) attachBodies(span *otelpkg.Span, rc *models.RequestContext) {
 	redactor := p.redactorFor(rc)
-	mode := rc.Metadata["privacy_mode"]
-	if orgMode := rc.Metadata["org_privacy_mode"]; orgMode != "" {
-		mode = orgMode
-	}
+	mode := privacyMode(rc)
 
 	p.attachMessages(span, rc, redactor, mode)
 
@@ -89,16 +86,29 @@ func prepareBody(v string, r *privacy.Redactor, mode string) preparedBody {
 	if len(v) <= maxBodyAttrBytes {
 		return preparedBody{value: v}
 	}
-	// Walk back to a rune boundary. Slicing by byte index can end the string
-	// mid-rune, and an OTLP attribute is a proto string: proto.Marshal rejects
-	// the whole message rather than the offending field, so a single body cut
-	// through a multi-byte character would take its entire batch of unrelated
-	// spans with it. Non-ASCII prompts are not an edge case.
-	cut := maxBodyAttrBytes
+	return preparedBody{value: truncateAtRune(v, maxBodyAttrBytes), originalBytes: len(v), truncated: true}
+}
+
+// truncateAtRune cuts to at most max bytes on a rune boundary. An OTLP
+// attribute is a proto string and proto.Marshal rejects the whole message, so
+// one value cut mid-rune takes its entire batch of unrelated spans with it.
+func truncateAtRune(v string, max int) string {
+	if len(v) <= max {
+		return v
+	}
+	cut := max
 	for cut > 0 && !utf8.RuneStart(v[cut]) {
 		cut--
 	}
-	return preparedBody{value: v[:cut], originalBytes: len(v), truncated: true}
+	return v[:cut]
+}
+
+// privacyMode prefers the org's setting over the caller's, as the log does.
+func privacyMode(rc *models.RequestContext) string {
+	if orgMode := rc.Metadata["org_privacy_mode"]; orgMode != "" {
+		return orgMode
+	}
+	return rc.Metadata["privacy_mode"]
 }
 
 // redactorFor prefers the org's redactor over the gateway-wide one, matching

--- a/agentcc-gateway/internal/plugins/otel/otel.go
+++ b/agentcc-gateway/internal/plugins/otel/otel.go
@@ -2,7 +2,6 @@ package otel
 
 import (
 	"context"
-	"encoding/json"
 	"hash/fnv"
 	"log/slog"
 	"os"
@@ -30,8 +29,16 @@ type Plugin struct {
 	// Body capture: off unless configured, and redacted through the same
 	// per-org privacy config the request log uses.
 	includeBodies bool
-	redactor      *privacy.Redactor
-	tenantStore   *tenant.Store
+	// tracePropagation honours an inbound W3C traceparent (see config).
+	tracePropagation bool
+	// metadataAttributes flattens caller metadata into its own attributes.
+	metadataAttributes bool
+	// captureHeaders is the compiled request-header allowlist; nil captures none.
+	captureHeaders *headerMatcher
+	// bodyAttributes exports the body's unknown top-level fields.
+	bodyAttributes bool
+	redactor       *privacy.Redactor
+	tenantStore    *tenant.Store
 
 	// spans stores in-flight spans keyed by request ID.
 	spans sync.Map
@@ -79,15 +86,24 @@ func New(cfg config.OTelConfig) *Plugin {
 	if cfg.Enabled && cfg.IncludeBodies {
 		slog.Warn("otel body capture is enabled — prompts and completions will be sent to the trace collector")
 	}
+	if cfg.Enabled && len(cfg.CaptureHeaders) > 0 {
+		slog.Warn("otel request-header capture is enabled — matching headers will be sent to the trace collector",
+			"patterns", cfg.CaptureHeaders)
+	}
 
 	return &Plugin{
-		exporter:      exp,
-		metrics:       &otelpkg.Metrics{},
-		sampleRate:    sampleRate,
-		enabled:       cfg.Enabled,
-		serviceName:   serviceName,
-		attributes:    cfg.Attributes,
-		includeBodies: cfg.Enabled && cfg.IncludeBodies,
+		exporter:         exp,
+		metrics:          &otelpkg.Metrics{},
+		sampleRate:       sampleRate,
+		enabled:          cfg.Enabled,
+		serviceName:      serviceName,
+		attributes:       cfg.Attributes,
+		includeBodies:    cfg.Enabled && cfg.IncludeBodies,
+		tracePropagation: cfg.TracePropagation,
+		// Unset means on — the flattened copies are additive.
+		metadataAttributes: cfg.MetadataAttributes == nil || *cfg.MetadataAttributes,
+		bodyAttributes:     cfg.BodyAttributes == nil || *cfg.BodyAttributes,
+		captureHeaders:     newHeaderMatcher(cfg.CaptureHeaders),
 	}
 }
 
@@ -101,11 +117,13 @@ func (p *Plugin) SetTenantStore(s *tenant.Store) { p.tenantStore = s }
 // NewWithExporter creates a plugin with a specific exporter (for testing).
 func NewWithExporter(exp otelpkg.SpanExporter, sampleRate float64, enabled bool) *Plugin {
 	return &Plugin{
-		exporter:    exp,
-		metrics:     &otelpkg.Metrics{},
-		sampleRate:  sampleRate,
-		enabled:     enabled,
-		serviceName: "agentcc-gateway",
+		exporter:           exp,
+		metrics:            &otelpkg.Metrics{},
+		sampleRate:         sampleRate,
+		enabled:            enabled,
+		serviceName:        "agentcc-gateway",
+		metadataAttributes: true,
+		bodyAttributes:     true,
 	}
 }
 
@@ -135,6 +153,20 @@ func (p *Plugin) ProcessRequest(_ context.Context, rc *models.RequestContext) pi
 		span.TraceID = rc.TraceID
 	}
 
+	// Nest under the caller's span rather than starting a second root.
+	if p.tracePropagation {
+		if traceID, parentID, ok := parseTraceparent(rc.RequestHeaders.Get("traceparent")); ok {
+			// agentcc.trace_id is normally derived from span.TraceID and is what
+			// joins a span to its request-log row, so pin the gateway's own id
+			// before the caller's overwrites it.
+			if rc.TraceID != "" {
+				span.SetAttribute("agentcc.trace_id", rc.TraceID)
+			}
+			span.TraceID = traceID
+			span.ParentID = parentID
+		}
+	}
+
 	// Classification. Without span.kind the platform files every span as
 	// UNKNOWN, so this is not optional.
 	kind, operation := classifyEndpoint(rc.EndpointType)
@@ -156,20 +188,11 @@ func (p *Plugin) ProcessRequest(_ context.Context, rc *models.RequestContext) pi
 		span.SetAttribute("gen_ai.request.max_tokens", *rc.Request.MaxTokens)
 	}
 
-	// Caller-supplied dimensions from x-agentcc-metadata (profile, tenant,
-	// application...), as one JSON object under the conventional `metadata`
-	// key. JSON, not a Go map — the consumer parses this string.
-	if len(rc.CustomMetadataKeys) > 0 {
-		custom := make(map[string]string, len(rc.CustomMetadataKeys))
-		for _, k := range rc.CustomMetadataKeys {
-			if v, ok := rc.Metadata[k]; ok {
-				custom[k] = v
-			}
-		}
-		if encoded, err := json.Marshal(custom); err == nil {
-			span.SetAttribute("metadata", string(encoded))
-		}
-	}
+	// Caller-supplied dimensions (profile, tenant, application...) and, when
+	// configured, allowlisted request headers.
+	p.attachMetadata(span, rc)
+	p.attachBodyExtras(span, rc)
+	p.attachRequestHeaders(span, rc)
 
 	// Add resource attributes from config.
 	for k, v := range p.attributes {
@@ -348,4 +371,52 @@ func (p *Plugin) shouldSample(requestID string) bool {
 	h := fnv.New32a()
 	_, _ = h.Write([]byte(requestID))
 	return float64(h.Sum32()%10000)/10000.0 < p.sampleRate
+}
+
+// parseTraceparent extracts the trace id and span id from a W3C `traceparent`
+// header, per https://www.w3.org/TR/trace-context/.
+//
+//	00-<32 hex trace id>-<16 hex span id>-<2 hex flags>
+//
+// It reports ok only for a sampled (flags bit 0 set) version-00 header with
+// non-zero ids. An unsampled caller never exports the span it names, so
+// parenting to it would leave a permanently dangling reference.
+func parseTraceparent(h string) (traceID, parentID string, ok bool) {
+	parts := strings.Split(strings.TrimSpace(h), "-")
+	if len(parts) != 4 {
+		return "", "", false
+	}
+	version, tid, sid, flags := parts[0], parts[1], parts[2], parts[3]
+
+	// Only version 00 is defined. "ff" is explicitly invalid.
+	if version != "00" {
+		return "", "", false
+	}
+	if !isHex(tid, 32) || !isHex(sid, 16) {
+		return "", "", false
+	}
+	if strings.Trim(tid, "0") == "" || strings.Trim(sid, "0") == "" {
+		return "", "", false
+	}
+	if !isHex(flags, 2) {
+		return "", "", false
+	}
+	f, err := strconv.ParseUint(flags, 16, 8)
+	if err != nil || f&0x01 == 0 {
+		return "", "", false
+	}
+	return tid, sid, true
+}
+
+func isHex(s string, n int) bool {
+	if len(s) != n {
+		return false
+	}
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		if (c < '0' || c > '9') && (c < 'a' || c > 'f') {
+			return false
+		}
+	}
+	return true
 }

--- a/agentcc-gateway/internal/plugins/otel/traceparent_test.go
+++ b/agentcc-gateway/internal/plugins/otel/traceparent_test.go
@@ -1,0 +1,255 @@
+package otel
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/futureagi/agentcc-gateway/internal/models"
+	otelpkg "github.com/futureagi/agentcc-gateway/internal/otel"
+)
+
+const (
+	validTrace  = "0af7651916cd43dd8448eb211c80319c"
+	validParent = "b7ad6b7169203331"
+)
+
+func TestParseTraceparent(t *testing.T) {
+	tests := []struct {
+		name   string
+		header string
+		wantOK bool
+		trace  string
+		parent string
+	}{
+		{
+			name:   "valid sampled",
+			header: "00-" + validTrace + "-" + validParent + "-01",
+			wantOK: true, trace: validTrace, parent: validParent,
+		},
+		{
+			name:   "valid, other flag bits set alongside sampled",
+			header: "00-" + validTrace + "-" + validParent + "-03",
+			wantOK: true, trace: validTrace, parent: validParent,
+		},
+		{
+			name:   "surrounding whitespace tolerated",
+			header: "  00-" + validTrace + "-" + validParent + "-01  ",
+			wantOK: true, trace: validTrace, parent: validParent,
+		},
+
+		// Not sampled: the caller will never export the span we would point at,
+		// so parenting to it would dangle forever.
+		{name: "not sampled", header: "00-" + validTrace + "-" + validParent + "-00"},
+
+		// Version handling. Only 00 is defined; ff is explicitly invalid.
+		{name: "future version", header: "01-" + validTrace + "-" + validParent + "-01"},
+		{name: "version ff", header: "ff-" + validTrace + "-" + validParent + "-01"},
+
+		// All-zero ids are invalid per spec.
+		{name: "zero trace id", header: "00-" + "00000000000000000000000000000000" + "-" + validParent + "-01"},
+		{name: "zero parent id", header: "00-" + validTrace + "-0000000000000000-01"},
+
+		// Malformed shapes.
+		{name: "empty", header: ""},
+		{name: "too few fields", header: "00-" + validTrace + "-" + validParent},
+		{name: "too many fields", header: "00-" + validTrace + "-" + validParent + "-01-extra"},
+		{name: "trace id too short", header: "00-abc-" + validParent + "-01"},
+		{name: "parent id too long", header: "00-" + validTrace + "-" + validParent + "ff-01"},
+		{name: "non-hex trace id", header: "00-" + "ZZf7651916cd43dd8448eb211c80319c" + "-" + validParent + "-01"},
+		{name: "uppercase hex rejected", header: "00-" + "0AF7651916CD43DD8448EB211C80319C" + "-" + validParent + "-01"},
+		{name: "flags not hex", header: "00-" + validTrace + "-" + validParent + "-zz"},
+		{name: "flags wrong width", header: "00-" + validTrace + "-" + validParent + "-1"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			trace, parent, ok := parseTraceparent(tt.header)
+			if ok != tt.wantOK {
+				t.Fatalf("ok = %v, want %v (header %q)", ok, tt.wantOK, tt.header)
+			}
+			if !tt.wantOK {
+				return
+			}
+			if trace != tt.trace {
+				t.Errorf("trace = %q, want %q", trace, tt.trace)
+			}
+			if parent != tt.parent {
+				t.Errorf("parent = %q, want %q", parent, tt.parent)
+			}
+		})
+	}
+}
+
+// newRC builds a request context carrying the given traceparent header.
+func newRC(traceparent string) *models.RequestContext {
+	rc := &models.RequestContext{
+		RequestID:      "req-1",
+		Model:          "gpt-4o",
+		Metadata:       map[string]string{},
+		RequestHeaders: http.Header{},
+	}
+	if traceparent != "" {
+		rc.RequestHeaders.Set("traceparent", traceparent)
+	}
+	return rc
+}
+
+// spanFor runs ProcessRequest and returns the span the plugin stored.
+func spanFor(t *testing.T, p *Plugin, rc *models.RequestContext) *otelpkg.Span {
+	t.Helper()
+	p.ProcessRequest(nil, rc)
+	v, ok := p.spans.Load(rc.RequestID)
+	if !ok {
+		t.Fatal("no span was stored for the request")
+	}
+	return v.(*otelpkg.Span)
+}
+
+func TestProcessRequest_TracePropagationDisabled(t *testing.T) {
+	p := NewWithExporter(otelpkg.NoopExporter{}, 1.0, true)
+	p.tracePropagation = false
+
+	rc := newRC("00-" + validTrace + "-" + validParent + "-01")
+	span := spanFor(t, p, rc)
+
+	if span.ParentID != "" {
+		t.Errorf("ParentID = %q, want empty when propagation is off", span.ParentID)
+	}
+	if span.TraceID == validTrace {
+		t.Error("trace id was adopted from traceparent while propagation is off")
+	}
+}
+
+func TestProcessRequest_TracePropagationEnabled(t *testing.T) {
+	p := NewWithExporter(otelpkg.NoopExporter{}, 1.0, true)
+	p.tracePropagation = true
+
+	rc := newRC("00-" + validTrace + "-" + validParent + "-01")
+	span := spanFor(t, p, rc)
+
+	if span.TraceID != validTrace {
+		t.Errorf("TraceID = %q, want %q", span.TraceID, validTrace)
+	}
+	if span.ParentID != validParent {
+		t.Errorf("ParentID = %q, want %q", span.ParentID, validParent)
+	}
+}
+
+// An unsampled caller must not become a parent — see parseTraceparent.
+func TestProcessRequest_UnsampledCallerIsNotParented(t *testing.T) {
+	p := NewWithExporter(otelpkg.NoopExporter{}, 1.0, true)
+	p.tracePropagation = true
+
+	rc := newRC("00-" + validTrace + "-" + validParent + "-00")
+	span := spanFor(t, p, rc)
+
+	if span.ParentID != "" {
+		t.Errorf("ParentID = %q, want empty for an unsampled caller", span.ParentID)
+	}
+}
+
+func TestProcessRequest_MalformedHeaderLeavesSpanAsRoot(t *testing.T) {
+	p := NewWithExporter(otelpkg.NoopExporter{}, 1.0, true)
+	p.tracePropagation = true
+
+	rc := newRC("not-a-traceparent")
+	span := spanFor(t, p, rc)
+
+	if span.ParentID != "" {
+		t.Errorf("ParentID = %q, want empty for a malformed header", span.ParentID)
+	}
+	if span.TraceID == "" {
+		t.Error("span lost its generated trace id on a malformed header")
+	}
+}
+
+// x-agentcc-trace-id still sets the trace id; traceparent wins when both are
+// present, because only it can also supply a parent.
+func TestProcessRequest_TraceparentOverridesRequestTraceID(t *testing.T) {
+	p := NewWithExporter(otelpkg.NoopExporter{}, 1.0, true)
+	p.tracePropagation = true
+
+	rc := newRC("00-" + validTrace + "-" + validParent + "-01")
+	rc.TraceID = "11111111111111111111111111111111"
+
+	span := spanFor(t, p, rc)
+
+	if span.TraceID != validTrace {
+		t.Errorf("TraceID = %q, want traceparent's %q", span.TraceID, validTrace)
+	}
+	if span.ParentID != validParent {
+		t.Errorf("ParentID = %q, want %q", span.ParentID, validParent)
+	}
+}
+
+// No traceparent at all: the existing x-agentcc-trace-id behaviour is untouched.
+func TestProcessRequest_NoTraceparentKeepsRequestTraceID(t *testing.T) {
+	p := NewWithExporter(otelpkg.NoopExporter{}, 1.0, true)
+	p.tracePropagation = true
+
+	rc := newRC("")
+	rc.TraceID = "11111111111111111111111111111111"
+
+	span := spanFor(t, p, rc)
+
+	if span.TraceID != rc.TraceID {
+		t.Errorf("TraceID = %q, want %q", span.TraceID, rc.TraceID)
+	}
+	if span.ParentID != "" {
+		t.Errorf("ParentID = %q, want empty", span.ParentID)
+	}
+}
+
+// A nil header map must not panic.
+func TestProcessRequest_NilRequestHeaders(t *testing.T) {
+	p := NewWithExporter(otelpkg.NoopExporter{}, 1.0, true)
+	p.tracePropagation = true
+
+	rc := newRC("")
+	rc.RequestHeaders = nil
+
+	span := spanFor(t, p, rc)
+	if span.ParentID != "" {
+		t.Errorf("ParentID = %q, want empty", span.ParentID)
+	}
+}
+
+// With propagation on, span.TraceID becomes the caller's id — so the gateway's
+// own id must be pinned as an attribute, or the documented span-to-log-row join
+// silently breaks.
+func TestProcessRequest_PreservesGatewayTraceIDForLogJoin(t *testing.T) {
+	p := NewWithExporter(otelpkg.NoopExporter{}, 1.0, true)
+	p.tracePropagation = true
+
+	rc := newRC("00-" + validTrace + "-" + validParent + "-01")
+	rc.TraceID = "01ARZ3NDEKTSV4RRFFQ69G5FAV"
+
+	span := spanFor(t, p, rc)
+
+	if span.TraceID != validTrace {
+		t.Errorf("TraceID = %q, want the caller's %q", span.TraceID, validTrace)
+	}
+	got, ok := span.Attributes["agentcc.trace_id"]
+	if !ok {
+		t.Fatal("agentcc.trace_id attribute missing; the log join is broken")
+	}
+	if got != rc.TraceID {
+		t.Errorf("agentcc.trace_id = %v, want the gateway id %q", got, rc.TraceID)
+	}
+}
+
+// Without propagation the exporter supplies the attribute itself, so the plugin
+// must not set it — two sources would emit a duplicate OTLP key.
+func TestProcessRequest_NoDuplicateTraceIDAttributeWhenDisabled(t *testing.T) {
+	p := NewWithExporter(otelpkg.NoopExporter{}, 1.0, true)
+	p.tracePropagation = false
+
+	rc := newRC("00-" + validTrace + "-" + validParent + "-01")
+	rc.TraceID = "01ARZ3NDEKTSV4RRFFQ69G5FAV"
+
+	span := spanFor(t, p, rc)
+
+	if _, ok := span.Attributes["agentcc.trace_id"]; ok {
+		t.Error("plugin set agentcc.trace_id while propagation is off; the exporter already does")
+	}
+}

--- a/agentcc-gateway/internal/server/handlers.go
+++ b/agentcc-gateway/internal/server/handlers.go
@@ -6,7 +6,9 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
+	"math"
 	"net/http"
+	"slices"
 	"strconv"
 	"strings"
 	"sync/atomic"
@@ -872,10 +874,10 @@ func (h *Handlers) ChatCompletion(w http.ResponseWriter, r *http.Request) {
 	// Pass Authorization header for auth plugin.
 	setAuthMetadataFromRequest(rc, r)
 
-	// Extract Agentcc metadata from headers (with security key blocklist).
-	if meta := r.Header.Get("x-agentcc-metadata"); meta != "" {
-		parseMetadataHeader(meta, rc)
-	}
+	// Caller dimensions, from the x-agentcc-metadata header and the body's
+	// own metadata field (with security key blocklist).
+	applyCallerMetadata(rc, r, req.Extra["metadata"])
+	applyCallerExtras(rc, req.Extra)
 	if sid := r.Header.Get("x-agentcc-session-id"); sid != "" {
 		if len(sid) > maxSessionIDLen {
 			models.WriteError(w, models.ErrBadRequest("session_id_too_long",
@@ -1886,21 +1888,167 @@ func splitCSV(s string) []string {
 	return result
 }
 
-// parseMetadataHeader parses the x-agentcc-metadata JSON header into the request
-// context. Security-sensitive keys are blocked to prevent client-side injection.
-// Accepted keys are recorded on the context so telemetry can distinguish them
-// from the metadata plugins write themselves.
+// applyCallerMetadata records the caller's own dimensions on the request
+// context, from both channels that carry them: the x-agentcc-metadata header
+// and the OpenAI-spec `metadata` body field. Either one is the gateway's
+// equivalent of calling span.SetAttribute() in a natively instrumented service.
+//
+// The header wins on conflict. It is set by the calling infrastructure, and
+// infrastructure tagging should not be overridable by the payload it forwards.
+//
+// body is the request body's own metadata object, or nil for endpoints whose
+// body has no such field.
+func applyCallerMetadata(rc *models.RequestContext, r *http.Request, body json.RawMessage) {
+	if len(body) > 0 {
+		mergeCallerMetadata(rc, body)
+	}
+	if meta := r.Header.Get("x-agentcc-metadata"); meta != "" {
+		mergeCallerMetadata(rc, json.RawMessage(meta))
+	}
+}
+
+// parseMetadataHeader records the dimensions carried by the x-agentcc-metadata
+// header alone, for endpoints that read the header before their body exists.
 func parseMetadataHeader(meta string, rc *models.RequestContext) {
-	var m map[string]string
-	if err := json.Unmarshal([]byte(meta), &m); err != nil {
+	mergeCallerMetadata(rc, json.RawMessage(meta))
+}
+
+// applyCallerExtras snapshots the request body's unknown top-level fields onto
+// the request context, so telemetry can export what the caller actually sent.
+//
+// These are not exotic: ChatCompletionRequest.UnmarshalJSON matches against a
+// fixed list of ~23 field names, so every OpenAI parameter added since —
+// reasoning_effort, parallel_tool_calls, store, prediction — arrives here too,
+// alongside whatever an SDK's extra_body carried.
+//
+// Taken at parse time on purpose. The translation layer writes its own state
+// into the same Extra map on the canonical request, and reading it later would
+// export gateway internals as if the caller had sent them. A snapshot taken
+// before any of that runs excludes them by provenance, with no list of our own
+// key names to keep correct.
+//
+// Scalars only. A nested object or array cannot be exported as a queryable
+// attribute anyway, and objects are where credentials live when someone passes
+// service-account JSON through extra_body.
+func applyCallerExtras(rc *models.RequestContext, extra map[string]json.RawMessage) {
+	for k, raw := range extra {
+		// metadata is the curated dimension channel and has already been read.
+		if k == "metadata" {
+			continue
+		}
+		recordCallerExtra(rc, k, raw)
+	}
+}
+
+// applyCallerExtrasFromBody is applyCallerExtras for dialects the gateway does
+// not unmarshal into a canonical struct — the Anthropic and Gemini endpoints.
+//
+// It reads the raw body instead of a parsed request because both of those
+// handlers have a native pass-through path that forwards the caller's bytes
+// untouched; there is no struct to hang unknown fields off, and adding one
+// would still miss the pass-through. `known` is the dialect's own field set.
+func applyCallerExtrasFromBody(rc *models.RequestContext, body []byte, known map[string]struct{}) {
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(body, &raw); err != nil {
 		return
 	}
-	for k, v := range m {
+	for k, v := range raw {
+		if _, isSpec := known[k]; isSpec {
+			continue
+		}
+		recordCallerExtra(rc, k, v)
+	}
+}
+
+// recordCallerExtra vets one caller-supplied body field and stores it.
+func recordCallerExtra(rc *models.RequestContext, key string, raw json.RawMessage) {
+	if isCredentialShapedKey(key) {
+		rc.CallerExtrasDropped++
+		return
+	}
+	v, ok := decodeScalar(raw)
+	if !ok {
+		rc.CallerExtrasDropped++
+		return
+	}
+	if rc.CallerExtras == nil {
+		rc.CallerExtras = make(map[string]any, 8)
+	}
+	rc.CallerExtras[key] = v
+}
+
+// decodeScalar returns a JSON string, number or bool as its Go value. Anything
+// else — object, array, null — is not a scalar and is reported as such.
+//
+// Numbers keep their type rather than becoming strings: an integer exported as
+// an int lands in the platform's numeric attribute column, where a range filter
+// works. That is worth more than matching how metadata stringifies everything.
+func decodeScalar(raw json.RawMessage) (any, bool) {
+	var v any
+	if err := json.Unmarshal(raw, &v); err != nil {
+		return nil, false
+	}
+	switch t := v.(type) {
+	case string, bool:
+		return t, true
+	case float64:
+		// json.Unmarshal makes every number a float64. Integral values go back
+		// to int64 so they render as 3 rather than 3.0 in a trace UI.
+		if t == math.Trunc(t) && math.Abs(t) < 1<<53 {
+			return int64(t), true
+		}
+		return t, true
+	default:
+		return nil, false
+	}
+}
+
+// isCredentialShapedKey is the last line of defence over scalar-only filtering
+// and value redaction, not the only one. Over-blocking here costs an absent
+// attribute; under-blocking costs a leaked secret, so the match is deliberately
+// broad.
+func isCredentialShapedKey(key string) bool {
+	lower := strings.ToLower(key)
+	for _, needle := range []string{
+		"secret", "token", "credential", "password", "passwd",
+		"api_key", "apikey", "auth", "private_key", "bearer", "signature",
+	} {
+		if strings.Contains(lower, needle) {
+			return true
+		}
+	}
+	return false
+}
+
+// mergeCallerMetadata merges one JSON object of caller dimensions into the
+// request context. Security-sensitive keys are blocked to prevent client-side
+// injection, and accepted keys are recorded on the context so telemetry can
+// tell them apart from the metadata plugins write themselves.
+//
+// Values are decoded leniently: a JSON string is unquoted, anything else keeps
+// its JSON text. Strict string-only decoding threw away the whole object over
+// one numeric value, which is a silent and very confusing way to lose every
+// dimension a caller sent.
+func mergeCallerMetadata(rc *models.RequestContext, raw json.RawMessage) {
+	var m map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &m); err != nil {
+		return
+	}
+	for k, rv := range m {
 		if isBlockedMetadataKey(k) {
 			continue
 		}
+		var v string
+		if err := json.Unmarshal(rv, &v); err != nil {
+			v = string(rv)
+		}
+		// Dedup against the accepted list, not against rc.Metadata: that map
+		// also holds internal keys the plugins wrote, and a caller key that
+		// collides with one still has to be recorded as caller-supplied.
+		if !slices.Contains(rc.CustomMetadataKeys, k) {
+			rc.CustomMetadataKeys = append(rc.CustomMetadataKeys, k)
+		}
 		rc.Metadata[k] = v
-		rc.CustomMetadataKeys = append(rc.CustomMetadataKeys, k)
 	}
 }
 
@@ -1911,15 +2059,20 @@ func isBlockedMetadataKey(key string) bool {
 	lower := strings.ToLower(key)
 	for _, prefix := range []string{
 		"auth_", "key_", "org_", "budget_", "ratelimit_",
-		"cost", "cache_", "guardrail_", "credit_",
+		"cache_", "guardrail_", "credit_", "credits_",
 	} {
 		if strings.HasPrefix(lower, prefix) {
 			return true
 		}
 	}
 	// Block specific keys that don't follow a prefix pattern.
+	//
+	// The cost family is listed exactly rather than by prefix. The plugins own
+	// "cost" and "cost_source" and nothing else, while any prefix wide enough
+	// to cover them also swallows cost_center and cost_code — ordinary business
+	// dimensions. A new internal cost_* key must be added here by hand.
 	switch lower {
-	case "authorization", "client_ip", "timeout_ms":
+	case "authorization", "client_ip", "timeout_ms", "cost", "cost_source":
 		return true
 	}
 	return false

--- a/agentcc-gateway/internal/server/handlers.go
+++ b/agentcc-gateway/internal/server/handlers.go
@@ -2011,7 +2011,11 @@ func isCredentialShapedKey(key string) bool {
 	lower := strings.ToLower(key)
 	for _, needle := range []string{
 		"secret", "token", "credential", "password", "passwd",
-		"api_key", "apikey", "auth", "private_key", "bearer", "signature",
+		"api_key", "apikey", "private_key", "bearer", "signature",
+		// Not a bare "auth": that also swallows author and authority, which
+		// are ordinary body fields. Separator-less forms like authtoken are
+		// caught by "token" above.
+		"authorization", "auth_", "auth-",
 	} {
 		if strings.Contains(lower, needle) {
 			return true

--- a/agentcc-gateway/internal/server/handlers_anthropic.go
+++ b/agentcc-gateway/internal/server/handlers_anthropic.go
@@ -15,7 +15,7 @@ import (
 	"github.com/futureagi/agentcc-gateway/internal/models"
 	"github.com/futureagi/agentcc-gateway/internal/providers"
 	"github.com/futureagi/agentcc-gateway/internal/translation"
-	_ "github.com/futureagi/agentcc-gateway/internal/translation/anthropic" // register translator
+	anthropictrans "github.com/futureagi/agentcc-gateway/internal/translation/anthropic"
 )
 
 // MappingRestorer is satisfied by translators that can restore truncated tool
@@ -71,9 +71,11 @@ func (h *Handlers) AnthropicMessages(w http.ResponseWriter, r *http.Request) {
 
 	// Extract headers.
 	setAuthMetadataFromRequest(rc, r)
-	if meta := r.Header.Get("x-agentcc-metadata"); meta != "" {
-		parseMetadataHeader(meta, rc)
-	}
+	// Caller dimensions, from the x-agentcc-metadata header and the body's own
+	// non-spec fields. Read from the raw bytes: the native pass-through below
+	// never unmarshals this body.
+	applyCallerMetadata(rc, r, nil)
+	applyCallerExtrasFromBody(rc, body, anthropictrans.KnownRequestFields())
 
 	// Resolve timeout and context.
 	timeout := h.resolveTimeout(rc, r)

--- a/agentcc-gateway/internal/server/handlers_assistants.go
+++ b/agentcc-gateway/internal/server/handlers_assistants.go
@@ -58,9 +58,8 @@ func (h *Handlers) setupAssistantsRC(r *http.Request, operation string) *models.
 	rc.Metadata["client_ip"] = extractClientIP(r)
 
 	setAuthMetadataFromRequest(rc, r)
-	if meta := r.Header.Get("x-agentcc-metadata"); meta != "" {
-		parseMetadataHeader(meta, rc)
-	}
+	// Caller dimensions, from the x-agentcc-metadata header.
+	applyCallerMetadata(rc, r, nil)
 
 	// Peek key org_id before resolving org config (same as ChatCompletion).
 	h.peekKeyOrgID(rc)

--- a/agentcc-gateway/internal/server/handlers_audio.go
+++ b/agentcc-gateway/internal/server/handlers_audio.go
@@ -61,6 +61,7 @@ func (h *Handlers) CreateSpeech(w http.ResponseWriter, r *http.Request) {
 	rc.SpeechRequest = &req
 
 	setAuthMetadataFromRequest(rc, r)
+	applyCallerMetadata(rc, r, nil)
 
 	// Resolve timeout and apply.
 	timeout := h.resolveTimeout(rc, r)
@@ -197,6 +198,7 @@ func (h *Handlers) CreateTranslation(w http.ResponseWriter, r *http.Request) {
 	rc.TranslationReq = &req
 
 	setAuthMetadataFromRequest(rc, r)
+	applyCallerMetadata(rc, r, nil)
 
 	// Resolve timeout and apply.
 	timeout := h.resolveTimeout(rc, r)
@@ -327,6 +329,7 @@ func (h *Handlers) CreateTranscription(w http.ResponseWriter, r *http.Request) {
 	rc.TranscriptionReq = &req
 
 	setAuthMetadataFromRequest(rc, r)
+	applyCallerMetadata(rc, r, nil)
 
 	// Resolve timeout and apply.
 	timeout := h.resolveTimeout(rc, r)
@@ -503,6 +506,7 @@ func (h *Handlers) StreamSpeech(w http.ResponseWriter, r *http.Request) {
 	rc.SpeechRequest = &req
 
 	setAuthMetadataFromRequest(rc, r)
+	applyCallerMetadata(rc, r, nil)
 
 	// Resolve timeout and apply.
 	timeout := h.resolveTimeout(rc, r)

--- a/agentcc-gateway/internal/server/handlers_completion.go
+++ b/agentcc-gateway/internal/server/handlers_completion.go
@@ -73,10 +73,8 @@ func (h *Handlers) TextCompletion(w http.ResponseWriter, r *http.Request) {
 
 	setAuthMetadataFromRequest(rc, r)
 
-	// Extract Agentcc metadata from headers (with security key blocklist).
-	if meta := r.Header.Get("x-agentcc-metadata"); meta != "" {
-		parseMetadataHeader(meta, rc)
-	}
+	// Caller dimensions, from the x-agentcc-metadata header.
+	applyCallerMetadata(rc, r, nil)
 	if sid := r.Header.Get("x-agentcc-session-id"); sid != "" {
 		if len(sid) > maxSessionIDLen {
 			models.WriteError(w, models.ErrBadRequest("session_id_too_long",

--- a/agentcc-gateway/internal/server/handlers_genai.go
+++ b/agentcc-gateway/internal/server/handlers_genai.go
@@ -14,7 +14,7 @@ import (
 	"github.com/futureagi/agentcc-gateway/internal/models"
 	"github.com/futureagi/agentcc-gateway/internal/providers"
 	"github.com/futureagi/agentcc-gateway/internal/translation"
-	_ "github.com/futureagi/agentcc-gateway/internal/translation/gemini" // register translator
+	geminitrans "github.com/futureagi/agentcc-gateway/internal/translation/gemini"
 )
 
 // GenAIHandler handles POST /v1beta/models/{model_action} — native Google GenAI API pass-through.
@@ -85,6 +85,10 @@ func (h *Handlers) GenAIHandler(w http.ResponseWriter, r *http.Request) {
 			fmt.Sprintf("Request body exceeds maximum size of %d bytes", h.maxBodySize))
 		return
 	}
+
+	// Caller dimensions from the body's own non-spec fields. Read from the raw
+	// bytes: the native pass-through below never unmarshals this body.
+	applyCallerExtrasFromBody(rc, body, geminitrans.KnownRequestFields())
 
 	// Resolve timeout and context.
 	timeout := h.resolveTimeout(rc, r)

--- a/agentcc-gateway/internal/server/handlers_image.go
+++ b/agentcc-gateway/internal/server/handlers_image.go
@@ -53,6 +53,7 @@ func (h *Handlers) CreateImage(w http.ResponseWriter, r *http.Request) {
 	rc.ImageRequest = &req
 
 	setAuthMetadataFromRequest(rc, r)
+	applyCallerMetadata(rc, r, nil)
 
 	// Resolve timeout and apply.
 	timeout := h.resolveTimeout(rc, r)

--- a/agentcc-gateway/internal/server/handlers_ocr.go
+++ b/agentcc-gateway/internal/server/handlers_ocr.go
@@ -51,6 +51,7 @@ func (h *Handlers) OCR(w http.ResponseWriter, r *http.Request) {
 
 	// Pass Authorization header for auth plugin.
 	setAuthMetadataFromRequest(rc, r)
+	applyCallerMetadata(rc, r, nil)
 
 	// Resolve timeout (longer default for OCR).
 	timeout := h.resolveTimeout(rc, r)

--- a/agentcc-gateway/internal/server/handlers_rerank.go
+++ b/agentcc-gateway/internal/server/handlers_rerank.go
@@ -57,6 +57,7 @@ func (h *Handlers) Rerank(w http.ResponseWriter, r *http.Request) {
 	rc.RerankRequest = &req
 
 	setAuthMetadataFromRequest(rc, r)
+	applyCallerMetadata(rc, r, nil)
 
 	// Resolve timeout and apply.
 	timeout := h.resolveTimeout(rc, r)

--- a/agentcc-gateway/internal/server/handlers_responses.go
+++ b/agentcc-gateway/internal/server/handlers_responses.go
@@ -59,10 +59,9 @@ func (h *Handlers) CreateResponse(w http.ResponseWriter, r *http.Request) {
 	// Pass Authorization header for auth plugin.
 	setAuthMetadataFromRequest(rc, r)
 
-	// Extract Agentcc metadata (with security key blocklist).
-	if meta := r.Header.Get("x-agentcc-metadata"); meta != "" {
-		parseMetadataHeader(meta, rc)
-	}
+	// Caller dimensions, from the x-agentcc-metadata header and the body's metadata field.
+	applyCallerMetadata(rc, r, req.Metadata)
+	applyCallerExtras(rc, req.Extra)
 
 	// Resolve timeout.
 	timeout := h.resolveTimeout(rc, r)

--- a/agentcc-gateway/internal/server/handlers_search.go
+++ b/agentcc-gateway/internal/server/handlers_search.go
@@ -61,6 +61,7 @@ func (h *Handlers) Search(w http.ResponseWriter, r *http.Request) {
 	rc.SearchRequest = &req
 
 	setAuthMetadataFromRequest(rc, r)
+	applyCallerMetadata(rc, r, nil)
 
 	// Resolve timeout.
 	timeout := h.resolveTimeout(rc, r)

--- a/agentcc-gateway/internal/server/metadata_header_test.go
+++ b/agentcc-gateway/internal/server/metadata_header_test.go
@@ -4,7 +4,9 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"sort"
+	"strings"
 	"testing"
 
 	"github.com/futureagi/agentcc-gateway/internal/models"
@@ -343,6 +345,63 @@ func TestKnownRequestFieldsCoverEachDialect(t *testing.T) {
 		"tools", "toolConfig", "safetySettings", "cachedContent"} {
 		if _, ok := gem[f]; !ok {
 			t.Errorf("gemini field %q missing from KnownRequestFields", f)
+		}
+	}
+}
+
+// The credential filter over-blocks on purpose — a missing attribute costs
+// nothing, a leaked one costs a lot — but it must not swallow ordinary words
+// that merely start the same way.
+func TestIsCredentialShapedKey(t *testing.T) {
+	dropped := []string{
+		"vertex_credentials", "api_key", "apiKey", "auth_token", "auth-token",
+		"authtoken", "Authorization", "upstream_secret", "user_password",
+		"private_key", "bearer_token", "request_signature",
+	}
+	for _, k := range dropped {
+		if !isCredentialShapedKey(k) {
+			t.Errorf("%q reaches the span but looks like a credential", k)
+		}
+	}
+
+	kept := []string{"author", "authority", "author_id", "authored_at", "routing_weight", "store"}
+	for _, k := range kept {
+		if isCredentialShapedKey(k) {
+			t.Errorf("%q is an ordinary field and must not be dropped", k)
+		}
+	}
+}
+
+// The dialect endpoints capture caller extras from their own raw body bytes,
+// since they never build a canonical request the OTel plugin could read them
+// from. That capture only reaches a span if it happens before the pipeline
+// runs — TH-7619 wired h.engine.Process onto these two handlers, so the calls
+// that were inert when they were written are now live.
+//
+// Asserted against the source for the same reason TestBillableHandlersRunThePipeline
+// is: the failure mode is an omission or a reordering, not a wrong value.
+func TestDialectHandlersCaptureCallerExtrasBeforeThePipeline(t *testing.T) {
+	for _, file := range []string{"handlers_anthropic.go", "handlers_genai.go"} {
+		src, err := os.ReadFile(file)
+		if err != nil {
+			t.Fatalf("read %s: %v", file, err)
+		}
+		text := string(src)
+
+		capture := strings.Index(text, "applyCallerExtrasFromBody(")
+		if capture < 0 {
+			t.Errorf("%s never calls applyCallerExtrasFromBody — caller body fields "+
+				"reach no span, and this path builds no canonical request to recover them from", file)
+			continue
+		}
+		process := strings.Index(text, "h.engine.Process(")
+		if process < 0 {
+			t.Errorf("%s never calls h.engine.Process", file)
+			continue
+		}
+		if capture > process {
+			t.Errorf("%s captures caller extras after the pipeline runs; the OTel "+
+				"plugin reads rc.CallerExtras inside it, so they would be exported empty", file)
 		}
 	}
 }

--- a/agentcc-gateway/internal/server/metadata_header_test.go
+++ b/agentcc-gateway/internal/server/metadata_header_test.go
@@ -1,10 +1,15 @@
 package server
 
 import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
 	"sort"
 	"testing"
 
 	"github.com/futureagi/agentcc-gateway/internal/models"
+	anthropictrans "github.com/futureagi/agentcc-gateway/internal/translation/anthropic"
+	geminitrans "github.com/futureagi/agentcc-gateway/internal/translation/gemini"
 )
 
 func TestParseMetadataHeader(t *testing.T) {
@@ -33,8 +38,16 @@ func TestParseMetadataHeader(t *testing.T) {
 			wantCustom: nil,
 		},
 		{
-			name:       "non-string values are ignored",
-			header:     `{"depth":3}`,
+			// Strict string-only decoding threw the whole object away over one
+			// numeric value, losing every dimension the caller sent.
+			name:       "non-string values keep their JSON text",
+			header:     `{"depth":3,"beta":true,"tenant":"ok"}`,
+			wantMeta:   map[string]string{"depth": "3", "beta": "true", "tenant": "ok"},
+			wantCustom: []string{"beta", "depth", "tenant"},
+		},
+		{
+			name:       "a non-object body is ignored",
+			header:     `["a","b"]`,
 			wantMeta:   map[string]string{},
 			wantCustom: nil,
 		},
@@ -80,5 +93,256 @@ func TestParseMetadataHeaderDoesNotRecordBlockedKeys(t *testing.T) {
 	}
 	if len(rc.CustomMetadataKeys) != 0 {
 		t.Errorf("CustomMetadataKeys = %v, want empty", rc.CustomMetadataKeys)
+	}
+}
+
+// The gateway's stand-in for span.SetAttribute() has two channels. Both must
+// land on the same context, and the header must win: it is set by the calling
+// infrastructure, which the payload it forwards should not be able to override.
+func TestApplyCallerMetadata(t *testing.T) {
+	tests := []struct {
+		name     string
+		header   string
+		body     string
+		wantMeta map[string]string
+	}{
+		{
+			name:     "header only",
+			header:   `{"tenant":"acme"}`,
+			wantMeta: map[string]string{"tenant": "acme"},
+		},
+		{
+			name:     "body metadata field only",
+			body:     `{"tenant":"acme"}`,
+			wantMeta: map[string]string{"tenant": "acme"},
+		},
+		{
+			name:     "both channels merge",
+			header:   `{"tenant":"acme"}`,
+			body:     `{"workflow":"auto-reply"}`,
+			wantMeta: map[string]string{"tenant": "acme", "workflow": "auto-reply"},
+		},
+		{
+			name:     "header wins on conflict",
+			header:   `{"tenant":"acme"}`,
+			body:     `{"tenant":"spoofed"}`,
+			wantMeta: map[string]string{"tenant": "acme"},
+		},
+		{
+			name:     "body cannot set a reserved key either",
+			body:     `{"org_id":"evil","tenant":"acme"}`,
+			wantMeta: map[string]string{"tenant": "acme"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", nil)
+			if tt.header != "" {
+				r.Header.Set("x-agentcc-metadata", tt.header)
+			}
+			var body json.RawMessage
+			if tt.body != "" {
+				body = json.RawMessage(tt.body)
+			}
+
+			rc := &models.RequestContext{Metadata: map[string]string{}}
+			applyCallerMetadata(rc, r, body)
+
+			if len(rc.Metadata) != len(tt.wantMeta) {
+				t.Fatalf("Metadata = %v, want %v", rc.Metadata, tt.wantMeta)
+			}
+			for k, v := range tt.wantMeta {
+				if rc.Metadata[k] != v {
+					t.Errorf("Metadata[%q] = %q, want %q", k, rc.Metadata[k], v)
+				}
+			}
+		})
+	}
+}
+
+// A key set by both channels must be recorded once, or it counts twice against
+// the export cap and appears twice while the blob is built.
+func TestApplyCallerMetadataRecordsEachKeyOnce(t *testing.T) {
+	r := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", nil)
+	r.Header.Set("x-agentcc-metadata", `{"tenant":"acme"}`)
+
+	rc := &models.RequestContext{Metadata: map[string]string{}}
+	applyCallerMetadata(rc, r, json.RawMessage(`{"tenant":"spoofed"}`))
+
+	if len(rc.CustomMetadataKeys) != 1 {
+		t.Errorf("CustomMetadataKeys = %v, want one entry", rc.CustomMetadataKeys)
+	}
+}
+
+// Body fields the request struct has no field for. Not exotic: every OpenAI
+// parameter newer than the `known` list in UnmarshalJSON arrives this way.
+func TestApplyCallerExtras(t *testing.T) {
+	tests := []struct {
+		name        string
+		body        string
+		wantExtras  map[string]any
+		wantDropped int
+	}{
+		{
+			name:       "scalars keep their types",
+			body:       `{"reasoning_effort":"high","parallel_tool_calls":true,"routing_weight":3,"threshold":0.75}`,
+			wantExtras: map[string]any{"reasoning_effort": "high", "parallel_tool_calls": true, "routing_weight": int64(3), "threshold": 0.75},
+		},
+		{
+			name:        "nested objects and arrays are skipped, not stringified",
+			body:        `{"routing_hint":{"pool":"east"},"tags":["a","b"],"nothing":null,"ok":"yes"}`,
+			wantExtras:  map[string]any{"ok": "yes"},
+			wantDropped: 3,
+		},
+		{
+			// metadata is the curated dimension channel; it has its own path.
+			name:       "metadata is not duplicated into extras",
+			body:       `{"metadata":{"tenant":"acme"},"store":false}`,
+			wantExtras: map[string]any{"store": false},
+		},
+		{
+			name:        "credential-shaped keys are dropped",
+			body:        `{"vertex_credentials":"blob","x_auth_token":"t","upstream_secret":"s","store":true}`,
+			wantExtras:  map[string]any{"store": true},
+			wantDropped: 3,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var req models.ChatCompletionRequest
+			if err := json.Unmarshal([]byte(tt.body), &req); err != nil {
+				t.Fatalf("unmarshal: %v", err)
+			}
+
+			rc := &models.RequestContext{Metadata: map[string]string{}}
+			applyCallerExtras(rc, req.Extra)
+
+			if len(rc.CallerExtras) != len(tt.wantExtras) {
+				t.Fatalf("CallerExtras = %v, want %v", rc.CallerExtras, tt.wantExtras)
+			}
+			for k, v := range tt.wantExtras {
+				if rc.CallerExtras[k] != v {
+					t.Errorf("CallerExtras[%q] = %#v, want %#v", k, rc.CallerExtras[k], v)
+				}
+			}
+			if rc.CallerExtrasDropped != tt.wantDropped {
+				t.Errorf("CallerExtrasDropped = %d, want %d", rc.CallerExtrasDropped, tt.wantDropped)
+			}
+		})
+	}
+}
+
+// Guards the claim that decides the default: these are ordinary OpenAI
+// parameters, not exotic passthrough, and the request struct has no field for
+// any of them. If one is ever promoted to a real field, this test says so.
+func TestModernOpenAIParamsLandInExtra(t *testing.T) {
+	var req models.ChatCompletionRequest
+	body := `{"model":"gpt-4o","messages":[],"reasoning_effort":"high",
+	          "parallel_tool_calls":true,"store":true,"web_search_options":1}`
+	if err := json.Unmarshal([]byte(body), &req); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	for _, k := range []string{"reasoning_effort", "parallel_tool_calls", "store", "web_search_options"} {
+		if _, ok := req.Extra[k]; !ok {
+			t.Errorf("%q is no longer captured in Extra — give it a body-attribute path of its own", k)
+		}
+	}
+}
+
+// The reserved-key list is a prefix match, and both halves of the cost family
+// were wrong: "cost" as a prefix swallowed ordinary business dimensions, while
+// "credit_" missed the keys the credits plugin actually writes.
+func TestIsBlockedMetadataKeyCostFamily(t *testing.T) {
+	blocked := []string{
+		"cost", "cost_source", "cost_SOURCE",
+		"credits_used", "credits_remaining", "credit_balance",
+		"budget_remaining", "ratelimit_limit", "org_id", "authorization",
+	}
+	for _, k := range blocked {
+		if !isBlockedMetadataKey(k) {
+			t.Errorf("%q is writable by callers but plugins own it", k)
+		}
+	}
+
+	allowed := []string{"cost_center", "cost_code", "costing_model", "customer_id"}
+	for _, k := range allowed {
+		if isBlockedMetadataKey(k) {
+			t.Errorf("%q is a caller dimension and must not be reserved", k)
+		}
+	}
+}
+
+// The Anthropic and Gemini endpoints never unmarshal the body into a canonical
+// struct on their native pass-through path, so extras are read from the raw
+// bytes against each dialect's own field set.
+func TestApplyCallerExtrasFromBody(t *testing.T) {
+	tests := []struct {
+		name       string
+		body       string
+		known      map[string]struct{}
+		wantExtras map[string]any
+	}{
+		{
+			name: "anthropic spec fields are not reported as caller additions",
+			body: `{"model":"claude-3","messages":[],"max_tokens":100,"top_k":5,
+			        "thinking":{"type":"enabled"},"stop_sequences":["x"],
+			        "tenant":"acme","routing_weight":3}`,
+			known:      anthropictrans.KnownRequestFields(),
+			wantExtras: map[string]any{"tenant": "acme", "routing_weight": int64(3)},
+		},
+		{
+			name: "gemini spec fields are not reported as caller additions",
+			body: `{"contents":[],"generationConfig":{"temperature":1},
+			        "safetySettings":[],"cachedContent":"c","systemInstruction":{},
+			        "tenant":"acme","beta_flag":true}`,
+			known:      geminitrans.KnownRequestFields(),
+			wantExtras: map[string]any{"tenant": "acme", "beta_flag": true},
+		},
+		{
+			name:       "a malformed body is ignored",
+			body:       `not json`,
+			known:      anthropictrans.KnownRequestFields(),
+			wantExtras: map[string]any{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rc := &models.RequestContext{Metadata: map[string]string{}}
+			applyCallerExtrasFromBody(rc, []byte(tt.body), tt.known)
+
+			if len(rc.CallerExtras) != len(tt.wantExtras) {
+				t.Fatalf("CallerExtras = %v, want %v", rc.CallerExtras, tt.wantExtras)
+			}
+			for k, v := range tt.wantExtras {
+				if rc.CallerExtras[k] != v {
+					t.Errorf("CallerExtras[%q] = %#v, want %#v", k, rc.CallerExtras[k], v)
+				}
+			}
+		})
+	}
+}
+
+// The field sets come from the structs themselves, so adding a field to a
+// dialect's request type cannot silently start reporting it as caller data.
+func TestKnownRequestFieldsCoverEachDialect(t *testing.T) {
+	anth := anthropictrans.KnownRequestFields()
+	for _, f := range []string{"model", "messages", "max_tokens", "system", "tools",
+		"tool_choice", "stream", "temperature", "top_p", "top_k", "stop_sequences",
+		"thinking", "metadata"} {
+		if _, ok := anth[f]; !ok {
+			t.Errorf("anthropic field %q missing from KnownRequestFields", f)
+		}
+	}
+
+	gem := geminitrans.KnownRequestFields()
+	for _, f := range []string{"contents", "systemInstruction", "generationConfig",
+		"tools", "toolConfig", "safetySettings", "cachedContent"} {
+		if _, ok := gem[f]; !ok {
+			t.Errorf("gemini field %q missing from KnownRequestFields", f)
+		}
 	}
 }

--- a/agentcc-gateway/internal/translation/anthropic/types.go
+++ b/agentcc-gateway/internal/translation/anthropic/types.go
@@ -4,19 +4,24 @@
 // Messages API spec is at https://platform.claude.com/docs/en/api/messages.
 package anthropic
 
-import "encoding/json"
+import (
+	"encoding/json"
+	"sync"
+
+	"github.com/futureagi/agentcc-gateway/internal/models"
+)
 
 // ─── Request types ────────────────────────────────────────────────────────────
 
 // MessagesRequest is the top-level body for POST /v1/messages.
 type MessagesRequest struct {
-	Model     string           `json:"model"`
-	Messages  []AnthropicMsg   `json:"messages"`
-	MaxTokens int              `json:"max_tokens"`
-	System    json.RawMessage  `json:"system,omitempty"` // string or []TextBlockParam
-	Tools     []AnthropicTool  `json:"tools,omitempty"`
+	Model      string          `json:"model"`
+	Messages   []AnthropicMsg  `json:"messages"`
+	MaxTokens  int             `json:"max_tokens"`
+	System     json.RawMessage `json:"system,omitempty"` // string or []TextBlockParam
+	Tools      []AnthropicTool `json:"tools,omitempty"`
 	ToolChoice json.RawMessage `json:"tool_choice,omitempty"`
-	Stream    bool             `json:"stream,omitempty"`
+	Stream     bool            `json:"stream,omitempty"`
 
 	// Sampling params.
 	Temperature *float64 `json:"temperature,omitempty"`
@@ -154,36 +159,36 @@ type MessageStartMsg struct {
 
 // ContentBlockStartEvent announces a new content block.
 type ContentBlockStartEvent struct {
-	Type         string       `json:"type"`  // "content_block_start"
+	Type         string       `json:"type"` // "content_block_start"
 	Index        int          `json:"index"`
 	ContentBlock ContentBlock `json:"content_block"`
 }
 
 // ContentBlockDeltaEvent carries an incremental delta.
 type ContentBlockDeltaEvent struct {
-	Type  string        `json:"type"`  // "content_block_delta"
-	Index int           `json:"index"`
-	Delta ContentDelta  `json:"delta"`
+	Type  string       `json:"type"` // "content_block_delta"
+	Index int          `json:"index"`
+	Delta ContentDelta `json:"delta"`
 }
 
 // ContentBlockStopEvent closes a content block.
 type ContentBlockStopEvent struct {
-	Type  string `json:"type"`  // "content_block_stop"
+	Type  string `json:"type"` // "content_block_stop"
 	Index int    `json:"index"`
 }
 
 // ContentDelta holds the actual increment; type discriminates.
 type ContentDelta struct {
-	Type        string `json:"type"`                  // "text_delta" | "input_json_delta" | "thinking_delta"
-	Text        string `json:"text,omitempty"`        // text_delta
+	Type        string `json:"type"`                   // "text_delta" | "input_json_delta" | "thinking_delta"
+	Text        string `json:"text,omitempty"`         // text_delta
 	PartialJSON string `json:"partial_json,omitempty"` // input_json_delta
-	Thinking    string `json:"thinking,omitempty"`    // thinking_delta
+	Thinking    string `json:"thinking,omitempty"`     // thinking_delta
 }
 
 // MessageDeltaEvent carries final stop-reason and output usage.
 type MessageDeltaEvent struct {
-	Type  string       `json:"type"`  // "message_delta"
-	Delta MessageDelta `json:"delta"`
+	Type  string        `json:"type"` // "message_delta"
+	Delta MessageDelta  `json:"delta"`
 	Usage ResponseUsage `json:"usage"`
 }
 
@@ -223,3 +228,10 @@ type ErrorDetail struct {
 	Type    string `json:"type"`
 	Message string `json:"message"`
 }
+
+// KnownRequestFields returns the JSON keys POST /v1/messages defines, so a
+// caller's own additions to the body can be told apart from the spec's fields.
+// Derived from MessagesRequest, so it cannot drift from it.
+var KnownRequestFields = sync.OnceValue(func() map[string]struct{} {
+	return models.JSONFieldNames(MessagesRequest{})
+})

--- a/agentcc-gateway/internal/translation/gemini/types.go
+++ b/agentcc-gateway/internal/translation/gemini/types.go
@@ -6,7 +6,12 @@
 // needed for inbound translation.
 package gemini
 
-import "encoding/json"
+import (
+	"encoding/json"
+	"sync"
+
+	"github.com/futureagi/agentcc-gateway/internal/models"
+)
 
 // ── Inbound request types ───────────────────────────────────────────────────
 
@@ -112,3 +117,10 @@ type geminiErrorDetail struct {
 	Message string `json:"message"`
 	Status  string `json:"status"`
 }
+
+// KnownRequestFields returns the JSON keys a generateContent body defines, so a
+// caller's own additions can be told apart from the spec's fields. Derived from
+// geminiRequest, so it cannot drift from it.
+var KnownRequestFields = sync.OnceValue(func() map[string]struct{} {
+	return models.JSONFieldNames(geminiRequest{})
+})


### PR DESCRIPTION
Closes TH-7618.

Gives the gateway an equivalent of `span.SetAttribute()` for callers who reach it through an SDK.

Today a caller's own dimensions reach the trace only as one opaque `metadata` JSON string — substring-matchable and nothing more. Anything sent as `extra_body` never reaches the span at all, and that is not an edge case: `ChatCompletionRequest.UnmarshalJSON` matches a fixed list of ~23 field names, so **every OpenAI parameter newer than that list** — `reasoning_effort`, `parallel_tool_calls`, `store`, `prediction` — lands in `Extra` and is invisible on a trace that otherwise looks complete.

## What changes

**`agentcc.metadata.<key>`** — each caller key is flattened *in addition to* the `metadata` JSON object. The object stays: platform ingest reads that exact key and parses it (`tracer/utils/otel.py:807`, `:948`, `:1590`), so dropping it would blank the metadata panel. Flat string attributes are what fi-collector's `Split` routes into the queryable `attrs_string`; a JSON blob is one string.

**Body `metadata` field** — the OpenAI-spec field now feeds the same path as the `x-agentcc-metadata` header, so per-call tagging works from an SDK with no custom headers. The header wins on conflict: infrastructure tagging should not be overridable by the payload it forwards.

**`agentcc.body.<key>`** (on by default) — unknown top-level body fields. Scalars only, and numbers keep their type so range filters work rather than everything piling into `attrs_string`.

**`otel.capture_headers`** (empty by default) — request headers as `http.request.header.<name>`.

**`otel.trace_propagation`** (off by default) — honours an inbound W3C `traceparent` so the gateway span nests under its caller instead of starting a second root in the same trace.

## Three decisions worth reviewing

**Body extras are captured at parse time, not read from `Request.Extra` at export time.** The translation layer writes its own state into that same map — `tool_name_mapping`, `anthropic_thinking_config`, `gemini_tool_call_id_map` — on the canonical request the OTel plugin later sees. Taking the caller's fields before any of that runs excludes gateway internals *by provenance*, so nobody has to keep a list of our own key names correct forever. Pinned by `TestAttachBodyExtras_NeverReadsRequestExtra`.

**Header capture is an allowlist, and the denylist wins even over an exact entry.** `cloneRequestHeaders` (`handlers.go:126`) copies `x-api-key` into `Authorization`, so `rc.RequestHeaders` *always* holds a live credential — even for callers who never sent one under that name. A pattern as ordinary as `x-*` would ship it to a trace backend that far more people can read than can read a log. Tested with `capture_headers: ["*"]` and a live key present: zero credentials exported.

**Scalars only, for body fields.** A nested object cannot be queried anyway (`Split` routes maps and slices to the non-queryable `attributes_extra`), and an object is precisely the shape credentials arrive in when someone passes service-account JSON through `extra_body`. Skipping non-scalars is the cheapest secret filter in the design; a key-name denylist and value redaction sit behind it.

Metadata values are deliberately **not** redacted, unlike header and body values — metadata is a dimension the caller chose in order to group by it, and rewriting an id that merely looks like an email would silently break their grouping.

## Bug fix

`isBlockedMetadataKey` reserved the bare prefix `cost`, which swallowed ordinary business dimensions (`cost_center`, `cost_code`, `costing_model`) — the plugins only own `cost` and `cost_source`. In the other direction `credit_` never matched `credits_used` / `credits_remaining`, the keys the credits plugin actually writes and the API echoes back in response headers, so callers could set them. Both halves fixed.

## Caps

16 pairs / 64-char keys / 512-char values, mirroring OpenAI's own metadata limits so a payload that fits one fits the other. Truncation is sorted, because ranging a Go map would make the surviving set follow randomised hash order and flicker between two identical requests. Drops are counted in `agentcc.metadata_dropped` / `agentcc.body_dropped` rather than being silent.

## Verified

End to end against live Vertex AI, spans rendering in the platform UI with `agentcc.metadata.*` as first-class attribute rows:

```
-> agentcc.metadata.customer_id:      Str(cust-4711)
-> agentcc.body.reasoning_effort:     Str(high)
-> agentcc.body.parallel_tool_calls:  Bool(true)
-> agentcc.body.routing_weight:       Int(3)
-> agentcc.body.threshold:            Double(0.75)
-> agentcc.body_dropped:              Int(4)
-> metadata: Str({"tenant":"acme", ...})
```

The four dropped were a nested object, an array, and two credential-shaped key names; the credential value appeared nowhere on the span. Trace propagation verified nesting a gateway span under a .NET caller's span while preserving `agentcc.trace_id` for the request-log join.

Full suite green.

## Note for reviewers

`applyCallerExtrasFromBody` is wired into the Anthropic and Gemini handlers and is **live there** as of the rebase onto #2231 (TH-7619), which landed first and put `h.engine.Process` on both endpoints. The OTel plugin reads `rc.CallerExtras` inside that pipeline and this PR's capture runs before it, so caller metadata and body fields now reach spans on `/v1/messages` and `generateContent` too.

That ordering is load-bearing and invisible: a capture moved below `h.engine.Process` still compiles and exports nothing. `TestDialectHandlersCaptureCallerExtrasBeforeThePipeline` pins it, in the same source-asserted style as #2231's own `TestBillableHandlersRunThePipeline`, because the failure mode is an omission rather than a wrong value.
