### PR TITLE
chore(frontend): update package.json name and metadata from template defaults

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,8 +1,8 @@
 {
-  "name": "@minimal-kit/starter-vite-js",
-  "author": "Minimals",
+  "name": "@future-agi/frontend",
+  "author": "Future AGI",
   "version": "5.6.0",
-  "description": "Vite Starter & JavaScript",
+  "description": "Future AGI frontend",
   "private": true,
   "type": "module",
   "engines": {


### PR DESCRIPTION
## Summary

The frontend package.json still carried the Vite starter template values (@minimal-kit/starter-vite-js, author 'Minimals', description 'Vite Starter & JavaScript'). Update to the actual project identity.

## Changes

- rontend/package.json: Updated name to @future-agi/frontend, author to 'Future AGI', description to 'Future AGI frontend'