### PR TITLE
fix(annotations): unify Active/Archived toggle height across Queues and Labels

### DIFF
--- a/frontend/src/sections/annotations/labels/view/annotation-labels-view.jsx
+++ b/frontend/src/sections/annotations/labels/view/annotation-labels-view.jsx
@@ -231,7 +231,7 @@ export default function AnnotationLabelsView() {
             value={filters.archived ? "archived" : "active"}
             onChange={handleArchiveViewChange}
             sx={{
-              height: 36,
+              height: 30,
               "& .MuiToggleButton-root": {
                 px: 1.25,
                 borderRadius: "4px",


### PR DESCRIPTION
## Summary

The Queues view Active/Archived toggle was 30px tall while the Labels view was 36px, creating a visual inconsistency in the annotation toolbar.

## Changes

- nnotation-labels-view.jsx: Changed ToggleButtonGroup height from 36 to 30 to match the Queues view

## Testing

- Verified both toolbars render at the same height

Closes #1580