### PR TITLE
[fix] eval: update eval name validation and handling in EditAndRunUse…

### DIFF
--- a/frontend/src/sections/common/EvalPicker/EvalPickerConfigFull.jsx
+++ b/frontend/src/sections/common/EvalPicker/EvalPickerConfigFull.jsx
@@ -1304,7 +1304,6 @@ const EvalPickerConfigFull = ({ evalData, onBack, onSave, isSaving }) => {
           size="small"
           placeholder="e.g. toxicity-check, my-custom-eval"
           value={evalName}
-          disabled={isEditMode} // Name is not editable in edit mode — it's the name of the UserEvalMetric instance, not the template
           onChange={(e) => {
             // Sanitise: lowercase, replace spaces with hyphens, only allow a-z 0-9 _ -
             const raw = e.target.value
@@ -1314,13 +1313,11 @@ const EvalPickerConfigFull = ({ evalData, onBack, onSave, isSaving }) => {
             setEvalName(raw);
             setIsDirty(true);
           }}
-          error={!isEditMode && evalName.length >= 51}
+          error={evalName.length >= 51}
           helperText={
-            isEditMode
-              ? undefined
-              : evalName.length >= 51
-                ? "Name can't be longer than 50 characters"
-                : `Lowercase letters, numbers, hyphens and underscores only · ${evalName.length}/50`
+            evalName.length >= 51
+              ? "Name can't be longer than 50 characters"
+              : `Lowercase letters, numbers, hyphens and underscores only · ${evalName.length}/50`
           }
           FormHelperTextProps={{ sx: { fontSize: "11px", mt: 0.25, mx: 0 } }}
           sx={{ "& .MuiInputBase-root": { fontSize: "13px", height: 34 } }}

--- a/futureagi/model_hub/tests/test_evaluation_api.py
+++ b/futureagi/model_hub/tests/test_evaluation_api.py
@@ -1664,7 +1664,7 @@ class TestEditAndRunUserEvalView:
     ):
         """Test successfully editing and running a user evaluation."""
         payload = {
-            "name": "Updated Eval",
+            "name": "updated-eval",
             "output_column_id": str(output_column.id),
             "config": {
                 "model": "gpt-4",
@@ -1682,6 +1682,8 @@ class TestEditAndRunUserEvalView:
             )
 
         assert response.status_code == status.HTTP_200_OK
+        user_eval_metric.refresh_from_db()
+        assert user_eval_metric.name == "updated-eval"
 
     def test_edit_and_run_user_eval_without_name(
         self, auth_client, dataset, user_eval_metric, output_column
@@ -1705,6 +1707,142 @@ class TestEditAndRunUserEvalView:
 
         # Name is optional in edit API, so it should succeed
         assert response.status_code == status.HTTP_200_OK
+        user_eval_metric.refresh_from_db()
+        assert user_eval_metric.name == "Test Evaluation"
+
+    def test_edit_and_run_user_eval_with_blank_name_keeps_existing_name(
+        self, auth_client, dataset, user_eval_metric, output_column
+    ):
+        """A blank optional name must not overwrite the saved eval name."""
+        response = auth_client.post(
+            f"/model-hub/develops/{dataset.id}/edit_and_run_user_eval/{user_eval_metric.id}/",
+            {
+                "name": "",
+                "config": {
+                    "model": "gpt-4",
+                    "mapping": {"output": "Output Column"},
+                },
+            },
+            format="json",
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        user_eval_metric.refresh_from_db()
+        assert user_eval_metric.name == "Test Evaluation"
+
+    def test_edit_and_run_user_eval_rejects_invalid_name(
+        self, auth_client, dataset, user_eval_metric, output_column
+    ):
+        """Invalid names are rejected before the eval binding is modified."""
+        response = auth_client.post(
+            f"/model-hub/develops/{dataset.id}/edit_and_run_user_eval/{user_eval_metric.id}/",
+            {
+                "name": "My Eval!",
+                "config": {
+                    "model": "gpt-4",
+                    "mapping": {"output": "Output Column"},
+                },
+            },
+            format="json",
+        )
+
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert "Name can only contain lowercase letters" in str(response.data)
+        user_eval_metric.refresh_from_db()
+        assert user_eval_metric.name == "Test Evaluation"
+
+    def test_edit_and_run_user_eval_rejects_duplicate_dataset_name(
+        self,
+        auth_client,
+        dataset,
+        user_eval_metric,
+        output_column,
+        organization,
+        workspace,
+        eval_template,
+    ):
+        """A rename cannot duplicate an active eval name in the same dataset."""
+        UserEvalMetric.objects.create(
+            name="existing-eval",
+            dataset=dataset,
+            organization=organization,
+            workspace=workspace,
+            template=eval_template,
+            config={"model": "gpt-4"},
+        )
+
+        response = auth_client.post(
+            f"/model-hub/develops/{dataset.id}/edit_and_run_user_eval/{user_eval_metric.id}/",
+            {
+                "name": "existing-eval",
+                "config": {
+                    "model": "gpt-4",
+                    "mapping": {"output": "Output Column"},
+                },
+            },
+            format="json",
+        )
+
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        user_eval_metric.refresh_from_db()
+        assert user_eval_metric.name == "Test Evaluation"
+
+    def test_edit_and_run_user_eval_renames_dataset_columns_without_rerun(
+        self, auth_client, dataset, user_eval_metric, output_column, row
+    ):
+        """Renaming a dataset eval keeps its existing values and cell states."""
+        eval_column = Column.objects.create(
+            name=user_eval_metric.name,
+            dataset=dataset,
+            data_type=DataTypeChoices.TEXT.value,
+            source=SourceChoices.EVALUATION.value,
+            source_id=str(user_eval_metric.id),
+        )
+        reason_column = Column.objects.create(
+            name=f"{user_eval_metric.name}-reason",
+            dataset=dataset,
+            data_type=DataTypeChoices.TEXT.value,
+            source=SourceChoices.EVALUATION_REASON.value,
+            source_id=f"{eval_column.id}-sourceid-{user_eval_metric.id}",
+        )
+        eval_cell = Cell.objects.create(
+            dataset=dataset,
+            column=eval_column,
+            row=row,
+            value="0.9",
+            status=CellStatus.PASS.value,
+        )
+        reason_cell = Cell.objects.create(
+            dataset=dataset,
+            column=reason_column,
+            row=row,
+            value="Existing reason",
+            status=CellStatus.PASS.value,
+        )
+
+        response = auth_client.post(
+            f"/model-hub/develops/{dataset.id}/edit_and_run_user_eval/{user_eval_metric.id}/",
+            {
+                "name": "renamed-eval",
+                "config": {
+                    "model": "gpt-4",
+                    "mapping": {"output": "Output Column"},
+                },
+            },
+            format="json",
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        user_eval_metric.refresh_from_db()
+        eval_column.refresh_from_db()
+        reason_column.refresh_from_db()
+        eval_cell.refresh_from_db()
+        reason_cell.refresh_from_db()
+        assert user_eval_metric.name == "renamed-eval"
+        assert eval_column.name == "renamed-eval"
+        assert reason_column.name == "renamed-eval-reason"
+        assert eval_cell.status == CellStatus.PASS.value
+        assert reason_cell.status == CellStatus.PASS.value
 
     def test_edit_and_run_user_eval_nonexistent(
         self, auth_client, dataset, output_column

--- a/futureagi/model_hub/views/develop_dataset.py
+++ b/futureagi/model_hub/views/develop_dataset.py
@@ -7934,6 +7934,34 @@ class EditAndRunUserEvalView(APIView):
                         f"{get_error_message('COLUMN_DELETED')} {eval_metric.name}"
                     )
 
+                # Validate a requested instance name before any operation that can
+                # write data. Returning from transaction.atomic() commits, so a
+                # validation failure later in this method could leave side effects.
+                new_name = None
+                if not save_as_template:
+                    requested_name = (request_data.get("name") or "").strip()
+                    if requested_name and requested_name != eval_metric.name:
+                        from model_hub.utils.eval_validators import validate_eval_name
+
+                        try:
+                            new_name = validate_eval_name(requested_name)
+                        except ValueError as e:
+                            return self._gm.bad_request(str(e))
+
+                        if (
+                            UserEvalMetric.objects.filter(
+                                name=new_name,
+                                organization=eval_metric.organization,
+                                dataset_id=eval_metric.dataset_id,
+                                deleted=False,
+                            )
+                            .exclude(id=eval_metric.id)
+                            .exists()
+                        ):
+                            return self._gm.bad_request(
+                                get_error_message("EVAL_NAME_EXISTS")
+                            )
+
                 if save_as_template:
                     template = eval_metric.template
 
@@ -8229,6 +8257,23 @@ class EditAndRunUserEvalView(APIView):
                             column__dataset=eval_metric.dataset,
                             deleted=False,
                         ).update(status=CellStatus.RUNNING.value)
+
+                if new_name:
+                    eval_metric.name = new_name
+
+                    if not experiment_id:
+                        Column.objects.filter(
+                            source=SourceChoices.EVALUATION.value,
+                            source_id=str(eval_metric.id),
+                            dataset=eval_metric.dataset,
+                            deleted=False,
+                        ).update(name=new_name)
+                        Column.objects.filter(
+                            source=SourceChoices.EVALUATION_REASON.value,
+                            source_id__endswith=f"-sourceid-{eval_metric.id}",
+                            dataset=eval_metric.dataset,
+                            deleted=False,
+                        ).update(name=f"{new_name}-reason")
 
                 eval_metric.save()
                 return self._gm.success_response(


### PR DESCRIPTION
## Summary

Fixes the dataset-eval edit flow so an existing evaluation can be renamed instead of requiring deletion and re-creation. The renamed value is persisted on the `UserEvalMetric`, and the existing evaluation and reason-column headers are updated in place without re-running the evaluation or losing prior results.

## Linked issues

Closes #1769  
Linear: N/A — external OSS contribution

## Type of change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📖 Documentation only
- [ ] 🧹 Chore / refactor (no user-visible change)
- [ ] 🚀 Performance improvement
- [ ] 🧪 Test-only change

---

## 1) What changes were done

**A. Editable eval name in the UI**

- Removed the edit-mode restriction on the Name field in the eval configuration drawer.
- Applies the existing 50-character validation and helper text in both create and edit modes.

**B. Safe persistence and column-header synchronization**

- Validates a requested dataset-eval name before operations that may create or modify related records.
- Rejects invalid names and duplicate active eval names within the same dataset.
- Persists valid names on `UserEvalMetric`.
- Renames the existing dataset evaluation column and paired reason column in place.
- Does not rename experiment-scoped columns and does not set `run`, so previously computed cell values remain intact.

**C. Regression coverage**

- Added API coverage for persisted renames, omitted/blank names, invalid names, duplicate names, and preserving existing dataset evaluation/reason columns and cells.

---

## 2) Why the changes were done

- **Product/UX:** Users can correct or improve an eval name without deleting it, re-running it, or losing existing evaluation results.
- **Technical:** The frontend already submitted the name during edits; this change completes the server-side handling and keeps the grid headers synchronized.
- **Architecture:** Reuses the existing eval-name validator, duplicate-name behavior, and source identifiers rather than adding a separate rename endpoint.

---

## 3) Tests written + scenarios each covers

**`futureagi/model_hub/tests/test_evaluation_api.py`** — `EditAndRunUserEvalView` regression coverage

- `test_edit_and_run_user_eval_success` — persists a valid renamed eval.
- `test_edit_and_run_user_eval_without_name` — preserves the existing name when `name` is omitted.
- `test_edit_and_run_user_eval_with_blank_name_keeps_existing_name` — preserves the existing name for a blank optional name.
- `test_edit_and_run_user_eval_rejects_invalid_name` — rejects invalid names without modifying the eval.
- `test_edit_and_run_user_eval_rejects_duplicate_dataset_name` — rejects collisions with another active eval in the same dataset.
- `test_edit_and_run_user_eval_renames_dataset_columns_without_rerun` — renames evaluation/reason headers while preserving existing cell statuses.

> Run result: Not run locally. Docker Desktop was unavailable in my environment, so the repository’s isolated backend test stack could not start. Python syntax and whitespace checks were completed.

---

## 4) How to run / test

### Backend tests

```bash
cd futureagi
bin/test model_hub/tests/test_evaluation_api.py -k "EditAndRunUserEvalView" -v
```

### UI steps (manual)

1. Start the stack and open a dataset containing a completed eval column.
2. Right-click the eval column and select **Edit Eval**.
3. Change the Name field to a valid, unused name and save with `run: false`.
4. Verify the eval and paired reason column headers update after refresh.
5. Verify existing evaluation values and their statuses remain unchanged.
6. Confirm invalid and duplicate names return validation errors.

---

## 5) Screenshots / recordings

Not included.

---

## 6) Edge cases & considerations

- Blank or omitted `name` values leave the current eval name unchanged.
- Renaming an eval to its current name is a no-op.
- Invalid or duplicate names are rejected before related writes occur.
- Dataset-scoped reason columns are renamed with the eval.
- Experiment-scoped columns are intentionally out of scope.

---

## 7) Pre-existing issues (NOT introduced by this PR)

No known product issues identified. Local integration tests were not run because Docker Desktop was unavailable.

---

## 8) Architectural / important decisions

- **Validate before side effects:** `transaction.atomic()` does not roll back on a normal response return, so name validation occurs before versioning or reason-column work.
- **Update columns in place:** Existing results are preserved and unnecessary evaluation work is avoided.

---

## Checklist

- [x] My code follows the [style guide](../CONTRIBUTING.md#code-style)
- [x] I've added tests that prove my fix is effective
- [ ] `bin/test` passes locally (backend)
- [ ] `yarn test:run` passes locally (frontend)
- [ ] `yarn contracts:check` passes if API surface changed
- [ ] I've updated the documentation where relevant
- [x] No hardcoded secrets, URLs, or PII
- [ ] I've signed the [CLA](../CONTRIBUTING.md#contributor-license-agreement-cla)
- [x] PR title follows Conventional Commits
- [ ] Linear issue is linked and updated with status
