### PR TITLE
fix: classify workflow cancel retries by RPC status

### DIFF
--- a/futureagi/simulate/temporal/client.py
+++ b/futureagi/simulate/temporal/client.py
@@ -295,6 +295,14 @@ async def _cancel_with_retries(client, workflow_id: str, max_retries: int = 3) -
     because failing to cancel means workflows keep running and overwrite the
     CANCELLED status in DB.
     """
+    from temporalio.service import RPCError, RPCStatusCode
+
+    retryable_statuses = {
+        RPCStatusCode.UNAVAILABLE,
+        RPCStatusCode.DEADLINE_EXCEEDED,
+        RPCStatusCode.RESOURCE_EXHAUSTED,
+        RPCStatusCode.ABORTED,
+    }
     last_error = None
     for attempt in range(max_retries):
         try:
@@ -302,15 +310,9 @@ async def _cancel_with_retries(client, workflow_id: str, max_retries: int = 3) -
             await handle.cancel()
             logger.info(f"Cancelled workflow: {workflow_id}")
             return True
-        except Exception as e:
+        except RPCError as e:
             last_error = e
-            error_msg = str(e).lower()
-            # Transient errors worth retrying
-            # TODO: Adding raw strings for now. Need to find better and reliable mechanisms
-            is_transient = any(
-                s in error_msg
-                for s in ["timeout", "h2 protocol", "connection reset", "unavailable"]
-            )
+            is_transient = e.status in retryable_statuses
             if is_transient and attempt < max_retries - 1:
                 wait = (attempt + 1) * 2  # 2s, 4s
                 logger.warning(
@@ -320,6 +322,10 @@ async def _cancel_with_retries(client, workflow_id: str, max_retries: int = 3) -
                 await asyncio.sleep(wait)
                 continue
             # Non-transient or final attempt
+            logger.warning(f"Could not cancel workflow {workflow_id}: {e}")
+            return False
+        except Exception as e:
+            last_error = e
             logger.warning(f"Could not cancel workflow {workflow_id}: {e}")
             return False
 

--- a/futureagi/simulate/temporal/tests/test_client_cancel.py
+++ b/futureagi/simulate/temporal/tests/test_client_cancel.py
@@ -1,0 +1,55 @@
+import asyncio
+import sys
+import types
+from unittest.mock import AsyncMock, Mock, patch
+
+import pytest
+from temporalio.service import RPCError, RPCStatusCode
+
+# The cancellation helper is independent of the graph input models, but the
+# client module imports those models at module load time. Keep this unit test
+# focused on cancellation without bootstrapping the Django model graph.
+rerun_types = types.ModuleType("simulate.temporal.types.rerun")
+rerun_types.MergeCallsSignal = object
+rerun_types.RerunCoordinatorInput = object
+test_execution_types = types.ModuleType("simulate.temporal.types.test_execution")
+test_execution_types.TestExecutionInput = object
+sys.modules.setdefault("simulate.temporal.types", types.ModuleType("simulate.temporal.types"))
+sys.modules["simulate.temporal.types.rerun"] = rerun_types
+sys.modules["simulate.temporal.types.test_execution"] = test_execution_types
+
+from simulate.temporal.client import _cancel_with_retries  # noqa: E402
+
+
+def _rpc_error(status):
+    return RPCError("cancel failed", status, b"")
+
+
+@pytest.mark.parametrize(
+    "status",
+    [RPCStatusCode.UNAVAILABLE, RPCStatusCode.DEADLINE_EXCEEDED],
+)
+def test_cancel_retries_typed_transient_rpc_errors(status):
+    handle = Mock()
+    handle.cancel = AsyncMock(side_effect=[_rpc_error(status), None])
+    client = Mock()
+    client.get_workflow_handle.return_value = handle
+
+    with patch("simulate.temporal.client.asyncio.sleep", new_callable=AsyncMock):
+        result = asyncio.run(_cancel_with_retries(client, "workflow-id"))
+
+    assert result is True
+    assert handle.cancel.await_count == 2
+
+
+def test_cancel_does_not_retry_non_rpc_errors_with_transient_words():
+    handle = Mock()
+    handle.cancel = AsyncMock(side_effect=RuntimeError("timeout while cancelling"))
+    client = Mock()
+    client.get_workflow_handle.return_value = handle
+
+    with patch("simulate.temporal.client.asyncio.sleep", new_callable=AsyncMock):
+        result = asyncio.run(_cancel_with_retries(client, "workflow-id"))
+
+    assert result is False
+    assert handle.cancel.await_count == 1


### PR DESCRIPTION
## Summary

- replace exception-message substring matching in workflow cancellation retries with Temporal RPC status classification
- retry only UNAVAILABLE, DEADLINE_EXCEEDED, RESOURCE_EXHAUSTED, and ABORTED
- stop retrying ordinary exceptions that merely contain words such as 	imeout
- add focused regression coverage for transient RPC errors and misleading generic errors

Fixes #1949.

The cooperative cancellation signal question described in the issue is intentionally left out of this focused change.

## Validation

- python -m pytest simulate/temporal/tests/test_client_cancel.py -q --confcutdir=simulate/temporal/tests -o addopts='' — 3 passed
- python -m ruff check simulate/temporal/client.py simulate/temporal/tests/test_client_cancel.py — passed
- python -m compileall -q simulate/temporal/client.py simulate/temporal/tests/test_client_cancel.py — passed

AI assistance was used during implementation; the changes were reviewed before submission.