### PR TITLE
fix(annotations): route conversation traces to the voice UI in the queue

### DIFF
--- a/frontend/src/sections/annotations/queues/__tests__/content-panel.test.jsx
+++ b/frontend/src/sections/annotations/queues/__tests__/content-panel.test.jsx
@@ -284,6 +284,60 @@ describe("Annotation queue ContentPanel", () => {
     expect(screen.queryByTestId("new-scenario-view")).not.toBeInTheDocument();
   });
 
+  it("uses the voice drawer for conversation traces outside simulator projects", async () => {
+    axios.get.mockResolvedValue({
+      data: {
+        result: {
+          status: "ended",
+          scenario_name: "Vapi inbound call",
+          transcript: [],
+          eval_outputs: {},
+        },
+      },
+    });
+
+    renderWithQuery(
+      <ContentPanel
+        item={{
+          source_type: "trace",
+          source_content: {
+            trace_id: "trace-voice-1",
+            observation_type: "conversation",
+            project_source: "prototype",
+          },
+        }}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("voice-drawer")).toHaveAttribute(
+        "data-scenario",
+        "Vapi inbound call",
+      );
+    });
+    expect(screen.queryByTestId("trace-display-panel")).not.toBeInTheDocument();
+  });
+
+  it("falls back to the inline trace view when voice call detail is empty", async () => {
+    axios.get.mockResolvedValue({ data: {} });
+
+    renderWithQuery(
+      <ContentPanel
+        item={{
+          source_type: "trace",
+          source_content: {
+            trace_id: "trace-voice-2",
+            observation_type: "conversation",
+            project_source: "prototype",
+          },
+        }}
+      />,
+    );
+
+    await screen.findByTestId("trace-display-panel");
+    expect(screen.queryByTestId("voice-drawer")).not.toBeInTheDocument();
+  });
+
   it("copies every dataset field including JSON objects and booleans", async () => {
     const user = userEvent.setup();
 

--- a/frontend/src/sections/annotations/queues/annotate/content-panel.jsx
+++ b/frontend/src/sections/annotations/queues/annotate/content-panel.jsx
@@ -101,14 +101,16 @@ export default function ContentPanel({ item }) {
   }
 
   // For trace / observation_span, show the full trace view inline
-  // Voice traces (from simulator projects) get the voice-specific UI
+  // Voice traces (conversation root span) get the voice-specific UI
   if (sourceType === "trace" || sourceType === "observation_span") {
     const traceId = content?.trace_id;
-    const isVoiceProject = content?.project_source === "simulator";
+    const isVoiceTrace =
+      content?.observation_type === "conversation" ||
+      content?.project_source === "simulator";
     const spanId =
       sourceType === "observation_span" ? content?.span_id : undefined;
 
-    if (traceId && sourceType === "trace" && isVoiceProject) {
+    if (traceId && sourceType === "trace" && isVoiceTrace) {
       // Voice calls mount the embedded drawer which manages its own
       // scroll; skip the padding/overflow wrapper the other sources use
       // so the drawer can fill the full content panel height.
@@ -655,11 +657,7 @@ function VoiceCallContent({ traceId }) {
   }
 
   if (!callData) {
-    return (
-      <Typography color="text.secondary">
-        Voice call data not available.
-      </Typography>
-    );
+    return <InlineTraceView traceId={traceId} />;
   }
 
   const drawerData = {

--- a/futureagi/model_hub/utils/annotation_queue_helpers.py
+++ b/futureagi/model_hub/utils/annotation_queue_helpers.py
@@ -1521,7 +1521,8 @@ def resolve_source_content(item, *, ch_cache=None, cell_cache=None):
             data["type"] = "trace"
             data["trace_id"] = str(item.trace_id)
             data.pop("span_id", None)
-            # The FE picks the voice call UI off project_source == "simulator".
+            # The FE picks the voice call UI off observation_type ==
+            # "conversation", with project_source == "simulator" as a fallback.
             data["project_source"] = _queue_item_project_source(item)
             return data
 


### PR DESCRIPTION
## Description

The annotation queue's annotate workspace gated the voice call view on `project_source === "simulator"`, so Vapi conversation traces ingested into observability projects rendered the generic trace view (span tree + span detail) instead of the voice observability UI. Voice-ness is a property of the trace, not the project — the gate now keys off the trace root span's `observation_type === "conversation"`, keeping the simulator arm as a fallback.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Changes

- `content-panel.jsx`: replace the project-level `isVoiceProject` gate with a trace-level `isVoiceTrace` check (`observation_type === "conversation"` OR `project_source === "simulator"`)
- `VoiceCallContent` now degrades to `InlineTraceView` when `voice_call_detail` returns no data, instead of a dead-end "Voice call data not available." message
- `annotation_queue_helpers.py`: updated the stale comment describing how the FE picks the voice UI

## Testing

- Two regression tests added in `content-panel.test.jsx`: a non-simulator conversation trace renders the voice drawer; an empty voice-call-detail response falls back to the inline trace view
- `npx vitest run src/sections/annotations/queues/__tests__/content-panel.test.jsx` — 10/10 pass

## Related Issues

None — reported directly from the annotation queue UI.

Companion PR into dev: https://github.com/future-agi/future-agi/pull/2277
