### PR TITLE
fix(develop): apply caller backgroundColor to outer container, not textarea

### DIFF
--- a/frontend/src/sections/develop-detail/AddColumn/AddColumnApiCall/RequestBody.jsx
+++ b/frontend/src/sections/develop-detail/AddColumn/AddColumnApiCall/RequestBody.jsx
@@ -342,8 +342,8 @@ const RequestBody = ({
       <div
         style={{
           position: "relative",
-          backgroundColor: theme.palette.background.default,
-          borderRadius: "8px",
+          backgroundColor: sx?.backgroundColor || theme.palette.background.default,
+          borderRadius: sx?.borderRadius || "8px",
         }}
       >
         {/* Highlight backdrop — same text with colored variables */}
@@ -395,10 +395,10 @@ const RequestBody = ({
             outline: "none",
             color: theme.palette.text.primary,
             caretColor: theme.palette.text.primary,
-            backgroundColor: "transparent",
             position: "relative",
             verticalAlign: "top",
             ...sx,
+            backgroundColor: "transparent",
           }}
           onKeyDown={onKeyDown}
         />


### PR DESCRIPTION
## Summary

RequestBody spreads caller-provided sx into the textarea inline styles, which overrides backgroundColor:'transparent' with an opaque paper color. This hides the syntax-highlight backdrop underneath, making {{variable}} references invisible in synthetic dataset column descriptions.

## Changes

- RequestBody.jsx: Moved caller backgroundColor and borderRadius to the outer container div, and forced textarea to always remain transparent so the highlight layer shows through

## Testing

- Verified {{variable}} highlighting is visible in the synthetic dataset column description fields
- Other RequestBody callers (AddColumn forms) unaffected

Closes #1586