### PR TITLE
fix(agentic-eval): remove mp4 from image URL extension pattern

### DIFF
--- a/futureagi/agentic_eval/core/utils/llm_payloads.py
+++ b/futureagi/agentic_eval/core/utils/llm_payloads.py
@@ -381,7 +381,7 @@ def build_user_message(content: Sequence[ContentBlock]) -> Message:
 _SUPPORTED_MEDIA = {"image", "images", "audio", "pdf"}
 
 _IMAGE_EXT_PAT = re.compile(
-    r"https?://\S+\.(png|jpg|jpeg|gif|webp|svg|bmp|tiff|mp4)(\?|$)",
+    r"https?://\S+\.(png|jpg|jpeg|gif|webp|svg|bmp|tiff)(\?|$)",
     re.IGNORECASE,
 )
 


### PR DESCRIPTION
## Summary

_IMAGE_EXT_PAT included mp4 which is a video format, not an image. Video URLs matched the image pattern, were routed to the image builder, and Pillow crashed with MediaNotAccessibleError since it cannot decode video bytes.

## Changes

- gentic_eval/core/utils/llm_payloads.py: Removed mp4 from the _IMAGE_EXT_PAT regex

## Testing

- Existing tests pass
- Video URLs no longer match the image extension pattern

Closes #1673