### PR TITLE
fix: eval task failures — unscoped CH span reads, empty mapping paths, string row limit

### DIFF
--- a/frontend/src/sections/common/EvalPicker/index.js
+++ b/frontend/src/sections/common/EvalPicker/index.js
@@ -7,4 +7,7 @@ export { default as EvalPickerCreateNew } from "./EvalPickerCreateNew";
 export { useEvalPickerContext } from "./context/EvalPickerContext";
 export { default as EvalPickerProvider } from "./context/EvalPickerProvider";
 export { useEvalPickerData } from "./hooks/useEvalPickerData";
-export { serializeEvalConfig } from "./serializeEvalConfig";
+export {
+  sanitizeEvalMapping,
+  serializeEvalConfig,
+} from "./serializeEvalConfig";

--- a/frontend/src/sections/common/EvalPicker/serializeEvalConfig.js
+++ b/frontend/src/sections/common/EvalPicker/serializeEvalConfig.js
@@ -19,6 +19,18 @@ const RUN_CONFIG_KEYS = [
   "params",
 ];
 
+// A cleared auto-mapped field reaches us as "" — the eval runner treats a
+// present-but-empty path as a required attribute it can never resolve and
+// fails every row, while an absent key falls through to context injection.
+export function sanitizeEvalMapping(mapping) {
+  return Object.fromEntries(
+    Object.entries(mapping || {}).filter(
+      ([, path]) =>
+        path != null && !(typeof path === "string" && path.trim() === ""),
+    ),
+  );
+}
+
 export function serializeEvalConfig(evalConfig) {
   const runConfig = {};
   for (const k of RUN_CONFIG_KEYS) {
@@ -31,7 +43,7 @@ export function serializeEvalConfig(evalConfig) {
     template_id: evalConfig.templateId,
     name: evalConfig.name,
     model: evalConfig.model,
-    mapping: evalConfig.mapping || {},
+    mapping: sanitizeEvalMapping(evalConfig.mapping),
     config: {
       ...(evalConfig.config || {}),
       // BE looks up function-param values at `config.params` (normalize_eval_runtime_config).

--- a/frontend/src/sections/common/EvalPicker/serializeEvalConfig.test.js
+++ b/frontend/src/sections/common/EvalPicker/serializeEvalConfig.test.js
@@ -35,6 +35,30 @@ describe("serializeEvalConfig", () => {
     expect(payload).not.toHaveProperty("knowledge_bases");
   });
 
+  it("drops mapping entries the user cleared (empty-string paths)", () => {
+    // Auto-mapped fields the user removed come through as "" — sending them
+    // makes the eval runner treat the key as a required attribute with an
+    // empty path and fail every row ("Required attribute '' ... not found").
+    // No mapping at all must serialize as {} so context-only evals run.
+    const payload = serializeEvalConfig({
+      templateId: "template-1",
+      name: "context_only",
+      mapping: { agent_prompt: "", conversation: "   ", output: "answer" },
+    });
+
+    expect(payload.mapping).toEqual({ output: "answer" });
+  });
+
+  it("serializes an all-cleared mapping as an empty object", () => {
+    const payload = serializeEvalConfig({
+      templateId: "template-1",
+      name: "context_only",
+      mapping: { agent_prompt: "", conversation: "" },
+    });
+
+    expect(payload.mapping).toEqual({});
+  });
+
   it("keeps canonical filter lists unchanged", () => {
     const filters = [
       {

--- a/frontend/src/sections/common/EvalsTasks/EditTaskDrawer/DetailsEdit.jsx
+++ b/frontend/src/sections/common/EvalsTasks/EditTaskDrawer/DetailsEdit.jsx
@@ -43,6 +43,7 @@ import {
 import ConfiguredEvaluationType from "src/sections/develop-detail/Common/ConfiguredEvaluationType/ConfiguredEvaluationType";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import axios, { endpoints } from "src/utils/axios";
+import { sanitizeEvalMapping } from "src/sections/common/EvalPicker/serializeEvalConfig";
 import { useDebounce } from "src/hooks/use-debounce";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { getDefaultTaskValues } from "../common";
@@ -386,7 +387,7 @@ const DetailsEdit = ({
             project: project,
             name: values.name,
             eval_template: values.eval_template,
-            mapping: values.mapping,
+            mapping: sanitizeEvalMapping(values.mapping),
             config: values.config,
             filters: getNewTaskFilters(formValues, observeId, true).filters,
           });

--- a/frontend/src/sections/common/EvalsTasks/NewTaskDrawer/__tests__/validation.test.js
+++ b/frontend/src/sections/common/EvalsTasks/NewTaskDrawer/__tests__/validation.test.js
@@ -253,3 +253,39 @@ describe("eval task filter payload contract", () => {
     expect(attributeFilters[0].filter_config.filter_value).toBe("");
   });
 });
+
+describe("spansLimit coercion", () => {
+  // The custom row-limit input yields a string ("10"); the request contract
+  // declares spans_limit as an integer, and strict request-contract
+  // validation aborts the POST before it is sent — surfacing only a generic
+  // "Something went wrong". Preset buttons set numbers and work.
+  const baseForm = {
+    name: "t",
+    project: "1372e742-a10b-4d98-9ca4-31ef4d67115f",
+    samplingRate: 50,
+    evalsDetails: [{ id: "cfg-1" }],
+    startDate: "2026-08-01",
+    endDate: "2026-08-20",
+    runType: "historical",
+    rowType: "traces",
+    filters: [],
+  };
+
+  it("coerces a custom string row limit to a number", async () => {
+    const { NewTaskValidationSchema } = await import("../validation");
+    const parsed = NewTaskValidationSchema().parse({
+      ...baseForm,
+      spansLimit: "10",
+    });
+    expect(parsed.spansLimit).toBe(10);
+  });
+
+  it("keeps preset numeric row limits as numbers", async () => {
+    const { NewTaskValidationSchema } = await import("../validation");
+    const parsed = NewTaskValidationSchema().parse({
+      ...baseForm,
+      spansLimit: 100000,
+    });
+    expect(parsed.spansLimit).toBe(100000);
+  });
+});

--- a/frontend/src/sections/common/EvalsTasks/NewTaskDrawer/validation.js
+++ b/frontend/src/sections/common/EvalsTasks/NewTaskDrawer/validation.js
@@ -32,66 +32,68 @@ const TOP_LEVEL_SIBLING_KEY_BY_PROPERTY = {
 // into "in [A, B]" and invert intent. OR is expressed within a single multi-
 // value `in`/`not_in` row, not across rows.
 export const extractAttributeFilters = (filters) => {
-  return (filters || [])
-    .filter((f) => {
-      if (!f) return false;
-      // Sibling keys are emitted separately by getNewTaskFilters.
-      if (f.property in TOP_LEVEL_SIBLING_KEY_BY_PROPERTY) return false;
-      // Legacy rows with neither apiColType nor propertyId are BE no-ops.
-      if (!f.propertyId && f.property !== "attributes") return false;
-      return true;
-    })
-    .map((f) => {
-      const columnId = f.propertyId || f.property;
-      const op = f?.filterConfig?.filterOp || "equals";
-      const filterType = f?.filterConfig?.filterType || "text";
-      const v = f?.filterConfig?.filterValue;
+  return (
+    (filters || [])
+      .filter((f) => {
+        if (!f) return false;
+        // Sibling keys are emitted separately by getNewTaskFilters.
+        if (f.property in TOP_LEVEL_SIBLING_KEY_BY_PROPERTY) return false;
+        // Legacy rows with neither apiColType nor propertyId are BE no-ops.
+        if (!f.propertyId && f.property !== "attributes") return false;
+        return true;
+      })
+      .map((f) => {
+        const columnId = f.propertyId || f.property;
+        const op = f?.filterConfig?.filterOp || "equals";
+        const filterType = f?.filterConfig?.filterType || "text";
+        const v = f?.filterConfig?.filterValue;
 
-      // Resolution: pinned ANNOTATION ids → row.apiColType (canonical) →
-      // fieldCategory fallback → SPAN_ATTRIBUTE default.
-      let apiColType;
-      if (ANNOTATION_COLUMN_IDS.has(columnId)) {
-        apiColType = "ANNOTATION";
-      } else if (f?.apiColType) {
-        apiColType = f.apiColType;
-      } else if (FIELD_CATEGORY_TO_COL_TYPE[f?.fieldCategory]) {
-        apiColType = FIELD_CATEGORY_TO_COL_TYPE[f.fieldCategory];
-      } else {
-        apiColType = "SPAN_ATTRIBUTE";
-      }
+        // Resolution: pinned ANNOTATION ids → row.apiColType (canonical) →
+        // fieldCategory fallback → SPAN_ATTRIBUTE default.
+        let apiColType;
+        if (ANNOTATION_COLUMN_IDS.has(columnId)) {
+          apiColType = "ANNOTATION";
+        } else if (f?.apiColType) {
+          apiColType = f.apiColType;
+        } else if (FIELD_CATEGORY_TO_COL_TYPE[f?.fieldCategory]) {
+          apiColType = FIELD_CATEGORY_TO_COL_TYPE[f.fieldCategory];
+        } else {
+          apiColType = "SPAN_ATTRIBUTE";
+        }
 
-      let filterValue;
-      if (NO_VALUE_OPS.has(op)) {
-        filterValue = "";
-      } else if (RANGE_OPS.has(op)) {
-        if (Array.isArray(v) && v.length > 0) filterValue = v;
-      } else if (LIST_OPS.has(op)) {
-        const arr = Array.isArray(v)
-          ? v
-          : v !== undefined && v !== null && v !== ""
-            ? [v]
-            : [];
-        if (arr.length > 0) filterValue = arr;
-      } else if (v !== undefined && v !== null && v !== "") {
-        filterValue = v;
-      }
+        let filterValue;
+        if (NO_VALUE_OPS.has(op)) {
+          filterValue = "";
+        } else if (RANGE_OPS.has(op)) {
+          if (Array.isArray(v) && v.length > 0) filterValue = v;
+        } else if (LIST_OPS.has(op)) {
+          const arr = Array.isArray(v)
+            ? v
+            : v !== undefined && v !== null && v !== ""
+              ? [v]
+              : [];
+          if (arr.length > 0) filterValue = arr;
+        } else if (v !== undefined && v !== null && v !== "") {
+          filterValue = v;
+        }
 
-      return {
-        column_id: columnId,
-        filter_config: {
-          filter_type: filterType,
-          filter_op: op,
-          col_type: apiColType,
-          ...(filterValue !== undefined && { filter_value: filterValue }),
-        },
-      };
-    })
-    // Drop value-less in/not_in (legacy/hand-edited)
-    .filter(
-      (entry) =>
-        !LIST_OPS.has(entry.filter_config.filter_op) ||
-        entry.filter_config.filter_value !== undefined,
-    );
+        return {
+          column_id: columnId,
+          filter_config: {
+            filter_type: filterType,
+            filter_op: op,
+            col_type: apiColType,
+            ...(filterValue !== undefined && { filter_value: filterValue }),
+          },
+        };
+      })
+      // Drop value-less in/not_in (legacy/hand-edited)
+      .filter(
+        (entry) =>
+          !LIST_OPS.has(entry.filter_config.filter_op) ||
+          entry.filter_config.filter_value !== undefined,
+      )
+  );
 };
 
 // Sibling-key extraction: rows whose property maps to a top-level BE key
@@ -205,7 +207,13 @@ export const NewTaskValidationSchema = () =>
       const finalData = {
         name: data?.name,
         project: data?.project,
-        spansLimit: data?.spansLimit,
+        // The custom row-limit input yields a string; the API contract
+        // requires spans_limit as an integer, and strict request-contract
+        // validation aborts the POST on a string.
+        spansLimit:
+          data?.spansLimit != null && data?.spansLimit !== ""
+            ? Number(data.spansLimit)
+            : data?.spansLimit,
         samplingRate: data?.samplingRate,
         evals: data?.evalsDetails,
         runType: data?.runType,

--- a/frontend/src/sections/common/EvaluationDrawer/EvaluationMappingForm.jsx
+++ b/frontend/src/sections/common/EvaluationDrawer/EvaluationMappingForm.jsx
@@ -33,6 +33,7 @@ import { useRunEvalMutation } from "./getEvalsList";
 import { format } from "date-fns";
 import logger from "src/utils/logger";
 import EvaluationMappingFormContent from "./EvaluationMappingFormContent";
+import { sanitizeEvalMapping } from "src/sections/common/EvalPicker/serializeEvalConfig";
 
 function removeElements(array1, array2) {
   return array1.filter((element) => !array2.includes(element));
@@ -583,7 +584,7 @@ const EvaluationMappingFormChild = ({
               ...(payload?.kb_id ? { kb_id: payload.kb_id } : {}),
             },
             page_id: EVALUATION_PAGE_ID_MAPPER[module],
-            mapping: payload.config?.mapping,
+            mapping: sanitizeEvalMapping(payload.config?.mapping),
             params: payload.config?.params || {},
             ...(removedEvals?.length > 0 && { deselected_evals: removedEvals }),
           };
@@ -595,7 +596,7 @@ const EvaluationMappingFormChild = ({
             project: id,
             name: payload.name,
             eval_template: payload.template_id,
-            mapping: payload.config?.mapping,
+            mapping: sanitizeEvalMapping(payload.config?.mapping),
             config: {
               ...(payload.config?.config || {}),
               params: payload.config?.params || {},

--- a/frontend/src/sections/tasks/components/TaskConfigPanel.jsx
+++ b/frontend/src/sections/tasks/components/TaskConfigPanel.jsx
@@ -397,10 +397,10 @@ const TaskConfigPanel = ({
         eval_template: tplId,
         name: evalConfig.name,
         model: evalConfig.model || null,
-        mapping: evalConfig.mapping || {},
+        mapping: serialized.mapping,
         config: {
           ...serialized.config,
-          mapping: evalConfig.mapping || {},
+          mapping: serialized.mapping,
         },
         error_localizer: !!evalConfig.errorLocalizerEnabled,
       };
@@ -421,7 +421,7 @@ const TaskConfigPanel = ({
               ...(evalConfig.config || {}),
               ...corePayload.config,
             },
-            mapping: evalConfig.mapping || {},
+            mapping: serialized.mapping,
           };
         } else {
           const { data: resp } = await axios.post(
@@ -437,7 +437,7 @@ const TaskConfigPanel = ({
               ...(evalConfig.config || {}),
               ...corePayload.config,
             },
-            mapping: evalConfig.mapping || {},
+            mapping: serialized.mapping,
           };
         }
       } catch (error) {

--- a/futureagi/tracer/services/eval_tasks/run_entry.py
+++ b/futureagi/tracer/services/eval_tasks/run_entry.py
@@ -115,6 +115,7 @@ def _run_for_target(entry: EvalLogger, config: CustomEvalConfig) -> None:
                 eval_task_id=task_id,
                 run_params=run_params,
                 type=OBSERVE,
+                project_id=task_project.id,
             )
             # Single evals write inside _execute_evaluation; composites return the
             # logger kwargs for the caller to persist (mirrors the span wrapper).

--- a/futureagi/tracer/tests/test_run_entry_cross_project_scoping.py
+++ b/futureagi/tracer/tests/test_run_entry_cross_project_scoping.py
@@ -144,6 +144,49 @@ class TestRunEntryCrossProjectScoping:
         )
         _assert_completed(run_entry(entry), entry)
 
+    def test_every_span_load_in_run_entry_is_scoped_by_the_task_project(
+        self, project, config_project, eval_template, stub_run_eval, stub_cost_log
+    ):
+        """Every CH span point-read under run_entry must carry the task's
+        project_id. An unscoped read (`WHERE id = ...` alone) gets zero
+        primary-key pruning on the prod `spans` table and rides the per-query
+        memory limit — the 2026-08-20 incident where 3/10 task evals died with
+        "Observation span not found" was `_execute_evaluation`'s inner refetch
+        omitting project_id (CH code 241 masked as a missing span)."""
+        from tracer.services.clickhouse.v2 import eval_loader
+
+        config = _borrowed_config(
+            config_project, eval_template, {"input": "input", "output": "output"}
+        )
+        task = _task_with(project, config)
+        trace = Trace.objects.create(project=project, name="t")
+        span = _ch_only_span(project, trace)
+        entry = _make_entry(
+            target_type=EvalTargetType.SPAN,
+            observation_span_id=span.id,
+            trace=trace,
+            custom_eval_config=config,
+            eval_task_id=str(task.id),
+        )
+
+        real_get = eval_loader.get_observation_span
+        seen_project_ids = []
+
+        def recording_get(span_id, **kwargs):
+            seen_project_ids.append(kwargs.get("project_id"))
+            return real_get(span_id, **kwargs)
+
+        eval_loader.get_observation_span = recording_get
+        try:
+            _assert_completed(run_entry(entry), entry)
+        finally:
+            eval_loader.get_observation_span = real_get
+
+        assert seen_project_ids, "run_entry never loaded the span from CH"
+        assert all(str(pid) == str(project.id) for pid in seen_project_ids), (
+            f"unscoped span load(s) during run_entry: {seen_project_ids}"
+        )
+
     def test_session_target_completes_when_config_lives_in_sibling_project(
         self,
         observe_project,

--- a/futureagi/tracer/utils/eval.py
+++ b/futureagi/tracer/utils/eval.py
@@ -73,6 +73,7 @@ def _stamp_eval_version(source_config, eval_template):
             exc_info=True,
         )
 
+
 # Re-export for backward compat
 from tracer.utils.eval_helpers import resolve_eval_config_id  # noqa: F401, E402
 
@@ -1110,6 +1111,7 @@ def _execute_composite_on_span(
     eval_task_id,
     run_params=None,
     feedback_id=None,
+    project_id=None,
 ):
     """Execute a composite `EvalTemplate` against a tracer span.
 
@@ -1133,6 +1135,7 @@ def _execute_composite_on_span(
         observation_span = get_observation_span(
             observation_span_id,
             select_related=("project", "project__organization", "project__workspace"),
+            project_id=project_id,
         )
         custom_eval_config = CustomEvalConfig.objects.get(
             id=custom_eval_config_id, deleted=False
@@ -1498,6 +1501,7 @@ def _execute_evaluation(
     type,
     run_params=None,
     feedback_id=None,
+    project_id=None,
 ):
     from evaluations.constants import FUTUREAGI_EVAL_TYPES
     from evaluations.engine import EvalRequest, run_eval
@@ -1506,9 +1510,13 @@ def _execute_evaluation(
     try:
         from tracer.services.clickhouse.v2.eval_loader import get_observation_span
 
+        # project_id scopes the CH point-read to one tenant's primary-key
+        # range; an unscoped `id =` read merges the whole table under FINAL
+        # and can hit the per-query memory limit.
         observation_span = get_observation_span(
             observation_span_id,
             select_related=("project", "project__organization", "project__workspace"),
+            project_id=project_id,
         )
 
         custom_eval_config = CustomEvalConfig.objects.get(
@@ -1537,6 +1545,7 @@ def _execute_evaluation(
             eval_task_id=eval_task_id,
             run_params=run_params,
             feedback_id=feedback_id,
+            project_id=project_id,
         )
 
     # Apply the shared empty-input rules so eval tasks behave the same as
@@ -1965,6 +1974,7 @@ def evaluate_observation_span(
             run_params=run_params,
             type=EXPERIMENT,
             feedback_id=feedback_id,
+            project_id=observation_span.project_id,
         )
         return True
     except ValueError as e:
@@ -2078,6 +2088,7 @@ def evaluate_observation_span_observe(
             run_params=run_params,
             type=OBSERVE,
             feedback_id=feedback_id,
+            project_id=observation_span.project_id,
         )
 
         # Composite evals return a logger_kwargs dict instead of writing


### PR DESCRIPTION
Fixes TH-7617

Three independent fixes for the eval-task failures investigated on 2026-08-20 (prod tasks `2717ee38`, `aa3019b8` and local repro).

## 1. Backend — scope eval-runner CH span reads by project

`_execute_evaluation` / `_execute_composite_on_span` refetched the span without `project_id`, so the ClickHouse point-read ran as an unscoped `WHERE id = ...` under `FINAL`: zero primary-key pruning over the 279M-row `spans` table (~300k rows / ~7 GiB decompressed per read), riding the 4 GiB per-query memory cap. Three reads died with CH code 241 in prod and surfaced as the misleading "Observation span not found" (forced-CH mode disables the PG fallback).

Measured on prod for one of the incident spans: unscoped ≈ 212k–333k rows / 3.2–4.0 GiB / 10–17 s → scoped = 7,982 rows / 137 MiB / 188 ms.

Fix: thread `project_id` through both executors from all three call sites. Regression test asserts every CH span load under `run_entry` carries the task's project.

## 2. Frontend — drop cleared eval mapping entries before save

A cleared auto-mapped field reached the payload as `""`; the eval runner treats a present-but-empty required key as unresolvable and fails every row (`Required attribute '' ... not found` — prod task failed 100/100), while an absent key correctly falls through to context injection.

Fix: `sanitizeEvalMapping` in `serializeEvalConfig`, routed through every live save path (`TaskConfigPanel`, `DetailsEdit`, both `EvaluationMappingForm` task payloads — the group-eval path was fully unsanitized). Dead `NewTaskDrawerV2` / `EditTaskDrawerV2` intentionally untouched.

## 3. Frontend — coerce custom row limit to a number

The custom row-limit input yields a string; the API contract declares `spans_limit: integer`, and strict dev request-contract validation aborted the POST before it was sent — surfacing only a generic "Something went wrong" (the axios error interceptor replaces errors without a response). Presets set numbers and worked. Fix: coerce once in the shared `NewTaskValidationSchema` transform.

## Testing

- New regression tests written first (TDD) for all three fixes; backend `tracer` suite 5,733 passed, frontend suite 2,468 passed, builds green.
- End-to-end browser verification on the local stack: cleared mapping saves as `{}`, Custom row limit `10` creates and runs a Traces task successfully.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SL5jwQcQb5XxWcpcvjCN2c