### PR TITLE
fix: document the gateway container port

### DIFF
--- a/futureagi/.env.example
+++ b/futureagi/.env.example
@@ -525,7 +525,7 @@ GUARDRAILS_TOKEN=your-guardrails-token
 # -----------------------------------------------------------------------------
 AGENTCC_GATEWAY_PORT=8090
 AGENTCC_GATEWAY_PUBLIC_URL=https://your-gateway-domain.com
-AGENTCC_GATEWAY_INTERNAL_URL=http://agentcc-gateway:8090
+AGENTCC_GATEWAY_INTERNAL_URL=http://agentcc-gateway:8080
 AGENTCC_ADMIN_TOKEN=agentcc-admin-secret
 AGENTCC_WEBHOOK_SECRET=test-webhook-secret
 
@@ -534,7 +534,7 @@ AGENTCC_WEBHOOK_SECRET=test-webhook-secret
 # Uses the SAME agentcc-gateway, but with a dedicated API key tagged as "internal".
 # Internal calls bypass user quota but are still cost-tracked.
 # -----------------------------------------------------------------------------
-AGENTCC_INTERNAL_URL=http://agentcc-gateway:8090
+AGENTCC_INTERNAL_URL=http://agentcc-gateway:8080
 AGENTCC_INTERNAL_API_KEY=fi-internal-dev-key-change-in-prod
 
 # -----------------------------------------------------------------------------

--- a/futureagi/agentcc/services/gateway_client.py
+++ b/futureagi/agentcc/services/gateway_client.py
@@ -32,7 +32,7 @@ def resolve_gateway_internal_url():
 
 # Default gateway address — set via env vars in docker-compose / .env
 AGENTCC_GATEWAY_URL = resolve_gateway_public_url()
-# Internal URL for container-to-container communication (e.g. http://agentcc-gateway:8090)
+# Internal URL for container-to-container communication (e.g. http://agentcc-gateway:8080)
 AGENTCC_GATEWAY_INTERNAL_URL = resolve_gateway_internal_url()
 AGENTCC_ADMIN_TOKEN = os.environ.get("AGENTCC_ADMIN_TOKEN", "")
 if not AGENTCC_ADMIN_TOKEN:


### PR DESCRIPTION
## Summary

- correct both internal AgentCC gateway URLs in .env.example from the host port 8090 to the container port 8080
- update the gateway client comment to document the container-to-container port accurately

Completes the remaining stale configuration from #1058. docker-compose.yml already uses port 8080 for the internal gateway URL on current dev.

## Validation

- confirmed no stale gentcc-gateway:8090 reference remains in .env.example, docker-compose.yml, or the gateway client comment
- git diff --check passed
- the existing gentcc/tests/test_services.py could not collect in this local isolated environment because Django settings are not bootstrapped; no production test failure was observed

AI assistance was used during implementation; the changes were reviewed before submission.