### PR TITLE
fix(agentcc): inject provider default for dict-shaped guardrail checks

### DIFF
--- a/futureagi/agentcc/services/config_push.py
+++ b/futureagi/agentcc/services/config_push.py
@@ -245,6 +245,11 @@ def _transform_guardrails(guardrails_data, org_id=None):
                 else cfg
             )
             inner = clean_cfg.get("config") if isinstance(clean_cfg, dict) else None
+            if isinstance(clean_cfg, dict) and name in _RULE_PROVIDER_DEFAULTS:
+                if not isinstance(inner, dict):
+                    inner = {}
+                    clean_cfg["config"] = inner
+                inner.setdefault("provider", _RULE_PROVIDER_DEFAULTS[name])
             _normalize_eval_ids(inner)
             mapped[registry_name] = clean_cfg
         if org_id:

--- a/futureagi/agentcc/tests/test_config_push.py
+++ b/futureagi/agentcc/tests/test_config_push.py
@@ -1,0 +1,81 @@
+"""
+Tests for config_push._transform_guardrails — Django org-config -> gateway
+tenant-config translation.
+"""
+
+from agentcc.services.config_push import _transform_guardrails
+
+
+class TestTransformGuardrailsProviderDefaults:
+    """Provider auto-fill must apply the same way regardless of whether the
+    frontend saved guardrails as a `checks` dict or a `rules` list."""
+
+    def test_rules_list_injects_provider_default(self):
+        guardrails_data = {
+            "rules": [
+                {
+                    "name": "llama-guard",
+                    "enabled": True,
+                    "action": "block",
+                    "config": {},
+                },
+            ],
+        }
+
+        result = _transform_guardrails(guardrails_data)
+
+        assert result["checks"]["llama-guard"]["config"]["provider"] == "llama_guard"
+
+    def test_checks_dict_injects_provider_default(self):
+        guardrails_data = {
+            "checks": {
+                "llama-guard": {"enabled": True, "action": "block", "config": {}},
+            },
+        }
+
+        result = _transform_guardrails(guardrails_data)
+
+        assert result["checks"]["llama-guard"]["config"]["provider"] == "llama_guard"
+
+    def test_checks_dict_injects_provider_default_when_config_missing(self):
+        guardrails_data = {
+            "checks": {
+                "presidio-pii": {"enabled": True, "action": "block"},
+            },
+        }
+
+        result = _transform_guardrails(guardrails_data)
+
+        assert result["checks"]["presidio-pii"]["config"]["provider"] == "presidio"
+
+    def test_checks_dict_does_not_override_explicit_provider(self):
+        guardrails_data = {
+            "checks": {
+                "llama-guard": {
+                    "enabled": True,
+                    "action": "block",
+                    "config": {"provider": "custom_override"},
+                },
+            },
+        }
+
+        result = _transform_guardrails(guardrails_data)
+
+        assert (
+            result["checks"]["llama-guard"]["config"]["provider"] == "custom_override"
+        )
+
+    def test_checks_dict_leaves_non_provider_rules_untouched(self):
+        guardrails_data = {
+            "checks": {
+                "content-moderation": {
+                    "enabled": True,
+                    "action": "block",
+                    "config": {},
+                },
+            },
+        }
+
+        result = _transform_guardrails(guardrails_data)
+
+        assert "provider" not in result["checks"]["content-moderation"]["config"]


### PR DESCRIPTION
## Summary
- `_transform_guardrails()` auto-fills a `"provider"` key from `_RULE_PROVIDER_DEFAULTS` for the `rules`-array and `checks`-list input shapes, but was missing it for the `checks`-dict shape — which is what the standard UI save path (`AgentccOrgConfigViewSet.create`) actually sends.
- Without `provider`, the gateway's external-guardrail factory (`internal/guardrails/external/external.go`) matches no adapter and the check silently no-ops instead of enforcing anything — no error surfaced anywhere.
- Fix mirrors the existing injection logic for the dict-shaped branch: only touches rules that need a provider, never overwrites an explicit one, creates the `config` sub-dict only when it's missing.

Fixes #2262

## Test plan
- [x] Added `agentcc/tests/test_config_push.py` — 5 unit tests covering rules-list injection (control), checks-dict injection (the bug), checks-dict injection when `config` is entirely absent, that an explicit `provider` isn't clobbered, and that non-provider rules are left untouched.
- [x] Verified regression: reverted the fix locally and confirmed the two dict-shaped tests fail (`KeyError: 'provider'`, `KeyError: 'config'`) against unpatched code, then confirmed all 5 pass with the fix restored.
- [x] `ruff check` / `ruff format --check` clean on both changed files.
- [ ] Full `make check-all` (black/isort/mypy via pre-commit, docker-based integration suite) not run in this environment — no docker available. Should be re-verified in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)