### PR TITLE
feat(evals): add counterfactual replay regression gates

### DIFF
--- a/docs/counterfactual-trace-replay.md
+++ b/docs/counterfactual-trace-replay.md
@@ -79,7 +79,6 @@ report.raise_for_regressions()
 - Requests that differ only by credentials never share candidate execution.
   The exported public fingerprint redacts credential values, while a separate
   non-exported digest controls execution reuse.
-- Candidate calls and evaluator calls share one global concurrency bound.
 - Requests, baselines, metadata, candidate outputs, and evaluator case objects
   are deep-copied so mutation does not contaminate later cases or evaluators.
   Values that cannot be copied fail before shared mutable state is exposed; an
@@ -109,10 +108,12 @@ successful candidate call without a quality or safety evaluator cannot be
 promoted accidentally. Set `minimum_evaluation_count=0` only for an explicit
 candidate-execution smoke test.
 
-Candidate and evaluator timeouts cancel asynchronous callables. Python cannot
-forcibly stop a synchronous function already running in a worker thread, so
-integrations that need enforceable cancellation should use asynchronous
-clients or enforce the timeout in the downstream client itself.
+Candidate and evaluator timeouts cancel asynchronous callables. Replay-level
+timeouts are rejected for synchronous callables because Python cannot forcibly
+stop a function already running in a worker thread; releasing the concurrency
+permit while that thread continued would violate the configured global bound.
+Synchronous integrations must enforce their timeout in the downstream client,
+or expose an asynchronous wrapper and use the replay-level timeout.
 
 ## Privacy defaults
 
@@ -137,7 +138,14 @@ payload = report.to_dict(
 ```
 
 To retain exception messages at all, the replay engine must also be constructed
-with `capture_error_messages=True`.
+with `capture_error_messages=True`. Captured messages are sanitized against
+credentials found in the replay case and common authorization/key patterns.
+Omission remains the safest setting for arbitrary provider exception text.
+
+Structurally known output values are redacted recursively. An unsupported
+object is represented by its type name only; its `repr()` is never exported,
+because arbitrary representations can contain credentials or execute unsafe
+formatting code.
 
 ## Self-healing loop
 

--- a/docs/counterfactual-trace-replay.md
+++ b/docs/counterfactual-trace-replay.md
@@ -1,0 +1,155 @@
+# Counterfactual trace replay
+
+Counterfactual replay is a promotion gate for candidate changes to an AI agent.
+It runs production-shaped requests through a new model, prompt, routing policy,
+tool policy, or guardrail, evaluates the candidate against the current baseline,
+and rejects promotion when quality or reliability regresses.
+
+The implementation lives in `agentic_eval.core.replay` and has no provider or
+network dependency. A candidate callable can invoke the Future AGI Gateway, a
+hosted provider, or a local OpenAI-compatible runtime such as MLX-LM, oMLX,
+Ollama, or llama.cpp.
+
+## Example
+
+```python
+import asyncio
+
+from agentic_eval.core.replay import (
+    CounterfactualReplay,
+    Evaluation,
+    RegressionPolicy,
+    ReplayCase,
+)
+
+
+async def candidate(request):
+    # Call a hosted endpoint or an OpenAI-compatible local runtime here.
+    return await model_client.complete(**request)
+
+
+def task_quality(output, baseline, case):
+    candidate_score = score_task(output)
+    baseline_score = score_task(baseline)
+    return Evaluation(
+        name="task-quality",
+        score=candidate_score,
+        passed=candidate_score >= 0.8,
+        baseline_score=baseline_score,
+        details={"trace_id": case.metadata.get("trace_id")},
+    )
+
+
+cases = [
+    ReplayCase(
+        case_id="trace-001",
+        request={"messages": [{"role": "user", "content": "..."}]},
+        baseline=current_production_output,
+        metadata={"trace_id": "trace-001", "split": "held-out"},
+    )
+]
+
+report = asyncio.run(
+    CounterfactualReplay(
+        candidate,
+        [task_quality],
+        concurrency=8,
+        policy=RegressionPolicy(
+            minimum_case_count=50,
+            minimum_evaluation_count=50,
+            minimum_pass_rate=0.95,
+            maximum_error_rate=0.01,
+            maximum_regression_rate=0.02,
+            maximum_mean_score_drop=0.01,
+        ),
+    ).run(cases)
+)
+
+report.raise_for_regressions()
+```
+
+## Determinism and isolation
+
+- Results retain input order even when candidate calls finish out of order.
+- Candidate and evaluator work share one concurrency ceiling, so an expensive
+  evaluator cannot silently exceed the configured replay bound.
+- Identical full requests share one candidate execution by default.
+- Evaluation remains case-specific, so duplicated requests can still have
+  different baselines and acceptance expectations.
+- Requests that differ only by credentials never share candidate execution.
+  The exported public fingerprint redacts credential values, while a separate
+  non-exported digest controls execution reuse.
+- Candidate calls and evaluator calls share one global concurrency bound.
+- Requests, baselines, metadata, candidate outputs, and evaluator case objects
+  are deep-copied so mutation does not contaminate later cases or evaluators.
+  Values that cannot be copied fail before shared mutable state is exposed; an
+  uncopyable candidate output becomes an isolated structured replay error.
+
+## Promotion policy
+
+`RegressionPolicy` can fail a promotion on:
+
+- too few replay cases;
+- too few completed evaluations;
+- insufficient pass rate;
+- excessive candidate or evaluator error rate;
+- excessive score-regression rate; or
+- excessive mean score drop.
+
+`minimum_evaluation_count` defaults to one, so a candidate-only smoke run is not
+promotable unless the caller explicitly opts out. `score_regression_tolerance`
+prevents insignificant floating-point noise from counting as a regression.
+`ReplayReport.violations` records every failed condition rather than only the
+first one.
+
+For a held-out gate, pass only held-out cases to the replay run. Training cases
+may be used during candidate generation, but they should not decide promotion.
+The default policy also requires at least one completed evaluation, so a
+successful candidate call without a quality or safety evaluator cannot be
+promoted accidentally. Set `minimum_evaluation_count=0` only for an explicit
+candidate-execution smoke test.
+
+Candidate and evaluator timeouts cancel asynchronous callables. Python cannot
+forcibly stop a synchronous function already running in a worker thread, so
+integrations that need enforceable cancellation should use asynchronous
+clients or enforce the timeout in the downstream client itself.
+
+## Privacy defaults
+
+The engine recursively redacts credential-shaped keys from public request
+fingerprints and from any diagnostic fields that are explicitly exported.
+Common forms such as `Authorization`, `api_key`, provider-specific `*_api_key`,
+tokens, cookies, passwords, and secret keys are covered. Deployment-specific
+names can be added with `additional_sensitive_keys`.
+
+`ReplayReport.to_dict()` and `to_json()` omit candidate outputs, exception
+messages, case metadata, and evaluator details by default. Any of those fields
+can contain prompts, user content, provider URLs, or credentials. Enable only
+the fields required for a controlled diagnostic artifact:
+
+```python
+payload = report.to_dict(
+    include_outputs=True,
+    include_error_messages=True,
+    include_metadata=True,
+    include_evaluation_details=True,
+)
+```
+
+To retain exception messages at all, the replay engine must also be constructed
+with `capture_error_messages=True`.
+
+## Self-healing loop
+
+A safe automated repair loop can use this sequence:
+
+1. Convert failed or low-scoring traces into `ReplayCase` objects.
+2. Generate a candidate prompt, model, routing, tool, or guardrail change.
+3. Replay a held-out production-shaped suite against the candidate.
+4. Evaluate task quality, safety, cost, and tool correctness.
+5. Apply `RegressionPolicy` as the promotion gate.
+6. Store the redacted report for auditability.
+7. Promote accepted candidates and reject or revise the rest.
+
+This establishes the verifier boundary without coupling the replay engine to a
+specific optimizer, provider, or deployment runtime.

--- a/futureagi/agentic_eval/core/replay/__init__.py
+++ b/futureagi/agentic_eval/core/replay/__init__.py
@@ -1,0 +1,26 @@
+"""Counterfactual replay and regression-gate primitives."""
+
+from agentic_eval.core.replay.engine import Candidate, CounterfactualReplay
+from agentic_eval.core.replay.models import (
+    Evaluation,
+    Evaluator,
+    RegressionPolicy,
+    ReplayCase,
+    ReplayRegressionError,
+    ReplayReport,
+    ReplayResult,
+)
+from agentic_eval.core.replay.privacy import request_fingerprint
+
+__all__ = [
+    "Candidate",
+    "CounterfactualReplay",
+    "Evaluation",
+    "Evaluator",
+    "RegressionPolicy",
+    "ReplayCase",
+    "ReplayRegressionError",
+    "ReplayReport",
+    "ReplayResult",
+    "request_fingerprint",
+]

--- a/futureagi/agentic_eval/core/replay/engine.py
+++ b/futureagi/agentic_eval/core/replay/engine.py
@@ -25,8 +25,10 @@ from agentic_eval.core.replay.models import (
 )
 from agentic_eval.core.replay.privacy import (
     _isolated_copy,
+    _redact_text,
     _request_digest,
     _sensitive_key_set,
+    _sensitive_values,
 )
 
 Candidate: TypeAlias = Callable[
@@ -50,17 +52,19 @@ class _CandidateOutcome:
     error_message: str | None = None
 
 
+def _is_async_callable(function: Callable[..., Any]) -> bool:
+    return inspect.iscoroutinefunction(function) or inspect.iscoroutinefunction(
+        type(function).__call__
+    )
+
+
 async def _invoke_callable(
     function: Callable[..., Any],
     *args: Any,
     timeout_seconds: float | None,
 ) -> Any:
     async def invoke() -> Any:
-        call_method = getattr(function, "__call__", None)
-        is_async = inspect.iscoroutinefunction(function) or (
-            call_method is not None and inspect.iscoroutinefunction(call_method)
-        )
-        if is_async:
+        if _is_async_callable(function):
             result = function(*args)
         else:
             result = await asyncio.to_thread(function, *args)
@@ -74,7 +78,13 @@ async def _invoke_callable(
 
 
 def _callable_name(function: Callable[..., Any]) -> str:
-    return getattr(function, "__name__", type(function).__qualname__)
+    try:
+        name = function.__name__
+    except Exception:
+        return type(function).__name__
+    if isinstance(name, str) and name:
+        return name
+    return type(function).__name__
 
 
 class CounterfactualReplay:
@@ -124,6 +134,26 @@ class CounterfactualReplay:
         evaluator_tuple = tuple(evaluators)
         if any(not callable(evaluator) for evaluator in evaluator_tuple):
             raise TypeError("every evaluator must be callable")
+        if (
+            normalized_timeouts["candidate_timeout_seconds"] is not None
+            and not _is_async_callable(candidate)
+        ):
+            raise ValueError(
+                "candidate_timeout_seconds requires an async candidate; "
+                "synchronous candidates must enforce their own downstream timeout"
+            )
+        if normalized_timeouts["evaluator_timeout_seconds"] is not None:
+            synchronous_evaluators = [
+                _callable_name(evaluator)
+                for evaluator in evaluator_tuple
+                if not _is_async_callable(evaluator)
+            ]
+            if synchronous_evaluators:
+                names = ", ".join(repr(name) for name in synchronous_evaluators)
+                raise ValueError(
+                    "evaluator_timeout_seconds requires async evaluators; "
+                    f"synchronous evaluators: {names}"
+                )
 
         self._candidate = candidate
         self._evaluators = evaluator_tuple
@@ -138,6 +168,38 @@ class CounterfactualReplay:
         ]
         self._capture_error_messages = capture_error_messages
         self._sensitive_keys = _sensitive_key_set(additional_sensitive_keys)
+
+    def _collect_sensitive_values(self, *context: Any) -> frozenset[str]:
+        known_secrets: set[str] = set()
+        for item in context:
+            try:
+                known_secrets.update(
+                    _sensitive_values(
+                        item,
+                        sensitive_keys=self._sensitive_keys,
+                    )
+                )
+            except Exception:
+                # Redaction discovery is best-effort and must not replace the
+                # original replay outcome with a secondary traversal error.
+                continue
+        return frozenset(known_secrets)
+
+    def _captured_error_message(
+        self,
+        error: Exception,
+        *context: Any,
+    ) -> str | None:
+        if not self._capture_error_messages:
+            return None
+        try:
+            message = str(error)
+        except Exception:
+            message = "[exception message unavailable]"
+        return _redact_text(
+            message,
+            sensitive_values=self._collect_sensitive_values(*context),
+        )
 
     async def _execute_candidate(
         self,
@@ -164,9 +226,12 @@ class CounterfactualReplay:
             return _CandidateOutcome(
                 output=None,
                 duration_ms=duration_ms,
-                error_type=type(error).__qualname__,
-                error_message=(
-                    str(error) if self._capture_error_messages else None
+                error_type=type(error).__name__,
+                error_message=self._captured_error_message(
+                    error,
+                    case.request,
+                    case.baseline,
+                    case.metadata,
                 ),
             )
 
@@ -213,9 +278,11 @@ class CounterfactualReplay:
                 candidate_duration_ms=outcome.duration_ms,
                 cache_hit=cache_hit,
                 error_stage="candidate-output-isolation",
-                error_type=type(error).__qualname__,
-                error_message=(
-                    str(error) if self._capture_error_messages else None
+                error_type=type(error).__name__,
+                error_message=self._captured_error_message(
+                    error,
+                    outcome.output,
+                    prepared.case,
                 ),
                 metadata=_isolated_copy(
                     prepared.case.metadata,
@@ -248,8 +315,15 @@ class CounterfactualReplay:
                 if not isinstance(evaluation, Evaluation):
                     raise TypeError(
                         f"evaluator {evaluator_name!r} returned "
-                        f"{type(evaluation).__qualname__}; expected Evaluation"
+                        f"{type(evaluation).__name__}; expected Evaluation"
                     )
+                evaluation = Evaluation(
+                    name=evaluation.name,
+                    score=evaluation.score,
+                    passed=evaluation.passed,
+                    baseline_score=evaluation.baseline_score,
+                    details=evaluation.details,
+                )
                 if evaluation.name in evaluation_names:
                     raise ValueError(
                         f"duplicate evaluation name {evaluation.name!r}"
@@ -266,9 +340,12 @@ class CounterfactualReplay:
                     candidate_duration_ms=outcome.duration_ms,
                     cache_hit=cache_hit,
                     error_stage=f"evaluator:{evaluator_name}",
-                    error_type=type(error).__qualname__,
-                    error_message=(
-                        str(error) if self._capture_error_messages else None
+                    error_type=type(error).__name__,
+                    error_message=self._captured_error_message(
+                        error,
+                        result_output,
+                        prepared.case,
+                        tuple(evaluations),
                     ),
                     metadata=_isolated_copy(
                         prepared.case.metadata,

--- a/futureagi/agentic_eval/core/replay/engine.py
+++ b/futureagi/agentic_eval/core/replay/engine.py
@@ -1,0 +1,371 @@
+"""Deterministic execution engine for candidate agent changes.
+
+The engine is provider-neutral. A candidate callable can invoke the Future AGI
+Gateway, a hosted API, or a local OpenAI-compatible runtime such as MLX-LM,
+oMLX, Ollama, or llama.cpp.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import inspect
+import math
+import time
+from collections.abc import Awaitable, Callable, Iterable, Mapping, Sequence
+from dataclasses import dataclass
+from typing import Any, TypeAlias
+
+from agentic_eval.core.replay.models import (
+    Evaluation,
+    Evaluator,
+    RegressionPolicy,
+    ReplayCase,
+    ReplayReport,
+    ReplayResult,
+)
+from agentic_eval.core.replay.privacy import (
+    _isolated_copy,
+    _request_digest,
+    _sensitive_key_set,
+)
+
+Candidate: TypeAlias = Callable[
+    [Mapping[str, Any]],
+    Any | Awaitable[Any],
+]
+
+
+@dataclass(frozen=True, slots=True)
+class _PreparedCase:
+    case: ReplayCase
+    fingerprint: str
+    execution_digest: str
+
+
+@dataclass(frozen=True, slots=True)
+class _CandidateOutcome:
+    output: Any
+    duration_ms: float
+    error_type: str | None = None
+    error_message: str | None = None
+
+
+async def _invoke_callable(
+    function: Callable[..., Any],
+    *args: Any,
+    timeout_seconds: float | None,
+) -> Any:
+    async def invoke() -> Any:
+        call_method = getattr(function, "__call__", None)
+        is_async = inspect.iscoroutinefunction(function) or (
+            call_method is not None and inspect.iscoroutinefunction(call_method)
+        )
+        if is_async:
+            result = function(*args)
+        else:
+            result = await asyncio.to_thread(function, *args)
+        if inspect.isawaitable(result):
+            return await result
+        return result
+
+    if timeout_seconds is None:
+        return await invoke()
+    return await asyncio.wait_for(invoke(), timeout=timeout_seconds)
+
+
+def _callable_name(function: Callable[..., Any]) -> str:
+    return getattr(function, "__name__", type(function).__qualname__)
+
+
+class CounterfactualReplay:
+    """Replay captured requests through a candidate and regression gate."""
+
+    def __init__(
+        self,
+        candidate: Candidate,
+        evaluators: Sequence[Evaluator] = (),
+        *,
+        policy: RegressionPolicy | None = None,
+        concurrency: int = 8,
+        deduplicate_requests: bool = True,
+        candidate_timeout_seconds: float | None = None,
+        evaluator_timeout_seconds: float | None = None,
+        capture_error_messages: bool = False,
+        additional_sensitive_keys: Iterable[str] = (),
+    ) -> None:
+        if not callable(candidate):
+            raise TypeError("candidate must be callable")
+        if policy is not None and not isinstance(policy, RegressionPolicy):
+            raise TypeError("policy must be a RegressionPolicy or None")
+        if isinstance(concurrency, bool) or not isinstance(concurrency, int):
+            raise TypeError("concurrency must be an int")
+        if concurrency < 1:
+            raise ValueError("concurrency must be at least 1")
+        if not isinstance(deduplicate_requests, bool):
+            raise TypeError("deduplicate_requests must be a bool")
+        if not isinstance(capture_error_messages, bool):
+            raise TypeError("capture_error_messages must be a bool")
+        normalized_timeouts: dict[str, float | None] = {}
+        for timeout_name, timeout in (
+            ("candidate_timeout_seconds", candidate_timeout_seconds),
+            ("evaluator_timeout_seconds", evaluator_timeout_seconds),
+        ):
+            if timeout is None:
+                normalized_timeouts[timeout_name] = None
+                continue
+            if isinstance(timeout, bool):
+                raise TypeError(f"{timeout_name} must be a number or None")
+            if not isinstance(timeout, (int, float)):
+                raise TypeError(f"{timeout_name} must be a number or None")
+            normalized_timeout = float(timeout)
+            if not math.isfinite(normalized_timeout) or normalized_timeout <= 0:
+                raise ValueError(f"{timeout_name} must be positive and finite")
+            normalized_timeouts[timeout_name] = normalized_timeout
+        evaluator_tuple = tuple(evaluators)
+        if any(not callable(evaluator) for evaluator in evaluator_tuple):
+            raise TypeError("every evaluator must be callable")
+
+        self._candidate = candidate
+        self._evaluators = evaluator_tuple
+        self._policy = policy or RegressionPolicy()
+        self._concurrency = concurrency
+        self._deduplicate_requests = deduplicate_requests
+        self._candidate_timeout_seconds = normalized_timeouts[
+            "candidate_timeout_seconds"
+        ]
+        self._evaluator_timeout_seconds = normalized_timeouts[
+            "evaluator_timeout_seconds"
+        ]
+        self._capture_error_messages = capture_error_messages
+        self._sensitive_keys = _sensitive_key_set(additional_sensitive_keys)
+
+    async def _execute_candidate(
+        self,
+        case: ReplayCase,
+        semaphore: asyncio.Semaphore,
+    ) -> _CandidateOutcome:
+        started: float | None = None
+        try:
+            async with semaphore:
+                started = time.perf_counter()
+                output = await _invoke_callable(
+                    self._candidate,
+                    _isolated_copy(case.request, label="candidate request"),
+                    timeout_seconds=self._candidate_timeout_seconds,
+                )
+            return _CandidateOutcome(
+                output=output,
+                duration_ms=(time.perf_counter() - started) * 1000,
+            )
+        except Exception as error:
+            duration_ms = 0.0
+            if started is not None:
+                duration_ms = (time.perf_counter() - started) * 1000
+            return _CandidateOutcome(
+                output=None,
+                duration_ms=duration_ms,
+                error_type=type(error).__qualname__,
+                error_message=(
+                    str(error) if self._capture_error_messages else None
+                ),
+            )
+
+    async def _process_case(
+        self,
+        prepared: _PreparedCase,
+        candidate_task: asyncio.Task[_CandidateOutcome],
+        semaphore: asyncio.Semaphore,
+        *,
+        cache_hit: bool,
+    ) -> ReplayResult:
+        started = time.perf_counter()
+        outcome = await asyncio.shield(candidate_task)
+        if outcome.error_type is not None:
+            return ReplayResult(
+                case_id=prepared.case.case_id,
+                fingerprint=prepared.fingerprint,
+                output=None,
+                evaluations=(),
+                duration_ms=(time.perf_counter() - started) * 1000,
+                candidate_duration_ms=outcome.duration_ms,
+                cache_hit=cache_hit,
+                error_stage="candidate",
+                error_type=outcome.error_type,
+                error_message=outcome.error_message,
+                metadata=_isolated_copy(
+                    prepared.case.metadata,
+                    label="result metadata",
+                ),
+            )
+
+        try:
+            result_output = _isolated_copy(
+                outcome.output,
+                label="candidate output",
+            )
+        except Exception as error:
+            return ReplayResult(
+                case_id=prepared.case.case_id,
+                fingerprint=prepared.fingerprint,
+                output=None,
+                evaluations=(),
+                duration_ms=(time.perf_counter() - started) * 1000,
+                candidate_duration_ms=outcome.duration_ms,
+                cache_hit=cache_hit,
+                error_stage="candidate-output-isolation",
+                error_type=type(error).__qualname__,
+                error_message=(
+                    str(error) if self._capture_error_messages else None
+                ),
+                metadata=_isolated_copy(
+                    prepared.case.metadata,
+                    label="result metadata",
+                ),
+            )
+
+        evaluations: list[Evaluation] = []
+        evaluation_names: set[str] = set()
+        for evaluator in self._evaluators:
+            evaluator_name = _callable_name(evaluator)
+            try:
+                async with semaphore:
+                    evaluation = await _invoke_callable(
+                        evaluator,
+                        _isolated_copy(
+                            result_output,
+                            label="evaluator candidate output",
+                        ),
+                        _isolated_copy(
+                            prepared.case.baseline,
+                            label="evaluator baseline",
+                        ),
+                        _isolated_copy(
+                            prepared.case,
+                            label="evaluator replay case",
+                        ),
+                        timeout_seconds=self._evaluator_timeout_seconds,
+                    )
+                if not isinstance(evaluation, Evaluation):
+                    raise TypeError(
+                        f"evaluator {evaluator_name!r} returned "
+                        f"{type(evaluation).__qualname__}; expected Evaluation"
+                    )
+                if evaluation.name in evaluation_names:
+                    raise ValueError(
+                        f"duplicate evaluation name {evaluation.name!r}"
+                    )
+                evaluation_names.add(evaluation.name)
+                evaluations.append(evaluation)
+            except Exception as error:
+                return ReplayResult(
+                    case_id=prepared.case.case_id,
+                    fingerprint=prepared.fingerprint,
+                    output=result_output,
+                    evaluations=tuple(evaluations),
+                    duration_ms=(time.perf_counter() - started) * 1000,
+                    candidate_duration_ms=outcome.duration_ms,
+                    cache_hit=cache_hit,
+                    error_stage=f"evaluator:{evaluator_name}",
+                    error_type=type(error).__qualname__,
+                    error_message=(
+                        str(error) if self._capture_error_messages else None
+                    ),
+                    metadata=_isolated_copy(
+                        prepared.case.metadata,
+                        label="result metadata",
+                    ),
+                )
+
+        return ReplayResult(
+            case_id=prepared.case.case_id,
+            fingerprint=prepared.fingerprint,
+            output=result_output,
+            evaluations=tuple(evaluations),
+            duration_ms=(time.perf_counter() - started) * 1000,
+            candidate_duration_ms=outcome.duration_ms,
+            cache_hit=cache_hit,
+            metadata=_isolated_copy(
+                prepared.case.metadata,
+                label="result metadata",
+            ),
+        )
+
+    async def run(self, cases: Iterable[ReplayCase]) -> ReplayReport:
+        """Run an ordered, bounded, deduplicated replay suite."""
+        case_list = tuple(cases)
+        if any(not isinstance(case, ReplayCase) for case in case_list):
+            raise TypeError("every replay case must be a ReplayCase")
+        case_ids = [case.case_id for case in case_list]
+        if len(set(case_ids)) != len(case_ids):
+            raise ValueError("case_id values must be unique within a replay run")
+
+        prepared_cases_list: list[_PreparedCase] = []
+        for case in case_list:
+            snapshot = ReplayCase(
+                case_id=case.case_id,
+                request=case.request,
+                baseline=case.baseline,
+                metadata=case.metadata,
+            )
+            prepared_cases_list.append(
+                _PreparedCase(
+                    case=snapshot,
+                    fingerprint=_request_digest(
+                        snapshot.request,
+                        sensitive_keys=self._sensitive_keys,
+                    ),
+                    execution_digest=_request_digest(
+                        snapshot.request,
+                        sensitive_keys=None,
+                    ),
+                )
+            )
+        prepared_cases = tuple(prepared_cases_list)
+
+        started_at_unix = time.time()
+        started = time.perf_counter()
+        semaphore = asyncio.Semaphore(self._concurrency)
+        candidate_tasks: dict[str, asyncio.Task[_CandidateOutcome]] = {}
+        process_tasks: list[asyncio.Task[ReplayResult]] = []
+
+        for index, prepared in enumerate(prepared_cases):
+            task_key = prepared.execution_digest
+            if not self._deduplicate_requests:
+                task_key = f"{task_key}:{index}"
+            cache_hit = task_key in candidate_tasks
+            if not cache_hit:
+                candidate_tasks[task_key] = asyncio.create_task(
+                    self._execute_candidate(prepared.case, semaphore)
+                )
+            process_tasks.append(
+                asyncio.create_task(
+                    self._process_case(
+                        prepared,
+                        candidate_tasks[task_key],
+                        semaphore,
+                        cache_hit=cache_hit,
+                    )
+                )
+            )
+
+        try:
+            results = tuple(await asyncio.gather(*process_tasks))
+        except BaseException:
+            for task in process_tasks:
+                task.cancel()
+            for task in candidate_tasks.values():
+                task.cancel()
+            await asyncio.gather(
+                *process_tasks,
+                *candidate_tasks.values(),
+                return_exceptions=True,
+            )
+            raise
+
+        return ReplayReport(
+            results=results,
+            policy=self._policy,
+            started_at_unix=started_at_unix,
+            duration_ms=(time.perf_counter() - started) * 1000,
+            sensitive_keys=self._sensitive_keys,
+        )

--- a/futureagi/agentic_eval/core/replay/models.py
+++ b/futureagi/agentic_eval/core/replay/models.py
@@ -8,7 +8,11 @@ from collections.abc import Awaitable, Callable, Mapping
 from dataclasses import dataclass, field
 from typing import Any, TypeAlias
 
-from agentic_eval.core.replay.privacy import _isolated_copy, _safe_report_value
+from agentic_eval.core.replay.privacy import (
+    _isolated_copy,
+    _redact_text,
+    _safe_report_value,
+)
 
 
 @dataclass(frozen=True, slots=True)
@@ -73,6 +77,8 @@ class Evaluation:
             baseline_score = float(self.baseline_score)
             if not math.isfinite(baseline_score):
                 raise ValueError("baseline_score must be finite")
+            if not math.isfinite(score - baseline_score):
+                raise ValueError("evaluation score delta must be finite")
             object.__setattr__(self, "baseline_score", baseline_score)
         if not isinstance(self.details, Mapping):
             raise TypeError("evaluation details must be a mapping")
@@ -143,7 +149,10 @@ class RegressionPolicy:
             "maximum_error_rate",
             "maximum_regression_rate",
         ):
-            value = float(getattr(self, field_name))
+            raw_value = getattr(self, field_name)
+            if isinstance(raw_value, bool):
+                raise TypeError(f"{field_name} must be numeric, not bool")
+            value = float(raw_value)
             if not math.isfinite(value) or not 0.0 <= value <= 1.0:
                 raise ValueError(f"{field_name} must be between 0 and 1")
             object.__setattr__(self, field_name, value)
@@ -151,7 +160,10 @@ class RegressionPolicy:
             "maximum_mean_score_drop",
             "score_regression_tolerance",
         ):
-            value = float(getattr(self, field_name))
+            raw_value = getattr(self, field_name)
+            if isinstance(raw_value, bool):
+                raise TypeError(f"{field_name} must be numeric, not bool")
+            value = float(raw_value)
             if not math.isfinite(value) or value < 0.0:
                 raise ValueError(f"{field_name} must be finite and non-negative")
             object.__setattr__(self, field_name, value)
@@ -200,7 +212,6 @@ class ReplayReport:
         return tuple(
             delta
             for result in self.results
-            if result.error_type is None
             for evaluation in result.evaluations
             if (delta := evaluation.delta) is not None
         )
@@ -224,7 +235,13 @@ class ReplayReport:
             return 0.0
         tolerance = self.policy.score_regression_tolerance
         drops = [0.0 if delta >= -tolerance else -delta for delta in deltas]
-        return sum(drops) / len(deltas)
+        maximum_drop = max(drops)
+        if maximum_drop == 0.0:
+            return 0.0
+        normalized_mean = math.fsum(
+            drop / maximum_drop for drop in drops
+        ) / len(drops)
+        return maximum_drop * normalized_mean
 
     @property
     def violations(self) -> tuple[str, ...]:
@@ -234,20 +251,17 @@ class ReplayReport:
                 f"case count {self.total} is below required "
                 f"{self.policy.minimum_case_count}"
             )
-        if (
-            self.results
-            and self.evaluation_count < self.policy.minimum_evaluation_count
-        ):
+        if self.evaluation_count < self.policy.minimum_evaluation_count:
             violations.append(
                 f"evaluation count {self.evaluation_count} is below required "
                 f"{self.policy.minimum_evaluation_count}"
             )
-        if self.results and self.pass_rate < self.policy.minimum_pass_rate:
+        if self.pass_rate < self.policy.minimum_pass_rate:
             violations.append(
                 f"pass rate {self.pass_rate:.4f} is below required "
                 f"{self.policy.minimum_pass_rate:.4f}"
             )
-        if self.results and self.error_rate > self.policy.maximum_error_rate:
+        if self.error_rate > self.policy.maximum_error_rate:
             violations.append(
                 f"error rate {self.error_rate:.4f} exceeds allowed "
                 f"{self.policy.maximum_error_rate:.4f}"
@@ -328,10 +342,9 @@ class ReplayReport:
                 row["output"] = _safe_report_value(
                     result.output,
                     sensitive_keys=self.sensitive_keys,
-                    include_object_repr=True,
                 )
             if include_error_messages and result.error_message is not None:
-                row["error_message"] = result.error_message
+                row["error_message"] = _redact_text(result.error_message)
             result_rows.append(row)
 
         return {

--- a/futureagi/agentic_eval/core/replay/models.py
+++ b/futureagi/agentic_eval/core/replay/models.py
@@ -1,0 +1,399 @@
+"""Immutable contracts and promotion policy for counterfactual replay."""
+
+from __future__ import annotations
+
+import json
+import math
+from collections.abc import Awaitable, Callable, Mapping
+from dataclasses import dataclass, field
+from typing import Any, TypeAlias
+
+from agentic_eval.core.replay.privacy import _isolated_copy, _safe_report_value
+
+
+@dataclass(frozen=True, slots=True)
+class ReplayCase:
+    """A captured request and its optional production baseline."""
+
+    case_id: str
+    request: Mapping[str, Any]
+    baseline: Any = None
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.case_id, str) or not self.case_id.strip():
+            raise ValueError("case_id must be a non-empty string")
+        object.__setattr__(self, "case_id", self.case_id.strip())
+        if not isinstance(self.request, Mapping):
+            raise TypeError("request must be a mapping")
+        if not isinstance(self.metadata, Mapping):
+            raise TypeError("metadata must be a mapping")
+        object.__setattr__(
+            self,
+            "request",
+            _isolated_copy(self.request, label="replay request"),
+        )
+        object.__setattr__(
+            self,
+            "baseline",
+            _isolated_copy(self.baseline, label="replay baseline"),
+        )
+        object.__setattr__(
+            self,
+            "metadata",
+            _isolated_copy(self.metadata, label="replay metadata"),
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class Evaluation:
+    """One evaluator's decision for a replayed case."""
+
+    name: str
+    score: float
+    passed: bool
+    baseline_score: float | None = None
+    details: Mapping[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.name, str) or not self.name.strip():
+            raise ValueError("evaluation name must be a non-empty string")
+        object.__setattr__(self, "name", self.name.strip())
+        if isinstance(self.score, bool):
+            raise TypeError("evaluation score must be numeric, not bool")
+        score = float(self.score)
+        if not math.isfinite(score):
+            raise ValueError("evaluation score must be finite")
+        object.__setattr__(self, "score", score)
+        if not isinstance(self.passed, bool):
+            raise TypeError("evaluation passed must be a bool")
+        if self.baseline_score is not None:
+            if isinstance(self.baseline_score, bool):
+                raise TypeError("baseline_score must be numeric, not bool")
+            baseline_score = float(self.baseline_score)
+            if not math.isfinite(baseline_score):
+                raise ValueError("baseline_score must be finite")
+            object.__setattr__(self, "baseline_score", baseline_score)
+        if not isinstance(self.details, Mapping):
+            raise TypeError("evaluation details must be a mapping")
+        object.__setattr__(
+            self,
+            "details",
+            _isolated_copy(self.details, label="evaluation details"),
+        )
+
+    @property
+    def delta(self) -> float | None:
+        """Return candidate score minus baseline score when comparable."""
+        if self.baseline_score is None:
+            return None
+        return float(self.score) - float(self.baseline_score)
+
+
+Evaluator: TypeAlias = Callable[
+    [Any, Any, ReplayCase],
+    Evaluation | Awaitable[Evaluation],
+]
+
+
+@dataclass(frozen=True, slots=True)
+class ReplayResult:
+    """Candidate and evaluator outcome for one replay case."""
+
+    case_id: str
+    fingerprint: str
+    output: Any
+    evaluations: tuple[Evaluation, ...]
+    duration_ms: float
+    candidate_duration_ms: float
+    cache_hit: bool = False
+    error_stage: str | None = None
+    error_type: str | None = None
+    error_message: str | None = None
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+
+    @property
+    def passed(self) -> bool:
+        return self.error_type is None and all(
+            evaluation.passed for evaluation in self.evaluations
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class RegressionPolicy:
+    """Promotion criteria for a complete replay report."""
+
+    minimum_case_count: int = 1
+    minimum_evaluation_count: int = 1
+    minimum_pass_rate: float = 1.0
+    maximum_error_rate: float = 0.0
+    maximum_regression_rate: float = 0.0
+    maximum_mean_score_drop: float = 0.0
+    score_regression_tolerance: float = 0.0
+
+    def __post_init__(self) -> None:
+        for field_name in ("minimum_case_count", "minimum_evaluation_count"):
+            value = getattr(self, field_name)
+            if isinstance(value, bool) or not isinstance(value, int):
+                raise TypeError(f"{field_name} must be an int")
+            if value < 0:
+                raise ValueError(f"{field_name} cannot be negative")
+        for field_name in (
+            "minimum_pass_rate",
+            "maximum_error_rate",
+            "maximum_regression_rate",
+        ):
+            value = float(getattr(self, field_name))
+            if not math.isfinite(value) or not 0.0 <= value <= 1.0:
+                raise ValueError(f"{field_name} must be between 0 and 1")
+            object.__setattr__(self, field_name, value)
+        for field_name in (
+            "maximum_mean_score_drop",
+            "score_regression_tolerance",
+        ):
+            value = float(getattr(self, field_name))
+            if not math.isfinite(value) or value < 0.0:
+                raise ValueError(f"{field_name} must be finite and non-negative")
+            object.__setattr__(self, field_name, value)
+
+
+@dataclass(frozen=True, slots=True)
+class ReplayReport:
+    """Ordered replay results plus an auditable promotion decision."""
+
+    results: tuple[ReplayResult, ...]
+    policy: RegressionPolicy
+    started_at_unix: float
+    duration_ms: float
+    sensitive_keys: frozenset[str] = field(repr=False, compare=False)
+
+    @property
+    def total(self) -> int:
+        return len(self.results)
+
+    @property
+    def passed_count(self) -> int:
+        return sum(result.passed for result in self.results)
+
+    @property
+    def error_count(self) -> int:
+        return sum(result.error_type is not None for result in self.results)
+
+    @property
+    def evaluation_count(self) -> int:
+        return sum(len(result.evaluations) for result in self.results)
+
+    @property
+    def pass_rate(self) -> float:
+        if not self.results:
+            return 0.0
+        return self.passed_count / self.total
+
+    @property
+    def error_rate(self) -> float:
+        if not self.results:
+            return 0.0
+        return self.error_count / self.total
+
+    @property
+    def score_deltas(self) -> tuple[float, ...]:
+        return tuple(
+            delta
+            for result in self.results
+            if result.error_type is None
+            for evaluation in result.evaluations
+            if (delta := evaluation.delta) is not None
+        )
+
+    @property
+    def regression_count(self) -> int:
+        tolerance = self.policy.score_regression_tolerance
+        return sum(delta < -tolerance for delta in self.score_deltas)
+
+    @property
+    def regression_rate(self) -> float:
+        deltas = self.score_deltas
+        if not deltas:
+            return 0.0
+        return self.regression_count / len(deltas)
+
+    @property
+    def mean_score_drop(self) -> float:
+        deltas = self.score_deltas
+        if not deltas:
+            return 0.0
+        tolerance = self.policy.score_regression_tolerance
+        drops = [0.0 if delta >= -tolerance else -delta for delta in deltas]
+        return sum(drops) / len(deltas)
+
+    @property
+    def violations(self) -> tuple[str, ...]:
+        violations: list[str] = []
+        if self.total < self.policy.minimum_case_count:
+            violations.append(
+                f"case count {self.total} is below required "
+                f"{self.policy.minimum_case_count}"
+            )
+        if (
+            self.results
+            and self.evaluation_count < self.policy.minimum_evaluation_count
+        ):
+            violations.append(
+                f"evaluation count {self.evaluation_count} is below required "
+                f"{self.policy.minimum_evaluation_count}"
+            )
+        if self.results and self.pass_rate < self.policy.minimum_pass_rate:
+            violations.append(
+                f"pass rate {self.pass_rate:.4f} is below required "
+                f"{self.policy.minimum_pass_rate:.4f}"
+            )
+        if self.results and self.error_rate > self.policy.maximum_error_rate:
+            violations.append(
+                f"error rate {self.error_rate:.4f} exceeds allowed "
+                f"{self.policy.maximum_error_rate:.4f}"
+            )
+        if self.regression_rate > self.policy.maximum_regression_rate:
+            violations.append(
+                f"regression rate {self.regression_rate:.4f} exceeds allowed "
+                f"{self.policy.maximum_regression_rate:.4f}"
+            )
+        if self.mean_score_drop > self.policy.maximum_mean_score_drop:
+            violations.append(
+                f"mean score drop {self.mean_score_drop:.6f} exceeds allowed "
+                f"{self.policy.maximum_mean_score_drop:.6f}"
+            )
+        return tuple(violations)
+
+    @property
+    def accepted(self) -> bool:
+        return not self.violations
+
+    def raise_for_regressions(self) -> None:
+        """Raise with all failed policy conditions when promotion is unsafe."""
+        if not self.accepted:
+            raise ReplayRegressionError(self)
+
+    def to_dict(
+        self,
+        *,
+        include_outputs: bool = False,
+        include_error_messages: bool = False,
+        include_metadata: bool = False,
+        include_evaluation_details: bool = False,
+    ) -> dict[str, Any]:
+        """Serialize a credential-redacted, CI-friendly report.
+
+        Outputs, exception messages, case metadata, and evaluator details are
+        omitted by default because any of them may contain prompts, user data,
+        provider URLs, or credentials.
+        """
+        result_rows: list[dict[str, Any]] = []
+        for result in self.results:
+            row: dict[str, Any] = {
+                "case_id": result.case_id,
+                "fingerprint": result.fingerprint,
+                "passed": result.passed,
+                "cache_hit": result.cache_hit,
+                "duration_ms": result.duration_ms,
+                "candidate_duration_ms": result.candidate_duration_ms,
+                "error_stage": result.error_stage,
+                "error_type": result.error_type,
+                "evaluations": [
+                    {
+                        "name": evaluation.name,
+                        "score": evaluation.score,
+                        "passed": evaluation.passed,
+                        "baseline_score": evaluation.baseline_score,
+                        "delta": evaluation.delta,
+                    }
+                    for evaluation in result.evaluations
+                ],
+            }
+            if include_metadata:
+                row["metadata"] = _safe_report_value(
+                    result.metadata,
+                    sensitive_keys=self.sensitive_keys,
+                )
+            if include_evaluation_details:
+                for evaluation_row, evaluation in zip(
+                    row["evaluations"],
+                    result.evaluations,
+                    strict=True,
+                ):
+                    evaluation_row["details"] = _safe_report_value(
+                        evaluation.details,
+                        sensitive_keys=self.sensitive_keys,
+                    )
+            if include_outputs:
+                row["output"] = _safe_report_value(
+                    result.output,
+                    sensitive_keys=self.sensitive_keys,
+                    include_object_repr=True,
+                )
+            if include_error_messages and result.error_message is not None:
+                row["error_message"] = result.error_message
+            result_rows.append(row)
+
+        return {
+            "accepted": self.accepted,
+            "violations": list(self.violations),
+            "started_at_unix": self.started_at_unix,
+            "duration_ms": self.duration_ms,
+            "summary": {
+                "total": self.total,
+                "passed": self.passed_count,
+                "errors": self.error_count,
+                "evaluations": self.evaluation_count,
+                "pass_rate": self.pass_rate,
+                "error_rate": self.error_rate,
+                "comparable_evaluations": len(self.score_deltas),
+                "regressions": self.regression_count,
+                "regression_rate": self.regression_rate,
+                "mean_score_drop": self.mean_score_drop,
+            },
+            "policy": {
+                "minimum_case_count": self.policy.minimum_case_count,
+                "minimum_evaluation_count": (
+                    self.policy.minimum_evaluation_count
+                ),
+                "minimum_pass_rate": self.policy.minimum_pass_rate,
+                "maximum_error_rate": self.policy.maximum_error_rate,
+                "maximum_regression_rate": self.policy.maximum_regression_rate,
+                "maximum_mean_score_drop": (
+                    self.policy.maximum_mean_score_drop
+                ),
+                "score_regression_tolerance": (
+                    self.policy.score_regression_tolerance
+                ),
+            },
+            "results": result_rows,
+        }
+
+    def to_json(
+        self,
+        *,
+        include_outputs: bool = False,
+        include_error_messages: bool = False,
+        include_metadata: bool = False,
+        include_evaluation_details: bool = False,
+        indent: int | None = 2,
+    ) -> str:
+        return json.dumps(
+            self.to_dict(
+                include_outputs=include_outputs,
+                include_error_messages=include_error_messages,
+                include_metadata=include_metadata,
+                include_evaluation_details=include_evaluation_details,
+            ),
+            ensure_ascii=False,
+            indent=indent,
+            sort_keys=True,
+        )
+
+
+class ReplayRegressionError(RuntimeError):
+    """Raised when a replay report fails its promotion policy."""
+
+    def __init__(self, report: ReplayReport) -> None:
+        self.report = report
+        super().__init__("; ".join(report.violations))

--- a/futureagi/agentic_eval/core/replay/privacy.py
+++ b/futureagi/agentic_eval/core/replay/privacy.py
@@ -6,6 +6,7 @@ import copy
 import hashlib
 import json
 import math
+import re
 from collections.abc import Iterable, Mapping
 from dataclasses import fields, is_dataclass
 from enum import Enum
@@ -47,6 +48,21 @@ _SENSITIVE_SUFFIXES: Final[tuple[str, ...]] = (
     "secret",
     "token",
 )
+_AUTHORIZATION_PATTERN: Final[re.Pattern[str]] = re.compile(
+    r"\b(Bearer|Basic)\s+[^\s,;]+",
+    re.IGNORECASE,
+)
+_CREDENTIAL_ASSIGNMENT_PATTERN: Final[re.Pattern[str]] = re.compile(
+    r"\b("
+    r"api[ _-]?key|access[ _-]?token|refresh[ _-]?token|session[ _-]?token|"
+    r"client[ _-]?secret|password|passwd|secret(?:[ _-]?key)?|authorization"
+    r")\b(\s*[:=]\s*)[^\s,;]+",
+    re.IGNORECASE,
+)
+_COMMON_API_KEY_PATTERN: Final[re.Pattern[str]] = re.compile(
+    r"\b(?:sk|gsk|hf|xai)[-_][A-Za-z0-9._-]{8,}\b",
+    re.IGNORECASE,
+)
 
 
 def _normalized_key(value: str) -> str:
@@ -54,6 +70,8 @@ def _normalized_key(value: str) -> str:
 
 
 def _sensitive_key_set(additional_sensitive_keys: Iterable[str]) -> frozenset[str]:
+    if isinstance(additional_sensitive_keys, (str, bytes)):
+        raise TypeError("additional sensitive keys must be an iterable of strings")
     additional_keys = tuple(additional_sensitive_keys)
     if any(not isinstance(key, str) for key in additional_keys):
         raise TypeError("additional sensitive keys must be strings")
@@ -68,6 +86,165 @@ def _sensitive_key_set(additional_sensitive_keys: Iterable[str]) -> frozenset[st
 def _is_sensitive_key(key: str, sensitive_keys: frozenset[str]) -> bool:
     normalized = _normalized_key(key)
     return normalized in sensitive_keys or normalized.endswith(_SENSITIVE_SUFFIXES)
+
+
+def _leaf_text_values(value: Any, *, seen: set[int]) -> set[str]:
+    """Collect scalar text nested beneath a credential-shaped field."""
+    if value is None:
+        return set()
+    if isinstance(value, str):
+        return {value} if value else set()
+    if isinstance(value, bytes):
+        decoded = value.decode("utf-8", errors="ignore")
+        return {decoded} if decoded else set()
+    if isinstance(value, (int, float)) and not isinstance(value, bool):
+        return {str(value)}
+    if isinstance(value, Path):
+        return {str(value)}
+    if isinstance(value, Enum):
+        return _leaf_text_values(value.value, seen=seen)
+
+    object_id = id(value)
+    if object_id in seen:
+        return set()
+
+    if is_dataclass(value) and not isinstance(value, type):
+        seen.add(object_id)
+        try:
+            collected: set[str] = set()
+            for item in fields(value):
+                collected.update(
+                    _leaf_text_values(getattr(value, item.name), seen=seen)
+                )
+            return collected
+        finally:
+            seen.remove(object_id)
+
+    if isinstance(value, Mapping):
+        seen.add(object_id)
+        try:
+            collected = set()
+            for item in value.values():
+                collected.update(_leaf_text_values(item, seen=seen))
+            return collected
+        finally:
+            seen.remove(object_id)
+
+    if isinstance(value, (list, tuple, set, frozenset)):
+        seen.add(object_id)
+        try:
+            collected = set()
+            for item in value:
+                collected.update(_leaf_text_values(item, seen=seen))
+            return collected
+        finally:
+            seen.remove(object_id)
+
+    return set()
+
+
+def _sensitive_values(
+    value: Any,
+    *,
+    sensitive_keys: frozenset[str],
+    seen: set[int] | None = None,
+) -> frozenset[str]:
+    """Collect credential values that can be removed from diagnostic text."""
+    if seen is None:
+        seen = set()
+    if value is None or isinstance(value, (str, bytes, int, float, bool, Path)):
+        return frozenset()
+    if isinstance(value, Enum):
+        return _sensitive_values(
+            value.value,
+            sensitive_keys=sensitive_keys,
+            seen=seen,
+        )
+
+    object_id = id(value)
+    if object_id in seen:
+        return frozenset()
+
+    collected: set[str] = set()
+    if is_dataclass(value) and not isinstance(value, type):
+        seen.add(object_id)
+        try:
+            for item in fields(value):
+                item_value = getattr(value, item.name)
+                if _is_sensitive_key(item.name, sensitive_keys):
+                    collected.update(_leaf_text_values(item_value, seen=set()))
+                else:
+                    collected.update(
+                        _sensitive_values(
+                            item_value,
+                            sensitive_keys=sensitive_keys,
+                            seen=seen,
+                        )
+                    )
+        finally:
+            seen.remove(object_id)
+        return frozenset(collected)
+
+    if isinstance(value, Mapping):
+        seen.add(object_id)
+        try:
+            for raw_key, item_value in value.items():
+                if isinstance(raw_key, str) and _is_sensitive_key(
+                    raw_key,
+                    sensitive_keys,
+                ):
+                    collected.update(_leaf_text_values(item_value, seen=set()))
+                else:
+                    collected.update(
+                        _sensitive_values(
+                            item_value,
+                            sensitive_keys=sensitive_keys,
+                            seen=seen,
+                        )
+                    )
+        finally:
+            seen.remove(object_id)
+        return frozenset(collected)
+
+    if isinstance(value, (list, tuple, set, frozenset)):
+        seen.add(object_id)
+        try:
+            for item in value:
+                collected.update(
+                    _sensitive_values(
+                        item,
+                        sensitive_keys=sensitive_keys,
+                        seen=seen,
+                    )
+                )
+        finally:
+            seen.remove(object_id)
+    return frozenset(collected)
+
+
+def _redact_text(
+    value: str,
+    *,
+    sensitive_values: Iterable[str] = (),
+) -> str:
+    """Remove known credentials and common credential forms from free text."""
+    redacted = value
+    known_values = {
+        item
+        for item in sensitive_values
+        if isinstance(item, str) and item
+    }
+    for secret in sorted(known_values, key=len, reverse=True):
+        redacted = redacted.replace(secret, "[REDACTED]")
+    redacted = _AUTHORIZATION_PATTERN.sub(
+        lambda match: f"{match.group(1)} [REDACTED]",
+        redacted,
+    )
+    redacted = _CREDENTIAL_ASSIGNMENT_PATTERN.sub(
+        lambda match: f"{match.group(1)}{match.group(2)}[REDACTED]",
+        redacted,
+    )
+    return _COMMON_API_KEY_PATTERN.sub("[REDACTED]", redacted)
 
 
 def _canonical_request_value(
@@ -103,7 +280,7 @@ def _canonical_request_value(
     if object_id in seen:
         raise TypeError("request contains a reference cycle")
 
-    if is_dataclass(value):
+    if is_dataclass(value) and not isinstance(value, type):
         seen.add(object_id)
         try:
             output: dict[str, Any] = {}
@@ -127,13 +304,14 @@ def _canonical_request_value(
         seen.add(object_id)
         try:
             output: dict[str, Any] = {}
-            for raw_key in sorted(value, key=lambda item: str(item)):
+            raw_keys = list(value)
+            for raw_key in raw_keys:
                 if not isinstance(raw_key, str):
                     raise TypeError(
                         "replay request mappings must use string keys; "
                         f"got {type(raw_key).__qualname__}"
                     )
-                key = raw_key
+            for key in sorted(raw_keys):
                 if sensitive_keys is not None and _is_sensitive_key(
                     key,
                     sensitive_keys,
@@ -141,7 +319,7 @@ def _canonical_request_value(
                     output[key] = "[REDACTED]"
                 else:
                     output[key] = _canonical_request_value(
-                        value[raw_key],
+                        value[key],
                         sensitive_keys=sensitive_keys,
                         seen=seen,
                     )
@@ -245,14 +423,24 @@ def _safe_report_value(
     value: Any,
     *,
     sensitive_keys: frozenset[str],
-    include_object_repr: bool = False,
+    sensitive_values: frozenset[str] | None = None,
     seen: set[int] | None = None,
 ) -> Any:
     """Return redacted, JSON-serializable report data."""
     if seen is None:
         seen = set()
-    if value is None or isinstance(value, (str, int, bool)):
+    if sensitive_values is None:
+        try:
+            sensitive_values = _sensitive_values(
+                value,
+                sensitive_keys=sensitive_keys,
+            )
+        except Exception:
+            sensitive_values = frozenset()
+    if value is None or isinstance(value, (int, bool)):
         return value
+    if isinstance(value, str):
+        return _redact_text(value, sensitive_values=sensitive_values)
     if isinstance(value, float):
         if math.isfinite(value):
             return value
@@ -263,12 +451,15 @@ def _safe_report_value(
             "length": len(value),
         }
     if isinstance(value, Path):
-        return str(value)
+        return _redact_text(
+            str(value),
+            sensitive_values=sensitive_values,
+        )
     if isinstance(value, Enum):
         return _safe_report_value(
             value.value,
             sensitive_keys=sensitive_keys,
-            include_object_repr=include_object_repr,
+            sensitive_values=sensitive_values,
             seen=seen,
         )
 
@@ -276,7 +467,7 @@ def _safe_report_value(
     if object_id in seen:
         return "[CYCLE]"
 
-    if is_dataclass(value):
+    if is_dataclass(value) and not isinstance(value, type):
         seen.add(object_id)
         try:
             output: dict[str, Any] = {}
@@ -287,7 +478,7 @@ def _safe_report_value(
                     output[item.name] = _safe_report_value(
                         getattr(value, item.name),
                         sensitive_keys=sensitive_keys,
-                        include_object_repr=include_object_repr,
+                        sensitive_values=sensitive_values,
                         seen=seen,
                     )
             return output
@@ -298,15 +489,29 @@ def _safe_report_value(
         seen.add(object_id)
         try:
             output: dict[str, Any] = {}
-            for raw_key in sorted(value, key=lambda item: str(item)):
-                key = str(raw_key)
-                if _is_sensitive_key(key, sensitive_keys):
+            reserved_keys = {
+                raw_key for raw_key in value if isinstance(raw_key, str)
+            }
+            for index, (raw_key, item_value) in enumerate(value.items()):
+                if isinstance(raw_key, str):
+                    key = raw_key
+                else:
+                    base_key = f"__key_{index}_{type(raw_key).__name__}"
+                    key = base_key
+                    suffix = 1
+                    while key in reserved_keys or key in output:
+                        key = f"{base_key}_{suffix}"
+                        suffix += 1
+                if isinstance(raw_key, str) and _is_sensitive_key(
+                    key,
+                    sensitive_keys,
+                ):
                     output[key] = "[REDACTED]"
                 else:
                     output[key] = _safe_report_value(
-                        value[raw_key],
+                        item_value,
                         sensitive_keys=sensitive_keys,
-                        include_object_repr=include_object_repr,
+                        sensitive_values=sensitive_values,
                         seen=seen,
                     )
             return output
@@ -320,7 +525,7 @@ def _safe_report_value(
                 _safe_report_value(
                     item,
                     sensitive_keys=sensitive_keys,
-                    include_object_repr=include_object_repr,
+                    sensitive_values=sensitive_values,
                     seen=seen,
                 )
                 for item in value
@@ -335,7 +540,7 @@ def _safe_report_value(
                 _safe_report_value(
                     item,
                     sensitive_keys=sensitive_keys,
-                    include_object_repr=include_object_repr,
+                    sensitive_values=sensitive_values,
                     seen=seen,
                 )
                 for item in value
@@ -344,7 +549,4 @@ def _safe_report_value(
             seen.remove(object_id)
         return sorted(items, key=lambda item: json.dumps(item, sort_keys=True))
 
-    output = {"__type__": type(value).__qualname__}
-    if include_object_repr:
-        output["repr"] = repr(value)
-    return output
+    return {"__type__": type(value).__name__}

--- a/futureagi/agentic_eval/core/replay/privacy.py
+++ b/futureagi/agentic_eval/core/replay/privacy.py
@@ -1,0 +1,350 @@
+"""Credential-aware canonicalization and report serialization helpers."""
+
+from __future__ import annotations
+
+import copy
+import hashlib
+import json
+import math
+from collections.abc import Iterable, Mapping
+from dataclasses import fields, is_dataclass
+from enum import Enum
+from pathlib import Path
+from typing import Any, Final
+
+_DEFAULT_SENSITIVE_KEYS: Final[frozenset[str]] = frozenset(
+    {
+        "authorization",
+        "proxy-authorization",
+        "api_key",
+        "apikey",
+        "api-key",
+        "x-api-key",
+        "x-secret-key",
+        "token",
+        "access_token",
+        "refresh_token",
+        "session_token",
+        "cookie",
+        "set-cookie",
+        "password",
+        "passwd",
+        "secret",
+        "secret_key",
+        "client_secret",
+        "private_key",
+        "aws_secret_access_key",
+    }
+)
+_SENSITIVE_SUFFIXES: Final[tuple[str, ...]] = (
+    "apikey",
+    "accesstoken",
+    "refreshtoken",
+    "sessiontoken",
+    "clientsecret",
+    "password",
+    "secretkey",
+    "secret",
+    "token",
+)
+
+
+def _normalized_key(value: str) -> str:
+    return "".join(character for character in value.casefold() if character.isalnum())
+
+
+def _sensitive_key_set(additional_sensitive_keys: Iterable[str]) -> frozenset[str]:
+    additional_keys = tuple(additional_sensitive_keys)
+    if any(not isinstance(key, str) for key in additional_keys):
+        raise TypeError("additional sensitive keys must be strings")
+    if any(not _normalized_key(key) for key in additional_keys):
+        raise ValueError("additional sensitive keys cannot be empty")
+    return frozenset(
+        _normalized_key(key)
+        for key in (*_DEFAULT_SENSITIVE_KEYS, *additional_keys)
+    )
+
+
+def _is_sensitive_key(key: str, sensitive_keys: frozenset[str]) -> bool:
+    normalized = _normalized_key(key)
+    return normalized in sensitive_keys or normalized.endswith(_SENSITIVE_SUFFIXES)
+
+
+def _canonical_request_value(
+    value: Any,
+    *,
+    sensitive_keys: frozenset[str] | None,
+    seen: set[int],
+) -> Any:
+    """Convert a JSON-shaped request into deterministic canonical data."""
+    if value is None or isinstance(value, (str, int, bool)):
+        return value
+    if isinstance(value, float):
+        if math.isnan(value):
+            return {"__float__": "nan"}
+        if math.isinf(value):
+            return {"__float__": "inf" if value > 0 else "-inf"}
+        return value
+    if isinstance(value, bytes):
+        return {
+            "__bytes_sha256__": hashlib.sha256(value).hexdigest(),
+            "length": len(value),
+        }
+    if isinstance(value, Path):
+        return str(value)
+    if isinstance(value, Enum):
+        return _canonical_request_value(
+            value.value,
+            sensitive_keys=sensitive_keys,
+            seen=seen,
+        )
+
+    object_id = id(value)
+    if object_id in seen:
+        raise TypeError("request contains a reference cycle")
+
+    if is_dataclass(value):
+        seen.add(object_id)
+        try:
+            output: dict[str, Any] = {}
+            for item in fields(value):
+                if sensitive_keys is not None and _is_sensitive_key(
+                    item.name,
+                    sensitive_keys,
+                ):
+                    output[item.name] = "[REDACTED]"
+                else:
+                    output[item.name] = _canonical_request_value(
+                        getattr(value, item.name),
+                        sensitive_keys=sensitive_keys,
+                        seen=seen,
+                    )
+            return output
+        finally:
+            seen.remove(object_id)
+
+    if isinstance(value, Mapping):
+        seen.add(object_id)
+        try:
+            output: dict[str, Any] = {}
+            for raw_key in sorted(value, key=lambda item: str(item)):
+                if not isinstance(raw_key, str):
+                    raise TypeError(
+                        "replay request mappings must use string keys; "
+                        f"got {type(raw_key).__qualname__}"
+                    )
+                key = raw_key
+                if sensitive_keys is not None and _is_sensitive_key(
+                    key,
+                    sensitive_keys,
+                ):
+                    output[key] = "[REDACTED]"
+                else:
+                    output[key] = _canonical_request_value(
+                        value[raw_key],
+                        sensitive_keys=sensitive_keys,
+                        seen=seen,
+                    )
+            return output
+        finally:
+            seen.remove(object_id)
+
+    if isinstance(value, (list, tuple)):
+        seen.add(object_id)
+        try:
+            return [
+                _canonical_request_value(
+                    item,
+                    sensitive_keys=sensitive_keys,
+                    seen=seen,
+                )
+                for item in value
+            ]
+        finally:
+            seen.remove(object_id)
+
+    if isinstance(value, (set, frozenset)):
+        seen.add(object_id)
+        try:
+            canonical_items = [
+                _canonical_request_value(
+                    item,
+                    sensitive_keys=sensitive_keys,
+                    seen=seen,
+                )
+                for item in value
+            ]
+        finally:
+            seen.remove(object_id)
+        return sorted(
+            canonical_items,
+            key=lambda item: json.dumps(
+                item,
+                ensure_ascii=False,
+                separators=(",", ":"),
+                sort_keys=True,
+            ),
+        )
+
+    raise TypeError(
+        "replay requests must contain JSON-compatible values; "
+        f"unsupported value type: {type(value).__qualname__}"
+    )
+
+
+def _request_digest(
+    request: Mapping[str, Any],
+    *,
+    sensitive_keys: frozenset[str] | None,
+) -> str:
+    canonical = _canonical_request_value(
+        request,
+        sensitive_keys=sensitive_keys,
+        seen=set(),
+    )
+    payload = json.dumps(
+        canonical,
+        ensure_ascii=False,
+        separators=(",", ":"),
+        sort_keys=True,
+    ).encode("utf-8")
+    return hashlib.sha256(payload).hexdigest()
+
+
+def request_fingerprint(
+    request: Mapping[str, Any],
+    *,
+    additional_sensitive_keys: Iterable[str] = (),
+) -> str:
+    """Return a stable public fingerprint without credential values.
+
+    The public fingerprint is intentionally unsuitable as a candidate-execution
+    cache key: requests that differ only by a credential have the same public
+    fingerprint. The replay engine uses a separate non-exported digest that
+    includes credential values, preventing cross-credential execution reuse.
+    """
+    if not isinstance(request, Mapping):
+        raise TypeError("request must be a mapping")
+    return _request_digest(
+        request,
+        sensitive_keys=_sensitive_key_set(additional_sensitive_keys),
+    )
+
+
+def _isolated_copy(value: Any, *, label: str) -> Any:
+    """Deep-copy replay data or fail before mutable state can be shared."""
+    try:
+        return copy.deepcopy(value)
+    except Exception as error:
+        raise TypeError(
+            f"{label} must support deepcopy for replay isolation"
+        ) from error
+
+
+def _safe_report_value(
+    value: Any,
+    *,
+    sensitive_keys: frozenset[str],
+    include_object_repr: bool = False,
+    seen: set[int] | None = None,
+) -> Any:
+    """Return redacted, JSON-serializable report data."""
+    if seen is None:
+        seen = set()
+    if value is None or isinstance(value, (str, int, bool)):
+        return value
+    if isinstance(value, float):
+        if math.isfinite(value):
+            return value
+        return str(value)
+    if isinstance(value, bytes):
+        return {
+            "__bytes_sha256__": hashlib.sha256(value).hexdigest(),
+            "length": len(value),
+        }
+    if isinstance(value, Path):
+        return str(value)
+    if isinstance(value, Enum):
+        return _safe_report_value(
+            value.value,
+            sensitive_keys=sensitive_keys,
+            include_object_repr=include_object_repr,
+            seen=seen,
+        )
+
+    object_id = id(value)
+    if object_id in seen:
+        return "[CYCLE]"
+
+    if is_dataclass(value):
+        seen.add(object_id)
+        try:
+            output: dict[str, Any] = {}
+            for item in fields(value):
+                if _is_sensitive_key(item.name, sensitive_keys):
+                    output[item.name] = "[REDACTED]"
+                else:
+                    output[item.name] = _safe_report_value(
+                        getattr(value, item.name),
+                        sensitive_keys=sensitive_keys,
+                        include_object_repr=include_object_repr,
+                        seen=seen,
+                    )
+            return output
+        finally:
+            seen.remove(object_id)
+
+    if isinstance(value, Mapping):
+        seen.add(object_id)
+        try:
+            output: dict[str, Any] = {}
+            for raw_key in sorted(value, key=lambda item: str(item)):
+                key = str(raw_key)
+                if _is_sensitive_key(key, sensitive_keys):
+                    output[key] = "[REDACTED]"
+                else:
+                    output[key] = _safe_report_value(
+                        value[raw_key],
+                        sensitive_keys=sensitive_keys,
+                        include_object_repr=include_object_repr,
+                        seen=seen,
+                    )
+            return output
+        finally:
+            seen.remove(object_id)
+
+    if isinstance(value, (list, tuple)):
+        seen.add(object_id)
+        try:
+            return [
+                _safe_report_value(
+                    item,
+                    sensitive_keys=sensitive_keys,
+                    include_object_repr=include_object_repr,
+                    seen=seen,
+                )
+                for item in value
+            ]
+        finally:
+            seen.remove(object_id)
+
+    if isinstance(value, (set, frozenset)):
+        seen.add(object_id)
+        try:
+            items = [
+                _safe_report_value(
+                    item,
+                    sensitive_keys=sensitive_keys,
+                    include_object_repr=include_object_repr,
+                    seen=seen,
+                )
+                for item in value
+            ]
+        finally:
+            seen.remove(object_id)
+        return sorted(items, key=lambda item: json.dumps(item, sort_keys=True))
+
+    output = {"__type__": type(value).__qualname__}
+    if include_object_repr:
+        output["repr"] = repr(value)
+    return output

--- a/futureagi/agentic_eval/core/tests/test_counterfactual_replay.py
+++ b/futureagi/agentic_eval/core/tests/test_counterfactual_replay.py
@@ -1,0 +1,755 @@
+"""Behavioral tests for deterministic counterfactual replay."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import threading
+import time
+from dataclasses import dataclass
+
+import pytest
+
+from agentic_eval.core.replay import (
+    CounterfactualReplay,
+    Evaluation,
+    RegressionPolicy,
+    ReplayCase,
+    ReplayRegressionError,
+    request_fingerprint,
+)
+
+
+def run(coroutine):
+    return asyncio.run(coroutine)
+
+
+def test_public_fingerprint_is_stable_and_redacts_nested_credentials():
+    left = {
+        "messages": [{"role": "user", "content": "hello"}],
+        "headers": {"Authorization": "Bearer one"},
+        "openai_api_key": "key-one",
+        "temperature": 0,
+    }
+    right = {
+        "temperature": 0,
+        "openai_api_key": "key-two",
+        "headers": {"Authorization": "Bearer two"},
+        "messages": [{"content": "hello", "role": "user"}],
+    }
+
+    assert request_fingerprint(left) == request_fingerprint(right)
+    assert request_fingerprint(left) != request_fingerprint(
+        {**left, "temperature": 0.1}
+    )
+
+
+def test_custom_sensitive_keys_are_redacted():
+    left = {"prompt": "hello", "tenant_credential": "one"}
+    right = {"prompt": "hello", "tenant_credential": "two"}
+
+    assert request_fingerprint(
+        left,
+        additional_sensitive_keys=("tenant_credential",),
+    ) == request_fingerprint(
+        right,
+        additional_sensitive_keys=("tenant_credential",),
+    )
+
+
+def test_dataclass_credentials_are_redacted_from_public_fingerprints():
+    @dataclass
+    class RequestPayload:
+        prompt: str
+        api_key: str
+
+    left = {"payload": RequestPayload(prompt="hello", api_key="one")}
+    right = {"payload": RequestPayload(prompt="hello", api_key="two")}
+
+    assert request_fingerprint(left) == request_fingerprint(right)
+
+    report = run(
+        CounterfactualReplay(
+            lambda request: request["payload"],
+            policy=RegressionPolicy(minimum_evaluation_count=0),
+        ).run([ReplayCase("case", left)])
+    )
+    assert report.to_dict(include_outputs=True)["results"][0]["output"] == {
+        "api_key": "[REDACTED]",
+        "prompt": "hello",
+    }
+
+
+def test_identical_requests_share_candidate_execution_but_not_evaluation():
+    calls = 0
+
+    async def candidate(request):
+        nonlocal calls
+        calls += 1
+        await asyncio.sleep(0)
+        return request["value"] * 2
+
+    def quality(output, baseline, case):
+        return Evaluation(
+            name="quality",
+            score=float(output),
+            passed=output >= baseline,
+            baseline_score=float(baseline),
+            details={"case": case.case_id},
+        )
+
+    report = run(
+        CounterfactualReplay(candidate, [quality]).run(
+            [
+                ReplayCase("passes", {"value": 2}, baseline=3),
+                ReplayCase("fails", {"value": 2}, baseline=5),
+            ]
+        )
+    )
+
+    assert calls == 1
+    assert [result.case_id for result in report.results] == ["passes", "fails"]
+    assert report.results[0].cache_hit is False
+    assert report.results[1].cache_hit is True
+    assert report.results[0].evaluations[0].baseline_score == 3
+    assert report.results[1].evaluations[0].baseline_score == 5
+    assert report.pass_rate == 0.5
+
+
+def test_different_credentials_never_share_candidate_execution():
+    calls = []
+
+    def candidate(request):
+        calls.append(request["api_key"])
+        return "ok"
+
+    cases = [
+        ReplayCase("first", {"prompt": "same", "api_key": "one"}),
+        ReplayCase("second", {"prompt": "same", "api_key": "two"}),
+    ]
+    report = run(
+        CounterfactualReplay(
+            candidate,
+            policy=RegressionPolicy(minimum_pass_rate=1.0),
+        ).run(cases)
+    )
+
+    assert sorted(calls) == ["one", "two"]
+    assert report.results[0].fingerprint == report.results[1].fingerprint
+    assert not any(result.cache_hit for result in report.results)
+
+
+def test_concurrency_is_bounded_and_result_order_is_preserved():
+    lock = threading.Lock()
+    active = 0
+    peak = 0
+
+    def candidate(request):
+        nonlocal active, peak
+        with lock:
+            active += 1
+            peak = max(peak, active)
+        try:
+            time.sleep(request["delay"])
+            return request["value"]
+        finally:
+            with lock:
+                active -= 1
+
+    cases = [
+        ReplayCase("slow", {"value": 1, "delay": 0.03}),
+        ReplayCase("fast", {"value": 2, "delay": 0.0}),
+        ReplayCase("middle", {"value": 3, "delay": 0.01}),
+    ]
+    report = run(CounterfactualReplay(candidate, concurrency=2).run(cases))
+
+    assert peak == 2
+    assert [result.case_id for result in report.results] == [
+        "slow",
+        "fast",
+        "middle",
+    ]
+    assert [result.output for result in report.results] == [1, 2, 3]
+
+
+def test_candidate_receives_a_copy_of_the_request():
+    request = {"messages": [{"content": "original"}]}
+
+    def candidate(candidate_request):
+        candidate_request["messages"][0]["content"] = "mutated"
+        return candidate_request
+
+    report = run(
+        CounterfactualReplay(candidate).run([ReplayCase("case", request)])
+    )
+
+    assert request == {"messages": [{"content": "original"}]}
+    assert report.results[0].output["messages"][0]["content"] == "mutated"
+
+
+def test_each_evaluator_receives_an_isolated_output_copy():
+    observations = []
+
+    def candidate(request):
+        return {"items": [1]}
+
+    def mutating_evaluator(output, baseline, case):
+        output["items"].append(2)
+        return Evaluation("mutating", 1.0, True)
+
+    def observing_evaluator(output, baseline, case):
+        observations.append(output)
+        return Evaluation("observing", 1.0, True)
+
+    report = run(
+        CounterfactualReplay(
+            candidate,
+            [mutating_evaluator, observing_evaluator],
+        ).run([ReplayCase("case", {"prompt": "hello"})])
+    )
+
+    assert report.accepted is True
+    assert observations == [{"items": [1]}]
+    assert report.results[0].output == {"items": [1]}
+
+
+def test_each_evaluator_receives_an_isolated_case_copy():
+    observations = []
+
+    def mutating_evaluator(output, baseline, case):
+        case.request["messages"][0]["content"] = "mutated"
+        case.metadata["suite"] = "mutated"
+        return Evaluation("mutating", 1.0, True)
+
+    def observing_evaluator(output, baseline, case):
+        observations.append((case.request, case.metadata))
+        return Evaluation("observing", 1.0, True)
+
+    original_request = {"messages": [{"content": "original"}]}
+    original_metadata = {"suite": "held-out"}
+    case = ReplayCase(
+        "case",
+        original_request,
+        metadata=original_metadata,
+    )
+    original_request["messages"][0]["content"] = "outside mutation"
+    original_metadata["suite"] = "outside mutation"
+
+    report = run(
+        CounterfactualReplay(
+            lambda request: "ok",
+            [mutating_evaluator, observing_evaluator],
+        ).run([case])
+    )
+
+    assert report.accepted is True
+    assert observations == [
+        (
+            {"messages": [{"content": "original"}]},
+            {"suite": "held-out"},
+        )
+    ]
+
+
+def test_candidate_and_evaluator_work_share_the_concurrency_bound():
+    lock = threading.Lock()
+    active = 0
+    peak = 0
+
+    def measured_call(delay):
+        nonlocal active, peak
+        with lock:
+            active += 1
+            peak = max(peak, active)
+        try:
+            time.sleep(delay)
+        finally:
+            with lock:
+                active -= 1
+
+    def candidate(request):
+        measured_call(0.01)
+        return request["value"]
+
+    def evaluator(output, baseline, case):
+        measured_call(0.02)
+        return Evaluation("quality", 1.0, True)
+
+    report = run(
+        CounterfactualReplay(
+            candidate,
+            [evaluator],
+            concurrency=2,
+        ).run(
+            [ReplayCase(str(index), {"value": index}) for index in range(6)]
+        )
+    )
+
+    assert report.accepted is True
+    assert peak == 2
+
+
+def test_policy_reports_every_failed_promotion_condition():
+    def candidate(request):
+        return request["score"]
+
+    def evaluator(output, baseline, case):
+        return Evaluation(
+            name="quality",
+            score=output,
+            passed=output >= 0.8,
+            baseline_score=baseline,
+        )
+
+    policy = RegressionPolicy(
+        minimum_case_count=3,
+        minimum_pass_rate=1.0,
+        maximum_error_rate=0.0,
+        maximum_regression_rate=0.25,
+        maximum_mean_score_drop=0.1,
+    )
+    report = run(
+        CounterfactualReplay(candidate, [evaluator], policy=policy).run(
+            [
+                ReplayCase("gain", {"score": 1.0}, baseline=0.5),
+                ReplayCase("loss", {"score": 0.0}, baseline=1.0),
+            ]
+        )
+    )
+
+    assert report.total == 2
+    assert report.pass_rate == 0.5
+    assert report.regression_rate == 0.5
+    assert report.mean_score_drop == 0.5
+    assert report.accepted is False
+    assert len(report.violations) == 4
+
+    with pytest.raises(ReplayRegressionError) as error:
+        report.raise_for_regressions()
+    assert error.value.report is report
+
+
+def test_score_regression_tolerance_ignores_numerical_noise():
+    def candidate(request):
+        return 0.999999
+
+    def evaluator(output, baseline, case):
+        return Evaluation("quality", output, True, baseline)
+
+    report = run(
+        CounterfactualReplay(
+            candidate,
+            [evaluator],
+            policy=RegressionPolicy(score_regression_tolerance=0.00001),
+        ).run([ReplayCase("noise", {"prompt": "hello"}, baseline=1.0)])
+    )
+
+    assert report.regression_count == 0
+    assert report.mean_score_drop == 0.0
+    assert report.accepted is True
+
+
+def test_empty_suite_fails_closed_by_default():
+    report = run(CounterfactualReplay(lambda request: request).run([]))
+
+    assert report.total == 0
+    assert report.pass_rate == 0.0
+    assert report.accepted is False
+    assert report.violations == ("case count 0 is below required 1",)
+
+
+def test_successful_candidate_without_evaluations_is_not_promotable_by_default():
+    case = ReplayCase("case", {"prompt": "hello"})
+
+    report = run(CounterfactualReplay(lambda request: "ok").run([case]))
+
+    assert report.evaluation_count == 0
+    assert report.accepted is False
+    assert report.violations == (
+        "evaluation count 0 is below required 1",
+    )
+
+    smoke_report = run(
+        CounterfactualReplay(
+            lambda request: "ok",
+            policy=RegressionPolicy(minimum_evaluation_count=0),
+        ).run([case])
+    )
+    assert smoke_report.accepted is True
+
+
+def test_candidate_errors_are_isolated_and_messages_are_opt_in():
+    def candidate(request):
+        if request["fail"]:
+            raise RuntimeError("Bearer provider-secret")
+        return "ok"
+
+    report = run(
+        CounterfactualReplay(
+            candidate,
+            policy=RegressionPolicy(
+                minimum_pass_rate=0.0,
+                maximum_error_rate=0.5,
+            ),
+            capture_error_messages=True,
+        ).run(
+            [
+                ReplayCase(
+                    "bad",
+                    {"fail": True, "authorization": "Bearer request-secret"},
+                    metadata={"password": "metadata-secret", "suite": "held-out"},
+                ),
+                ReplayCase("good", {"fail": False}),
+            ]
+        )
+    )
+
+    assert report.results[0].error_stage == "candidate"
+    assert report.results[0].error_type == "RuntimeError"
+    assert report.results[1].passed is True
+
+    safe_payload = report.to_dict()
+    safe_json = json.dumps(safe_payload)
+    assert "provider-secret" not in safe_json
+    assert "request-secret" not in safe_json
+    assert "metadata-secret" not in safe_json
+    assert "output" not in safe_payload["results"][1]
+    assert "metadata" not in safe_payload["results"][0]
+
+    diagnostic_payload = report.to_dict(
+        include_error_messages=True,
+        include_metadata=True,
+    )
+    assert diagnostic_payload["results"][0]["metadata"] == {
+        "password": "[REDACTED]",
+        "suite": "held-out",
+    }
+    assert diagnostic_payload["results"][0]["error_message"] == (
+        "Bearer provider-secret"
+    )
+
+
+def test_outputs_are_omitted_unless_explicitly_requested_and_then_redacted():
+    def candidate(request):
+        return {"answer": "ok", "token": "output-secret"}
+
+    report = run(
+        CounterfactualReplay(candidate).run(
+            [ReplayCase("case", {"prompt": "hello"})]
+        )
+    )
+
+    assert "output" not in report.to_dict()["results"][0]
+    assert report.to_dict(include_outputs=True)["results"][0]["output"] == {
+        "answer": "ok",
+        "token": "[REDACTED]",
+    }
+
+
+def test_evaluator_error_marks_only_its_case_as_error():
+    def candidate(request):
+        return request["value"]
+
+    def evaluator(output, baseline, case):
+        if case.case_id == "bad":
+            raise ValueError("unsafe detail")
+        return Evaluation("quality", 1.0, True)
+
+    report = run(
+        CounterfactualReplay(
+            candidate,
+            [evaluator],
+            policy=RegressionPolicy(
+                minimum_pass_rate=0.5,
+                maximum_error_rate=0.5,
+            ),
+        ).run(
+            [
+                ReplayCase("bad", {"value": 1}),
+                ReplayCase("good", {"value": 2}),
+            ]
+        )
+    )
+
+    assert report.results[0].error_stage == "evaluator:evaluator"
+    assert report.results[0].error_type == "ValueError"
+    assert report.results[1].passed is True
+    assert report.accepted is True
+
+
+def test_uncopyable_candidate_output_becomes_a_structured_isolation_error():
+    class Uncopyable:
+        def __deepcopy__(self, memo):
+            raise RuntimeError("cannot copy")
+
+    report = run(
+        CounterfactualReplay(
+            lambda request: Uncopyable(),
+            policy=RegressionPolicy(
+                minimum_evaluation_count=0,
+                minimum_pass_rate=0.0,
+                maximum_error_rate=1.0,
+            ),
+        ).run([ReplayCase("case", {"prompt": "hello"})])
+    )
+
+    assert report.results[0].error_stage == "candidate-output-isolation"
+    assert report.results[0].error_type == "TypeError"
+
+
+def test_candidate_timeout_is_reported_without_canceling_other_cases():
+    async def candidate(request):
+        await asyncio.sleep(request["delay"])
+        return "ok"
+
+    report = run(
+        CounterfactualReplay(
+            candidate,
+            candidate_timeout_seconds=0.01,
+            policy=RegressionPolicy(
+                minimum_pass_rate=0.5,
+                maximum_error_rate=0.5,
+            ),
+        ).run(
+            [
+                ReplayCase("timeout", {"delay": 0.05}),
+                ReplayCase("success", {"delay": 0.0}),
+            ]
+        )
+    )
+
+    assert report.results[0].error_type == "TimeoutError"
+    assert report.results[1].passed is True
+
+
+def test_evaluator_timeout_is_a_structured_case_error():
+    async def evaluator(output, baseline, case):
+        await asyncio.sleep(0.05)
+        return Evaluation("quality", 1.0, True)
+
+    report = run(
+        CounterfactualReplay(
+            lambda request: "ok",
+            [evaluator],
+            evaluator_timeout_seconds=0.01,
+            policy=RegressionPolicy(
+                minimum_evaluation_count=0,
+                minimum_pass_rate=0.0,
+                maximum_error_rate=1.0,
+            ),
+        ).run([ReplayCase("case", {"prompt": "hello"})])
+    )
+
+    assert report.results[0].error_stage == "evaluator:evaluator"
+    assert report.results[0].error_type == "TimeoutError"
+
+
+def test_invalid_evaluator_return_is_a_structured_error():
+    def invalid_evaluator(output, baseline, case):
+        return True
+
+    report = run(
+        CounterfactualReplay(
+            lambda request: "ok",
+            [invalid_evaluator],
+            policy=RegressionPolicy(
+                minimum_pass_rate=0.0,
+                maximum_error_rate=1.0,
+            ),
+        ).run([ReplayCase("case", {"prompt": "hello"})])
+    )
+
+    assert report.results[0].error_stage == "evaluator:invalid_evaluator"
+    assert report.results[0].error_type == "TypeError"
+
+
+def test_duplicate_evaluation_names_are_rejected():
+    def first(output, baseline, case):
+        return Evaluation("quality", 1.0, True)
+
+    def second(output, baseline, case):
+        return Evaluation("quality", 1.0, True)
+
+    report = run(
+        CounterfactualReplay(
+            lambda request: "ok",
+            [first, second],
+            policy=RegressionPolicy(
+                minimum_pass_rate=0.0,
+                maximum_error_rate=1.0,
+            ),
+        ).run([ReplayCase("case", {"prompt": "hello"})])
+    )
+
+    assert report.results[0].error_stage == "evaluator:second"
+    assert report.results[0].error_type == "ValueError"
+
+
+def test_duplicate_case_ids_fail_before_candidate_execution():
+    calls = 0
+
+    def candidate(request):
+        nonlocal calls
+        calls += 1
+        return "ok"
+
+    with pytest.raises(ValueError, match="case_id values must be unique"):
+        run(
+            CounterfactualReplay(candidate).run(
+                [
+                    ReplayCase("duplicate", {"value": 1}),
+                    ReplayCase("duplicate", {"value": 2}),
+                ]
+            )
+        )
+
+    assert calls == 0
+
+
+def test_non_json_request_values_fail_before_candidate_execution():
+    calls = 0
+
+    def candidate(request):
+        nonlocal calls
+        calls += 1
+        return "ok"
+
+    with pytest.raises(TypeError, match="unsupported value type: object"):
+        run(
+            CounterfactualReplay(candidate).run(
+                [ReplayCase("case", {"unsupported": object()})]
+            )
+        )
+
+    assert calls == 0
+
+
+def test_deduplication_can_be_disabled():
+    calls = 0
+
+    def candidate(request):
+        nonlocal calls
+        calls += 1
+        return "ok"
+
+    report = run(
+        CounterfactualReplay(
+            candidate,
+            deduplicate_requests=False,
+        ).run(
+            [
+                ReplayCase("first", {"prompt": "same"}),
+                ReplayCase("second", {"prompt": "same"}),
+            ]
+        )
+    )
+
+    assert calls == 2
+    assert not any(result.cache_hit for result in report.results)
+
+
+def test_evaluator_generators_are_not_consumed_during_validation():
+    def evaluator(output, baseline, case):
+        return Evaluation("quality", 1, True)
+
+    evaluators = (item for item in [evaluator])
+    report = run(
+        CounterfactualReplay(lambda request: "ok", evaluators).run(
+            [ReplayCase("case", {"prompt": "hello"})]
+        )
+    )
+
+    assert [item.name for item in report.results[0].evaluations] == ["quality"]
+
+
+def test_replay_rejects_non_case_items_before_candidate_execution():
+    calls = 0
+
+    def candidate(request):
+        nonlocal calls
+        calls += 1
+        return "ok"
+
+    with pytest.raises(TypeError, match="every replay case must be a ReplayCase"):
+        run(CounterfactualReplay(candidate).run([{"request": {}}]))
+
+    assert calls == 0
+
+
+def test_request_mapping_keys_must_be_strings():
+    with pytest.raises(TypeError, match="must use string keys"):
+        request_fingerprint({1: "not-json"})
+
+def test_evaluation_details_are_omitted_unless_requested_and_redacted():
+    def evaluator(output, baseline, case):
+        return Evaluation(
+            "quality",
+            1.0,
+            True,
+            details={"reason": "correct", "client_secret": "hidden"},
+        )
+
+    report = run(
+        CounterfactualReplay(
+            lambda request: "ok",
+            [evaluator],
+        ).run([ReplayCase("case", {"prompt": "hello"})])
+    )
+
+    safe_evaluation = report.to_dict()["results"][0]["evaluations"][0]
+    assert "details" not in safe_evaluation
+
+    detailed_evaluation = report.to_dict(
+        include_evaluation_details=True
+    )["results"][0]["evaluations"][0]
+    assert detailed_evaluation["details"] == {
+        "client_secret": "[REDACTED]",
+        "reason": "correct",
+    }
+
+
+def test_constructor_rejects_invalid_control_values():
+    with pytest.raises(TypeError, match="policy"):
+        CounterfactualReplay(lambda request: request, policy={})
+    with pytest.raises(TypeError, match="concurrency"):
+        CounterfactualReplay(lambda request: request, concurrency=True)
+    with pytest.raises(TypeError, match="deduplicate_requests"):
+        CounterfactualReplay(
+            lambda request: request,
+            deduplicate_requests=1,
+        )
+    with pytest.raises(TypeError, match="capture_error_messages"):
+        CounterfactualReplay(
+            lambda request: request,
+            capture_error_messages=1,
+        )
+    with pytest.raises(TypeError, match="candidate_timeout_seconds"):
+        CounterfactualReplay(
+            lambda request: request,
+            candidate_timeout_seconds=True,
+        )
+
+    with pytest.raises(TypeError, match="additional sensitive keys"):
+        CounterfactualReplay(
+            lambda request: request,
+            additional_sensitive_keys=(1,),
+        )
+
+
+def test_evaluation_and_policy_values_are_normalized():
+    evaluation = Evaluation(
+        name=" quality ",
+        score=1,
+        passed=True,
+        baseline_score="0.5",
+    )
+    policy = RegressionPolicy(minimum_pass_rate=1, maximum_error_rate=0)
+
+    assert evaluation.name == "quality"
+    assert evaluation.score == 1.0
+    assert evaluation.baseline_score == 0.5
+    assert policy.minimum_pass_rate == 1.0
+    assert policy.maximum_error_rate == 0.0
+
+    with pytest.raises(TypeError, match="numeric, not bool"):
+        Evaluation("invalid", True, True)

--- a/futureagi/agentic_eval/core/tests/test_counterfactual_replay.py
+++ b/futureagi/agentic_eval/core/tests/test_counterfactual_replay.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import math
 import threading
 import time
 from dataclasses import dataclass
@@ -355,7 +356,26 @@ def test_empty_suite_fails_closed_by_default():
     assert report.total == 0
     assert report.pass_rate == 0.0
     assert report.accepted is False
-    assert report.violations == ("case count 0 is below required 1",)
+    assert report.violations == (
+        "case count 0 is below required 1",
+        "evaluation count 0 is below required 1",
+        "pass rate 0.0000 is below required 1.0000",
+    )
+
+
+def test_empty_suite_requires_explicit_opt_out_of_every_minimum():
+    report = run(
+        CounterfactualReplay(
+            lambda request: request,
+            policy=RegressionPolicy(
+                minimum_case_count=0,
+                minimum_evaluation_count=0,
+                minimum_pass_rate=0.0,
+            ),
+        ).run([])
+    )
+
+    assert report.accepted is True
 
 
 def test_successful_candidate_without_evaluations_is_not_promotable_by_default():
@@ -381,7 +401,10 @@ def test_successful_candidate_without_evaluations_is_not_promotable_by_default()
 def test_candidate_errors_are_isolated_and_messages_are_opt_in():
     def candidate(request):
         if request["fail"]:
-            raise RuntimeError("Bearer provider-secret")
+            raise RuntimeError(
+                f"authorization={request['authorization']}; "
+                "Bearer provider-secret"
+            )
         return "ok"
 
     report = run(
@@ -425,7 +448,7 @@ def test_candidate_errors_are_isolated_and_messages_are_opt_in():
         "suite": "held-out",
     }
     assert diagnostic_payload["results"][0]["error_message"] == (
-        "Bearer provider-secret"
+        "authorization=[REDACTED]; Bearer [REDACTED]"
     )
 
 
@@ -443,6 +466,23 @@ def test_outputs_are_omitted_unless_explicitly_requested_and_then_redacted():
     assert report.to_dict(include_outputs=True)["results"][0]["output"] == {
         "answer": "ok",
         "token": "[REDACTED]",
+    }
+
+
+def test_unknown_output_repr_is_never_called_or_exported():
+    class SecretObject:
+        def __repr__(self):
+            raise AssertionError("repr must not be called")
+
+    report = run(
+        CounterfactualReplay(
+            lambda request: SecretObject(),
+            policy=RegressionPolicy(minimum_evaluation_count=0),
+        ).run([ReplayCase("case", {"prompt": "hello"})])
+    )
+
+    assert report.to_dict(include_outputs=True)["results"][0]["output"] == {
+        "__type__": "SecretObject",
     }
 
 
@@ -542,6 +582,29 @@ def test_evaluator_timeout_is_a_structured_case_error():
 
     assert report.results[0].error_stage == "evaluator:evaluator"
     assert report.results[0].error_type == "TimeoutError"
+
+
+def test_sync_candidate_timeout_is_rejected_before_execution():
+    with pytest.raises(ValueError, match="requires an async candidate"):
+        CounterfactualReplay(
+            lambda request: "ok",
+            candidate_timeout_seconds=0.1,
+        )
+
+
+def test_sync_evaluator_timeout_is_rejected_before_execution():
+    async def candidate(request):
+        return "ok"
+
+    def evaluator(output, baseline, case):
+        return Evaluation("quality", 1.0, True)
+
+    with pytest.raises(ValueError, match="requires async evaluators"):
+        CounterfactualReplay(
+            candidate,
+            [evaluator],
+            evaluator_timeout_seconds=0.1,
+        )
 
 
 def test_invalid_evaluator_return_is_a_structured_error():
@@ -680,6 +743,33 @@ def test_request_mapping_keys_must_be_strings():
     with pytest.raises(TypeError, match="must use string keys"):
         request_fingerprint({1: "not-json"})
 
+
+def test_invalid_request_key_does_not_invoke_user_string_conversion():
+    class UnsafeKey:
+        def __str__(self):
+            raise AssertionError("string conversion must not be called")
+
+    with pytest.raises(TypeError, match="must use string keys"):
+        request_fingerprint({UnsafeKey(): "not-json"})
+
+
+def test_report_mapping_keys_do_not_invoke_user_string_conversion():
+    class UnsafeKey:
+        def __str__(self):
+            raise AssertionError("string conversion must not be called")
+
+    report = run(
+        CounterfactualReplay(
+            lambda request: {UnsafeKey(): "value"},
+            policy=RegressionPolicy(minimum_evaluation_count=0),
+        ).run([ReplayCase("case", {"prompt": "hello"})])
+    )
+
+    assert report.to_dict(include_outputs=True)["results"][0]["output"] == {
+        "__key_0_UnsafeKey": "value",
+    }
+
+
 def test_evaluation_details_are_omitted_unless_requested_and_redacted():
     def evaluator(output, baseline, case):
         return Evaluation(
@@ -753,3 +843,242 @@ def test_evaluation_and_policy_values_are_normalized():
 
     with pytest.raises(TypeError, match="numeric, not bool"):
         Evaluation("invalid", True, True)
+
+    with pytest.raises(TypeError, match="minimum_pass_rate"):
+        RegressionPolicy(minimum_pass_rate=True)
+
+    with pytest.raises(TypeError, match="maximum_mean_score_drop"):
+        RegressionPolicy(maximum_mean_score_drop=False)
+
+
+def test_partial_evaluator_regression_is_not_hidden_by_a_later_error():
+    def regressing(output, baseline, case):
+        return Evaluation("quality", 0.0, False, baseline_score=1.0)
+
+    def broken(output, baseline, case):
+        raise RuntimeError("evaluation unavailable")
+
+    report = run(
+        CounterfactualReplay(
+            lambda request: "ok",
+            [regressing, broken],
+            policy=RegressionPolicy(
+                minimum_evaluation_count=0,
+                minimum_pass_rate=0.0,
+                maximum_error_rate=1.0,
+                maximum_regression_rate=0.0,
+            ),
+        ).run([ReplayCase("case", {"prompt": "hello"})])
+    )
+
+    assert report.error_count == 1
+    assert report.regression_count == 1
+    assert report.accepted is False
+    assert report.violations == (
+        "regression rate 1.0000 exceeds allowed 0.0000",
+        "mean score drop 1.000000 exceeds allowed 0.000000",
+    )
+
+def test_additional_sensitive_keys_reject_a_scalar_string():
+    with pytest.raises(TypeError, match="iterable of strings"):
+        request_fingerprint(
+            {"tenant_credential": "secret"},
+            additional_sensitive_keys="tenant_credential",
+        )
+
+
+def test_report_free_text_redacts_secrets_found_in_structured_fields():
+    secret = "tenant-secret-value"
+    report = run(
+        CounterfactualReplay(
+            lambda request: {
+                "api_key": secret,
+                "message": f"provider rejected {secret}",
+                "authorization_error": f"Bearer {secret}",
+            },
+            policy=RegressionPolicy(minimum_evaluation_count=0),
+        ).run([ReplayCase("case", {"prompt": "hello"})])
+    )
+
+    assert report.to_dict(include_outputs=True)["results"][0]["output"] == {
+        "api_key": "[REDACTED]",
+        "message": "provider rejected [REDACTED]",
+        "authorization_error": "Bearer [REDACTED]",
+    }
+
+
+def test_report_non_string_key_placeholders_cannot_overwrite_string_keys():
+    class UnsafeKey:
+        def __str__(self):
+            raise AssertionError("string conversion must not be called")
+
+    output = {
+        UnsafeKey(): "non-string",
+        "__key_0_UnsafeKey": "string",
+    }
+    report = run(
+        CounterfactualReplay(
+            lambda request: output,
+            policy=RegressionPolicy(minimum_evaluation_count=0),
+        ).run([ReplayCase("case", {"prompt": "hello"})])
+    )
+
+    assert report.to_dict(include_outputs=True)["results"][0]["output"] == {
+        "__key_0_UnsafeKey_1": "non-string",
+        "__key_0_UnsafeKey": "string",
+    }
+
+
+def test_error_message_capture_cannot_mask_an_exception_with_broken_str():
+    class BrokenMessageError(RuntimeError):
+        def __str__(self):
+            raise RuntimeError("message rendering failed")
+
+    def candidate(request):
+        raise BrokenMessageError()
+
+    report = run(
+        CounterfactualReplay(
+            candidate,
+            capture_error_messages=True,
+            policy=RegressionPolicy(
+                minimum_evaluation_count=0,
+                minimum_pass_rate=0.0,
+                maximum_error_rate=1.0,
+            ),
+        ).run([ReplayCase("case", {"prompt": "hello"})])
+    )
+
+    result = report.results[0]
+    assert result.error_type == "BrokenMessageError"
+    assert result.error_message == "[exception message unavailable]"
+
+
+def test_callable_name_lookup_cannot_break_evaluator_error_isolation():
+    class EvaluatorObject:
+        @property
+        def __name__(self):
+            raise RuntimeError("name lookup failed")
+
+        def __call__(self, output, baseline, case):
+            raise RuntimeError("evaluation failed")
+
+    report = run(
+        CounterfactualReplay(
+            lambda request: "ok",
+            [EvaluatorObject()],
+            policy=RegressionPolicy(
+                minimum_evaluation_count=0,
+                minimum_pass_rate=0.0,
+                maximum_error_rate=1.0,
+            ),
+        ).run([ReplayCase("case", {"prompt": "hello"})])
+    )
+
+    assert report.results[0].error_stage == "evaluator:EvaluatorObject"
+    assert report.results[0].error_type == "RuntimeError"
+
+
+def test_evaluation_is_snapshotted_before_entering_the_report():
+    returned = []
+
+    def evaluator(output, baseline, case):
+        evaluation = Evaluation(
+            "quality",
+            1.0,
+            True,
+            details={"items": [1]},
+        )
+        returned.append(evaluation)
+        return evaluation
+
+    report = run(
+        CounterfactualReplay(
+            lambda request: "ok",
+            [evaluator],
+        ).run([ReplayCase("case", {"prompt": "hello"})])
+    )
+
+    returned[0].details["items"].append(2)
+    assert report.results[0].evaluations[0].details == {"items": [1]}
+
+
+def test_score_delta_overflow_is_rejected_as_an_evaluator_error():
+    def evaluator(output, baseline, case):
+        return Evaluation(
+            "quality",
+            1e308,
+            True,
+            baseline_score=-1e308,
+        )
+
+    report = run(
+        CounterfactualReplay(
+            lambda request: "ok",
+            [evaluator],
+            policy=RegressionPolicy(
+                minimum_evaluation_count=0,
+                minimum_pass_rate=0.0,
+                maximum_error_rate=1.0,
+            ),
+        ).run([ReplayCase("case", {"prompt": "hello"})])
+    )
+
+    assert report.results[0].error_stage == "evaluator:evaluator"
+    assert report.results[0].error_type == "ValueError"
+
+
+def test_mean_score_drop_avoids_overflow_for_large_finite_deltas():
+    def evaluator(output, baseline, case):
+        return Evaluation(
+            "quality",
+            -8e307,
+            False,
+            baseline_score=8e307,
+        )
+
+    report = run(
+        CounterfactualReplay(
+            lambda request: "ok",
+            [evaluator],
+            policy=RegressionPolicy(
+                minimum_pass_rate=0.0,
+                maximum_regression_rate=1.0,
+                maximum_mean_score_drop=1.7e308,
+            ),
+        ).run(
+            [
+                ReplayCase("first", {"value": 1}),
+                ReplayCase("second", {"value": 2}),
+            ]
+        )
+    )
+
+    assert math.isfinite(report.mean_score_drop)
+    assert report.mean_score_drop == 1.6e308
+
+
+def test_dataclass_types_are_not_treated_as_request_instances():
+    @dataclass
+    class Payload:
+        prompt: str = "hello"
+
+    with pytest.raises(TypeError, match="unsupported value type: type"):
+        request_fingerprint({"payload": Payload})
+
+
+def test_dataclass_types_are_not_introspected_in_reports():
+    @dataclass
+    class Payload:
+        prompt: str = "hello"
+
+    report = run(
+        CounterfactualReplay(
+            lambda request: Payload,
+            policy=RegressionPolicy(minimum_evaluation_count=0),
+        ).run([ReplayCase("case", {"prompt": "hello"})])
+    )
+
+    assert report.to_dict(include_outputs=True)["results"][0]["output"] == {
+        "__type__": "type",
+    }


### PR DESCRIPTION
## Summary

Adds a deterministic, provider-neutral counterfactual replay engine and an auditable regression policy under `agentic_eval.core.replay`.

A candidate model, prompt, routing policy, tool policy, or guardrail can be run against production-shaped held-out cases before promotion:

```text
trace failure -> candidate repair -> replay -> evaluate -> promote or reject
```

The candidate callable can target the Future AGI Gateway, a hosted provider, or a local OpenAI-compatible runtime such as MLX-LM, oMLX, Ollama, or llama.cpp.

Related to #1542.

## What changed

- Added `ReplayCase`, `Evaluation`, `ReplayResult`, and `ReplayReport` contracts.
- Added `CounterfactualReplay` with bounded sync/async execution, stable result ordering, optional candidate-request deduplication, case-specific evaluation, structured error isolation, and deep-copy isolation.
- Added `RegressionPolicy` gates for minimum case/evaluation counts, pass rate, error rate, regression rate, mean score drop, and numerical tolerance.
- Added credential-redacted public fingerprints and privacy-safe report serialization.
- Added focused documentation and regression tests.

## Hardening follow-up

Commit `b3196b1d2b0685b4484db53ba7ce2c515876dd0f` is the verified hardening pass. It adds:

- rejection of replay-level timeouts for synchronous callables, preventing abandoned worker threads from escaping the configured concurrency ceiling;
- sanitized opt-in exception messages, including safe handling when `Exception.__str__` fails;
- fail-closed empty-suite and missing-evaluation promotion behavior;
- accounting for completed evaluations even when a later evaluator fails;
- evaluator-result snapshot isolation;
- finite score-delta validation and overflow-safe mean-score-drop calculation;
- safe diagnostic serialization without arbitrary `repr()` or unsafe key stringification;
- collision-safe placeholders for non-string report keys;
- redaction of known secrets repeated in exported free text;
- correct dataclass-class handling, boolean numeric-policy rejection, and defensive callable-name handling.

The remote hardening blobs match the locally verified Git object IDs for the documentation, engine, models, privacy helpers, and focused test module.

## Security and privacy decisions

The public request fingerprint is intentionally not the candidate-execution cache key. Requests that differ only by credentials share a redacted public fingerprint but execute separately through a non-exported digest that includes credential values.

Candidate outputs, metadata, evaluator details, and exception messages are omitted from serialized reports by default because any may contain prompts, customer data, provider URLs, or credentials. Diagnostic opt-ins recursively redact credential-shaped fields.

## Tests

**48 focused tests pass** after the hardening follow-up, covering ordering, bounded concurrency, case-specific evaluation, cross-credential isolation, mutation isolation, fail-closed promotion, partial-evaluation regression accounting, credential scrubbing, safe serialization, numeric overflow, synchronous-timeout validation, invalid evaluator returns, duplicate names/IDs, and unsupported request values.

```bash
cd futureagi
PYTHONPATH=. pytest -q agentic_eval/core/tests/test_counterfactual_replay.py
python -m compileall -q agentic_eval/core/replay agentic_eval/core/tests/test_counterfactual_replay.py
```

Upstream workflows are currently in `action_required` because this is an external-fork PR; a maintainer must approve them before jobs start.

## Scope

This PR establishes the replay and promotion-gate contract only. It does not add a Django endpoint, persist reports, select an optimizer, or automatically pull traces from storage.

## Checklist

- [x] Conventional Commit titles
- [x] Focused regression tests
- [x] No hardcoded credentials, production URLs, or PII
- [x] No database migration
- [x] No new runtime dependency
- [x] Privacy-sensitive diagnostic fields are opt-in
