### PR TITLE
fix(agentic_eval): cost embedding models instead of returning $0

### DIFF
--- a/futureagi/agentic_eval/core_evals/fi_utils/token_count_helper.py
+++ b/futureagi/agentic_eval/core_evals/fi_utils/token_count_helper.py
@@ -197,6 +197,8 @@ def calculate_total_cost(
         model_name: The model identifier (e.g., "gpt-4o", "tts-1", "whisper-1")
         token_usage: Dict with keys depending on model type:
             For LLM: {"prompt_tokens": int, "completion_tokens": int}
+            For multimodal embeddings (e.g. titan-embed-image): additionally
+                {"num_images": int} to bill the per-image input component
             For TTS: {"input_characters": int, "prompt_tokens": int, "completion_tokens": int}
             For STT: {"audio_seconds": float}
         fallback_pricing: Optional custom fallback pricing dict
@@ -252,8 +254,14 @@ def calculate_total_cost(
     # with only `input_per_1M_tokens` (they produce no output tokens), so accept
     # either key and treat a missing side as zero. Requiring both keys made every
     # embedding model fall through to the "unknown pricing structure" branch and be
-    # costed at $0.
-    if "input_per_1M_tokens" in pricing or "output_per_1M_tokens" in pricing:
+    # costed at $0. Multimodal embedding models (e.g. amazon.titan-embed-image-v1)
+    # additionally carry `input_per_image`, so enter this branch for that key too
+    # and add the per-image component below.
+    if (
+        "input_per_1M_tokens" in pricing
+        or "output_per_1M_tokens" in pricing
+        or "input_per_image" in pricing
+    ):
         input_cost_per_1M = pricing.get("input_per_1M_tokens") or 0
         output_cost_per_1M = pricing.get("output_per_1M_tokens") or 0
 
@@ -263,6 +271,22 @@ def calculate_total_cost(
 
         prompt_cost = round((prompt_tokens / 1_000_000) * input_cost_per_1M, 6)
         completion_cost = round((completion_tokens / 1_000_000) * output_cost_per_1M, 6)
+
+        # Per-image input pricing for multimodal embeddings. Titan multimodal
+        # embeddings charge `input_per_image` per input image on top of any token
+        # cost, so image-only requests are non-zero and mixed (text + image)
+        # requests include both components. Text-only requests supply no image
+        # count and are unaffected. `num_images` is the canonical key; fall back to
+        # `images_generated` for callers that already report image counts that way.
+        if "input_per_image" in pricing:
+            cost_per_image = pricing.get("input_per_image") or 0
+            num_images = (
+                token_usage.get("num_images")
+                or token_usage.get("images_generated")
+                or 0
+            )
+            image_cost = round(num_images * cost_per_image, 6)
+            prompt_cost = round(prompt_cost + image_cost, 6)
 
     # Character-based pricing (TTS models)
     elif "input_per_1M_characters" in pricing:

--- a/futureagi/agentic_eval/core_evals/fi_utils/token_count_helper.py
+++ b/futureagi/agentic_eval/core_evals/fi_utils/token_count_helper.py
@@ -248,10 +248,14 @@ def calculate_total_cost(
     prompt_cost = 0.0
     completion_cost = 0.0
 
-    # Token-based pricing (LLM/Chat models)
-    if "input_per_1M_tokens" in pricing and "output_per_1M_tokens" in pricing:
-        input_cost_per_1M = pricing["input_per_1M_tokens"]
-        output_cost_per_1M = pricing["output_per_1M_tokens"]
+    # Token-based pricing (LLM/Chat/embedding models). Embedding models are priced
+    # with only `input_per_1M_tokens` (they produce no output tokens), so accept
+    # either key and treat a missing side as zero. Requiring both keys made every
+    # embedding model fall through to the "unknown pricing structure" branch and be
+    # costed at $0.
+    if "input_per_1M_tokens" in pricing or "output_per_1M_tokens" in pricing:
+        input_cost_per_1M = pricing.get("input_per_1M_tokens") or 0
+        output_cost_per_1M = pricing.get("output_per_1M_tokens") or 0
 
         # Use `or 0` to handle both missing keys AND explicit None values
         prompt_tokens = token_usage.get("prompt_tokens") or 0

--- a/futureagi/agentic_eval/core_evals/fi_utils/token_count_helper.py
+++ b/futureagi/agentic_eval/core_evals/fi_utils/token_count_helper.py
@@ -256,11 +256,14 @@ def calculate_total_cost(
     # embedding model fall through to the "unknown pricing structure" branch and be
     # costed at $0. Multimodal embedding models (e.g. amazon.titan-embed-image-v1)
     # additionally carry `input_per_image`, so enter this branch for that key too
-    # and add the per-image component below.
+    # and add the per-image component below. Some vision models (e.g.
+    # vertex_ai/meta/llama-3.2-90b-vision-instruct-maas) carry the same per-image
+    # component under the key `image_input_per_image`, so accept it as an alias.
     if (
         "input_per_1M_tokens" in pricing
         or "output_per_1M_tokens" in pricing
         or "input_per_image" in pricing
+        or "image_input_per_image" in pricing
     ):
         input_cost_per_1M = pricing.get("input_per_1M_tokens") or 0
         output_cost_per_1M = pricing.get("output_per_1M_tokens") or 0
@@ -278,8 +281,14 @@ def calculate_total_cost(
         # requests include both components. Text-only requests supply no image
         # count and are unaffected. `num_images` is the canonical key; fall back to
         # `images_generated` for callers that already report image counts that way.
-        if "input_per_image" in pricing:
-            cost_per_image = pricing.get("input_per_image") or 0
+        # `image_input_per_image` is an alias some vision models use for the same
+        # per-image component.
+        if "input_per_image" in pricing or "image_input_per_image" in pricing:
+            cost_per_image = (
+                pricing.get("input_per_image")
+                or pricing.get("image_input_per_image")
+                or 0
+            )
             num_images = (
                 token_usage.get("num_images")
                 or token_usage.get("images_generated")

--- a/futureagi/agentic_eval/core_evals/run_prompt/tests/test_model_pricing.py
+++ b/futureagi/agentic_eval/core_evals/run_prompt/tests/test_model_pricing.py
@@ -270,6 +270,85 @@ class TestMultimodalEmbeddingPricing:
         assert result["total_cost"] > 0
 
 
+@pytest.mark.unit
+class TestVisionModelImageInputPerImageAlias:
+    """Some vision models carry the same per-image input component under the key
+    ``image_input_per_image`` instead of ``input_per_image`` (e.g.
+    ``vertex_ai/meta/llama-3.2-90b-vision-instruct-maas``, priced
+    ``{input_per_1M_tokens: 0.7, output_per_1M_tokens: 0.9,
+    image_input_per_image: 0.002}``). The per-image component must still be
+    added, otherwise the image cost is silently dropped.
+
+    Regression: before the alias was accepted, a mixed request of
+    ``{prompt_tokens: 1000, completion_tokens: 500, num_images: 4}`` returned
+    only $0.00115 in tokens and dropped 4 x $0.002 = $0.008 of image cost
+    (~87% undercharge)."""
+
+    MODEL = "vertex_ai/meta/llama-3.2-90b-vision-instruct-maas"
+
+    def test_catalog_entry_uses_alias_key(self):
+        pricing = get_model_pricing(self.MODEL)
+        # Guards the assumption behind this suite: this model prices per token
+        # AND per image, but under the ``image_input_per_image`` alias.
+        assert pricing is not None
+        assert "input_per_1M_tokens" in pricing
+        assert "output_per_1M_tokens" in pricing
+        assert "input_per_image" not in pricing
+        assert "image_input_per_image" in pricing
+        assert pricing["image_input_per_image"] > 0
+
+    def test_mixed_request_includes_image_component(self):
+        """Mixed text+image request must include token AND image cost billed
+        under the ``image_input_per_image`` alias.
+
+        Fail-without: before the alias was accepted, the image component was
+        dropped and total_cost was only the token cost ($0.00115)."""
+        pricing = get_model_pricing(self.MODEL)
+        input_rate = pricing["input_per_1M_tokens"]
+        output_rate = pricing["output_per_1M_tokens"]
+        per_image = pricing["image_input_per_image"]
+
+        token_usage = {
+            "prompt_tokens": 1000,
+            "completion_tokens": 500,
+            "num_images": 4,
+        }
+        result = calculate_total_cost(self.MODEL, token_usage)
+
+        expected_prompt_tokens = round((1000 / 1_000_000) * input_rate, 6)
+        expected_images = round(4 * per_image, 6)
+        expected_prompt = round(expected_prompt_tokens + expected_images, 6)
+        expected_completion = round((500 / 1_000_000) * output_rate, 6)
+        expected_total = round(expected_prompt + expected_completion, 6)
+
+        # The image component is strictly positive and actually counted.
+        assert expected_images == 0.008
+        assert result["prompt_cost"] == expected_prompt
+        assert result["completion_cost"] == expected_completion
+        assert result["total_cost"] == expected_total
+        # Regression guard: total must exceed the token-only cost by the full
+        # image component (fails when the alias is dropped).
+        token_only_total = round(expected_prompt_tokens + expected_completion, 6)
+        assert token_only_total == 0.00115
+        assert result["total_cost"] == round(token_only_total + expected_images, 6)
+        assert result["total_cost"] > token_only_total
+
+    def test_image_only_request_is_not_zero(self):
+        """Image-only request under the alias key must bill the per-image
+        component instead of returning $0."""
+        pricing = get_model_pricing(self.MODEL)
+        per_image = pricing["image_input_per_image"]
+
+        token_usage = {"prompt_tokens": 0, "completion_tokens": 0, "num_images": 4}
+        result = calculate_total_cost(self.MODEL, token_usage)
+
+        expected = round(4 * per_image, 6)
+        assert expected > 0
+        assert result["prompt_cost"] == expected
+        assert result["completion_cost"] == 0.0
+        assert result["total_cost"] == expected
+
+
 # =============================================================================
 # Unit Tests - Character-Based Pricing (TTS Models)
 # =============================================================================

--- a/futureagi/agentic_eval/core_evals/run_prompt/tests/test_model_pricing.py
+++ b/futureagi/agentic_eval/core_evals/run_prompt/tests/test_model_pricing.py
@@ -179,6 +179,97 @@ class TestEmbeddingModelPricing:
         assert result["pricing_source"] == "available_models"
 
 
+@pytest.mark.unit
+class TestMultimodalEmbeddingPricing:
+    """Multimodal embedding models (e.g. ``amazon.titan-embed-image-v1``) carry
+    both ``input_per_1M_tokens`` and ``input_per_image`` pricing. The per-image
+    component must be added on top of any token cost, otherwise image-only
+    requests are reported as $0 and mixed requests omit the image cost."""
+
+    MODEL = "amazon.titan-embed-image-v1"
+
+    def test_catalog_entry_has_both_components(self):
+        pricing = get_model_pricing(self.MODEL)
+        # Guards the assumption behind this suite: this model prices per token
+        # AND per image.
+        assert pricing is not None
+        assert "input_per_1M_tokens" in pricing
+        assert "input_per_image" in pricing
+        assert pricing["input_per_image"] > 0
+
+    def test_image_only_request_is_not_zero(self):
+        """Image-only request (no tokens) must bill the per-image component.
+
+        Regression: previously took the token branch, never added the image
+        component, and returned $0."""
+        pricing = get_model_pricing(self.MODEL)
+        per_image = pricing["input_per_image"]
+
+        token_usage = {"prompt_tokens": 0, "completion_tokens": 0, "num_images": 5}
+        result = calculate_total_cost(self.MODEL, token_usage)
+
+        expected = round(5 * per_image, 6)
+        assert expected > 0
+        assert result["prompt_cost"] == expected
+        assert result["completion_cost"] == 0.0
+        assert result["total_cost"] == expected
+        assert result["total_cost"] > 0  # regression: used to fall through to $0
+        assert result["pricing_source"] == "available_models"
+
+    def test_mixed_request_includes_both_components(self):
+        """Mixed text+image request must include token AND image cost."""
+        pricing = get_model_pricing(self.MODEL)
+        token_rate = pricing["input_per_1M_tokens"]
+        per_image = pricing["input_per_image"]
+
+        token_usage = {
+            "prompt_tokens": 1_000_000,
+            "completion_tokens": 0,
+            "num_images": 5,
+        }
+        result = calculate_total_cost(self.MODEL, token_usage)
+
+        expected_tokens = round((1_000_000 / 1_000_000) * token_rate, 6)
+        expected_images = round(5 * per_image, 6)
+        expected = round(expected_tokens + expected_images, 6)
+
+        assert result["prompt_cost"] == expected
+        assert result["completion_cost"] == 0.0
+        assert result["total_cost"] == expected
+        # Both components are strictly positive and both are counted.
+        assert expected_tokens > 0 and expected_images > 0
+        assert result["total_cost"] > expected_tokens
+
+    def test_text_only_request_unchanged(self):
+        """Text-only request (no image count) bills tokens only -- the image
+        branch must not add anything or break the existing token path."""
+        pricing = get_model_pricing(self.MODEL)
+        token_rate = pricing["input_per_1M_tokens"]
+
+        token_usage = {"prompt_tokens": 1_000_000, "completion_tokens": 0}
+        result = calculate_total_cost(self.MODEL, token_usage)
+
+        expected = round((1_000_000 / 1_000_000) * token_rate, 6)
+        assert result["prompt_cost"] == expected
+        assert result["total_cost"] == expected
+
+    def test_images_generated_key_is_accepted(self):
+        """Callers that report image counts as ``images_generated`` are billed
+        the per-image component too."""
+        pricing = get_model_pricing(self.MODEL)
+        per_image = pricing["input_per_image"]
+
+        token_usage = {
+            "prompt_tokens": 0,
+            "completion_tokens": 0,
+            "images_generated": 3,
+        }
+        result = calculate_total_cost(self.MODEL, token_usage)
+
+        assert result["total_cost"] == round(3 * per_image, 6)
+        assert result["total_cost"] > 0
+
+
 # =============================================================================
 # Unit Tests - Character-Based Pricing (TTS Models)
 # =============================================================================

--- a/futureagi/agentic_eval/core_evals/run_prompt/tests/test_model_pricing.py
+++ b/futureagi/agentic_eval/core_evals/run_prompt/tests/test_model_pricing.py
@@ -142,6 +142,44 @@ class TestTokenBasedPricing:
 
 
 # =============================================================================
+# Unit Tests - Embedding Model Pricing (input-only token pricing)
+# =============================================================================
+
+
+@pytest.mark.unit
+class TestEmbeddingModelPricing:
+    """Embedding models are priced with only ``input_per_1M_tokens`` (they
+    produce no output tokens). Their cost must be computed from that key, not
+    silently dropped to $0 because an ``output_per_1M_tokens`` key is absent."""
+
+    @pytest.mark.parametrize(
+        "model_name",
+        [
+            "text-embedding-3-large",
+            "text-embedding-3-small",
+            "text-embedding-ada-002",
+        ],
+    )
+    def test_embedding_cost_is_not_zero(self, model_name):
+        pricing = get_model_pricing(model_name)
+        # Sanity: embeddings are priced with an input token rate and no output rate.
+        assert "input_per_1M_tokens" in pricing
+        assert "output_per_1M_tokens" not in pricing
+        input_price = pricing["input_per_1M_tokens"]
+        assert input_price > 0
+
+        token_usage = {"prompt_tokens": 1_000_000, "completion_tokens": 0}
+        result = calculate_total_cost(model_name, token_usage)
+
+        expected = round((1_000_000 / 1_000_000) * input_price, 6)
+        assert result["prompt_cost"] == expected
+        assert result["completion_cost"] == 0.0
+        assert result["total_cost"] == expected
+        assert result["total_cost"] > 0  # regression: used to fall through to $0
+        assert result["pricing_source"] == "available_models"
+
+
+# =============================================================================
 # Unit Tests - Character-Based Pricing (TTS Models)
 # =============================================================================
 


### PR DESCRIPTION
## What

`calculate_total_cost` silently costs **every embedding model at $0**.

## Why

The token-pricing branch only fires when a model has **both** token-price keys:

```python
# token_count_helper.py
if "input_per_1M_tokens" in pricing and "output_per_1M_tokens" in pricing:
```

Embedding models are priced with **only** `input_per_1M_tokens` (they produce no output tokens — see `available_models.py`). So the condition is `False`, the character/minute/image branches are skipped, and the model falls through to the final `else`, which logs `"Unknown pricing structure"` and returns `total_cost: 0.0` — with a confidently-formatted `pricing_source: "available_models"`.

This affects all 15 catalogued embedding models (`text-embedding-3-large/small`, `text-embedding-ada-002` + Azure, `cohere embed-*`, `mistral/mistral-embed`, `gemini-embedding-2`, `titan-embed-*`), and `calculate_total_cost` is the cost fallback used from ~30 call sites, so embedding spend is recorded as $0 in usage/billing wherever litellm doesn't supply a cost.

Reproduction on `main`:

```text
text-embedding-3-large  {'input_per_1M_tokens': 0.4}  -> total_cost=0.0   (expected 0.40)
text-embedding-3-small  {'input_per_1M_tokens': 0.02} -> total_cost=0.0   (expected 0.02)
gpt-4o                  (both keys)                    -> total_cost=0.0125 (correct)
```

## How

Accept **either** token-price key and treat a missing side as zero:

```diff
-    if "input_per_1M_tokens" in pricing and "output_per_1M_tokens" in pricing:
-        input_cost_per_1M = pricing["input_per_1M_tokens"]
-        output_cost_per_1M = pricing["output_per_1M_tokens"]
+    if "input_per_1M_tokens" in pricing or "output_per_1M_tokens" in pricing:
+        input_cost_per_1M = pricing.get("input_per_1M_tokens") or 0
+        output_cost_per_1M = pricing.get("output_per_1M_tokens") or 0
```

TTS/STT/image models carry **no** token keys, so the character/minute/image branches are unaffected. Verified that `gpt-4o`, `tts-1`, `whisper-1` and `dall-e-3` results are unchanged, and embeddings now return correct costs.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Tests

Added `TestEmbeddingModelPricing` in `run_prompt/tests/test_model_pricing.py` (parametrized over `text-embedding-3-large/small`, `ada-002`): asserts the cost is computed from `input_per_1M_tokens` and is non-zero. It **fails on `main`** (returns $0, logs "Unknown pricing structure") and passes with this change; the full `test_model_pricing.py` suite stays green (58 passed).

---

*Disclosure: this change was prepared with AI assistance and reviewed/verified by me before submission.*