### PR TITLE
fix(frontend): pass sourceId when opening feedback from datapoint drawer

### DIFF
--- a/frontend/src/sections/develop-detail/DataTab/DatapointDrawerV2/DatapointDrawerV2.jsx
+++ b/frontend/src/sections/develop-detail/DataTab/DatapointDrawerV2/DatapointDrawerV2.jsx
@@ -1000,6 +1000,7 @@ const DatapointDrawerChild = () => {
                       setAddEvaluationFeeback({
                         ...evalColumn,
                         ...datapoint,
+                        sourceId: evalOpen?.evalMetricId ?? evalColumn?.source_id,
                         rowData: datapoint?.rowData,
                         value:
                           evalOpen?.cell_value ??


### PR DESCRIPTION
DatapointDrawerV2 was not passing the camelCase `sourceId` key when opening the feedback form. The column object comes from `useDatasetColumnConfig`, which does not call `enhanceCol()`, so it only has the snake_case `source_id`. The `AddEvaluationFeeback` component reads `data?.sourceId` to determine the eval metric ID — without it `metricId` is undefined, the template query never fires, and the entire feedback input area (choice radios, score input, etc.) renders blank. This adds an explicit `sourceId` to the feedback data, matching the pattern used by the old DatapointDrawer and the experiment drawer.

Closes TH-7608

## Test plan
- [ ] Open a dataset with a choice-type eval column
- [ ] Click a datapoint row to open the drawer
- [ ] Expand any eval, click "Add Feedback"
- [ ] Verify choice radio buttons / checkboxes render correctly
- [ ] Submit feedback and confirm it saves
- [ ] Also test hover cell → "Add Feedback" popup still works (regression check)

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)