### PR TITLE
fix: alerts dark-mode tooltips on config charts

### DIFF
--- a/frontend/src/sections/projects/Alerts/common.js
+++ b/frontend/src/sections/projects/Alerts/common.js
@@ -536,7 +536,11 @@ const STATUS_COLORS = {
   INSUFFICIENT_DATA: "#9E9E9E",
 };
 
-export function getCompareChartConfig(apiData, customOptions = {}) {
+export function getCompareChartConfig(
+  apiData,
+  customOptions = {},
+  { isDark = false } = {},
+) {
   if (!apiData?.result?.graph_data || !apiData?.result?.alert_bar_data) {
     throw new Error("Invalid API data structure");
   }
@@ -657,6 +661,7 @@ export function getCompareChartConfig(apiData, customOptions = {}) {
       },
     },
     tooltip: {
+      theme: isDark ? "dark" : "light",
       enabledOnSeries: [1],
       marker: {
         show: true,
@@ -792,6 +797,7 @@ export function getSimpleLineChartConfig(
       },
     },
     tooltip: {
+      theme: isDark ? "dark" : "light",
       y: {
         formatter: (value) => `${value}`,
       },

--- a/frontend/src/sections/projects/Alerts/components/AlertConfiguration.jsx
+++ b/frontend/src/sections/projects/Alerts/components/AlertConfiguration.jsx
@@ -162,14 +162,20 @@ export default function AlertConfiguration({ dateFilter, setDateFilter }) {
               },
             ];
 
-        chartConfig = getSimpleLineChartConfig(fetchedData?.data, {
-          seriesName: _.startCase(_.toLower(alertType)),
-          thresholds,
-        });
+        chartConfig = getSimpleLineChartConfig(
+          fetchedData?.data,
+          {
+            seriesName: _.startCase(_.toLower(alertType)),
+            thresholds,
+          },
+          { isDark },
+        );
       } else if (selectedThresHoldType === "percentage_change") {
-        chartConfig = getCompareChartConfig(fetchedData?.data, {
-          seriesName: _.startCase(_.toLower(alertType)),
-        });
+        chartConfig = getCompareChartConfig(
+          fetchedData?.data,
+          { seriesName: _.startCase(_.toLower(alertType)) },
+          { isDark },
+        );
       }
 
       if (chartConfig) {
@@ -199,6 +205,7 @@ export default function AlertConfiguration({ dateFilter, setDateFilter }) {
     thresholdOperator,
     warningValue,
     criticalValue,
+    isDark,
   ]);
 
   // Render chart with proper loading states

--- a/frontend/src/sections/projects/Alerts/components/AlertsSheetView/AlertsSheetView.jsx
+++ b/frontend/src/sections/projects/Alerts/components/AlertsSheetView/AlertsSheetView.jsx
@@ -154,14 +154,20 @@ export default function AlertsSheetView() {
               },
             ];
 
-        chartConfig = getSimpleLineChartConfig(data, {
-          seriesName: _.startCase(_.toLower(alertRuleDetails.metricType)),
-          thresholds,
-        });
+        chartConfig = getSimpleLineChartConfig(
+          data,
+          {
+            seriesName: _.startCase(_.toLower(alertRuleDetails.metricType)),
+            thresholds,
+          },
+          { isDark },
+        );
       } else if (selectedThresHoldType === "percentage_change") {
-        chartConfig = getCompareChartConfig(data, {
-          seriesName: _.startCase(_.toLower(alertRuleDetails.metricType)),
-        });
+        chartConfig = getCompareChartConfig(
+          data,
+          { seriesName: _.startCase(_.toLower(alertRuleDetails.metricType)) },
+          { isDark },
+        );
       }
 
       if (!chartConfig) return { series: [], options: {} };
@@ -182,7 +188,7 @@ export default function AlertsSheetView() {
     } catch (err) {
       return { series: [], options: {} };
     }
-  }, [selectedThresHoldType, data, alertRuleDetails]);
+  }, [selectedThresHoldType, data, alertRuleDetails, isDark]);
 
   // Render chart with proper loading states
   const renderChart = () => {


### PR DESCRIPTION
## Summary

Chart tooltips on the alert configuration/preview charts always rendered with the default light theme, so in dark mode they showed a white tooltip box over a dark chart and were effectively unreadable. This threads the current theme into the chart builders so tooltips match the active theme.

## Linked issues

Fixed TH-7628
Linear: https://linear.app/future-agi/issue/TH-7628/alerts-dark-mode-tooltips-on-config-charts

## Type of change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

---

## 1) What changes were done

**A. Theme-aware chart tooltips (`common.js`)**

- `getCompareChartConfig` now accepts an `{ isDark }` option and sets `tooltip.theme` to `"dark"`/`"light"`.
- `getSimpleLineChartConfig` sets the same `tooltip.theme` (it already received `isDark`).

**B. Callers pass the active theme**

- `AlertConfiguration.jsx` and `AlertsSheetView.jsx` pass `{ isDark }` into both chart builders and add `isDark` to the relevant memo dependency arrays so the chart re-renders when the theme toggles.

---

## 2) Why the changes were done

- **Product/UX:** Dark-mode users could not read chart tooltips (white box on a dark chart).
- **Technical:** ApexCharts exposes `tooltip.theme`; passing the already-available `isDark` flag is the minimal, self-contained fix. Adding `isDark` to the memo deps ensures a live theme switch re-renders the chart.

---

## 3) Tests

No automated tests — presentation-only change to tooltip theming. Verified manually.

## 4) How to test

1. Start the stack and log in.
2. Open Alerts → create/edit an alert to reach the configuration chart.
3. Toggle the app between light and dark mode.
4. Hover the chart: the tooltip background/text should match the active theme in both modes, on both the static (line) and percentage-change (compare) charts.

---

## 6) Edge cases & considerations

- Live theme toggle: `isDark` is in the memo deps, so switching theme while the chart is open re-renders with the correct tooltip theme.
- Scope intentionally limited to the tooltip theming fix; unrelated alert-graph issues (empty-data rendering, preview query firing) are tracked separately.
