### PR TITLE
docs(installation): list the published MinIO ports, not the container ports

### DIFF
--- a/INSTALLATION.md
+++ b/INSTALLATION.md
@@ -231,8 +231,8 @@ All ports are configurable via `.env`. Defaults:
 | ClickHouse HTTP            | `8123` | same                                   |
 | ClickHouse TCP             | `9000` | same                                   |
 | Redis                      | `6379` | same                                   |
-| MinIO S3 API               | `9000` | same                                   |
-| MinIO console              | `9001` | same                                   |
+| MinIO S3 API               | `9005` | same                                   |
+| MinIO console              | `9006` | same                                   |
 | Temporal gRPC              | `7233` | same                                   |
 | Temporal UI                | `8085` | dev mode only                          |
 


### PR DESCRIPTION
## Summary

The ports reference in `INSTALLATION.md` gives host ports for every service except MinIO, where it gives the two container ports. As written the table lists `9000` twice — for ClickHouse TCP and for the MinIO S3 API — which cannot both be true, since only one process can hold a host port. Two table cells, docs only.

## Type of change

- [x] 📖 Documentation only

---

## 1) What changes were done

`INSTALLATION.md:234-235`:

| row | table said | published default |
|---|---|---|
| MinIO S3 API | `9000` | **9005** — `docker-compose.yml:524` `127.0.0.1:${MINIO_API_PORT:-9005}:9000` |
| MinIO console | `9001` | **9006** — `docker-compose.yml:525` `127.0.0.1:${MINIO_CONSOLE_PORT:-9006}:9001` |

`9000` and `9001` are the ports *inside* the container. The env vars the table's own preamble points at (`MINIO_API_PORT`, `MINIO_CONSOLE_PORT`) set the host side.

Every other row is already a host port, so MinIO was the only inconsistent pair:

| service | table | mapping |
|---|---|---|
| Frontend | `3000` | `${FRONTEND_PORT:-3000}:80` |
| Backend API | `8000` | `${BACKEND_PORT:-8000}:80` |
| Gateway | `8090` | `${AGENTCC_GATEWAY_PORT:-8090}:8080` |
| Temporal UI | `8085` | `${TEMPORAL_UI_PORT:-8085}:8080` |

---

## 2) Why the changes were done

- **The table is the reference people copy from.** Its lead-in is "All ports are configurable via `.env`", and the line under it tells you to change every port to run two stacks side by side. Both only make sense for host ports.
- **It already contradicted the rest of the same file.** `INSTALLATION.md:263` says `MINIO_URL` "defaults to `http://localhost:9005`", and `futureagi/tfc/settings/settings.py:713` hardcodes that same `localhost:9005` as the local default.
- **9005/9006 holds in every mode**, so there is no configuration under which the old numbers were right: `docker-compose.dev.yml:103-104` overrides the bind address but keeps `9005`/`9006`, and the inner `futureagi/docker-compose.yml:433-434` uses them too.

The `same` in the URL column (meaning `127.0.0.1`, dev mode `0.0.0.0`) is accurate and unchanged.

---

## 3) Tests

None. Documentation only; no code path changes.

---

## 4) How to verify

```bash
grep -n "MINIO_API_PORT\|MINIO_CONSOLE_PORT" docker-compose.yml docker-compose.dev.yml
grep -n "9005" INSTALLATION.md futureagi/tfc/settings/settings.py
```

---

## Checklist

- [x] My code follows the style guide
- [ ] Tests — n/a, documentation only
- [ ] `bin/test` / `yarn test:run` — n/a, no code changed
- [ ] `yarn contracts:check` — n/a, no API surface change
- [x] I've updated the documentation where relevant
- [x] No hardcoded secrets, URLs, or PII
- [ ] CLA — not signed yet
- [x] PR title follows Conventional Commits
