### PR TITLE
fix(scanner): stop recording an unfinished scan as a clean trace

### DIFF
--- a/futureagi/ee/agenthub/trace_scanner/scanner.py
+++ b/futureagi/ee/agenthub/trace_scanner/scanner.py
@@ -366,7 +366,12 @@ class TraceScanner:
     """
 
     TEMPERATURE = 0.2
-    MAX_TOKENS = 6144
+    # The model spends this budget on thinking BEFORE the JSON: measured 945-3648
+    # completion tokens for 200-400 tokens of visible output, i.e. 70-90% thoughts.
+    # At 6144 the richest traces ran out mid-JSON, and a truncated response parses
+    # to nothing and is persisted as a permanent "clean" verdict. verify.py hit the
+    # identical failure and settled on 16k; the scanner needs the same headroom.
+    MAX_TOKENS = 16_000
 
     def __init__(self, model_config: Optional[ModelConfig] = None):
         self.model_config = model_config or _DEFAULT_SCANNER_MODEL
@@ -425,6 +430,12 @@ class TraceScanner:
             if raw_response is None:
                 raise RuntimeError("scanner_gateway_returned_none")
             parsed = self._parse_response(raw_response)
+            # Same contract as a transport failure: the scan did not happen. Without
+            # this the empty parse falls through to has_issues=False, error=None,
+            # retryable=False -- which write_scan_results persists as COMPLETED and
+            # filter_already_scanned then treats as terminal, forever.
+            if not parsed:
+                raise RuntimeError("scanner_json_parse_failed")
             # V8 returns ONE flat object per trace; the mapping below expects the
             # batched {label: {...}} shape the old multi-trace prompt produced.
             if "dimensions" in parsed or "key_moments" in parsed:
@@ -569,6 +580,16 @@ class TraceScanner:
                 usage, "completion_tokens", 0
             ) or 0
             self.token_usage["total_tokens"] += getattr(usage, "total_tokens", 0) or 0
+        # A response cut off by the token cap is a non-answer, not a clean trace.
+        # Raising here routes it to the retryable path below instead of letting a
+        # half-written JSON body fall through to has_issues=False.
+        finish_reason = None
+        try:
+            finish_reason = response.choices[0].finish_reason
+        except (AttributeError, IndexError):
+            pass
+        if finish_reason == "length":
+            raise RuntimeError("scanner_response_truncated")
         try:
             return response.choices[0].message.content
         except (AttributeError, IndexError):

--- a/futureagi/ee/agenthub/trace_scanner/tests/test_truncated_scan_is_not_clean.py
+++ b/futureagi/ee/agenthub/trace_scanner/tests/test_truncated_scan_is_not_clean.py
@@ -1,0 +1,94 @@
+"""A scan that did not finish must never be recorded as a clean trace.
+
+`MAX_TOKENS` is spent on thinking BEFORE the JSON body — measured 945-3648 completion
+tokens against 200-400 tokens of visible output, i.e. 70-90% thoughts. At the old cap
+of 6144 the richest traces ran out mid-JSON. Reproduced on the 2026-08-18 prod corpus:
+one 1358-span trace returned `finish_reason="length"` at 6144 and parsed to nothing;
+the same prompt at a higher cap finished in 6657 tokens and parsed fine.
+
+The damage was not the truncation, it was what happened next. `_parse_response`
+returned `{}` on a JSON failure, which is not an exception, so the scan fell through
+to `has_issues=False, error=None, retryable=False` — and `write_scan_results` persists
+that as COMPLETED while `filter_already_scanned` treats any persisted row as terminal.
+A truncated scan became a permanent "this trace is clean" verdict, and it landed
+preferentially on the traces carrying the most defects: the flash-arm silent failures
+were the corpus's #1, #2 and #3 traces by span count.
+
+This is the same contract `66019e53b` established for transport errors — the scan did
+not happen, so the trace is unknown rather than clean. Only the parse path was missed.
+"""
+
+from unittest.mock import patch
+
+from ee.agenthub.trace_scanner.scanner import TraceScanner
+
+
+def _trace(tid="11111111-1111-1111-1111-111111111111"):
+    return {
+        "trace_id": tid,
+        "spans": [
+            {
+                "span_id": "s1",
+                "span_name": "agent",
+                "duration": "PT1S",
+                "status_code": "Ok",
+                "span_attributes": {
+                    "span.kind": "AGENT",
+                    "input.value": "what is my refund status",
+                    "output.value": "let me check",
+                },
+                "child_spans": [],
+            }
+        ],
+    }
+
+
+def _scan_with_raw(raw):
+    """Run one scan with the gateway stubbed to return `raw` as the body."""
+    scanner = TraceScanner()
+    with patch.object(TraceScanner, "_invoke_llm", return_value=raw):
+        return scanner.scan_batch([_trace()])
+
+
+class TestAnUnparseableResponseIsNotAVerdict:
+    def test_truncated_json_is_retryable_not_clean(self):
+        """The exact shape of a cut-off response: valid prefix, no closing brace."""
+        truncated = '{"dimensions": {"goal": {"evidence": "let me check", "verdict": "FA'
+        results = _scan_with_raw(truncated)
+        assert len(results) == 1
+        r = results[0]
+        assert r.retryable is True, (
+            "a truncated scan was recorded as a finished one; write_scan_results will "
+            "persist it and filter_already_scanned will never revisit the trace"
+        )
+        assert r.error, "a truncated scan must carry an error so it is not read as clean"
+
+    def test_prose_instead_of_json_is_retryable(self):
+        """Observed in production: the model runs out mid-thought and returns narration."""
+        results = _scan_with_raw("Wait! Look at span 1.1.10.1 — the tool returned 504")
+        assert results[0].retryable is True
+        assert results[0].error
+
+    def test_empty_body_is_retryable(self):
+        """The shape a response takes when thinking consumed the entire budget."""
+        assert _scan_with_raw("")[0].retryable is True
+
+    def test_a_clean_trace_is_still_reported_clean(self):
+        """The fix must not turn a genuine no-issues verdict into a retry."""
+        clean = (
+            '{"dimensions": {"goal": {"evidence": "let me check", "verdict": "PASS"}}, '
+            '"issues": [], "key_moments": []}'
+        )
+        r = _scan_with_raw(clean)[0]
+        assert r.retryable is False, "a well-formed clean verdict must not be retried"
+        assert r.has_issues is False
+        assert not r.error
+
+
+class TestOutputBudget:
+    def test_cap_leaves_room_for_json_after_thinking(self):
+        """6144 was below the measured requirement of one real prod trace (6657)."""
+        assert TraceScanner.MAX_TOKENS >= 16_000, (
+            "the cap must clear the measured thinking overhead; verify.py settled on "
+            "16k for the identical failure mode"
+        )


### PR DESCRIPTION
## What

A scan that ran out of output tokens was persisted as "this trace has no issues", permanently.

`_parse_response` returns `{}` when the body will not parse. That is not an exception, so it
never reached the handler that marks a scan retryable. The run continued with an empty dict:
`"dimensions" in parsed` was False, `issues` came back empty, and the result was
`has_issues=False, error=None, retryable=False`. `write_scan_results` persists that as
COMPLETED, and `filter_already_scanned` treats any persisted row as terminal — so the trace
was never scanned again.

This is the same contract `66019e53b` established for transport errors ("treat a failed LLM
call as unfinished, not as a clean trace"). Only the parse path was missed.

## Why the body was truncated

The model spends the output budget on thinking before it writes the JSON. Measured on a
10-trace stratified sample at production settings: completion tokens ran 945–3648 while the
visible JSON was only 200–400 tokens — **70–90% of the allowance went to thoughts.** At
`MAX_TOKENS = 6144` the richest traces ran out mid-object.

Reproduced on the 2026-08-18 prod corpus: a 1358-span trace returned `finish_reason="length"`
with 6140 completion tokens and unparseable output; the same prompt with more headroom
finished in **6657 tokens** and parsed. It missed by 513.

`verify.py:104-108` hit this exact failure and settled on 16k, with a comment describing the
same symptom — *"the whole allowance went to reasoning and the answer came back empty, which
fails closed"*. The scanner never got that change.

## Measured incidence

From `scanner_json_parse_failed` counts, which correspond 1:1 with silently-empty result rows
(the prompt makes `key_moments` unconditional, so `error=None` + `issues=[]` + `key_moments=[]`
is a clean detector):

| arm (140-trace corpus) | silent failures |
|---|---|
| gemini-3.6-flash (production model) | 2 (1.4%) |
| gemini-3.1-pro-preview | **21 (15.0%)** |

A stronger reasoning model spends more of the budget thinking, so it truncates ~11x more
often. The failures are not random — the flash cases are the corpus's #1 (1418 spans), #2
(1358) and #3 (588) traces by span count, i.e. the defect-richest ones.

## This corrupted an experiment we were about to act on

The model-comparison scorer counts a silently-empty row as a legitimate miss, so 17 of 124
gold defects were scored against `gemini-3.1-pro-preview` without ever being judged:

| | as scored | excluding silent failures |
|---|---|---|
| aggregate recall | 46.8% | **54.2%** |
| `agentic_clean` | 69.6% — read as a 1.8pp regression vs flash | **83.0%** — actually +10pp |
| FP on clean controls | 2/16 | **2/11** (5 controls were also zeroed) |

The `agentic_clean` sign was inverted. That arm needs re-scanning before any model decision.

## Changes

- `MAX_TOKENS` 6144 -> 16_000, matching `verify.py`.
- `finish_reason == "length"` raises, so a cut-off response is never read as a verdict even
  if a fragment happens to parse.
- An empty parse raises, routing it to the existing retryable path instead of falling through
  to `has_issues=False`.

## Tests

`test_truncated_scan_is_not_clean.py` — truncated body, prose instead of JSON, empty body, and
the budget floor. **All four fail against the previous implementation.** A fifth pins that a
well-formed clean verdict is still reported clean and not retried.

## Cost note

Raising the cap does not change what a *successful* scan generates — it only stops the cut.
Traces that were being truncated will now bill for the thinking they were already doing plus
the JSON they were failing to finish.

## Still open, not in this PR

There is currently **no way to disable thinking through the gateway**. The scanner sends
`extra_body={"thinking_config": {"thinking_budget": 0}}` (nested), but
`agentcc-gateway/internal/providers/gemini/translate.go:333-352` only reads *top-level*
`thinking_budget` / `reasoning_effort`, so no `thinkingConfig` is sent and Gemini's default
thinking applies. Sending the shape it does read fails, because `buildThinkingConfig` always
sets `IncludeThoughts: true` and Gemini rejects that when thinking is off. Filed separately.