### PR TITLE
feat(gateway): support Anthropic server tools on the OpenAI-format endpoint

### DIFF
--- a/agentcc-gateway/internal/models/request.go
+++ b/agentcc-gateway/internal/models/request.go
@@ -4,29 +4,29 @@ import "encoding/json"
 
 // ChatCompletionRequest represents an OpenAI-compatible chat completion request.
 type ChatCompletionRequest struct {
-	Model            string          `json:"model"`
-	Messages         []Message       `json:"messages"`
-	Temperature      *float64        `json:"temperature,omitempty"`
-	TopP             *float64        `json:"top_p,omitempty"`
-	N                *int            `json:"n,omitempty"`
-	Stream           bool            `json:"stream,omitempty"`
-	StreamOptions    *StreamOptions  `json:"stream_options,omitempty"`
-	Stop             json.RawMessage `json:"stop,omitempty"`
-	MaxTokens        *int            `json:"max_tokens,omitempty"`
-	MaxCompletionTokens *int         `json:"max_completion_tokens,omitempty"`
-	PresencePenalty  *float64        `json:"presence_penalty,omitempty"`
-	FrequencyPenalty *float64        `json:"frequency_penalty,omitempty"`
-	LogitBias        map[string]int  `json:"logit_bias,omitempty"`
-	Logprobs         *bool           `json:"logprobs,omitempty"`
-	TopLogprobs      *int            `json:"top_logprobs,omitempty"`
-	User             string          `json:"user,omitempty"`
-	Seed             *int            `json:"seed,omitempty"`
-	Tools            []Tool          `json:"tools,omitempty"`
-	ToolChoice       json.RawMessage `json:"tool_choice,omitempty"`
-	ResponseFormat   *ResponseFormat `json:"response_format,omitempty"`
-	ServiceTier      string          `json:"service_tier,omitempty"`
-	Modalities       []string        `json:"modalities,omitempty"`
-	Audio            *AudioConfig    `json:"audio,omitempty"`
+	Model               string          `json:"model"`
+	Messages            []Message       `json:"messages"`
+	Temperature         *float64        `json:"temperature,omitempty"`
+	TopP                *float64        `json:"top_p,omitempty"`
+	N                   *int            `json:"n,omitempty"`
+	Stream              bool            `json:"stream,omitempty"`
+	StreamOptions       *StreamOptions  `json:"stream_options,omitempty"`
+	Stop                json.RawMessage `json:"stop,omitempty"`
+	MaxTokens           *int            `json:"max_tokens,omitempty"`
+	MaxCompletionTokens *int            `json:"max_completion_tokens,omitempty"`
+	PresencePenalty     *float64        `json:"presence_penalty,omitempty"`
+	FrequencyPenalty    *float64        `json:"frequency_penalty,omitempty"`
+	LogitBias           map[string]int  `json:"logit_bias,omitempty"`
+	Logprobs            *bool           `json:"logprobs,omitempty"`
+	TopLogprobs         *int            `json:"top_logprobs,omitempty"`
+	User                string          `json:"user,omitempty"`
+	Seed                *int            `json:"seed,omitempty"`
+	Tools               []Tool          `json:"tools,omitempty"`
+	ToolChoice          json.RawMessage `json:"tool_choice,omitempty"`
+	ResponseFormat      *ResponseFormat `json:"response_format,omitempty"`
+	ServiceTier         string          `json:"service_tier,omitempty"`
+	Modalities          []string        `json:"modalities,omitempty"`
+	Audio               *AudioConfig    `json:"audio,omitempty"`
 
 	// Extra captures unknown fields for pass-through to providers.
 	Extra map[string]json.RawMessage `json:"-"`
@@ -103,11 +103,11 @@ func (r ChatCompletionRequest) MarshalJSON() ([]byte, error) {
 }
 
 type Message struct {
-	Role           string          `json:"role"`
-	Content        json.RawMessage `json:"content,omitempty"`
-	Name           string          `json:"name,omitempty"`
-	ToolCalls      []ToolCall      `json:"tool_calls,omitempty"`
-	ToolCallID     string          `json:"tool_call_id,omitempty"`
+	Role       string          `json:"role"`
+	Content    json.RawMessage `json:"content,omitempty"`
+	Name       string          `json:"name,omitempty"`
+	ToolCalls  []ToolCall      `json:"tool_calls,omitempty"`
+	ToolCallID string          `json:"tool_call_id,omitempty"`
 	// ThinkingBlocks carries Anthropic extended-thinking content blocks on the
 	// canonical OpenAI Message.  Non-standard field (LiteLLM convention); present
 	// only when the upstream provider returned thinking blocks.  JSON key is
@@ -118,6 +118,11 @@ type Message struct {
 	// thought summaries, DeepSeek/LiteLLM convention). Non-standard OpenAI
 	// field, omitempty so it's silent for providers that don't emit it.
 	ReasoningContent string `json:"reasoning_content,omitempty"`
+	// Annotations carries source citations in OpenAI's own url_citation shape,
+	// which is what its web-search responses use.  Populated from Anthropic's
+	// web_search_result_location citations; omitempty so it is silent for
+	// providers and requests that produce none.
+	Annotations json.RawMessage `json:"annotations,omitempty"`
 }
 
 type ToolCall struct {
@@ -134,6 +139,42 @@ type FunctionCall struct {
 type Tool struct {
 	Type     string       `json:"type"`
 	Function ToolFunction `json:"function"`
+
+	// Raw holds the caller's original bytes for a tool that is not a plain
+	// "function" — Anthropic's server tools (web_search_20250305 and the
+	// versions after it, code_execution, ...) are executed by the provider and
+	// carry their own fields: max_uses, allowed_domains, user_location.  None
+	// of those fit ToolFunction, so re-marshalling this struct would silently
+	// strip them.  Keeping the bytes lets the entry reach the provider exactly
+	// as it was written, and lets a provider that does not support it answer
+	// with its own error instead of the gateway inventing one.
+	Raw json.RawMessage `json:"-"`
+}
+
+// UnmarshalJSON keeps the original bytes of a non-function tool.  New server
+// tool types ship regularly, so the test is "not a function" rather than a list
+// of known type strings that would need editing for each one.
+func (t *Tool) UnmarshalJSON(data []byte) error {
+	type toolAlias Tool
+	var a toolAlias
+	if err := json.Unmarshal(data, &a); err != nil {
+		return err
+	}
+	*t = Tool(a)
+	if t.Type != "" && t.Type != "function" {
+		t.Raw = append(json.RawMessage(nil), data...)
+	}
+	return nil
+}
+
+// MarshalJSON replays those bytes, so a server tool survives the round trip
+// through the canonical struct on every provider path.
+func (t Tool) MarshalJSON() ([]byte, error) {
+	if len(t.Raw) > 0 {
+		return t.Raw, nil
+	}
+	type toolAlias Tool
+	return json.Marshal(toolAlias(t))
 }
 
 type ToolFunction struct {

--- a/agentcc-gateway/internal/models/response.go
+++ b/agentcc-gateway/internal/models/response.go
@@ -52,18 +52,27 @@ type Usage struct {
 	TotalTokens             int              `json:"total_tokens"`
 	PromptTokensDetails     *json.RawMessage `json:"prompt_tokens_details,omitempty"`
 	CompletionTokensDetails *json.RawMessage `json:"completion_tokens_details,omitempty"`
+	// ServerToolUse counts provider-executed tool calls, which are billed per
+	// call on top of tokens.  A response that reports tokens alone understates
+	// what the request cost.
+	ServerToolUse *ServerToolUsage `json:"server_tool_use,omitempty"`
+}
+
+// ServerToolUsage mirrors Anthropic's usage.server_tool_use block.
+type ServerToolUsage struct {
+	WebSearchRequests int `json:"web_search_requests,omitempty"`
 }
 
 // StreamChunk represents a single SSE chunk in a streaming response.
 type StreamChunk struct {
-	ID                string               `json:"id"`
-	Object            string               `json:"object"`
-	Created           int64                `json:"created"`
-	Model             string               `json:"model"`
-	Choices           []StreamChoice       `json:"choices"`
-	Usage             *Usage               `json:"usage,omitempty"`
-	AgentccMetadata     *AgentccStreamMetadata `json:"agentcc_metadata,omitempty"`
-	SystemFingerprint string               `json:"system_fingerprint,omitempty"`
+	ID                string                 `json:"id"`
+	Object            string                 `json:"object"`
+	Created           int64                  `json:"created"`
+	Model             string                 `json:"model"`
+	Choices           []StreamChoice         `json:"choices"`
+	Usage             *Usage                 `json:"usage,omitempty"`
+	AgentccMetadata   *AgentccStreamMetadata `json:"agentcc_metadata,omitempty"`
+	SystemFingerprint string                 `json:"system_fingerprint,omitempty"`
 }
 
 type AgentccStreamMetadata struct {

--- a/agentcc-gateway/internal/providers/anthropic/anthropic_test.go
+++ b/agentcc-gateway/internal/providers/anthropic/anthropic_test.go
@@ -752,8 +752,11 @@ func TestIntegration_NonStreamingToolUseRoundtrip(t *testing.T) {
 		if len(ar.Tools) != 1 {
 			t.Errorf("tools length = %d, want 1", len(ar.Tools))
 		}
-		if ar.Tools[0].Name != "get_weather" {
-			t.Errorf("tool name = %q, want %q", ar.Tools[0].Name, "get_weather")
+		var tool anthropicTool
+		if err := json.Unmarshal(ar.Tools[0], &tool); err != nil {
+			t.Errorf("decoding tool: %v", err)
+		} else if tool.Name != "get_weather" {
+			t.Errorf("tool name = %q, want %q", tool.Name, "get_weather")
 		}
 
 		// Return a tool_use response.

--- a/agentcc-gateway/internal/providers/anthropic/stream.go
+++ b/agentcc-gateway/internal/providers/anthropic/stream.go
@@ -61,9 +61,9 @@ type messageDeltaData struct {
 }
 
 type contentBlockStartData struct {
-	Type  string `json:"type"`
-	ID    string `json:"id,omitempty"`
-	Name  string `json:"name,omitempty"`
+	Type string `json:"type"`
+	ID   string `json:"id,omitempty"`
+	Name string `json:"name,omitempty"`
 }
 
 // parseSSELine parses a single SSE data line and returns a StreamChunk if one should be emitted.
@@ -211,6 +211,15 @@ func (s *streamState) handleContentBlockDelta(event streamEvent) (*models.Stream
 	// Try input_json_delta (tool use arguments streaming).
 	var ijd inputJSONDelta
 	if err := json.Unmarshal(event.Delta, &ijd); err == nil && ijd.Type == "input_json_delta" {
+		// Only a client tool_use block streams arguments the caller must act
+		// on. A server_tool_use block streams its own input the same way — the
+		// web search query — and Anthropic has already run it. Forwarding that
+		// as tool-call arguments either invents a nameless tool call the caller
+		// never saw start, or appends the query onto a real tool call still in
+		// flight and corrupts its arguments into invalid JSON.
+		if !s.blockIsToolUse {
+			return nil, false, nil
+		}
 		// Use the tracked tool call index (0-based among tool_use blocks),
 		// not the Anthropic content block index which counts all block types.
 		tcIdx := s.toolCallIndex - 1

--- a/agentcc-gateway/internal/providers/anthropic/translate.go
+++ b/agentcc-gateway/internal/providers/anthropic/translate.go
@@ -22,7 +22,7 @@ type anthropicRequest struct {
 	TopP          *float64               `json:"top_p,omitempty"`
 	StopSequences []string               `json:"stop_sequences,omitempty"`
 	Stream        bool                   `json:"stream,omitempty"`
-	Tools         []anthropicTool        `json:"tools,omitempty"`
+	Tools         []json.RawMessage      `json:"tools,omitempty"`
 	ToolChoice    *anthropicToolChoice   `json:"tool_choice,omitempty"`
 	OutputConfig  *anthropicOutputConfig `json:"output_config,omitempty"`
 }
@@ -51,6 +51,7 @@ type anthropicContentBlock struct {
 	Content   json.RawMessage `json:"content,omitempty"`
 	Source    *imageSource    `json:"source,omitempty"`
 	Thinking  string          `json:"thinking,omitempty"`
+	Citations json.RawMessage `json:"citations,omitempty"`
 }
 
 type imageSource struct {
@@ -82,8 +83,21 @@ type anthropicResponse struct {
 }
 
 type anthropicUsage struct {
-	InputTokens  int `json:"input_tokens"`
-	OutputTokens int `json:"output_tokens"`
+	InputTokens   int                  `json:"input_tokens"`
+	OutputTokens  int                  `json:"output_tokens"`
+	ServerToolUse *anthropicServerTool `json:"server_tool_use,omitempty"`
+}
+
+type anthropicServerTool struct {
+	WebSearchRequests int `json:"web_search_requests,omitempty"`
+}
+
+// anthropicCitation is one web_search_result_location entry on a text block.
+type anthropicCitation struct {
+	Type      string `json:"type"`
+	URL       string `json:"url,omitempty"`
+	Title     string `json:"title,omitempty"`
+	CitedText string `json:"cited_text,omitempty"`
 }
 
 type anthropicErrorResponse struct {
@@ -156,17 +170,27 @@ func translateRequest(req *models.ChatCompletionRequest) (*anthropicRequest, err
 		ar.System = system
 	}
 
-	// Translate tools.
-	if len(req.Tools) > 0 {
-		for _, t := range req.Tools {
-			if t.Type != "function" {
-				continue
-			}
-			ar.Tools = append(ar.Tools, anthropicTool{
+	// Translate tools.  A function tool is rebuilt in Anthropic's shape; a
+	// server tool — web_search_20250305 and its successors, code_execution,
+	// anything Anthropic runs itself — is forwarded byte for byte, because its
+	// fields (max_uses, allowed_domains, user_location, allowed_callers) have
+	// nowhere to live on the canonical struct.  Dropping it, which is what this
+	// did before, left the model with no tool and no error to explain why.
+	for _, t := range req.Tools {
+		if t.Type == "function" {
+			encoded, err := json.Marshal(anthropicTool{
 				Name:        t.Function.Name,
 				Description: t.Function.Description,
 				InputSchema: t.Function.Parameters,
 			})
+			if err != nil {
+				return nil, fmt.Errorf("encoding tool %q: %w", t.Function.Name, err)
+			}
+			ar.Tools = append(ar.Tools, encoded)
+			continue
+		}
+		if len(t.Raw) > 0 {
+			ar.Tools = append(ar.Tools, t.Raw)
 		}
 	}
 
@@ -443,10 +467,18 @@ func translateResponse(resp *anthropicResponse) *models.ChatCompletionResponse {
 	}
 	var thinkingBlocks []thinkingBlock
 
+	// Citations arrive attached to the text block they support. The canonical
+	// message carries one flat annotation list over the joined text, so track
+	// where each block lands in that string to give every annotation a span.
+	var annotations []urlCitation
+	textLen := 0
+
 	for _, block := range resp.Content {
 		switch block.Type {
 		case "text":
 			textParts = append(textParts, block.Text)
+			annotations = append(annotations, citationsForBlock(block, textLen)...)
+			textLen += len(block.Text)
 		case "thinking":
 			// Anthropic extended thinking blocks (Claude 3.7+).
 			// Stash on the canonical message so the inbound translator can
@@ -482,6 +514,12 @@ func translateResponse(resp *anthropicResponse) *models.ChatCompletionResponse {
 	if len(thinkingBlocks) > 0 {
 		if b, err := json.Marshal(thinkingBlocks); err == nil {
 			msg.ThinkingBlocks = b
+		}
+	}
+
+	if len(annotations) > 0 {
+		if b, err := json.Marshal(annotations); err == nil {
+			msg.Annotations = b
 		}
 	}
 
@@ -552,8 +590,66 @@ func translateResponse(resp *anthropicResponse) *models.ChatCompletionResponse {
 			PromptTokens:     resp.Usage.InputTokens,
 			CompletionTokens: resp.Usage.OutputTokens,
 			TotalTokens:      resp.Usage.InputTokens + resp.Usage.OutputTokens,
+			ServerToolUse:    serverToolUsage(resp.Usage.ServerToolUse),
 		},
 	}
+}
+
+// urlCitation is OpenAI's annotation shape, which its own web-search responses
+// use, so a caller already handling those needs no gateway-specific parsing.
+type urlCitation struct {
+	Type        string          `json:"type"`
+	URLCitation urlCitationBody `json:"url_citation"`
+}
+
+type urlCitationBody struct {
+	StartIndex int    `json:"start_index"`
+	EndIndex   int    `json:"end_index"`
+	URL        string `json:"url"`
+	Title      string `json:"title,omitempty"`
+	CitedText  string `json:"cited_text,omitempty"`
+}
+
+// citationsForBlock maps one text block's citations onto the joined response
+// text. Anthropic cites a whole block rather than a character range, so the
+// span is the block's own extent — offset is where it starts in the join.
+func citationsForBlock(block anthropicContentBlock, offset int) []urlCitation {
+	if len(block.Citations) == 0 {
+		return nil
+	}
+	var cites []anthropicCitation
+	if err := json.Unmarshal(block.Citations, &cites); err != nil {
+		slog.Warn("anthropic: could not decode citations, dropping them",
+			"error", err)
+		return nil
+	}
+	out := make([]urlCitation, 0, len(cites))
+	for _, c := range cites {
+		if c.URL == "" {
+			continue
+		}
+		out = append(out, urlCitation{
+			Type: "url_citation",
+			URLCitation: urlCitationBody{
+				StartIndex: offset,
+				EndIndex:   offset + len(block.Text),
+				URL:        c.URL,
+				Title:      c.Title,
+				CitedText:  c.CitedText,
+			},
+		})
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+func serverToolUsage(u *anthropicServerTool) *models.ServerToolUsage {
+	if u == nil || u.WebSearchRequests == 0 {
+		return nil
+	}
+	return &models.ServerToolUsage{WebSearchRequests: u.WebSearchRequests}
 }
 
 func mapStopReason(reason string) string {
@@ -566,6 +662,11 @@ func mapStopReason(reason string) string {
 		return "stop"
 	case "tool_use":
 		return "tool_calls"
+	case "pause_turn":
+		// A long-running server tool turn that Anthropic paused and expects to
+		// be handed back. It is not finished, so do not report "stop" — the
+		// nearest honest OpenAI reason is a truncated generation.
+		return "length"
 	default:
 		return "stop"
 	}

--- a/agentcc-gateway/internal/providers/anthropic/translate_test.go
+++ b/agentcc-gateway/internal/providers/anthropic/translate_test.go
@@ -2,6 +2,7 @@ package anthropic
 
 import (
 	"encoding/json"
+	"reflect"
 	"strings"
 	"testing"
 
@@ -294,7 +295,7 @@ func TestTranslateRequest_ToolsTranslation(t *testing.T) {
 	if len(ar.Tools) != 1 {
 		t.Fatalf("tools length = %d, want 1", len(ar.Tools))
 	}
-	tool := ar.Tools[0]
+	tool := decodeTool(t, ar.Tools[0])
 	if tool.Name != "get_weather" {
 		t.Errorf("tool name = %q, want %q", tool.Name, "get_weather")
 	}
@@ -306,7 +307,19 @@ func TestTranslateRequest_ToolsTranslation(t *testing.T) {
 	}
 }
 
-func TestTranslateRequest_ToolsSkipNonFunction(t *testing.T) {
+// decodeTool reads back one entry of the raw tools array.
+func decodeTool(t *testing.T, raw json.RawMessage) anthropicTool {
+	t.Helper()
+	var tool anthropicTool
+	if err := json.Unmarshal(raw, &tool); err != nil {
+		t.Fatalf("decoding tool %s: %v", raw, err)
+	}
+	return tool
+}
+
+// A non-function tool with no original bytes has nothing to forward — it can
+// only have been built in Go, never parsed off the wire.
+func TestTranslateRequest_ToolsSkipNonFunctionWithoutRawBytes(t *testing.T) {
 	req := &models.ChatCompletionRequest{
 		Model: "claude-3-sonnet-20240229",
 		Messages: []models.Message{
@@ -323,10 +336,82 @@ func TestTranslateRequest_ToolsSkipNonFunction(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	if len(ar.Tools) != 1 {
-		t.Fatalf("tools length = %d, want 1 (non-function type should be skipped)", len(ar.Tools))
+		t.Fatalf("tools length = %d, want 1 (a non-function tool with no raw bytes has nothing to send)", len(ar.Tools))
 	}
-	if ar.Tools[0].Name != "keep_me" {
-		t.Errorf("tool name = %q, want %q", ar.Tools[0].Name, "keep_me")
+	if got := decodeTool(t, ar.Tools[0]).Name; got != "keep_me" {
+		t.Errorf("tool name = %q, want %q", got, "keep_me")
+	}
+}
+
+// The real case: a server tool arrives as JSON, so its bytes are kept and must
+// reach Anthropic unchanged. Dropping it is what made web search a silent no-op.
+func TestTranslateRequest_ForwardsServerToolsVerbatim(t *testing.T) {
+	const webSearch = `{"type":"web_search_20250305","name":"web_search","max_uses":5,` +
+		`"allowed_domains":["example.com"],` +
+		`"user_location":{"type":"approximate","city":"San Francisco","country":"US"}}`
+
+	body := []byte(`{"model":"claude-sonnet-4-20250514","messages":[{"role":"user","content":"hi"}],` +
+		`"tools":[` + webSearch + `,` +
+		`{"type":"function","function":{"name":"keep_me","parameters":{}}}]}`)
+
+	var req models.ChatCompletionRequest
+	if err := json.Unmarshal(body, &req); err != nil {
+		t.Fatalf("unmarshaling request: %v", err)
+	}
+
+	ar, err := translateRequest(&req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(ar.Tools) != 2 {
+		t.Fatalf("tools length = %d, want 2 (server tool + function tool)", len(ar.Tools))
+	}
+
+	// Byte-for-byte: max_uses, allowed_domains and user_location have nowhere
+	// to live on the canonical struct, so anything short of the original bytes
+	// loses them.
+	var got, want interface{}
+	if err := json.Unmarshal(ar.Tools[0], &got); err != nil {
+		t.Fatalf("decoding forwarded server tool: %v", err)
+	}
+	if err := json.Unmarshal([]byte(webSearch), &want); err != nil {
+		t.Fatalf("decoding expected server tool: %v", err)
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("server tool was not forwarded verbatim\n got %s\nwant %s", ar.Tools[0], webSearch)
+	}
+
+	if name := decodeTool(t, ar.Tools[1]).Name; name != "keep_me" {
+		t.Errorf("function tool name = %q, want %q", name, "keep_me")
+	}
+}
+
+// Version strings change — 20250305, 20260209, 20260318 and whatever follows.
+// The passthrough must key on "not a function", never on a known-version list.
+func TestTranslateRequest_ForwardsUnknownServerToolVersions(t *testing.T) {
+	for _, toolType := range []string{
+		"web_search_20250305",
+		"web_search_20260209",
+		"web_search_20260318",
+		"web_search_29991231",
+		"code_execution_20260120",
+	} {
+		t.Run(toolType, func(t *testing.T) {
+			body := []byte(`{"model":"claude-sonnet-4-20250514","messages":[{"role":"user","content":"hi"}],` +
+				`"tools":[{"type":"` + toolType + `","name":"t"}]}`)
+
+			var req models.ChatCompletionRequest
+			if err := json.Unmarshal(body, &req); err != nil {
+				t.Fatalf("unmarshaling request: %v", err)
+			}
+			ar, err := translateRequest(&req)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if len(ar.Tools) != 1 {
+				t.Fatalf("tools length = %d, want 1 — %q was dropped", len(ar.Tools), toolType)
+			}
+		})
 	}
 }
 
@@ -823,7 +908,9 @@ func TestStreamParse_ContentBlockDelta_TextDelta(t *testing.T) {
 }
 
 func TestStreamParse_ContentBlockDelta_InputJSONDelta(t *testing.T) {
-	state := &streamState{messageID: "msg_2", model: "claude-3"}
+	// A real stream always opens the tool_use block first; blockIsToolUse is
+	// what that content_block_start sets.
+	state := &streamState{messageID: "msg_2", model: "claude-3", blockIsToolUse: true, toolCallIndex: 1}
 	data := `{"type":"content_block_delta","index":1,"delta":{"type":"input_json_delta","partial_json":"{\"loc"}}`
 
 	chunk, done, err := state.parseSSELine("content_block_delta", data)
@@ -1611,5 +1698,232 @@ func TestMapStopReason(t *testing.T) {
 				t.Errorf("mapStopReason(%q) = %q, want %q", tt.input, got, tt.want)
 			}
 		})
+	}
+}
+
+// Web search answers are useless without their sources, and Anthropic requires
+// citations be shown when its output is displayed to end users. They arrive on
+// the text block; OpenAI carries them as url_citation annotations.
+func TestTranslateResponse_CitationsBecomeURLCitationAnnotations(t *testing.T) {
+	resp := &anthropicResponse{
+		ID:    "msg_1",
+		Model: "claude-sonnet-4-20250514",
+		Content: []anthropicContentBlock{
+			{Type: "text", Text: "Based on the search results, "},
+			{
+				Type: "text",
+				Text: "Claude Shannon was born on April 30, 1916.",
+				Citations: json.RawMessage(`[{"type":"web_search_result_location",
+					"url":"https://en.wikipedia.org/wiki/Claude_Shannon",
+					"title":"Claude Shannon - Wikipedia",
+					"encrypted_index":"Eo8BCioIAhgBIiQyYjQ0OWJmZi1lNm..",
+					"cited_text":"Claude Elwood Shannon (April 30, 1916 - February 24, 2001)"}]`),
+			},
+		},
+		StopReason: "end_turn",
+	}
+
+	out := translateResponse(resp)
+	msg := out.Choices[0].Message
+
+	if len(msg.Annotations) == 0 {
+		t.Fatal("no annotations: the citations were dropped")
+	}
+	var got []urlCitation
+	if err := json.Unmarshal(msg.Annotations, &got); err != nil {
+		t.Fatalf("decoding annotations: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("annotations = %d, want 1", len(got))
+	}
+	c := got[0]
+	if c.Type != "url_citation" {
+		t.Errorf("type = %q, want %q", c.Type, "url_citation")
+	}
+	if c.URLCitation.URL != "https://en.wikipedia.org/wiki/Claude_Shannon" {
+		t.Errorf("url = %q", c.URLCitation.URL)
+	}
+	if c.URLCitation.Title != "Claude Shannon - Wikipedia" {
+		t.Errorf("title = %q", c.URLCitation.Title)
+	}
+
+	// The span must index into the joined text, not the single block, or a
+	// caller highlighting the citation underlines the wrong words.
+	const firstBlock = "Based on the search results, "
+	if c.URLCitation.StartIndex != len(firstBlock) {
+		t.Errorf("start_index = %d, want %d (offset of the cited block in the joined text)",
+			c.URLCitation.StartIndex, len(firstBlock))
+	}
+	wantEnd := len(firstBlock) + len("Claude Shannon was born on April 30, 1916.")
+	if c.URLCitation.EndIndex != wantEnd {
+		t.Errorf("end_index = %d, want %d", c.URLCitation.EndIndex, wantEnd)
+	}
+
+	var text string
+	if err := json.Unmarshal(msg.Content, &text); err != nil {
+		t.Fatalf("decoding content: %v", err)
+	}
+	if text[c.URLCitation.StartIndex:c.URLCitation.EndIndex] != "Claude Shannon was born on April 30, 1916." {
+		t.Errorf("the span does not select the cited sentence: %q",
+			text[c.URLCitation.StartIndex:c.URLCitation.EndIndex])
+	}
+}
+
+// A server_tool_use block is a call Anthropic already ran. Turning it into an
+// OpenAI tool_call would tell the client to execute a tool it does not have,
+// and the client would hang waiting to answer a call nobody is expecting.
+func TestTranslateResponse_ServerToolUseIsNotAClientToolCall(t *testing.T) {
+	resp := &anthropicResponse{
+		ID:    "msg_2",
+		Model: "claude-sonnet-4-20250514",
+		Content: []anthropicContentBlock{
+			{Type: "server_tool_use", ID: "srvtoolu_01", Name: "web_search",
+				Input: json.RawMessage(`{"query":"claude shannon birth date"}`)},
+			{Type: "web_search_tool_result", ToolUseID: "srvtoolu_01",
+				Content: json.RawMessage(`[{"type":"web_search_result","url":"https://example.com","title":"T"}]`)},
+			{Type: "text", Text: "He was born in 1916."},
+		},
+		StopReason: "end_turn",
+	}
+
+	out := translateResponse(resp)
+	if tc := out.Choices[0].Message.ToolCalls; len(tc) != 0 {
+		t.Fatalf("server-executed tool surfaced as %d client tool_calls: %+v", len(tc), tc)
+	}
+	if got := out.Choices[0].FinishReason; got != "stop" {
+		t.Errorf("finish_reason = %q, want %q", got, "stop")
+	}
+}
+
+// Searches are billed per call on top of tokens, so a response reporting tokens
+// alone understates the cost.
+func TestTranslateResponse_CarriesServerToolUsage(t *testing.T) {
+	resp := &anthropicResponse{
+		ID:         "msg_3",
+		Model:      "claude-sonnet-4-20250514",
+		Content:    []anthropicContentBlock{{Type: "text", Text: "ok"}},
+		StopReason: "end_turn",
+		Usage: anthropicUsage{
+			InputTokens:   6039,
+			OutputTokens:  931,
+			ServerToolUse: &anthropicServerTool{WebSearchRequests: 3},
+		},
+	}
+
+	out := translateResponse(resp)
+	if out.Usage.ServerToolUse == nil {
+		t.Fatal("server_tool_use missing: the billable search count was dropped")
+	}
+	if got := out.Usage.ServerToolUse.WebSearchRequests; got != 3 {
+		t.Errorf("web_search_requests = %d, want 3", got)
+	}
+}
+
+func TestTranslateResponse_NoServerToolUsageWhenAbsent(t *testing.T) {
+	resp := &anthropicResponse{
+		ID:         "msg_4",
+		Model:      "claude-sonnet-4-20250514",
+		Content:    []anthropicContentBlock{{Type: "text", Text: "ok"}},
+		StopReason: "end_turn",
+		Usage:      anthropicUsage{InputTokens: 10, OutputTokens: 5},
+	}
+	if out := translateResponse(resp); out.Usage.ServerToolUse != nil {
+		t.Errorf("server_tool_use = %+v, want nil for a request that ran no server tools", out.Usage.ServerToolUse)
+	}
+}
+
+// pause_turn means Anthropic stopped a long search mid-turn and expects the
+// message handed back. Reporting "stop" tells the caller the answer is complete
+// when it is not.
+func TestMapStopReason_PauseTurnIsNotStop(t *testing.T) {
+	if got := mapStopReason("pause_turn"); got == "stop" {
+		t.Error(`pause_turn maps to "stop" — an unfinished turn reads as a finished one`)
+	}
+	for reason, want := range map[string]string{
+		"end_turn":      "stop",
+		"max_tokens":    "length",
+		"stop_sequence": "stop",
+		"tool_use":      "tool_calls",
+	} {
+		if got := mapStopReason(reason); got != want {
+			t.Errorf("mapStopReason(%q) = %q, want %q", reason, got, want)
+		}
+	}
+}
+
+func TestTranslateResponse_NoAnnotationsWhenNoCitations(t *testing.T) {
+	resp := &anthropicResponse{
+		ID:         "msg_5",
+		Model:      "claude-sonnet-4-20250514",
+		Content:    []anthropicContentBlock{{Type: "text", Text: "plain answer"}},
+		StopReason: "end_turn",
+	}
+	if out := translateResponse(resp); len(out.Choices[0].Message.Annotations) != 0 {
+		t.Errorf("annotations = %s, want none", out.Choices[0].Message.Annotations)
+	}
+}
+
+// Anthropic streams a server tool's own input as input_json_delta, exactly like
+// a client tool's arguments. It has already run the call, so forwarding those
+// bytes as tool-call arguments invents a call the caller never saw start.
+func TestStreamParse_ServerToolUseInputIsNotForwardedAsToolCallArgs(t *testing.T) {
+	state := &streamState{messageID: "msg_ws", model: "claude-sonnet-4-20250514"}
+
+	start := `{"type":"content_block_start","index":1,"content_block":` +
+		`{"type":"server_tool_use","id":"srvtoolu_xyz789","name":"web_search"}}`
+	chunk, _, err := state.parseSSELine("content_block_start", start)
+	if err != nil {
+		t.Fatalf("unexpected error on content_block_start: %v", err)
+	}
+	if chunk != nil {
+		t.Fatalf("server_tool_use opened a client tool call: %+v", chunk.Choices[0].Delta.ToolCalls)
+	}
+
+	delta := `{"type":"content_block_delta","index":1,"delta":{"type":"input_json_delta",` +
+		`"partial_json":"{\"query\":\"latest quantum computing breakthroughs\"}"}}`
+	chunk, _, err = state.parseSSELine("content_block_delta", delta)
+	if err != nil {
+		t.Fatalf("unexpected error on content_block_delta: %v", err)
+	}
+	if chunk != nil {
+		t.Fatalf("the search query was forwarded as tool-call arguments: %+v", chunk.Choices[0].Delta.ToolCalls)
+	}
+}
+
+// The corrupting case: a real client tool call is streaming when a server tool
+// runs. Without the guard the search query is appended to that call's arguments
+// and the caller unmarshals invalid JSON.
+func TestStreamParse_ServerToolUseDoesNotCorruptAnInFlightToolCall(t *testing.T) {
+	state := &streamState{messageID: "msg_mix", model: "claude-sonnet-4-20250514"}
+
+	toolStart := `{"type":"content_block_start","index":0,"content_block":` +
+		`{"type":"tool_use","id":"toolu_1","name":"get_weather"}}`
+	if _, _, err := state.parseSSELine("content_block_start", toolStart); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	args := `{"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"{\"city\":"}}`
+	chunk, _, err := state.parseSSELine("content_block_delta", args)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if chunk == nil || len(chunk.Choices[0].Delta.ToolCalls) != 1 {
+		t.Fatal("the client tool call's own arguments must still stream")
+	}
+
+	// Anthropic now opens a server tool block and streams its query.
+	srvStart := `{"type":"content_block_start","index":1,"content_block":` +
+		`{"type":"server_tool_use","id":"srvtoolu_1","name":"web_search"}}`
+	if _, _, err := state.parseSSELine("content_block_start", srvStart); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	srvDelta := `{"type":"content_block_delta","index":1,"delta":{"type":"input_json_delta",` +
+		`"partial_json":"{\"query\":\"weather\"}"}}`
+	chunk, _, err = state.parseSSELine("content_block_delta", srvDelta)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if chunk != nil {
+		t.Fatalf("the search query was appended to get_weather's arguments: %+v",
+			chunk.Choices[0].Delta.ToolCalls)
 	}
 }


### PR DESCRIPTION
Closes TH-7666.

## The bug

A caller on the OpenAI wire format (`POST /v1/chat/completions`) against an Anthropic provider cannot use Claude's built-in web search. `internal/providers/anthropic/translate.go` filtered the tool list to `type == "function"` and `continue`d past everything else:

```go
for _, t := range req.Tools {
    if t.Type != "function" {
        continue   // web_search_20250305 dropped here
    }
```

Anthropic's server tools are a different shape — `{"type":"web_search_20250305","name":"web_search","max_uses":5}` — so the entry was silently discarded. No error, no `x-agentcc-translation-drops`. The model never searched and answered from training data, which reads to the caller as a model quality problem rather than a gateway one.

The native dialect endpoint `/v1/messages` was never affected — it forwards caller bytes verbatim.

## Request side

`models.Tool` is `{Type, Function{Name, Description, Parameters, Strict}}`, which cannot carry `max_uses` / `allowed_domains` / `blocked_domains` / `user_location` / `allowed_callers` / `response_inclusion`. Relaxing the type check alone would have forwarded a tool stripped of every field that configures it.

So `Tool` keeps the caller's original bytes for a non-function tool and replays them on marshal. That makes the round trip lossless on **every** provider path, since the OpenAI provider also re-marshals the canonical struct — a provider that doesn't support the tool now answers with its own error instead of the gateway inventing one.

The test is **"not a function"**, never a list of known type strings. Three versions already exist (`web_search_20250305`, `web_search_20260209`, `web_search_20260318`) and more will follow; a version list would need editing for each one and would fail closed, silently, exactly as today.

## Response side

`translateResponse` switches on block type with no `default`, so everything below was dropped:

- **Citations** → now OpenAI `url_citation` annotations. This is the one that matters most: they carry the sources, and Anthropic's docs require citations be displayed when its output is shown to end users. Anthropic cites a whole text block, so the annotation is spanned against the **joined** response text — a test asserts `text[start:end]` selects exactly the cited sentence, because indexing the single block would underline the wrong words.
- **`usage.server_tool_use.web_search_requests`** → `Usage.ServerToolUse`. Searches bill at $10/1000 on top of tokens; reporting tokens alone understates what the request cost.
- **`stop_reason: "pause_turn"`** fell through `mapStopReason`'s default to `"stop"`, reporting a turn Anthropic paused mid-search as finished. Now `"length"` — the nearest honest OpenAI reason for an incomplete generation.

`server_tool_use` blocks were already safe by accident (no `default` case meant they never became client `tool_calls`); there is now a test pinning that, because it is load-bearing and was previously only true by omission.

## Streaming bug found on the way

`blockIsToolUse` was tracked — set false on every `content_block_start`, true only for `tool_use` — and then **never read**. Anthropic streams a server tool's own input as `input_json_delta`, byte-identical in shape to a client tool's arguments:

```
content_block_start  {"type":"server_tool_use","id":"srvtoolu_xyz","name":"web_search"}
content_block_delta  {"type":"input_json_delta","partial_json":"{\"query\":\"...\"}"}
```

Two failure modes, both silent:

- **No client tool call in flight** — `tcIdx` floors at 0 and the caller receives arguments for a tool call index that never had a start chunk: no id, no name.
- **A client tool call in flight** — the search query is appended onto *that* call's arguments and the caller unmarshals invalid JSON. This is the nasty one.

Gated on `blockIsToolUse`, which is what the field was for.

One existing test (`TestStreamParse_ContentBlockDelta_InputJSONDelta`) constructed a delta with no preceding `content_block_start`, which cannot happen in a real stream. It now sets up the state that a real `content_block_start` would, so it exercises the actual path rather than an impossible one.

## Deliberately not in this PR

**Multi-turn continuation.** `web_search_tool_result` blocks carry `encrypted_content` that Anthropic requires be echoed verbatim to restore search context on a later turn. Preserving them on the response is only half — the request side would need to translate them back into Anthropic content blocks, which is a larger change. Today a follow-up turn simply carries no search-result blocks, so nothing 400s; Claude re-searches if it needs to. Degraded, not broken, and called out rather than left to be discovered.

## Tests

Request: verbatim forwarding asserted by deep-equal against the original JSON (so a dropped `max_uses` or `user_location` fails); five tool type strings including a fabricated future version; a non-function tool with no raw bytes still skipped.

Response: citation → annotation mapping with the span asserted by slicing the response text; `server_tool_use` producing zero client tool calls; usage present and absent; `pause_turn` not mapping to `stop`.

Streaming: server tool input not forwarded as tool-call arguments, and the corruption case — a real `get_weather` call streaming when a search runs.

## Verification

Full gateway suite green (`go test ./... -count=1`, Go 1.25). `gofmt` clean on all six changed files. The one `go vet` warning (`internal/models/errors_test.go:109`) is pre-existing on `dev` and untouched here.

Not exercised against live Anthropic — that needs a key on the gateway. The wire shapes are taken from Anthropic's current web search tool documentation, and every request and response fixture in the tests is copied from its examples.
