### PR TITLE
feat(tasks): persist the eval task time-window preset [TH-7627]

### DIFF
--- a/api_contracts/openapi/swagger.json
+++ b/api_contracts/openapi/swagger.json
@@ -122494,6 +122494,22 @@
                             "maxItems": 2,
                             "description": "Inclusive start/end ISO timestamps."
                         },
+                        "date_preset": {
+                            "type": "string",
+                            "enum": [
+                                "30m",
+                                "6h",
+                                "today",
+                                "yesterday",
+                                "7d",
+                                "30d",
+                                "3m",
+                                "6m",
+                                "12m",
+                                "custom"
+                            ],
+                            "description": "Which time-window preset the user chose. The frontend resolves it to date_range at save time; this records the intent so a relative window can be re-anchored on the next save. Never read when building a query — date_range remains authoritative. Absent on tasks predating this field. The enum documents the accepted values; it is not enforced."
+                        },
                         "created_at": {
                             "type": "string",
                             "description": "Lower-bound ISO timestamp for legacy task filters."
@@ -122841,6 +122857,22 @@
                             "minItems": 2,
                             "maxItems": 2,
                             "description": "Inclusive start/end ISO timestamps."
+                        },
+                        "date_preset": {
+                            "type": "string",
+                            "enum": [
+                                "30m",
+                                "6h",
+                                "today",
+                                "yesterday",
+                                "7d",
+                                "30d",
+                                "3m",
+                                "6m",
+                                "12m",
+                                "custom"
+                            ],
+                            "description": "Which time-window preset the user chose. The frontend resolves it to date_range at save time; this records the intent so a relative window can be re-anchored on the next save. Never read when building a query — date_range remains authoritative. Absent on tasks predating this field. The enum documents the accepted values; it is not enforced."
                         },
                         "created_at": {
                             "type": "string",

--- a/frontend/src/api/contracts/openapi-contract.generated.js
+++ b/frontend/src/api/contracts/openapi-contract.generated.js
@@ -54548,6 +54548,22 @@ export const OPENAPI_CONTRACT = Object.freeze({
               "maxItems": 2,
               "description": "Inclusive start/end ISO timestamps."
             },
+            "date_preset": {
+              "type": "string",
+              "enum": [
+                "30m",
+                "6h",
+                "today",
+                "yesterday",
+                "7d",
+                "30d",
+                "3m",
+                "6m",
+                "12m",
+                "custom"
+              ],
+              "description": "Which time-window preset the user chose. The frontend resolves it to date_range at save time; this records the intent so a relative window can be re-anchored on the next save. Never read when building a query — date_range remains authoritative. Absent on tasks predating this field. The enum documents the accepted values; it is not enforced."
+            },
             "created_at": {
               "type": "string",
               "description": "Lower-bound ISO timestamp for legacy task filters."
@@ -54869,6 +54885,22 @@ export const OPENAPI_CONTRACT = Object.freeze({
               "minItems": 2,
               "maxItems": 2,
               "description": "Inclusive start/end ISO timestamps."
+            },
+            "date_preset": {
+              "type": "string",
+              "enum": [
+                "30m",
+                "6h",
+                "today",
+                "yesterday",
+                "7d",
+                "30d",
+                "3m",
+                "6m",
+                "12m",
+                "custom"
+              ],
+              "description": "Which time-window preset the user chose. The frontend resolves it to date_range at save time; this records the intent so a relative window can be re-anchored on the next save. Never read when building a query — date_range remains authoritative. Absent on tasks predating this field. The enum documents the accepted values; it is not enforced."
             },
             "created_at": {
               "type": "string",

--- a/frontend/src/generated/api-contracts/api.schemas.ts
+++ b/frontend/src/generated/api-contracts/api.schemas.ts
@@ -19476,6 +19476,25 @@ export interface ObserveDatasetApi {
   readonly user?: string;
 }
 
+/**
+ * Which time-window preset the user chose. The frontend resolves it to date_range at save time; this records the intent so a relative window can be re-anchored on the next save. Never read when building a query — date_range remains authoritative. Absent on tasks predating this field. The enum documents the accepted values; it is not enforced.
+ */
+export type EvalTaskApiFiltersDatePreset = typeof EvalTaskApiFiltersDatePreset[keyof typeof EvalTaskApiFiltersDatePreset];
+
+
+export const EvalTaskApiFiltersDatePreset = {
+  '30m': '30m',
+  '6h': '6h',
+  today: 'today',
+  yesterday: 'yesterday',
+  '7d': '7d',
+  '30d': '30d',
+  '3m': '3m',
+  '6m': '6m',
+  '12m': '12m',
+  custom: 'custom',
+} as const;
+
 export type EvalTaskApiFiltersFiltersItemFilterConfig = {
   /** Canonical field type, for example text, number, boolean, datetime, categorical, thumbs, annotator, or array. */
   filter_type: string;
@@ -19531,6 +19550,8 @@ export type EvalTaskApiFilters = {
      * @maxItems 2
      */
   date_range?: string[];
+  /** Which time-window preset the user chose. The frontend resolves it to date_range at save time; this records the intent so a relative window can be re-anchored on the next save. Never read when building a query — date_range remains authoritative. Absent on tasks predating this field. The enum documents the accepted values; it is not enforced. */
+  date_preset?: EvalTaskApiFiltersDatePreset;
   /** Lower-bound ISO timestamp for legacy task filters. */
   created_at?: string;
   /** Trace session id(s) to constrain the task. */
@@ -19635,6 +19656,25 @@ export interface EvalTaskMessageResponseApi {
   result: EvalTaskMessageResultApi;
 }
 
+/**
+ * Which time-window preset the user chose. The frontend resolves it to date_range at save time; this records the intent so a relative window can be re-anchored on the next save. Never read when building a query — date_range remains authoritative. Absent on tasks predating this field. The enum documents the accepted values; it is not enforced.
+ */
+export type EvalTaskUpdateRequestApiFiltersDatePreset = typeof EvalTaskUpdateRequestApiFiltersDatePreset[keyof typeof EvalTaskUpdateRequestApiFiltersDatePreset];
+
+
+export const EvalTaskUpdateRequestApiFiltersDatePreset = {
+  '30m': '30m',
+  '6h': '6h',
+  today: 'today',
+  yesterday: 'yesterday',
+  '7d': '7d',
+  '30d': '30d',
+  '3m': '3m',
+  '6m': '6m',
+  '12m': '12m',
+  custom: 'custom',
+} as const;
+
 export type EvalTaskUpdateRequestApiFiltersFiltersItemFilterConfig = {
   /** Canonical field type, for example text, number, boolean, datetime, categorical, thumbs, annotator, or array. */
   filter_type: string;
@@ -19690,6 +19730,8 @@ export type EvalTaskUpdateRequestApiFilters = {
      * @maxItems 2
      */
   date_range?: string[];
+  /** Which time-window preset the user chose. The frontend resolves it to date_range at save time; this records the intent so a relative window can be re-anchored on the next save. Never read when building a query — date_range remains authoritative. Absent on tasks predating this field. The enum documents the accepted values; it is not enforced. */
+  date_preset?: EvalTaskUpdateRequestApiFiltersDatePreset;
   /** Lower-bound ISO timestamp for legacy task filters. */
   created_at?: string;
   /** Trace session id(s) to constrain the task. */

--- a/frontend/src/generated/api-contracts/api.zod.ts
+++ b/frontend/src/generated/api-contracts/api.zod.ts
@@ -35935,6 +35935,7 @@ export const TracerEvalTaskListResponse = zod.object({
   "filters": zod.object({
   "project_id": zod.string().optional().describe('Project scope for the evaluation task.'),
   "date_range": zod.array(zod.string()).min(tracerEvalTaskListResponseResultsItemFiltersDateRangeMin).max(tracerEvalTaskListResponseResultsItemFiltersDateRangeMax).optional().describe('Inclusive start\/end ISO timestamps.'),
+  "date_preset": zod.enum(['30m', '6h', 'today', 'yesterday', '7d', '30d', '3m', '6m', '12m', 'custom']).optional().describe('Which time-window preset the user chose. The frontend resolves it to date_range at save time; this records the intent so a relative window can be re-anchored on the next save. Never read when building a query — date_range remains authoritative. Absent on tasks predating this field. The enum documents the accepted values; it is not enforced.'),
   "created_at": zod.string().optional().describe('Lower-bound ISO timestamp for legacy task filters.'),
   "session_id": zod.array(zod.string()).optional().describe('Trace session id(s) to constrain the task.'),
   "trace_id": zod.array(zod.string()).optional().describe('Trace id(s) to constrain linked-source tasks.'),
@@ -36005,6 +36006,7 @@ export const TracerEvalTaskCreateBody = zod.object({
   "filters": zod.object({
   "project_id": zod.string().optional().describe('Project scope for the evaluation task.'),
   "date_range": zod.array(zod.string()).min(tracerEvalTaskCreateBodyFiltersDateRangeMin).max(tracerEvalTaskCreateBodyFiltersDateRangeMax).optional().describe('Inclusive start\/end ISO timestamps.'),
+  "date_preset": zod.enum(['30m', '6h', 'today', 'yesterday', '7d', '30d', '3m', '6m', '12m', 'custom']).optional().describe('Which time-window preset the user chose. The frontend resolves it to date_range at save time; this records the intent so a relative window can be re-anchored on the next save. Never read when building a query — date_range remains authoritative. Absent on tasks predating this field. The enum documents the accepted values; it is not enforced.'),
   "created_at": zod.string().optional().describe('Lower-bound ISO timestamp for legacy task filters.'),
   "session_id": zod.array(zod.string()).optional().describe('Trace session id(s) to constrain the task.'),
   "trace_id": zod.array(zod.string()).optional().describe('Trace id(s) to constrain linked-source tasks.'),
@@ -36090,6 +36092,7 @@ export const TracerEvalTaskGetEvalDetailsResponse = zod.object({
   "filters": zod.object({
   "project_id": zod.string().optional().describe('Project scope for the evaluation task.'),
   "date_range": zod.array(zod.string()).min(tracerEvalTaskGetEvalDetailsResponseResultsItemFiltersDateRangeMin).max(tracerEvalTaskGetEvalDetailsResponseResultsItemFiltersDateRangeMax).optional().describe('Inclusive start\/end ISO timestamps.'),
+  "date_preset": zod.enum(['30m', '6h', 'today', 'yesterday', '7d', '30d', '3m', '6m', '12m', 'custom']).optional().describe('Which time-window preset the user chose. The frontend resolves it to date_range at save time; this records the intent so a relative window can be re-anchored on the next save. Never read when building a query — date_range remains authoritative. Absent on tasks predating this field. The enum documents the accepted values; it is not enforced.'),
   "created_at": zod.string().optional().describe('Lower-bound ISO timestamp for legacy task filters.'),
   "session_id": zod.array(zod.string()).optional().describe('Trace session id(s) to constrain the task.'),
   "trace_id": zod.array(zod.string()).optional().describe('Trace id(s) to constrain linked-source tasks.'),
@@ -36170,6 +36173,7 @@ export const TracerEvalTaskGetEvalTaskLogsResponse = zod.object({
   "filters": zod.object({
   "project_id": zod.string().optional().describe('Project scope for the evaluation task.'),
   "date_range": zod.array(zod.string()).min(tracerEvalTaskGetEvalTaskLogsResponseResultsItemFiltersDateRangeMin).max(tracerEvalTaskGetEvalTaskLogsResponseResultsItemFiltersDateRangeMax).optional().describe('Inclusive start\/end ISO timestamps.'),
+  "date_preset": zod.enum(['30m', '6h', 'today', 'yesterday', '7d', '30d', '3m', '6m', '12m', 'custom']).optional().describe('Which time-window preset the user chose. The frontend resolves it to date_range at save time; this records the intent so a relative window can be re-anchored on the next save. Never read when building a query — date_range remains authoritative. Absent on tasks predating this field. The enum documents the accepted values; it is not enforced.'),
   "created_at": zod.string().optional().describe('Lower-bound ISO timestamp for legacy task filters.'),
   "session_id": zod.array(zod.string()).optional().describe('Trace session id(s) to constrain the task.'),
   "trace_id": zod.array(zod.string()).optional().describe('Trace id(s) to constrain linked-source tasks.'),
@@ -36250,6 +36254,7 @@ export const TracerEvalTaskGetUsageResponse = zod.object({
   "filters": zod.object({
   "project_id": zod.string().optional().describe('Project scope for the evaluation task.'),
   "date_range": zod.array(zod.string()).min(tracerEvalTaskGetUsageResponseResultsItemFiltersDateRangeMin).max(tracerEvalTaskGetUsageResponseResultsItemFiltersDateRangeMax).optional().describe('Inclusive start\/end ISO timestamps.'),
+  "date_preset": zod.enum(['30m', '6h', 'today', 'yesterday', '7d', '30d', '3m', '6m', '12m', 'custom']).optional().describe('Which time-window preset the user chose. The frontend resolves it to date_range at save time; this records the intent so a relative window can be re-anchored on the next save. Never read when building a query — date_range remains authoritative. Absent on tasks predating this field. The enum documents the accepted values; it is not enforced.'),
   "created_at": zod.string().optional().describe('Lower-bound ISO timestamp for legacy task filters.'),
   "session_id": zod.array(zod.string()).optional().describe('Trace session id(s) to constrain the task.'),
   "trace_id": zod.array(zod.string()).optional().describe('Trace id(s) to constrain linked-source tasks.'),
@@ -36345,6 +36350,7 @@ export const TracerEvalTaskListEvalTasksResponseItem = zod.object({
   "filters": zod.object({
   "project_id": zod.string().optional().describe('Project scope for the evaluation task.'),
   "date_range": zod.array(zod.string()).min(tracerEvalTaskListEvalTasksResponseFiltersDateRangeMin).max(tracerEvalTaskListEvalTasksResponseFiltersDateRangeMax).optional().describe('Inclusive start\/end ISO timestamps.'),
+  "date_preset": zod.enum(['30m', '6h', 'today', 'yesterday', '7d', '30d', '3m', '6m', '12m', 'custom']).optional().describe('Which time-window preset the user chose. The frontend resolves it to date_range at save time; this records the intent so a relative window can be re-anchored on the next save. Never read when building a query — date_range remains authoritative. Absent on tasks predating this field. The enum documents the accepted values; it is not enforced.'),
   "created_at": zod.string().optional().describe('Lower-bound ISO timestamp for legacy task filters.'),
   "session_id": zod.array(zod.string()).optional().describe('Trace session id(s) to constrain the task.'),
   "trace_id": zod.array(zod.string()).optional().describe('Trace id(s) to constrain linked-source tasks.'),
@@ -36440,6 +36446,7 @@ export const TracerEvalTaskListEvalTasksWithProjectNameResponseItem = zod.object
   "filters": zod.object({
   "project_id": zod.string().optional().describe('Project scope for the evaluation task.'),
   "date_range": zod.array(zod.string()).min(tracerEvalTaskListEvalTasksWithProjectNameResponseFiltersDateRangeMin).max(tracerEvalTaskListEvalTasksWithProjectNameResponseFiltersDateRangeMax).optional().describe('Inclusive start\/end ISO timestamps.'),
+  "date_preset": zod.enum(['30m', '6h', 'today', 'yesterday', '7d', '30d', '3m', '6m', '12m', 'custom']).optional().describe('Which time-window preset the user chose. The frontend resolves it to date_range at save time; this records the intent so a relative window can be re-anchored on the next save. Never read when building a query — date_range remains authoritative. Absent on tasks predating this field. The enum documents the accepted values; it is not enforced.'),
   "created_at": zod.string().optional().describe('Lower-bound ISO timestamp for legacy task filters.'),
   "session_id": zod.array(zod.string()).optional().describe('Trace session id(s) to constrain the task.'),
   "trace_id": zod.array(zod.string()).optional().describe('Trace id(s) to constrain linked-source tasks.'),
@@ -36566,6 +36573,7 @@ export const TracerEvalTaskUpdateEvalTaskBody = zod.object({
   "filters": zod.object({
   "project_id": zod.string().optional().describe('Project scope for the evaluation task.'),
   "date_range": zod.array(zod.string()).min(tracerEvalTaskUpdateEvalTaskBodyFiltersDateRangeMin).max(tracerEvalTaskUpdateEvalTaskBodyFiltersDateRangeMax).optional().describe('Inclusive start\/end ISO timestamps.'),
+  "date_preset": zod.enum(['30m', '6h', 'today', 'yesterday', '7d', '30d', '3m', '6m', '12m', 'custom']).optional().describe('Which time-window preset the user chose. The frontend resolves it to date_range at save time; this records the intent so a relative window can be re-anchored on the next save. Never read when building a query — date_range remains authoritative. Absent on tasks predating this field. The enum documents the accepted values; it is not enforced.'),
   "created_at": zod.string().optional().describe('Lower-bound ISO timestamp for legacy task filters.'),
   "session_id": zod.array(zod.string()).optional().describe('Trace session id(s) to constrain the task.'),
   "trace_id": zod.array(zod.string()).optional().describe('Trace id(s) to constrain linked-source tasks.'),
@@ -36642,6 +36650,7 @@ export const TracerEvalTaskReadResponse = zod.object({
   "filters": zod.object({
   "project_id": zod.string().optional().describe('Project scope for the evaluation task.'),
   "date_range": zod.array(zod.string()).min(tracerEvalTaskReadResponseFiltersDateRangeMin).max(tracerEvalTaskReadResponseFiltersDateRangeMax).optional().describe('Inclusive start\/end ISO timestamps.'),
+  "date_preset": zod.enum(['30m', '6h', 'today', 'yesterday', '7d', '30d', '3m', '6m', '12m', 'custom']).optional().describe('Which time-window preset the user chose. The frontend resolves it to date_range at save time; this records the intent so a relative window can be re-anchored on the next save. Never read when building a query — date_range remains authoritative. Absent on tasks predating this field. The enum documents the accepted values; it is not enforced.'),
   "created_at": zod.string().optional().describe('Lower-bound ISO timestamp for legacy task filters.'),
   "session_id": zod.array(zod.string()).optional().describe('Trace session id(s) to constrain the task.'),
   "trace_id": zod.array(zod.string()).optional().describe('Trace id(s) to constrain linked-source tasks.'),
@@ -36715,6 +36724,7 @@ export const TracerEvalTaskUpdateBody = zod.object({
   "filters": zod.object({
   "project_id": zod.string().optional().describe('Project scope for the evaluation task.'),
   "date_range": zod.array(zod.string()).min(tracerEvalTaskUpdateBodyFiltersDateRangeMin).max(tracerEvalTaskUpdateBodyFiltersDateRangeMax).optional().describe('Inclusive start\/end ISO timestamps.'),
+  "date_preset": zod.enum(['30m', '6h', 'today', 'yesterday', '7d', '30d', '3m', '6m', '12m', 'custom']).optional().describe('Which time-window preset the user chose. The frontend resolves it to date_range at save time; this records the intent so a relative window can be re-anchored on the next save. Never read when building a query — date_range remains authoritative. Absent on tasks predating this field. The enum documents the accepted values; it is not enforced.'),
   "created_at": zod.string().optional().describe('Lower-bound ISO timestamp for legacy task filters.'),
   "session_id": zod.array(zod.string()).optional().describe('Trace session id(s) to constrain the task.'),
   "trace_id": zod.array(zod.string()).optional().describe('Trace id(s) to constrain linked-source tasks.'),
@@ -36781,6 +36791,7 @@ export const TracerEvalTaskUpdateResponse = zod.object({
   "filters": zod.object({
   "project_id": zod.string().optional().describe('Project scope for the evaluation task.'),
   "date_range": zod.array(zod.string()).min(tracerEvalTaskUpdateResponseFiltersDateRangeMin).max(tracerEvalTaskUpdateResponseFiltersDateRangeMax).optional().describe('Inclusive start\/end ISO timestamps.'),
+  "date_preset": zod.enum(['30m', '6h', 'today', 'yesterday', '7d', '30d', '3m', '6m', '12m', 'custom']).optional().describe('Which time-window preset the user chose. The frontend resolves it to date_range at save time; this records the intent so a relative window can be re-anchored on the next save. Never read when building a query — date_range remains authoritative. Absent on tasks predating this field. The enum documents the accepted values; it is not enforced.'),
   "created_at": zod.string().optional().describe('Lower-bound ISO timestamp for legacy task filters.'),
   "session_id": zod.array(zod.string()).optional().describe('Trace session id(s) to constrain the task.'),
   "trace_id": zod.array(zod.string()).optional().describe('Trace id(s) to constrain linked-source tasks.'),
@@ -36854,6 +36865,7 @@ export const TracerEvalTaskPartialUpdateBody = zod.object({
   "filters": zod.object({
   "project_id": zod.string().optional().describe('Project scope for the evaluation task.'),
   "date_range": zod.array(zod.string()).min(tracerEvalTaskPartialUpdateBodyFiltersDateRangeMin).max(tracerEvalTaskPartialUpdateBodyFiltersDateRangeMax).optional().describe('Inclusive start\/end ISO timestamps.'),
+  "date_preset": zod.enum(['30m', '6h', 'today', 'yesterday', '7d', '30d', '3m', '6m', '12m', 'custom']).optional().describe('Which time-window preset the user chose. The frontend resolves it to date_range at save time; this records the intent so a relative window can be re-anchored on the next save. Never read when building a query — date_range remains authoritative. Absent on tasks predating this field. The enum documents the accepted values; it is not enforced.'),
   "created_at": zod.string().optional().describe('Lower-bound ISO timestamp for legacy task filters.'),
   "session_id": zod.array(zod.string()).optional().describe('Trace session id(s) to constrain the task.'),
   "trace_id": zod.array(zod.string()).optional().describe('Trace id(s) to constrain linked-source tasks.'),
@@ -36920,6 +36932,7 @@ export const TracerEvalTaskPartialUpdateResponse = zod.object({
   "filters": zod.object({
   "project_id": zod.string().optional().describe('Project scope for the evaluation task.'),
   "date_range": zod.array(zod.string()).min(tracerEvalTaskPartialUpdateResponseFiltersDateRangeMin).max(tracerEvalTaskPartialUpdateResponseFiltersDateRangeMax).optional().describe('Inclusive start\/end ISO timestamps.'),
+  "date_preset": zod.enum(['30m', '6h', 'today', 'yesterday', '7d', '30d', '3m', '6m', '12m', 'custom']).optional().describe('Which time-window preset the user chose. The frontend resolves it to date_range at save time; this records the intent so a relative window can be re-anchored on the next save. Never read when building a query — date_range remains authoritative. Absent on tasks predating this field. The enum documents the accepted values; it is not enforced.'),
   "created_at": zod.string().optional().describe('Lower-bound ISO timestamp for legacy task filters.'),
   "session_id": zod.array(zod.string()).optional().describe('Trace session id(s) to constrain the task.'),
   "trace_id": zod.array(zod.string()).optional().describe('Trace id(s) to constrain linked-source tasks.'),

--- a/frontend/src/sections/common/EvalsTasks/NewTaskDrawer/__tests__/getNewTaskFilters.test.js
+++ b/frontend/src/sections/common/EvalsTasks/NewTaskDrawer/__tests__/getNewTaskFilters.test.js
@@ -1,0 +1,89 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { getNewTaskFilters } from "../validation";
+
+const NOW = new Date("2026-08-21T06:00:00Z");
+const historical = (extra) => ({ runType: "historical", ...extra });
+
+describe("getNewTaskFilters time window", () => {
+  beforeEach(() => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    vi.setSystemTime(NOW);
+  });
+  afterEach(() => vi.useRealTimers());
+
+  it("sends the wire token alongside a re-anchored range", () => {
+    const { filters } = getNewTaskFilters(
+      historical({
+        datePreset: "12M",
+        startDate: "2025-07-23 18:13:32",
+        endDate: "2026-07-23 23:59:59",
+      }),
+      "proj",
+    );
+    expect(filters.date_preset).toBe("12m");
+    expect(new Date(filters.date_range[1]).getTime()).toBeGreaterThan(
+      NOW.getTime(),
+    );
+  });
+
+  // The case inference could never solve: the stored dates look Custom.
+  it("re-anchors Today from the stored key", () => {
+    const { filters } = getNewTaskFilters(
+      historical({
+        datePreset: "Today",
+        startDate: "2026-08-18 00:00:00",
+        endDate: "2026-08-19 00:00:00",
+      }),
+      "proj",
+    );
+    expect(filters.date_preset).toBe("today");
+    expect(new Date(filters.date_range[1]).getTime()).toBeGreaterThan(
+      NOW.getTime(),
+    );
+  });
+
+  it("sends a Custom window verbatim", () => {
+    const { filters } = getNewTaskFilters(
+      historical({
+        datePreset: "Custom",
+        startDate: "2026-06-01 00:00:00",
+        endDate: "2026-07-01 00:00:00",
+      }),
+      "proj",
+    );
+    expect(filters.date_preset).toBe("custom");
+    expect(filters.date_range).toEqual([
+      new Date("2026-06-01 00:00:00").toISOString(),
+      new Date("2026-07-01 00:00:00").toISOString(),
+    ]);
+  });
+
+  it("treats a missing preset as Custom", () => {
+    const { filters } = getNewTaskFilters(
+      historical({
+        startDate: "2026-06-01 00:00:00",
+        endDate: "2026-07-01 00:00:00",
+      }),
+      "proj",
+    );
+    expect(filters.date_preset).toBe("custom");
+  });
+
+  it("omits both keys for continuous tasks and when ignoreDate is set", () => {
+    expect(
+      getNewTaskFilters({ runType: "continuous", datePreset: "12M" }, "proj")
+        .filters.date_preset,
+    ).toBeUndefined();
+    expect(
+      getNewTaskFilters(
+        historical({
+          datePreset: "12M",
+          startDate: "2026-06-01 00:00:00",
+          endDate: "2026-07-01 00:00:00",
+        }),
+        "proj",
+        true,
+      ).filters.date_preset,
+    ).toBeUndefined();
+  });
+});

--- a/frontend/src/sections/common/EvalsTasks/NewTaskDrawer/validation.js
+++ b/frontend/src/sections/common/EvalsTasks/NewTaskDrawer/validation.js
@@ -7,6 +7,10 @@ import {
   LIST_OPS,
   NO_VALUE_OPS,
 } from "src/sections/common/EvalsTasks/common";
+import {
+  presetToRange,
+  presetToToken,
+} from "src/sections/projects/timeWindowPresets";
 
 const TASK_FILTER_PROPERTY_TO_API = {
   span_kind: "observation_type",
@@ -126,9 +130,15 @@ export const getNewTaskFilters = (data, projectId, ignoreDate = false) => {
   Object.assign(filters, extractSiblingFilters(data?.filters));
 
   if (data?.runType === "historical" && !ignoreDate) {
+    // A relative preset re-anchors to now on save; Custom is kept verbatim.
+    // Writing the key every save is also what migrates pre-existing tasks.
+    const preset = data?.datePreset || "Custom";
+    const range = presetToRange(preset);
+    const [start, end] = range || [data?.startDate, data?.endDate];
+    filters["date_preset"] = presetToToken(preset);
     filters["date_range"] = [
-      new Date(data?.startDate).toISOString(),
-      new Date(data?.endDate).toISOString(),
+      new Date(start).toISOString(),
+      new Date(end).toISOString(),
     ];
   }
 
@@ -159,6 +169,8 @@ export const NewTaskValidationSchema = () =>
         .transform((evals) => evals.map((e) => e.id)),
       startDate: z.string(),
       endDate: z.string(),
+      // Listed for the same reason as rowType below — zod strips unlisted keys.
+      datePreset: z.string().optional(),
       runType: z.enum(["historical", "continuous"], {
         message: "Run Type is required",
       }),

--- a/frontend/src/sections/common/EvalsTasks/__tests__/getDefaultTaskValues.test.js
+++ b/frontend/src/sections/common/EvalsTasks/__tests__/getDefaultTaskValues.test.js
@@ -1,0 +1,95 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { startOfToday, startOfTomorrow } from "date-fns";
+import { formatDate } from "src/utils/report-utils";
+import { getDefaultTaskValues } from "../common";
+
+const task = (dateRange, extra = {}, runType = "historical") => ({
+  run_type: runType,
+  filters_applied: { date_range: dateRange, ...extra },
+  evals_applied: [],
+  spans_limit: 100000,
+  sampling_rate: 50,
+});
+
+// Hydration is a pure restore. Re-anchoring here slid the window forward on
+// every poll of the task-details query and misreported what a completed task
+// actually ran on — it happens at save time instead.
+describe("getDefaultTaskValues time window", () => {
+  beforeEach(() => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    vi.setSystemTime(new Date("2026-08-21T06:00:00Z"));
+  });
+  afterEach(() => vi.useRealTimers());
+
+  it("uses the stored preset when present", () => {
+    const v = getDefaultTaskValues(
+      task(["2026-08-18 00:00:00", "2026-08-19 00:00:00"], {
+        date_preset: "today",
+      }),
+      null,
+    );
+    expect(v.datePreset).toBe("Today");
+  });
+
+  it("infers the preset for a legacy task", () => {
+    expect(
+      getDefaultTaskValues(
+        task(["2025-07-23 18:13:32", "2026-07-23 23:59:59"]),
+        null,
+      ).datePreset,
+    ).toBe("12M");
+  });
+
+  it("keeps a legacy Custom window as Custom", () => {
+    expect(
+      getDefaultTaskValues(
+        task(["2026-06-01 00:00:00", "2026-07-01 00:00:00"]),
+        null,
+      ).datePreset,
+    ).toBe("Custom");
+  });
+
+  // An inferred Today stops being identifiable once its day passes, so trusting
+  // one would re-anchor the task onto the wrong day.
+  it("downgrades an inferred Today to Custom", () => {
+    const v = getDefaultTaskValues(
+      task([formatDate(startOfToday()), formatDate(startOfTomorrow())]),
+      null,
+    );
+    expect(v.datePreset).toBe("Custom");
+  });
+
+  it("returns the stored dates verbatim", () => {
+    const v = getDefaultTaskValues(
+      task(["2025-07-23 18:13:32", "2026-07-23 23:59:59"]),
+      null,
+    );
+    expect(v.startDate).toBe("2025-07-23 18:13:32");
+    expect(v.endDate).toBe("2026-07-23 23:59:59");
+  });
+
+  // Continuous tasks skip the date block; without a preset here, switching to
+  // historical later would send "custom" with the untouched 6-month default.
+  it("sets a preset on continuous tasks too", () => {
+    const v = getDefaultTaskValues(task(["a", "b"], {}, "continuous"), null);
+    expect(v.datePreset).toBeDefined();
+  });
+
+  // date_preset lives inside filters, but it is time-window metadata, not a
+  // filter row — hydrating it as one renders a bogus "date_preset is one of
+  // 12m" chip in the Filters panel.
+  it("does not hydrate date_preset as a filter row", () => {
+    const v = getDefaultTaskValues(
+      task(["2025-08-21 14:33:22", "2026-08-22 00:00:00"], {
+        date_preset: "12m",
+      }),
+      null,
+    );
+    expect(v.filters.map((f) => f.property)).not.toContain("date_preset");
+    expect(v.filters).toHaveLength(0);
+  });
+
+  it("starts create mode explicit", () => {
+    expect(getDefaultTaskValues(null, null).datePreset).toBe("Custom");
+  });
+});

--- a/frontend/src/sections/common/EvalsTasks/__tests__/getDefaultTaskValues.test.js
+++ b/frontend/src/sections/common/EvalsTasks/__tests__/getDefaultTaskValues.test.js
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { startOfToday, startOfTomorrow } from "date-fns";
 import { formatDate } from "src/utils/report-utils";
 import { getDefaultTaskValues } from "../common";
+import { inferPreset } from "src/sections/projects/legacyPresetInference";
 
 const task = (dateRange, extra = {}, runType = "historical") => ({
   run_type: runType,
@@ -89,7 +90,12 @@ describe("getDefaultTaskValues time window", () => {
     expect(v.filters).toHaveLength(0);
   });
 
-  it("starts create mode explicit", () => {
-    expect(getDefaultTaskValues(null, null).datePreset).toBe("Custom");
+  // Placeholder shape only — every caller resets with real data before render.
+  // It still has to describe its own range, or it seeds a frozen window if a
+  // caller ever loses its load guard.
+  it("labels the no-data placeholder to match its six-month range", () => {
+    const v = getDefaultTaskValues(null, null);
+    expect(v.datePreset).toBe("6M");
+    expect(inferPreset(v.startDate, v.endDate)).toBe("6M");
   });
 });

--- a/frontend/src/sections/common/EvalsTasks/common.js
+++ b/frontend/src/sections/common/EvalsTasks/common.js
@@ -1,4 +1,6 @@
 import { endOfToday, sub } from "date-fns";
+import { tokenToPreset } from "src/sections/projects/timeWindowPresets";
+import { inferPreset } from "src/sections/projects/legacyPresetInference";
 import EvalsAndTasksCustomTooltip from "./Renderers/EvalsAndTasksCustomToolTip";
 import FilterChipsRenderer from "./Renderers/FilterChipsRenderer";
 import RunningStatusRenderer from "./Renderers/RunningStatusRenderer";
@@ -208,6 +210,7 @@ export const ANNOTATION_COLUMN_IDS = new Set(["annotator", "my_annotations"]);
 const RESERVED_FILTER_KEYS = new Set([
   "project_id",
   "date_range",
+  "date_preset",
   "start_date",
   "end_date",
   "filters",
@@ -301,6 +304,14 @@ export const getDefaultTaskValues = (data, observeId) => {
       }
     }
 
+    // Without a stored key the task predates the field, so infer — except
+    // Today/Yesterday, which stop being identifiable once their day passes.
+    const storedPreset = tokenToPreset(data?.filters_applied?.date_preset);
+    const inferred = inferPreset(values.startDate, values.endDate);
+    values.datePreset =
+      storedPreset ||
+      (inferred === "Today" || inferred === "Yesterday" ? "Custom" : inferred);
+
     return values;
   } else {
     return {
@@ -317,6 +328,7 @@ export const getDefaultTaskValues = (data, observeId) => {
         }),
       ),
       endDate: formatDate(endOfToday()),
+      datePreset: "Custom",
       runType: "",
     };
   }

--- a/frontend/src/sections/common/EvalsTasks/common.js
+++ b/frontend/src/sections/common/EvalsTasks/common.js
@@ -328,7 +328,7 @@ export const getDefaultTaskValues = (data, observeId) => {
         }),
       ),
       endDate: formatDate(endOfToday()),
-      datePreset: "Custom",
+      datePreset: "6M",
       runType: "",
     };
   }

--- a/frontend/src/sections/common/EvalsTasks/common.js
+++ b/frontend/src/sections/common/EvalsTasks/common.js
@@ -1,6 +1,6 @@
 import { endOfToday, sub } from "date-fns";
 import { tokenToPreset } from "src/sections/projects/timeWindowPresets";
-import { inferPreset } from "src/sections/projects/legacyPresetInference";
+import { inferPresetForLegacy } from "src/sections/projects/legacyPresetInference";
 import EvalsAndTasksCustomTooltip from "./Renderers/EvalsAndTasksCustomToolTip";
 import FilterChipsRenderer from "./Renderers/FilterChipsRenderer";
 import RunningStatusRenderer from "./Renderers/RunningStatusRenderer";
@@ -304,13 +304,10 @@ export const getDefaultTaskValues = (data, observeId) => {
       }
     }
 
-    // Without a stored key the task predates the field, so infer — except
-    // Today/Yesterday, which stop being identifiable once their day passes.
+    // Without a stored key the task predates the field, so infer.
     const storedPreset = tokenToPreset(data?.filters_applied?.date_preset);
-    const inferred = inferPreset(values.startDate, values.endDate);
     values.datePreset =
-      storedPreset ||
-      (inferred === "Today" || inferred === "Yesterday" ? "Custom" : inferred);
+      storedPreset || inferPresetForLegacy(values.startDate, values.endDate);
 
     return values;
   } else {

--- a/frontend/src/sections/projects/DateTimeRangePicker.jsx
+++ b/frontend/src/sections/projects/DateTimeRangePicker.jsx
@@ -1,36 +1,11 @@
 import { Box, Button } from "@mui/material";
 import React, { useEffect, useRef, useState } from "react";
 import { formatDate } from "src/utils/report-utils";
-import {
-  endOfToday,
-  format,
-  startOfToday,
-  startOfYesterday,
-  startOfTomorrow,
-  sub,
-  differenceInMinutes,
-  differenceInHours,
-  differenceInDays,
-  differenceInMonths,
-  parseISO,
-} from "date-fns";
+import { endOfToday, format, sub } from "date-fns";
 import PropTypes from "prop-types";
-import logger from "src/utils/logger";
 import Iconify from "src/components/iconify";
 import CustomDateRangePicker from "src/components/custom-datepicker/DatePicker";
-// Time period options exactly as shown in screenshot
-const TIME_PERIOD_OPTIONS = [
-  { title: "30 mins" },
-  { title: "6 hrs" },
-  { title: "Today" },
-  { title: "Yesterday" },
-  { title: "7D" },
-  { title: "30D" },
-  { title: "3M" },
-  { title: "6M" },
-  { title: "12M" },
-];
-
+import { TIME_PERIOD_OPTIONS, presetToRange } from "./timeWindowPresets";
 const DateTimeRangePicker = ({
   setParentDateFilter,
   zoomRange = [null, null],
@@ -58,151 +33,11 @@ const DateTimeRangePicker = ({
     ];
   });
 
-  // Function to detect the time period based on date filter
-  const detectTimePeriod = (start, end) => {
-    if (!start || !end) {
-      return null;
-    }
-
-    try {
-      // Parse the dates if they are strings (format: "2025-05-15 15:12:25")
-      const startDate = typeof start === "string" ? parseISO(start) : start;
-      const endDate = typeof end === "string" ? parseISO(end) : end;
-
-      // Calculate the difference
-      const minutesDiff = differenceInMinutes(endDate, startDate);
-      const hoursDiff = differenceInHours(endDate, startDate);
-      const daysDiff = differenceInDays(endDate, startDate);
-      const monthsDiff = differenceInMonths(endDate, startDate);
-
-      // Check if it matches any predefined option
-      if (minutesDiff >= 25 && minutesDiff <= 35) {
-        return "30 mins";
-      } else if (hoursDiff >= 5.5 && hoursDiff <= 6.5) {
-        return "6 hrs";
-      } else if (
-        format(startDate, "yyyy-MM-dd") ===
-          format(startOfToday(), "yyyy-MM-dd") &&
-        (format(endDate, "yyyy-MM-dd") ===
-          format(startOfTomorrow(), "yyyy-MM-dd") ||
-          format(endDate, "yyyy-MM-dd") === format(endOfToday(), "yyyy-MM-dd"))
-      ) {
-        return "Today";
-      } else if (
-        format(startDate, "yyyy-MM-dd") ===
-          format(startOfYesterday(), "yyyy-MM-dd") &&
-        format(endDate, "yyyy-MM-dd") === format(startOfToday(), "yyyy-MM-dd")
-      ) {
-        return "Yesterday";
-      } else if (daysDiff >= 6 && daysDiff <= 8) {
-        return "7D";
-      } else if (daysDiff >= 29 && daysDiff <= 31) {
-        return "30D";
-      } else if (monthsDiff >= 2.8 && monthsDiff <= 3.2) {
-        return "3M";
-      } else if (monthsDiff >= 5.8 && monthsDiff <= 6.2) {
-        return "6M";
-      } else if (monthsDiff >= 11.8 && monthsDiff <= 12.2) {
-        return "12M";
-      }
-
-      return "Custom";
-    } catch (error) {
-      logger.error("Error detecting time period:", error);
-      return "Custom";
-    }
-  };
-
   const handleDataOptionChange = (newOption) => {
-    let filter = null;
     setStartDate(null);
     setEndDate(null);
-
-    switch (newOption) {
-      case "Today":
-        filter = [formatDate(startOfToday()), formatDate(startOfTomorrow())];
-        break;
-      case "Yesterday":
-        filter = [formatDate(startOfYesterday()), formatDate(startOfToday())];
-        break;
-      case "7D":
-        filter = [
-          formatDate(
-            sub(new Date(), {
-              days: 7,
-            }),
-          ),
-          formatDate(startOfTomorrow()),
-        ];
-        break;
-      case "30D":
-        filter = [
-          formatDate(
-            sub(new Date(), {
-              days: 30,
-            }),
-          ),
-          formatDate(startOfTomorrow()),
-        ];
-        break;
-      case "3M":
-        filter = [
-          formatDate(
-            sub(new Date(), {
-              months: 3,
-            }),
-          ),
-          formatDate(startOfTomorrow()),
-        ];
-        break;
-      case "6M":
-        filter = [
-          formatDate(
-            sub(new Date(), {
-              months: 6,
-            }),
-          ),
-          formatDate(startOfTomorrow()),
-        ];
-        break;
-      case "12M":
-        filter = [
-          formatDate(
-            sub(new Date(), {
-              months: 12,
-            }),
-          ),
-          formatDate(startOfTomorrow()),
-        ];
-        break;
-      case "30 mins":
-        filter = [
-          formatDate(
-            sub(new Date(), {
-              minutes: 30,
-            }),
-          ),
-          formatDate(new Date()),
-        ];
-        break;
-      case "6 hrs":
-        filter = [
-          formatDate(
-            sub(new Date(), {
-              hours: 6,
-            }),
-          ),
-          formatDate(new Date()),
-        ];
-        break;
-      default:
-        break;
-    }
-
-    if (filter) {
-      setDateFilter(filter);
-    }
-
+    const range = presetToRange(newOption);
+    if (range) setDateFilter([formatDate(range[0]), formatDate(range[1])]);
     setDateOption(newOption);
   };
   const getButtonStyles = (selected, isFirst = false, isLast = false) => ({
@@ -238,17 +73,6 @@ const DateTimeRangePicker = ({
       setDateOption("Custom");
     }
   }, [zoomRange]);
-
-  useEffect(() => {
-    if (isEdit && dateFilter && dateFilter[0] && dateFilter[1]) {
-      const detectedPeriod = detectTimePeriod(dateFilter[0], dateFilter[1]);
-      if (detectedPeriod && detectedPeriod !== dateOption) {
-        setDateOption(detectedPeriod);
-      } else if (detectedPeriod === "Custom" && dateOption !== "Custom") {
-        setDateOption("Custom");
-      }
-    }
-  }, [dateFilter, isEdit]);
 
   useEffect(() => {
     if (setParentDateFilter) {
@@ -340,6 +164,7 @@ const DateTimeRangePicker = ({
           open={isDatePickerOpen}
           onClose={() => setIsDatePickerOpen(false)}
           anchorEl={dateDisplayRef?.current}
+          value={dateFilter}
           setDateFilter={setDateFilter}
           setDateOption={setDateOption}
         />

--- a/frontend/src/sections/projects/LLMTracing/__tests__/buildAddEvalsDraft.test.js
+++ b/frontend/src/sections/projects/LLMTracing/__tests__/buildAddEvalsDraft.test.js
@@ -1,0 +1,62 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { buildAddEvalsDraft } from "../buildAddEvalsDraft";
+
+// The draft is the only thing that survives the hop to the create page, so
+// whatever preset the toolbar was showing has to travel with the range.
+// Dropping it forces the create page to guess, and a day-granular guess
+// rewrites the window the user was actually looking at.
+const draftValues = (url) => {
+  const draftId = new URLSearchParams(url.split("?")[1]).get("draft");
+  return JSON.parse(localStorage.getItem(`task-draft-${draftId}`)).values;
+};
+
+describe("buildAddEvalsDraft time window", () => {
+  beforeEach(() => localStorage.clear());
+
+  it("carries the toolbar's preset into the draft", () => {
+    const url = buildAddEvalsDraft({
+      observeId: "proj",
+      rowType: "spans",
+      dateFilter: {
+        dateFilter: ["2026-02-21 00:00:00", "2026-08-21 00:00:00"],
+        dateOption: "6M",
+      },
+    });
+    expect(draftValues(url).datePreset).toBe("6M");
+  });
+
+  it("keeps a zoomed window as Custom", () => {
+    const url = buildAddEvalsDraft({
+      observeId: "proj",
+      rowType: "spans",
+      dateFilter: {
+        dateFilter: ["2026-08-21 08:00:00", "2026-08-21 15:00:00"],
+        dateOption: "Custom",
+      },
+    });
+    const values = draftValues(url);
+    expect(values.datePreset).toBe("Custom");
+    expect([values.startDate, values.endDate]).toEqual([
+      "2026-08-21 08:00:00",
+      "2026-08-21 15:00:00",
+    ]);
+  });
+
+  it("treats a range with no preset as Custom rather than guessing", () => {
+    const url = buildAddEvalsDraft({
+      observeId: "proj",
+      rowType: "spans",
+      dateFilter: {
+        dateFilter: ["2026-08-21 08:00:00", "2026-08-21 15:00:00"],
+      },
+    });
+    expect(draftValues(url).datePreset).toBe("Custom");
+  });
+
+  // With no incoming window the helper generates a twelve-month range, so the
+  // preset has to agree with the range it just built.
+  it("labels its own generated fallback range 12M", () => {
+    const url = buildAddEvalsDraft({ observeId: "proj", rowType: "spans" });
+    expect(draftValues(url).datePreset).toBe("12M");
+  });
+});

--- a/frontend/src/sections/projects/LLMTracing/buildAddEvalsDraft.js
+++ b/frontend/src/sections/projects/LLMTracing/buildAddEvalsDraft.js
@@ -59,6 +59,12 @@ export function buildAddEvalsDraft({
   const startDate =
     dateFilter?.dateFilter?.[0] ?? formatDate(sub(new Date(), { months: 12 }));
   const endDate = dateFilter?.dateFilter?.[1] ?? formatDate(endOfToday());
+  // The toolbar's own label is authoritative — passing it through spares the
+  // create page a guess it can only make on calendar-day granularity. An
+  // incoming window with no label is absolute; the fallback above is ours.
+  const datePreset = dateFilter?.dateFilter
+    ? (dateFilter?.dateOption ?? "Custom")
+    : "12M";
 
   const values = {
     name: "",
@@ -70,6 +76,7 @@ export function buildAddEvalsDraft({
     evalsDetails: [],
     startDate,
     endDate,
+    datePreset,
     runType: "historical",
   };
 

--- a/frontend/src/sections/projects/__tests__/DateTimeRangePicker.test.jsx
+++ b/frontend/src/sections/projects/__tests__/DateTimeRangePicker.test.jsx
@@ -1,0 +1,24 @@
+import React from "react";
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import DateTimeRangePicker from "../DateTimeRangePicker";
+
+// The calendar seeds itself from a `value` prop on the open transition
+// (DatePicker.jsx:25-36), but this component never passed one, so picking
+// Custom always opened a blank calendar even when a range was already set.
+describe("DateTimeRangePicker custom calendar", () => {
+  it("seeds the calendar with the current range", () => {
+    render(
+      <DateTimeRangePicker
+        dateOption="Custom"
+        setDateOption={vi.fn()}
+        setParentDateFilter={vi.fn()}
+        dateFilter={["2026-08-01 00:00:00", "2026-08-05 00:00:00"]}
+        isEdit
+      />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: /01\/08\/2026/ }));
+    expect(screen.getByDisplayValue("2026-08-01")).toBeInTheDocument();
+    expect(screen.getByDisplayValue("2026-08-05")).toBeInTheDocument();
+  });
+});

--- a/frontend/src/sections/projects/__tests__/legacyPresetInference.test.js
+++ b/frontend/src/sections/projects/__tests__/legacyPresetInference.test.js
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { inferPreset } from "../legacyPresetInference";
+import { add, startOfToday, sub } from "date-fns";
+import { inferPreset, inferPresetForLegacy } from "../legacyPresetInference";
 import { TIME_PERIOD_OPTIONS, presetToRange } from "../timeWindowPresets";
 
 describe("inferPreset", () => {
@@ -46,5 +47,44 @@ describe("inferPreset", () => {
     expect(inferPreset(null, null)).toBe("Custom");
     expect(inferPreset("garbage", "garbage")).toBe("Custom");
     expect(inferPreset(undefined, "2026-07-01 00:00:00")).toBe("Custom");
+  });
+});
+
+// The Add Evals entrypoint hands us a window with no stored preset, so the
+// preset has to be measured back out. Today/Yesterday are day-granular
+// matches — any same-day window infers Today, and any window straddling one
+// midnight infers Yesterday — so re-anchoring those would rewrite the user's
+// range. Only relative presets are safe to carry over.
+describe("inferPresetForLegacy", () => {
+  beforeEach(() => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    vi.setSystemTime(new Date("2026-08-21T06:00:00Z"));
+  });
+  afterEach(() => vi.useRealTimers());
+
+  it("keeps a partial same-day window instead of widening it to a full day", () => {
+    const start = add(startOfToday(), { hours: 8 });
+    const end = add(startOfToday(), { hours: 15 });
+    expect(inferPreset(start, end)).toBe("Today");
+    expect(inferPresetForLegacy(start, end)).toBe("Custom");
+  });
+
+  it("keeps a window that straddles midnight instead of snapping it to yesterday", () => {
+    const start = sub(startOfToday(), { hours: 1 });
+    const end = add(startOfToday(), { hours: 23 });
+    expect(inferPreset(start, end)).toBe("Yesterday");
+    expect(inferPresetForLegacy(start, end)).toBe("Custom");
+  });
+
+  it("downgrades the exact Today and Yesterday windows to Custom", () => {
+    expect(inferPresetForLegacy(...presetToRange("Today"))).toBe("Custom");
+    expect(inferPresetForLegacy(...presetToRange("Yesterday"))).toBe("Custom");
+  });
+
+  it("passes every other preset through untouched", () => {
+    for (const { title } of TIME_PERIOD_OPTIONS) {
+      if (title === "Today" || title === "Yesterday") continue;
+      expect(inferPresetForLegacy(...presetToRange(title))).toBe(title);
+    }
   });
 });

--- a/frontend/src/sections/projects/__tests__/legacyPresetInference.test.js
+++ b/frontend/src/sections/projects/__tests__/legacyPresetInference.test.js
@@ -1,0 +1,50 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { inferPreset } from "../legacyPresetInference";
+import { TIME_PERIOD_OPTIONS, presetToRange } from "../timeWindowPresets";
+
+describe("inferPreset", () => {
+  beforeEach(() => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    vi.setSystemTime(new Date("2026-08-21T06:00:00Z"));
+  });
+  afterEach(() => vi.useRealTimers());
+
+  it("recognises every preset on the day it was generated", () => {
+    for (const { title } of TIME_PERIOD_OPTIONS) {
+      expect(inferPreset(...presetToRange(title))).toBe(title);
+    }
+  });
+
+  // Presets derive their start from an instant and carry a wall-clock time; the
+  // date-only Custom calendar always starts at midnight. Duration alone cannot
+  // separate a custom 30-day pick from the 30D preset — this can.
+  it("classifies midnight-bounded ranges as Custom whatever their length", () => {
+    expect(inferPreset("2026-06-01 00:00:00", "2026-07-01 00:00:00")).toBe(
+      "Custom",
+    );
+    expect(inferPreset("2026-06-01 00:00:00", "2026-06-08 00:00:00")).toBe(
+      "Custom",
+    );
+    expect(inferPreset("2025-06-01 00:00:00", "2026-06-01 00:00:00")).toBe(
+      "Custom",
+    );
+  });
+
+  it("still recognises a machine-generated 30-day range", () => {
+    expect(inferPreset("2026-07-22 10:31:18", "2026-08-22 00:00:00")).toBe(
+      "30D",
+    );
+  });
+
+  it("recognises the escalation task's stored window", () => {
+    expect(inferPreset("2025-07-23 18:13:32", "2026-07-23 23:59:59")).toBe(
+      "12M",
+    );
+  });
+
+  it("returns Custom on bad input rather than guessing", () => {
+    expect(inferPreset(null, null)).toBe("Custom");
+    expect(inferPreset("garbage", "garbage")).toBe("Custom");
+    expect(inferPreset(undefined, "2026-07-01 00:00:00")).toBe("Custom");
+  });
+});

--- a/frontend/src/sections/projects/__tests__/timeWindowPresets.test.js
+++ b/frontend/src/sections/projects/__tests__/timeWindowPresets.test.js
@@ -1,0 +1,96 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import {
+  TIME_PERIOD_OPTIONS,
+  presetToRange,
+  presetToToken,
+  tokenToPreset,
+  formatTimeWindow,
+} from "../timeWindowPresets";
+
+const freezeClock = () => {
+  beforeEach(() => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    vi.setSystemTime(new Date("2026-08-21T06:00:00Z"));
+  });
+  afterEach(() => vi.useRealTimers());
+};
+
+describe("tokens", () => {
+  it("round-trips every chip title", () => {
+    for (const { title } of TIME_PERIOD_OPTIONS) {
+      expect(tokenToPreset(presetToToken(title))).toBe(title);
+    }
+    expect(tokenToPreset(presetToToken("Custom"))).toBe("Custom");
+  });
+
+  it("uses the agreed wire tokens", () => {
+    expect(presetToToken("12M")).toBe("12m");
+    expect(presetToToken("30 mins")).toBe("30m");
+    expect(presetToToken("Today")).toBe("today");
+    expect(presetToToken("Custom")).toBe("custom");
+  });
+
+  it("returns null for an unknown token", () => {
+    expect(tokenToPreset("nonsense")).toBeNull();
+    expect(tokenToPreset(undefined)).toBeNull();
+  });
+});
+
+describe("presetToRange", () => {
+  freezeClock();
+
+  it("returns null for Custom and unknown keys", () => {
+    expect(presetToRange("Custom")).toBeNull();
+    expect(presetToRange("nonsense")).toBeNull();
+  });
+
+  it("produces an ordered range for every preset", () => {
+    for (const { title } of TIME_PERIOD_OPTIONS) {
+      const [from, to] = presetToRange(title);
+      expect(from.getTime()).toBeLessThan(to.getTime());
+    }
+  });
+});
+
+describe("formatTimeWindow", () => {
+  freezeClock();
+
+  it("collapses a single-day window to one date", () => {
+    expect(formatTimeWindow(...presetToRange("Today"))).toBe("21 Aug 2026");
+    expect(formatTimeWindow(...presetToRange("Yesterday"))).toBe("20 Aug 2026");
+  });
+
+  it("includes times for a sub-day window", () => {
+    expect(formatTimeWindow(...presetToRange("6 hrs"))).toMatch(
+      /^21 Aug 2026, .+ – .+$/,
+    );
+  });
+
+  it("shows both dates when a sub-day window crosses midnight", () => {
+    expect(
+      formatTimeWindow("2026-08-20 23:50:00", "2026-08-21 00:20:00"),
+    ).toMatch(/^20 Aug 2026 .+ – 21 Aug 2026 .+$/);
+  });
+
+  it("shows a plain range when the window spans days", () => {
+    expect(formatTimeWindow(...presetToRange("7D"))).toBe(
+      "14 Aug 2026 – 21 Aug 2026",
+    );
+  });
+
+  it("keeps a Custom end verbatim", () => {
+    expect(
+      formatTimeWindow("2026-06-01 00:00:00", "2026-07-01 00:00:00", {
+        isCustom: true,
+      }),
+    ).toBe("01 Jun 2026 – 01 Jul 2026");
+  });
+
+  it("returns an empty string for missing or reversed bounds", () => {
+    expect(formatTimeWindow(null, "2026-07-01 00:00:00")).toBe("");
+    expect(formatTimeWindow("2026-07-01 00:00:00", undefined)).toBe("");
+    expect(formatTimeWindow("2026-07-01 00:00:00", "2026-06-01 00:00:00")).toBe(
+      "",
+    );
+  });
+});

--- a/frontend/src/sections/projects/__tests__/timeWindowPresets.test.js
+++ b/frontend/src/sections/projects/__tests__/timeWindowPresets.test.js
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { format } from "date-fns";
 import {
   TIME_PERIOD_OPTIONS,
   presetToRange,
@@ -49,6 +50,40 @@ describe("presetToRange", () => {
       const [from, to] = presetToRange(title);
       expect(from.getTime()).toBeLessThan(to.getTime());
     }
+  });
+
+  // The whole point of the parameter is to compute a window without touching
+  // the global clock. Honouring it for the start but not the end produced a
+  // range spanning from the given instant to the real today.
+  describe("with an explicit now", () => {
+    const NOW = new Date("2020-01-15T10:00:00");
+
+    it("anchors Today and Yesterday to the given day", () => {
+      const [tFrom, tTo] = presetToRange("Today", NOW);
+      expect(format(tFrom, "yyyy-MM-dd HH:mm")).toBe("2020-01-15 00:00");
+      expect(format(tTo, "yyyy-MM-dd HH:mm")).toBe("2020-01-16 00:00");
+
+      const [yFrom, yTo] = presetToRange("Yesterday", NOW);
+      expect(format(yFrom, "yyyy-MM-dd HH:mm")).toBe("2020-01-14 00:00");
+      expect(format(yTo, "yyyy-MM-dd HH:mm")).toBe("2020-01-15 00:00");
+    });
+
+    it("ends the duration presets on the day after the given day", () => {
+      for (const { title } of TIME_PERIOD_OPTIONS) {
+        const [, to] = presetToRange(title, NOW);
+        expect(to.getFullYear()).toBe(2020);
+      }
+    });
+
+    it("keeps every preset's span the length it claims", () => {
+      const days = (title) => {
+        const [from, to] = presetToRange(title, NOW);
+        return (to.getTime() - from.getTime()) / 86400000;
+      };
+      expect(days("7D")).toBeGreaterThan(7);
+      expect(days("7D")).toBeLessThan(9);
+      expect(days("12M")).toBeLessThan(370);
+    });
   });
 });
 

--- a/frontend/src/sections/projects/legacyPresetInference.js
+++ b/frontend/src/sections/projects/legacyPresetInference.js
@@ -55,3 +55,12 @@ export function inferPreset(start, end) {
 
   return "Custom";
 }
+
+// Today and Yesterday are matched on the calendar day alone, so any same-day
+// window infers Today and any window straddling one midnight infers Yesterday.
+// Re-anchoring either would rewrite the range the user actually picked, so a
+// measured-out preset only ever carries a relative one.
+export function inferPresetForLegacy(start, end) {
+  const preset = inferPreset(start, end);
+  return preset === "Today" || preset === "Yesterday" ? "Custom" : preset;
+}

--- a/frontend/src/sections/projects/legacyPresetInference.js
+++ b/frontend/src/sections/projects/legacyPresetInference.js
@@ -1,0 +1,57 @@
+import {
+  differenceInDays,
+  differenceInHours,
+  differenceInMinutes,
+  differenceInMonths,
+  endOfToday,
+  format,
+  startOfToday,
+  startOfTomorrow,
+  startOfYesterday,
+} from "date-fns";
+import { toDate } from "./timeWindowPresets";
+
+// LEGACY. Tasks saved before filters.date_preset existed carry only an absolute
+// range, so their preset has to be measured back out.
+const sameDay = (a, b) => format(a, "yyyy-MM-dd") === format(b, "yyyy-MM-dd");
+
+// The Custom calendar is date-only, so a hand-picked range starts at midnight;
+// a generated preset carries the o'clock it was made at.
+const isMidnight = (d) =>
+  d.getHours() === 0 && d.getMinutes() === 0 && d.getSeconds() === 0;
+
+// Order matters: 30 mins/6 hrs before Today (a 30-minute window is same-day, so
+// Today would swallow it); the midnight guard after Today/Yesterday, which
+// legitimately start at midnight, and before the duration branches.
+export function inferPreset(start, end) {
+  const s = toDate(start);
+  const e = toDate(end);
+  if (!s || !e) return "Custom";
+
+  const minutes = differenceInMinutes(e, s);
+  const hours = differenceInHours(e, s);
+  if (minutes >= 25 && minutes <= 35) return "30 mins";
+  if (hours >= 5.5 && hours <= 6.5) return "6 hrs";
+
+  if (
+    sameDay(s, startOfToday()) &&
+    (sameDay(e, startOfTomorrow()) || sameDay(e, endOfToday()))
+  ) {
+    return "Today";
+  }
+  if (sameDay(s, startOfYesterday()) && sameDay(e, startOfToday())) {
+    return "Yesterday";
+  }
+
+  if (isMidnight(s)) return "Custom";
+
+  const days = differenceInDays(e, s);
+  const months = differenceInMonths(e, s);
+  if (days >= 6 && days <= 8) return "7D";
+  if (days >= 29 && days <= 31) return "30D";
+  if (months >= 2.8 && months <= 3.2) return "3M";
+  if (months >= 5.8 && months <= 6.2) return "6M";
+  if (months >= 11.8 && months <= 12.2) return "12M";
+
+  return "Custom";
+}

--- a/frontend/src/sections/projects/timeWindowPresets.js
+++ b/frontend/src/sections/projects/timeWindowPresets.js
@@ -1,0 +1,98 @@
+import {
+  format,
+  isValid,
+  parseISO,
+  startOfToday,
+  startOfTomorrow,
+  startOfYesterday,
+  sub,
+} from "date-fns";
+import { fDate, fDateTime } from "src/utils/format-time";
+
+export const TIME_PERIOD_OPTIONS = [
+  { title: "30 mins" },
+  { title: "6 hrs" },
+  { title: "Today" },
+  { title: "Yesterday" },
+  { title: "7D" },
+  { title: "30D" },
+  { title: "3M" },
+  { title: "6M" },
+  { title: "12M" },
+];
+
+const DURATIONS = {
+  "30 mins": { minutes: 30 },
+  "6 hrs": { hours: 6 },
+  "7D": { days: 7 },
+  "30D": { days: 30 },
+  "3M": { months: 3 },
+  "6M": { months: 6 },
+  "12M": { months: 12 },
+};
+
+const TOKEN_BY_TITLE = {
+  "30 mins": "30m",
+  "6 hrs": "6h",
+  Today: "today",
+  Yesterday: "yesterday",
+  "7D": "7d",
+  "30D": "30d",
+  "3M": "3m",
+  "6M": "6m",
+  "12M": "12m",
+  Custom: "custom",
+};
+
+const TITLE_BY_TOKEN = Object.fromEntries(
+  Object.entries(TOKEN_BY_TITLE).map(([title, token]) => [token, title]),
+);
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+export const toDate = (v) => {
+  if (!v) return null;
+  const d = typeof v === "string" ? parseISO(v) : v;
+  return isValid(d) ? d : null;
+};
+
+export const presetToToken = (title) => TOKEN_BY_TITLE[title] || "custom";
+
+export const tokenToPreset = (token) => TITLE_BY_TOKEN[token] || null;
+
+export function presetToRange(key, now = new Date()) {
+  if (key === "Today") return [startOfToday(), startOfTomorrow()];
+  if (key === "Yesterday") return [startOfYesterday(), startOfToday()];
+  if (key === "30 mins" || key === "6 hrs") {
+    return [sub(now, DURATIONS[key]), now];
+  }
+  const duration = DURATIONS[key];
+  if (!duration) return null;
+  return [sub(now, duration), startOfTomorrow()];
+}
+
+// Presets end at startOfTomorrow so the query covers all of today; showing that
+// boundary would read as "extends into tomorrow".
+const lastCoveredInstant = (end) =>
+  end.getHours() === 0 && end.getMinutes() === 0 && end.getSeconds() === 0
+    ? sub(end, { seconds: 1 })
+    : end;
+
+// Sub-day is judged on the stored span — Today is stored as a full 24h but
+// displays as 23:59:59, which would otherwise look sub-day.
+export function formatTimeWindow(start, end, { isCustom = false } = {}) {
+  const s = toDate(start);
+  const rawEnd = toDate(end);
+  if (!s || !rawEnd || rawEnd.getTime() < s.getTime()) return "";
+
+  const e = isCustom ? rawEnd : lastCoveredInstant(rawEnd);
+  const span = rawEnd.getTime() - s.getTime();
+  const sameDay = format(s, "yyyy-MM-dd") === format(e, "yyyy-MM-dd");
+
+  if (span > 0 && span < DAY_MS) {
+    return sameDay
+      ? `${fDate(s)}, ${format(s, "p")} – ${format(e, "p")}`
+      : `${fDateTime(s)} – ${fDateTime(e)}`;
+  }
+  return sameDay ? fDate(s) : `${fDate(s)} – ${fDate(e)}`;
+}

--- a/frontend/src/sections/projects/timeWindowPresets.js
+++ b/frontend/src/sections/projects/timeWindowPresets.js
@@ -1,11 +1,11 @@
 import {
+  addDays,
   format,
   isValid,
   parseISO,
-  startOfToday,
-  startOfTomorrow,
-  startOfYesterday,
+  startOfDay,
   sub,
+  subDays,
 } from "date-fns";
 import { fDate, fDateTime } from "src/utils/format-time";
 
@@ -60,15 +60,19 @@ export const presetToToken = (title) => TOKEN_BY_TITLE[title] || "custom";
 
 export const tokenToPreset = (token) => TITLE_BY_TOKEN[token] || null;
 
+// Every bound is derived from `now` so a caller can compute a window without
+// the global clock; defaulting it keeps the live behaviour identical.
 export function presetToRange(key, now = new Date()) {
-  if (key === "Today") return [startOfToday(), startOfTomorrow()];
-  if (key === "Yesterday") return [startOfYesterday(), startOfToday()];
+  const dayStart = startOfDay(now);
+  const nextDayStart = addDays(dayStart, 1);
+  if (key === "Today") return [dayStart, nextDayStart];
+  if (key === "Yesterday") return [subDays(dayStart, 1), dayStart];
   if (key === "30 mins" || key === "6 hrs") {
     return [sub(now, DURATIONS[key]), now];
   }
   const duration = DURATIONS[key];
   if (!duration) return null;
-  return [sub(now, duration), startOfTomorrow()];
+  return [sub(now, duration), nextDayStart];
 }
 
 // Presets end at startOfTomorrow so the query covers all of today; showing that

--- a/frontend/src/sections/tasks/TaskCreatePage.jsx
+++ b/frontend/src/sections/tasks/TaskCreatePage.jsx
@@ -5,6 +5,7 @@ import { useForm, useWatch } from "react-hook-form";
 import { useMutation } from "@tanstack/react-query";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { endOfToday, sub } from "date-fns";
+import { inferPreset } from "src/sections/projects/legacyPresetInference";
 import { useNavigate } from "react-router";
 import { useSearchParams } from "react-router-dom";
 import axios, { endpoints } from "src/utils/axios";
@@ -79,13 +80,25 @@ const TaskCreatePage = () => {
     startDate:
       preselectedStartDate || formatDate(sub(new Date(), { months: 12 })),
     endDate: preselectedEndDate || formatDate(endOfToday()),
+    // The default range above is twelve months; a preselected one isn't ours.
+    datePreset: preselectedStartDate || preselectedEndDate ? "Custom" : "12M",
     runType: "historical",
   };
+
+  // Drafts predating datePreset would inherit the 12M default from the spread
+  // below, re-anchoring a hand-picked range. Drafts expire after 7 days.
+  const draft =
+    draftValues && !draftValues.datePreset
+      ? {
+          ...draftValues,
+          datePreset: inferPreset(draftValues.startDate, draftValues.endDate),
+        }
+      : draftValues || {};
 
   const { control, handleSubmit, getValues, setValue, watch } = useForm({
     // Spread saved draft values OVER the defaults so any new fields
     // we add later still get their defaults when an old draft loads.
-    defaultValues: { ...baseDefaults, ...(draftValues || {}) },
+    defaultValues: { ...baseDefaults, ...draft },
     resolver: zodResolver(NewTaskValidationSchema()),
   });
 

--- a/frontend/src/sections/tasks/TaskCreatePage.jsx
+++ b/frontend/src/sections/tasks/TaskCreatePage.jsx
@@ -5,7 +5,7 @@ import { useForm, useWatch } from "react-hook-form";
 import { useMutation } from "@tanstack/react-query";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { endOfToday, sub } from "date-fns";
-import { inferPreset } from "src/sections/projects/legacyPresetInference";
+import { inferPresetForLegacy } from "src/sections/projects/legacyPresetInference";
 import { useNavigate } from "react-router";
 import { useSearchParams } from "react-router-dom";
 import axios, { endpoints } from "src/utils/axios";
@@ -85,13 +85,17 @@ const TaskCreatePage = () => {
     runType: "historical",
   };
 
-  // Drafts predating datePreset would inherit the 12M default from the spread
-  // below, re-anchoring a hand-picked range. Drafts expire after 7 days.
+  // A draft without a preset would inherit the 12M default from the spread
+  // below, re-anchoring a hand-picked range. Add Evals still mints such drafts
+  // for any window it can't label, so this is not only a legacy path.
   const draft =
     draftValues && !draftValues.datePreset
       ? {
           ...draftValues,
-          datePreset: inferPreset(draftValues.startDate, draftValues.endDate),
+          datePreset: inferPresetForLegacy(
+            draftValues.startDate,
+            draftValues.endDate,
+          ),
         }
       : draftValues || {};
 

--- a/frontend/src/sections/tasks/components/TaskSchedulingSection.jsx
+++ b/frontend/src/sections/tasks/components/TaskSchedulingSection.jsx
@@ -10,31 +10,9 @@ import {
 } from "@mui/material";
 import { alpha } from "@mui/material/styles";
 import { useController, useWatch } from "react-hook-form";
-import { differenceInDays, differenceInMonths, parseISO } from "date-fns";
 import Iconify from "src/components/iconify";
 import DateTimeRangePicker from "src/sections/projects/DateTimeRangePicker";
-
-// Map a [startDate, endDate] range to one of DateTimeRangePicker's preset
-// option keys, so the picker visually reflects a draft-prefilled time
-// window instead of always showing the "12M" default.
-function detectDateOption(start, end) {
-  if (!start || !end) return "12M";
-  try {
-    const s = typeof start === "string" ? parseISO(start) : start;
-    const e = typeof end === "string" ? parseISO(end) : end;
-    if (isNaN(s.getTime()) || isNaN(e.getTime())) return "12M";
-    const days = differenceInDays(e, s);
-    const months = differenceInMonths(e, s);
-    if (days >= 6 && days <= 8) return "7D";
-    if (days >= 29 && days <= 31) return "30D";
-    if (months >= 2.8 && months <= 3.2) return "3M";
-    if (months >= 5.5 && months <= 6.5) return "6M";
-    if (months >= 11 && months <= 13) return "12M";
-    return "Custom";
-  } catch {
-    return "12M";
-  }
-}
+import { formatTimeWindow } from "src/sections/projects/timeWindowPresets";
 
 // ───────────────────────────────────────────────────────────────
 // Run mode option cards (historical / continuous)
@@ -441,9 +419,10 @@ const TaskSchedulingSection = ({ control, isEdit = false }) => {
   });
 
   const runType = useWatch({ control, name: "runType" });
-  const [dateOption, setDateOption] = useState(() =>
-    detectDateOption(startDateField.value, endDateField.value),
-  );
+  const { field: datePresetField } = useController({
+    control,
+    name: "datePreset",
+  });
 
   const dateFilter = [startDateField.value, endDateField.value];
   const handleDateFilterChange = (next) => {
@@ -492,6 +471,18 @@ const TaskSchedulingSection = ({ control, isEdit = false }) => {
                 sx={{ fontSize: "12px", fontWeight: 600 }}
               >
                 Time window
+                {startDateField.value && endDateField.value && (
+                  <Box
+                    component="span"
+                    sx={{ fontSize: "10px", fontWeight: 500, ml: 0.5 }}
+                  >
+                    {`(${formatTimeWindow(
+                      startDateField.value,
+                      endDateField.value,
+                      { isCustom: datePresetField.value === "Custom" },
+                    )})`}
+                  </Box>
+                )}
               </Typography>
             </Box>
             <Typography
@@ -503,8 +494,8 @@ const TaskSchedulingSection = ({ control, isEdit = false }) => {
             </Typography>
             <DateTimeRangePicker
               setParentDateFilter={handleDateFilterChange}
-              dateOption={dateOption}
-              setDateOption={setDateOption}
+              dateOption={datePresetField.value}
+              setDateOption={datePresetField.onChange}
               dateFilter={dateFilter}
               isEdit={isEdit}
             />

--- a/frontend/src/sections/tasks/components/TaskUsageTab.jsx
+++ b/frontend/src/sections/tasks/components/TaskUsageTab.jsx
@@ -30,6 +30,7 @@ import PartialInputWarningDetails, {
 } from "src/sections/common/EvalsTasks/PartialInputWarningDetails";
 import { isEditableElement } from "src/utils/keyboardUtils";
 import { parsePythonReprIfNeeded } from "src/sections/develop-detail/DataTab/common";
+import { DATE_OPTION_TO_PERIOD } from "src/sections/evals/Helpers/evalUsageColumns";
 
 // ── Inline stat ──
 const StatPill = ({ label, value, color }) => (
@@ -52,23 +53,6 @@ const StatPill = ({ label, value, color }) => (
   </Box>
 );
 
-// ── Map date picker option to API period param ──
-// Tasks may run over months, so we extend the eval-usage map with the
-// "6M" and "12M" picker options (added to DateTimeRangePicker for the
-// task flow). Without these entries the lookup falls through to 30d
-// and the picker silently does nothing on those clicks.
-const DATE_OPTION_TO_PERIOD = {
-  "30 mins": "30m",
-  "6 hrs": "6h",
-  Today: "1d",
-  Yesterday: "1d",
-  "7D": "7d",
-  "30D": "30d",
-  "3M": "90d",
-  "6M": "180d",
-  "12M": "365d",
-  Custom: "30d",
-};
 
 // ── Score chip ──
 const ScoreCell = ({ value }) => {

--- a/frontend/src/sections/tasks/components/__tests__/TaskSchedulingSection.test.jsx
+++ b/frontend/src/sections/tasks/components/__tests__/TaskSchedulingSection.test.jsx
@@ -1,0 +1,88 @@
+import React from "react";
+import PropTypes from "prop-types";
+import { describe, it, expect } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { useForm } from "react-hook-form";
+import TaskSchedulingSection from "../TaskSchedulingSection";
+
+let form;
+const Harness = ({ defaults, isEdit = true }) => {
+  form = useForm({
+    defaultValues: { runType: "historical", spansLimit: 100000, ...defaults },
+  });
+  return <TaskSchedulingSection control={form.control} isEdit={isEdit} />;
+};
+Harness.propTypes = { defaults: PropTypes.object, isEdit: PropTypes.bool };
+
+const windowText = () => screen.getByText(/^\(.+\)$/).textContent;
+
+describe("TaskSchedulingSection preset", () => {
+  it("writes the clicked preset into form state", () => {
+    render(
+      <Harness
+        defaults={{
+          datePreset: "Custom",
+          startDate: "2026-06-01 00:00:00",
+          endDate: "2026-07-01 00:00:00",
+        }}
+      />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: "30D" }));
+    expect(form.getValues().datePreset).toBe("30D");
+  });
+
+  // The stored key is authoritative — a Today window three days old reads as
+  // Custom by shape, and nothing may overwrite the key with that guess.
+  it("keeps the stored preset when the dates no longer imply it", () => {
+    render(
+      <Harness
+        defaults={{
+          datePreset: "Today",
+          startDate: "2026-08-18 00:00:00",
+          endDate: "2026-08-19 00:00:00",
+        }}
+      />,
+    );
+    expect(form.getValues().datePreset).toBe("Today");
+  });
+
+  it("renders the window beside the label, in brackets", () => {
+    render(
+      <Harness
+        defaults={{
+          datePreset: "12M",
+          startDate: "2025-08-21 10:03:00",
+          endDate: "2026-08-22 00:00:00",
+        }}
+      />,
+    );
+    expect(windowText()).toBe("(21 Aug 2025 – 21 Aug 2026)");
+  });
+
+  it("renders a single date for a Today window", () => {
+    render(
+      <Harness
+        defaults={{
+          datePreset: "Today",
+          startDate: "2026-08-21 00:00:00",
+          endDate: "2026-08-22 00:00:00",
+        }}
+      />,
+    );
+    expect(windowText()).toBe("(21 Aug 2026)");
+  });
+
+  it("renders on the create path too", () => {
+    render(
+      <Harness
+        isEdit={false}
+        defaults={{
+          datePreset: "12M",
+          startDate: "2025-08-21 10:03:00",
+          endDate: "2026-08-22 00:00:00",
+        }}
+      />,
+    );
+    expect(windowText()).toBe("(21 Aug 2025 – 21 Aug 2026)");
+  });
+});

--- a/futureagi/tracer/serializers/filters.py
+++ b/futureagi/tracer/serializers/filters.py
@@ -92,6 +92,29 @@ EVAL_TASK_FILTERS_SCHEMA = {
             "maxItems": 2,
             "description": "Inclusive start/end ISO timestamps.",
         },
+        "date_preset": {
+            "type": "string",
+            "enum": [
+                "30m",
+                "6h",
+                "today",
+                "yesterday",
+                "7d",
+                "30d",
+                "3m",
+                "6m",
+                "12m",
+                "custom",
+            ],
+            "description": (
+                "Which time-window preset the user chose. The frontend resolves "
+                "it to date_range at save time; this records the intent so a "
+                "relative window can be re-anchored on the next save. Never read "
+                "when building a query — date_range remains authoritative. Absent "
+                "on tasks predating this field. The enum documents the accepted "
+                "values; it is not enforced."
+            ),
+        },
         "created_at": {
             "type": "string",
             "description": "Lower-bound ISO timestamp for legacy task filters.",

--- a/futureagi/tracer/tests/test_eval_task_date_preset.py
+++ b/futureagi/tracer/tests/test_eval_task_date_preset.py
@@ -1,0 +1,30 @@
+import pytest
+from rest_framework import serializers
+
+from tracer.serializers.filters import eval_task_filters_field
+
+BASE = {"project_id": "11111111-1111-1111-1111-111111111111"}
+
+
+class TestEvalTaskDatePreset:
+    """`filters.date_preset` records which time-window preset the user chose.
+
+    The frontend still resolves it to `date_range` at save time, so the backend
+    only stores it — nothing here reads it back when building a query.
+    """
+
+    def test_accepts_a_preset_token(self):
+        out = eval_task_filters_field().run_validation(
+            {**BASE, "date_preset": "12m"}
+        )
+        assert out["date_preset"] == "12m"
+
+    def test_accepts_filters_without_a_preset(self):
+        out = eval_task_filters_field().run_validation(
+            {**BASE, "date_range": ["2025-08-21T05:00:00Z", "2026-08-21T18:30:00Z"]}
+        )
+        assert "date_preset" not in out
+
+    def test_still_rejects_a_genuinely_unknown_key(self):
+        with pytest.raises(serializers.ValidationError):
+            eval_task_filters_field().run_validation({**BASE, "not_a_real_key": "x"})


### PR DESCRIPTION
## 🐛 Bug

An eval task stored only an absolute `date_range`. The relative chip ("30D", "12M") was *inferred* by measuring that range, which caused two failures:

1. **Stale windows.** A task created 23 Jul kept evaluating 23 Jul − 12M while the UI said "12M". This is the trace-count mismatch escalated on 20 Aug — the eval task page and the tracing page were querying different windows.
2. **Custom mislabelled.** Duration alone can't tell a deliberate 30-day Custom pick from the 30D preset, so custom ranges snapped to a preset chip.

Root cause: intent was never stored, only its result.

## 🔧 What changed

**Backend** — one schema property, `filters.date_preset` (`tracer/serializers/filters.py`). The frontend still resolves the preset to `date_range` at save time, so **the backend never reads the key** — `date_range` stays authoritative for every query. No `row_resolver` change, no migration. `EVAL_TASK_FILTER_ALLOWED_KEYS` derives from the schema's own properties, so there's no second allowlist. Swagger + generated client regenerated.

**Frontend**
- `timeWindowPresets.js` (new) — options, `presetToRange`, wire tokens, `formatTimeWindow`. No inference.
- `legacyPresetInference.js` (new) — `inferPreset` moved verbatim out of `DateTimeRangePicker`, used only for tasks with no stored key. Deletable once the fleet turns over.
- `DateTimeRangePicker` −185/+5. Nearly all of that **moved** into those two modules. The one real deletion is the `isEdit` effect (see Why).
- Hydration reads the stored key at all three entry points — saved tasks, `TaskCreatePage.baseDefaults`, and localStorage drafts — and stays a pure restore.
- The chip moves into form state so it reaches the payload; save re-anchors and writes the key.
- `date_preset` added to `RESERVED_FILTER_KEYS` so it stops rendering as a filter row.

## 🤔 Why

**The key rather than a smarter heuristic.** `Today`/`Yesterday` are matched by absolute date equality, which expires overnight — a stored `Today` reads as `Yesterday` the next day and `Custom` the day after (already true on `dev` today, but harmless there since nothing re-anchors). Their stored shape is byte-identical to a Custom single-day pick, so no heuristic can recover it. Storing intent is the only correct fix.

**Why the `isEdit` effect had to go.** It re-derived the chip from the dates. Now that the chip is persisted form state, a `Today` window three days old infers as `Custom`, that guess overwrites the real key, and the next save writes `"custom"` — losing the intent permanently. Among live callers only `TaskSchedulingSection` passed `isEdit`, and it now owns the preset explicitly.

**No data migration.** A server-side backfill would re-implement the midnight heuristic in Python and get it wrong — midnight means *the user's* timezone, and an IST range has `18:30Z` boundaries. Instead every save writes the key, so tasks migrate themselves on first edit, in the browser. Legacy `Today`/`Yesterday` are frozen as `Custom` rather than moved to the wrong day.

**Also fixed here** (pre-existing, in the component this touches): the custom calendar always opened blank. `CustomDateRangePicker` already seeds from a `value` prop; `DateTimeRangePicker` just never passed one.

cc @atharva-bhange — this is the UX issue you root-caused on 20 Aug.

## 🧪 Tests

**Backend (3)** — a preset token is accepted; filters without a preset still validate; a genuinely unknown key is still rejected.

**Frontend (26 new)**
- Wire tokens round-trip every chip title; unknown tokens return null.
- `formatTimeWindow`: single-day collapses to one date; sub-day shows times; sub-day crossing midnight shows both dates; multi-day shows a plain range; Custom end kept verbatim; missing/reversed bounds return "".
- `inferPreset`: recognises all 9 presets on their own day; midnight-bounded ranges are Custom at any length; a machine-generated 30-day range is still 30D; the escalation task's window is 12M; bad input returns Custom.
- Hydration: stored key wins; legacy task infers; legacy Custom stays Custom; inferred Today downgrades to Custom; dates returned verbatim; continuous tasks get a preset; `date_preset` never becomes a filter row.
- Save: token sent with a re-anchored range; Today re-anchors from the key even though its dates look Custom; Custom sent verbatim; missing preset treated as Custom; continuous and `ignoreDate` omit both keys.
- Picker: the custom calendar seeds from the current range.

## ▶️ How to verify

**Before:** open an eval task saved with a relative preset weeks ago — chip says "12M", but it evaluates the window frozen at creation.

**After** (verified with Playwright on a seeded task):
1. Open it — chip `12M`, label shows the **stored** dates `(15 Jan 2025 – 15 Jan 2026)`. Viewing never moves the window.
2. Save → PATCH carries `date_preset: "12m"` and a range anchored to today.
3. Reload → `(21 Aug 2025 – 21 Aug 2026)`.
4. Pick Custom, exactly 30 days, save, reopen → chip reads **Custom**, dates unchanged.
5. Custom calendar opens **pre-filled**, not blank.

Also worth a glance, since they share the picker: **Task Usage** and **Eval Usage** tabs. Neither passes `isEdit`, so the deleted effect can't affect them; the only difference is their Custom calendar now seeds.

## 💻 Commands

```
$ uv run pytest tracer/tests/test_eval_task_date_preset.py -v
platform darwin -- Python 3.12.12, pytest-9.0.2, pluggy-1.6.0
rootdir: /Users/apple/Documents/test-oss-setup/future-agi/futureagi
tracer/tests/test_eval_task_date_preset.py::TestEvalTaskDatePreset::test_accepts_a_preset_token PASSED [ 33%]
tracer/tests/test_eval_task_date_preset.py::TestEvalTaskDatePreset::test_accepts_filters_without_a_preset PASSED [ 66%]
tracer/tests/test_eval_task_date_preset.py::TestEvalTaskDatePreset::test_still_rejects_a_genuinely_unknown_key PASSED [100%]
============================== 3 passed in 0.16s ===============================
```

```
$ yarn contracts:check
Management API contract debt report is up to date.
Runtime Management API contract debt report is up to date.
Management API contract coverage:
  paths: 984
  operations: 1329
  mutation endpoints without request body schemas: 0/0
  operations without response schemas: 0/0
  broad success response schemas: 0/0
  operations without error response schemas: 0/0
  broad error response schemas: 0/0
Runtime Management API contract coverage:
  runtime-backed validated_request decorators: 358/317 minimum
  direct swagger_auto_schema decorators: 134/137 maximum
  doc-only input contract decorators: 0/0 maximum
  broad request contract decorators: 0/0 maximum
Runtime Product API contract coverage:
  runtime-backed validated_request decorators: 471/458 minimum
  direct swagger_auto_schema decorators: 242/288 maximum
  doc-only input contract decorators: 0/0 maximum
  broad request contract decorators: 0/0 maximum
Endpoint registry contract coverage:
  apiPath calls backed by Swagger: 788/788
  raw registry paths: 0/0
  contracted by Swagger: 0
  unmarked uncontracted paths: 0/0
  contract exception paths: 0/0
  contract exception manifest paths: 0/0
```

Frontend suite, run in both zones since CI is UTC and local is IST:
```
TZ=UTC           Test Files 99 passed (99)   Tests 769 passed (769)
TZ=Asia/Kolkata  Test Files 99 passed (99)   Tests 769 passed (769)
eslint           0 errors (2 pre-existing warnings in LLMTracing/common.js)
yarn build       ✓ built in 58.54s
```

Backend filter/eval-task/serializer selection: `1150 passed`. The 3 failures (`test_monitor_metrics_integration.py`) and 1575 errors are pre-existing locally — the test Postgres (15432) and ClickHouse (18123) aren't running — and are identical to the pre-change baseline.

## 📹 Videos & Screenshots

Stale `12M` task → open (stored dates shown) → Save → re-anchored to today:

https://github.com/user-attachments/assets/a39abbb5-91e4-4866-9d14-f2f9b2c3b026

## ⚠️ Deploy order

Both halves are in this PR, but they **do not deploy together**. `frontend-dev-cdn.yaml` triggers on push to `dev` filtered to `frontend/**`, so the frontend auto-deploys within minutes of merge. The backend has no push-triggered deploy — it ships via `release-images.yml` (git tag) or a manual `release-backend.yml` dispatch.

Unknown filter keys are hard-rejected, so in the window between the two, the new frontend sends `date_preset` to an old backend and **every eval task save 400s**. The backend needs to be live first.
