### PR TITLE
fix(agentic_eval): don't silently bill $0 for unrecognized/placeholder model pricing

### DIFF
--- a/futureagi/agentic_eval/core_evals/fi_utils/token_count_helper.py
+++ b/futureagi/agentic_eval/core_evals/fi_utils/token_count_helper.py
@@ -182,69 +182,39 @@ DEFAULT_TTS_FALLBACK_PRICING = {"input_per_1M_characters": 15.0}
 DEFAULT_STT_FALLBACK_PRICING = {"input_per_minute": 0.006}
 
 
-def calculate_total_cost(
-    model_name: str, token_usage: dict, fallback_pricing: Optional[dict] = None
-) -> dict:
+def _select_fallback_pricing(
+    token_usage: dict, fallback_pricing: Optional[dict]
+) -> tuple[dict, str]:
     """
-    Calculate total cost for a model inference using pricing from AVAILABLE_MODELS.
+    Choose a fallback pricing dict based on the token_usage fields.
 
-    Supports multiple pricing models:
-    - LLM/Chat: Token-based pricing (input/output tokens)
-    - TTS: Character-based pricing (input characters)
-    - STT: Time-based pricing (audio seconds/minutes)
-
-    Args:
-        model_name: The model identifier (e.g., "gpt-4o", "tts-1", "whisper-1")
-        token_usage: Dict with keys depending on model type:
-            For LLM: {"prompt_tokens": int, "completion_tokens": int}
-            For TTS: {"input_characters": int, "prompt_tokens": int, "completion_tokens": int}
-            For STT: {"audio_seconds": float}
-        fallback_pricing: Optional custom fallback pricing dict
-
-    Returns:
-        Dict with keys:
-            - total_cost (float): Total cost in USD (rounded to 6 decimals)
-            - prompt_cost (float): Input cost in USD (rounded to 6 decimals)
-            - completion_cost (float): Output cost in USD (rounded to 6 decimals)
-            - pricing_source (str): "available_models", "fallback", or "default"
+    Returns a ``(pricing, fallback_type)`` tuple. Mirrors the historical
+    fallback selection so both the "model not found" path and the
+    "unrecognized pricing" path resolve to the same conservative estimates.
     """
-    from agentic_eval.core_evals.run_prompt.model_pricing import get_model_pricing
+    if fallback_pricing:
+        return fallback_pricing, "custom"
+    if "images_generated" in token_usage:
+        # Image generation model
+        return DEFAULT_IMAGE_FALLBACK_PRICING, "default_image"
+    if "input_characters" in token_usage:
+        # TTS model
+        return DEFAULT_TTS_FALLBACK_PRICING, "default_tts"
+    if "audio_seconds" in token_usage:
+        # STT model
+        return DEFAULT_STT_FALLBACK_PRICING, "default_stt"
+    # Default to LLM token-based pricing
+    return DEFAULT_FALLBACK_PRICING, "default"
 
-    # Try to get pricing from available_models.py
-    pricing = get_model_pricing(model_name)
-    pricing_source = "available_models"
 
-    # Fallback chain
-    if pricing is None:
-        # Determine appropriate fallback based on token_usage fields
-        if fallback_pricing:
-            pricing = fallback_pricing
-            fallback_type = "custom"
-        elif "images_generated" in token_usage:
-            # Image generation model
-            pricing = DEFAULT_IMAGE_FALLBACK_PRICING
-            fallback_type = "default_image"
-        elif "input_characters" in token_usage:
-            # TTS model
-            pricing = DEFAULT_TTS_FALLBACK_PRICING
-            fallback_type = "default_tts"
-        elif "audio_seconds" in token_usage:
-            # STT model
-            pricing = DEFAULT_STT_FALLBACK_PRICING
-            fallback_type = "default_stt"
-        else:
-            # Default to LLM token-based pricing
-            pricing = DEFAULT_FALLBACK_PRICING
-            fallback_type = "default"
+def _compute_costs(pricing: dict, token_usage: dict) -> tuple[float, float, bool]:
+    """
+    Compute (prompt_cost, completion_cost, recognized) for a pricing dict.
 
-        logger.warning(
-            f"Model '{model_name}' not found in AVAILABLE_MODELS, using fallback pricing",
-            model=model_name,
-            fallback_type=fallback_type,
-        )
-        pricing_source = "fallback" if fallback_pricing else "default"
-
-    # Detect pricing type and calculate accordingly
+    ``recognized`` is False when the pricing dict does not match any known
+    pricing shape (token/character/minute/image based). Callers use this to
+    distinguish a genuine $0 from an unrecognized pricing structure.
+    """
     prompt_cost = 0.0
     completion_cost = 0.0
 
@@ -311,12 +281,74 @@ def calculate_total_cost(
         completion_cost = round(total_image_cost, 6)
 
     else:
-        # Unknown pricing structure - log warning and return zero costs
+        # Unrecognized pricing structure
+        return 0.0, 0.0, False
+
+    return prompt_cost, completion_cost, True
+
+
+def calculate_total_cost(
+    model_name: str, token_usage: dict, fallback_pricing: Optional[dict] = None
+) -> dict:
+    """
+    Calculate total cost for a model inference using pricing from AVAILABLE_MODELS.
+
+    Supports multiple pricing models:
+    - LLM/Chat: Token-based pricing (input/output tokens)
+    - TTS: Character-based pricing (input characters)
+    - STT: Time-based pricing (audio seconds/minutes)
+
+    Args:
+        model_name: The model identifier (e.g., "gpt-4o", "tts-1", "whisper-1")
+        token_usage: Dict with keys depending on model type:
+            For LLM: {"prompt_tokens": int, "completion_tokens": int}
+            For TTS: {"input_characters": int, "prompt_tokens": int, "completion_tokens": int}
+            For STT: {"audio_seconds": float}
+        fallback_pricing: Optional custom fallback pricing dict
+
+    Returns:
+        Dict with keys:
+            - total_cost (float): Total cost in USD (rounded to 6 decimals)
+            - prompt_cost (float): Input cost in USD (rounded to 6 decimals)
+            - completion_cost (float): Output cost in USD (rounded to 6 decimals)
+            - pricing_source (str): "available_models", "fallback", or "default".
+              A genuine $0 keeps "available_models"; an unrecognized pricing
+              structure now reports "fallback"/"default" so downstream can tell
+              a real $0 apart from a missed one.
+    """
+    from agentic_eval.core_evals.run_prompt.model_pricing import get_model_pricing
+
+    # Try to get pricing from available_models.py
+    pricing = get_model_pricing(model_name)
+    pricing_source = "available_models"
+
+    # Fallback chain: model not found (or placeholder/non-numeric pricing).
+    if pricing is None:
+        pricing, fallback_type = _select_fallback_pricing(token_usage, fallback_pricing)
         logger.warning(
-            f"Unknown pricing structure for model '{model_name}': {pricing}",
+            f"Model '{model_name}' not found in AVAILABLE_MODELS, using fallback pricing",
+            model=model_name,
+            fallback_type=fallback_type,
+        )
+        pricing_source = "fallback" if fallback_pricing else "default"
+
+    # Detect pricing type and calculate accordingly.
+    prompt_cost, completion_cost, recognized = _compute_costs(pricing, token_usage)
+
+    # Unrecognized pricing structure from AVAILABLE_MODELS: do NOT silently bill
+    # $0 with source "available_models". Fall through to fallback pricing and
+    # stamp a detectable source so downstream can distinguish a real $0.
+    if not recognized and pricing_source == "available_models":
+        logger.warning(
+            f"Unrecognized pricing structure for model '{model_name}', "
+            f"using fallback pricing instead of $0: {pricing}",
             model=model_name,
             pricing=pricing,
         )
+        pricing, fallback_type = _select_fallback_pricing(token_usage, fallback_pricing)
+        pricing_source = "fallback" if fallback_pricing else "default"
+        prompt_cost, completion_cost, _ = _compute_costs(pricing, token_usage)
+
     return {
         "total_cost": round(prompt_cost + completion_cost, 6),
         "prompt_cost": prompt_cost,

--- a/futureagi/agentic_eval/core_evals/run_prompt/model_pricing.py
+++ b/futureagi/agentic_eval/core_evals/run_prompt/model_pricing.py
@@ -319,6 +319,24 @@ def get_model_info(model_name: str) -> Optional[dict]:
     )
 
 
+def _has_numeric_pricing(pricing: dict) -> bool:
+    """
+    Return True if the pricing dict contains at least one usable numeric price.
+
+    Some catalogue entries carry placeholder pricing that is present but not
+    actually priceable, e.g. azure_ai ``{"details": "Varies by deployment..."}``
+    or together_ai ``{"per_1M_tokens": "pay-per-token"}``. Such dicts have no
+    numeric value and must be treated as "no pricing" so a detectable fallback
+    estimate is used instead of silently costing $0.
+
+    ``bool`` is explicitly excluded because ``isinstance(True, int)`` is True.
+    """
+    return any(
+        isinstance(value, (int, float)) and not isinstance(value, bool)
+        for value in pricing.values()
+    )
+
+
 @lru_cache(maxsize=512)
 def get_model_pricing(model_name: str) -> Optional[dict]:
     """
@@ -339,11 +357,18 @@ def get_model_pricing(model_name: str) -> Optional[dict]:
         For STT (Speech-to-Text) models:
             {"input_per_minute": float}
 
-        Returns None if model not found or pricing not available
+        Returns None if model not found, pricing not available, or pricing is a
+        placeholder with no numeric values (so callers apply fallback pricing).
     """
     model_info = get_model_info(model_name)
     if model_info and "pricing" in model_info:
-        return model_info["pricing"].copy()  # Return a copy to prevent mutations
+        pricing = model_info["pricing"]
+        if isinstance(pricing, dict):
+            # Placeholder / non-numeric pricing (present but not priceable) is
+            # treated as missing so the fallback chain applies a real estimate.
+            if not _has_numeric_pricing(pricing):
+                return None
+            return pricing.copy()  # Return a copy to prevent mutations
     return None
 
 

--- a/futureagi/agentic_eval/core_evals/run_prompt/tests/test_model_pricing.py
+++ b/futureagi/agentic_eval/core_evals/run_prompt/tests/test_model_pricing.py
@@ -553,6 +553,152 @@ class TestFallbackPricing:
 
 
 # =============================================================================
+# Unit Tests - Unrecognized / Placeholder Pricing Are Not Silent $0
+# =============================================================================
+
+
+@pytest.mark.unit
+class TestUnrecognizedPricingNotSilentZero:
+    """Regression tests: pricing that is present but not priceable must NOT be
+    billed as a silent $0 with source "available_models".
+
+    Two root causes are covered:
+      (A) An unrecognized-but-present pricing structure (numeric values, but no
+          key shape the cost calculator understands) used to fall through to a
+          $0 cost while still reporting source "available_models" -- making it
+          indistinguishable from a legitimate $0. It must now fall back to a
+          real estimate and stamp a detectable source ("default"/"fallback").
+      (B) Placeholder / non-numeric pricing (e.g. azure_ai "details" strings or
+          together_ai "pay-per-token" strings) is returned as a non-None dict by
+          get_model_pricing, so the fallback never runs. get_model_pricing must
+          treat such pricing as missing (return None) so a real estimate applies.
+    """
+
+    UNRECOGNIZED_PRICING_MOD = (
+        "agentic_eval.core_evals.run_prompt.model_pricing.get_model_pricing"
+    )
+
+    # ---- (A) unrecognized-but-present numeric pricing ----------------------
+
+    def test_unrecognized_pricing_falls_back_not_silent_zero(self, monkeypatch):
+        """Unrecognized (but numeric) pricing -> fallback estimate, detectable source.
+
+        Fails on old code: old behavior returned total_cost 0.0 with
+        pricing_source "available_models".
+        """
+        # e.g. an embedding-style entry that only carries an input price, which
+        # the token cost path (needs BOTH input and output) does not recognize.
+        unrecognized = {"input_per_1M_tokens": 5.0}
+        monkeypatch.setattr(self.UNRECOGNIZED_PRICING_MOD, lambda name: unrecognized)
+
+        token_usage = {"prompt_tokens": 1000, "completion_tokens": 500}
+        result = calculate_total_cost("some-model-with-weird-pricing", token_usage)
+
+        # The whole point of the fix: not a silent $0 attributed to the catalog.
+        assert result["pricing_source"] != "available_models"
+        assert result["pricing_source"] == "default"
+        assert result["total_cost"] > 0.0
+
+        # Should equal the standard default fallback estimate.
+        expected_prompt = round(
+            (1000 / 1_000_000) * DEFAULT_FALLBACK_PRICING["input_per_1M_tokens"], 6
+        )
+        expected_completion = round(
+            (500 / 1_000_000) * DEFAULT_FALLBACK_PRICING["output_per_1M_tokens"], 6
+        )
+        assert result["prompt_cost"] == expected_prompt
+        assert result["completion_cost"] == expected_completion
+
+    def test_unrecognized_pricing_honors_custom_fallback(self, monkeypatch):
+        """Custom fallback pricing is used (source 'fallback') on the unrecognized path."""
+        monkeypatch.setattr(
+            self.UNRECOGNIZED_PRICING_MOD, lambda name: {"per_1000_pairs": 2.0}
+        )
+        custom_fallback = {"input_per_1M_tokens": 1.0, "output_per_1M_tokens": 2.0}
+
+        token_usage = {"prompt_tokens": 1000, "completion_tokens": 500}
+        result = calculate_total_cost(
+            "reranker-weird", token_usage, fallback_pricing=custom_fallback
+        )
+
+        assert result["pricing_source"] == "fallback"
+        assert result["prompt_cost"] == round((1000 / 1_000_000) * 1.0, 6)
+        assert result["completion_cost"] == round((500 / 1_000_000) * 2.0, 6)
+
+    def test_genuine_zero_pricing_stays_available_models(self, monkeypatch):
+        """A real $0 (recognized zero pricing) must stay source 'available_models'.
+
+        This is the distinction the fix preserves: a true $0 is detectable
+        apart from a missed/unrecognized $0.
+        """
+        monkeypatch.setattr(
+            self.UNRECOGNIZED_PRICING_MOD,
+            lambda name: {"input_per_1M_tokens": 0.0, "output_per_1M_tokens": 0.0},
+        )
+        token_usage = {"prompt_tokens": 1000, "completion_tokens": 500}
+        result = calculate_total_cost("free-model", token_usage)
+
+        assert result["pricing_source"] == "available_models"
+        assert result["total_cost"] == 0.0
+
+    # ---- (B) placeholder / non-numeric pricing in the real catalog ---------
+
+    def test_has_numeric_pricing_helper(self):
+        """_has_numeric_pricing distinguishes priceable from placeholder dicts."""
+        from agentic_eval.core_evals.run_prompt.model_pricing import (
+            _has_numeric_pricing,
+        )
+
+        assert _has_numeric_pricing({"input_per_1M_tokens": 5, "output_per_1M_tokens": 15})
+        assert _has_numeric_pricing({"per_image": 0.04})
+        assert _has_numeric_pricing({"input_per_1M_tokens": 0.0})  # real $0 counts
+        # Placeholders have no numeric values:
+        assert not _has_numeric_pricing({"details": "Varies by deployment and usage"})
+        assert not _has_numeric_pricing({"per_1M_tokens": "pay-per-token"})
+        assert not _has_numeric_pricing({"per_image": "N/A"})
+        # bool must not count as numeric:
+        assert not _has_numeric_pricing({"free": True})
+
+    def test_azure_ai_details_placeholder_returns_none(self):
+        """azure_ai '{details: ...}' placeholder pricing -> None (so fallback runs)."""
+        assert get_model_pricing("azure_ai/mistral-large") is None
+
+    def test_together_ai_string_placeholder_returns_none(self):
+        """together_ai '{per_1M_tokens: "pay-per-token"}' placeholder -> None."""
+        assert get_model_pricing("together-ai-8.1b-21b") is None
+
+    def test_azure_ai_placeholder_model_routes_to_fallback(self):
+        """A catalogued placeholder model now yields a real estimate, not silent $0."""
+        token_usage = {"prompt_tokens": 1000, "completion_tokens": 500}
+        result = calculate_total_cost("azure_ai/mistral-large", token_usage)
+
+        assert result["pricing_source"] != "available_models"
+        assert result["pricing_source"] == "default"
+        assert result["total_cost"] > 0.0
+
+    def test_together_ai_placeholder_model_routes_to_fallback(self):
+        """together_ai string-priced model routes to fallback estimate."""
+        token_usage = {"prompt_tokens": 1000, "completion_tokens": 500}
+        result = calculate_total_cost("together-ai-8.1b-21b", token_usage)
+
+        assert result["pricing_source"] != "available_models"
+        assert result["pricing_source"] == "default"
+        assert result["total_cost"] > 0.0
+
+    def test_real_pricing_unchanged(self):
+        """Sanity: a normally-priced model is unaffected by the fix."""
+        assert get_model_pricing("gpt-4o") == {
+            "input_per_1M_tokens": 5,
+            "output_per_1M_tokens": 15,
+        }
+        result = calculate_total_cost(
+            "gpt-4o", {"prompt_tokens": 1000, "completion_tokens": 500}
+        )
+        assert result["pricing_source"] == "available_models"
+        assert result["total_cost"] == round((1000 / 1_000_000) * 5 + (500 / 1_000_000) * 15, 6)
+
+
+# =============================================================================
 # Unit Tests - Image Model Name Parsing and Cost Calculation
 # =============================================================================
 


### PR DESCRIPTION
## Summary

`calculate_total_cost` in `futureagi/agentic_eval/core_evals/fi_utils/token_count_helper.py` had an "Unknown pricing structure" branch that returned cost **$0** while keeping `pricing_source="available_models"` whenever a model's pricing dict didn't match any recognized shape. That made a *missed* price indistinguishable from a *legitimate* $0 — downstream billing/analytics can't tell "this model is free" from "we failed to price this model."

This is the systemic fix for that class. It complements #2252 (which fixed one instance — embeddings — by adding their pricing), by making the cost path itself fail loud instead of silently zeroing whenever pricing is present-but-unpriceable.

**Verified impact:** across the catalog, dozens of models are silently billed $0 this way (35+ catalogued entries), including two concrete placeholder families that are ironclad:
- **11** `azure_ai/*` models with `{"details": "Varies by deployment and usage; contact Azure sales for quote"}`
- **8** `together_ai/*` models with `{"per_1M_tokens": "pay-per-token"}` (a string, not a number)

plus a large "unrecognized shape" set (embeddings that carry only `input_per_1M_tokens`, rerankers priced `per_1000_pairs`, `per_minute_audio`, etc.) that has numeric values but no branch the calculator understands.

## Root causes and fixes

**(A) Unrecognized-but-present pricing → silent $0.**
`token_count_helper.py`: the branch cascade is factored into `_compute_costs(...)`, which now reports whether the pricing shape was `recognized`. When pricing came from the catalog but no shape matched, `calculate_total_cost` no longer returns $0 with source `"available_models"`; it falls through to the same `DEFAULT_FALLBACK_PRICING` chain the "model not found" path uses (`_select_fallback_pricing`) and stamps a **detectable** `pricing_source` (`"default"`, or `"fallback"` when a custom fallback is supplied). A warning is logged.

**(B) Placeholder / non-numeric pricing returned a non-None dict, so the fallback never ran.**
`model_pricing.py`: `get_model_pricing` now treats a pricing dict with **no numeric values** as missing (returns `None`) via the new `_has_numeric_pricing` helper, so the fallback estimate applies. `bool` is explicitly excluded from "numeric" (since `isinstance(True, int)` is True).

## `pricing_source` behavior change (the point of the PR)

| Pricing situation | Before | After |
|---|---|---|
| Recognized pricing, real nonzero cost | `available_models`, cost>0 | **unchanged** |
| Recognized pricing that is genuinely `0.0` | `available_models`, cost 0 | **unchanged** (`available_models`, 0) |
| Present but **unrecognized** shape (e.g. embeddings input-only) | `available_models`, **$0 (silent)** | `default`/`fallback`, real estimate |
| **Placeholder** (`azure_ai` details / `together_ai` string / `per_image: "N/A"`) | `available_models`, **$0 (silent)** | `default`/`fallback`, real estimate |

A genuine free model still reports `available_models` + $0, so downstream can now distinguish a real $0 from a missed one by `pricing_source != "available_models"`.

## Correctness / no regressions

Every currently-correct path is byte-identical: I diffed `calculate_total_cost` output for **all 433 catalogued models across 5 usage shapes** (token / character / audio / image×2), before vs after. Every single change is a formerly-silent `$0 + available_models` entry now producing a nonzero fallback estimate with a detectable source. **No model that derives a real (nonzero) cost from the catalog changed its cost or its source.** The one `{"per_image": "N/A"}` placeholder keeps an identical cost for real image usage (0.04/image) and only flips its source to `default`.

## Tests

Adds `TestUnrecognizedPricingNotSilentZero` to `test_model_pricing.py` covering both root causes, with fail-without/pass-with verified:
- unrecognized-but-numeric pricing → fallback estimate + non-`available_models` source
- custom fallback honored on the unrecognized path (`fallback`)
- genuine `0.0` pricing stays `available_models` (the distinction is preserved)
- `azure_ai/*` "details" and `together_ai/*` string placeholders → `get_model_pricing` returns `None` and the model routes to a fallback estimate
- `_has_numeric_pricing` unit coverage; sanity that normal models (gpt-4o) are untouched

Against the pre-fix source, the 7 fix-exercising tests fail; the 2 invariance-control tests pass on both. With the fix, the full file is green: **64 passed** (55 pre-existing + 9 new) via `pytest agentic_eval/core_evals/run_prompt/tests/test_model_pricing.py`.

Refs #2252.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
