### PR TITLE
Allow creating a Knowledge Base directly from an existing dataset

### DIFF
--- a/frontend/src/components/FromSearchSelectField/FormSearchSelectFieldState.jsx
+++ b/frontend/src/components/FromSearchSelectField/FormSearchSelectFieldState.jsx
@@ -29,6 +29,10 @@ const FormSearchSelectFieldState = React.forwardRef(
       onScrollEnd,
       isFetchingNextPage,
       selectAll,
+      // Optional: told what the user typed, for a caller driving a
+      // server-side search (client-side filtering below still applies to
+      // whatever `options` that search resolves to).
+      onSearchChange,
       // Filter ``shrink`` out of ``rest`` — see rhf-text-field.jsx note.
       // eslint-disable-next-line no-unused-vars
       shrink: _shrink,
@@ -63,12 +67,14 @@ const FormSearchSelectFieldState = React.forwardRef(
     const onClose = () => {
       setOpenDropdown(false);
       setSearchedValue("");
+      onSearchChange?.("");
     };
 
     const handleOpen = useCallback(() => {
       if (rest?.disabled) return;
       setOpenDropdown(true);
       setSearchedValue("");
+      onSearchChange?.("");
 
       const boxRect = containerRef.current.getBoundingClientRect();
       const spaceBelow = window.innerHeight - boxRect.bottom;
@@ -79,7 +85,7 @@ const FormSearchSelectFieldState = React.forwardRef(
       } else {
         setPosition("bottom");
       }
-    }, [rest?.disabled]);
+    }, [rest?.disabled, onSearchChange]);
 
     const handleOnFocus = useCallback(() => {
       setFocus(true);
@@ -96,15 +102,20 @@ const FormSearchSelectFieldState = React.forwardRef(
       (e) => {
         e.stopPropagation();
         setSearchedValue("");
+        onSearchChange?.("");
         handleOpen();
         inputRef.current?.focus();
       },
-      [handleOpen],
+      [handleOpen, onSearchChange],
     );
 
-    const handleOnChange = useCallback((e) => {
-      setSearchedValue(e.target.value);
-    }, []);
+    const handleOnChange = useCallback(
+      (e) => {
+        setSearchedValue(e.target.value);
+        onSearchChange?.(e.target.value);
+      },
+      [onSearchChange],
+    );
 
     const handleDropdownIconClick = useCallback(
       (e) => {
@@ -330,4 +341,5 @@ FormSearchSelectFieldState.propTypes = {
   isFetchingNextPage: PropTypes.bool,
   selectAll: PropTypes.bool,
   shrink: PropTypes.bool,
+  onSearchChange: PropTypes.func,
 };

--- a/frontend/src/sections/knowledge-base/CreateKnowledgeBase/CreateKnowledgeBaseDrawer.jsx
+++ b/frontend/src/sections/knowledge-base/CreateKnowledgeBase/CreateKnowledgeBaseDrawer.jsx
@@ -16,6 +16,7 @@ import Iconify from "src/components/iconify";
 import HelperText from "src/sections/develop-detail/Common/HelperText";
 import UploadKnowledgeBaseFile from "./UploadKnowledgeBaseFile";
 import UploadKnowledgeBaseSDK from "./UploadKnowledgeBaseSDK";
+import SelectDatasetSource from "./SelectDatasetSource";
 import SingleFileDetail from "./SingleFileDetail";
 import { getFileExtension } from "src/utils/utils";
 import { LoadingButton } from "@mui/lab";
@@ -33,6 +34,13 @@ import { useBeforeUnload } from "src/hooks/useBeforeUnload";
 
 const tabItems = [
   { label: "Upload", value: "Upload", disabled: false },
+  {
+    label: "From dataset",
+    value: "FromDataset",
+    disabled: false,
+    // creation-only: an existing KB's dataset-derived content isn't editable here
+    hideOnAddFiles: true,
+  },
   {
     label: "Import from SDK",
     value: "ImprortfromSDK",
@@ -64,6 +72,8 @@ const CreateKnowledgeBaseDrawerChild = ({
   const theme = useTheme();
   const navigate = useNavigate();
   const [currentTab, setCurrentTab] = useState("Upload");
+  const [datasetId, setDatasetId] = useState(null);
+  const [columnIds, setColumnIds] = useState([]);
   const { refetch: refetchKnowledgeBaseList } = useKnowledgeBaseList();
 
   const [showSdkInfo, setShowSdkInfo] = useState(false);
@@ -183,6 +193,15 @@ const CreateKnowledgeBaseDrawerChild = ({
     if (knowledgeId) {
       formData.append("kb_id", knowledgeId);
     }
+    //@ts-ignore
+    createKnowledgeBase(formData);
+  };
+
+  const onCreateFromDataset = (data) => {
+    const formData = new FormData();
+    formData.append("name", data?.name);
+    formData.append("dataset_id", datasetId);
+    columnIds.forEach((columnId) => formData.append("column_ids", columnId));
     //@ts-ignore
     createKnowledgeBase(formData);
   };
@@ -329,7 +348,9 @@ const CreateKnowledgeBaseDrawerChild = ({
                   }}
                   sx={{ borderBottom: "1px solid", borderColor: "divider" }}
                 >
-                  {tabItems.map((tab) => (
+                  {tabItems
+                    .filter((tab) => !(knowledgeId && tab.hideOnAddFiles))
+                    .map((tab) => (
                     <Tab
                       disabled={tab.disabled}
                       key={tab.value}
@@ -360,6 +381,15 @@ const CreateKnowledgeBaseDrawerChild = ({
                     isPending={isPending}
                     handleShowSdkInfo={handleShowSdkInfo}
                     control={control}
+                  />
+                )}
+                {currentTab === "FromDataset" && (
+                  <SelectDatasetSource
+                    datasetId={datasetId}
+                    setDatasetId={setDatasetId}
+                    columnIds={columnIds}
+                    setColumnIds={setColumnIds}
+                    disabled={isPending}
                   />
                 )}
                 {currentTab === "ImprortfromSDK" && (
@@ -450,6 +480,26 @@ const CreateKnowledgeBaseDrawerChild = ({
             >
               <Typography typography="s1" fontWeight={"fontWeightSemiBold"}>
                 {knowledgeId ? "Add" : "Create"}
+              </Typography>
+            </LoadingButton>
+          </Box>
+        )}
+        {currentTab === "FromDataset" && (
+          <Box marginTop={"auto"}>
+            <LoadingButton
+              disabled={!datasetId || columnIds.length === 0}
+              loading={isPending}
+              fullWidth
+              type="button"
+              variant="contained"
+              color="primary"
+              onClick={handleSubmit(onCreateFromDataset)}
+              sx={{
+                py: "8px",
+              }}
+            >
+              <Typography typography="s1" fontWeight={"fontWeightSemiBold"}>
+                Create
               </Typography>
             </LoadingButton>
           </Box>

--- a/frontend/src/sections/knowledge-base/CreateKnowledgeBase/SelectDatasetSource.jsx
+++ b/frontend/src/sections/knowledge-base/CreateKnowledgeBase/SelectDatasetSource.jsx
@@ -1,10 +1,11 @@
 import { Box, Typography } from "@mui/material";
 import PropTypes from "prop-types";
-import React from "react";
+import React, { useState } from "react";
 import { useQuery } from "@tanstack/react-query";
 import axios, { endpoints } from "src/utils/axios";
 import FormSearchSelectFieldState from "src/components/FromSearchSelectField/FormSearchSelectFieldState";
 import { useDatasetsList } from "src/sections/develop/hooks/useDatasetsList";
+import { useDebounce } from "src/hooks/use-debounce";
 import HelperText from "src/sections/develop-detail/Common/HelperText";
 
 // Alternative source to file uploads: build the KB from an existing
@@ -16,8 +17,11 @@ const SelectDatasetSource = ({
   setColumnIds,
   disabled,
 }) => {
+  const [datasetSearch, setDatasetSearch] = useState("");
+  const debouncedDatasetSearch = useDebounce(datasetSearch, 300);
   const { data: datasetsData, isLoading: datasetsLoading } = useDatasetsList({
     pageSize: 100,
+    search: debouncedDatasetSearch,
   });
 
   const { data: columns, isLoading: columnsLoading } = useQuery({
@@ -43,6 +47,7 @@ const SelectDatasetSource = ({
             setDatasetId(e.target.value);
             setColumnIds([]);
           }}
+          onSearchChange={setDatasetSearch}
           options={(datasetsData?.items ?? []).map((dataset) => ({
             label: dataset.name,
             value: dataset.id,

--- a/frontend/src/sections/knowledge-base/CreateKnowledgeBase/SelectDatasetSource.jsx
+++ b/frontend/src/sections/knowledge-base/CreateKnowledgeBase/SelectDatasetSource.jsx
@@ -1,0 +1,94 @@
+import { Box, Typography } from "@mui/material";
+import PropTypes from "prop-types";
+import React from "react";
+import { useQuery } from "@tanstack/react-query";
+import axios, { endpoints } from "src/utils/axios";
+import FormSearchSelectFieldState from "src/components/FromSearchSelectField/FormSearchSelectFieldState";
+import { useDatasetsList } from "src/sections/develop/hooks/useDatasetsList";
+import HelperText from "src/sections/develop-detail/Common/HelperText";
+
+// Alternative source to file uploads: build the KB from an existing
+// dataset's rows, indexing only the chosen columns as content.
+const SelectDatasetSource = ({
+  datasetId,
+  setDatasetId,
+  columnIds,
+  setColumnIds,
+  disabled,
+}) => {
+  const { data: datasetsData, isLoading: datasetsLoading } = useDatasetsList({
+    pageSize: 100,
+  });
+
+  const { data: columns, isLoading: columnsLoading } = useQuery({
+    queryKey: ["kb-dataset-columns", datasetId],
+    enabled: Boolean(datasetId),
+    queryFn: () =>
+      axios
+        .get(endpoints.develop.getDatasetColumns(datasetId))
+        .then((res) => res.data),
+    select: (data) => data?.result?.columns ?? [],
+  });
+
+  return (
+    <Box sx={{ display: "flex", flexDirection: "column", gap: 2 }}>
+      <Box>
+        <FormSearchSelectFieldState
+          fullWidth
+          label="Dataset"
+          placeholder={datasetsLoading ? "Loading datasets..." : "Select dataset"}
+          disabled={disabled || datasetsLoading}
+          value={datasetId}
+          onChange={(e) => {
+            setDatasetId(e.target.value);
+            setColumnIds([]);
+          }}
+          options={(datasetsData?.items ?? []).map((dataset) => ({
+            label: dataset.name,
+            value: dataset.id,
+          }))}
+          size="small"
+        />
+        <HelperText text="Rows from this dataset will be indexed into the knowledge base." />
+      </Box>
+      <Box>
+        <FormSearchSelectFieldState
+          fullWidth
+          multiple
+          label="Columns"
+          placeholder={
+            !datasetId
+              ? "Select a dataset first"
+              : columnsLoading
+                ? "Loading columns..."
+                : "Select columns"
+          }
+          disabled={disabled || !datasetId || columnsLoading}
+          value={columnIds}
+          onChange={(e) => setColumnIds(e.target.value)}
+          options={(columns ?? []).map((column) => ({
+            label: column.name,
+            value: column.id,
+          }))}
+          size="small"
+        />
+        <HelperText text="Values from the selected columns are concatenated into each document." />
+      </Box>
+      {datasetId && !columnsLoading && columns?.length === 0 && (
+        <Typography typography="s2" color="text.disabled">
+          This dataset has no columns to index.
+        </Typography>
+      )}
+    </Box>
+  );
+};
+
+export default SelectDatasetSource;
+
+SelectDatasetSource.propTypes = {
+  datasetId: PropTypes.string,
+  setDatasetId: PropTypes.func,
+  columnIds: PropTypes.array,
+  setColumnIds: PropTypes.func,
+  disabled: PropTypes.bool,
+};

--- a/frontend/src/sections/knowledge-base/CreateKnowledgeBase/SelectDatasetSource.test.jsx
+++ b/frontend/src/sections/knowledge-base/CreateKnowledgeBase/SelectDatasetSource.test.jsx
@@ -1,0 +1,79 @@
+import React from "react";
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, userEvent } from "src/utils/test-utils";
+import SelectDatasetSource from "./SelectDatasetSource";
+
+const mockDatasets = [
+  { id: "ds-1", name: "Support tickets" },
+  { id: "ds-2", name: "FAQ dataset" },
+];
+const mockColumns = [
+  { id: "col-1", name: "question" },
+  { id: "col-2", name: "answer" },
+];
+
+vi.mock("@tanstack/react-query", async () => {
+  const actual = await vi.importActual("@tanstack/react-query");
+  return {
+    ...actual,
+    useQuery: ({ queryKey, enabled }) => {
+      if (queryKey[0] === "datasets") {
+        return {
+          data: { items: mockDatasets, total: mockDatasets.length },
+          isLoading: false,
+        };
+      }
+      if (queryKey[0] === "kb-dataset-columns") {
+        return {
+          data: enabled ? mockColumns : undefined,
+          isLoading: false,
+        };
+      }
+      return { data: undefined, isLoading: false };
+    },
+  };
+});
+
+describe("SelectDatasetSource", () => {
+  it("disables the column picker until a dataset is chosen, and resets columns on dataset change", async () => {
+    const user = userEvent.setup();
+    const setDatasetId = vi.fn();
+    const setColumnIds = vi.fn();
+
+    render(
+      <SelectDatasetSource
+        datasetId={null}
+        setDatasetId={setDatasetId}
+        columnIds={[]}
+        setColumnIds={setColumnIds}
+      />,
+    );
+
+    expect(screen.getByPlaceholderText("Select a dataset first")).toBeDisabled();
+
+    await user.click(screen.getByPlaceholderText("Select dataset"));
+    await user.click(await screen.findByText("Support tickets"));
+
+    expect(setDatasetId).toHaveBeenCalledWith("ds-1");
+    expect(setColumnIds).toHaveBeenCalledWith([]);
+  });
+
+  it("passes the full selected array back through setColumnIds on multi-select", async () => {
+    const user = userEvent.setup();
+    const setColumnIds = vi.fn();
+
+    render(
+      <SelectDatasetSource
+        datasetId="ds-1"
+        setDatasetId={vi.fn()}
+        columnIds={[]}
+        setColumnIds={setColumnIds}
+      />,
+    );
+
+    await user.click(screen.getByPlaceholderText("Select columns"));
+    await user.click(await screen.findByText("question"));
+
+    expect(setColumnIds).toHaveBeenCalledWith(["col-1"]);
+  });
+});

--- a/frontend/src/sections/knowledge-base/CreateKnowledgeBase/SelectDatasetSource.test.jsx
+++ b/frontend/src/sections/knowledge-base/CreateKnowledgeBase/SelectDatasetSource.test.jsx
@@ -1,12 +1,18 @@
 import React from "react";
 import { describe, it, expect, vi } from "vitest";
-import { render, screen, userEvent } from "src/utils/test-utils";
+import { render, screen, userEvent, waitFor } from "src/utils/test-utils";
 import SelectDatasetSource from "./SelectDatasetSource";
 
 const mockDatasets = [
   { id: "ds-1", name: "Support tickets" },
   { id: "ds-2", name: "FAQ dataset" },
 ];
+// Only ever returned when the query is actually re-run with this search term
+// — it's not in mockDatasets, so it can never appear via the existing
+// client-side label filter alone. Its appearance is the only way to prove
+// onSearchChange reached useDatasetsList's `search` param, not just the
+// dropdown's own local filtering of the initial page.
+const searchOnlyDataset = { id: "ds-3", name: "Archived export Q1" };
 const mockColumns = [
   { id: "col-1", name: "question" },
   { id: "col-2", name: "answer" },
@@ -18,8 +24,11 @@ vi.mock("@tanstack/react-query", async () => {
     ...actual,
     useQuery: ({ queryKey, enabled }) => {
       if (queryKey[0] === "datasets") {
+        const search = queryKey[4];
+        const items =
+          search === "archive" ? [searchOnlyDataset] : mockDatasets;
         return {
-          data: { items: mockDatasets, total: mockDatasets.length },
+          data: { items, total: items.length },
           isLoading: false,
         };
       }
@@ -75,5 +84,28 @@ describe("SelectDatasetSource", () => {
     await user.click(await screen.findByText("question"));
 
     expect(setColumnIds).toHaveBeenCalledWith(["col-1"]);
+  });
+
+  it("drives the dataset list query from what the user types, not just a fixed page", async () => {
+    const user = userEvent.setup();
+
+    render(
+      <SelectDatasetSource
+        datasetId={null}
+        setDatasetId={vi.fn()}
+        columnIds={[]}
+        setColumnIds={vi.fn()}
+      />,
+    );
+
+    const datasetField = screen.getByPlaceholderText("Select dataset");
+    await user.click(datasetField);
+    expect(await screen.findByText("Support tickets")).toBeInTheDocument();
+
+    await user.type(datasetField, "archive");
+
+    await waitFor(() => {
+      expect(screen.getByText("Archived export Q1")).toBeInTheDocument();
+    });
   });
 });

--- a/futureagi/model_hub/serializers/contracts.py
+++ b/futureagi/model_hub/serializers/contracts.py
@@ -706,6 +706,14 @@ class LegacyKnowledgeBaseMutationRequestSerializer(serializers.Serializer):
         required=False,
         default=list,
     )
+    # Alternative source to `file` uploads: build the KB from an existing
+    # dataset's rows instead, indexing only the chosen columns.
+    dataset_id = serializers.UUIDField(required=False)
+    column_ids = serializers.ListField(
+        child=serializers.UUIDField(),
+        required=False,
+        default=list,
+    )
 
 
 class LegacyKnowledgeBaseFilesRequestSerializer(serializers.Serializer):

--- a/futureagi/model_hub/tasks/develop_dataset.py
+++ b/futureagi/model_hub/tasks/develop_dataset.py
@@ -803,29 +803,36 @@ def ingest_dataset_rows_to_kb(dataset_id, column_ids, kb_id, org):
         indexed_count = 0
         error_count = 0
 
-        for row in rows:
-            if is_kb_deleted_or_cancelled(kb_id):
-                logger.info(
-                    f"KB {kb_id} was deleted/cancelled during dataset ingestion, stopping"
+        # One worker pool shared across every row, instead of process_content
+        # spinning up its own each call — the difference between one pool and
+        # one per row at real dataset sizes.
+        with ThreadPoolExecutor(max_workers=20) as shared_executor:
+            for row in rows:
+                if is_kb_deleted_or_cancelled(kb_id):
+                    logger.info(
+                        f"KB {kb_id} was deleted/cancelled during dataset ingestion, stopping"
+                    )
+                    return None
+
+                row_cells = cells_by_row.get(row.id, {})
+                row_text = "\n\n".join(
+                    row_cells[col_id] for col_id in column_ids if col_id in row_cells
                 )
-                return None
+                if not row_text.strip():
+                    continue
 
-            row_cells = cells_by_row.get(row.id, {})
-            row_text = "\n\n".join(
-                row_cells[col_id] for col_id in column_ids if col_id in row_cells
-            )
-            if not row_text.strip():
-                continue
-
-            try:
-                # ponytail: one process_content() call per row (spins up its own
-                # worker pool each time) - fine at typical dataset sizes; batch
-                # rows together if large-dataset ingestion becomes common.
-                indexer.process_content(row_text, str(row.id), str(kb_id), str(org))
-                indexed_count += 1
-            except Exception as e:
-                logger.error(f"Error indexing row {row.id} into KB {kb_id}: {e}")
-                error_count += 1
+                try:
+                    indexer.process_content(
+                        row_text,
+                        str(row.id),
+                        str(kb_id),
+                        str(org),
+                        executor=shared_executor,
+                    )
+                    indexed_count += 1
+                except Exception as e:
+                    logger.error(f"Error indexing row {row.id} into KB {kb_id}: {e}")
+                    error_count += 1
 
         if is_kb_deleted_or_cancelled(kb_id):
             logger.info(f"KB {kb_id} was deleted/cancelled, skipping status update")

--- a/futureagi/model_hub/tasks/develop_dataset.py
+++ b/futureagi/model_hub/tasks/develop_dataset.py
@@ -769,6 +769,96 @@ def ingest_files_to_s3(files, kb_id, org):
 
 
 @temporal_activity(time_limit=3600, queue="tasks_l")
+def ingest_dataset_rows_to_kb(dataset_id, column_ids, kb_id, org):
+    """Index an existing dataset's rows into a Knowledge Base.
+
+    For each row, the values of `column_ids` are concatenated (in the given
+    order) into one document and embedded via KBIndexer.process_content,
+    reusing the same chunk/embed/upsert path as file-based ingestion.
+    """
+    if not column_ids:
+        return None
+
+    if is_kb_deleted_or_cancelled(kb_id):
+        logger.info(f"KB {kb_id} was deleted/cancelled, skipping dataset ingestion")
+        return None
+
+    try:
+        kb_file = KnowledgeBaseFile.objects.get(id=kb_id)
+        kb_file.status = StatusType.PROCESSING.value
+        kb_file.save()
+
+        rows = Row.objects.filter(dataset_id=dataset_id, deleted=False).order_by(
+            "order"
+        )
+        cells = Cell.objects.filter(
+            dataset_id=dataset_id, column_id__in=column_ids, deleted=False
+        ).exclude(value__isnull=True).exclude(value="")
+
+        cells_by_row = {}
+        for cell in cells:
+            cells_by_row.setdefault(cell.row_id, {})[str(cell.column_id)] = cell.value
+
+        indexer = KBIndexer()
+        indexed_count = 0
+        error_count = 0
+
+        for row in rows:
+            if is_kb_deleted_or_cancelled(kb_id):
+                logger.info(
+                    f"KB {kb_id} was deleted/cancelled during dataset ingestion, stopping"
+                )
+                return None
+
+            row_cells = cells_by_row.get(row.id, {})
+            row_text = "\n\n".join(
+                row_cells[col_id] for col_id in column_ids if col_id in row_cells
+            )
+            if not row_text.strip():
+                continue
+
+            try:
+                # ponytail: one process_content() call per row (spins up its own
+                # worker pool each time) - fine at typical dataset sizes; batch
+                # rows together if large-dataset ingestion becomes common.
+                indexer.process_content(row_text, str(row.id), str(kb_id), str(org))
+                indexed_count += 1
+            except Exception as e:
+                logger.error(f"Error indexing row {row.id} into KB {kb_id}: {e}")
+                error_count += 1
+
+        if is_kb_deleted_or_cancelled(kb_id):
+            logger.info(f"KB {kb_id} was deleted/cancelled, skipping status update")
+            return None
+
+        kb_file.refresh_from_db()
+        if indexed_count == 0:
+            kb_file.status = StatusType.FAILED.value
+            kb_file.last_error = "No content found in the selected columns to index."
+        elif error_count:
+            kb_file.status = StatusType.PARTIAL_COMPLETED.value
+            kb_file.last_error = f"{error_count} row(s) failed to index."
+        else:
+            kb_file.status = StatusType.COMPLETED.value
+        kb_file.save()
+
+        return {"indexed": indexed_count, "errors": error_count}
+
+    except Exception as e:
+        logger.exception(
+            f"Error ingesting dataset {dataset_id} into KB {kb_id}: {e}"
+        )
+        try:
+            kb_file = KnowledgeBaseFile.objects.get(id=kb_id)
+            kb_file.status = StatusType.FAILED.value
+            kb_file.last_error = str(e)
+            kb_file.save()
+        except Exception as inner_e:
+            logger.error(f"Error updating KB status: {inner_e}")
+        return None
+
+
+@temporal_activity(time_limit=3600, queue="tasks_l")
 def remove_kb_files(files, org, kb_id):
     if not kb_id:
         return None

--- a/futureagi/model_hub/tests/test_ingest_dataset_rows_to_kb.py
+++ b/futureagi/model_hub/tests/test_ingest_dataset_rows_to_kb.py
@@ -1,0 +1,134 @@
+"""Regression coverage for ``ingest_dataset_rows_to_kb`` (#933 review follow-up).
+
+``KBIndexer`` is mocked at the class boundary — the real indexer talks to S3
+and an embedding service, neither available here — so these tests verify the
+task's own row selection, per-row concatenation, and worker-pool reuse.
+"""
+
+import pytest
+
+from model_hub.models.choices import (
+    DataTypeChoices,
+    DatasetSourceChoices,
+    SourceChoices,
+    StatusType,
+)
+from model_hub.models.develop_dataset import Cell, Column, Dataset, KnowledgeBaseFile, Row
+from model_hub.tasks.develop_dataset import ingest_dataset_rows_to_kb
+from tfc.middleware.workspace_context import clear_workspace_context
+
+MODULE = "model_hub.tasks.develop_dataset"
+
+
+@pytest.fixture(autouse=True)
+def _clear_workspace_context():
+    """These tests query KnowledgeBaseFile.objects (workspace-scoped) against
+    a KB created with no workspace — make sure no earlier test's thread-local
+    workspace context is still set."""
+    clear_workspace_context()
+    yield
+    clear_workspace_context()
+
+
+def _dataset_with_rows(organization, rows):
+    """``rows`` is a list of ``{column_name: value}`` dicts, one per row."""
+    dataset = Dataset.objects.create(
+        name="ingest-source-dataset",
+        source=DatasetSourceChoices.BUILD.value,
+        organization=organization,
+    )
+    column_names = list({name for row in rows for name in row})
+    columns = {
+        name: Column.objects.create(
+            name=name,
+            data_type=DataTypeChoices.TEXT.value,
+            dataset=dataset,
+            source=SourceChoices.OTHERS.value,
+            status=StatusType.COMPLETED.value,
+        )
+        for name in column_names
+    }
+    for order, row_values in enumerate(rows):
+        row = Row.objects.create(dataset=dataset, order=order)
+        for name, value in row_values.items():
+            Cell.objects.create(
+                dataset=dataset, column=columns[name], row=row, value=value
+            )
+    return dataset, columns
+
+
+@pytest.fixture
+def kb(organization):
+    return KnowledgeBaseFile.objects.create(
+        organization=organization, name="ingest-target-kb"
+    )
+
+
+@pytest.mark.integration
+class TestIngestDatasetRowsToKb:
+    def test_concatenates_selected_columns_per_row_in_order(
+        self, mocker, organization, kb
+    ):
+        dataset, columns = _dataset_with_rows(
+            organization,
+            [
+                {"title": "Row One Title", "body": "Row one body text."},
+                {"title": "Row Two Title", "body": "Row two body text."},
+            ],
+        )
+        indexer = mocker.patch(f"{MODULE}.KBIndexer").return_value
+
+        result = ingest_dataset_rows_to_kb(
+            str(dataset.id),
+            [str(columns["title"].id), str(columns["body"].id)],
+            str(kb.id),
+            str(organization.id),
+        )
+
+        assert result == {"indexed": 2, "errors": 0}
+        texts = [call.args[0] for call in indexer.process_content.call_args_list]
+        assert texts == [
+            "Row One Title\n\nRow one body text.",
+            "Row Two Title\n\nRow two body text.",
+        ]
+        kb.refresh_from_db()
+        assert kb.status == StatusType.COMPLETED.value
+
+    def test_shares_one_executor_across_all_rows(self, mocker, organization, kb):
+        dataset, columns = _dataset_with_rows(
+            organization,
+            [{"body": "first"}, {"body": "second"}, {"body": "third"}],
+        )
+        indexer = mocker.patch(f"{MODULE}.KBIndexer").return_value
+
+        ingest_dataset_rows_to_kb(
+            str(dataset.id),
+            [str(columns["body"].id)],
+            str(kb.id),
+            str(organization.id),
+        )
+
+        executors_used = {
+            call.kwargs["executor"] for call in indexer.process_content.call_args_list
+        }
+        assert indexer.process_content.call_count == 3
+        assert len(executors_used) == 1
+
+    def test_rows_with_no_selected_column_content_are_skipped(
+        self, mocker, organization, kb
+    ):
+        dataset, columns = _dataset_with_rows(
+            organization,
+            [{"body": "has content"}, {"body": ""}],
+        )
+        indexer = mocker.patch(f"{MODULE}.KBIndexer").return_value
+
+        result = ingest_dataset_rows_to_kb(
+            str(dataset.id),
+            [str(columns["body"].id)],
+            str(kb.id),
+            str(organization.id),
+        )
+
+        assert result == {"indexed": 1, "errors": 0}
+        assert indexer.process_content.call_count == 1

--- a/futureagi/model_hub/tests/test_knowledge_base_create.py
+++ b/futureagi/model_hub/tests/test_knowledge_base_create.py
@@ -18,7 +18,14 @@ from model_hub.models.choices import (
     SourceChoices,
     StatusType,
 )
-from model_hub.models.develop_dataset import Column, Dataset, Files, KnowledgeBaseFile
+from model_hub.models.develop_dataset import (
+    Cell,
+    Column,
+    Dataset,
+    Files,
+    KnowledgeBaseFile,
+    Row,
+)
 from tfc.constants.api_calls import APICallStatusChoices
 
 VIEW = "model_hub.views.develop_dataset.CreateKnowledgeBaseView"
@@ -294,7 +301,7 @@ class TestLegacyKbCreateFromDataset:
         response = auth_client.post(
             KB_URL,
             {"name": "ghost-dataset-kb", "dataset_id": "00000000-0000-0000-0000-000000000000"},
-            format="json",
+            format="multipart",
         )
 
         assert response.status_code == status.HTTP_400_BAD_REQUEST
@@ -308,7 +315,7 @@ class TestLegacyKbCreateFromDataset:
         response = auth_client.post(
             KB_URL,
             {"name": "no-columns-kb", "dataset_id": str(dataset.id)},
-            format="json",
+            format="multipart",
         )
 
         assert response.status_code == status.HTTP_400_BAD_REQUEST
@@ -329,7 +336,7 @@ class TestLegacyKbCreateFromDataset:
                 "dataset_id": str(dataset.id),
                 "column_ids": [str(foreign_column.id)],
             },
-            format="json",
+            format="multipart",
         )
 
         assert response.status_code == status.HTTP_400_BAD_REQUEST
@@ -338,6 +345,9 @@ class TestLegacyKbCreateFromDataset:
     def test_creates_kb_with_no_files_and_schedules_dataset_ingestion(
         self, mocker, auth_client, allow_entitlements, organization
     ):
+        # Posted as multipart, matching how the drawer actually submits this
+        # (CreateKnowledgeBaseDrawer.jsx appends dataset_id/column_ids to a
+        # FormData) — a JSON body would mask a QueryDict-only parsing bug.
         dataset, column = _dataset_with_column(organization)
         schedule = mocker.patch(
             f"{MODULE}.schedule_dataset_kb_ingestion_on_commit"
@@ -350,7 +360,7 @@ class TestLegacyKbCreateFromDataset:
                 "dataset_id": str(dataset.id),
                 "column_ids": [str(column.id)],
             },
-            format="json",
+            format="multipart",
         )
 
         assert response.status_code == status.HTTP_200_OK
@@ -359,10 +369,14 @@ class TestLegacyKbCreateFromDataset:
 
         kb = KnowledgeBaseFile.objects.get(id=result["kb_id"])
         assert kb.organization_id == organization.id
+        assert kb.workspace_id == dataset.workspace_id
+        # No cells for this column in this dataset, so no content to size.
         assert kb.size == 0
         assert kb.files.count() == 0
 
-        schedule.assert_called_once_with(dataset.id, [str(column.id)], kb.id, organization.id)
+        # column_ids is a ListField(UUIDField) — validated_data holds UUID
+        # objects, not the strings that were posted.
+        schedule.assert_called_once_with(dataset.id, [column.id], kb.id, organization.id)
 
     def test_duplicate_column_ids_are_deduped_before_scheduling(
         self, mocker, auth_client, allow_entitlements, organization
@@ -379,14 +393,93 @@ class TestLegacyKbCreateFromDataset:
                 "dataset_id": str(dataset.id),
                 "column_ids": [str(column.id), str(column.id)],
             },
-            format="json",
+            format="multipart",
         )
 
         assert response.status_code == status.HTTP_200_OK
-        kb_id = response.json()["result"]["kb_id"]
+        kb = KnowledgeBaseFile.objects.get(id=response.json()["result"]["kb_id"])
         schedule.assert_called_once_with(
-            dataset.id, [str(column.id)], kb_id, organization.id
+            dataset.id, [column.id], kb.id, organization.id
         )
+
+    def test_kb_size_reflects_selected_column_content(
+        self, mocker, auth_client, allow_entitlements, organization
+    ):
+        """size must come from the actual cell content, not stay pinned at 0
+        (a create-time quota gate that reads kb.size would fail open otherwise)."""
+        dataset, column = _dataset_with_column(organization)
+        row = Row.objects.create(dataset=dataset, order=0)
+        Cell.objects.create(
+            dataset=dataset, column=column, row=row, value="twelve chars"
+        )
+        mocker.patch(f"{MODULE}.schedule_dataset_kb_ingestion_on_commit")
+
+        response = auth_client.post(
+            KB_URL,
+            {
+                "name": "sized-dataset-kb",
+                "dataset_id": str(dataset.id),
+                "column_ids": [str(column.id)],
+            },
+            format="multipart",
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        kb = KnowledgeBaseFile.objects.get(id=response.json()["result"]["kb_id"])
+        assert kb.size == len("twelve chars")
+
+    def test_dataset_in_another_workspace_is_rejected(
+        self, mocker, auth_client, allow_entitlements, organization, user, workspace
+    ):
+        """The picker is org-wide (GetDatasetsView), but indexing must stay
+        workspace-scoped like every other dataset lookup in this file."""
+        from accounts.models.workspace import Workspace
+
+        other_workspace = Workspace.objects.create(
+            name="other-workspace",
+            organization=organization,
+            is_default=False,
+            created_by=user,
+        )
+        dataset, column = _dataset_with_column(
+            organization, workspace=other_workspace
+        )
+        schedule = mocker.patch(
+            f"{MODULE}.schedule_dataset_kb_ingestion_on_commit"
+        )
+
+        response = auth_client.post(
+            KB_URL,
+            {
+                "name": "cross-workspace-kb",
+                "dataset_id": str(dataset.id),
+                "column_ids": [str(column.id)],
+            },
+            format="multipart",
+        )
+
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert not KnowledgeBaseFile.objects.filter(name="cross-workspace-kb").exists()
+        schedule.assert_not_called()
+
+    def test_dataset_and_files_together_is_rejected(
+        self, auth_client, allow_entitlements, organization
+    ):
+        dataset, column = _dataset_with_column(organization)
+
+        response = auth_client.post(
+            KB_URL,
+            {
+                "name": "mixed-source-kb",
+                "dataset_id": str(dataset.id),
+                "column_ids": [str(column.id)],
+                "file": _upload(),
+            },
+            format="multipart",
+        )
+
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert not KnowledgeBaseFile.objects.filter(name="mixed-source-kb").exists()
 
 
 @pytest.mark.integration

--- a/futureagi/model_hub/tests/test_knowledge_base_create.py
+++ b/futureagi/model_hub/tests/test_knowledge_base_create.py
@@ -12,8 +12,13 @@ from django.core.files.uploadedfile import SimpleUploadedFile
 from rest_framework import status
 
 from model_hub.constants import MAX_KB_SIZE
-from model_hub.models.choices import StatusType
-from model_hub.models.develop_dataset import Files, KnowledgeBaseFile
+from model_hub.models.choices import (
+    DataTypeChoices,
+    DatasetSourceChoices,
+    SourceChoices,
+    StatusType,
+)
+from model_hub.models.develop_dataset import Column, Dataset, Files, KnowledgeBaseFile
 from tfc.constants.api_calls import APICallStatusChoices
 
 VIEW = "model_hub.views.develop_dataset.CreateKnowledgeBaseView"
@@ -34,6 +39,23 @@ def _existing_file(name="already-there.txt"):
         updated_by="Test User",
         uploaded_url="https://example.com/test.txt",
     )
+
+
+def _dataset_with_column(organization, workspace=None, column_name="content"):
+    dataset = Dataset.objects.create(
+        name="kb-source-dataset",
+        source=DatasetSourceChoices.BUILD.value,
+        organization=organization,
+        workspace=workspace,
+    )
+    column = Column.objects.create(
+        name=column_name,
+        data_type=DataTypeChoices.TEXT.value,
+        dataset=dataset,
+        source=SourceChoices.OTHERS.value,
+        status=StatusType.COMPLETED.value,
+    )
+    return dataset, column
 
 
 @pytest.fixture
@@ -259,6 +281,112 @@ class TestLegacyKbCreateHappyPath:
         kb = KnowledgeBaseFile.objects.get(id=response.json()["result"]["kb_id"])
         assert kb.organization_id == organization.id
         assert kb.size == 0
+
+
+@pytest.mark.integration
+@pytest.mark.api
+class TestLegacyKbCreateFromDataset:
+    """``dataset_id``/``column_ids`` as an alternative source to ``file`` uploads."""
+
+    def test_missing_dataset_is_rejected(
+        self, auth_client, allow_entitlements, organization
+    ):
+        response = auth_client.post(
+            KB_URL,
+            {"name": "ghost-dataset-kb", "dataset_id": "00000000-0000-0000-0000-000000000000"},
+            format="json",
+        )
+
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert not KnowledgeBaseFile.objects.filter(name="ghost-dataset-kb").exists()
+
+    def test_no_columns_selected_is_rejected(
+        self, auth_client, allow_entitlements, organization
+    ):
+        dataset, _column = _dataset_with_column(organization)
+
+        response = auth_client.post(
+            KB_URL,
+            {"name": "no-columns-kb", "dataset_id": str(dataset.id)},
+            format="json",
+        )
+
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert not KnowledgeBaseFile.objects.filter(name="no-columns-kb").exists()
+
+    def test_column_from_another_dataset_is_rejected(
+        self, auth_client, allow_entitlements, organization
+    ):
+        dataset, _column = _dataset_with_column(organization)
+        _other_dataset, foreign_column = _dataset_with_column(
+            organization, column_name="other"
+        )
+
+        response = auth_client.post(
+            KB_URL,
+            {
+                "name": "wrong-column-kb",
+                "dataset_id": str(dataset.id),
+                "column_ids": [str(foreign_column.id)],
+            },
+            format="json",
+        )
+
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert not KnowledgeBaseFile.objects.filter(name="wrong-column-kb").exists()
+
+    def test_creates_kb_with_no_files_and_schedules_dataset_ingestion(
+        self, mocker, auth_client, allow_entitlements, organization
+    ):
+        dataset, column = _dataset_with_column(organization)
+        schedule = mocker.patch(
+            f"{MODULE}.schedule_dataset_kb_ingestion_on_commit"
+        )
+
+        response = auth_client.post(
+            KB_URL,
+            {
+                "name": "dataset-sourced-kb",
+                "dataset_id": str(dataset.id),
+                "column_ids": [str(column.id)],
+            },
+            format="json",
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        result = response.json()["result"]
+        assert result["file_ids"] == []
+
+        kb = KnowledgeBaseFile.objects.get(id=result["kb_id"])
+        assert kb.organization_id == organization.id
+        assert kb.size == 0
+        assert kb.files.count() == 0
+
+        schedule.assert_called_once_with(dataset.id, [str(column.id)], kb.id, organization.id)
+
+    def test_duplicate_column_ids_are_deduped_before_scheduling(
+        self, mocker, auth_client, allow_entitlements, organization
+    ):
+        dataset, column = _dataset_with_column(organization)
+        schedule = mocker.patch(
+            f"{MODULE}.schedule_dataset_kb_ingestion_on_commit"
+        )
+
+        response = auth_client.post(
+            KB_URL,
+            {
+                "name": "dedup-columns-kb",
+                "dataset_id": str(dataset.id),
+                "column_ids": [str(column.id), str(column.id)],
+            },
+            format="json",
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        kb_id = response.json()["result"]["kb_id"]
+        schedule.assert_called_once_with(
+            dataset.id, [str(column.id)], kb_id, organization.id
+        )
 
 
 @pytest.mark.integration

--- a/futureagi/model_hub/utils/kb_helpers.py
+++ b/futureagi/model_hub/utils/kb_helpers.py
@@ -167,6 +167,35 @@ def schedule_kb_ingestion_on_commit(file_metadata, kb_id, org_id):
     transaction.on_commit(_start_ingestion)
 
 
+def schedule_dataset_kb_ingestion_on_commit(dataset_id, column_ids, kb_id, org_id):
+    """
+    Schedule KB ingestion from an existing dataset's rows to run after
+    transaction commits. Mirrors schedule_kb_ingestion_on_commit, but the
+    source is dataset rows/columns instead of uploaded files, so there is
+    no S3 upload to poll for first.
+
+    Args:
+        dataset_id: Source Dataset ID
+        column_ids: Ordered list of Column IDs whose cell values become
+            document content, in the order they should be concatenated
+        kb_id: Knowledge Base ID
+        org_id: Organization ID
+    """
+    dataset_id_str = str(dataset_id)
+    column_ids_str = [str(c) for c in column_ids]
+    kb_id_str = str(kb_id)
+    org_id_str = str(org_id)
+
+    def _start_ingestion():
+        from model_hub.tasks.develop_dataset import ingest_dataset_rows_to_kb
+
+        ingest_dataset_rows_to_kb.delay(
+            dataset_id_str, column_ids_str, kb_id_str, org_id_str
+        )
+
+    transaction.on_commit(_start_ingestion)
+
+
 def cancel_kb_ingestion_workflow(kb_id):
     """
     Cancel a running KB ingestion workflow.

--- a/futureagi/model_hub/utils/kb_indexer.py
+++ b/futureagi/model_hub/utils/kb_indexer.py
@@ -160,8 +160,20 @@ class KBIndexer:
 
     @log_performance
     def process_content(
-        self, text: str, file_id: str, kb_id: str, organization_id: str
+        self,
+        text: str,
+        file_id: str,
+        kb_id: str,
+        organization_id: str,
+        executor: concurrent.futures.ThreadPoolExecutor | None = None,
     ):
+        """Chunk, embed and upsert one document's text.
+
+        By default spins up its own worker pool for this call. Pass an
+        existing ``executor`` (e.g. one shared across a batch of documents)
+        to submit onto that instead — this call never shuts down an
+        executor it didn't create itself.
+        """
         # Optimize chunk size based on text length
         chunk_size = 800
         chunk_overlap = 150
@@ -242,10 +254,12 @@ class KBIndexer:
         # Wrap function with OTel context propagation for thread safety
         wrapped_process_batch = wrap_for_thread(process_batch)
 
-        with concurrent.futures.ThreadPoolExecutor(max_workers=20) as executor:
+        owns_pool = executor is None
+        pool = executor or concurrent.futures.ThreadPoolExecutor(max_workers=20)
+        try:
             # Submit all batch processing tasks
             future_to_batch = {
-                executor.submit(wrapped_process_batch, i): i
+                pool.submit(wrapped_process_batch, i): i
                 for i in range((len(documents) + batch_size - 1) // batch_size)
             }
 
@@ -259,6 +273,9 @@ class KBIndexer:
                     error_msg = f"Error in batch {batch_idx}: {str(e)}"
                     logger.exception(error_msg)
                     errors.append(error_msg)
+        finally:
+            if owns_pool:
+                pool.shutdown(wait=True)
 
         # After all batches are processed, check for errors
         if errors:

--- a/futureagi/model_hub/views/develop_dataset.py
+++ b/futureagi/model_hub/views/develop_dataset.py
@@ -53,7 +53,7 @@ from django.db.models import (
     Value,
     When,
 )
-from django.db.models.functions import Cast, Coalesce
+from django.db.models.functions import Cast, Coalesce, Length
 from django.forms import model_to_dict
 from django.http import FileResponse, Http404
 from django.shortcuts import get_object_or_404
@@ -14821,6 +14821,22 @@ class CreateKnowledgeBaseView(APIView):
         size = kb.size if kb is not None else 0
         return size + sum(f.size for f in files)  # 1 GB
 
+    def calculate_dataset_kb_size(self, dataset, column_ids):
+        """Character length of the selected cells, as a size proxy for the
+        MAX_KB_SIZE gate — the same role ``calculate_total_size`` plays for
+        uploaded file bytes. Computed in the DB so it scales with the
+        dataset instead of loading every cell's text into Python."""
+        total = (
+            Cell.objects.filter(
+                dataset=dataset, column_id__in=column_ids, deleted=False
+            )
+            .exclude(value__isnull=True)
+            .exclude(value="")
+            .annotate(char_len=Length("value"))
+            .aggregate(total=Sum("char_len"))["total"]
+        )
+        return total or 0
+
     def validate_all_files(self, files):
         """
         Validate ALL files using ThreadPoolExecutor (same pattern as original dev).
@@ -15157,11 +15173,16 @@ class CreateKnowledgeBaseView(APIView):
             # twice into every row's indexed text.
             column_ids = list(dict.fromkeys(data.get("column_ids") or []))
 
+            if dataset_id and request.FILES.getlist("file"):
+                return self._gm.bad_request(
+                    get_error_message("DATASET_AND_FILES_PROVIDED")
+                )
+
             dataset = None
             if dataset_id:
-                dataset = Dataset.objects.filter(
-                    id=dataset_id, organization=org, deleted=False
-                ).first()
+                dataset = (
+                    _request_dataset_queryset(request).filter(id=dataset_id).first()
+                )
                 if not dataset:
                     return self._gm.bad_request(get_error_message("DATASET_NOT_FOUND"))
                 if not column_ids:
@@ -15169,7 +15190,7 @@ class CreateKnowledgeBaseView(APIView):
                         get_error_message("NO_COLUMNS_SELECTED")
                     )
                 matched_columns = Column.objects.filter(
-                    id__in=column_ids, dataset=dataset
+                    id__in=column_ids, dataset=dataset, deleted=False
                 ).count()
                 if matched_columns != len(set(column_ids)):
                     return self._gm.bad_request(get_error_message("COLUMN_NOT_FOUND"))
@@ -15179,7 +15200,11 @@ class CreateKnowledgeBaseView(APIView):
             if len(file_names) != len(uploaded_files):
                 return self._gm.bad_request(get_error_message("DUPLICATE_FILES"))
 
-            updated_size = self.calculate_total_size(uploaded_files)
+            updated_size = (
+                self.calculate_dataset_kb_size(dataset, column_ids)
+                if dataset
+                else self.calculate_total_size(uploaded_files)
+            )
             if updated_size > MAX_KB_SIZE:
                 return self._gm.bad_request(get_error_message("MAX_KB_SIZE_EXCEEDED"))
 
@@ -15253,11 +15278,15 @@ class CreateKnowledgeBaseView(APIView):
                     )
 
                 # All files are valid - create KB
+                # workspace=None for the upload path preserves its existing
+                # (pre-existing, out of scope here) behavior; the dataset
+                # path inherits the source dataset's own workspace.
                 kb = KnowledgeBaseFile.objects.create(
                     organization=org,
                     created_by=created_by,
                     name=final_kb_name,
                     size=updated_size,
+                    workspace=dataset.workspace if dataset else None,
                 )
 
                 if dataset:

--- a/futureagi/model_hub/views/develop_dataset.py
+++ b/futureagi/model_hub/views/develop_dataset.py
@@ -244,6 +244,7 @@ from model_hub.utils.function_eval_params import (
 )
 from model_hub.utils.kb_helpers import (
     cancel_kb_ingestion_workflow,
+    schedule_dataset_kb_ingestion_on_commit,
     schedule_kb_ingestion_on_commit,
 )
 from model_hub.utils.SQL_queries import SQLQueryHandler
@@ -15150,7 +15151,30 @@ class CreateKnowledgeBaseView(APIView):
 
             data = request.validated_data
             created_by = User.objects.get(id=request.user.id).name
-            uploaded_files = request.FILES.getlist("file")
+            dataset_id = data.get("dataset_id")
+            # De-dupe (order-preserving): a repeated column would otherwise
+            # double-count toward matched_columns below and get concatenated
+            # twice into every row's indexed text.
+            column_ids = list(dict.fromkeys(data.get("column_ids") or []))
+
+            dataset = None
+            if dataset_id:
+                dataset = Dataset.objects.filter(
+                    id=dataset_id, organization=org, deleted=False
+                ).first()
+                if not dataset:
+                    return self._gm.bad_request(get_error_message("DATASET_NOT_FOUND"))
+                if not column_ids:
+                    return self._gm.bad_request(
+                        get_error_message("NO_COLUMNS_SELECTED")
+                    )
+                matched_columns = Column.objects.filter(
+                    id__in=column_ids, dataset=dataset
+                ).count()
+                if matched_columns != len(set(column_ids)):
+                    return self._gm.bad_request(get_error_message("COLUMN_NOT_FOUND"))
+
+            uploaded_files = [] if dataset else request.FILES.getlist("file")
             file_names = {file.name for file in uploaded_files}
             if len(file_names) != len(uploaded_files):
                 return self._gm.bad_request(get_error_message("DUPLICATE_FILES"))
@@ -15236,20 +15260,30 @@ class CreateKnowledgeBaseView(APIView):
                     size=updated_size,
                 )
 
-                # Create file records and start S3 upload (fire-and-forget)
-                created_files = self.create_files_and_upload(
-                    uploaded_files, created_by, kb.id, org_id=str(org.id)
-                )
+                if dataset:
+                    created_files = {"files": [], "file_metadata": {}}
+                    # Schedule dataset-row ingestion after transaction commits
+                    schedule_dataset_kb_ingestion_on_commit(
+                        dataset.id,
+                        column_ids,
+                        kb.id,
+                        org.id,
+                    )
+                else:
+                    # Create file records and start S3 upload (fire-and-forget)
+                    created_files = self.create_files_and_upload(
+                        uploaded_files, created_by, kb.id, org_id=str(org.id)
+                    )
 
-                kb.files.set(Files.objects.filter(id__in=created_files["files"]))
-                kb.save()
+                    kb.files.set(Files.objects.filter(id__in=created_files["files"]))
+                    kb.save()
 
-                # Schedule ingestion after transaction commits
-                schedule_kb_ingestion_on_commit(
-                    created_files.get("file_metadata", {}),
-                    kb.id,
-                    org.id,
-                )
+                    # Schedule ingestion after transaction commits
+                    schedule_kb_ingestion_on_commit(
+                        created_files.get("file_metadata", {}),
+                        kb.id,
+                        org.id,
+                    )
 
             end_time = time.time()
             logger.info(f"END TIME: {str(end_time)}")

--- a/futureagi/tfc/utils/error_codes.py
+++ b/futureagi/tfc/utils/error_codes.py
@@ -699,6 +699,9 @@ err_dict = {
     "INVALID_FILES_PROVIDED": ["Invalid files provided. Please try again."],
     "KNOWLEDGE_BASE_NOT_FOUND": ["Knowledge base not found."],
     "KNOWLEDGE_BASE_ALREADY_EXISTS": ["Knowledge base name must be unique."],
+    "NO_COLUMNS_SELECTED": [
+        "Select at least one column to index from the dataset."
+    ],
     "NO_EVALUATION_COLUMNS_FOUND": ["No evaluation columns present in given datasets."],
     "MAX_KB_SIZE_EXCEEDED": ["Maximum knowledge base size exceeded."],
     "KB_CREATION_LIMIT_REACHED": [

--- a/futureagi/tfc/utils/error_codes.py
+++ b/futureagi/tfc/utils/error_codes.py
@@ -702,6 +702,9 @@ err_dict = {
     "NO_COLUMNS_SELECTED": [
         "Select at least one column to index from the dataset."
     ],
+    "DATASET_AND_FILES_PROVIDED": [
+        "Provide either a dataset or files to build the knowledge base from, not both."
+    ],
     "NO_EVALUATION_COLUMNS_FOUND": ["No evaluation columns present in given datasets."],
     "MAX_KB_SIZE_EXCEEDED": ["Maximum knowledge base size exceeded."],
     "KB_CREATION_LIMIT_REACHED": [


### PR DESCRIPTION
## Summary
- Add `dataset_id`/`column_ids` as an alternative source to `file` uploads on the legacy KB create endpoint (`/model-hub/knowledge-base/`): selected dataset rows are indexed with the same `KBIndexer` used for files, scheduled after commit like the existing upload path.
- Add validation: dataset must exist, at least one column must be selected, and all `column_ids` must belong to the chosen dataset.
- Dedupe `column_ids` server-side so a client sending the same column twice can't get its content double-indexed.
- Add a dataset + column picker (`SelectDatasetSource.jsx`) to the create-KB drawer for this new source.

Fixes #933

## Test plan
- [x] `python3 -m py_compile` on all changed backend files
- [x] Added `TestLegacyKbCreateFromDataset` covering: missing dataset, no columns selected, column from another dataset, happy path (KB created with no files, ingestion scheduled), and duplicate `column_ids` deduped before scheduling
- [x] Added `SelectDatasetSource.test.jsx` covering dataset selection resetting `columnIds`/disabling the column picker, and multi-select column picking
- [ ] Backend/frontend test suites need to be run in CI (Docker/yarn install not available in the dev environment used to write this PR)