### PR TITLE
fix(scanner): restore span kind, status and per-message payload fidelity

### DIFF
--- a/futureagi/ee/agenthub/trace_scanner/compress.py
+++ b/futureagi/ee/agenthub/trace_scanner/compress.py
@@ -27,6 +27,7 @@ def _get_span_kind(attrs: dict) -> str:
                 return str(value)
     return ""
 
+
 # ---------------------------------------------------------------------------
 # KEVINIFY — "Why waste time say lot word when few word do trick"
 # ---------------------------------------------------------------------------
@@ -362,7 +363,7 @@ def structural_prefilter(trace_data):
     by_depth = {}
     for s in spans_flat:
         by_depth.setdefault(s["depth"], []).append(s)
-    for depth, siblings in by_depth.items():
+    for _depth, siblings in by_depth.items():
         durations = [s["duration"] for s in siblings if s["duration"] > 0]
         if len(durations) >= 3:
             mean = statistics.mean(durations)
@@ -402,7 +403,7 @@ def structural_prefilter(trace_data):
         signals["llm_only_trace"] = True
 
     anomalous_ids = set()
-    for key, ids in signals.items():
+    for _key, ids in signals.items():
         if isinstance(ids, list):
             anomalous_ids.update(ids)
 
@@ -468,7 +469,7 @@ def structural_prefilter_with_ids(trace_data):
     by_depth = {}
     for s in spans_flat:
         by_depth.setdefault(s["depth"], []).append(s)
-    for depth, siblings in by_depth.items():
+    for _depth, siblings in by_depth.items():
         durations = [s["duration"] for s in siblings if s["duration"] > 0]
         if len(durations) >= 3:
             mean = statistics.mean(durations)
@@ -539,7 +540,7 @@ def extract_programmatic_metadata(trace_data, prefilter_result):
         flat_spans.extend(flatten_spans(top_span))
 
     tools_called = []
-    for span, depth in flat_spans:
+    for span, _depth in flat_spans:
         attrs = span.get("span_attributes", {})
         kind = _get_span_kind(attrs)
         if kind in {"Tool", "TOOL"} or "Tool" in span["span_name"]:
@@ -556,7 +557,7 @@ def extract_programmatic_metadata(trace_data, prefilter_result):
 
     all_inputs = []
     all_outputs = []
-    for span, depth in flat_spans:
+    for span, _depth in flat_spans:
         attrs = span.get("span_attributes", {})
         inp = str(attrs.get("input.value", ""))
         out = str(attrs.get("output.value", ""))
@@ -750,7 +751,8 @@ def _is_nontextual(d):
             if isinstance(head, (int, float)):
                 return True
             if isinstance(head, dict) and any(
-                isinstance(head.get(kk), list) and head.get(kk)
+                isinstance(head.get(kk), list)
+                and head.get(kk)
                 and isinstance(head[kk][0], (int, float))
                 for kk in ("embedding", "values", "vector", "scores")
             ):
@@ -786,7 +788,7 @@ def unwrap_output(raw):
             # the completion dimension fires. 11 corpus roots are function-call-only.
             fc = x.get("function_call") or x.get("functionCall")
             if isinstance(fc, dict) and str(fc.get("arguments") or "").strip():
-                return f"[function_call {fc.get('name','')}] {fc['arguments']}"
+                return f"[function_call {fc.get('name', '')}] {fc['arguments']}"
             tcs = x.get("tool_calls")
             if isinstance(tcs, list) and tcs:
                 got = []
@@ -803,7 +805,9 @@ def unwrap_output(raw):
                     if not isinstance(fn, dict):
                         continue
                     if str(fn.get("arguments") or "").strip():
-                        got.append(f"[tool_call {fn.get('name','')}] {fn['arguments']}")
+                        got.append(
+                            f"[tool_call {fn.get('name', '')}] {fn['arguments']}"
+                        )
                 if got:
                     return "\n".join(got)
             if isinstance(x.get("content"), (list, dict)):
@@ -841,6 +845,86 @@ def unwrap_output(raw):
     return raw or ""
 
 
+# ---------------------------------------------------------------------------
+# CHAT TRANSCRIPT — reconstruct ordered turns from per-message attributes
+# ---------------------------------------------------------------------------
+#
+# Producers emit the conversation as per-message attributes
+# (gen_ai./llm. ...messages.N.message.*). A flat input.value is a partial or
+# serialized blob; the attrs are the full ordered turns. Rebuild a readable
+# transcript so the judge sees who said what, in order, with tool calls
+# attached to the message that made them. Input messages render first (the
+# request), then output messages (the reply).
+
+_MSG_DIRECTIONS = (
+    ("gen_ai.input.messages", "llm.input_messages"),
+    ("gen_ai.output.messages", "llm.output_messages"),
+)
+
+
+def _build_message_transcript(attrs: dict) -> str:
+    """Ordered chat turns from per-message attrs, or "" when none exist."""
+    out = []
+    for genai, oinfer in _MSG_DIRECTIONS:
+        msgs: dict[int, dict] = {}
+        for key, val in attrs.items():
+            m = re.match(rf"^{re.escape(genai)}\.(\d+)\.message(?:\.(.+))?$", key)
+            if m:
+                msgs.setdefault(int(m.group(1)), {})[m.group(2) or ""] = val
+        if not msgs:
+            for key, val in attrs.items():
+                m = re.match(rf"^{re.escape(oinfer)}\.(\d+)\.message(?:\.(.+))?$", key)
+                if m:
+                    msgs.setdefault(int(m.group(1)), {})[m.group(2) or ""] = val
+        for idx in sorted(msgs):
+            m = msgs[idx]
+            role = str(m.get("role") or "message")
+            body = []
+            if m.get("content"):
+                body.append(str(m["content"]))
+            for k in sorted(
+                (
+                    k
+                    for k in m
+                    if re.match(r"^contents\.\d+\.message_content\.text$", k)
+                ),
+                key=lambda k: int(k.split(".")[1]),
+            ):
+                body.append(str(m[k]))
+            for k in sorted(
+                (
+                    k
+                    for k in m
+                    if re.match(r"^tool_calls\.\d+\.tool_call\.function\.name$", k)
+                ),
+                key=lambda k: int(k.split(".")[1]),
+            ):
+                n = int(k.split(".")[1])
+                args = m.get(f"tool_calls.{n}.tool_call.function.arguments", "")
+                body.append(f"tool_call {m[k]}({args})")
+            if m.get("function_call_name"):
+                body.append(
+                    f"function_call {m['function_call_name']}"
+                    f"({m.get('function_call_arguments_json', '')})"
+                )
+            if body:
+                out.append(f"{role}: {' | '.join(body)}")
+    return "\n".join(out)
+
+
+def _exception_text(attrs: dict) -> str:
+    """The reason a span errored, from standard OTel exception-event attrs."""
+    parts = []
+    if attrs.get("exception.type"):
+        parts.append(str(attrs["exception.type"]))
+    if attrs.get("exception.message"):
+        parts.append(str(attrs["exception.message"]))
+    if attrs.get("exception.stacktrace"):
+        st = str(attrs["exception.stacktrace"])
+        parts.append("stacktrace: " + (st[:500] + "…" if len(st) > 500 else st))
+    return " | ".join(parts)
+
+
 def build_trace_payload(trace_data, prefilter_result, retry_ids=()):
     """The scanner model's input: every span, raw, in execution order.
 
@@ -871,9 +955,18 @@ def build_trace_payload(trace_data, prefilter_result, retry_ids=()):
         is_flagged = sid in flagged
         inp = _v3_plain(a.get("input.value", ""), FIELD_RUNAWAY_BUDGET)
         out = _v3_plain(a.get("output.value", ""), FIELD_RUNAWAY_BUDGET)
+        msg = _v3_plain(_build_message_transcript(a), FIELD_RUNAWAY_BUDGET)
+        err = _exception_text(a)
         # A span with no content, no status and no flag adds nothing the flow
         # outline doesn't already carry.
-        if not (inp or out or span.get("status_code") not in (None, "Unset") or is_flagged):
+        if not (
+            inp
+            or out
+            or msg
+            or err
+            or span.get("status_code") not in (None, "Unset")
+            or is_flagged
+        ):
             continue
         entry = {
             "id": sid,
@@ -883,6 +976,10 @@ def build_trace_payload(trace_data, prefilter_result, retry_ids=()):
             "in": inp,
             "out": out,
         }
+        if msg:
+            entry["msg"] = msg
+        if err:
+            entry["err"] = err
         kind = _get_span_kind(a)
         if kind:
             entry["kind"] = kind

--- a/futureagi/ee/agenthub/trace_scanner/prompt.py
+++ b/futureagi/ee/agenthub/trace_scanner/prompt.py
@@ -254,9 +254,11 @@ def build_prompt_v8(payloads):
     gate verifies its claim against the named span's real output).
     """
     t = payloads[0] if isinstance(payloads, list) else payloads
-    parts = [f"TRACE {t.get('tid','t1')}"]
+    parts = [f"TRACE {t.get('tid', 't1')}"]
     if t.get("tools_available"):
-        parts.append("\nTOOLS AVAILABLE: " + ", ".join(map(str, t["tools_available"]))[:1200])
+        parts.append(
+            "\nTOOLS AVAILABLE: " + ", ".join(map(str, t["tools_available"]))[:1200]
+        )
     if t.get("flow"):
         parts.append(f"\nEXECUTION FLOW:\n{t['flow']}")
     if t.get("signals"):
@@ -279,13 +281,19 @@ def build_prompt_v8(payloads):
                 parts.append(f"      in : {s['in']}")
             if s.get("out"):
                 parts.append(f"      out: {s['out']}")
+            if s.get("msg"):
+                parts.append(f"      msgs: {s['msg']}")
+            if s.get("err"):
+                parts.append(f"      err: {s['err']}")
     prompt = "\n".join(parts)
     if len(prompt) > PROMPT_RUNAWAY_BUDGET:
         cut = prompt[:PROMPT_RUNAWAY_BUDGET]
         nl = cut.rfind("\n")
         if nl > 0:
             cut = cut[:nl]
-        prompt = f"{cut}\n{SCANNER_TRUNCATION_MARK}, {len(prompt) - len(cut)} chars omitted⟩"
+        prompt = (
+            f"{cut}\n{SCANNER_TRUNCATION_MARK}, {len(prompt) - len(cut)} chars omitted⟩"
+        )
     return prompt
 
 

--- a/futureagi/ee/agenthub/trace_scanner/tests/test_message_transcript.py
+++ b/futureagi/ee/agenthub/trace_scanner/tests/test_message_transcript.py
@@ -1,0 +1,134 @@
+"""The judge must see the conversation as ordered turns, not one flattened blob.
+
+Per-message attributes reach the payload as a flat key/value map. Without
+reconstruction the judge gets `input.value` — the whole serialized message list —
+and cannot tell which agent reply answered which user question.
+
+Two classes of content were invisible before this, measured on the 2026-08-18
+prod corpus (6,266 real spans):
+
+  * structured multi-part content (`contents.N.message_content.text`) on 869
+    spans — the actual message text on multimodal messages, not metadata. Those
+    messages carry no flat `.content`, so they were **entirely** unreadable.
+  * per-message `tool_calls` (name + arguments) on 52/41 spans, and the legacy
+    `function_call_*` pair.
+
+Together 834/6,266 spans (13.3%) carried at least one attribute that the old
+`.role|.content` filter dropped before the judge ever ran.
+
+These tests pin what the transcript must contain and the order it must preserve,
+not the exact separators — rendering stays free to change.
+"""
+
+from ee.agenthub.trace_scanner.compress import (
+    _build_message_transcript,
+    _exception_text,
+)
+
+
+class TestTranscriptReconstruction:
+    def test_flat_role_and_content_render_as_a_turn(self):
+        out = _build_message_transcript(
+            {
+                "gen_ai.input.messages.0.message.role": "user",
+                "gen_ai.input.messages.0.message.content": "where is my refund",
+            }
+        )
+        assert "user:" in out
+        assert "where is my refund" in out
+
+    def test_structured_multipart_content_is_not_lost(self):
+        """The 869-span case: text lives under contents.N, there is no .content."""
+        out = _build_message_transcript(
+            {
+                "gen_ai.input.messages.0.message.role": "user",
+                "gen_ai.input.messages.0.message.contents.0.message_content.text": "describe this",
+                "gen_ai.input.messages.0.message.contents.0.message_content.type": "text",
+                "gen_ai.input.messages.0.message.contents.1.message_content.text": "and this",
+            }
+        )
+        assert "describe this" in out, f"multimodal message text was dropped: {out!r}"
+        assert "and this" in out
+        assert out.index("describe this") < out.index("and this"), "content parts reordered"
+
+    def test_tool_calls_stay_attached_to_the_message_that_made_them(self):
+        out = _build_message_transcript(
+            {
+                "gen_ai.output.messages.0.message.role": "assistant",
+                "gen_ai.output.messages.0.message.tool_calls.0.tool_call.function.name": "search_pokedex",
+                "gen_ai.output.messages.0.message.tool_calls.0.tool_call.function.arguments": '{"q":"krabby"}',
+            }
+        )
+        assert "search_pokedex" in out, f"tool call name was dropped: {out!r}"
+        assert '{"q":"krabby"}' in out, "tool call arguments were dropped"
+        assert out.startswith("assistant:"), "tool call detached from its message"
+
+    def test_legacy_function_call_is_read(self):
+        out = _build_message_transcript(
+            {
+                "gen_ai.output.messages.0.message.role": "assistant",
+                "gen_ai.output.messages.0.message.function_call_name": "get_weather",
+                "gen_ai.output.messages.0.message.function_call_arguments_json": '{"city":"pune"}',
+            }
+        )
+        assert "get_weather" in out
+        assert '{"city":"pune"}' in out
+
+    def test_messages_order_numerically_not_lexically(self):
+        """Message 2 precedes message 10 — string sorting would invert them."""
+        out = _build_message_transcript(
+            {
+                "gen_ai.input.messages.2.message.role": "user",
+                "gen_ai.input.messages.2.message.content": "SECOND",
+                "gen_ai.input.messages.10.message.role": "user",
+                "gen_ai.input.messages.10.message.content": "TENTH",
+            }
+        )
+        assert out.index("SECOND") < out.index("TENTH"), f"turns out of order: {out!r}"
+
+    def test_input_turns_render_before_output_turns(self):
+        out = _build_message_transcript(
+            {
+                "gen_ai.output.messages.0.message.role": "assistant",
+                "gen_ai.output.messages.0.message.content": "THE-REPLY",
+                "gen_ai.input.messages.0.message.role": "user",
+                "gen_ai.input.messages.0.message.content": "THE-REQUEST",
+            }
+        )
+        assert out.index("THE-REQUEST") < out.index("THE-REPLY"), (
+            f"the reply rendered before the request: {out!r}"
+        )
+
+    def test_openinference_namespace_is_read_when_genai_is_absent(self):
+        """Both ingest namespaces are live in prod; neither may be ignored."""
+        out = _build_message_transcript(
+            {
+                "llm.input_messages.0.message.role": "user",
+                "llm.input_messages.0.message.content": "openinference path",
+            }
+        )
+        assert "openinference path" in out
+
+    def test_a_span_with_no_messages_yields_nothing(self):
+        assert _build_message_transcript({"input.value": "not a message attr"}) == ""
+
+
+class TestExceptionText:
+    def test_type_and_message_are_surfaced(self):
+        """The judge saw status_code=Error but never why. 142/6,266 spans carry this."""
+        out = _exception_text(
+            {
+                "exception.type": "TimeoutError",
+                "exception.message": "upstream did not respond in 30s",
+            }
+        )
+        assert "TimeoutError" in out
+        assert "upstream did not respond in 30s" in out
+
+    def test_long_stacktrace_is_truncated(self):
+        out = _exception_text({"exception.stacktrace": "x" * 900})
+        assert len(out) < 900, "an unbounded stacktrace would crowd out the trace itself"
+        assert out.endswith("…")
+
+    def test_a_span_without_an_exception_yields_nothing(self):
+        assert _exception_text({"status_code": "Error"}) == ""

--- a/futureagi/tracer/queries/trace_scanner.py
+++ b/futureagi/tracer/queries/trace_scanner.py
@@ -133,12 +133,21 @@ def mark_traces_failed(trace_ids: list[str], project_id: str, reason: str) -> in
 # Map our observation_type to the span role the scanner understands.
 # Kept vendor-neutral — the scanner reads span kind by suffix, not by
 # a specific SDK prefix, so we just emit plain "span.kind".
+#
+# Keys MUST be the lowercase `ObservationType` canon (tracer.models
+# .observation_span.ObservationType); both ingest paths lowercase and validate
+# against it before writing CH. Values are the scanner's own vocabulary — it
+# matches {"Tool","TOOL"}, {"LLM","llm"}, {"Retriever","RETRIEVER"} — so these
+# spellings are load-bearing, not cosmetic.
 _OBS_TYPE_TO_KIND = {
-    "GENERATION": "LLM",
-    "SPAN": "CHAIN",
-    "TOOL": "Tool",
-    "RETRIEVER": "Retriever",
-    "AGENT": "AGENT",
+    "llm": "LLM",
+    "tool": "Tool",
+    "retriever": "Retriever",
+    "agent": "AGENT",
+    "chain": "CHAIN",
+    # Langfuse-style spellings that predate the lowercase canon.
+    "generation": "LLM",
+    "span": "CHAIN",
 }
 
 _TOKEN_KEYS = [
@@ -244,9 +253,11 @@ def _ch_span_to_span(span) -> SpanData:
     if span.model:
         attrs["llm.model_name"] = span.model
 
-    obs_type = span.observation_type or ""
-    # Default unrecognized / missing types (commonly "unknown" from older SDKs)
-    # to CHAIN so the scanner still sees structural role info instead of a blank span.
+    # Case-fold before lookup: CH stores the lowercase canon, but legacy rows and
+    # non-canonical producers have shipped other casings. Default unrecognized /
+    # missing types (commonly "unknown" from older SDKs) to CHAIN so the scanner
+    # still sees structural role info instead of a blank span.
+    obs_type = (span.observation_type or "").lower()
     attrs["span.kind"] = _OBS_TYPE_TO_KIND.get(obs_type, "CHAIN")
 
     # Surface function-calling tool definitions so the scanner can derive the
@@ -285,9 +296,19 @@ def _ch_span_to_span(span) -> SpanData:
         if key in metadata:
             attrs[key] = metadata[key]
 
-    status = "Unset"
-    if span.status_message:
+    # `status` is the authoritative CH column ("OK" / "ERROR"); `status_message`
+    # is free text and only a fallback for rows carrying a message but no status.
+    # Reading the message alone mis-reports a failed span as Ok whenever the text
+    # doesn't happen to contain "error" (e.g. "tool call failed").
+    raw_status = (span.status or "").upper()
+    if raw_status == "ERROR":
+        status = "Error"
+    elif raw_status == "OK":
+        status = "Ok"
+    elif span.status_message:
         status = "Error" if "error" in str(span.status_message).lower() else "Ok"
+    else:
+        status = "Unset"
 
     return SpanData(
         span_id=str(span.id),

--- a/futureagi/tracer/queries/trace_scanner.py
+++ b/futureagi/tracer/queries/trace_scanner.py
@@ -17,11 +17,21 @@ from tracer.types.scan_types import ScanConfig, SpanData, TraceData
 logger = structlog.get_logger(__name__)
 
 # Per-message attributes emitted by every ingest adapter, in either the OTel
-# GenAI (gen_ai.*) or OpenInference (llm.*) namespace.
+# GenAI (gen_ai.*) or OpenInference (llm.*) namespace. Everything under a
+# message is kept — role/content, structured multi-part content
+# (contents.N.message_content.text/type — the actual text on multimodal
+# messages), per-message tool_calls and function_call attrs. Measured on the
+# 2026-08-18 prod corpus: filtering to `.role|.content` alone silently dropped
+# structured content + tool_calls from the judge on 13.3% of spans.
 _MESSAGE_ATTR_RE = re.compile(
     r"^(?:gen_ai\.(?:input|output)\.messages\.\d+\.message"
-    r"|llm\.(?:input|output)_messages\.\d+\.message)\.(?:role|content)$"
+    r"|llm\.(?:input|output)_messages\.\d+\.message)"
 )
+
+# Standard OTel exception-event attributes. On a genuine exception these carry
+# the reason a span errored, and nothing in the scanner read them — the judge
+# saw only status_code=Error, never why.
+_EXCEPTION_ATTR_RE = re.compile(r"^exception\.(?:type|message|stacktrace)$")
 
 
 # ---------------------------------------------------------------------------
@@ -290,6 +300,13 @@ def _ch_span_to_span(span) -> SpanData:
     # answer from another and reports failures that never happened.
     for key, val in (span.attrs_string or {}).items():
         if _MESSAGE_ATTR_RE.match(key):
+            attrs[key] = val
+
+    # Exception-event attributes, so the judge can see WHY a span errored rather
+    # than only that it did. Present on 2.27% of prod spans; the reason was
+    # previously invisible to the scanner pipeline.
+    for key, val in (span.attrs_string or {}).items():
+        if _EXCEPTION_ATTR_RE.match(key):
             attrs[key] = val
 
     for key in _TOKEN_KEYS:

--- a/futureagi/tracer/tests/test_scan_message_attrs.py
+++ b/futureagi/tracer/tests/test_scan_message_attrs.py
@@ -1,0 +1,115 @@
+"""Pin which raw span attributes survive the fetch layer (no DB).
+
+`_ch_span_to_span` decides what the judge is allowed to see. Two filters there
+were silently discarding real content in production:
+
+  * `_MESSAGE_ATTR_RE` matched only keys ending `.role` or `.content`, so
+    structured multi-part content and per-message `tool_calls` were dropped —
+    834/6,266 spans (13.3%) on the 2026-08-18 prod corpus.
+  * exception attributes were never read at all. The judge saw
+    `status_code=Error` and never the reason, on 142/6,266 spans (2.27%).
+
+Fixtures are CH-shaped: attributes arrive in the `attrs_string` Map column.
+"""
+
+from datetime import datetime
+
+from tracer.queries.trace_scanner import _ch_span_to_span
+from tracer.services.clickhouse.v2.span_reader import CHSpan
+
+_MSG = "gen_ai.input.messages.0.message"
+
+
+def _span(**overrides) -> CHSpan:
+    base = {
+        "id": "11111111-1111-1111-1111-111111111111",
+        "project_id": "22222222-2222-2222-2222-222222222222",
+        "trace_id": "33333333-3333-3333-3333-333333333333",
+        "parent_span_id": "",
+        "name": "chat",
+        "observation_type": "llm",
+        "operation_name": "chat",
+        "start_time": datetime(2026, 8, 18, 1, 2, 3),
+        "end_time": datetime(2026, 8, 18, 1, 2, 4),
+        "latency_ms": 1000,
+        "model": "gemini-3.6-flash",
+        "provider": "vertex_ai",
+        "prompt_tokens": 0,
+        "completion_tokens": 0,
+        "total_tokens": 0,
+        "cost": 0.0,
+        "status": "OK",
+        "status_message": "",
+        "org_id": None,
+        "project_version_id": None,
+        "end_user_id": None,
+        "trace_session_id": None,
+        "prompt_version_id": None,
+        "prompt_label_id": None,
+        "custom_eval_config_id": None,
+        "input": "hi",
+        "output": "hello",
+        "tags": "[]",
+        "span_events": "",
+        "metadata": "{}",
+        "resource_attrs": "{}",
+        "attributes_extra": "{}",
+        "trace_name": "my-trace",
+    }
+    base.update(overrides)
+    return CHSpan(**base)
+
+
+def _attrs(attrs_string: dict) -> dict:
+    return _ch_span_to_span(_span(attrs_string=attrs_string)).span_attributes
+
+
+class TestPerMessageAttributesSurvive:
+    def test_role_and_content_still_pass(self):
+        """The pre-existing behaviour must not regress."""
+        out = _attrs({f"{_MSG}.role": "user", f"{_MSG}.content": "where is my refund"})
+        assert out[f"{_MSG}.role"] == "user"
+        assert out[f"{_MSG}.content"] == "where is my refund"
+
+    def test_structured_multipart_content_passes(self):
+        """These messages carry no flat .content — dropping this key hides the whole turn."""
+        key = f"{_MSG}.contents.0.message_content.text"
+        assert key in _attrs({key: "describe this image"}), (
+            "structured message content was filtered out before the judge"
+        )
+
+    def test_per_message_tool_calls_pass(self):
+        name = f"{_MSG}.tool_calls.0.tool_call.function.name"
+        args = f"{_MSG}.tool_calls.0.tool_call.function.arguments"
+        out = _attrs({name: "search_pokedex", args: '{"q":"krabby"}'})
+        assert name in out, "the judge could not see which tool a message invoked"
+        assert args in out, "the judge could not see what the tool was called with"
+
+    def test_openinference_messages_pass(self):
+        key = "llm.output_messages.0.message.tool_calls.0.tool_call.function.name"
+        assert key in _attrs({key: "lookup_order"})
+
+    def test_unrelated_attributes_are_still_dropped(self):
+        """Widening the filter must not turn it into a passthrough."""
+        out = _attrs({"some.vendor.debug.blob": "x", "llm.usage.total": "42"})
+        assert "some.vendor.debug.blob" not in out
+        assert "llm.usage.total" not in out
+
+
+class TestExceptionAttributesAreRead:
+    def test_standard_otel_exception_attrs_pass(self):
+        out = _attrs(
+            {
+                "exception.type": "TimeoutError",
+                "exception.message": "upstream did not respond in 30s",
+                "exception.stacktrace": "Traceback...",
+            }
+        )
+        assert out["exception.type"] == "TimeoutError"
+        assert out["exception.message"] == "upstream did not respond in 30s"
+        assert out["exception.stacktrace"] == "Traceback..."
+
+    def test_a_non_standard_exception_key_is_not_swept_in(self):
+        assert "exception.custom_vendor_field" not in _attrs(
+            {"exception.custom_vendor_field": "noise"}
+        )

--- a/futureagi/tracer/tests/test_scan_span_kind_mapping.py
+++ b/futureagi/tracer/tests/test_scan_span_kind_mapping.py
@@ -1,0 +1,152 @@
+"""Pin the CH-row → scanner SpanData contract (no DB).
+
+Both fields under test were silently wrong in production for four months, and
+both failed the same way: the fetch layer described the span in a vocabulary the
+stored row never uses, and the fail-open default hid it.
+
+``observation_type`` is written lowercase by both ingest paths (Python
+``get_observation_type`` and the Go collector's ``resolveObservationType``, each
+validating against ``ObservationType``). The lookup map was keyed UPPERCASE, so
+it never matched and every span reached the scanner as ``CHAIN`` — which in turn
+left ``turn_count``, ``tools_called`` and ``tools_available`` empty and made the
+``tool_failures`` / ``no_tool_calls`` / ``llm_only_trace`` prefilter signals
+unreachable.
+
+``status`` was derived from the free-text ``status_message`` while the
+authoritative ``status`` column was ignored, so a failed span whose message did
+not happen to contain the substring "error" was reported to the judge as ``Ok``.
+
+Fixtures below are therefore CH-shaped on purpose — lowercase ``observation_type``,
+populated ``status``. A fixture written in the map's own vocabulary would pass
+against the broken code forever, which is how this survived.
+"""
+
+from datetime import datetime
+
+import pytest
+
+from tracer.queries.trace_scanner import _ch_span_to_span
+from tracer.services.clickhouse.v2.span_reader import CHSpan
+
+
+def _span(**overrides) -> CHSpan:
+    base = {
+        "id": "11111111-1111-1111-1111-111111111111",
+        "project_id": "22222222-2222-2222-2222-222222222222",
+        "trace_id": "33333333-3333-3333-3333-333333333333",
+        "parent_span_id": "",
+        "name": "lookup_payment",
+        "observation_type": "tool",
+        "operation_name": "chat",
+        "start_time": datetime(2026, 8, 17, 1, 2, 3),
+        "end_time": datetime(2026, 8, 17, 1, 2, 4),
+        "latency_ms": 1000,
+        "model": "",
+        "provider": "openai",
+        "prompt_tokens": 0,
+        "completion_tokens": 0,
+        "total_tokens": 0,
+        "cost": 0.0,
+        "status": "OK",
+        "status_message": "",
+        "org_id": None,
+        "project_version_id": None,
+        "end_user_id": None,
+        "trace_session_id": None,
+        "prompt_version_id": None,
+        "prompt_label_id": None,
+        "custom_eval_config_id": None,
+        "input": "hi",
+        "output": "hello",
+        "tags": "[]",
+        "span_events": "",
+        "metadata": "{}",
+        "resource_attrs": "{}",
+        "attributes_extra": "{}",
+        "trace_name": "my-trace",
+    }
+    base.update(overrides)
+    return CHSpan(**base)
+
+
+def _kind(obs_type: str) -> str:
+    return _ch_span_to_span(_span(observation_type=obs_type)).span_attributes[
+        "span.kind"
+    ]
+
+
+@pytest.mark.parametrize(
+    ("obs_type", "expected"),
+    [
+        # The lowercase canon actually stored in ClickHouse. Values are the
+        # scanner's own vocabulary: it matches {"Tool","TOOL"}, {"LLM","llm"},
+        # {"Retriever","RETRIEVER"} — so these spellings are load-bearing.
+        ("llm", "LLM"),
+        ("tool", "Tool"),
+        ("retriever", "Retriever"),
+        ("agent", "AGENT"),
+        ("chain", "CHAIN"),
+    ],
+)
+def test_lowercase_canon_maps_to_scanner_vocabulary(obs_type, expected):
+    assert _kind(obs_type) == expected
+
+
+@pytest.mark.parametrize(
+    ("obs_type", "expected"),
+    [
+        ("GENERATION", "LLM"),  # Langfuse-style, predates the lowercase canon
+        ("generation", "LLM"),
+        ("SPAN", "CHAIN"),
+        ("TOOL", "Tool"),
+        ("LLM", "LLM"),
+    ],
+)
+def test_legacy_and_uppercase_spellings_still_resolve(obs_type, expected):
+    assert _kind(obs_type) == expected
+
+
+@pytest.mark.parametrize("obs_type", ["unknown", "", "guardrail", "embedding"])
+def test_unrecognised_type_falls_open_to_chain(obs_type):
+    """Fail-open is intended — but it must be the exception, not every row."""
+    assert _kind(obs_type) == "CHAIN"
+
+
+def test_no_canonical_type_silently_degrades_to_chain():
+    """Guards the actual regression: a real trace must not come back all-CHAIN.
+
+    This is the assertion the old UPPERCASE map failed on every production row.
+    """
+    kinds = {_kind(t) for t in ("llm", "tool", "retriever", "chain")}
+    assert kinds == {"LLM", "Tool", "Retriever", "CHAIN"}
+
+
+def _status(**overrides) -> str:
+    return _ch_span_to_span(_span(**overrides)).status_code
+
+
+def test_error_column_wins_over_message_text():
+    """The regression: "tool call failed" contains no "error" substring.
+
+    Under the old message-only derivation this returned "Ok" for a span that had
+    genuinely failed, so the judge was told every error span succeeded.
+    """
+    assert _status(status="ERROR", status_message="tool call failed") == "Error"
+
+
+def test_error_column_without_any_message():
+    assert _status(status="ERROR", status_message="") == "Error"
+
+
+def test_ok_column_maps_to_ok():
+    assert _status(status="OK", status_message="") == "Ok"
+
+
+def test_message_fallback_survives_when_status_column_is_blank():
+    """Rows predating the status column still get a best-effort read."""
+    assert _status(status="", status_message="upstream error 504") == "Error"
+    assert _status(status="", status_message="completed fine") == "Ok"
+
+
+def test_no_status_and_no_message_is_unset():
+    assert _status(status="", status_message="") == "Unset"


### PR DESCRIPTION
## What

Three defects in what the judge is allowed to see. All measured on the 2026-08-18 prod corpus
(140 traces, 6,266 real spans).

**Read the measurement section before merging: this buys no measurable recall.** It is a
correctness fix, and the PR should not be sold as anything else.

### 1. Every production span reached the judge as `CHAIN`

`_OBS_TYPE_TO_KIND` was keyed UPPERCASE in Langfuse vocabulary (`"GENERATION"`, `"SPAN"`, ...)
and looked up without case folding, but `observation_type` is written lowercase by both
ingest paths. No key could ever match:

| span.kind the judge sees | before | after |
|---|---|---|
| CHAIN | **6266 (100.0%)** | 3825 (61.0%) |
| LLM | 0 | 2161 |
| Tool | 0 | 183 |
| AGENT | 0 | 97 |

Downstream, with everything at CHAIN: `compress.py:552-556` `llm_spans` is empty so
`turn_count = 0` on every trace; `compress.py:546-549` `tools_called` degrades to a
`"Tool" in span_name` substring match. Checklist row S2 is a symptom of this, not a separate
defect.

`status` was also derived from the free-text `status_message` while the authoritative `status`
column was ignored — 93.4% of spans reached the judge as `Unset` instead of `Ok`, and a span
that genuinely failed read as `Ok` whenever its message did not contain "error".

### 2. Per-message attributes were filtered down to `.role`/`.content`

Structured multi-part content (`contents.N.message_content.text` — the actual text on
multimodal messages, not metadata) and per-message `tool_calls` were dropped before the judge
ran, on **834/6266 spans (13.3%)**. Those messages carry no flat `.content`, so they were
entirely invisible, not merely missing metadata.

`compress.py` now reconstructs ordered chat turns per span (`_build_message_transcript`) and
renders them as a `msgs:` line.

### 3. Exception attributes were never read at all

`exception.type` / `.message` / `.stacktrace` are present on **142/6266 spans (2.27%)** and
nothing in the scanner pipeline read them. The judge saw `status_code=Error` and never why.
Now surfaced as an `err:` line.

## Measurement — this does not move recall, and that is the honest headline

Because the eval harness has always built span kind and status correctly, no arm had ever
measured what production actually scores. We built one (harness reverted to `dev`'s exact
behaviour) and compared:

| arm (n=124 gold defects) | aggregate recall | FP on 16 clean |
|---|---|---|
| production today (S1-less) | **46.8%** | 1 |
| + span kind & status fix | 42.7% | 0 |
| + full bundle (this PR) | 45.2% | 1 |

One-sided exact McNemar: bundle vs production `gain=4 loss=6, p=0.83`. Net -2 defects against
a pre-declared >=8-defect noise floor (6.1% measured flip rate on byte-identical rescans).
**Every delta is inside noise.**

So: merge this because the judge should not be told that an LLM call is a CHAIN, or that a
failed span is fine, or be shown a multimodal message with the text removed. Do not merge it
expecting a recall gain.

Full protocol with predictions locked before the run:
`golden-data-feed/experiments/s1-value-2026-08-18/`.

## Correction to the first commit's own message

`c6ce1c9df` claims the CHAIN bug also caused `tools_available` to be empty. That is **wrong**
and this PR does not fix `tools_available`. `_tool_names_from_definitions` (`compress.py:269`)
reads tool definitions straight from span attributes and never consults span kind;
`declared_tools` (`:321`) iterates every span regardless of kind. The likely cause is that
structured-value tool lists route to `attributes_extra`, which `fetch_trace_data` stubs to
`''` — untouched here. `TOOLS AVAILABLE:` will still never render for those producers.

## Tests

- `test_scan_span_kind_mapping.py` (20) — CH-shaped fixtures on purpose: lowercase
  `observation_type`, populated `status`. A fixture written in the map's own vocabulary would
  have passed against the broken code forever, which is how this survived four months.
- `test_message_transcript.py` + `test_scan_message_attrs.py` (18, new) — 4 fail against the
  pre-fix code; 3 are deliberate both-ways regression guards proving the widened filter did
  not become a passthrough.

134 scanner tests green locally.