### PR TITLE
fix: alerts graph default window to 7 days (avoid ClickHouse timeout)

### DIFF
--- a/frontend/src/sections/projects/Alerts/common.js
+++ b/frontend/src/sections/projects/Alerts/common.js
@@ -196,7 +196,7 @@ export const getDefaultDateRange = () => {
     return [
       formatDate(
         sub(new Date(), {
-          months: 6,
+          days: 7,
         }),
       ),
       formatDate(endOfToday()),
@@ -205,7 +205,7 @@ export const getDefaultDateRange = () => {
 
   return {
     dateFilter: getDateArray(),
-    dateOption: "6M",
+    dateOption: "7D",
   };
 };
 


### PR DESCRIPTION
## Summary

The alert graph endpoint (`GET /tracer/user-alerts/{id}/graph/`) was returning a 500 ("Unable to retrieve details for the selected alert") because the ClickHouse time-series query exceeded the 10s graph timeout. The alert graph views defaulted their date filter to a **6-month** window and sent it to the graph endpoint, so ClickHouse bucketed the `spans` table at the monitor frequency (e.g. 5m) over 6 months and hit `Code: 159 — Timeout exceeded (~10.4s > 10s)`. This changes the default window to **7 days** (matching the backend's own default), keeping the scan well under the timeout.

## Linked issues

Fixed TH-7629
Linear: https://linear.app/future-agi/issue/TH-7629/alerts-graph-500s-on-6-month-default-window-clickhouse-timeout

## Type of change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

---

## 1) What changes were done

**A. Alerts graph default window (`Alerts/common.js`)**

- `getDefaultDateRange()` now returns a **7-day** window (`dateOption: "7D"`) instead of 6 months.
- Consumed by both alert graph views (`CreateAlertsDrawer`, `AlertsSheetView`) as the initial `dateFilter`, so the graph request now scans ~7 days instead of ~6 months.

---

## 2) Why the changes were done

- **Product/UX:** Users saw a 500 and no graph when opening/creating alerts. The graph is a preview/context chart — 7 days is plenty and loads reliably.
- **Technical:** The graph query is already partition-pruned on `start_time`; the timeout was purely scan volume from the window. The backend defaults to a 7-day window when none is passed, so this aligns the FE with that.

---

## 3) Tests

No automated tests — one-line default-value change. Verified manually against local (graph loads; CH timeout gone).

## 4) How to test

1. Start the stack and log in.
2. Open Alerts and view/create an alert to load the graph.
3. Confirm the graph renders instead of erroring, and backend logs no longer show `Failed to get monitor graph data: Code: 159 ... Timeout exceeded`.

---

## 6) Edge cases & considerations

- A user can still manually select a 6-month range in the date picker, which could time out again for the heaviest metrics on smaller ClickHouse deployments. A server-side clamp on the graph window is noted as a follow-up on TH-7629 (out of scope here).
