### PR TITLE
chore: replace isort placeholder values with actual project package names

### DIFF
--- a/futureagi/pyproject.toml
+++ b/futureagi/pyproject.toml
@@ -202,8 +202,7 @@ exclude = '''
 [tool.isort]
 profile = "black"
 line_length = 88
-known_third_party = ["your_third_party_packages"]
-known_first_party = ["your_project_name"]
+known_first_party = ["tracer", "model_hub", "accounts", "tfc", "agentic_eval", "simulate", "common", "analytics", "integrations", "sockets", "ai_tools", "ee", "agent_playground", "agentcc"]
 multi_line_output = 3
 include_trailing_comma = true
 use_parentheses = true


### PR DESCRIPTION
## Summary

isort config in pyproject.toml still had template placeholder values ('your_third_party_packages' / 'your_project_name'). Replace with the actual first-party packages so isort groups imports correctly.

## Changes

- utureagi/pyproject.toml: Replaced known_first_party with actual project packages (tracer, model_hub, accounts, tfc, agentic_eval, simulate, etc.) and removed the unused known_third_party placeholder

## Testing

- isort now correctly identifies first-party imports