### PR TITLE
fix(tracer): classify data:audio base64 values as AUDIO type

### DIFF
--- a/futureagi/tracer/utils/helper.py
+++ b/futureagi/tracer/utils/helper.py
@@ -237,6 +237,10 @@ def is_image(value: str) -> bool:
     return value.startswith(("data:image", "iVBORw0KGgo"))
 
 
+def is_audio(value: str) -> bool:
+    return value.startswith(("data:audio",))
+
+
 def determine_value_type(value):
     # Determine data type based on value
     if isinstance(value, bool):
@@ -258,6 +262,8 @@ def determine_value_type(value):
             return DataTypeChoices.DATETIME.value
         elif is_image(value):
             return DataTypeChoices.IMAGE.value
+        elif is_audio(value):
+            return DataTypeChoices.AUDIO.value
         return DataTypeChoices.TEXT.value
     else:
         return DataTypeChoices.OTHERS.value


### PR DESCRIPTION
## Summary

determine_value_type() had no audio detection. Base64-encoded audio data URLs (e.g. data:audio/wav;base64,...) fell through to TEXT type.

## Changes

- 	racer/utils/helper.py: Added is_audio() helper (mirrors existing is_image()) and integrated it into determine_value_type() string branch before the TEXT fallback

## Testing

- Existing tests pass
- A data:audio/wav;base64,... string now correctly returns AUDIO instead of TEXT

Closes #1664