### PR TITLE
fix(develop): add code editor mode to JSON cell editor

### DIFF
--- a/frontend/src/sections/develop-detail/DataTab/DoubleClickEditCell/JsonCellEditor.jsx
+++ b/frontend/src/sections/develop-detail/DataTab/DoubleClickEditCell/JsonCellEditor.jsx
@@ -224,6 +224,26 @@ const JsonCellEditor = forwardRef((props, ref) => {
     });
   };
 
+  const [codeMode, setCodeMode] = useState(false);
+  const [codeText, setCodeText] = useState("");
+  const [codeError, setCodeError] = useState("");
+
+  const enterCodeMode = () => {
+    setCodeText(JSON.stringify(value, null, 2));
+    setCodeError("");
+    setCodeMode(true);
+  };
+
+  const applyCodeMode = () => {
+    try {
+      const parsed = JSON.parse(codeText);
+      setValue(parsed);
+      setCodeMode(false);
+    } catch (e) {
+      setCodeError(e.message);
+    }
+  };
+
   return (
     <div
       style={{
@@ -295,54 +315,96 @@ const JsonCellEditor = forwardRef((props, ref) => {
         </div>
       )}
 
-      <Box
-        sx={{
-          resize: "both",
-          overflow: "auto",
-          minHeight: "180px",
-          maxHeight: "500px",
-          width: "412px",
-          scrollbarWidth: "none",
-          msOverflowStyle: "none",
-          "&::-webkit-scrollbar": {
-            display: "none",
-          },
-        }}
-      >
-        <JsonViewer
-          value={value}
-          theme={theme.palette.mode}
-          displayDataTypes={false}
-          displaySize={false}
-          indentWidth={2}
-          rootName={false}
-          editable={true}
-          enableAdd={(path, currentValue) =>
-            typeof currentValue === "object" && currentValue !== null
-          }
-          enableDelete={() => true}
-          onDelete={handleRemoveElement}
-          onAdd={handleInlineAdd}
-          onChange={handleValueChange}
-          valueTypes={[imageType]}
+      {codeMode ? (
+        <Box sx={{ flex: 1, display: "flex", flexDirection: "column", gap: 1 }}>
+          <TextField
+            multiline
+            fullWidth
+            minRows={8}
+            maxRows={20}
+            value={codeText}
+            onChange={(e) => {
+              setCodeText(e.target.value);
+              setCodeError("");
+            }}
+            error={!!codeError}
+            helperText={codeError || "Paste valid JSON, then click Apply"}
+            sx={{
+              flex: 1,
+              "& .MuiInputBase-root": {
+                fontFamily: "monospace",
+                fontSize: "13px",
+                height: "100%",
+              },
+              "& textarea": { height: "100% !important" },
+            }}
+          />
+        </Box>
+      ) : (
+        <Box
           sx={{
-            fontSize: "14px",
-            "& .jv-edit-input": {
-              border: "1px solid var(--border-default)",
-              borderRadius: "4px",
-              padding: "2px 4px",
+            resize: "both",
+            overflow: "auto",
+            minHeight: "180px",
+            maxHeight: "500px",
+            width: "412px",
+            scrollbarWidth: "none",
+            msOverflowStyle: "none",
+            "&::-webkit-scrollbar": {
+              display: "none",
             },
           }}
-        />
-      </Box>
+        >
+          <JsonViewer
+            value={value}
+            theme={theme.palette.mode}
+            displayDataTypes={false}
+            displaySize={false}
+            indentWidth={2}
+            rootName={false}
+            editable={true}
+            enableAdd={(path, currentValue) =>
+              typeof currentValue === "object" && currentValue !== null
+            }
+            enableDelete={() => true}
+            onDelete={handleRemoveElement}
+            onAdd={handleInlineAdd}
+            onChange={handleValueChange}
+            valueTypes={[imageType]}
+            sx={{
+              fontSize: "14px",
+              "& .jv-edit-input": {
+                border: "1px solid var(--border-default)",
+                borderRadius: "4px",
+                padding: "2px 4px",
+              },
+            }}
+          />
+        </Box>
+      )}
 
       <div style={{ marginTop: "12px", textAlign: "right" }}>
         <Stack
           direction="row"
           spacing={2}
-          justifyContent="flex-start"
+          justifyContent="space-between"
           sx={{ mt: 1.5 }}
         >
+          <Button
+            variant="text"
+            size="small"
+            color="primary"
+            startIcon={
+              <Icon
+                icon={codeMode ? "mdi:tree" : "mdi:code-json"}
+                style={{ width: 16, height: 16, color: "inherit" }}
+              />
+            }
+            onClick={codeMode ? () => setCodeMode(false) : enterCodeMode}
+            sx={{ fontSize: "12px", fontWeight: 500 }}
+          >
+            {codeMode ? "Visual editor" : "Code editor"}
+          </Button>
           <Button
             variant="outlined"
             size="small"
@@ -357,7 +419,7 @@ const JsonCellEditor = forwardRef((props, ref) => {
                 }}
               />
             }
-            onClick={triggerValueChange}
+            onClick={codeMode ? applyCodeMode : triggerValueChange}
             sx={{
               fontSize: "12px",
               fontWeight: 500,


### PR DESCRIPTION
## What
JSON cell editing required adding fields one at a time via the tree view. This adds a "Code editor" toggle button that switches to a textarea where users can paste raw JSON and validate it before applying. The tree view remains the default for interactive editing.

Closes #515

## Why
Populating a JSON column with anything non-trivial (nested objects, arrays, multi-field structures) required clicking "Add field" for every key/value pair. Users who already have JSON data (e.g., from API responses or config files) have no way to paste it directly. The codebase already contained an unused `EditJson` Monaco editor — this takes a lighter approach by adding a simple textarea toggle directly in the existing `JsonCellEditor`, avoiding the overhead of a separate dialog and Monaco bundle.

## How
- Added `codeMode`/`codeText`/`codeError` state to `JsonCellEditor`
- "Code editor" toggle button switches between the tree viewer and a multiline textarea
- Textarea pre-fills with formatted JSON from the current value
- Apply validates via `JSON.parse` and shows inline errors if invalid
- Switching back to visual editor discards unsaved code edits

## Test
1. Open a dataset detail page with a JSON column
2. Double-click a cell in the JSON column
3. Verify "Code editor" button appears in the bottom toolbar
4. Click "Code editor" — verify the tree view is replaced by a textarea with formatted JSON
5. Edit the JSON, click "Apply Changes" — verify the cell updates
6. Enter invalid JSON, click "Apply Changes" — verify an error message appears
7. Click "Visual editor" to switch back — verify the tree view returns
