### PR TITLE
fix(observe): allow scrolling to attributes in JSON view [TH-7622]

### DIFF
--- a/frontend/src/components/traceDetail/SpanDetailPane.jsx
+++ b/frontend/src/components/traceDetail/SpanDetailPane.jsx
@@ -17,7 +17,7 @@ import {
   Tabs,
   Typography,
 } from "@mui/material";
-import { alpha } from "@mui/material/styles";
+import { alpha, useTheme } from "@mui/material/styles";
 import Iconify from "src/components/iconify";
 import CustomTooltip from "src/components/tooltip/CustomTooltip";
 import {
@@ -26,7 +26,12 @@ import {
   formatTokenCount,
 } from "src/sections/projects/LLMTracing/formatters";
 import Markdown from "react-markdown";
-import { JsonView, allExpanded, defaultStyles } from "react-json-view-lite";
+import {
+  JsonView,
+  allExpanded,
+  darkStyles,
+  defaultStyles,
+} from "react-json-view-lite";
 import "react-json-view-lite/dist/index.css";
 import { Prism as SyntaxHighlighter } from "react-syntax-highlighter";
 import { enqueueSnackbar } from "notistack";
@@ -405,6 +410,8 @@ const JsonPreviewBlock = ({
   hideInlineSearch = false,
 }) => {
   const [jsonSearch, setJsonSearch] = useState("");
+  const isDark = useTheme().palette.mode === "dark";
+  const jsonViewBase = isDark ? darkStyles : defaultStyles;
 
   const jsonData = useMemo(() => {
     const data = {};
@@ -507,11 +514,27 @@ const JsonPreviewBlock = ({
       {/* JSON tree view */}
       <Box
         sx={{
-          maxHeight: "calc(100vh - 380px)",
-          overflow: "auto",
+          // No vertical cap: a fixed height nests a second scroll container
+          // inside the Preview pane and traps the wheel there.
+          overflowX: "auto",
           p: 1,
           fontSize: 12,
-          "& > div": { fontFamily: "monospace !important" },
+          "& > div": {
+            fontFamily: "monospace !important",
+            backgroundColor: "transparent !important",
+          },
+          // Syntax palette, theme-aware via global.css.
+          "& .fi-json-label": { color: "var(--text-primary)" },
+          "& .fi-json-clickable": {
+            color: "var(--text-primary)",
+            fontWeight: 600,
+            cursor: "pointer",
+          },
+          "& .fi-json-string": { color: "var(--syntax-string)" },
+          "& .fi-json-number": { color: "var(--syntax-number)" },
+          "& .fi-json-boolean": { color: "var(--syntax-boolean)" },
+          "& .fi-json-nullish": { color: "var(--text-disabled)" },
+          "& .fi-json-punctuation": { color: "var(--syntax-punctuation)" },
           // Highlight matching text lines
           ...(activeSearch
             ? {
@@ -526,22 +549,21 @@ const JsonPreviewBlock = ({
           data={jsonData}
           shouldExpandNode={allExpanded}
           clickToExpandNode
+          // Class names, not style objects — the objects previously here
+          // became `class="[object Object]"` and applied nothing. Blank
+          // container/basicChildStyle preserves the original spacing.
           style={{
-            ...defaultStyles,
-            container: {
-              fontFamily: "'IBM Plex Mono', monospace",
-              fontSize: "11px",
-              lineHeight: "18px",
-              backgroundColor: "transparent",
-            },
-            basicChildStyle: { paddingLeft: "16px" },
-            label: { color: "var(--text-primary)", fontWeight: 500 },
-            stringValue: { color: "var(--syntax-string)" },
-            numberValue: { color: "var(--syntax-number)" },
-            booleanValue: { color: "var(--syntax-boolean)" },
-            nullValue: { color: "var(--text-disabled)" },
-            undefinedValue: { color: "var(--text-disabled)" },
-            punctuation: { color: "var(--text-disabled)" },
+            ...jsonViewBase,
+            container: "",
+            basicChildStyle: "",
+            label: "fi-json-label",
+            clickableLabel: `${jsonViewBase.clickableLabel} fi-json-clickable`,
+            stringValue: "fi-json-string",
+            numberValue: "fi-json-number",
+            booleanValue: "fi-json-boolean",
+            nullValue: "fi-json-nullish",
+            undefinedValue: "fi-json-nullish",
+            punctuation: "fi-json-punctuation",
           }}
         />
       </Box>


### PR DESCRIPTION
## 🐛 Bug

In the trace drawer's **Preview → JSON** view, the `attributes` section could not be reached by scrolling. Switching back to Markdown let you scroll to it fine.

**Root cause.** The JSON tree box was sized `maxHeight: calc(100vh - 380px)` with its own `overflow: auto`, which made it a *second* scroll container nested inside the Preview pane's own. Measured on a span with a large `input`:

| | Pane scroll range | Where `attributes` lives |
|---|---|---|
| Markdown | **282 px** — pane scrolls normally | own card, one short scroll away |
| JSON (before) | **4 px** — pane effectively frozen | 38,011 px down inside a nested 520 px box |

That box claimed 520 of the pane's 617 px, so the pane had nothing left to scroll. The wheel only ever moved the inner tree, and wheeling anywhere *outside* it did nothing at all. Markdown escapes this because every card caps its own body (`ContentCard` 300 px, attribute rows 350 px), so the Attributes card sits just below the fold.

The `100vh` budget was the core mistake — this renders into a pane that is nowhere near viewport height.

## 🔧 What changed

`frontend/src/components/traceDetail/SpanDetailPane.jsx` (`JsonPreviewBlock`):

- **Scroll fix** — dropped the vertical cap so the Preview pane owns vertical scrolling. `overflowX: "auto"` stays so long unwrapped values still pan sideways.
- **Theming fix** (separate pre-existing bug, found while verifying the above) — `react-json-view-lite` assigns its `style` fields straight to `className`, but they were being passed as **style objects**, so every one became `class="[object Object]"` and applied nothing. `clickableLabel` was the only field never overridden, so it kept the spread-in *light-theme* class — which is why expandable keys like `attributes:` rendered black on the dark theme. Now passes real class names, with the app's own `--syntax-*` palette from `global.css` so it follows the theme toggle.

`container` and `basicChildStyle` are deliberately passed as `""`: the library's layout classes tighten line-height and indentation away from how this view has always rendered.

## 🤔 Why

Removing the nested scroller — rather than just shrinking it — is what actually fixes the report. Any fixed height re-creates the same trap; it only changes how much scrolling is wasted before you hit it.

The theming fix is bundled because it lives in the same 20 lines and would otherwise conflict. It is genuinely independent and can be split out if preferred.

## 🧪 Tests

No new tests — this is a CSS/rendering change with no logic to assert, and there is currently no test covering `JsonPreviewBlock`. Verified in the browser instead (below). Existing suites still pass: 85 tests across `traceDetail`, the annotations content panel, and `SharedView`.

## ▶️ How to reproduce / verify

**Before:** open a trace → click a span with a large `input`/`output` → Preview → JSON → try to scroll to `attributes`. The wheel only moves the inner box, and only while the cursor is inside it.

**After:** the whole payload scrolls with the pane, `attributes` reachable, one scrollbar.

Verified with Playwright against a span carrying a ~60 KB `input` string plus 61 attributes:

| | before | after |
|---|---|---|
| nested vertical scrollers | 1 | **0** |
| pane scroll range @1600×900 | 4 px | **16,397 px** |
| pane scroll range @1280×720 | 4 px | **23,821 px** |
| last attribute reachable | no | **yes** |

For the theming fix, the real component was rendered before/after in both themes and diffed property by property — indent 26 px, line-height 24 px, key weights 600/400, colon gap 0 px, bracket gap 5 px and block height 327 px are all **identical**. The only change is `attributes:` moving from `rgb(0,0,0)` to the theme's text colour, plus the value colours the original config always intended.

## 💻 Commands

```bash
cd frontend
yarn vitest run src/components/traceDetail
npx eslint src/components/traceDetail/SpanDetailPane.jsx
```

## 📹 Videos & Screenshots

https://github.com/user-attachments/assets/10e8915a-54c1-4615-9f39-0896cacd8d0b
