### PR TITLE
fix(eval): safely extract Azure OpenAI model when deployment version is None (#2158)

### DIFF
--- a/futureagi/agentic_eval/core_evals/fi_utils/extract_model.py
+++ b/futureagi/agentic_eval/core_evals/fi_utils/extract_model.py
@@ -109,7 +109,12 @@ def _extract_model_name(
                 invocation_params = kwargs.get("invocation_params") or {}
                 model = invocation_params.get("model")
                 if model:
-                    return model + "-" + llm.serialized["kwargs"]["model_version"]
+                    llm_serialized = getattr(llm, "serialized", None)
+                    ser_kwargs = llm_serialized.get("kwargs", {}) if isinstance(llm_serialized, dict) else {}
+                    model_version = getattr(llm, "model_version", None) or ser_kwargs.get("model_version")
+                    if model_version:
+                        return f"{model}-{model_version}"
+                    return model
 
             if isinstance(llm, ChatBaichuan):
                 return llm.model
@@ -256,23 +261,40 @@ def _extract_model_name(
     if model:
         return model
 
-    if serialized.get("id")[-1] == "AzureChatOpenAI":
+    ser_id = serialized.get("id") if isinstance(serialized, dict) else None
+    last_id = ser_id[-1] if isinstance(ser_id, (list, tuple)) and len(ser_id) > 0 else None
+
+    if last_id == "AzureChatOpenAI":
         invocation_params = kwargs.get("invocation_params") or {}
         if invocation_params.get("model"):
             return invocation_params.get("model")
 
-    if serialized.get("id")[-1] == "AzureOpenAI":
+    if last_id == "AzureOpenAI":
         invocation_params = kwargs.get("invocation_params") or {}
         if invocation_params.get("model_name"):
             return invocation_params.get("model_name")
+        if invocation_params.get("model"):
+            return invocation_params.get("model")
 
-        deployment_name = None
-        if serialized.get("kwargs").get("openai_api_version"):
-            deployment_name = serialized.get("kwargs").get("deployment_version")
-        deployment_version = None
-        if serialized.get("kwargs").get("deployment_name"):
-            deployment_name = serialized.get("kwargs").get("deployment_name")
-        return deployment_name + "-" + deployment_version
+        ser_kwargs = (serialized.get("kwargs") or {}) if isinstance(serialized, dict) else {}
+        deployment_name = (
+            ser_kwargs.get("deployment_name")
+            or ser_kwargs.get("model_name")
+            or ser_kwargs.get("model")
+        )
+        deployment_version = (
+            ser_kwargs.get("deployment_version")
+            or ser_kwargs.get("openai_api_version")
+            or ser_kwargs.get("model_version")
+        )
+
+        if deployment_name and deployment_version:
+            return f"{deployment_name}-{deployment_version}"
+        if deployment_name:
+            return str(deployment_name)
+        if deployment_version:
+            return str(deployment_version)
+        return None
 
     # anthropic
     model = _extract_model_by_pattern("Anthropic", serialized, "model", "anthropic")

--- a/futureagi/agentic_eval/core_evals/fi_utils/tests/test_extract_model.py
+++ b/futureagi/agentic_eval/core_evals/fi_utils/tests/test_extract_model.py
@@ -46,3 +46,89 @@ class TestExtractModelName:
                 serialized, invocation_params={"model_name": "gpt-4-turbo"}
             )
         assert result == "gpt-4-turbo"
+
+    def test_azure_openai_none_deployment_version_no_typeerror(self):
+        """Regression test for #2158: no TypeError when deployment_version is unavailable."""
+        serialized = {
+            "type": "not_implemented",
+            "id": ["langchain_community", "llms", "AzureOpenAI"],
+            "repr": "",
+            "kwargs": {"deployment_name": "my-azure-gpt4"},
+        }
+        with (
+            patch(
+                "agentic_eval.core_evals.fi_utils.extract_model._extract_model_by_key",
+                return_value=None,
+            ),
+            patch(
+                "agentic_eval.core_evals.fi_utils.extract_model._extract_model_by_pattern",
+                return_value=None,
+            ),
+        ):
+            result = _extract_model_name(serialized)
+        assert result == "my-azure-gpt4"
+
+    def test_azure_openai_with_deployment_version(self):
+        serialized = {
+            "type": "not_implemented",
+            "id": ["langchain_community", "llms", "AzureOpenAI"],
+            "repr": "",
+            "kwargs": {
+                "deployment_name": "my-azure-gpt4",
+                "deployment_version": "2024-02-15-preview",
+            },
+        }
+        with (
+            patch(
+                "agentic_eval.core_evals.fi_utils.extract_model._extract_model_by_key",
+                return_value=None,
+            ),
+            patch(
+                "agentic_eval.core_evals.fi_utils.extract_model._extract_model_by_pattern",
+                return_value=None,
+            ),
+        ):
+            result = _extract_model_name(serialized)
+        assert result == "my-azure-gpt4-2024-02-15-preview"
+
+    def test_azure_openai_with_openai_api_version(self):
+        serialized = {
+            "type": "not_implemented",
+            "id": ["langchain_community", "llms", "AzureOpenAI"],
+            "repr": "",
+            "kwargs": {
+                "deployment_name": "gpt-4",
+                "openai_api_version": "0301",
+            },
+        }
+        with (
+            patch(
+                "agentic_eval.core_evals.fi_utils.extract_model._extract_model_by_key",
+                return_value=None,
+            ),
+            patch(
+                "agentic_eval.core_evals.fi_utils.extract_model._extract_model_by_pattern",
+                return_value=None,
+            ),
+        ):
+            result = _extract_model_name(serialized)
+        assert result == "gpt-4-0301"
+
+    def test_azure_openai_empty_id_and_missing_kwargs(self):
+        serialized = {
+            "type": "not_implemented",
+            "id": [],
+            "kwargs": None,
+        }
+        with (
+            patch(
+                "agentic_eval.core_evals.fi_utils.extract_model._extract_model_by_key",
+                return_value=None,
+            ),
+            patch(
+                "agentic_eval.core_evals.fi_utils.extract_model._extract_model_by_pattern",
+                return_value=None,
+            ),
+        ):
+            result = _extract_model_name(serialized)
+        assert result is None


### PR DESCRIPTION
## Problem

When extracting Azure OpenAI model names in `futureagi/agentic_eval/core_evals/fi_utils/extract_model.py`, if `deployment_version` is `None` or unavailable, string concatenation raises a runtime exception:
`TypeError: can only concatenate str (not "NoneType") to str`

Additionally, `deployment_version` was never assigned from `serialized["kwargs"]` in the fallback block, and `serialized.get("id")[-1]` was susceptible to indexing errors if `id` was empty.

## Solution

1. In `_extract_model_name()`:
   - Safely retrieve `deployment_name` and `deployment_version` from `serialized.get("kwargs")` with fallbacks for `model_name`, `model`, `openai_api_version`, and `model_version`.
   - Return `f"{deployment_name}-{deployment_version}"` when both are present.
   - Return `deployment_name` directly when `deployment_version` is `None` or unavailable, resolving the `TypeError`.
   - Safely guard `serialized.get("id")` indexing.
2. In the deserialized `isinstance(llm, AzureOpenAI)` handler, guard `model_version` and `serialized["kwargs"]` access.
3. Add comprehensive regression tests in `futureagi/agentic_eval/core_evals/fi_utils/tests/test_extract_model.py` covering missing version, valid version, API version fallbacks, and missing kwargs.

## Verification

- Ran test suite: `pytest futureagi/agentic_eval/core_evals/fi_utils/tests/test_extract_model.py -v` (6/6 passed).
- Verified syntax with `py_compile`.

Fixes #2158
