### PR TITLE
docs(contributing): point setup at the env file compose reads

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,11 +41,11 @@ cd future-agi
 ### 2. Start the stack
 
 ```bash
-cp futureagi/.env.example futureagi/.env
+cp .env.example .env
 docker compose up -d
 ```
 
-The backend will be at `http://localhost:8000`, the frontend at `http://localhost:3031`.
+The backend will be at `http://localhost:8000`, the frontend at `http://localhost:3000`.
 
 ### 3. Install git hooks
 


### PR DESCRIPTION
## Summary

`CONTRIBUTING.md` step 2 pairs `docker compose up -d` with an env file that stack never reads, and with the Vite dev-server port instead of the published one. Followed as written, compose reads no `.env` at all and the browser lands on a port with nothing on it. Two lines, docs only.

## Type of change

- [x] 📖 Documentation only

---

## 1) What changes were done

**A. The env file**

`docker compose up -d` at the repo root reads `docker-compose.yml`. There, `backend`, `worker`, `worker-default`, `agentcc-gateway` and `serving` declare `env_file: - path: .env`, which resolves relative to the compose file, so it is the **root** `.env`. Compose also interpolates every `${VAR:-default}` in that file from the same root `.env`.

`futureagi/.env` is not read anywhere on that path:

- no service bind-mounts `./futureagi` as a directory — only three individual files (`futureagi/.ci/clickhouse-storage-policy.xml`, `futureagi/config/peerdb/temporal-dynamicconfig.yaml`, `futureagi/scripts/peerdb-setup-mirrors.sh`)
- `.dockerignore:12` excludes `**/.env` from the build context, so it cannot reach an image either
- `futureagi/tfc/settings/settings.py` reads config with plain `os.getenv`; there is no `load_dotenv()` on the boot path

`bin/install:145` and `bin/install.ps1:131` both `cp .env.example .env` at the root, and `INSTALLATION.md:199` says "`docker compose` automatically loads `.env` from the directory where you run it."

`futureagi/.env.example` belongs to the separate inner compose project under `futureagi/`.

**B. The port**

| where | frontend host port |
|---|---|
| `docker-compose.yml:152` | `${FRONTEND_PORT:-3000}:80` |
| `docker-compose.dev.yml:20` | `${FRONTEND_PORT:-3000}:3000` |
| `docker-compose.frontend.yml:14` | `${FRONTEND_PORT:-3000}:80` |
| `frontend/Dockerfile:30` (dev stage) | `yarn dev --host --port 3000` |
| `README.md:140` | Open http://localhost:3000 |
| `INSTALLATION.md:58` | **Frontend**: http://localhost:3000 |

`3031` is the bare-host Vite port (`frontend/vite.config.js:80`), which `docker compose up -d` does not start. The inner `futureagi/` compose project defines no frontend service, which is where that project's `APP_URL=localhost:3031` comes from.

The backend URL in the same sentence is correct (`${BACKEND_PORT:-8000}:80`) and is unchanged.

---

## 2) Why the changes were done

- **Contributor onboarding:** this is step 2 of the first-run instructions. Both errors are silent — no warning that `futureagi/.env` was ignored, and an empty page rather than an error on 3031.
- **Consistency:** `README.md`, `INSTALLATION.md`, `bin/install` and all three root compose files already agree on the root `.env` and port 3000. `CONTRIBUTING.md:44,48` is the only place that disagrees.

---

## 3) Tests

None. Documentation only; no code path changes.

---

## 4) How to verify

```bash
grep -n "path: .env" docker-compose.yml          # env_file resolves at the repo root
grep -rn "\./futureagi" docker-compose.yml       # three individual files, no directory mount
sed -n '12p' .dockerignore                       # **/.env excluded from the build context
grep -rn "FRONTEND_PORT" docker-compose*.yml     # 3000 in all three
sed -n '30p' frontend/Dockerfile                 # dev stage serves on 3000
```

---

## 5) Prior art

Closed PR #172 made the same `cp .env.example .env` correction, inside an 11-file change that also rewrote the pre-commit config, the Makefile and CI. It resolved the port conflict the other way — changing compose and `INSTALLATION.md` to 3031 — and was closed unmerged. Everything shipped since is on 3000, so this goes the other direction and touches only the two lines that still disagree with it.

## 6) Deliberately not touched

`.github/PULL_REQUEST_TEMPLATE.md:141` also says `http://localhost:3031`. Left alone: a contributor testing their own frontend change may genuinely be running `yarn dev`, where 3031 is right. Say the word and I'll fold it in.

---

## Checklist

- [x] My code follows the style guide
- [ ] Tests — n/a, documentation only
- [ ] `bin/test` / `yarn test:run` — n/a, no code changed
- [ ] `yarn contracts:check` — n/a, no API surface change
- [x] I've updated the documentation where relevant
- [x] No hardcoded secrets, URLs, or PII
- [ ] CLA — not signed yet
- [x] PR title follows Conventional Commits
