### PR TITLE
ci: add backend quality checks

### DIFF
--- a/futureagi/.github/workflows/backend-quality.yml
+++ b/futureagi/.github/workflows/backend-quality.yml
@@ -1,0 +1,64 @@
+name: Backend Quality
+
+on:
+  pull_request:
+    branches:
+      - main
+      - dev
+      - develop
+    paths:
+      - "**/*.py"
+      - "pyproject.toml"
+      - "uv.lock"
+      - "uv.toml"
+      - "mypy-baseline.txt"
+      - "bin/check_mypy.sh"
+      - ".github/workflows/backend-quality.yml"
+  push:
+    branches:
+      - main
+      - dev
+      - develop
+    paths:
+      - "**/*.py"
+      - "pyproject.toml"
+      - "uv.lock"
+      - "uv.toml"
+      - "mypy-baseline.txt"
+      - "bin/check_mypy.sh"
+      - ".github/workflows/backend-quality.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  quality:
+    name: Backend Quality Checks
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version-file: pyproject.toml
+
+      - name: Install dependencies
+        run: uv sync --frozen
+
+      - name: Run Ruff
+        run: uv run ruff check .
+
+      - name: Check Black formatting
+        run: uv run black --check .
+
+      - name: Check baseline mypy
+        run: uv run ./bin/check_mypy.sh


### PR DESCRIPTION
## Summary

- add a standalone Backend Quality workflow for pull requests and pushes to `main`, `dev`, and `develop`
- scope runs to Python and quality configuration changes
- install the locked environment with `uv sync --frozen`
- run Ruff, Black `--check`, and the repository's baseline-driven mypy checker as separate steps
- grant the workflow read-only repository permissions and a bounded 20-minute timeout

Fixes #2105.

The issue references an older `backend-ci.yml`; current `dev` has no active backend CI workflow, so this adds the quality gate as a standalone workflow without changing the commented legacy test workflow.

## Validation

- workflow YAML parsed successfully
- `git diff --check` passed
- local `uv run ruff check .` initiated the pinned dependency sync but did not finish within the local validation window

AI assistance was used during implementation; the workflow and scope were reviewed before submission.