### PR TITLE
fix(observe): use neutral tab labels for primary/comparison view

### DIFF
--- a/frontend/src/sections/projects/LLMTracing/LLMTracingView.jsx
+++ b/frontend/src/sections/projects/LLMTracing/LLMTracingView.jsx
@@ -3623,7 +3623,7 @@ const LLMTracingView = ({ mode = "project", userIdForUserMode = null }) => {
                     margin: theme.spacing(0),
                     px: theme.spacing(1.875),
                   }}
-                  label="Primary Graph"
+                  label="Primary"
                   value="primary"
                 />
                 <Tab
@@ -3631,7 +3631,7 @@ const LLMTracingView = ({ mode = "project", userIdForUserMode = null }) => {
                     margin: theme.spacing(0),
                     px: theme.spacing(1.875),
                   }}
-                  label="Comparison Graph"
+                  label="Comparison"
                   value="compare"
                 />
               </Tabs>


### PR DESCRIPTION
## Summary

The Primary Graph / Comparison Graph tab labels were misleading when the view mode shows data tables instead of graphs. Simplify to 'Primary' and 'Comparison' so the labels are accurate regardless of view mode.

## Changes

- LLMTracingView.jsx: Changed tab labels from "Primary Graph" / "Comparison Graph" to "Primary" / "Comparison"

## Testing

- Verified the tab labels render correctly in both graph and table view modes
- No functional change, label-only update

Closes #1686