### PR TITLE
fix(gateway): reject non-numeric values in conditional $lt/$lte routing

### DIFF
--- a/agentcc-gateway/internal/routing/conditional.go
+++ b/agentcc-gateway/internal/routing/conditional.go
@@ -297,15 +297,17 @@ func evalOp(op string, resolved interface{}, expected interface{}, re *regexp.Re
 		}
 		return re.MatchString(fmt.Sprint(resolved))
 	case OpGt:
-		return compareNumeric(resolved, expected) > 0
+		cmp, ok := compareNumeric(resolved, expected)
+		return ok && cmp > 0
 	case OpLt:
-		return compareNumeric(resolved, expected) < 0
+		cmp, ok := compareNumeric(resolved, expected)
+		return ok && cmp < 0
 	case OpGte:
-		cmp := compareNumeric(resolved, expected)
-		return cmp >= 0
+		cmp, ok := compareNumeric(resolved, expected)
+		return ok && cmp >= 0
 	case OpLte:
-		cmp := compareNumeric(resolved, expected)
-		return cmp <= 0
+		cmp, ok := compareNumeric(resolved, expected)
+		return ok && cmp <= 0
 	case OpExists:
 		exists := resolved != nil
 		if b, ok := expected.(bool); ok {
@@ -363,20 +365,21 @@ func inSlice(resolved interface{}, expected interface{}) bool {
 }
 
 // compareNumeric converts both values to float64 and returns -1, 0, or 1.
-// Returns -2 on conversion failure (which makes all comparisons false).
-func compareNumeric(a, b interface{}) int {
+// The second return value is false when either value is not numeric, in which
+// case every comparison operator ($gt/$lt/$gte/$lte) must evaluate to false.
+func compareNumeric(a, b interface{}) (int, bool) {
 	af, aOk := toFloat64(a)
 	bf, bOk := toFloat64(b)
 	if !aOk || !bOk {
-		return -2
+		return 0, false
 	}
 	if af < bf {
-		return -1
+		return -1, true
 	}
 	if af > bf {
-		return 1
+		return 1, true
 	}
-	return 0
+	return 0, true
 }
 
 // toFloat64 attempts to convert a value to float64.

--- a/agentcc-gateway/internal/routing/conditional_numeric_test.go
+++ b/agentcc-gateway/internal/routing/conditional_numeric_test.go
@@ -1,0 +1,45 @@
+package routing
+
+import "testing"
+
+// A non-numeric (or missing) resolved value must not satisfy ANY numeric
+// comparison operator. Regression: $lt and $lte previously matched because
+// compareNumeric returned a -2 sentinel on conversion failure, and -2 < 0 and
+// -2 <= 0 are both true, so a conditional route matched every request whose
+// field was absent or non-numeric.
+func TestEvalOpNumericComparisonsRejectNonNumeric(t *testing.T) {
+	nonNumeric := []interface{}{"not-a-number", "", nil, []interface{}{1, 2}}
+	ops := []string{OpGt, OpLt, OpGte, OpLte}
+	for _, v := range nonNumeric {
+		for _, op := range ops {
+			if evalOp(op, v, 1000, nil) {
+				t.Errorf("evalOp(%q, %#v, 1000) = true, want false (non-numeric must not match)", op, v)
+			}
+		}
+	}
+}
+
+// The numeric comparisons themselves must still behave correctly.
+func TestEvalOpNumericComparisons(t *testing.T) {
+	cases := []struct {
+		op       string
+		resolved interface{}
+		expected interface{}
+		want     bool
+	}{
+		{OpLt, 5, 10, true},
+		{OpLt, 10, 5, false},
+		{OpLt, 10, 10, false},
+		{OpLte, 10, 10, true},
+		{OpGt, 10, 5, true},
+		{OpGt, 5, 10, false},
+		{OpGte, 10, 10, true},
+		{OpGte, 5, 10, false},
+		{OpLt, "5", "10", true}, // numeric strings are parsed
+	}
+	for _, c := range cases {
+		if got := evalOp(c.op, c.resolved, c.expected, nil); got != c.want {
+			t.Errorf("evalOp(%q, %v, %v) = %v, want %v", c.op, c.resolved, c.expected, got, c.want)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Closes #2286.

The conditional router's numeric comparisons (`evalOp` in `agentcc-gateway/internal/routing/conditional.go`) went through `compareNumeric`, which returned a `-2` sentinel when a value wasn't numeric. The doc comment claimed this "makes all comparisons false", but it only did for `$gt`/`$gte`:

| Op | On conversion failure | Result |
|---|---|---|
| `$gt` (`-2 > 0`) | false | ✅ |
| `$gte` (`-2 >= 0`) | false | ✅ |
| `$lt` (`-2 < 0`) | **true** | ❌ |
| `$lte` (`-2 <= 0`) | **true** | ❌ |

So a route like `{ field: "metadata.tokens", op: "$lt", value: 1000 }` matched **every** request whose field was missing or non-numeric, misrouting that traffic.

The fix replaces the `-2` sentinel: `compareNumeric` now returns an explicit `(int, bool)` where the bool reports convertibility, and all four comparison branches (`$gt`/`$lt`/`$gte`/`$lte`) require it — so a non-numeric value can never satisfy a numeric comparison.

## Test plan

Added `agentcc-gateway/internal/routing/conditional_numeric_test.go`:
- `TestEvalOpNumericComparisonsRejectNonNumeric` — every numeric op returns false for non-numeric/missing values (`"not-a-number"`, `""`, `nil`, a slice).
- `TestEvalOpNumericComparisons` — the numeric comparisons themselves still behave correctly (incl. numeric strings).

Verified it fails before the fix (only the `$lt`/`$lte` cases) and passes after:

```
$ go test ./internal/routing/ -run TestEvalOpNumeric
ok  	github.com/futureagi/agentcc-gateway/internal/routing
```

`gofmt` and `go vet` are clean on the changed files.
