### PR TITLE
fix(clickhouse): classify booleans as BOOLEAN instead of INTEGER

### DIFF
--- a/futureagi/tfc/utils/tests/test_types.py
+++ b/futureagi/tfc/utils/tests/test_types.py
@@ -1,0 +1,44 @@
+"""
+Unit tests for ClickhouseDatatypes.get_data_type.
+
+get_data_type infers the ClickHouse column type for a Python value before it is
+written to ClickHouse (see model_hub/utils/clickhouse.py). Because bool is a
+subclass of int, the bool check must run before the int check; otherwise every
+boolean value is classified as INTEGER and the BOOLEAN branch is dead.
+
+Run with: futureagi/bin/test tfc/utils/tests/test_types.py -v
+"""
+
+import uuid
+from datetime import datetime
+
+import pytest
+
+from tfc.utils.types import ClickhouseDatatypes
+
+
+class TestClickhouseDatatypesGetDataType:
+    """Tests for ClickhouseDatatypes.get_data_type type inference."""
+
+    @pytest.mark.unit
+    def test_bool_is_classified_as_boolean_not_integer(self):
+        # Regression: bool subclasses int, so an int-first check misclassifies
+        # booleans as INTEGER. Both True and False must resolve to BOOLEAN.
+        assert ClickhouseDatatypes.get_data_type(True) == ClickhouseDatatypes.BOOLEAN
+        assert ClickhouseDatatypes.get_data_type(False) == ClickhouseDatatypes.BOOLEAN
+
+    @pytest.mark.unit
+    @pytest.mark.parametrize(
+        "value,expected",
+        [
+            ("hello", ClickhouseDatatypes.STRING),
+            (42, ClickhouseDatatypes.INTEGER),
+            (3.14, ClickhouseDatatypes.FLOAT),
+            (datetime(2024, 1, 1), ClickhouseDatatypes.DATE),
+            ([1, 2, 3], ClickhouseDatatypes.LIST),
+            ({"a": 1}, ClickhouseDatatypes.JSON),
+            (uuid.uuid4(), ClickhouseDatatypes.UUID),
+        ],
+    )
+    def test_other_types_are_unaffected(self, value, expected):
+        assert ClickhouseDatatypes.get_data_type(value) == expected

--- a/futureagi/tfc/utils/types.py
+++ b/futureagi/tfc/utils/types.py
@@ -41,12 +41,14 @@ class ClickhouseDatatypes(Enum):
     def get_data_type(value):
         if isinstance(value, str):
             return ClickhouseDatatypes.STRING
+        elif isinstance(value, bool):
+            # bool is a subclass of int, so this must be checked before int,
+            # otherwise every boolean is classified as INTEGER.
+            return ClickhouseDatatypes.BOOLEAN
         elif isinstance(value, int):
             return ClickhouseDatatypes.INTEGER
         elif isinstance(value, float):
             return ClickhouseDatatypes.FLOAT
-        elif isinstance(value, bool):
-            return ClickhouseDatatypes.BOOLEAN
         elif isinstance(value, datetime):
             return ClickhouseDatatypes.DATE
         elif isinstance(value, list):


### PR DESCRIPTION
## Summary

Closes #2288.

`ClickhouseDatatypes.get_data_type` (`futureagi/tfc/utils/types.py`) infers the ClickHouse column type for a Python value before it is written to ClickHouse (used in `model_hub/utils/clickhouse.py`). It checked `isinstance(value, int)` **before** `isinstance(value, bool)`:

```python
elif isinstance(value, int):
    return ClickhouseDatatypes.INTEGER
elif isinstance(value, bool):        # unreachable
    return ClickhouseDatatypes.BOOLEAN
```

Because `bool` is a subclass of `int` in Python, every boolean matches the `int` branch first, so `get_data_type(True)` returns `INTEGER` and the `BOOLEAN` branch is dead code. Boolean values therefore get typed as integers on the ClickHouse write path.

The fix moves the `bool` check ahead of the `int` check (a comment notes why the order matters). No other type is affected.

## Test plan

Added `futureagi/tfc/utils/tests/test_types.py` — a plain unit test (no external services) that asserts `True`/`False` classify as `BOOLEAN` and that `str`/`int`/`float`/`datetime`/`list`/`dict`/`uuid` are unchanged.

Verified it fails before the fix and passes after:

```
# before: get_data_type(True) -> Integer   (expected Boolean)  → FAIL
# after:  get_data_type(True) -> Boolean                        → PASS
# all other types unchanged in both cases
```

Run: `futureagi/bin/test tfc/utils/tests/test_types.py -v`

`black --check` (line length 88), `isort --profile black`, and `ruff check` all pass on the changed files.
