### PR TITLE
ci(contracts): fall back to the PR base branch for the EE checkout

### DIFF
--- a/.github/workflows/api-contracts.yml
+++ b/.github/workflows/api-contracts.yml
@@ -87,7 +87,7 @@ jobs:
     env:
       EE_REPO_READ_TOKEN: ${{ secrets.EE_REPO_READ_TOKEN }}
       EE_REPO_BRANCH: ${{ github.head_ref || github.ref_name }}
-      EE_REPO_BASE_BRANCH: ${{ github.base_ref || '' }}
+      EE_BASE_REF: ${{ github.base_ref || 'dev' }}
     steps:
       - uses: actions/checkout@v4
 
@@ -111,19 +111,23 @@ jobs:
       - name: Use matching EE branch when available
         working-directory: futureagi/ee/cloud
         run: |
-          # Prefer an EE branch matching the PR head branch; otherwise fall
-          # back to the PR base branch (e.g. dev) so a PR pairs with the EE
-          # code its base was built against — the EE default branch can lag
-          # behind and fail to boot against newer backend code.
-          for ee_ref in "${EE_REPO_BRANCH}" "${EE_REPO_BASE_BRANCH}"; do
-            if [ -n "${ee_ref}" ] && git ls-remote --exit-code --heads origin "${ee_ref}" >/dev/null 2>&1; then
-              git fetch --depth=1 origin "${ee_ref}"
+          # EE's default branch trails its own dev, so never settle for whatever
+          # the checkout landed on: walk the same candidate chain backend-ci
+          # and the SDK compatibility workflow use and take the first branch
+          # that exists.
+          for candidate in "${EE_REPO_BRANCH}" "${EE_BASE_REF}" dev main; do
+            if [ -z "${candidate}" ]; then
+              continue
+            fi
+            if git ls-remote --exit-code --heads origin "${candidate}" >/dev/null 2>&1; then
+              git fetch --depth=1 origin "${candidate}"
               git checkout --detach FETCH_HEAD
-              echo "Using EE branch ${ee_ref}"
+              echo "::notice::Using EE branch ${candidate}"
               exit 0
             fi
           done
-          echo "::notice::No EE branch matching ${EE_REPO_BRANCH} or the base branch; using the EE repository default branch."
+          echo "::error::No EE branch found among ${EE_REPO_BRANCH}, ${EE_BASE_REF}, dev, main"
+          exit 1
 
       - name: Drop EE checkout credentials
         working-directory: futureagi/ee/cloud
@@ -203,7 +207,7 @@ jobs:
       TESTING: "false"
       EE_REPO_READ_TOKEN: ${{ secrets.EE_REPO_READ_TOKEN }}
       EE_REPO_BRANCH: ${{ github.head_ref || github.ref_name }}
-      EE_REPO_BASE_BRANCH: ${{ github.base_ref || '' }}
+      EE_BASE_REF: ${{ github.base_ref || 'dev' }}
     steps:
       - uses: actions/checkout@v4
 
@@ -253,19 +257,23 @@ jobs:
       - name: Use matching EE branch when available
         working-directory: futureagi/ee/cloud
         run: |
-          # Prefer an EE branch matching the PR head branch; otherwise fall
-          # back to the PR base branch (e.g. dev) so a PR pairs with the EE
-          # code its base was built against — the EE default branch can lag
-          # behind and fail to boot against newer backend code.
-          for ee_ref in "${EE_REPO_BRANCH}" "${EE_REPO_BASE_BRANCH}"; do
-            if [ -n "${ee_ref}" ] && git ls-remote --exit-code --heads origin "${ee_ref}" >/dev/null 2>&1; then
-              git fetch --depth=1 origin "${ee_ref}"
+          # EE's default branch trails its own dev, so never settle for whatever
+          # the checkout landed on: walk the same candidate chain backend-ci
+          # and the SDK compatibility workflow use and take the first branch
+          # that exists.
+          for candidate in "${EE_REPO_BRANCH}" "${EE_BASE_REF}" dev main; do
+            if [ -z "${candidate}" ]; then
+              continue
+            fi
+            if git ls-remote --exit-code --heads origin "${candidate}" >/dev/null 2>&1; then
+              git fetch --depth=1 origin "${candidate}"
               git checkout --detach FETCH_HEAD
-              echo "Using EE branch ${ee_ref}"
+              echo "::notice::Using EE branch ${candidate}"
               exit 0
             fi
           done
-          echo "::notice::No EE branch matching ${EE_REPO_BRANCH} or the base branch; using the EE repository default branch."
+          echo "::error::No EE branch found among ${EE_REPO_BRANCH}, ${EE_BASE_REF}, dev, main"
+          exit 1
 
       - name: Drop EE checkout credentials
         working-directory: futureagi/ee/cloud

--- a/.github/workflows/api-contracts.yml
+++ b/.github/workflows/api-contracts.yml
@@ -87,6 +87,7 @@ jobs:
     env:
       EE_REPO_READ_TOKEN: ${{ secrets.EE_REPO_READ_TOKEN }}
       EE_REPO_BRANCH: ${{ github.head_ref || github.ref_name }}
+      EE_REPO_BASE_BRANCH: ${{ github.base_ref || '' }}
     steps:
       - uses: actions/checkout@v4
 
@@ -110,13 +111,19 @@ jobs:
       - name: Use matching EE branch when available
         working-directory: futureagi/ee/cloud
         run: |
-          if git ls-remote --exit-code --heads origin "${EE_REPO_BRANCH}" >/dev/null 2>&1; then
-            git fetch --depth=1 origin "${EE_REPO_BRANCH}"
-            git checkout --detach FETCH_HEAD
-            echo "Using EE branch ${EE_REPO_BRANCH}"
-          else
-            echo "::notice::No EE branch named ${EE_REPO_BRANCH}; using the EE repository default branch."
-          fi
+          # Prefer an EE branch matching the PR head branch; otherwise fall
+          # back to the PR base branch (e.g. dev) so a PR pairs with the EE
+          # code its base was built against — the EE default branch can lag
+          # behind and fail to boot against newer backend code.
+          for ee_ref in "${EE_REPO_BRANCH}" "${EE_REPO_BASE_BRANCH}"; do
+            if [ -n "${ee_ref}" ] && git ls-remote --exit-code --heads origin "${ee_ref}" >/dev/null 2>&1; then
+              git fetch --depth=1 origin "${ee_ref}"
+              git checkout --detach FETCH_HEAD
+              echo "Using EE branch ${ee_ref}"
+              exit 0
+            fi
+          done
+          echo "::notice::No EE branch matching ${EE_REPO_BRANCH} or the base branch; using the EE repository default branch."
 
       - name: Drop EE checkout credentials
         working-directory: futureagi/ee/cloud
@@ -196,6 +203,7 @@ jobs:
       TESTING: "false"
       EE_REPO_READ_TOKEN: ${{ secrets.EE_REPO_READ_TOKEN }}
       EE_REPO_BRANCH: ${{ github.head_ref || github.ref_name }}
+      EE_REPO_BASE_BRANCH: ${{ github.base_ref || '' }}
     steps:
       - uses: actions/checkout@v4
 
@@ -245,13 +253,19 @@ jobs:
       - name: Use matching EE branch when available
         working-directory: futureagi/ee/cloud
         run: |
-          if git ls-remote --exit-code --heads origin "${EE_REPO_BRANCH}" >/dev/null 2>&1; then
-            git fetch --depth=1 origin "${EE_REPO_BRANCH}"
-            git checkout --detach FETCH_HEAD
-            echo "Using EE branch ${EE_REPO_BRANCH}"
-          else
-            echo "::notice::No EE branch named ${EE_REPO_BRANCH}; using the EE repository default branch."
-          fi
+          # Prefer an EE branch matching the PR head branch; otherwise fall
+          # back to the PR base branch (e.g. dev) so a PR pairs with the EE
+          # code its base was built against — the EE default branch can lag
+          # behind and fail to boot against newer backend code.
+          for ee_ref in "${EE_REPO_BRANCH}" "${EE_REPO_BASE_BRANCH}"; do
+            if [ -n "${ee_ref}" ] && git ls-remote --exit-code --heads origin "${ee_ref}" >/dev/null 2>&1; then
+              git fetch --depth=1 origin "${ee_ref}"
+              git checkout --detach FETCH_HEAD
+              echo "Using EE branch ${ee_ref}"
+              exit 0
+            fi
+          done
+          echo "::notice::No EE branch matching ${EE_REPO_BRANCH} or the base branch; using the EE repository default branch."
 
       - name: Drop EE checkout credentials
         working-directory: futureagi/ee/cloud


### PR DESCRIPTION
## Summary

The `backend-contracts` / `frontend-contracts` jobs pair a PR with the **EE repo's default branch (`main`)** whenever no EE branch matches the PR head branch name. EE `main` lags well behind EE `dev` (currently Aug 13, pre-TH-7256 layout), so any dev-based PR without a same-named EE branch fails OpenAPI generation **before the swagger diff even runs**:

```
ModuleNotFoundError: No module named 'ee.cloud.urls'
```

`tfc/openapi_urls.py` gates on `has_ee("ee.cloud")`, which passes on the stale checkout (the package exists), but the included `ee/cloud/urls.py` / `ee/cloud/telemetry/` modules only exist on EE `dev`. Reproduced locally by pairing a dev-based branch with EE `main`. Recent examples of PRs failing this way: #2263, `fix/annotation-queue-voice-trace-ui-dev` (Aug 22).

Pushes to `dev` are unaffected (their `EE_REPO_BRANCH` resolves to `dev`, which exists in EE) — which is why the check is green on dev but red on feature PRs.

## Change

In both contract jobs, the "Use matching EE branch when available" step now tries, in order:

1. an EE branch matching the **PR head branch** (unchanged behavior), then
2. the **PR base branch** (`github.base_ref`, e.g. `dev`) — new, so a PR pairs with the EE code its base was built against, then
3. the EE repository default branch (unchanged fallback).

Push events have no `base_ref`, so their behavior is unchanged.

## Testing

- Reproduced the failure locally: dev-based branch + EE `main` → `ModuleNotFoundError: ee.cloud.urls` at `tfc/openapi_urls.py:13`.
- With EE `dev`, `scripts/generate-openapi-schema.sh` succeeds and yields a byte-identical `api_contracts/openapi/swagger.json` (zero diff).
- YAML validated. `pull_request` workflows run from the PR merge ref, so this PR exercises its own fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017JLjRsrXCAYk6X4Do7SiAF


> Supersedes #2299 — that PR was auto-closed by GitHub when the head branch was renamed `ci/…` → `chore/…` to satisfy the branch-name check. Content is identical.
