### PR TITLE
[fix] agentcc-gateway: upgrade Go toolchain to patch stdlib CVEs

### DIFF
--- a/agentcc-gateway/Dockerfile
+++ b/agentcc-gateway/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.23-alpine AS builder
+FROM golang:1.26-alpine AS builder
 
 WORKDIR /build
 

--- a/agentcc-gateway/go.mod
+++ b/agentcc-gateway/go.mod
@@ -1,6 +1,6 @@
 module github.com/futureagi/agentcc-gateway
 
-go 1.23.0
+go 1.25.0
 
 require (
 	github.com/gorilla/websocket v1.5.3

--- a/agentcc-gateway/internal/server/server.go
+++ b/agentcc-gateway/internal/server/server.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"crypto/subtle"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"log/slog"
@@ -810,7 +811,7 @@ func New(cfg *config.Config, configPath string, registry *providers.Registry, en
 					if errResp.Error.Code != "" {
 						return nil, fmt.Errorf("%s: %s", errResp.Error.Code, errResp.Error.Message)
 					}
-					return nil, fmt.Errorf(errResp.Error.Message)
+					return nil, errors.New(errResp.Error.Message)
 				}
 				return nil, fmt.Errorf("chat completion failed with status %d", rec.Code)
 			}


### PR DESCRIPTION
## Summary

Upgrades the `agentcc-gateway` Go toolchain to remediate 5 stdlib CVEs (1 CRITICAL, 4 HIGH) flagged by Trivy on `futureagi/agentcc-gateway:latest`. All findings were in the Go standard library baked into the binary (stdlib v1.23.12) — no third-party dependency was affected. Rebuilt image scans clean (0 vulnerabilities, stdlib v1.26.7).

## Linked issues

Fixed TH-7621
Linear: https://linear.app/future-agi/issue/TH-7621

## Type of change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

---

## 1) What changes were done

**A. Go toolchain upgrade**

- `Dockerfile`: builder `golang:1.23-alpine` → `golang:1.26-alpine` (ships stdlib ≥ 1.26.4, covers all 5 CVEs).
- `go.mod`: `go 1.23.0` → `go 1.25.0` (minimum-version floor; CI reads `go-version-file`, release builds from the Dockerfile).

**B. Vet-required source fix**

- `internal/server/server.go`: `fmt.Errorf(errResp.Error.Message)` → `errors.New(errResp.Error.Message)`. Go 1.24+ `go vet` (enforced by `go test`) rejects a non-constant format string, so the package failed to build under test until this was fixed. Behavior-preserving, and also avoids `%`-mangling of provider error messages.

## 2) Why the changes were done

- **Security:** clears CVE-2025-68121 (CRITICAL, crypto/tls), CVE-2025-61726, CVE-2025-61729, CVE-2026-25679, CVE-2026-27145 (HIGH, crypto/x509 + net/url). Go 1.23 is EOL and no longer receives patches.

## Verification

- `go build` / `go test ./...` pass; no new `go vet` or race findings.
- Rebuilt image scanned with Trivy: **0 vulnerabilities**, stdlib **v1.26.7**.
- End-to-end: upgraded gateway deployed locally, a real eval routed through it (`turing_large` → Vertex, `x-agentcc-*` headers returned).

## Notes

- Pre-existing data race in `internal/a2a/server.go` surfaced once the package compiled under the stricter vet — not caused by this change, tracked separately.
- `agentcc-gateway/README.md` Go 1.23 badges and `fi-collector` (Go 1.24) are follow-ups.
