### PR TITLE
fix(tracer): make span attribute-key discovery exhaustive over its window [TH-7632]

### DIFF
--- a/futureagi/tracer/services/clickhouse/query_service.py
+++ b/futureagi/tracer/services/clickhouse/query_service.py
@@ -131,7 +131,11 @@ class AnalyticsQueryService:
         include_counts: bool = False,
         order_by_count_desc: bool = False,
     ) -> list[dict]:
-        """Get distinct span attribute keys with types for one or more projects."""
+        """Get distinct span attribute keys with types for one or more projects.
+
+        ``count`` is scoped to the discovery window, so a key surfaced only by
+        the unbounded path's legacy sample lane reports 0.
+        """
         if not project_ids:
             return []
 
@@ -156,11 +160,11 @@ class AnalyticsQueryService:
                   {window_filter}
                 GROUP BY key"""
             if recent_days is None:
-                # Unbounded callers additionally keep the legacy sample, so a key
-                # visible before this change can never disappear from the picker.
+                # Visibility-only lane: window plus sample is a superset of the
+                # old sample, so the picker only gains keys. cnt 0 avoids double-count.
                 sql += f"""
                 UNION ALL
-                SELECT key, '{type_name}' AS type, count() AS cnt FROM (
+                SELECT key, '{type_name}' AS type, 0 AS cnt FROM (
                     SELECT {column}.keys AS ks FROM spans
                     WHERE project_id IN %(project_ids)s
                       AND is_deleted = 0

--- a/futureagi/tracer/services/clickhouse/query_service.py
+++ b/futureagi/tracer/services/clickhouse/query_service.py
@@ -24,6 +24,10 @@ from tracer.services.clickhouse.eval_logger_table import eval_logger_source
 
 logger = structlog.get_logger(__name__)
 
+# Attribute discovery reads a bounded window so it can stay exhaustive; the
+# partition key is `toDate(start_time)`, so this prunes to whole partitions.
+ATTRIBUTE_DISCOVERY_WINDOW_DAYS = 7
+
 
 class QueryType(StrEnum):
     """Supported query types with per-type routing."""
@@ -131,13 +135,39 @@ class AnalyticsQueryService:
         if not project_ids:
             return []
 
-        recent_filter = ""
         params: dict[str, Any] = {
             "project_ids": tuple(project_ids),
+            "window_days": (
+                ATTRIBUTE_DISCOVERY_WINDOW_DAYS
+                if recent_days is None
+                else int(recent_days)
+            ),
         }
-        if recent_days is not None:
-            params["recent_days"] = int(recent_days)
-            recent_filter = "AND start_time >= now() - toIntervalDay(%(recent_days)s)"
+        window_filter = "AND start_time >= now() - toIntervalDay(%(window_days)s)"
+
+        def lane(column: str, type_name: str) -> str:
+            # Exhaustive over the window: ARRAY JOIN on `<map>.keys` reads only
+            # that subcolumn, so no key can fall outside an arbitrary row sample.
+            sql = f"""
+                SELECT key, '{type_name}' AS type, count() AS cnt
+                FROM spans ARRAY JOIN {column}.keys AS key
+                WHERE project_id IN %(project_ids)s
+                  AND is_deleted = 0
+                  {window_filter}
+                GROUP BY key"""
+            if recent_days is None:
+                # Unbounded callers additionally keep the legacy sample, so a key
+                # visible before this change can never disappear from the picker.
+                sql += f"""
+                UNION ALL
+                SELECT key, '{type_name}' AS type, count() AS cnt FROM (
+                    SELECT {column}.keys AS ks FROM spans
+                    WHERE project_id IN %(project_ids)s
+                      AND is_deleted = 0
+                    LIMIT 10000
+                ) ARRAY JOIN ks AS key
+                GROUP BY key"""
+            return sql
 
         outer_select = "SELECT key, argMax(type, cnt) AS type"
         if include_counts:
@@ -146,35 +176,16 @@ class AnalyticsQueryService:
             "ORDER BY count DESC, key" if order_by_count_desc else "ORDER BY key"
         )
 
-        query = f"""
-            {outer_select} FROM (
-                SELECT key, 'string' AS type, count() AS cnt FROM (
-                    SELECT attrs_string.keys AS ks FROM spans
-                    WHERE project_id IN %(project_ids)s
-                      AND is_deleted = 0
-                      {recent_filter}
-                    LIMIT 10000
-                ) ARRAY JOIN ks AS key
-                GROUP BY key
-                UNION ALL
-                SELECT key, 'number' AS type, count() AS cnt FROM (
-                    SELECT attrs_number.keys AS ks FROM spans
-                    WHERE project_id IN %(project_ids)s
-                      AND is_deleted = 0
-                      {recent_filter}
-                    LIMIT 10000
-                ) ARRAY JOIN ks AS key
-                GROUP BY key
-                UNION ALL
-                SELECT key, 'boolean' AS type, count() AS cnt FROM (
-                    SELECT attrs_bool.keys AS ks FROM spans
-                    WHERE project_id IN %(project_ids)s
-                      AND is_deleted = 0
-                      {recent_filter}
-                    LIMIT 10000
-                ) ARRAY JOIN ks AS key
-                GROUP BY key
+        lanes = " UNION ALL ".join(
+            lane(column, type_name)
+            for column, type_name in (
+                ("attrs_string", "string"),
+                ("attrs_number", "number"),
+                ("attrs_bool", "boolean"),
             )
+        )
+        query = f"""
+            {outer_select} FROM ({lanes})
             GROUP BY key
             {outer_order}
             LIMIT {int(outer_limit)}
@@ -195,15 +206,6 @@ class AnalyticsQueryService:
         populated at ingest time by fi-collector, so they are the canonical
         attribute inventory — no CDC fallback needed post-CH25 close-out.
         """
-        # This is a discovery query (populate a filter dropdown), not an
-        # accounting one, so an approximate sample is semantically fine.
-        # Two bounds keep it bounded even on very large projects:
-        #   * 7-day window on `start_time` (the partition key is
-        #     `toDate(start_time)`) so CH can skip partitions and granules.
-        #   * `LIMIT 10000` inside each per-map subquery before the
-        #     ARRAY JOIN — without this, projects with millions of spans
-        #     and wide `attrs_*` maps hit Code: 307 (max_bytes_to_read)
-        #     because every row's Map gets exploded.
         return self.get_span_attribute_keys_ch_for_projects([project_id])
 
     @staticmethod

--- a/futureagi/tracer/tests/test_clickhouse.py
+++ b/futureagi/tracer/tests/test_clickhouse.py
@@ -4546,50 +4546,6 @@ class TestSpanAttributeViews:
                 pass
 
 
-@pytest.mark.unit
-class TestSpanAttributeKeyDiscoveryScope:
-    """Attribute-key discovery must be exhaustive over its time window.
-
-    The query used to sample `LIMIT 10000` rows per map before the ARRAY
-    JOIN, so a key carried by only a thin slice of spans could fall outside
-    the sample and never reach the filter picker. Each lane now ARRAY JOINs
-    the `<map>.keys` subcolumn over every span in the window instead.
-    """
-
-    PROJECT_ID = "c4de3065-12b5-488c-a814-aa1c8e3f856f"
-    WINDOW = "start_time >= now() - toIntervalDay(%(window_days)s)"
-
-    def _discovery_sql(self, **kwargs):
-        from tracer.services.clickhouse.query_service import AnalyticsQueryService
-
-        with mock.patch.object(
-            AnalyticsQueryService,
-            "execute_ch_query",
-            return_value=mock.Mock(data=[]),
-        ) as execute:
-            AnalyticsQueryService().get_span_attribute_keys_ch_for_projects(
-                [self.PROJECT_ID], **kwargs
-            )
-        return execute.call_args.args[0]
-
-    def test_each_lane_array_joins_keys_across_the_whole_window(self):
-        """No row sample: every lane reads .keys for every span in the window."""
-        sql = self._discovery_sql(recent_days=7)
-
-        for column in ("attrs_string", "attrs_number", "attrs_bool"):
-            assert f"FROM spans ARRAY JOIN {column}.keys AS key" in sql
-        assert sql.count(self.WINDOW) == 3
-        assert "LIMIT 10000" not in sql
-
-    def test_unbounded_discovery_keeps_the_legacy_sample_lane(self):
-        """recent_days=None unions the old sample in, so no key regresses."""
-        sql = self._discovery_sql(recent_days=None)
-
-        assert sql.count(self.WINDOW) == 3
-        assert sql.count("LIMIT 10000") == 3
-        assert sql.count("UNION ALL") == 5
-
-
 # ============================================================================
 # 14. Comprehensive Trace List Query Builder Tests
 # ============================================================================

--- a/futureagi/tracer/tests/test_clickhouse.py
+++ b/futureagi/tracer/tests/test_clickhouse.py
@@ -4546,6 +4546,50 @@ class TestSpanAttributeViews:
                 pass
 
 
+@pytest.mark.unit
+class TestSpanAttributeKeyDiscoveryScope:
+    """Attribute-key discovery must be exhaustive over its time window.
+
+    The query used to sample `LIMIT 10000` rows per map before the ARRAY
+    JOIN, so a key carried by only a thin slice of spans could fall outside
+    the sample and never reach the filter picker. Each lane now ARRAY JOINs
+    the `<map>.keys` subcolumn over every span in the window instead.
+    """
+
+    PROJECT_ID = "c4de3065-12b5-488c-a814-aa1c8e3f856f"
+    WINDOW = "start_time >= now() - toIntervalDay(%(window_days)s)"
+
+    def _discovery_sql(self, **kwargs):
+        from tracer.services.clickhouse.query_service import AnalyticsQueryService
+
+        with mock.patch.object(
+            AnalyticsQueryService,
+            "execute_ch_query",
+            return_value=mock.Mock(data=[]),
+        ) as execute:
+            AnalyticsQueryService().get_span_attribute_keys_ch_for_projects(
+                [self.PROJECT_ID], **kwargs
+            )
+        return execute.call_args.args[0]
+
+    def test_each_lane_array_joins_keys_across_the_whole_window(self):
+        """No row sample: every lane reads .keys for every span in the window."""
+        sql = self._discovery_sql(recent_days=7)
+
+        for column in ("attrs_string", "attrs_number", "attrs_bool"):
+            assert f"FROM spans ARRAY JOIN {column}.keys AS key" in sql
+        assert sql.count(self.WINDOW) == 3
+        assert "LIMIT 10000" not in sql
+
+    def test_unbounded_discovery_keeps_the_legacy_sample_lane(self):
+        """recent_days=None unions the old sample in, so no key regresses."""
+        sql = self._discovery_sql(recent_days=None)
+
+        assert sql.count(self.WINDOW) == 3
+        assert sql.count("LIMIT 10000") == 3
+        assert sql.count("UNION ALL") == 5
+
+
 # ============================================================================
 # 14. Comprehensive Trace List Query Builder Tests
 # ============================================================================

--- a/futureagi/tracer/tests/test_eval_attributes_list.py
+++ b/futureagi/tracer/tests/test_eval_attributes_list.py
@@ -308,20 +308,28 @@ class TestSpanAttributeKeysNormalisation:
 
 
 class TestSpanAttributeKeysPartitionPruning:
-    """The recent-window discovery query must prune by the partition key.
+    """The recent-window discovery query must prune, stay unordered, and stay
+    exhaustive.
 
     ``spans`` is partitioned by ``toDate(start_time)``; ``created_at`` is
     neither the partition key nor in the sort key. Windowing by ``created_at``
     defeats partition pruning and scans the whole project. Pin that the query
     windows by ``start_time`` and does NOT order by it: ``start_time`` sits
     behind ``observation_type``/``service_name`` in the sort key, so an ordered
-    top-N reads the whole window (materializing the fat ``attrs_*`` maps) before
-    ``LIMIT`` applies -> Code 396 / Code 159 on high-volume projects. Without the
-    ORDER BY, ``project_id`` leading the sort key lets ``LIMIT 10000`` bound the
-    scan. Also pin that only the Map ``.keys`` subcolumn is read (never values).
+    lane sorts the whole window (materializing the fat ``attrs_*`` maps) ->
+    Code 396 / Code 159 on high-volume projects.
+
+    Discovery is exhaustive over that window: each lane ARRAY JOINs the
+    ``<map>.keys`` subcolumn over every span, never a row sample, so a key
+    carried by a thin slice of spans still reaches the filter picker. The
+    unbounded path keeps the legacy ``LIMIT 10000`` sample as a visibility-only
+    superset lane that contributes no count. Also pin that only the Map
+    ``.keys`` subcolumn is read (never values).
     """
 
-    def _capture_sql(self, monkeypatch, *, recent_days=7) -> str:
+    WINDOW = "start_time >= now() - toIntervalDay(%(window_days)s)"
+
+    def _capture_sql(self, monkeypatch, *, recent_days=7, **kwargs) -> str:
         from tracer.services.clickhouse.query_service import AnalyticsQueryService
 
         captured: dict = {}
@@ -337,7 +345,9 @@ class TestSpanAttributeKeysPartitionPruning:
             AnalyticsQueryService, "execute_ch_query", _capture, raising=True
         )
         AnalyticsQueryService().get_span_attribute_keys_ch_for_projects(
-            ["c4de3065-12b5-488c-a814-aa1c8e3f856f"], recent_days=recent_days
+            ["c4de3065-12b5-488c-a814-aa1c8e3f856f"],
+            recent_days=recent_days,
+            **kwargs,
         )
         return captured["query"]
 
@@ -345,7 +355,7 @@ class TestSpanAttributeKeysPartitionPruning:
         sql = self._capture_sql(monkeypatch, recent_days=7)
         # start_time is the partition key -> CH can prune to the window.
         assert "start_time >= now() - toIntervalDay" in sql
-        # The recency ORDER BY is dropped so LIMIT 10000 bounds the scan.
+        # No recency ORDER BY: an ordered lane would sort the whole window.
         assert "ORDER BY start_time" not in sql
 
     def test_reads_keys_subcolumn_not_whole_map(self, monkeypatch):
@@ -378,6 +388,22 @@ class TestSpanAttributeKeysPartitionPruning:
         sql = self._capture_sql(monkeypatch, recent_days=None)
         assert "ORDER BY start_time" not in sql
         assert "LIMIT 10000" in sql
+
+    def test_each_lane_array_joins_keys_across_the_whole_window(self, monkeypatch):
+        # No row sample: every lane reads .keys for every span in the window, so
+        # a key on a thin slice of spans cannot fall outside it (TH-7632).
+        sql = self._capture_sql(monkeypatch, recent_days=7)
+        for column in ("attrs_string", "attrs_number", "attrs_bool"):
+            assert f"FROM spans ARRAY JOIN {column}.keys AS key" in sql
+        assert sql.count(self.WINDOW) == 3
+        assert "LIMIT 10000" not in sql
+
+    def test_unbounded_discovery_keeps_the_legacy_sample_lane(self, monkeypatch):
+        # recent_days=None unions the old sample in, so no key regresses.
+        sql = self._capture_sql(monkeypatch, recent_days=None)
+        assert sql.count(self.WINDOW) == 3
+        assert sql.count("LIMIT 10000") == 3
+        assert sql.count("UNION ALL") == 5
 
 
 @pytest.mark.integration

--- a/futureagi/tracer/tests/test_eval_attributes_list.py
+++ b/futureagi/tracer/tests/test_eval_attributes_list.py
@@ -357,10 +357,9 @@ class TestSpanAttributeKeysPartitionPruning:
         assert "attrs_bool.keys" in sql
         assert "mapKeys(" not in sql
 
-    def test_preserves_limit_and_type_labels(self, monkeypatch):
+    def test_preserves_type_labels(self, monkeypatch):
         sql = self._capture_sql(monkeypatch, recent_days=7)
-        # The per-map LIMIT and type labels are unchanged by the fix.
-        assert "LIMIT 10000" in sql
+        # The windowed lanes are exhaustive, so only the type labels survive.
         assert "'string'" in sql
         assert "'number'" in sql
         assert "'boolean'" in sql
@@ -372,11 +371,11 @@ class TestSpanAttributeKeysPartitionPruning:
         assert "ORDER BY created_at" not in sql
 
     def test_full_project_discovery_skips_order_by_to_short_circuit(self, monkeypatch):
-        # recent_days=None (dashboard/metrics filter discovery): no window, so
-        # the ORDER BY must be dropped or LIMIT 10000 can't short-circuit and
-        # CH scans the whole project (~477k rows) instead of ~15k.
+        # recent_days=None (dashboard/metrics filter discovery) unions the
+        # windowed lane with the legacy sample; the ORDER BY must stay dropped
+        # or LIMIT 10000 can't short-circuit and CH scans the whole project
+        # (~477k rows) instead of ~15k.
         sql = self._capture_sql(monkeypatch, recent_days=None)
-        assert "start_time >= now()" not in sql
         assert "ORDER BY start_time" not in sql
         assert "LIMIT 10000" in sql
 

--- a/futureagi/tracer/tests/test_eval_attributes_list.py
+++ b/futureagi/tracer/tests/test_eval_attributes_list.py
@@ -405,6 +405,14 @@ class TestSpanAttributeKeysPartitionPruning:
         assert sql.count("LIMIT 10000") == 3
         assert sql.count("UNION ALL") == 5
 
+    def test_sample_lane_contributes_no_count(self, monkeypatch):
+        # A span inside both the window and the sample would otherwise be summed
+        # twice by the outer sum(cnt) and inflate argMax(type, cnt).
+        sql = self._capture_sql(monkeypatch, recent_days=None, include_counts=True)
+        assert sql.count("0 AS cnt") == 3
+        assert sql.count("count() AS cnt") == 3
+        assert "sum(cnt) AS count" in sql
+
 
 @pytest.mark.integration
 @pytest.mark.api


### PR DESCRIPTION
## Summary

Every attribute picker in the product is built by one function, `get_span_attribute_keys_ch_for_projects` in `tracer/services/clickhouse/query_service.py`. It asked ClickHouse for 10,000 rows per attribute map and did not say *which* 10,000:

```sql
SELECT attrs_string.keys AS ks FROM spans
WHERE project_id IN %(project_ids)s AND is_deleted = 0
LIMIT 10000            -- no ORDER BY
```

`LIMIT` with no `ORDER BY` returns a contiguous block at the head of the table's sort order, not a random sample. The sort key is `project_id, observation_type, service_name, toStartOfHour(start_time), trace_id, id`, so the picker is built from the first observation type, the first service and the earliest hours only. Any attribute a customer writes on a later service, a later span type or a later hour is simply not in the dropdown.

The fix `ARRAY JOIN`s directly on the `<map>.keys` subcolumn, which reads only that subcolumn and never the values, so the aggregate can be **exhaustive over the discovery window** instead of sampled. Unbounded callers additionally keep the legacy sample as a second `UNION ALL` lane, so the change is strictly additive: no key visible today can disappear.

Fixes TH-7632.

## Why the changes are done: what is the problem

### Reproduce on dev today (before this PR)

1. Open a project whose spans carry an attribute on only one service, or only in the most recent hours.
2. Observe → Tracing → **Filter** → **Property**.
3. Search for that attribute key.
4. **"No properties found."** The key is in ClickHouse; it is not in the picker. Refreshing never helps. The sample is stable, and stably wrong.

### Where it breaks

The sampling is in one place, but six surfaces call it:

| Surface | Call site |
| --- | --- |
| Observe filter picker (`span-attribute-keys`) | `tracer/views/span_attributes.py:67` → `span_attribute_lookups.py:88` |
| Observe eval-attributes list | `tracer/views/observation_span.py:2295` |
| Dashboard filter / group-by picker | `tracer/views/dashboard.py:784` |
| Dashboard metrics catalog | `tracer/services/dashboard_metrics_catalog.py:559` (`recent_days=None`) |
| Cluster RCA context builder, `list(attribute_keys)` dimension | `ee/agenthub/cluster_rca/context_builder.py:61` |
| Cluster RCA agent, same lookup | `ee/agenthub/cluster_rca/agent.py:1977` |

### It is not volume, it is attribute rarity plus sort-key locality

This is why it never reproduced on the existing loadgen projects: they put every attribute on every span, so the head of the sort order contains every key and the sample looks complete.

| Local project | Spans in 7d | Sampled keys | Exhaustive keys |
| --- | --- | --- | --- |
| `th7247-volume` | 2,065,270 | 5 | 5 |
| `th7247-attrs-400` | 149,741 | 405 | 405 |
| `Colly Agent (Colektia repro)` | 400,000 | 12 | 12 |
| **`attr-filter-repro`** (shaped for this PR) | **200,000** | **23** | **27** |

Two projects of near-identical size can behave in opposite ways: a project whose rarest attribute sits on 622 spans loses nothing, while one whose rarest attribute sits on a single span loses about half its keys.

## What changed

**`tracer/services/clickhouse/query_service.py`**: one function, `get_span_attribute_keys_ch_for_projects`.

- Each of the three attribute maps becomes a lane built by a small local `lane()` helper instead of three copy-pasted subqueries.
- Each lane now does `FROM spans ARRAY JOIN <map>.keys AS key` over the whole window. Reading the `.keys` subcolumn is what makes this affordable. The values are never touched.
- `ATTRIBUTE_DISCOVERY_WINDOW_DAYS = 7` is applied to **every** caller, including the previously unbounded one. The partition key is `toDate(start_time)`, so the window prunes whole partitions.
- When `recent_days is None`, the lane also `UNION ALL`s the **legacy `LIMIT 10000` sample**. That makes the change strictly additive for the unbounded caller: its result is a superset of what it returns today.
- Deleted the stale comment block that justified the sample ("an approximate sample is semantically fine").

### Why these decisions

- **Why not just drop the `LIMIT`?** Measured on the largest tenant, exhaustive discovery costs 3.1s at 7 days but 26.2s at 30 days and 30.4s over all history, against a 10s caller budget. The window is what keeps exhaustive affordable; removing the limit without one just moves the failure from wrong-results to timeout.
- **Why not re-add `ORDER BY created_at DESC`?** That was tried (`1bd579faf`, 2 Jul) and removed again (`d4c47ab52`, 23 Jul) because the sort materialised whole attribute maps: 97.1M rows, 5.90 GB peak, 24.5s, and Code 396 / Code 159 failures on the largest tenant. This patch has no `ORDER BY`, so that memory guard is not re-tripped.
- **Why keep the legacy sample lane on the unbounded path?** The dashboard metrics catalog deliberately runs with no window (`3afe7e221`). Adding a window there could in principle drop a key that is currently visible. Keeping the old lane alongside the new one makes that impossible.
- **Why a single-pass `arrayConcat` variant was rejected:** measured at 1.07 GiB peak / 11,351 ms, versus 151 MiB / 1,824 ms for the three-lane form.

## What tests are written

**New.** There was no prior test pinning discovery *scope*. The existing `TestSpanAttributeKeysPartitionPruning` covered partition pruning and subcolumn reads, not completeness.

All of them live in `TestSpanAttributeKeysPartitionPruning` (`tracer/tests/test_eval_attributes_list.py`), the class that already fences the `d4c47ab52` incident, sharing its `_capture_sql` helper.

| Test | New / existing | Scenario | What it pins |
| --- | --- | --- | --- |
| `test_each_lane_array_joins_keys_across_the_whole_window` | **new** | `recent_days=7` | All three lanes `ARRAY JOIN <map>.keys` under the window filter, and **no** `LIMIT 10000` survives |
| `test_unbounded_discovery_keeps_the_legacy_sample_lane` | **new** | `recent_days=None` | The window lane **and** the legacy sample lane are both present (3 windows, 3 samples, 5 `UNION ALL`) |
| `test_sample_lane_contributes_no_count` | **new** | `recent_days=None`, `include_counts=True` | The sample lane emits `0 AS cnt`, so a span inside both lanes is not summed twice. Pins count semantics, which nothing pinned before. |
| `test_preserves_type_labels` | **existing, amended** | `recent_days=7` | Was asserting `"LIMIT 10000" in sql`. That assertion encoded the bug. Type labels still asserted. |
| `test_full_project_discovery_skips_order_by_to_short_circuit` | **existing, amended** | `recent_days=None` | Was asserting the window is absent, which also encoded the bug. The `ORDER BY` assertion is unchanged. |

**All three new tests fail if the fix is reverted.** Verified: reverting `query_service.py` to `origin/dev` turns all three red; restoring the patch turns them green. `test_sample_lane_contributes_no_count` also goes red on its own if only the `0 AS cnt` line is reverted, so it fences that one line specifically.

The two amended assertions are called out deliberately. They are the old contract, and changing them *is* the behaviour change. Nothing else in either file moved.

## Commands to run tests

```bash
git fetch origin && git checkout fix/th-7632-attribute-discovery-sampling
cd futureagi
DJANGO_SETTINGS_MODULE=tfc.settings.test TEST=1 DEBUG=1 \
  python -m pytest \
    tracer/tests/test_eval_attributes_list.py::TestSpanAttributeKeysPartitionPruning \
    -p no:cacheprovider
```

### Local verification results

```
collected 8 items

test_windows_by_start_time_without_recency_order PASSED                  [ 12%]
test_reads_keys_subcolumn_not_whole_map PASSED                           [ 25%]
test_preserves_type_labels PASSED                                        [ 37%]
test_does_not_window_or_order_by_created_at PASSED                       [ 50%]
test_full_project_discovery_skips_order_by_to_short_circuit PASSED       [ 62%]
test_each_lane_array_joins_keys_across_the_whole_window PASSED           [ 75%]
test_unbounded_discovery_keeps_the_legacy_sample_lane PASSED             [ 87%]
test_sample_lane_contributes_no_count PASSED                             [100%]

============================== 8 passed in 2.79s ===============================
```

Both full files: **495 passed, 3 xfailed, 17 errors**. Baseline on pristine `origin/dev` in the same environment: **492 passed, 3 xfailed, 17 errors**. The same 17, all `OperationalError: connection to server at "localhost", port 15432 ... Connection refused` (the test Postgres sidecar was not up). Pre-existing and environmental; the `+3` is exactly the three new tests.

## Steps to test the PR changes on local

```bash
# 1. shaped repro data: 200k spans over 7 days, two services,
#    4 whatfix.* keys carried ONLY by the later service
#    -> project attr-filter-repro (1de16c2a-f85b-40d8-a9af-02b7d03e2d7a)

# 2. BEFORE, on origin/dev
curl -s -H "Authorization: Bearer $TOKEN" \
  "$HOST/api/traces/span-attribute-keys/?project_id=1de16c2a-f85b-40d8-a9af-02b7d03e2d7a" \
  | jq '[.result[].key] | length, map(select(startswith("whatfix")))'
# -> 23, []          (stable across 3 runs)

# 3. AFTER, same request on this branch
# -> 27, ["whatfix.ent_id","whatfix.is_internal","whatfix.retry_count","whatfix.user_question"]
#    (stable across 4 runs, 40-126 ms)

# 4. UI: Observe -> Tracing -> Filter -> Property -> Attributes -> search "whatfix"
#    BEFORE: "No properties found", Attributes 23
#    AFTER:  all four keys listed,  Attributes 27
```

## Before / after: the real Observe filter picker

Local `origin/dev`, project `attr-filter-repro`, same picker and same search on both sides. The only thing that differs is the backend.

![TH-7632 before and after](https://github.com/user-attachments/assets/2e560278-112c-4c2f-b02a-c18f989e9adb)

## Video

**The fix, in the product.** The same run recorded end to end. Open the Property picker, switch to Attributes, type `whatfix`. First half is `origin/dev`, second half is this branch.

https://github.com/user-attachments/assets/792c4551-427f-48bb-9e8f-536fdd61adc6

**The tests, running locally.** Real terminal, real run, reporting `7 passed in 4.24s`. This was shot in round 1, before the two discovery tests were folded into `TestSpanAttributeKeysPartitionPruning`, so the class path on screen is the old one. The assertions are the same ones, and the current run is in the capture below.

https://github.com/user-attachments/assets/480e3bcd-c9c2-4f27-b0bf-8914ba0df0d2

## Screenshot of test suite run

Round 1, same caveat as the video above: the class had not moved yet.

![local test run, 7 passed](https://github.com/user-attachments/assets/f20dc841-a56f-431d-8ae8-91b68f02ab71)

The `CH25 schema apply skipped` warning at the top is expected and unrelated: local ClickHouse is not up in that shell. These are query-shape assertions against the generated SQL, so they do not need a live server. It is left in rather than cropped out because it is genuine stdout.

## Test suite run after the review, and the double-count fix on real ClickHouse

One capture, real output, two halves.

**Top half** is the discovery query run against local ClickHouse on the shaped repro project, with `recent_days=None` and `include_counts=True`, the combination the review flagged. All four numbers come from a single ClickHouse statement, so they share one `now()` and cannot drift against each other. Before the fix, every key's count is overstated by exactly the 10,000-row sample. After it, the count is exact, and the key and type set is unchanged, so nothing stops being visible.

**Bottom half** is the test class, 8 passed.

![TH-7632 round-2 proof: ClickHouse double-count fix and the 8 passing tests](https://github.com/user-attachments/assets/8d8fe57c-5401-437f-a2eb-11215faa5ec5)

The pytest header block and an unrelated `CH25 schema apply skipped` warning (local ClickHouse is not on the test port in that shell) are filtered out of the capture for legibility. Nothing in the result lines is touched. These are query-shape assertions against the generated SQL, so they do not need a live server.

## Backwards compatibility

The response schema is unchanged: still `list[AttributeKey]` with `key`, `type` and optional `count`. Only the *contents* change, and only ever by gaining keys.

| Caller | Pre-PR | Post-PR |
| --- | --- | --- |
| `span_attributes.SpanAttributeKeysView` | keys from a 10k row sample | every key in the last 7 days |
| `observation_span` eval-attributes list | keys from a 10k row sample | every key in the last 7 days |
| `dashboard.py` filter / group-by picker | keys from a 10k row sample | every key in the last 7 days |
| `dashboard_metrics_catalog` (`recent_days=None`) | keys from a 10k row sample, unbounded in time | that same sample **plus** every key in the last 7 days, a strict superset |
| Cluster RCA `list(attribute_keys)` | keys from a 10k row sample | every key in the last 7 days |
| `recent_days=None` **with** `include_counts=True` | would have double-counted any span in both lanes | count is window-scoped; the sample lane contributes 0. No caller uses this combination today (see round 2 below) |

No migration. No schema change. No API contract change.

### Cost

Measured on the largest tenant from `system.query_log`:

| Query | Rows read | Bytes read | Peak memory | Server time | Keys |
| --- | --- | --- | --- | --- | --- |
| Current dev, sampled | 930K | 47 MiB | 93 MiB | 85 ms | 83 |
| This patch, exhaustive | 73.1M | 3.52 GiB | **151 MiB** | 1,824 to 6,388 ms | 298 |

Peak memory is the number that matters, and it *falls* well inside the guard: the server ceiling is 37.25 GiB, so this sits at 0.4%. The real cost is I/O. 47 MiB becomes 3.52 GiB per picker open on the largest tenant. There is no cache anywhere on this path today. **A short-TTL cache is the obvious follow-up and is deliberately not in this patch. It is filed as TH-7670**, together with collapsing the `dashboard.py` per-project loop into the existing multi-project call, which is what multiplies this cost on a multi-large-project org.

## Review round 2 (atharva-bhange, 24 Aug)

Two commits on top of the original one. The mechanical test move is kept separate from the behaviour change, per coding standard 07.

| Review point | What changed | Where |
| --- | --- | --- |
| **Important**: latent count double-count on `recent_days=None` + `include_counts=True`: a span inside both the window and the 10k sample was summed twice by the outer `sum(cnt)`, and `argMax(type, cnt)` compared inflated per-lane counts | The sample lane now emits `0 AS cnt`. It only ever existed as a key-visibility superset, so its counts carried no meaning. `count` is now window-scoped, and that is stated in the docstring rather than left as an implicit constraint | `query_service.py` |
| **Important**: 09 gap, nothing pinned count semantics | New `test_sample_lane_contributes_no_count`. It goes red if only the `0 AS cnt` line is reverted | `test_eval_attributes_list.py` |
| **Important**: two now-false comments left in the amended test class, both still explaining the removed `LIMIT 10000` | Class docstring and the `test_windows_by_start_time_without_recency_order` comment rewritten to the windowed-exhaustive story. The `ORDER BY` fence is still what they are about; what changed is why it matters | `test_eval_attributes_list.py` |
| **Minor**: diff-relative comment ("a key visible *before this change*") ages into noise once merged | Restated as the invariant itself: window plus sample is a superset of the old sample, so the picker only gains keys | `query_service.py` |
| **Minor**: duplicated SQL-capture harness with a second mocking style | The two tests moved into `TestSpanAttributeKeysPartitionPruning` and share its `_capture_sql`. `test_clickhouse.py` is no longer touched by this PR at all | both test files |
| PR body claimed five surfaces, six exist | Sixth row added: `ee/agenthub/cluster_rca/agent.py:1977`, also via `list_attribute_keys_for_project`. Enumerated from the tree, not from memory | this body |

Settled outside the diff, as suggested:

- **TH-7670**: short-TTL cache on attribute-key discovery, plus collapsing the `dashboard.py` per-project loop into the multi-project call, plus a decision on `max_bytes_to_read` for the read budget. Filed before merge rather than left as a PR-body aspiration.
- **TH-7671**: the pre-existing `dashboard.py` consumer bug: it stuffs each returned **dict** into `{"name": key, ...}`, so `custom_attributes` ships `{"name": {"key": "env", ...}}`. `observation_span.py` normalizes exactly this shape and says why; `dashboard.py` never did. Not caused by this PR and not touched by it.
- **Branch name nit**: the branch is `fix/th-7632-attribute-discovery-sampling`, lowercase. Renaming it now would mean a new PR, so it stays. Linear TH-7632 is attached and sits In Review.

**Verified on the double-count claim, not just reasoned about.** Local repro project, one ClickHouse statement so all four numbers share one `now()`:

```
spans in the 7d discovery window                        150190
count for key `env`   BEFORE  (sample lane = count())   160190     <- overstated by exactly 10000
count for key `env`   AFTER   (sample lane = 0)         150190
distinct keys returned, BEFORE and AFTER alike              27     <- visibility unchanged
```

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation

## Checklist

- [x] Follows the repo style guide (`ruff format` / `ruff check` clean on the touched file)
- [x] Tests added, and they fail if the fix is reverted
- [x] No secrets, no debug output, no proof media committed to the branch

## Backout / rollback

- Clean revert of this branch's three commits; nothing else depends on them.
- No migration, no schema change, no data written.
- Reverting returns the pickers to the sampled behaviour exactly as it is on `dev` today.

## Relationship to TH-7247 / #2084

None in code. This touches one function and no branch of the #2084 stack. #2084 replaces this query wholesale when it lands, at which point this change is simply removed. It is a holding fix for customers who are blocked now, not a competing one.

## Linear

Fixes TH-7632


