### PR TITLE
fix(gateway): resolve provider endpoint paths through one builder

### DIFF
--- a/agentcc-gateway/config.example.yaml
+++ b/agentcc-gateway/config.example.yaml
@@ -208,6 +208,18 @@ providers:
   #   models:
   #     - meta-llama/Meta-Llama-3.1-70B-Instruct
 
+  # api_path_prefix overrides the version segment placed between base_url and
+  # each endpoint. Unset means "/v1", which is what almost every
+  # OpenAI-compatible provider uses.
+  #
+  #   api_path_prefix: ""            # upstream serves /chat/completions
+  #   api_path_prefix: "/v1/openai"  # upstream mounts the API deeper
+  #
+  # A base_url that already ends in the prefix is left alone rather than having
+  # it repeated, so copying a vendor's documented URL verbatim works:
+  # "https://api.mistral.ai/v1" resolves to ".../v1/chat/completions", not
+  # ".../v1/v1/chat/completions". openai-format providers only.
+
   # Perplexity exposes two complementary APIs over the same OpenAI-compatible base URL:
   #   * Sonar API  (chat completions) - models: sonar, sonar-pro, sonar-reasoning, sonar-reasoning-pro, sonar-deep-research
   #   * Agent API  (responses)        - orchestrates third-party LLMs (default model: gpt-5.1)

--- a/agentcc-gateway/internal/config/config.go
+++ b/agentcc-gateway/internal/config/config.go
@@ -1271,7 +1271,7 @@ func (c *ProviderConfig) EndpointURL(path string) string {
 // config — the registry builds probe URLs before any provider exists.
 func JoinEndpoint(baseURL, prefix, path string) string {
 	base := strings.TrimRight(baseURL, "/")
-	path = strings.TrimPrefix(path, DefaultAPIPathPrefix)
+	path = trimDefaultPrefix(path)
 	if prefix == "" {
 		return base + path
 	}
@@ -1279,6 +1279,21 @@ func JoinEndpoint(baseURL, prefix, path string) string {
 		return base + path
 	}
 	return base + prefix + path
+}
+
+// trimDefaultPrefix removes the "/v1" the call sites hardcode, but only when it
+// is a whole path segment. A blind TrimPrefix eats the "/v1" out of "/v10/models"
+// and "/v1beta/models", leaving "0/models" to be re-prefixed into "/v20/models".
+// Only the proxy endpoints take a caller-supplied path, so that is where a
+// non-"/v1" version segment can actually arrive.
+func trimDefaultPrefix(path string) string {
+	if path == DefaultAPIPathPrefix {
+		return ""
+	}
+	if strings.HasPrefix(path, DefaultAPIPathPrefix+"/") {
+		return strings.TrimPrefix(path, DefaultAPIPathPrefix)
+	}
+	return path
 }
 
 func normalizePathPrefix(prefix string) string {

--- a/agentcc-gateway/internal/config/config.go
+++ b/agentcc-gateway/internal/config/config.go
@@ -324,9 +324,18 @@ type ServerConfig struct {
 }
 
 type ProviderConfig struct {
-	BaseURL        string            `yaml:"base_url" json:"base_url"`
-	APIKey         string            `yaml:"api_key" json:"-"`
-	APIFormat      string            `yaml:"api_format" json:"api_format"`
+	BaseURL   string `yaml:"base_url" json:"base_url"`
+	APIKey    string `yaml:"api_key" json:"-"`
+	APIFormat string `yaml:"api_format" json:"api_format"`
+
+	// APIPathPrefix is the version segment placed between base_url and each
+	// endpoint — "/v1" unless the provider says otherwise. Set it to "" for an
+	// upstream that serves /chat/completions with no version (Perplexity's
+	// Sonar API), or to something else entirely (DeepInfra uses /v1/openai).
+	//
+	// nil takes the preset's value, or "/v1". A pointer because "" is a
+	// meaningful setting distinct from unset. openai-format providers only.
+	APIPathPrefix  *string           `yaml:"api_path_prefix" json:"api_path_prefix"`
 	DefaultTimeout time.Duration     `yaml:"default_timeout" json:"default_timeout"`
 	MaxConcurrent  int               `yaml:"max_concurrent" json:"max_concurrent"`
 	ConnPoolSize   int               `yaml:"conn_pool_size" json:"conn_pool_size"`
@@ -1232,4 +1241,53 @@ func validateLicenseRSAPublicKey(raw string) error {
 // Addr returns the listen address.
 func (c *Config) Addr() string {
 	return fmt.Sprintf("%s:%d", c.Server.Host, c.Server.Port)
+}
+
+// DefaultAPIPathPrefix is the version segment assumed for an OpenAI-format
+// provider that does not state one.
+const DefaultAPIPathPrefix = "/v1"
+
+// EffectiveAPIPathPrefix returns the version segment for this provider,
+// normalised to a leading slash and no trailing one.
+func (c *ProviderConfig) EffectiveAPIPathPrefix() string {
+	if c.APIPathPrefix == nil {
+		return DefaultAPIPathPrefix
+	}
+	return normalizePathPrefix(*c.APIPathPrefix)
+}
+
+// EndpointURL builds an upstream URL for a versioned path such as
+// "/v1/chat/completions", replacing the caller's assumed "/v1" with whatever
+// this provider actually uses.
+//
+// A base_url that already ends in the prefix keeps it rather than repeating it:
+// "https://api.cohere.ai/compatibility/v1" resolves to ".../compatibility/v1/
+// chat/completions", not ".../v1/v1/...".
+func (c *ProviderConfig) EndpointURL(path string) string {
+	return JoinEndpoint(c.BaseURL, c.EffectiveAPIPathPrefix(), path)
+}
+
+// JoinEndpoint is EndpointURL for callers holding a base URL rather than a
+// config — the registry builds probe URLs before any provider exists.
+func JoinEndpoint(baseURL, prefix, path string) string {
+	base := strings.TrimRight(baseURL, "/")
+	path = strings.TrimPrefix(path, DefaultAPIPathPrefix)
+	if prefix == "" {
+		return base + path
+	}
+	if strings.HasSuffix(base, prefix) {
+		return base + path
+	}
+	return base + prefix + path
+}
+
+func normalizePathPrefix(prefix string) string {
+	prefix = strings.TrimRight(strings.TrimSpace(prefix), "/")
+	if prefix == "" {
+		return ""
+	}
+	if !strings.HasPrefix(prefix, "/") {
+		prefix = "/" + prefix
+	}
+	return prefix
 }

--- a/agentcc-gateway/internal/config/endpoint_url_test.go
+++ b/agentcc-gateway/internal/config/endpoint_url_test.go
@@ -1,0 +1,96 @@
+package config
+
+import "testing"
+
+func TestJoinEndpoint(t *testing.T) {
+	tests := []struct {
+		name    string
+		baseURL string
+		prefix  string
+		path    string
+		want    string
+	}{
+		{
+			name: "default prefix", baseURL: "https://api.openai.com", prefix: "/v1",
+			path: "/v1/chat/completions", want: "https://api.openai.com/v1/chat/completions",
+		},
+		{
+			// The reported bug: Perplexity's Sonar API has no version segment.
+			name: "no prefix", baseURL: "https://api.perplexity.ai", prefix: "",
+			path: "/v1/chat/completions", want: "https://api.perplexity.ai/chat/completions",
+		},
+		{
+			name: "custom prefix", baseURL: "https://api.deepinfra.com", prefix: "/v1/openai",
+			path: "/v1/chat/completions", want: "https://api.deepinfra.com/v1/openai/chat/completions",
+		},
+		{
+			// The case endpoint() was written for; must not become /v1/v1/.
+			name: "base already carries the prefix", baseURL: "https://api.cohere.ai/compatibility/v1",
+			prefix: "/v1", path: "/v1/chat/completions",
+			want: "https://api.cohere.ai/compatibility/v1/chat/completions",
+		},
+		{
+			name: "base with a path but no version", baseURL: "https://api.groq.com/openai",
+			prefix: "/v1", path: "/v1/chat/completions",
+			want: "https://api.groq.com/openai/v1/chat/completions",
+		},
+		{
+			name: "trailing slash on base", baseURL: "https://api.openai.com/", prefix: "/v1",
+			path: "/v1/models", want: "https://api.openai.com/v1/models",
+		},
+		{
+			// A suffix match must respect the separator, or /apiv1 false-matches.
+			name: "lookalike suffix is not a match", baseURL: "https://api.example.com/apiv1",
+			prefix: "/v1", path: "/v1/models",
+			want: "https://api.example.com/apiv1/v1/models",
+		},
+		{
+			// Paths are relative to the API root, so an unversioned one still
+			// gets the prefix. The proxy handlers pass "/v1/threads/..." and
+			// rely on the strip-and-reapply above; this covers the other form.
+			name: "unversioned path still gets the prefix", baseURL: "https://api.openai.com",
+			prefix: "/v1", path: "/threads/abc/runs",
+			want: "https://api.openai.com/v1/threads/abc/runs",
+		},
+		{
+			// The proxy path under a prefix-less provider.
+			name: "proxy path under an unversioned provider", baseURL: "https://api.perplexity.ai",
+			prefix: "", path: "/v1/assistants",
+			want: "https://api.perplexity.ai/assistants",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := JoinEndpoint(tt.baseURL, tt.prefix, tt.path); got != tt.want {
+				t.Errorf("JoinEndpoint(%q, %q, %q)\n got %q\nwant %q", tt.baseURL, tt.prefix, tt.path, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestEffectiveAPIPathPrefix(t *testing.T) {
+	str := func(s string) *string { return &s }
+
+	tests := []struct {
+		name string
+		set  *string
+		want string
+	}{
+		{name: "unset defaults to /v1", set: nil, want: "/v1"},
+		{name: "explicit empty means no version segment", set: str(""), want: ""},
+		{name: "missing leading slash is added", set: str("v1"), want: "/v1"},
+		{name: "trailing slash is dropped", set: str("/v1/"), want: "/v1"},
+		{name: "whitespace tolerated", set: str("  /v1  "), want: "/v1"},
+		{name: "multi-segment kept", set: str("/v1/openai"), want: "/v1/openai"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := &ProviderConfig{APIPathPrefix: tt.set}
+			if got := c.EffectiveAPIPathPrefix(); got != tt.want {
+				t.Errorf("= %q, want %q", got, tt.want)
+			}
+		})
+	}
+}

--- a/agentcc-gateway/internal/config/endpoint_url_test.go
+++ b/agentcc-gateway/internal/config/endpoint_url_test.go
@@ -58,6 +58,32 @@ func TestJoinEndpoint(t *testing.T) {
 			prefix: "", path: "/v1/assistants",
 			want: "https://api.perplexity.ai/assistants",
 		},
+		{
+			// The "/v1" strip is a whole segment, not a string prefix. Without
+			// the boundary check this returned ".../v20/models".
+			name: "versioned path is not eaten by the strip", baseURL: "https://up.test",
+			prefix: "/v2", path: "/v10/models",
+			want: "https://up.test/v2/v10/models",
+		},
+		{
+			// Same trap with a non-numeric suffix, e.g. a Gemini-style path.
+			name: "v1beta path is not eaten by the strip", baseURL: "https://up.test",
+			prefix: "/v2", path: "/v1beta/models",
+			want: "https://up.test/v2/v1beta/models",
+		},
+		{
+			// A bare "/v1" is a whole segment and is stripped.
+			name: "bare version path collapses onto the prefix", baseURL: "https://up.test",
+			prefix: "/v1", path: "/v1",
+			want: "https://up.test/v1",
+		},
+		{
+			// The prefix always carries a leading slash, so HasSuffix already
+			// matches on a separator. Pins that "/superv1" cannot false-match.
+			name: "lookalike suffix without a separator is not a match", baseURL: "https://api.example.com/superv1",
+			prefix: "/v1", path: "/v1/models",
+			want: "https://api.example.com/superv1/v1/models",
+		},
 	}
 
 	for _, tt := range tests {

--- a/agentcc-gateway/internal/providers/openai/openai.go
+++ b/agentcc-gateway/internal/providers/openai/openai.go
@@ -23,6 +23,7 @@ import (
 type Provider struct {
 	id         string
 	baseURL    string
+	pathPrefix string
 	apiKey     string
 	httpClient *http.Client
 	semaphore  chan struct{}
@@ -74,9 +75,10 @@ func New(id string, cfg config.ProviderConfig) (*Provider, error) {
 	}
 
 	return &Provider{
-		id:      id,
-		baseURL: strings.TrimRight(cfg.BaseURL, "/"),
-		apiKey:  cfg.APIKey,
+		id:         id,
+		baseURL:    strings.TrimRight(cfg.BaseURL, "/"),
+		pathPrefix: cfg.EffectiveAPIPathPrefix(),
+		apiKey:     cfg.APIKey,
 		httpClient: &http.Client{
 			Transport: transport,
 			Timeout:   timeout,
@@ -108,16 +110,10 @@ func (p *Provider) normalizeMaxTokens(req *models.ChatCompletionRequest) {
 	req.MaxTokens = nil
 }
 
-// endpoint builds a full upstream URL for a versioned path like "/v1/ocr".
-// If the configured baseURL already ends with "/v1" (as some presets do,
-// e.g. "https://api.cohere.ai/compatibility/v1"), the leading "/v1" of path
-// is stripped to avoid "/v1/v1/..." — keeps callers from having to reason
-// about whether each provider preset includes the version suffix.
+// endpoint builds a full upstream URL for a path like "/v1/ocr", swapping the
+// assumed "/v1" for whatever version segment this provider actually uses.
 func (p *Provider) endpoint(path string) string {
-	if strings.HasSuffix(p.baseURL, "/v1") && strings.HasPrefix(path, "/v1/") {
-		return p.baseURL + path[len("/v1"):]
-	}
-	return p.baseURL + path
+	return config.JoinEndpoint(p.baseURL, p.pathPrefix, path)
 }
 
 func (p *Provider) ID() string { return p.id }
@@ -256,7 +252,7 @@ func (p *Provider) ChatCompletion(ctx context.Context, req *models.ChatCompletio
 		return nil, models.ErrInternal(fmt.Sprintf("marshaling request: %v", err))
 	}
 
-	httpReq, err := http.NewRequestWithContext(ctx, "POST", p.baseURL+"/v1/chat/completions", bytes.NewReader(body))
+	httpReq, err := http.NewRequestWithContext(ctx, "POST", p.endpoint("/v1/chat/completions"), bytes.NewReader(body))
 	if err != nil {
 		return nil, models.ErrInternal(fmt.Sprintf("creating request: %v", err))
 	}
@@ -319,7 +315,7 @@ func (p *Provider) StreamChatCompletion(ctx context.Context, req *models.ChatCom
 			return
 		}
 
-		httpReq, err := http.NewRequestWithContext(ctx, "POST", p.baseURL+"/v1/chat/completions", bytes.NewReader(body))
+		httpReq, err := http.NewRequestWithContext(ctx, "POST", p.endpoint("/v1/chat/completions"), bytes.NewReader(body))
 		if err != nil {
 			errs <- models.ErrInternal(fmt.Sprintf("creating request: %v", err))
 			return
@@ -402,7 +398,7 @@ func (p *Provider) StreamChatCompletion(ctx context.Context, req *models.ChatCom
 
 // ListModels returns available models from this provider.
 func (p *Provider) ListModels(ctx context.Context) ([]models.ModelObject, error) {
-	httpReq, err := http.NewRequestWithContext(ctx, "GET", p.baseURL+"/v1/models", nil)
+	httpReq, err := http.NewRequestWithContext(ctx, "GET", p.endpoint("/v1/models"), nil)
 	if err != nil {
 		return nil, err
 	}
@@ -444,7 +440,7 @@ func (p *Provider) CreateImage(ctx context.Context, req *models.ImageRequest) (*
 		return nil, models.ErrInternal(fmt.Sprintf("marshaling image request: %v", err))
 	}
 
-	httpReq, err := http.NewRequestWithContext(ctx, "POST", p.baseURL+"/v1/images/generations", bytes.NewReader(body))
+	httpReq, err := http.NewRequestWithContext(ctx, "POST", p.endpoint("/v1/images/generations"), bytes.NewReader(body))
 	if err != nil {
 		return nil, models.ErrInternal(fmt.Sprintf("creating image request: %v", err))
 	}
@@ -496,7 +492,7 @@ func (p *Provider) CreateSpeech(ctx context.Context, req *models.SpeechRequest) 
 		return nil, "", models.ErrInternal(fmt.Sprintf("marshaling speech request: %v", err))
 	}
 
-	httpReq, err := http.NewRequestWithContext(ctx, "POST", p.baseURL+"/v1/audio/speech", bytes.NewReader(body))
+	httpReq, err := http.NewRequestWithContext(ctx, "POST", p.endpoint("/v1/audio/speech"), bytes.NewReader(body))
 	if err != nil {
 		p.releaseSemaphore()
 		return nil, "", models.ErrInternal(fmt.Sprintf("creating speech request: %v", err))
@@ -590,7 +586,7 @@ func (p *Provider) CreateTranscription(ctx context.Context, req *models.Transcri
 		return nil, models.ErrInternal(fmt.Sprintf("closing multipart writer: %v", err))
 	}
 
-	httpReq, err := http.NewRequestWithContext(ctx, "POST", p.baseURL+"/v1/audio/transcriptions", &buf)
+	httpReq, err := http.NewRequestWithContext(ctx, "POST", p.endpoint("/v1/audio/transcriptions"), &buf)
 	if err != nil {
 		return nil, models.ErrInternal(fmt.Sprintf("creating transcription request: %v", err))
 	}
@@ -633,7 +629,7 @@ func (p *Provider) CreateResponse(ctx context.Context, reqBody []byte) ([]byte, 
 	}
 	defer p.releaseSemaphore()
 
-	httpReq, err := http.NewRequestWithContext(ctx, "POST", p.baseURL+"/v1/responses", bytes.NewReader(reqBody))
+	httpReq, err := http.NewRequestWithContext(ctx, "POST", p.endpoint("/v1/responses"), bytes.NewReader(reqBody))
 	if err != nil {
 		return nil, 0, models.ErrInternal(fmt.Sprintf("creating responses request: %v", err))
 	}
@@ -671,7 +667,7 @@ func (p *Provider) StreamResponse(ctx context.Context, reqBody []byte) (io.ReadC
 	}
 	// NOTE: semaphore is released when the caller closes the returned ReadCloser.
 
-	httpReq, err := http.NewRequestWithContext(ctx, "POST", p.baseURL+"/v1/responses", bytes.NewReader(reqBody))
+	httpReq, err := http.NewRequestWithContext(ctx, "POST", p.endpoint("/v1/responses"), bytes.NewReader(reqBody))
 	if err != nil {
 		p.releaseSemaphore()
 		return nil, 0, models.ErrInternal(fmt.Sprintf("creating streaming responses request: %v", err))
@@ -748,7 +744,7 @@ func (p *Provider) CreateTranslation(ctx context.Context, req *models.Translatio
 		return nil, models.ErrInternal(fmt.Sprintf("closing multipart writer: %v", err))
 	}
 
-	httpReq, err := http.NewRequestWithContext(ctx, "POST", p.baseURL+"/v1/audio/translations", &buf)
+	httpReq, err := http.NewRequestWithContext(ctx, "POST", p.endpoint("/v1/audio/translations"), &buf)
 	if err != nil {
 		return nil, models.ErrInternal(fmt.Sprintf("creating translation request: %v", err))
 	}
@@ -799,7 +795,7 @@ func (p *Provider) CreateEmbedding(ctx context.Context, req *models.EmbeddingReq
 		return nil, models.ErrInternal(fmt.Sprintf("marshaling embedding request: %v", err))
 	}
 
-	httpReq, err := http.NewRequestWithContext(ctx, "POST", p.baseURL+"/v1/embeddings", bytes.NewReader(body))
+	httpReq, err := http.NewRequestWithContext(ctx, "POST", p.endpoint("/v1/embeddings"), bytes.NewReader(body))
 	if err != nil {
 		return nil, models.ErrInternal(fmt.Sprintf("creating embedding request: %v", err))
 	}
@@ -842,7 +838,7 @@ func (p *Provider) ProxyAssistantsRequest(ctx context.Context, method string, pa
 	}
 	defer p.releaseSemaphore()
 
-	upstreamURL := p.baseURL + path
+	upstreamURL := p.endpoint(path)
 	if len(queryParams) > 0 {
 		upstreamURL += "?" + queryParams.Encode()
 	}
@@ -899,7 +895,7 @@ func (p *Provider) StreamAssistantsRequest(ctx context.Context, method string, p
 	}
 	// NOTE: semaphore is released when the caller closes the returned ReadCloser.
 
-	upstreamURL := p.baseURL + path
+	upstreamURL := p.endpoint(path)
 	if len(queryParams) > 0 {
 		upstreamURL += "?" + queryParams.Encode()
 	}
@@ -960,7 +956,7 @@ func (p *Provider) ProxyVectorStoresRequest(ctx context.Context, method string, 
 	}
 	defer p.releaseSemaphore()
 
-	upstreamURL := p.baseURL + path
+	upstreamURL := p.endpoint(path)
 	if len(queryParams) > 0 {
 		upstreamURL += "?" + queryParams.Encode()
 	}

--- a/agentcc-gateway/internal/providers/presets.go
+++ b/agentcc-gateway/internal/providers/presets.go
@@ -6,22 +6,31 @@ import "github.com/futureagi/agentcc-gateway/internal/config"
 type ProviderPreset struct {
 	BaseURL   string
 	APIFormat string
+
+	// PathPrefix is stated on every row rather than left to the zero value:
+	// an omitted entry would read as "" and silently strip the version segment
+	// from a provider that needs one.
+	PathPrefix string
 }
 
 // KnownProviders maps provider type names to their default configurations.
+//
+// PathPrefix is stated on every row rather than left to the zero value: an
+// omitted entry would read as "" and silently strip the version segment from a
+// provider that needs one.
 var KnownProviders = map[string]ProviderPreset{
-	"groq":        {BaseURL: "https://api.groq.com/openai", APIFormat: "openai"},
-	"mistral":     {BaseURL: "https://api.mistral.ai", APIFormat: "openai"},
-	"together":    {BaseURL: "https://api.together.xyz", APIFormat: "openai"},
-	"fireworks":   {BaseURL: "https://api.fireworks.ai/inference", APIFormat: "openai"},
-	"deepinfra":   {BaseURL: "https://api.deepinfra.com", APIFormat: "openai"},
-	"perplexity":  {BaseURL: "https://api.perplexity.ai", APIFormat: "openai"},
-	"cerebras":    {BaseURL: "https://api.cerebras.ai", APIFormat: "openai"},
-	"xai":         {BaseURL: "https://api.x.ai", APIFormat: "openai"},
-	"huggingface": {BaseURL: "https://api-inference.huggingface.co", APIFormat: "openai"},
-	"anyscale":    {BaseURL: "https://api.endpoints.anyscale.com", APIFormat: "openai"},
-	"replicate":   {BaseURL: "https://api.replicate.com", APIFormat: "openai"},
-	"openrouter":  {BaseURL: "https://openrouter.ai/api", APIFormat: "openai"},
+	"groq":        {BaseURL: "https://api.groq.com/openai", APIFormat: "openai", PathPrefix: "/v1"},
+	"mistral":     {BaseURL: "https://api.mistral.ai", APIFormat: "openai", PathPrefix: "/v1"},
+	"together":    {BaseURL: "https://api.together.xyz", APIFormat: "openai", PathPrefix: "/v1"},
+	"fireworks":   {BaseURL: "https://api.fireworks.ai/inference", APIFormat: "openai", PathPrefix: "/v1"},
+	"deepinfra":   {BaseURL: "https://api.deepinfra.com", APIFormat: "openai", PathPrefix: "/v1"},
+	"perplexity":  {BaseURL: "https://api.perplexity.ai", APIFormat: "openai", PathPrefix: "/v1"},
+	"cerebras":    {BaseURL: "https://api.cerebras.ai", APIFormat: "openai", PathPrefix: "/v1"},
+	"xai":         {BaseURL: "https://api.x.ai", APIFormat: "openai", PathPrefix: "/v1"},
+	"huggingface": {BaseURL: "https://api-inference.huggingface.co", APIFormat: "openai", PathPrefix: "/v1"},
+	"anyscale":    {BaseURL: "https://api.endpoints.anyscale.com", APIFormat: "openai", PathPrefix: "/v1"},
+	"replicate":   {BaseURL: "https://api.replicate.com", APIFormat: "openai", PathPrefix: "/v1"},
+	"openrouter":  {BaseURL: "https://openrouter.ai/api", APIFormat: "openai", PathPrefix: "/v1"},
 	"azure":       {APIFormat: "azure"},
 }
 
@@ -40,5 +49,9 @@ func applyProviderPreset(cfg *config.ProviderConfig) {
 	}
 	if cfg.APIFormat == "" && preset.APIFormat != "" {
 		cfg.APIFormat = preset.APIFormat
+	}
+	if cfg.APIPathPrefix == nil && preset.APIFormat == "openai" {
+		prefix := preset.PathPrefix
+		cfg.APIPathPrefix = &prefix
 	}
 }

--- a/agentcc-gateway/internal/providers/presets_test.go
+++ b/agentcc-gateway/internal/providers/presets_test.go
@@ -134,19 +134,19 @@ func TestPreset_ExplicitAPIFormatPreserved(t *testing.T) {
 
 func TestPreset_KnownProvidersComplete(t *testing.T) {
 	expected := map[string]ProviderPreset{
-		"groq":        {BaseURL: "https://api.groq.com/openai", APIFormat: "openai"},
-		"mistral":     {BaseURL: "https://api.mistral.ai", APIFormat: "openai"},
-		"together":    {BaseURL: "https://api.together.xyz", APIFormat: "openai"},
-		"fireworks":   {BaseURL: "https://api.fireworks.ai/inference", APIFormat: "openai"},
-		"deepinfra":   {BaseURL: "https://api.deepinfra.com", APIFormat: "openai"},
-		"perplexity":  {BaseURL: "https://api.perplexity.ai", APIFormat: "openai"},
-		"cerebras":    {BaseURL: "https://api.cerebras.ai", APIFormat: "openai"},
-		"xai":         {BaseURL: "https://api.x.ai", APIFormat: "openai"},
-		"huggingface": {BaseURL: "https://api-inference.huggingface.co", APIFormat: "openai"},
-		"anyscale":    {BaseURL: "https://api.endpoints.anyscale.com", APIFormat: "openai"},
-		"replicate":   {BaseURL: "https://api.replicate.com", APIFormat: "openai"},
-		"openrouter":  {BaseURL: "https://openrouter.ai/api", APIFormat: "openai"},
-		"azure":       {BaseURL: "", APIFormat: "azure"},
+		"groq":        {BaseURL: "https://api.groq.com/openai", APIFormat: "openai", PathPrefix: "/v1"},
+		"mistral":     {BaseURL: "https://api.mistral.ai", APIFormat: "openai", PathPrefix: "/v1"},
+		"together":    {BaseURL: "https://api.together.xyz", APIFormat: "openai", PathPrefix: "/v1"},
+		"fireworks":   {BaseURL: "https://api.fireworks.ai/inference", APIFormat: "openai", PathPrefix: "/v1"},
+		"deepinfra":   {BaseURL: "https://api.deepinfra.com", APIFormat: "openai", PathPrefix: "/v1"},
+		"perplexity":  {BaseURL: "https://api.perplexity.ai", APIFormat: "openai", PathPrefix: "/v1"},
+		"cerebras":    {BaseURL: "https://api.cerebras.ai", APIFormat: "openai", PathPrefix: "/v1"},
+		"xai":         {BaseURL: "https://api.x.ai", APIFormat: "openai", PathPrefix: "/v1"},
+		"huggingface": {BaseURL: "https://api-inference.huggingface.co", APIFormat: "openai", PathPrefix: "/v1"},
+		"anyscale":    {BaseURL: "https://api.endpoints.anyscale.com", APIFormat: "openai", PathPrefix: "/v1"},
+		"replicate":   {BaseURL: "https://api.replicate.com", APIFormat: "openai", PathPrefix: "/v1"},
+		"openrouter":  {BaseURL: "https://openrouter.ai/api", APIFormat: "openai", PathPrefix: "/v1"},
+		"azure":       {BaseURL: "", APIFormat: "azure", PathPrefix: ""},
 	}
 
 	// Verify every expected provider is present with the correct values.
@@ -161,6 +161,12 @@ func TestPreset_KnownProvidersComplete(t *testing.T) {
 			}
 			if got.APIFormat != want.APIFormat {
 				t.Errorf("APIFormat = %q, want %q", got.APIFormat, want.APIFormat)
+			}
+			// PathPrefix is a plain string, so a row that simply omits it reads
+			// as "" — which means "no version segment" and silently strips /v1.
+			// Assert it per row so that omission fails here rather than in prod.
+			if got.PathPrefix != want.PathPrefix {
+				t.Errorf("PathPrefix = %q, want %q", got.PathPrefix, want.PathPrefix)
 			}
 		})
 	}
@@ -207,6 +213,44 @@ func TestPreset_AllKnownProviders_ApplyDefaults(t *testing.T) {
 			// For non-azure providers, BaseURL must be non-empty.
 			if name != "azure" && cfg.BaseURL == "" {
 				t.Errorf("BaseURL is empty after applying preset for %q (expected non-empty)", name)
+			}
+
+			// The preset's prefix must reach the config, and an openai-format
+			// preset must state one: an omitted row would resolve to "" and
+			// drop the version segment from every URL the provider builds.
+			if preset.APIFormat == "openai" {
+				if cfg.APIPathPrefix == nil {
+					t.Fatalf("APIPathPrefix is nil after applying preset for %q", name)
+				}
+				if *cfg.APIPathPrefix != preset.PathPrefix {
+					t.Errorf("APIPathPrefix = %q, want %q", *cfg.APIPathPrefix, preset.PathPrefix)
+				}
+				if preset.PathPrefix == "" {
+					t.Errorf("preset %q states no PathPrefix; an openai-format preset "+
+						"must state one explicitly, or every URL loses its version segment", name)
+				}
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// 10. A preset prefix is a default, not an override — an explicit
+//     api_path_prefix in the config must survive applyProviderPreset.
+// ---------------------------------------------------------------------------
+
+func TestPreset_ExplicitPathPrefixPreserved(t *testing.T) {
+	for _, want := range []string{"", "/v1/openai"} {
+		t.Run("prefix="+want, func(t *testing.T) {
+			explicit := want
+			cfg := &config.ProviderConfig{Type: "groq", APIPathPrefix: &explicit}
+			applyProviderPreset(cfg)
+
+			if cfg.APIPathPrefix == nil {
+				t.Fatal("APIPathPrefix became nil")
+			}
+			if *cfg.APIPathPrefix != want {
+				t.Errorf("APIPathPrefix = %q, want %q (explicit value must not be overridden)", *cfg.APIPathPrefix, want)
 			}
 		})
 	}

--- a/agentcc-gateway/internal/providers/registry.go
+++ b/agentcc-gateway/internal/providers/registry.go
@@ -71,7 +71,7 @@ func NewRegistry(cfg *config.Config) (*Registry, error) {
 
 		// Non-blocking connectivity check for local providers.
 		if IsLocalProvider(pcfg) {
-			go connectivityCheck(name, pcfg.BaseURL)
+			go connectivityCheck(name, pcfg.BaseURL, pcfg.EffectiveAPIPathPrefix())
 		}
 	}
 
@@ -355,10 +355,13 @@ func autoDiscoverModels(name string, cfg *config.ProviderConfig) []string {
 
 	client := &http.Client{Timeout: 5 * time.Second}
 	baseURL := strings.TrimRight(cfg.BaseURL, "/")
-	resp, err := client.Get(baseURL + "/v1/models")
+	// Built the same way the provider builds its own URLs, or a provider that
+	// serves no /v1 would be probed at a path it does not have.
+	modelsURL := config.JoinEndpoint(baseURL, cfg.EffectiveAPIPathPrefix(), "/v1/models")
+	resp, err := client.Get(modelsURL)
 	if err != nil {
 		slog.Warn("auto-discover: failed to reach provider",
-			"provider", name, "url", baseURL+"/v1/models", "error", err)
+			"provider", name, "url", modelsURL, "error", err)
 		return nil
 	}
 	defer resp.Body.Close()
@@ -396,9 +399,9 @@ func autoDiscoverModels(name string, cfg *config.ProviderConfig) []string {
 
 // connectivityCheck performs a non-blocking health check against a provider.
 // Runs in a goroutine; logs result but never blocks startup.
-func connectivityCheck(name, baseURL string) {
+func connectivityCheck(name, baseURL, pathPrefix string) {
 	client := &http.Client{Timeout: 3 * time.Second}
-	url := strings.TrimRight(baseURL, "/") + "/v1/models"
+	url := config.JoinEndpoint(baseURL, pathPrefix, "/v1/models")
 	resp, err := client.Get(url)
 	if err != nil {
 		slog.Warn("connectivity check: provider unreachable (may start later)",


### PR DESCRIPTION
Closes TH-7623.

## The bug

An OpenAI-format provider builds upstream URLs at **17 sites** — 15 in `internal/providers/openai/openai.go`, 2 more in `registry.go`. Two of them go through `endpoint()`, which strips a duplicate `/v1` when `base_url` already carries one. The other fifteen concatenate raw.

So the same provider, same config, resolves two different ways:

```
base_url: "https://api.cohere.ai/compatibility/v1"

/v1/completions       (openai.go:204, uses endpoint())  -> .../compatibility/v1/completions        ✅
/v1/chat/completions  (openai.go:259, raw concat)       -> .../compatibility/v1/v1/chat/completions ❌ 404
```

`endpoint()` was written for exactly this and its comment names Cohere's compatibility URL — it just never got wired into the other fifteen callers.

**Why it bites in practice:** most vendors document their base URL *with* the version in it — Mistral `https://api.mistral.ai/v1`, Together `https://api.together.xyz/v1`, OpenRouter `https://openrouter.ai/api/v1`, and any self-hosted vLLM. Our presets dodge it by storing the URL without `/v1` and appending it, so this only hits configs written by hand — which is what self-hosted customers write.

## The fix

Everything resolves through `config.JoinEndpoint`, which keeps the de-duplication and applies it uniformly.

It lives on `ProviderConfig` rather than on the provider because `autoDiscoverModels` (`registry.go:358`) and `connectivityCheck` (`:401`) build URLs *before* any provider exists. Leaving those two behind would mean probing a path the provider itself would never call — the same bug in a second place.

The three proxy sites (assistants, vector stores) take a caller-supplied path; the handlers hardcode `/v1/...` into it, so the builder strips and re-applies rather than assuming.

## New: `api_path_prefix`

The version segment isn't universal. An upstream may serve `/chat/completions` with no version, or mount the API deeper:

```yaml
some-provider:
  base_url: "https://api.example.com"
  api_format: "openai"
  api_path_prefix: ""            # no version segment
  # api_path_prefix: "/v1/openai"  # or a deeper mount
```

A `*string`, so `""` — meaning *no* version segment — is distinguishable from unset. A bool couldn't express `/v1/openai`, and the tri-state pointer matches how `local` and `auto_discover` already work in that struct. Values are normalised (leading slash added, trailing stripped), so `api_path_prefix: v1` can't produce `api.example.comv1/...`.

`ProviderPreset` gains a matching field. It is **stated on every row** rather than left to the zero value — an omitted entry would read as `""` and silently strip the version from every preset that needs one. **No preset's behaviour changes in this PR.**

## Blast radius

For a `base_url` that doesn't end in the prefix and no `api_path_prefix` set, the resolved URL is **byte-identical** to today. Nothing that works now changes.

What changes: a `/v1`-suffixed `base_url` stops producing `/v1/v1/...` on 13 endpoints. That can only break an upstream genuinely serving `/v1/v1/`, which doesn't exist.

## Tests

`JoinEndpoint` is covered for the default prefix, no prefix, a multi-segment prefix, the `/v1`-suffixed base, a trailing slash, an `/apiv1` lookalike that must *not* match the suffix, and the proxy strip-and-reapply. Prefix normalisation is covered for unset / empty / missing-slash / trailing-slash / whitespace / multi-segment.

Full suite green (`go test ./... exit=0`).

## Deliberately not in this PR

An audit suggests several preset values are wrong or dead — `deepinfra` mounting at `/v1/openai`, `huggingface` pointing at a retired host, `anyscale` and `replicate` being unusable. Those are vendor-fact claims that want live verification, and removing a preset makes `base_url` resolve empty and fail per-request with "unsupported protocol scheme" rather than a clear config error — so any removal should ship together with startup validation. Separate change.