### PR TITLE
fix(gateway): run the plugin pipeline on /v1/messages and Gemini generateContent

### DIFF
--- a/agentcc-gateway/internal/anthropicfmt/stream_usage.go
+++ b/agentcc-gateway/internal/anthropicfmt/stream_usage.go
@@ -1,0 +1,140 @@
+package anthropicfmt
+
+import (
+	"bytes"
+	"encoding/json"
+)
+
+// An Anthropic stream carries its counts at the two ends — input in
+// message_start, output in message_delta — so both ends are enough, and
+// buffering whole responses to bill them would not be.
+const maxUsageScanBytes = 16 << 10
+
+// StreamUsageScanner collects token counts from a relayed SSE stream without
+// buffering it. Priced at zero, a stream would be logged as if that were its
+// real cost — worse than not billing it.
+type StreamUsageScanner struct {
+	head    []byte
+	tail    []byte
+	sawHead bool
+}
+
+// Write feeds a relayed chunk in. An unparseable stream yields no usage, which
+// the caller can tell apart from a genuine zero.
+func (s *StreamUsageScanner) Write(chunk []byte) {
+	if !s.sawHead {
+		room := maxUsageScanBytes - len(s.head)
+		if room > 0 {
+			if len(chunk) < room {
+				room = len(chunk)
+			}
+			s.head = append(s.head, chunk[:room]...)
+		}
+		if len(s.head) >= maxUsageScanBytes {
+			s.sawHead = true
+		}
+	}
+
+	s.tail = append(s.tail, chunk...)
+	if len(s.tail) > maxUsageScanBytes {
+		s.tail = s.tail[len(s.tail)-maxUsageScanBytes:]
+	}
+}
+
+// Usage returns the counts seen. input_tokens comes from the first usage object
+// and output_tokens from the last: Anthropic states input once, then revises
+// output as the message grows.
+func (s *StreamUsageScanner) Usage() (inputTokens, outputTokens int, ok bool) {
+	if in, found := firstUsageField(s.head, "input_tokens"); found {
+		inputTokens, ok = in, true
+	}
+	if out, found := lastUsageField(s.tail, "output_tokens"); found {
+		outputTokens, ok = out, true
+	}
+	return inputTokens, outputTokens, ok
+}
+
+// Model returns the model from message_start, if still in the retained head.
+func (s *StreamUsageScanner) Model() string {
+	for _, data := range sseDataLines(s.head) {
+		var ev struct {
+			Message struct {
+				Model string `json:"model"`
+			} `json:"message"`
+		}
+		if err := json.Unmarshal(data, &ev); err == nil && ev.Message.Model != "" {
+			return ev.Message.Model
+		}
+	}
+	return ""
+}
+
+// usage is nested one level deeper on message_start than on message_delta.
+type usageEvent struct {
+	Usage struct {
+		InputTokens  *int `json:"input_tokens"`
+		OutputTokens *int `json:"output_tokens"`
+	} `json:"usage"`
+	Message struct {
+		Usage struct {
+			InputTokens  *int `json:"input_tokens"`
+			OutputTokens *int `json:"output_tokens"`
+		} `json:"usage"`
+	} `json:"message"`
+}
+
+func firstUsageField(buf []byte, field string) (int, bool) {
+	for _, data := range sseDataLines(buf) {
+		if v, ok := usageField(data, field); ok {
+			return v, true
+		}
+	}
+	return 0, false
+}
+
+func lastUsageField(buf []byte, field string) (int, bool) {
+	lines := sseDataLines(buf)
+	for i := len(lines) - 1; i >= 0; i-- {
+		if v, ok := usageField(lines[i], field); ok {
+			return v, true
+		}
+	}
+	return 0, false
+}
+
+func usageField(data []byte, field string) (int, bool) {
+	var ev usageEvent
+	if err := json.Unmarshal(data, &ev); err != nil {
+		return 0, false
+	}
+	for _, candidate := range [][2]*int{
+		{ev.Usage.InputTokens, ev.Usage.OutputTokens},
+		{ev.Message.Usage.InputTokens, ev.Message.Usage.OutputTokens},
+	} {
+		v := candidate[0]
+		if field == "output_tokens" {
+			v = candidate[1]
+		}
+		if v != nil {
+			return *v, true
+		}
+	}
+	return 0, false
+}
+
+// A retained window starts mid-stream, so a partial line at either edge is
+// expected and is dropped by the JSON parse.
+func sseDataLines(buf []byte) [][]byte {
+	var out [][]byte
+	for _, line := range bytes.Split(buf, []byte("\n")) {
+		line = bytes.TrimSpace(line)
+		if !bytes.HasPrefix(line, []byte("data:")) {
+			continue
+		}
+		payload := bytes.TrimSpace(line[len("data:"):])
+		if len(payload) > 0 && payload[0] == '{' {
+			out = append(out, payload)
+		}
+	}
+	return out
+}

--- a/agentcc-gateway/internal/anthropicfmt/stream_usage_test.go
+++ b/agentcc-gateway/internal/anthropicfmt/stream_usage_test.go
@@ -1,0 +1,93 @@
+package anthropicfmt
+
+import (
+	"strings"
+	"testing"
+)
+
+// A real Anthropic stream: input tokens stated once in message_start, output
+// revised upward until message_delta.
+const anthropicStream = `event: message_start
+data: {"type":"message_start","message":{"id":"msg_1","model":"claude-3-5-sonnet","usage":{"input_tokens":41,"output_tokens":1}}}
+
+event: content_block_delta
+data: {"type":"content_block_delta","delta":{"type":"text_delta","text":"hi"}}
+
+event: message_delta
+data: {"type":"message_delta","delta":{"stop_reason":"end_turn"},"usage":{"output_tokens":87}}
+
+event: message_stop
+data: {"type":"message_stop"}
+`
+
+func TestStreamUsageScanner(t *testing.T) {
+	var s StreamUsageScanner
+	s.Write([]byte(anthropicStream))
+
+	in, out, ok := s.Usage()
+	if !ok {
+		t.Fatal("no usage found in a stream that reports it")
+	}
+	if in != 41 {
+		t.Errorf("input = %d, want 41 (from message_start)", in)
+	}
+	if out != 87 {
+		t.Errorf("output = %d, want 87 (from message_delta, not message_start's 1)", out)
+	}
+	if got := s.Model(); got != "claude-3-5-sonnet" {
+		t.Errorf("model = %q, want claude-3-5-sonnet", got)
+	}
+}
+
+// The relay hands over arbitrary byte slices, so events arrive split.
+func TestStreamUsageScannerAcrossChunkBoundaries(t *testing.T) {
+	var s StreamUsageScanner
+	for i := 0; i < len(anthropicStream); i += 7 {
+		end := i + 7
+		if end > len(anthropicStream) {
+			end = len(anthropicStream)
+		}
+		s.Write([]byte(anthropicStream[i:end]))
+	}
+
+	in, out, ok := s.Usage()
+	if !ok || in != 41 || out != 87 {
+		t.Errorf("in=%d out=%d ok=%v, want 41/87/true when fed in 7-byte pieces", in, out, ok)
+	}
+}
+
+// A long response pushes message_start out of the retained head, but the
+// billable output count is at the other end and must survive.
+func TestStreamUsageScannerKeepsOutputOnLongStream(t *testing.T) {
+	var s StreamUsageScanner
+	s.Write([]byte(anthropicStream[:strings.Index(anthropicStream, "event: content_block_delta")]))
+	filler := "event: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"delta\":{\"text\":\"" +
+		strings.Repeat("x", 200) + "\"}}\n\n"
+	for i := 0; i < 200; i++ {
+		s.Write([]byte(filler))
+	}
+	s.Write([]byte("event: message_delta\ndata: {\"type\":\"message_delta\",\"usage\":{\"output_tokens\":512}}\n\n"))
+
+	_, out, ok := s.Usage()
+	if !ok || out != 512 {
+		t.Errorf("output = %d ok=%v, want 512 after the head aged out", out, ok)
+	}
+}
+
+func TestStreamUsageScannerNoUsage(t *testing.T) {
+	var s StreamUsageScanner
+	s.Write([]byte("event: ping\ndata: {\"type\":\"ping\"}\n\n"))
+
+	if _, _, ok := s.Usage(); ok {
+		t.Error("reported usage for a stream that carried none — cost must skip, not bill zero")
+	}
+}
+
+func TestStreamUsageScannerIgnoresGarbage(t *testing.T) {
+	var s StreamUsageScanner
+	s.Write([]byte("data: not-json\ndata: {broken\n\n"))
+
+	if _, _, ok := s.Usage(); ok {
+		t.Error("parsed usage out of unparseable data")
+	}
+}

--- a/agentcc-gateway/internal/genaifmt/format.go
+++ b/agentcc-gateway/internal/genaifmt/format.go
@@ -121,3 +121,14 @@ func extractTextFromPart(raw json.RawMessage) string {
 	}
 	return ""
 }
+
+// ExtractModelVersion names the concrete model behind an alias.
+func ExtractModelVersion(respBody []byte) string {
+	var m struct {
+		ModelVersion string `json:"modelVersion"`
+	}
+	if err := json.Unmarshal(respBody, &m); err != nil {
+		return ""
+	}
+	return m.ModelVersion
+}

--- a/agentcc-gateway/internal/genaifmt/stream_usage.go
+++ b/agentcc-gateway/internal/genaifmt/stream_usage.go
@@ -1,0 +1,64 @@
+package genaifmt
+
+import (
+	"bytes"
+)
+
+// Gemini repeats usageMetadata as the response grows and the final chunk
+// carries the complete counts, so only the tail is worth keeping.
+const maxUsageScanBytes = 16 << 10
+
+// StreamUsageScanner collects token counts from a relayed SSE stream without
+// buffering it. Priced at zero, a stream would be logged as if that were its
+// real cost — worse than not billing it.
+type StreamUsageScanner struct {
+	tail []byte
+}
+
+// Write feeds a relayed chunk to the scanner.
+func (s *StreamUsageScanner) Write(chunk []byte) {
+	s.tail = append(s.tail, chunk...)
+	if len(s.tail) > maxUsageScanBytes {
+		s.tail = s.tail[len(s.tail)-maxUsageScanBytes:]
+	}
+}
+
+// Usage returns the last counts reported — Gemini revises usageMetadata upward
+// as it goes, so the final reading is the billable one.
+func (s *StreamUsageScanner) Usage() (promptTokens, completionTokens int, ok bool) {
+	lines := sseDataLines(s.tail)
+	for i := len(lines) - 1; i >= 0; i-- {
+		p, c, _ := ExtractUsageMetadata(lines[i])
+		if p > 0 || c > 0 {
+			return p, c, true
+		}
+	}
+	return 0, 0, false
+}
+
+// Model returns the model named by the most recent chunk, if any.
+func (s *StreamUsageScanner) Model() string {
+	lines := sseDataLines(s.tail)
+	for i := len(lines) - 1; i >= 0; i-- {
+		if m := ExtractModelVersion(lines[i]); m != "" {
+			return m
+		}
+	}
+	return ""
+}
+
+// A retained window begins mid-stream, so a partial head line is expected and
+// is dropped by the JSON parse.
+func sseDataLines(buf []byte) [][]byte {
+	var out [][]byte
+	for _, line := range bytes.Split(buf, []byte("\n")) {
+		line = bytes.TrimSpace(line)
+		if bytes.HasPrefix(line, []byte("data:")) {
+			line = bytes.TrimSpace(line[len("data:"):])
+		}
+		if len(line) > 0 && line[0] == '{' {
+			out = append(out, line)
+		}
+	}
+	return out
+}

--- a/agentcc-gateway/internal/genaifmt/stream_usage_test.go
+++ b/agentcc-gateway/internal/genaifmt/stream_usage_test.go
@@ -1,0 +1,54 @@
+package genaifmt
+
+import "testing"
+
+// Gemini repeats usageMetadata as the response grows; the last one is billable.
+const geminiStream = `data: {"candidates":[{"content":{"parts":[{"text":"He"}]}}],"modelVersion":"gemini-2.0-flash","usageMetadata":{"promptTokenCount":9,"candidatesTokenCount":1,"totalTokenCount":10}}
+
+data: {"candidates":[{"content":{"parts":[{"text":"llo"}]}}],"modelVersion":"gemini-2.0-flash","usageMetadata":{"promptTokenCount":9,"candidatesTokenCount":48,"thoughtsTokenCount":12,"totalTokenCount":69}}
+`
+
+func TestStreamUsageScanner(t *testing.T) {
+	var s StreamUsageScanner
+	s.Write([]byte(geminiStream))
+
+	prompt, completion, ok := s.Usage()
+	if !ok {
+		t.Fatal("no usage found in a stream that reports it")
+	}
+	if prompt != 9 {
+		t.Errorf("prompt = %d, want 9", prompt)
+	}
+	// Thinking tokens bill as output, so the last chunk is 48+12.
+	if completion != 60 {
+		t.Errorf("completion = %d, want 60 (48 candidates + 12 thoughts)", completion)
+	}
+	if got := s.Model(); got != "gemini-2.0-flash" {
+		t.Errorf("model = %q, want gemini-2.0-flash", got)
+	}
+}
+
+func TestStreamUsageScannerAcrossChunkBoundaries(t *testing.T) {
+	var s StreamUsageScanner
+	for i := 0; i < len(geminiStream); i += 11 {
+		end := i + 11
+		if end > len(geminiStream) {
+			end = len(geminiStream)
+		}
+		s.Write([]byte(geminiStream[i:end]))
+	}
+
+	prompt, completion, ok := s.Usage()
+	if !ok || prompt != 9 || completion != 60 {
+		t.Errorf("prompt=%d completion=%d ok=%v, want 9/60/true", prompt, completion, ok)
+	}
+}
+
+func TestStreamUsageScannerNoUsage(t *testing.T) {
+	var s StreamUsageScanner
+	s.Write([]byte(`data: {"candidates":[{"content":{"parts":[{"text":"hi"}]}}]}` + "\n\n"))
+
+	if _, _, ok := s.Usage(); ok {
+		t.Error("reported usage for a stream that carried none — cost must skip, not bill zero")
+	}
+}

--- a/agentcc-gateway/internal/plugins/cache/nil_request_test.go
+++ b/agentcc-gateway/internal/plugins/cache/nil_request_test.go
@@ -1,0 +1,40 @@
+package cache
+
+import (
+	"context"
+	"testing"
+
+	"github.com/futureagi/agentcc-gateway/internal/models"
+)
+
+// The dialect pass-through handlers forward the caller's raw bytes and never
+// build a canonical request, so rc.Request stays nil and the cache has to skip.
+//
+// Handing it a carrier with empty Messages instead would be worse than useless:
+// BuildCacheKey marshals Messages, so every prompt for a model would hash to
+// one key, and the response stored against it holds usage only — the next
+// request would be served a content-less 200 without the provider being called.
+func TestProcessRequestSkipsWhenRequestIsNil(t *testing.T) {
+	p := &Plugin{}
+	rc := &models.RequestContext{Metadata: map[string]string{}}
+
+	result := p.ProcessRequest(context.Background(), rc)
+
+	if result.Action == 1 { // ShortCircuit
+		t.Fatal("cache served a response for a request it cannot key")
+	}
+	if got := rc.Metadata["cache_status"]; got != "skip" {
+		t.Errorf("cache_status = %q, want \"skip\"", got)
+	}
+}
+
+// The collision that makes the nil skip load-bearing.
+func TestBuildCacheKeyCollidesOnEmptyMessages(t *testing.T) {
+	a := BuildCacheKey("default", &models.ChatCompletionRequest{Model: "claude-3"})
+	b := BuildCacheKey("default", &models.ChatCompletionRequest{Model: "claude-3"})
+
+	if a != b {
+		t.Fatal("expected two message-less requests to collide; if they no longer " +
+			"do, the pass-through paths could safely carry a minimal request")
+	}
+}

--- a/agentcc-gateway/internal/plugins/toolpolicy/nil_request_test.go
+++ b/agentcc-gateway/internal/plugins/toolpolicy/nil_request_test.go
@@ -1,0 +1,23 @@
+package toolpolicy
+
+import (
+	"context"
+	"testing"
+
+	"github.com/futureagi/agentcc-gateway/internal/config"
+	"github.com/futureagi/agentcc-gateway/internal/models"
+)
+
+// Embeddings, images, audio, ocr, rerank, search and responses run the pipeline
+// without setting rc.Request. Dereferencing it panicked into a 500 on all of
+// them whenever tool policy was enabled.
+func TestProcessRequestSurvivesNilRequest(t *testing.T) {
+	p := New(config.ToolPolicyConfig{Enabled: true}, nil)
+	rc := &models.RequestContext{Metadata: map[string]string{}}
+
+	result := p.ProcessRequest(context.Background(), rc)
+
+	if result.Error != nil {
+		t.Errorf("Error = %v, want none for a request that cannot carry tools", result.Error)
+	}
+}

--- a/agentcc-gateway/internal/plugins/toolpolicy/toolpolicy.go
+++ b/agentcc-gateway/internal/plugins/toolpolicy/toolpolicy.go
@@ -50,7 +50,9 @@ func (p *Plugin) Priority() int { return 60 } // After guardrails (50), before v
 
 // ProcessRequest filters tools based on policy (global → org → per-key).
 func (p *Plugin) ProcessRequest(ctx context.Context, rc *models.RequestContext) pipeline.PluginResult {
-	if len(rc.Request.Tools) == 0 {
+	// Embeddings, images, audio, ocr, rerank and search run the pipeline with
+	// rc.Request nil; none can carry tools, and dereferencing here 500'd them.
+	if rc.Request == nil || len(rc.Request.Tools) == 0 {
 		return pipeline.ResultContinue()
 	}
 

--- a/agentcc-gateway/internal/server/handlers_anthropic.go
+++ b/agentcc-gateway/internal/server/handlers_anthropic.go
@@ -160,13 +160,11 @@ func (h *Handlers) AnthropicMessages(w http.ResponseWriter, r *http.Request) {
 
 	// Fast path: provider natively speaks Anthropic.
 	if ap, ok := provider.(providers.AnthropicNativeProvider); ok {
-		// This path forwards the caller's bytes and never builds a canonical
-		// request, so plugins get a carrier rather than a nil pointer. Messages
-		// and tools are absent on purpose: a plugin rewriting them would have
-		// its edit discarded, so tool policy and semantic caching do not apply.
-		if rc.Request == nil {
-			rc.Request = &models.ChatCompletionRequest{Model: rc.Model, Stream: isStream}
-		}
+		// rc.Request is deliberately left nil, as it is on the genai path.
+		// A carrier with empty Messages would hash to the same cache key for
+		// every prompt (BuildCacheKey marshals Messages), and the response
+		// stored against it holds usage only — so a later request would be
+		// served a content-less 200. Request-shaped plugins skip on nil.
 		if isStream {
 			h.handleAnthropicStream(ctx, w, rc, ap, body, anthropicHeaders)
 		} else {
@@ -436,13 +434,16 @@ func (h *Handlers) handleAnthropicStream(ctx context.Context, w http.ResponseWri
 		h.engine.RunPostPlugins(pluginCtx, rc)
 	}
 
-	// If upstream returned an error status, read and forward.
+	// If upstream returned an error status, read and forward. Still finalised:
+	// the non-streaming path records a 4xx through Process, and a streamed one
+	// that skipped it would be missing from the log and the trace.
 	if statusCode >= 400 {
 		errBody, _ := io.ReadAll(io.LimitReader(stream, 1024*1024))
 		h.setAgentccHeaders(w, rc)
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(statusCode)
 		w.Write(errBody)
+		finalize(false)
 		return
 	}
 
@@ -673,7 +674,7 @@ func (h *Handlers) handleAnthropicStreamViaCanonical(
 
 	// Tee for usage: the counts are already structured here, unlike in the
 	// translated SSE bytes.
-	chunkCh, usageCh := teeStreamUsage(rawChunkCh)
+	chunkCh, usageCh := teeStreamUsage(ctx, rawChunkCh)
 
 	// Must be reached from every exit below — the tokens were spent either way.
 	finalize := func(detach bool) {
@@ -816,9 +817,18 @@ type streamUsage struct {
 // teeStreamUsage passes chunks through untouched, keeping the last usage and
 // model. The result travels on a channel so reading it after the drain loop is
 // ordered against the goroutine that wrote it.
-func teeStreamUsage(in <-chan models.StreamChunk) (<-chan models.StreamChunk, <-chan streamUsage) {
+func teeStreamUsage(ctx context.Context, in <-chan models.StreamChunk) (<-chan models.StreamChunk, <-chan streamUsage) {
 	out := make(chan models.StreamChunk)
 	done := make(chan streamUsage, 1)
+
+	record := func(seen *streamUsage, chunk models.StreamChunk) {
+		if chunk.Usage != nil {
+			seen.usage = chunk.Usage
+		}
+		if chunk.Model != "" {
+			seen.model = chunk.Model
+		}
+	}
 
 	go func() {
 		var seen streamUsage
@@ -828,13 +838,20 @@ func teeStreamUsage(in <-chan models.StreamChunk) (<-chan models.StreamChunk, <-
 			close(out)
 		}()
 		for chunk := range in {
-			if chunk.Usage != nil {
-				seen.usage = chunk.Usage
+			record(&seen, chunk)
+			select {
+			case out <- chunk:
+			case <-ctx.Done():
+				// The consumer is gone — the translator returns on ctx.Done
+				// without draining. Forwarding would park here forever while
+				// finalize waits on the usage channel, leaking both goroutines
+				// and the provider stream. Keep draining so the counts still
+				// arrive, just stop forwarding.
+				for c := range in {
+					record(&seen, c)
+				}
+				return
 			}
-			if chunk.Model != "" {
-				seen.model = chunk.Model
-			}
-			out <- chunk
 		}
 	}()
 
@@ -851,13 +868,23 @@ func applyCanonicalStreamUsage(rc *models.RequestContext, usageCh <-chan streamU
 	if seen.usage == nil {
 		return
 	}
-	rc.Metadata["input_tokens"] = strconv.Itoa(seen.usage.PromptTokens)
-	rc.Metadata["output_tokens"] = strconv.Itoa(seen.usage.CompletionTokens)
+	if seen.usage.PromptTokens > 0 {
+		rc.Metadata["input_tokens"] = strconv.Itoa(seen.usage.PromptTokens)
+	}
+	if seen.usage.CompletionTokens > 0 {
+		rc.Metadata["output_tokens"] = strconv.Itoa(seen.usage.CompletionTokens)
+	}
 	model := rc.ResolvedModel
 	if model == "" {
 		model = rc.Model
 	}
-	rc.Response = &models.ChatCompletionResponse{Model: model, Usage: seen.usage}
+	usage := *seen.usage
+	if usage.TotalTokens == 0 {
+		// Providers vary on whether they send it; the native paths always fill
+		// it, so do the same here rather than diverge.
+		usage.TotalTokens = usage.PromptTokens + usage.CompletionTokens
+	}
+	rc.Response = &models.ChatCompletionResponse{Model: model, Usage: &usage}
 }
 
 // setUsageResponse gives the post-plugins the minimal canonical response they

--- a/agentcc-gateway/internal/server/handlers_anthropic.go
+++ b/agentcc-gateway/internal/server/handlers_anthropic.go
@@ -160,6 +160,13 @@ func (h *Handlers) AnthropicMessages(w http.ResponseWriter, r *http.Request) {
 
 	// Fast path: provider natively speaks Anthropic.
 	if ap, ok := provider.(providers.AnthropicNativeProvider); ok {
+		// This path forwards the caller's bytes and never builds a canonical
+		// request, so plugins get a carrier rather than a nil pointer. Messages
+		// and tools are absent on purpose: a plugin rewriting them would have
+		// its edit discarded, so tool policy and semantic caching do not apply.
+		if rc.Request == nil {
+			rc.Request = &models.ChatCompletionRequest{Model: rc.Model, Stream: isStream}
+		}
 		if isStream {
 			h.handleAnthropicStream(ctx, w, rc, ap, body, anthropicHeaders)
 		} else {
@@ -299,9 +306,28 @@ func (h *Handlers) AnthropicCountTokens(w http.ResponseWriter, r *http.Request) 
 // ─── Native pass-through helpers (unchanged from original) ───────────────────
 
 func (h *Handlers) handleAnthropicNonStream(ctx context.Context, w http.ResponseWriter, rc *models.RequestContext, ap providers.AnthropicNativeProvider, body []byte, headers map[string]string) {
-	respBody, statusCode, err := ap.CreateAnthropicMessage(ctx, body, headers)
+	var respBody []byte
+	var statusCode int
+
+	err := h.engine.Process(ctx, rc, func(ctx context.Context, rc *models.RequestContext) error {
+		var callErr error
+		respBody, statusCode, callErr = ap.CreateAnthropicMessage(ctx, body, headers)
+		if callErr != nil {
+			return callErr
+		}
+		if statusCode < 400 {
+			applyAnthropicUsage(rc, respBody)
+		}
+		return nil
+	})
 	if err != nil {
 		writeAnthropicErrorFromError(w, err)
+		return
+	}
+
+	// A plugin answered it — a cache hit. Its response is canonical.
+	if respBody == nil {
+		h.writeAnthropicShortCircuit(w, rc)
 		return
 	}
 
@@ -314,7 +340,16 @@ func (h *Handlers) handleAnthropicNonStream(ctx context.Context, w http.Response
 		return
 	}
 
-	// Extract usage for cost tracking.
+	h.setAgentccHeaders(w, rc)
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	w.Write(respBody)
+}
+
+// applyAnthropicUsage lifts the usage block onto rc. rc.Response is populated
+// because that is what the cost plugin prices from; it carries usage only, not
+// a translation of the response.
+func applyAnthropicUsage(rc *models.RequestContext, respBody []byte) {
 	inputTokens, outputTokens := anthropicfmt.ExtractUsage(respBody)
 	if inputTokens > 0 {
 		rc.Metadata["input_tokens"] = strconv.Itoa(inputTokens)
@@ -322,25 +357,84 @@ func (h *Handlers) handleAnthropicNonStream(ctx context.Context, w http.Response
 	if outputTokens > 0 {
 		rc.Metadata["output_tokens"] = strconv.Itoa(outputTokens)
 	}
-
-	// Extract resolved model.
 	if resolvedModel := anthropicfmt.ExtractModel(respBody); resolvedModel != "" {
 		rc.ResolvedModel = resolvedModel
 	}
+	if inputTokens == 0 && outputTokens == 0 {
+		return
+	}
+	model := rc.ResolvedModel
+	if model == "" {
+		model = rc.Model
+	}
+	rc.Response = &models.ChatCompletionResponse{
+		Model: model,
+		Usage: &models.Usage{
+			PromptTokens:     inputTokens,
+			CompletionTokens: outputTokens,
+			TotalTokens:      inputTokens + outputTokens,
+		},
+	}
+}
 
+// writeAnthropicShortCircuit renders a plugin-produced response in Anthropic
+// wire format.
+func (h *Handlers) writeAnthropicShortCircuit(w http.ResponseWriter, rc *models.RequestContext) {
+	translator, ok := translation.InboundFor("anthropic")
+	if !ok || rc.Response == nil {
+		h.setAgentccHeaders(w, rc)
+		anthropicfmt.WriteError(w, http.StatusInternalServerError, "api_error",
+			"request was answered internally but the response could not be formatted")
+		return
+	}
+	out, err := translator.ResponseFromCanonical(rc.Response)
+	if err != nil {
+		h.setAgentccHeaders(w, rc)
+		anthropicfmt.WriteError(w, http.StatusInternalServerError, "api_error",
+			"failed to format response: "+err.Error())
+		return
+	}
 	h.setAgentccHeaders(w, rc)
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusOK)
-	w.Write(respBody)
+	w.Write(out)
 }
 
 func (h *Handlers) handleAnthropicStream(ctx context.Context, w http.ResponseWriter, rc *models.RequestContext, ap providers.AnthropicNativeProvider, body []byte, headers map[string]string) {
-	stream, statusCode, err := ap.StreamAnthropicMessage(ctx, body, headers)
-	if err != nil {
+	var stream io.ReadCloser
+	var statusCode int
+
+	// Post-plugins wait for the close, when the counts are known.
+	if err := h.engine.Process(ctx, rc, func(ctx context.Context, rc *models.RequestContext) error {
+		var callErr error
+		stream, statusCode, callErr = ap.StreamAnthropicMessage(ctx, body, headers)
+		return callErr
+	}); err != nil {
 		writeAnthropicErrorFromError(w, err)
 		return
 	}
+
+	if rc.Flags.ShortCircuited && rc.Response != nil {
+		// JSON even though a stream was asked for, as the chat handler does.
+		h.writeAnthropicShortCircuit(w, rc)
+		return
+	}
+	if stream == nil {
+		writeAnthropicErrorFromError(w, models.ErrInternal("no stream from provider"))
+		return
+	}
 	defer stream.Close()
+
+	// Without this the stream would be priced at zero and logged as such.
+	var usage anthropicfmt.StreamUsageScanner
+	finalize := func(detach bool) {
+		applyAnthropicStreamUsage(rc, &usage)
+		pluginCtx := ctx
+		if detach {
+			pluginCtx = context.Background()
+		}
+		h.engine.RunPostPlugins(pluginCtx, rc)
+	}
 
 	// If upstream returned an error status, read and forward.
 	if statusCode >= 400 {
@@ -361,6 +455,8 @@ func (h *Handlers) handleAnthropicStream(ctx context.Context, w http.ResponseWri
 	flusher, ok := w.(http.Flusher)
 	if !ok {
 		slog.Warn("streaming not supported", "request_id", rc.RequestID)
+		// Stream is open, so the request still has to be accounted for.
+		finalize(true)
 		return
 	}
 	flusher.Flush()
@@ -370,8 +466,11 @@ func (h *Handlers) handleAnthropicStream(ctx context.Context, w http.ResponseWri
 	for {
 		n, readErr := stream.Read(buf)
 		if n > 0 {
+			usage.Write(buf[:n])
 			if _, writeErr := w.Write(buf[:n]); writeErr != nil {
 				slog.Warn("error writing anthropic stream", "request_id", rc.RequestID, "error", writeErr)
+				// Client gone, tokens still spent — detach from its context.
+				finalize(true)
 				return
 			}
 			flusher.Flush()
@@ -380,14 +479,47 @@ func (h *Handlers) handleAnthropicStream(ctx context.Context, w http.ResponseWri
 			if readErr != io.EOF {
 				slog.Warn("error reading anthropic stream", "request_id", rc.RequestID, "error", readErr)
 			}
+			finalize(false)
 			return
 		}
 
 		select {
 		case <-ctx.Done():
+			finalize(true)
 			return
 		default:
 		}
+	}
+}
+
+// applyAnthropicStreamUsage moves collected counts onto rc.
+func applyAnthropicStreamUsage(rc *models.RequestContext, usage *anthropicfmt.StreamUsageScanner) {
+	if model := usage.Model(); model != "" {
+		rc.ResolvedModel = model
+	}
+	inputTokens, outputTokens, ok := usage.Usage()
+	if !ok {
+		// Leave rc.Response nil so the cost plugin skips it — a gap is honest
+		// where a zero is not.
+		return
+	}
+	if inputTokens > 0 {
+		rc.Metadata["input_tokens"] = strconv.Itoa(inputTokens)
+	}
+	if outputTokens > 0 {
+		rc.Metadata["output_tokens"] = strconv.Itoa(outputTokens)
+	}
+	model := rc.ResolvedModel
+	if model == "" {
+		model = rc.Model
+	}
+	rc.Response = &models.ChatCompletionResponse{
+		Model: model,
+		Usage: &models.Usage{
+			PromptTokens:     inputTokens,
+			CompletionTokens: outputTokens,
+			TotalTokens:      inputTokens + outputTokens,
+		},
 	}
 }
 
@@ -403,7 +535,19 @@ func (h *Handlers) handleAnthropicNonStreamViaCanonical(
 	translator translation.InboundTranslator,
 	canonicalReq *models.ChatCompletionRequest,
 ) {
-	canonicalResp, err := provider.ChatCompletion(ctx, canonicalReq)
+	// Without this the pipeline sees a nil rc.Request.
+	rc.Request = canonicalReq
+
+	var canonicalResp *models.ChatCompletionResponse
+	err := h.engine.Process(ctx, rc, func(ctx context.Context, rc *models.RequestContext) error {
+		var callErr error
+		canonicalResp, callErr = provider.ChatCompletion(ctx, canonicalReq)
+		if callErr != nil {
+			return callErr
+		}
+		rc.Response = canonicalResp
+		return nil
+	})
 	if err != nil {
 		var apiErr *models.APIError
 		if errors.As(err, &apiErr) {
@@ -423,6 +567,23 @@ func (h *Handlers) handleAnthropicNonStreamViaCanonical(
 		w.Header().Set("Content-Type", ct)
 		w.WriteHeader(status)
 		w.Write(body)
+		return
+	}
+
+	// A plugin answered instead of the provider — a cache hit.
+	if canonicalResp == nil {
+		canonicalResp = rc.Response
+	}
+	if canonicalResp == nil {
+		status, errBody, ct := translator.ErrorFromCanonical(&models.APIError{
+			Status:  http.StatusInternalServerError,
+			Type:    models.ErrTypeServer,
+			Message: "no response from provider",
+		})
+		h.setAgentccHeaders(w, rc)
+		w.Header().Set("Content-Type", ct)
+		w.WriteHeader(status)
+		w.Write(errBody)
 		return
 	}
 
@@ -484,7 +645,45 @@ func (h *Handlers) handleAnthropicStreamViaCanonical(
 	translator translation.InboundTranslator,
 	canonicalReq *models.ChatCompletionRequest,
 ) {
-	chunkCh, errCh := provider.StreamChatCompletion(ctx, canonicalReq)
+	rc.Request = canonicalReq
+
+	var rawChunkCh <-chan models.StreamChunk
+	var errCh <-chan error
+
+	// Pre-plugins run before the upstream stream opens; post-plugins wait for
+	// the final chunk, which is where usage arrives.
+	if err := h.engine.Process(ctx, rc, func(ctx context.Context, rc *models.RequestContext) error {
+		rawChunkCh, errCh = provider.StreamChatCompletion(ctx, canonicalReq)
+		return nil
+	}); err != nil {
+		writeAnthropicErrorFromError(w, err)
+		return
+	}
+
+	if rc.Flags.ShortCircuited && rc.Response != nil {
+		// Answered by a plugin, returned as JSON — the canonical chat handler
+		// does the same for a cache hit on a streaming request.
+		h.writeAnthropicShortCircuit(w, rc)
+		return
+	}
+	if rawChunkCh == nil {
+		writeAnthropicErrorFromError(w, models.ErrInternal("no stream from provider"))
+		return
+	}
+
+	// Tee for usage: the counts are already structured here, unlike in the
+	// translated SSE bytes.
+	chunkCh, usageCh := teeStreamUsage(rawChunkCh)
+
+	// Must be reached from every exit below — the tokens were spent either way.
+	finalize := func(detach bool) {
+		applyCanonicalStreamUsage(rc, usageCh)
+		pluginCtx := ctx
+		if detach {
+			pluginCtx = context.Background()
+		}
+		h.engine.RunPostPlugins(pluginCtx, rc)
+	}
 
 	// Translate the OpenAI chunk stream into Anthropic SSE events. If the
 	// request came in with a tool_name_mapping (a tool was truncated to fit
@@ -515,6 +714,8 @@ func (h *Handlers) handleAnthropicStreamViaCanonical(
 	flusher, ok := w.(http.Flusher)
 	if !ok {
 		slog.Warn("streaming not supported", "request_id", rc.RequestID)
+		// Stream is open, so the request still has to be accounted for.
+		finalize(true)
 		return
 	}
 	flusher.Flush()
@@ -524,6 +725,7 @@ func (h *Handlers) handleAnthropicStreamViaCanonical(
 	for {
 		select {
 		case <-ctx.Done():
+			finalize(true)
 			return
 
 		case event, ok := <-eventCh:
@@ -534,6 +736,7 @@ func (h *Handlers) handleAnthropicStreamViaCanonical(
 			}
 			if _, writeErr := w.Write(event); writeErr != nil {
 				slog.Warn("error writing translated anthropic stream", "request_id", rc.RequestID, "error", writeErr)
+				finalize(true)
 				return
 			}
 			flusher.Flush()
@@ -551,6 +754,7 @@ func (h *Handlers) handleAnthropicStreamViaCanonical(
 			if err != nil {
 				slog.Warn("translator stream error", "request_id", rc.RequestID, "error", err)
 				// Error event already emitted by the translator; just stop.
+				finalize(false)
 				return
 			}
 
@@ -561,12 +765,14 @@ func (h *Handlers) handleAnthropicStreamViaCanonical(
 			}
 			if err != nil {
 				slog.Warn("provider stream error", "request_id", rc.RequestID, "error", err)
+				finalize(false)
 				return
 			}
 		}
 
 		// Once every channel is drained, we're done.
 		if eventCh == nil && errCh == nil && translatorErrCh == nil {
+			finalize(false)
 			return
 		}
 	}
@@ -599,4 +805,74 @@ func extractToolNameMapping(req *models.ChatCompletionRequest) map[string]string
 		return nil
 	}
 	return m
+}
+
+// streamUsage is what a finished stream reported about itself.
+type streamUsage struct {
+	usage *models.Usage
+	model string
+}
+
+// teeStreamUsage passes chunks through untouched, keeping the last usage and
+// model. The result travels on a channel so reading it after the drain loop is
+// ordered against the goroutine that wrote it.
+func teeStreamUsage(in <-chan models.StreamChunk) (<-chan models.StreamChunk, <-chan streamUsage) {
+	out := make(chan models.StreamChunk)
+	done := make(chan streamUsage, 1)
+
+	go func() {
+		var seen streamUsage
+		defer func() {
+			done <- seen
+			close(done)
+			close(out)
+		}()
+		for chunk := range in {
+			if chunk.Usage != nil {
+				seen.usage = chunk.Usage
+			}
+			if chunk.Model != "" {
+				seen.model = chunk.Model
+			}
+			out <- chunk
+		}
+	}()
+
+	return out, done
+}
+
+// applyCanonicalStreamUsage moves a finished stream's usage onto rc. Left nil
+// when the provider sent none, so the cost plugin skips rather than bills zero.
+func applyCanonicalStreamUsage(rc *models.RequestContext, usageCh <-chan streamUsage) {
+	seen := <-usageCh
+	if seen.model != "" {
+		rc.ResolvedModel = seen.model
+	}
+	if seen.usage == nil {
+		return
+	}
+	rc.Metadata["input_tokens"] = strconv.Itoa(seen.usage.PromptTokens)
+	rc.Metadata["output_tokens"] = strconv.Itoa(seen.usage.CompletionTokens)
+	model := rc.ResolvedModel
+	if model == "" {
+		model = rc.Model
+	}
+	rc.Response = &models.ChatCompletionResponse{Model: model, Usage: seen.usage}
+}
+
+// setUsageResponse gives the post-plugins the minimal canonical response they
+// price from. The dialect handlers forward native bytes and never build one.
+func setUsageResponse(rc *models.RequestContext, promptTokens, completionTokens int) {
+	model := rc.ResolvedModel
+	if model == "" {
+		model = rc.Model
+	}
+	rc.Response = &models.ChatCompletionResponse{
+		Model: model,
+		Usage: &models.Usage{
+			PromptTokens:     promptTokens,
+			CompletionTokens: completionTokens,
+			TotalTokens:      promptTokens + completionTokens,
+		},
+	}
 }

--- a/agentcc-gateway/internal/server/handlers_genai.go
+++ b/agentcc-gateway/internal/server/handlers_genai.go
@@ -273,13 +273,16 @@ func (h *Handlers) handleGenAIStream(ctx context.Context, w http.ResponseWriter,
 		h.engine.RunPostPlugins(pluginCtx, rc)
 	}
 
-	// If upstream returned an error status, read and forward.
+	// If upstream returned an error status, read and forward. Still finalised:
+	// the non-streaming path records a 4xx through Process, and a streamed one
+	// that skipped it would be missing from the log and the trace.
 	if statusCode >= 400 {
 		errBody, _ := io.ReadAll(io.LimitReader(stream, 1024*1024))
 		h.setAgentccHeaders(w, rc)
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(statusCode)
 		w.Write(errBody)
+		finalize(false)
 		return
 	}
 
@@ -562,7 +565,7 @@ func (h *Handlers) handleGenAIStreamViaCanonical(
 	}
 
 	// Tee for usage from the final chunk.
-	chunkCh, usageCh := teeStreamUsage(rawChunkCh)
+	chunkCh, usageCh := teeStreamUsage(ctx, rawChunkCh)
 
 	finalize := func(detach bool) {
 		applyCanonicalStreamUsage(rc, usageCh)

--- a/agentcc-gateway/internal/server/handlers_genai.go
+++ b/agentcc-gateway/internal/server/handlers_genai.go
@@ -199,9 +199,28 @@ func (h *Handlers) GenAIHandler(w http.ResponseWriter, r *http.Request) {
 // ─── Native pass-through helpers ─────────────────────────────────────────────
 
 func (h *Handlers) handleGenAINonStream(ctx context.Context, w http.ResponseWriter, rc *models.RequestContext, gp providers.GenAINativeProvider, model string, reqBody []byte, headers map[string]string) {
-	respBody, statusCode, err := gp.GenerateContent(ctx, model, reqBody, headers)
+	var respBody []byte
+	var statusCode int
+
+	err := h.engine.Process(ctx, rc, func(ctx context.Context, rc *models.RequestContext) error {
+		var callErr error
+		respBody, statusCode, callErr = gp.GenerateContent(ctx, model, reqBody, headers)
+		if callErr != nil {
+			return callErr
+		}
+		if statusCode < 400 {
+			applyGenAIUsage(rc, respBody)
+		}
+		return nil
+	})
 	if err != nil {
 		writeGenAIErrorFromError(w, err)
+		return
+	}
+
+	// A plugin answered instead of the provider — a cache hit.
+	if respBody == nil {
+		h.writeGenAIShortCircuit(w, rc)
 		return
 	}
 
@@ -214,15 +233,6 @@ func (h *Handlers) handleGenAINonStream(ctx context.Context, w http.ResponseWrit
 		return
 	}
 
-	// Extract usage for cost tracking (completion folds in thinking tokens).
-	promptTokens, completionTokens, _ := genaifmt.ExtractUsageMetadata(respBody)
-	if promptTokens > 0 {
-		rc.Metadata["input_tokens"] = strconv.Itoa(promptTokens)
-	}
-	if completionTokens > 0 {
-		rc.Metadata["output_tokens"] = strconv.Itoa(completionTokens)
-	}
-
 	h.setAgentccHeaders(w, rc)
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusOK)
@@ -230,12 +240,38 @@ func (h *Handlers) handleGenAINonStream(ctx context.Context, w http.ResponseWrit
 }
 
 func (h *Handlers) handleGenAIStream(ctx context.Context, w http.ResponseWriter, rc *models.RequestContext, gp providers.GenAINativeProvider, model string, reqBody []byte, headers map[string]string) {
-	stream, statusCode, err := gp.StreamGenerateContent(ctx, model, reqBody, headers)
-	if err != nil {
+	var stream io.ReadCloser
+	var statusCode int
+
+	// Post-plugins wait for the closing chunk, where the counts arrive.
+	if err := h.engine.Process(ctx, rc, func(ctx context.Context, rc *models.RequestContext) error {
+		var callErr error
+		stream, statusCode, callErr = gp.StreamGenerateContent(ctx, model, reqBody, headers)
+		return callErr
+	}); err != nil {
 		writeGenAIErrorFromError(w, err)
 		return
 	}
+
+	if rc.Flags.ShortCircuited && rc.Response != nil {
+		h.writeGenAIShortCircuit(w, rc)
+		return
+	}
+	if stream == nil {
+		writeGenAIErrorFromError(w, models.ErrInternal("no stream from provider"))
+		return
+	}
 	defer stream.Close()
+
+	var usage genaifmt.StreamUsageScanner
+	finalize := func(detach bool) {
+		applyGenAIStreamUsage(rc, &usage)
+		pluginCtx := ctx
+		if detach {
+			pluginCtx = context.Background()
+		}
+		h.engine.RunPostPlugins(pluginCtx, rc)
+	}
 
 	// If upstream returned an error status, read and forward.
 	if statusCode >= 400 {
@@ -256,6 +292,8 @@ func (h *Handlers) handleGenAIStream(ctx context.Context, w http.ResponseWriter,
 	flusher, ok := w.(http.Flusher)
 	if !ok {
 		slog.Warn("streaming not supported", "request_id", rc.RequestID)
+		// Stream is open, so the request still has to be accounted for.
+		finalize(true)
 		return
 	}
 	flusher.Flush()
@@ -265,8 +303,11 @@ func (h *Handlers) handleGenAIStream(ctx context.Context, w http.ResponseWriter,
 	for {
 		n, readErr := stream.Read(buf)
 		if n > 0 {
+			usage.Write(buf[:n])
 			if _, writeErr := w.Write(buf[:n]); writeErr != nil {
 				slog.Warn("error writing genai stream", "request_id", rc.RequestID, "error", writeErr)
+				// Client gone, tokens still spent — detach from its context.
+				finalize(true)
 				return
 			}
 			flusher.Flush()
@@ -275,15 +316,77 @@ func (h *Handlers) handleGenAIStream(ctx context.Context, w http.ResponseWriter,
 			if readErr != io.EOF {
 				slog.Warn("error reading genai stream", "request_id", rc.RequestID, "error", readErr)
 			}
+			finalize(false)
 			return
 		}
 
 		select {
 		case <-ctx.Done():
+			finalize(true)
 			return
 		default:
 		}
 	}
+}
+
+// applyGenAIUsage lifts usageMetadata onto rc. rc.Response is populated because
+// that is what the cost plugin prices from; it carries usage only.
+func applyGenAIUsage(rc *models.RequestContext, respBody []byte) {
+	promptTokens, completionTokens, _ := genaifmt.ExtractUsageMetadata(respBody)
+	if model := genaifmt.ExtractModelVersion(respBody); model != "" {
+		rc.ResolvedModel = model
+	}
+	if promptTokens > 0 {
+		rc.Metadata["input_tokens"] = strconv.Itoa(promptTokens)
+	}
+	if completionTokens > 0 {
+		rc.Metadata["output_tokens"] = strconv.Itoa(completionTokens)
+	}
+	if promptTokens == 0 && completionTokens == 0 {
+		return
+	}
+	setUsageResponse(rc, promptTokens, completionTokens)
+}
+
+// applyGenAIStreamUsage moves collected counts onto rc. Left nil when the
+// stream reported none, so the cost plugin skips rather than bills zero.
+func applyGenAIStreamUsage(rc *models.RequestContext, usage *genaifmt.StreamUsageScanner) {
+	if model := usage.Model(); model != "" {
+		rc.ResolvedModel = model
+	}
+	promptTokens, completionTokens, ok := usage.Usage()
+	if !ok {
+		return
+	}
+	if promptTokens > 0 {
+		rc.Metadata["input_tokens"] = strconv.Itoa(promptTokens)
+	}
+	if completionTokens > 0 {
+		rc.Metadata["output_tokens"] = strconv.Itoa(completionTokens)
+	}
+	setUsageResponse(rc, promptTokens, completionTokens)
+}
+
+// writeGenAIShortCircuit renders a plugin-produced response in GenAI format.
+func (h *Handlers) writeGenAIShortCircuit(w http.ResponseWriter, rc *models.RequestContext) {
+	translator, ok := translation.InboundFor("google")
+	if !ok || rc.Response == nil {
+		h.setAgentccHeaders(w, rc)
+		genaifmt.WriteError(w, http.StatusInternalServerError, "INTERNAL",
+			"request was answered internally but the response could not be formatted")
+		return
+	}
+	out, err := translator.ResponseFromCanonical(rc.Response)
+	if err != nil {
+		h.setAgentccHeaders(w, rc)
+		genaifmt.WriteError(w, http.StatusInternalServerError, "INTERNAL",
+			"failed to format response: "+err.Error())
+		return
+	}
+	h.setAgentccHeaders(w, rc)
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	w.Write(out)
 }
 
 func (h *Handlers) handleGenAICountTokens(ctx context.Context, w http.ResponseWriter, rc *models.RequestContext, gp providers.GenAINativeProvider, model string, reqBody []byte, headers map[string]string) {
@@ -340,7 +443,19 @@ func (h *Handlers) handleGenAINonStreamViaCanonical(
 	translator translation.InboundTranslator,
 	canonicalReq *models.ChatCompletionRequest,
 ) {
-	canonicalResp, err := provider.ChatCompletion(ctx, canonicalReq)
+	// Without this the pipeline sees a nil rc.Request.
+	rc.Request = canonicalReq
+
+	var canonicalResp *models.ChatCompletionResponse
+	err := h.engine.Process(ctx, rc, func(ctx context.Context, rc *models.RequestContext) error {
+		var callErr error
+		canonicalResp, callErr = provider.ChatCompletion(ctx, canonicalReq)
+		if callErr != nil {
+			return callErr
+		}
+		rc.Response = canonicalResp
+		return nil
+	})
 	if err != nil {
 		var apiErr *models.APIError
 		if errors.As(err, &apiErr) {
@@ -360,6 +475,23 @@ func (h *Handlers) handleGenAINonStreamViaCanonical(
 		w.Header().Set("Content-Type", ct)
 		w.WriteHeader(status)
 		w.Write(body)
+		return
+	}
+
+	// A plugin answered instead of the provider — a cache hit.
+	if canonicalResp == nil {
+		canonicalResp = rc.Response
+	}
+	if canonicalResp == nil {
+		status, errBody, ct := translator.ErrorFromCanonical(&models.APIError{
+			Status:  http.StatusInternalServerError,
+			Type:    models.ErrTypeServer,
+			Message: "no response from provider",
+		})
+		h.setAgentccHeaders(w, rc)
+		w.Header().Set("Content-Type", ct)
+		w.WriteHeader(status)
+		w.Write(errBody)
 		return
 	}
 
@@ -407,7 +539,39 @@ func (h *Handlers) handleGenAIStreamViaCanonical(
 	translator translation.InboundTranslator,
 	canonicalReq *models.ChatCompletionRequest,
 ) {
-	chunkCh, errCh := provider.StreamChatCompletion(ctx, canonicalReq)
+	rc.Request = canonicalReq
+
+	var rawChunkCh <-chan models.StreamChunk
+	var errCh <-chan error
+
+	if err := h.engine.Process(ctx, rc, func(ctx context.Context, rc *models.RequestContext) error {
+		rawChunkCh, errCh = provider.StreamChatCompletion(ctx, canonicalReq)
+		return nil
+	}); err != nil {
+		writeGenAIErrorFromError(w, err)
+		return
+	}
+
+	if rc.Flags.ShortCircuited && rc.Response != nil {
+		h.writeGenAIShortCircuit(w, rc)
+		return
+	}
+	if rawChunkCh == nil {
+		writeGenAIErrorFromError(w, models.ErrInternal("no stream from provider"))
+		return
+	}
+
+	// Tee for usage from the final chunk.
+	chunkCh, usageCh := teeStreamUsage(rawChunkCh)
+
+	finalize := func(detach bool) {
+		applyCanonicalStreamUsage(rc, usageCh)
+		pluginCtx := ctx
+		if detach {
+			pluginCtx = context.Background()
+		}
+		h.engine.RunPostPlugins(pluginCtx, rc)
+	}
 
 	// Translate OpenAI chunks into Gemini SSE events.
 	// Gemini's translator uses blocking sends (cap 32); the consumer here drives
@@ -423,6 +587,8 @@ func (h *Handlers) handleGenAIStreamViaCanonical(
 	flusher, ok := w.(http.Flusher)
 	if !ok {
 		slog.Warn("streaming not supported", "request_id", rc.RequestID)
+		// Stream is open, so the request still has to be accounted for.
+		finalize(true)
 		return
 	}
 	flusher.Flush()
@@ -430,6 +596,7 @@ func (h *Handlers) handleGenAIStreamViaCanonical(
 	for {
 		select {
 		case <-ctx.Done():
+			finalize(true)
 			return
 
 		case event, ok := <-eventCh:
@@ -439,6 +606,7 @@ func (h *Handlers) handleGenAIStreamViaCanonical(
 			}
 			if _, writeErr := w.Write(event); writeErr != nil {
 				slog.Warn("error writing translated genai stream", "request_id", rc.RequestID, "error", writeErr)
+				finalize(true)
 				return
 			}
 			flusher.Flush()
@@ -452,6 +620,7 @@ func (h *Handlers) handleGenAIStreamViaCanonical(
 			}
 			if err != nil {
 				slog.Warn("translator stream error", "request_id", rc.RequestID, "error", err)
+				finalize(false)
 				return
 			}
 
@@ -462,11 +631,13 @@ func (h *Handlers) handleGenAIStreamViaCanonical(
 			}
 			if err != nil {
 				slog.Warn("provider stream error", "request_id", rc.RequestID, "error", err)
+				finalize(false)
 				return
 			}
 		}
 
 		if eventCh == nil && errCh == nil && translatorErrCh == nil {
+			finalize(false)
 			return
 		}
 	}

--- a/agentcc-gateway/internal/server/pipeline_coverage_test.go
+++ b/agentcc-gateway/internal/server/pipeline_coverage_test.go
@@ -1,0 +1,62 @@
+package server
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+// An endpoint that skips the pipeline is billable traffic that is invisible and
+// unmetered — cost, budget, credits, logging and tracing all live in plugins.
+//
+// Asserted against the source because the failure is an omission, not a
+// behaviour: /v1/messages and generateContent shipped without calling h.engine,
+// worked perfectly, and were free and untraced for as long as they existed.
+// Handlers with no provider call behind them are not listed.
+func TestBillableHandlersRunThePipeline(t *testing.T) {
+	billable := map[string][]string{
+		"handlers.go":            {"ChatCompletion"},
+		"handlers_completion.go": {"TextCompletion"},
+		"handlers_embedding.go":  {"CreateEmbedding"},
+		"handlers_image.go":      {"CreateImage"},
+		"handlers_audio.go":      {"CreateSpeech", "CreateTranscription", "CreateTranslation"},
+		"handlers_rerank.go":     {"Rerank"},
+		"handlers_search.go":     {"Search"},
+		"handlers_ocr.go":        {"OCR"},
+		"handlers_responses.go":  {"CreateResponse"},
+		"handlers_anthropic.go":  {"AnthropicMessages"},
+		"handlers_genai.go":      {"GenAIHandler"},
+	}
+
+	for file, handlers := range billable {
+		src, err := os.ReadFile(file)
+		if err != nil {
+			t.Fatalf("read %s: %v", file, err)
+		}
+		if !strings.Contains(string(src), "h.engine.Process(") {
+			t.Errorf("%s never calls h.engine.Process — %s bypasses cost, budget, "+
+				"credits, logging and tracing", file, strings.Join(handlers, "/"))
+		}
+	}
+}
+
+// Process skips post-plugins for streams, since usage arrives only at close, so
+// a streaming handler must call RunPostPlugins itself or never be costed.
+func TestStreamingHandlersRunPostPlugins(t *testing.T) {
+	for _, file := range []string{
+		"handlers.go",
+		"handlers_completion.go",
+		"handlers_responses.go",
+		"handlers_anthropic.go",
+		"handlers_genai.go",
+	} {
+		src, err := os.ReadFile(file)
+		if err != nil {
+			t.Fatalf("read %s: %v", file, err)
+		}
+		if !strings.Contains(string(src), "RunPostPlugins(") {
+			t.Errorf("%s streams but never calls RunPostPlugins — streamed "+
+				"requests there are never costed or logged", file)
+		}
+	}
+}

--- a/agentcc-gateway/internal/server/stream_usage_test.go
+++ b/agentcc-gateway/internal/server/stream_usage_test.go
@@ -1,0 +1,115 @@
+package server
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/futureagi/agentcc-gateway/internal/models"
+)
+
+// The translator returns on ctx.Done without draining its input, so on client
+// disconnect or a stream error nobody reads the tee's output again. Forwarding
+// would park there forever while finalize waits on the usage channel, leaking
+// the handler goroutine, the tee and the provider stream.
+func TestTeeStreamUsage_ConsumerAbandonsStream(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	in := make(chan models.StreamChunk)
+	out, usageCh := teeStreamUsage(ctx, in)
+
+	go func() {
+		defer close(in)
+		for i := 0; i < 8; i++ {
+			in <- models.StreamChunk{Model: "claude-3"}
+		}
+		in <- models.StreamChunk{
+			Model: "claude-3",
+			Usage: &models.Usage{PromptTokens: 11, CompletionTokens: 23},
+		}
+	}()
+
+	<-out // read one, then abandon the stream exactly as the translator does
+	cancel()
+
+	rc := &models.RequestContext{Metadata: map[string]string{}, Model: "claude-3"}
+	done := make(chan struct{})
+	go func() {
+		applyCanonicalStreamUsage(rc, usageCh)
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("deadlock: finalize blocked on the usage channel while the tee was " +
+			"parked forwarding to a consumer that had gone away")
+	}
+
+	// The counts still have to arrive — the tokens were spent.
+	if rc.Response == nil || rc.Response.Usage == nil {
+		t.Fatal("usage lost when the consumer abandoned the stream")
+	}
+	if got := rc.Response.Usage.PromptTokens; got != 11 {
+		t.Errorf("PromptTokens = %d, want 11", got)
+	}
+	if got := rc.Response.Usage.CompletionTokens; got != 23 {
+		t.Errorf("CompletionTokens = %d, want 23", got)
+	}
+}
+
+func TestTeeStreamUsage_ForwardsEveryChunk(t *testing.T) {
+	in := make(chan models.StreamChunk)
+	out, usageCh := teeStreamUsage(context.Background(), in)
+
+	go func() {
+		defer close(in)
+		for i := 0; i < 3; i++ {
+			in <- models.StreamChunk{Model: "m"}
+		}
+		in <- models.StreamChunk{Model: "resolved-m", Usage: &models.Usage{PromptTokens: 2, CompletionTokens: 4}}
+	}()
+
+	seen := 0
+	for range out {
+		seen++
+	}
+	if seen != 4 {
+		t.Errorf("forwarded %d chunks, want 4", seen)
+	}
+
+	rc := &models.RequestContext{Metadata: map[string]string{}, Model: "m"}
+	applyCanonicalStreamUsage(rc, usageCh)
+
+	if rc.ResolvedModel != "resolved-m" {
+		t.Errorf("ResolvedModel = %q, want %q", rc.ResolvedModel, "resolved-m")
+	}
+	if rc.Response == nil || rc.Response.Usage.TotalTokens != 6 {
+		t.Errorf("usage not carried through: %+v", rc.Response)
+	}
+}
+
+// A provider that sends no usage must leave rc.Response nil, so the cost plugin
+// skips the request rather than pricing it at zero.
+func TestTeeStreamUsage_NoUsageLeavesResponseNil(t *testing.T) {
+	in := make(chan models.StreamChunk)
+	out, usageCh := teeStreamUsage(context.Background(), in)
+
+	go func() {
+		defer close(in)
+		in <- models.StreamChunk{Model: "m"}
+	}()
+	for range out {
+	}
+
+	rc := &models.RequestContext{Metadata: map[string]string{}, Model: "m"}
+	applyCanonicalStreamUsage(rc, usageCh)
+
+	if rc.Response != nil {
+		t.Errorf("rc.Response = %+v, want nil so cost skips rather than billing zero", rc.Response)
+	}
+	if _, ok := rc.Metadata["input_tokens"]; ok {
+		t.Error("input_tokens recorded for a stream that reported none")
+	}
+}


### PR DESCRIPTION
Closes TH-7619.

`handlers_anthropic.go` and `handlers_genai.go` contain **zero** references to `h.engine`. Every other billable endpoint calls `h.engine.Process(ctx, rc, providerCall)`; these two never did, so no plugin has ever run on them.

Anyone calling the gateway with the **Anthropic SDK or the Google GenAI SDK** got:

- no OTel span — the request appears nowhere in the platform
- no request-log row
- no cost attribution
- no budget enforcement, no credit deduction, no rate limiting

Billable traffic, invisible and unmetered.

## Why nobody noticed

The endpoints work. Correct Anthropic/Gemini-shaped responses, correct translation, correct routing — nothing errors. The telemetry is just absent, which looks identical to "no traffic yet".

The proof, before this change:

```
POST /v1/messages
X-Agentcc-Latency-Ms: 22
X-Agentcc-Provider: mock
X-Agentcc-Model-Used: gpt-4o
                                ← no X-Agentcc-Cost
```

`setAgentccHeaders` is shared and emits `x-agentcc-cost` whenever `rc.Metadata["cost"]` is set. The OpenAI path on the same gateway returned `x-agentcc-cost: 0.004115`. Its absence here is the cost plugin never running — and by the same token, neither did budget, credits, logging or otel.

Auth still applied throughout: it is enforced in middleware, not by the auth plugin, which is why the gap was invisible from outside.

## ⚠️ Behaviour change — read this first

Budget, credits, rate limiting and the auth plugin's model-availability gate **begin enforcing** on these two endpoints. Traffic that works today can newly return 402, 429 or 403 (`"model X is not available for this API key"` for a `byok` key). That is the intended fix — these endpoints stop being a free, unmetered hole — but it is a real change in behaviour for anyone already using them, and worth staging deliberately rather than shipping quietly.

## Scope

All eight paths: native pass-through and translated, streaming and not, per dialect.

**Usage recovery.** The cost plugin prices from `rc.Response.Usage`, which the native pass-through paths never build — they forward the caller's bytes and return the provider's bytes. So each path recovers usage: from the response body where there is one (`ExtractUsage` / `ExtractUsageMetadata`), from the teed canonical chunk channel on the translated streams, and from a new bounded scanner over the relayed SSE on the native streams.

**Streams keep a 16 KB window at each end, not the whole response.** Anthropic reports input tokens in the opening `message_start` and output in the closing `message_delta`; Gemini revises `usageMetadata` up to the last chunk. Buffering whole responses to bill them would hold every concurrent stream in memory.

**A stream reporting no usage leaves `rc.Response` nil**, so the cost plugin skips it. A missing cost is honest; a `$0.00` cost is a wrong number that reads as authoritative.

**Post-plugins run from every exit**, including client disconnect — on a context the disconnect cannot cancel. The tokens were spent whether or not anyone stayed to read them.

**Short-circuits are handled.** A plugin answering the request (a cache hit) produces a canonical response, which is converted back to the dialect's wire format rather than leaking OpenAI shape to an Anthropic client.

## Also fixed: nil dereference in toolpolicy

`toolpolicy.ProcessRequest` does `len(rc.Request.Tools)` with no nil check (`toolpolicy.go:53`). Only three handlers set `rc.Request`, so **enabling `tool_policy` returns a 500 on `/v1/embeddings`, `/v1/images/generations`, `/v1/audio/*`, `/v1/ocr`, `/v1/rerank`, `/v1/search` and `/v1/responses`.** Reproduced with a panic and stack trace; the recovery middleware turns it into a 500 rather than a crash. Included here because this PR adds two more callers with a nil `rc.Request`.

## Regression guard

`TestBillableHandlersRunThePipeline` asserts all 11 billable handlers call `h.engine.Process`, and `TestStreamingHandlersRunPostPlugins` asserts the streaming ones close the loop.

These read the source rather than driving the handlers, deliberately. The failure being guarded is an **omission that works perfectly** — no behavioural test would ever have caught the original bug, because nothing misbehaved. Only the missing call says so. Verified the guard discriminates: `handlers_files.go` and `handlers_vector_stores.go` score zero and would fail if listed.

## Verified

Built from this branch and run against the live stack:

```
POST /v1/messages                  → X-Agentcc-Cost: 0.000053   (was absent)
POST /v1beta/.../generateContent   → X-Agentcc-Cost: 0.001138   (live Vertex, was absent)
```

Both produced spans at the collector with `gen_ai.cost.total`, `gen_ai.usage.*` and the correct `gen_ai.span.kind` — `classifyEndpoint` already mapped `anthropic_messages` / `genai_generate` / `genai_stream`, so someone anticipated these spans; they simply were never produced.

Full suite green.

## Known limitations

- **Tool policy and semantic caching do not apply on the native pass-through path.** It forwards the caller's original bytes, so anything a plugin rewrote on the request would be silently discarded. Those handlers get a minimal `rc.Request` carrying model and stream only — honest non-enforcement rather than a false one. Called out in a comment at the fork.
- **`/v1/audio/speech/stream` has the identical defect** — `StreamSpeech` calls `sp.CreateSpeech` directly with no pipeline. Not fixed here; it is a different handler shape and deserves its own change.
- **`/v1/videos` submits to an async worker** whose pipeline usage I have not verified. Worth a separate look.
- Guardrails are wired outside the engine in the chat handler and are untouched by this PR.

## Overlaps with #2230

Both PRs modify `handlers_anthropic.go` and `handlers_genai.go`. This one is based on current `dev` and contains only the pipeline wiring — #2230's caller-dimension calls are not here, so whichever merges second will need a small conflict resolution in those two files. Not stacked, so gateway CI runs the Go suite on both.