### PR TITLE
Self-hosted: stop masking the auto-created system key so quickstart works

### DIFF
--- a/frontend/src/pages/dashboard/settings/api-keys/CellRenderer.jsx
+++ b/frontend/src/pages/dashboard/settings/api-keys/CellRenderer.jsx
@@ -20,6 +20,7 @@ import { enqueueSnackbar } from "notistack";
 import axios, { endpoints } from "src/utils/axios";
 import { useMutation } from "@tanstack/react-query";
 import { LoadingButton } from "@mui/lab";
+import SecretKeyRenderer from "src/sections/keys/view/SecretKeyRenderer";
 
 const allMenuItems = [
   {
@@ -423,6 +424,10 @@ const CellRenderer = (props) => {
         )}
       </Box>
     );
+  }
+
+  if (columnKey === "api_key" || columnKey === "secret_key") {
+    return <SecretKeyRenderer value={value} />;
   }
 
   return (

--- a/futureagi/accounts/tests/test_keys.py
+++ b/futureagi/accounts/tests/test_keys.py
@@ -614,6 +614,31 @@ class TestGetSecretKeysRowContent:
             "type",
         }
 
+    def test_system_key_is_not_masked_so_quickstart_copy_works(
+        self, auth_client, organization
+    ):
+        """Regression for #1304: the system key has no other reveal path.
+
+        Unlike a user-generated key (shown in full once, at creation), the
+        auto-created ``system`` key is only ever surfaced through this list.
+        Masking it here left the Keys page's copy button handing out a value
+        that never matches ``accounts_orgapikey``, so the documented
+        quickstart always 401s.
+        """
+        from accounts.models.user import OrgApiKey
+
+        system_key = OrgApiKey.objects.create(
+            organization=organization, type="system"
+        )
+
+        response = auth_client.get(f"{SECRET_KEYS_URL}?search={system_key.name}")
+
+        row = _rows(response)[0]
+        assert row["api_key"] == system_key.api_key
+        assert row["secret_key"] == system_key.secret_key
+        assert "*" not in row["api_key"]
+        assert "*" not in row["secret_key"]
+
 
 @pytest.mark.integration
 @pytest.mark.api

--- a/futureagi/accounts/views/keys.py
+++ b/futureagi/accounts/views/keys.py
@@ -166,12 +166,19 @@ class SecretKeyAPIViewSet(ViewSet):
             start = page_number * page_size
             paginated_keys = apiKeys[start : start + page_size]
 
+            # The auto-created "system" key is never shown at creation time the
+            # way a user-generated key is (see generate_secret_key), so it has
+            # no other UI path to its real value — masking it here left the
+            # Keys page's quickstart copy buttons handing out material that
+            # doesn't match accounts_orgapikey (see #1304). User-generated
+            # keys keep the mask since they're already fully shown once, at
+            # creation.
             table = [
                 {
                     "id": key.id,
                     "key_name": key.name,
-                    "api_key": mask_key(key.api_key),
-                    "secret_key": mask_key(key.secret_key),
+                    "api_key": key.api_key if key.type == "system" else mask_key(key.api_key),
+                    "secret_key": key.secret_key if key.type == "system" else mask_key(key.secret_key),
                     "created_by": key.user.name if key.user else None,
                     "created_at": key.created_at,
                     "enabled": key.enabled,


### PR DESCRIPTION
## Problem

On the Keys page (Build → Keys), the auto-created `system_org_key` row's API Key / Secret Key values displayed and copied from the UI don't match what's actually stored in `accounts_orgapikey`, so following the documented quickstart (copy keys from Dashboard → Build → Keys into `FI_API_KEY`/`FI_SECRET_KEY`) always yields a 401.

## Root cause

Unlike a user-generated key — which is shown in full exactly once, at creation time, via `generate_secret_key` — the auto-created `system` key has no other UI path to its real value. `SecretKeyAPIViewSet.get_secret_keys` (the only endpoint the Keys page reads from) masked every row's `api_key`/`secret_key` unconditionally, including the system row, so there was no way left in the UI to ever retrieve its real, working value.

## Fix

- `accounts/views/keys.py`: `get_secret_keys` no longer masks rows where `type == "system"`. User-generated keys keep the mask, since they're already fully shown once at creation. The frontend's `SecretKeyRenderer` already gates its copy button on whether the value contains `*`, so this alone re-enables a working copy button with the real value — no changes needed on the Build → Keys page.
- `pages/dashboard/settings/api-keys/CellRenderer.jsx`: the separate Settings → API Keys grid renders `api_key`/`secret_key` as raw text with no masking component at all. Now that the system row comes back unmasked, route it through the existing `SecretKeyRenderer` (reused from the Build → Keys page) so it keeps masking the display and gating the copy affordance, instead of leaking the raw value onto the screen.
- `accounts/tests/test_keys.py`: added a regression test asserting a `type="system"` row's `api_key`/`secret_key` in the `get_secret_keys` response exactly match the model instance's values (no `*`), while existing tests continue to assert masking for `type="user"` rows.

## Test plan

- [x] `python3 -m py_compile accounts/views/keys.py accounts/tests/test_keys.py`
- [x] `esbuild` syntax check on the touched frontend files
- [ ] Manual verification on a running stack: copy the system key from Build → Keys, confirm it authenticates and matches `accounts_orgapikey`

Fixes #1304