### PR TITLE
fix(model-hub): use removesuffix to strip reason suffix from eval names

### DIFF
--- a/futureagi/model_hub/utils/eval_reasons.py
+++ b/futureagi/model_hub/utils/eval_reasons.py
@@ -59,7 +59,7 @@ def get_eval_reasons(
 
     # Process reason columns
     for column in reason_columns:
-        eval_name = column.name.split("-reason")[0]
+        eval_name = column.name.removesuffix("-reason")
         # Extract user_eval_metric_id from source_id (format: "prefix-sourceid-id")
         user_eval_metric_id = None
         if column.source_id and "-sourceid-" in str(column.source_id):

--- a/futureagi/model_hub/views/experiments.py
+++ b/futureagi/model_hub/views/experiments.py
@@ -1147,13 +1147,13 @@ class DatasetExperimentsView(APIView):
                                 )
                             ),
                             "name": (
-                                column.name
-                                if "-reason" not in column.name
-                                else column.name.split("-reason")[0]
+                                column.name.removesuffix("-reason")
+                                if column.name.endswith("-reason")
+                                else column.name
                             ),
                             "data_type": (
                                 column.data_type
-                                if "-reason" not in column.name
+                                if not column.name.endswith("-reason")
                                 else "text"
                             ),
                             "origin": (


### PR DESCRIPTION
## Summary

split('-reason')[0] truncates at the FIRST occurrence of '-reason' in the string. An eval named 'no-reason-check-reason' would incorrectly recover 'no'.

## Changes

- model_hub/views/experiments.py: Replaced split('-reason')[0] with removesuffix('-reason') and tightened the guard from substring 'in' to endswith()
- model_hub/utils/eval_reasons.py: Replaced split('-reason')[0] with removesuffix('-reason')

## Testing

- Eval names containing '-reason' mid-string (e.g. 'no-reason-check') are now preserved correctly
- Only a trailing '-reason' suffix is stripped

Closes #1721