### PR TITLE
fix(agentcc): preserve Google model discovery host

### DIFF
--- a/futureagi/agentcc/tests/test_provider_credential_api.py
+++ b/futureagi/agentcc/tests/test_provider_credential_api.py
@@ -5,9 +5,9 @@ import pytest
 from accounts.models.organization import Organization
 from accounts.models.organization_membership import OrganizationMembership
 from accounts.models.workspace import Workspace, WorkspaceMembership
+from agentcc.models.provider_credential import AgentccProviderCredential
 from conftest import WorkspaceAwareAPIClient
 from integrations.services.credentials import CredentialManager
-from agentcc.models.provider_credential import AgentccProviderCredential
 from tfc.constants.levels import Level
 from tfc.constants.roles import OrganizationRoles
 
@@ -125,6 +125,7 @@ class TestAgentccProviderCredentialOrganizationIsolation:
             provider_name="openai",
             display_name="Org B OpenAI",
             encrypted_credentials=CredentialManager.encrypt({"api_key": "sk-org-b"}),
+            base_url="https://api.org-b.example/v1",
             api_format="openai",
         )
 
@@ -134,15 +135,68 @@ class TestAgentccProviderCredentialOrganizationIsolation:
         ) as mock_fetch:
             response = secondary_org_client.post(
                 "/agentcc/provider-credentials/fetch_models/",
-                {"provider_name": "openai"},
+                {
+                    "provider_name": "openai",
+                    "base_url": "https://attacker.example",
+                    "api_key": "attacker-key",
+                    "api_format": "google",
+                },
                 format="json",
             )
 
         assert response.status_code == 200, response.json()
-        args, _ = mock_fetch.call_args
-        # Signature: (provider_name, base_url, api_key, api_format)
-        assert args[0] == "openai"
-        assert args[2] == "sk-org-b"
+        mock_fetch.assert_called_once_with(
+            "openai",
+            "https://api.org-b.example/v1",
+            "sk-org-b",
+            "openai",
+        )
+
+    def test_fetch_models_rejects_missing_saved_credential(
+        self, secondary_org_context, secondary_org_client
+    ):
+        with patch(
+            "agentcc.views.provider_credential.AgentccProviderCredentialViewSet._fetch_models_from_provider",
+        ) as mock_fetch:
+            response = secondary_org_client.post(
+                "/agentcc/provider-credentials/fetch_models/",
+                {
+                    "provider_name": "missing",
+                    "base_url": "https://attacker.example",
+                    "api_key": "attacker-key",
+                    "api_format": "google",
+                },
+                format="json",
+            )
+
+        assert response.status_code == 400, response.json()
+        assert "No saved credential found" in response.json()["message"]
+        mock_fetch.assert_not_called()
+
+    def test_fetch_models_forwards_raw_values_without_provider_name(
+        self, secondary_org_client
+    ):
+        with patch(
+            "agentcc.views.provider_credential.AgentccProviderCredentialViewSet._fetch_models_from_provider",
+            return_value=["gemini-custom"],
+        ) as mock_fetch:
+            response = secondary_org_client.post(
+                "/agentcc/provider-credentials/fetch_models/",
+                {
+                    "base_url": "https://models.example.com/",
+                    "api_key": "custom-key",
+                    "api_format": "google",
+                },
+                format="json",
+            )
+
+        assert response.status_code == 200, response.json()
+        mock_fetch.assert_called_once_with(
+            None,
+            "https://models.example.com",
+            "custom-key",
+            "google",
+        )
 
     def test_fetch_models_returns_bad_request_when_saved_credential_cannot_decrypt(
         self, secondary_org_context, secondary_org_client
@@ -187,9 +241,7 @@ class TestAgentccProviderCredentialOrganizationIsolation:
             api_format="openai",
         )
 
-        response = secondary_org_client.get(
-            f"/agentcc/provider-credentials/{cred.id}/"
-        )
+        response = secondary_org_client.get(f"/agentcc/provider-credentials/{cred.id}/")
 
         assert response.status_code == 200, response.json()
         data = response.json()["result"]
@@ -215,9 +267,7 @@ class TestAgentccProviderCredentialOrganizationIsolation:
             api_format="openai",
         )
 
-        response = secondary_org_client.get(
-            f"/agentcc/provider-credentials/{cred.id}/"
-        )
+        response = secondary_org_client.get(f"/agentcc/provider-credentials/{cred.id}/")
         assert response.status_code == 404
 
     def test_update_writes_safe_fields_and_pushes_config(
@@ -228,7 +278,9 @@ class TestAgentccProviderCredentialOrganizationIsolation:
             organization=org_b,
             provider_name="openai",
             display_name="Old Display",
-            encrypted_credentials=CredentialManager.encrypt({"api_key": "sk-untouched"}),
+            encrypted_credentials=CredentialManager.encrypt(
+                {"api_key": "sk-untouched"}
+            ),
             api_format="openai",
             models_list=["gpt-4o-mini"],
         )

--- a/futureagi/agentcc/tests/test_provider_model_discovery.py
+++ b/futureagi/agentcc/tests/test_provider_model_discovery.py
@@ -1,0 +1,113 @@
+from unittest.mock import Mock, patch
+
+from agentcc.views.provider_credential import AgentccProviderCredentialViewSet
+
+
+def _mock_response(payload=None):
+    response = Mock()
+    response.json.return_value = payload or {"models": []}
+    return response
+
+
+class TestAgentccProviderCredentialModelDiscovery:
+    def test_custom_google_format_uses_configured_base_url(self):
+        response = _mock_response({"models": [{"name": "models/gemini-custom"}]})
+        safe_session = Mock()
+        safe_session.get.return_value = response
+
+        with (
+            patch(
+                "agentcc.views.provider_credential.ensure_public_http_url"
+            ) as mock_validate_url,
+            patch(
+                "agentcc.views.provider_credential.build_ssrf_safe_session",
+                return_value=safe_session,
+            ) as mock_safe_session,
+        ):
+            models = AgentccProviderCredentialViewSet()._fetch_models_from_provider(
+                None,
+                "https://models.example.com",
+                "custom-api-key",
+                "google",
+            )
+
+        assert models == ["gemini-custom"]
+        mock_validate_url.assert_called_once_with(
+            "https://models.example.com", "Invalid base URL"
+        )
+        mock_safe_session.assert_called_once_with(
+            "Connection to private address blocked"
+        )
+        safe_session.get.assert_called_once_with(
+            "https://models.example.com/v1beta/models",
+            params={"key": "custom-api-key"},
+            timeout=15,
+        )
+
+    def test_custom_google_format_does_not_duplicate_v1beta_path(self):
+        safe_session = Mock()
+        safe_session.get.return_value = _mock_response()
+
+        with (
+            patch("agentcc.views.provider_credential.ensure_public_http_url"),
+            patch(
+                "agentcc.views.provider_credential.build_ssrf_safe_session",
+                return_value=safe_session,
+            ),
+        ):
+            AgentccProviderCredentialViewSet()._fetch_models_from_provider(
+                None,
+                "https://models.example.com/v1beta",
+                "custom-api-key",
+                "google",
+            )
+
+        safe_session.get.assert_called_once_with(
+            "https://models.example.com/v1beta/models",
+            params={"key": "custom-api-key"},
+            timeout=15,
+        )
+
+    def test_google_preset_without_base_url_uses_official_endpoint(self):
+        response = _mock_response()
+
+        with patch(
+            "agentcc.views.provider_credential.http_requests.get",
+            return_value=response,
+        ) as mock_get:
+            AgentccProviderCredentialViewSet()._fetch_models_from_provider(
+                "google",
+                "",
+                "google-api-key",
+                "google",
+            )
+
+        mock_get.assert_called_once_with(
+            "https://generativelanguage.googleapis.com/v1beta/models",
+            params={"key": "google-api-key"},
+            timeout=15,
+        )
+
+    def test_google_preset_with_official_base_url_uses_official_endpoint(self):
+        safe_session = Mock()
+        safe_session.get.return_value = _mock_response()
+
+        with (
+            patch("agentcc.views.provider_credential.ensure_public_http_url"),
+            patch(
+                "agentcc.views.provider_credential.build_ssrf_safe_session",
+                return_value=safe_session,
+            ),
+        ):
+            AgentccProviderCredentialViewSet()._fetch_models_from_provider(
+                "google",
+                "https://generativelanguage.googleapis.com",
+                "google-api-key",
+                "google",
+            )
+
+        safe_session.get.assert_called_once_with(
+            "https://generativelanguage.googleapis.com/v1beta/models",
+            params={"key": "google-api-key"},
+            timeout=15,
+        )

--- a/futureagi/agentcc/views/provider_credential.py
+++ b/futureagi/agentcc/views/provider_credential.py
@@ -5,7 +5,6 @@ from rest_framework.decorators import action
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.viewsets import ModelViewSet
 
-from integrations.services.credentials import CredentialManager
 from agentcc.models.org_config import AgentccOrgConfig
 from agentcc.models.provider_credential import AgentccProviderCredential
 from agentcc.serializers.provider_credential import (
@@ -15,6 +14,7 @@ from agentcc.serializers.provider_credential import (
 )
 from agentcc.services.config_push import push_org_config
 from agentcc.services.url_safety import build_ssrf_safe_session, ensure_public_http_url
+from integrations.services.credentials import CredentialManager
 from tfc.utils.base_viewset import BaseModelViewSetMixinWithUserOrg
 from tfc.utils.general_methods import GeneralMethods
 
@@ -219,33 +219,34 @@ class AgentccProviderCredentialViewSet(BaseModelViewSetMixinWithUserOrg, ModelVi
                 organization=organization,
                 deleted=False,
             ).first()
-            if cred:
-                try:
-                    decrypted = CredentialManager.decrypt(cred.encrypted_credentials)
-                except Exception:
-                    logger.warning(
-                        "provider_credential_decrypt_failed",
-                        provider_name=provider_name,
-                        organization_id=str(organization.id),
-                        exc_info=True,
-                    )
-                    return self._gm.bad_request(
-                        "Saved provider credential could not be decrypted. "
-                        "Rotate the credential or check the encryption configuration."
-                    )
-                api_key = decrypted.get("api_key", "")
-                base_url = cred.base_url.rstrip("/") if cred.base_url else ""
-                api_format = cred.api_format
-
-        # Raw values from request body override or fill gaps.
-        base_url = (request.data.get("base_url") or base_url or "").rstrip("/")
-        api_key = request.data.get("api_key") or api_key or ""
-        api_format = request.data.get("api_format") or api_format or "openai"
+            if cred is None:
+                return self._gm.bad_request(
+                    f"No saved credential found for provider '{provider_name}'."
+                )
+            try:
+                decrypted = CredentialManager.decrypt(cred.encrypted_credentials)
+            except Exception:
+                logger.warning(
+                    "provider_credential_decrypt_failed",
+                    provider_name=provider_name,
+                    organization_id=str(organization.id),
+                    exc_info=True,
+                )
+                return self._gm.bad_request(
+                    "Saved provider credential could not be decrypted. "
+                    "Rotate the credential or check the encryption configuration."
+                )
+            api_key = decrypted.get("api_key", "")
+            base_url = cred.base_url.rstrip("/") if cred.base_url else ""
+            api_format = cred.api_format
+        else:
+            base_url = (request.data.get("base_url") or "").rstrip("/")
+            api_key = request.data.get("api_key") or ""
+            api_format = request.data.get("api_format") or "openai"
 
         if not api_key:
             msg = (
-                f"No saved credential found for provider '{provider_name}'. "
-                "Provide an api_key to fetch models."
+                f"Saved credential for provider '{provider_name}' has no api_key."
                 if provider_name
                 else "api_key is required"
             )
@@ -308,8 +309,16 @@ class AgentccProviderCredentialViewSet(BaseModelViewSetMixinWithUserOrg, ModelVi
             data = resp.json()
             return sorted(m["id"] for m in data.get("data", []))
 
-        if name in ("google", "gemini", "google_gemini") or api_format in ("gemini", "google"):
-            url = "https://generativelanguage.googleapis.com/v1beta/models"
+        if name in ("google", "gemini", "google_gemini") or api_format in (
+            "gemini",
+            "google",
+        ):
+            base = (base_url or "https://generativelanguage.googleapis.com").rstrip("/")
+            url = (
+                f"{base}/models"
+                if base.endswith("/v1beta")
+                else f"{base}/v1beta/models"
+            )
             resp = http.get(
                 url,
                 params={"key": api_key},


### PR DESCRIPTION
## Summary

Custom Google-format provider discovery now keeps the configured provider host instead of sending its API key to Google's public endpoint. Saved-credential discovery also ignores request-body URL, key, and format overrides, so a stored key cannot be paired with a caller-supplied host.

E2E: exempt (harness-gap provider credential model discovery)

## Linked issues

Closes #2280
Linear: N/A

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature which changes existing behavior)
- [ ] Documentation only
- [ ] Chore / refactor
- [ ] Performance improvement
- [ ] Test-only change

---

## 1) What changes were done

**A. Preserve the configured Google-compatible provider host**

- Build the model-discovery URL from `base_url` when one is supplied.
- Keep `https://generativelanguage.googleapis.com` as the fallback for the official Google preset.
- Avoid generating `/v1beta/v1beta/models` when the configured URL already ends in `/v1beta`.
- Preserve query-key authentication, response parsing, URL validation, and the DNS-rebinding-safe HTTP session.

**B. Keep credential lookup and raw create-mode discovery mutually exclusive**

- With `provider_name`, load `base_url`, `api_key`, and `api_format` only from the current organization's saved credential.
- Reject an unknown saved provider instead of falling back to request-body values.
- Without `provider_name`, continue forwarding the raw values used by the create form.

**C. Add focused regression coverage**

- Assert exact outbound URLs and query parameters for custom and official Google endpoints.
- Assert custom endpoints still pass through URL validation and the SSRF-safe session.
- Assert saved credentials cannot be combined with request-supplied connection fields.
- Assert raw create-mode discovery still works without `provider_name`.

No serializer, database, or frontend contract changes are introduced.

---

## 2) Why the changes were done

- **Security/privacy:** A key intended for one host must not be transmitted to a different host.
- **Product:** Custom Google-format providers can now discover their own models.
- **Technical:** The change stays inside the existing provider-specific discovery path and preserves current safety and parsing behavior.

---

## 3) Validation

- Four URL-routing regression tests passed for custom, versioned, fallback, and explicit official Google endpoints.
- Python syntax compilation passed for all three changed files.
- Ruff lint and Ruff format checks passed for all three changed files.
- `git diff --check upstream/dev` passed.
- The three database-backed API regression tests were added but not run locally because the required test service stack was not available.

---

## 4) How to run / test

```bash
cd futureagi
bin/test \
  agentcc/tests/test_provider_model_discovery.py \
  agentcc/tests/test_provider_credential_api.py::TestAgentccProviderCredentialOrganizationIsolation::test_fetch_models_reads_credential_from_active_request_organization \
  agentcc/tests/test_provider_credential_api.py::TestAgentccProviderCredentialOrganizationIsolation::test_fetch_models_rejects_missing_saved_credential \
  agentcc/tests/test_provider_credential_api.py::TestAgentccProviderCredentialOrganizationIsolation::test_fetch_models_forwards_raw_values_without_provider_name \
  -v
```

---

## 5) Edge cases & considerations

- A custom URL ending in `/v1beta` receives only `/models`.
- A custom URL without the version prefix receives `/v1beta/models`.
- An empty URL retains the official Google endpoint.
- Any non-empty URL still undergoes the existing public-URL validation and per-request DNS-rebinding check.
- A supplied `provider_name` never falls back to request-body credentials or connection settings.

---

## Checklist

- [x] My code follows the style guide
- [x] I've added tests that prove the fix is effective
- [ ] Full `bin/test` passes locally
- [x] No API contract regeneration is needed
- [x] No hardcoded secrets or PII
- [x] PR title follows Conventional Commits

