### PR TITLE
fix(tracer): prevent CDC versions inflating eval graphs

### DIFF
--- a/futureagi/tracer/services/clickhouse/graph_dispatch.py
+++ b/futureagi/tracer/services/clickhouse/graph_dispatch.py
@@ -2,7 +2,6 @@ from typing import Any, Dict, List
 
 from model_hub.models.choices import AnnotationTypeChoices
 from model_hub.models.develop_annotations import AnnotationsLabels
-
 from tracer.services.clickhouse.query_builders import (
     AnnotationGraphQueryBuilder,
     EvalMetricsQueryBuilder,
@@ -84,6 +83,8 @@ def fetch_eval_graph_ch(
         interval=interval,
         eval_output_type=req_data_config.get("eval_output_type", "SCORE"),
         choices=req_data_config.get("choices", []),
+        # The hourly rollup does not handle updated CDC rows.
+        use_preaggregated=False,
     )
     query, params = builder.build()
     result = analytics.execute_ch_query(query, params, timeout_ms=timeout_ms)

--- a/futureagi/tracer/services/clickhouse/query_builders/eval_metrics.py
+++ b/futureagi/tracer/services/clickhouse/query_builders/eval_metrics.py
@@ -5,10 +5,10 @@ Replaces ``get_eval_graph_data()`` and its helpers from
 ``tracer.utils.graphs_optimized`` with ClickHouse-native queries.
 
 Strategy:
-- Unfiltered eval dashboard queries read from the ``eval_metrics_hourly``
-  pre-aggregated table.
-- Filtered queries or per-eval-config breakdowns read from the
-  ``tracer_eval_logger`` CDC table (with FINAL for correct deduplication).
+- Eval dashboard queries read from the ``tracer_eval_logger`` CDC table with
+  ``FINAL`` by default.
+- ``eval_metrics_hourly`` remains available as an explicit opt-in. Its CDC
+  materialized view does not retract aggregates for updated source rows.
 
 Supports three eval output types:
 - **float (SCORE):** ``avg(output_float) * 100`` per time bucket.
@@ -21,6 +21,7 @@ Supports three eval output types:
 from datetime import datetime, timedelta
 from typing import Any, Dict, List, Optional, Tuple, Union
 
+from tracer.services.clickhouse.eval_logger_table import eval_logger_source
 from tracer.services.clickhouse.query_builders.base import BaseQueryBuilder
 
 # Eval output type constants (mirrors EvalOutputType from Django models)
@@ -53,9 +54,9 @@ class EvalMetricsQueryBuilder(BaseQueryBuilder):
         eval_name: Human-readable name of the eval config (for output).
         choices: List of choice strings (required when ``eval_output_type``
             is ``"CHOICES"``).
-        use_preaggregated: Whether to attempt reading from the pre-aggregated
-            table.  Defaults to ``True``; set ``False`` when specific filters
-            prevent using the aggregate table.
+        use_preaggregated: Whether to read from the pre-aggregated table.
+            Defaults to ``False`` because its CDC materialized view does not
+            retract aggregates for updated source rows.
     """
 
     AGG_TABLE = "eval_metrics_hourly"
@@ -71,7 +72,7 @@ class EvalMetricsQueryBuilder(BaseQueryBuilder):
         eval_output_type: str = SCORE,
         eval_name: str = "",
         choices: Optional[List[str]] = None,
-        use_preaggregated: bool = True,
+        use_preaggregated: bool = False,
         filters: Optional[List[dict]] = None,
         **kwargs: Any,
     ) -> None:
@@ -133,6 +134,30 @@ class EvalMetricsQueryBuilder(BaseQueryBuilder):
                 f"AND {extra_where})"
             )
         return ""
+
+    @staticmethod
+    def _project_id_expr(alias: str = "e") -> str:
+        """Resolve project_id for span/trace and session eval rows."""
+        prefix = f"{alias}." if alias else ""
+        return (
+            "if("
+            f"{prefix}target_type = 'session', "
+            "dictGetOrDefault('trace_session_dict', 'project_id', "
+            f"toUUID({prefix}trace_session_id), "
+            "toUUID('00000000-0000-0000-0000-000000000000')), "
+            "dictGetOrDefault('trace_dict', 'project_id', "
+            f"toUUID({prefix}trace_id), "
+            "toUUID('00000000-0000-0000-0000-000000000000'))"
+            ")"
+        )
+
+    @staticmethod
+    def _raw_source() -> Tuple[str, str]:
+        """Return the configured eval logger table and delete predicate."""
+        table, predicate = eval_logger_source(
+            alias="e", include_cdc_tombstone_guard=True
+        )
+        return f"{table} AS e FINAL", predicate
 
     # ------------------------------------------------------------------
     # Public API
@@ -206,19 +231,20 @@ class EvalMetricsQueryBuilder(BaseQueryBuilder):
         return query, self.params
 
     def _build_score_raw(self) -> Tuple[str, Dict[str, Any]]:
-        """Score query against the raw CDC table."""
+        """Score query against the deduplicated eval logger table."""
         bucket_fn = self.time_bucket_expr(self.interval)
         filter_frag = self._filter_fragment()
+        source, delete_predicate = self._raw_source()
         query = f"""
         SELECT
-            {bucket_fn}(created_at) AS time_bucket,
-            ifNotFinite(avg(output_float) * 100, NULL) AS value
-        FROM {self.RAW_TABLE} FINAL
-        WHERE project_id = %(project_id)s
-          AND (deleted = 0 OR deleted IS NULL)
-          AND custom_eval_config_id = toUUID(%(eval_config_id)s)
-          AND created_at >= %(start_date)s
-          AND created_at < %(end_date)s
+            {bucket_fn}(e.created_at) AS time_bucket,
+            ifNotFinite(avg(e.output_float) * 100, NULL) AS value
+        FROM {source}
+        WHERE {self._project_id_expr()} = toUUID(%(project_id)s)
+          AND {delete_predicate}
+          AND e.custom_eval_config_id = toUUID(%(eval_config_id)s)
+          AND e.created_at >= %(start_date)s
+          AND e.created_at < %(end_date)s
           {filter_frag}
         GROUP BY time_bucket
         ORDER BY time_bucket
@@ -254,20 +280,21 @@ class EvalMetricsQueryBuilder(BaseQueryBuilder):
         return query, self.params
 
     def _build_pass_fail_raw(self) -> Tuple[str, Dict[str, Any]]:
-        """Pass/Fail query against the raw CDC table."""
+        """Pass/fail query against the deduplicated eval logger table."""
         bucket_fn = self.time_bucket_expr(self.interval)
         filter_frag = self._filter_fragment()
+        source, delete_predicate = self._raw_source()
         query = f"""
         SELECT
-            {bucket_fn}(created_at) AS time_bucket,
-            ifNotFinite(avg(CASE WHEN output_bool = 1 THEN 100.0 ELSE 0.0 END), NULL)
+            {bucket_fn}(e.created_at) AS time_bucket,
+            ifNotFinite(avg(CASE WHEN e.output_bool = 1 THEN 100.0 ELSE 0.0 END), NULL)
                 AS value
-        FROM {self.RAW_TABLE} FINAL
-        WHERE project_id = %(project_id)s
-          AND (deleted = 0 OR deleted IS NULL)
-          AND custom_eval_config_id = toUUID(%(eval_config_id)s)
-          AND created_at >= %(start_date)s
-          AND created_at < %(end_date)s
+        FROM {source}
+        WHERE {self._project_id_expr()} = toUUID(%(project_id)s)
+          AND {delete_predicate}
+          AND e.custom_eval_config_id = toUUID(%(eval_config_id)s)
+          AND e.created_at >= %(start_date)s
+          AND e.created_at < %(end_date)s
           {filter_frag}
         GROUP BY time_bucket
         ORDER BY time_bucket
@@ -294,30 +321,31 @@ class EvalMetricsQueryBuilder(BaseQueryBuilder):
         # string, so parse it before calling has(); output_str is kept as the
         # single-choice fallback for older rows/imports.
         choice_cols: List[str] = []
-        choice_array_expr = "JSONExtract(output_str_list, 'Array(String)')"
+        choice_array_expr = "JSONExtract(e.output_str_list, 'Array(String)')"
         for i, choice in enumerate(self.choices):
             param_name = f"choice_{i}"
             self.params[param_name] = choice
             choice_cols.append(
                 f"countIf(has({choice_array_expr}, %({param_name})s) "
-                f"OR output_str = %({param_name})s) * 100.0 "
+                f"OR e.output_str = %({param_name})s) * 100.0 "
                 f"/ greatest(count(), 1) AS `choice_{i}`"
             )
 
         choice_select = ",\n            ".join(choice_cols)
 
         filter_frag = self._filter_fragment()
+        source, delete_predicate = self._raw_source()
         query = f"""
         SELECT
-            {bucket_fn}(created_at) AS time_bucket,
+            {bucket_fn}(e.created_at) AS time_bucket,
             count() AS total_count,
             {choice_select}
-        FROM {self.RAW_TABLE} FINAL
-        WHERE project_id = %(project_id)s
-          AND (deleted = 0 OR deleted IS NULL)
-          AND custom_eval_config_id = toUUID(%(eval_config_id)s)
-          AND created_at >= %(start_date)s
-          AND created_at < %(end_date)s
+        FROM {source}
+        WHERE {self._project_id_expr()} = toUUID(%(project_id)s)
+          AND {delete_predicate}
+          AND e.custom_eval_config_id = toUUID(%(eval_config_id)s)
+          AND e.created_at >= %(start_date)s
+          AND e.created_at < %(end_date)s
           {filter_frag}
         GROUP BY time_bucket
         ORDER BY time_bucket

--- a/futureagi/tracer/tests/test_clickhouse.py
+++ b/futureagi/tracer/tests/test_clickhouse.py
@@ -3658,7 +3658,7 @@ class TestEvalMetricsQueryBuilder:
     """Test eval metrics query builder."""
 
     def test_build_float_eval(self):
-        """SCORE eval type should produce a query computing score aggregation."""
+        """Default SCORE queries must deduplicate the CDC source with FINAL."""
         from tracer.services.clickhouse.query_builders import EvalMetricsQueryBuilder
 
         builder = EvalMetricsQueryBuilder(
@@ -3668,8 +3668,13 @@ class TestEvalMetricsQueryBuilder:
             eval_output_type="SCORE",
         )
         query, params = builder.build()
-        # Pre-aggregated uses float_sum/float_count; raw uses output_float
-        assert "float_sum" in query or "output_float" in query
+        assert "output_float" in query
+        assert "tracer_eval_logger" in query
+        assert "FINAL" in query
+        assert "eval_metrics_hourly" not in query
+        assert "dictGetOrDefault('trace_dict'" in query
+        assert "dictGetOrDefault('trace_session_dict'" in query
+        assert "is_deleted = 0" in query or "deleted = 0" in query
         assert "eval_config_id" in params
 
     def test_build_float_eval_raw(self):
@@ -3688,7 +3693,7 @@ class TestEvalMetricsQueryBuilder:
         assert "eval_config_id" in params
 
     def test_build_bool_eval(self):
-        """PASS_FAIL eval type should produce a query computing pass rate."""
+        """Default PASS_FAIL queries must deduplicate the CDC source with FINAL."""
         from tracer.services.clickhouse.query_builders import EvalMetricsQueryBuilder
 
         builder = EvalMetricsQueryBuilder(
@@ -3698,8 +3703,13 @@ class TestEvalMetricsQueryBuilder:
             eval_output_type="PASS_FAIL",
         )
         query, params = builder.build()
-        # Pre-aggregated uses bool_pass/bool_fail; raw uses output_bool
-        assert "bool_pass" in query or "output_bool" in query
+        assert "output_bool" in query
+        assert "tracer_eval_logger" in query
+        assert "FINAL" in query
+        assert "eval_metrics_hourly" not in query
+        assert "dictGetOrDefault('trace_dict'" in query
+        assert "dictGetOrDefault('trace_session_dict'" in query
+        assert "is_deleted = 0" in query or "deleted = 0" in query
 
     def test_build_bool_eval_raw(self):
         """PASS_FAIL eval with use_preaggregated=False should use output_bool."""
@@ -3749,7 +3759,7 @@ class TestEvalMetricsQueryBuilder:
         assert len(query) > 0
 
     def test_build_with_preaggregated(self):
-        """When use_preaggregated=True, SCORE should use eval_metrics_hourly."""
+        """Pre-aggregation remains an explicit opt-in for legacy callers."""
         from tracer.services.clickhouse.query_builders import EvalMetricsQueryBuilder
 
         builder = EvalMetricsQueryBuilder(
@@ -3761,6 +3771,42 @@ class TestEvalMetricsQueryBuilder:
         )
         query, params = builder.build()
         assert "eval_metrics_hourly" in query
+
+    def test_default_raw_query_supports_v2_eval_logger(self):
+        """The correctness path must follow the configured eval logger table."""
+        from django.test import override_settings
+
+        from tracer.services.clickhouse.query_builders import EvalMetricsQueryBuilder
+
+        with override_settings(CH25_EVAL_LOGGER_TABLE="tracer_eval_logger_v2"):
+            builder = EvalMetricsQueryBuilder(
+                project_id="test-project-id",
+                custom_eval_config_id="00000000-0000-0000-0000-000000000001",
+                eval_output_type="SCORE",
+            )
+            query, _params = builder.build()
+
+        assert "FROM tracer_eval_logger_v2 AS e FINAL" in query
+        assert "e.is_deleted = 0" in query
+        assert "_peerdb_is_deleted" not in query
+
+    def test_default_raw_query_filters_legacy_cdc_tombstones(self):
+        """Legacy CDC reads must hide both tombstones and app soft deletes."""
+        from django.test import override_settings
+
+        from tracer.services.clickhouse.query_builders import EvalMetricsQueryBuilder
+
+        with override_settings(CH25_EVAL_LOGGER_TABLE="tracer_eval_logger"):
+            builder = EvalMetricsQueryBuilder(
+                project_id="test-project-id",
+                custom_eval_config_id="00000000-0000-0000-0000-000000000001",
+                eval_output_type="SCORE",
+            )
+            query, _params = builder.build()
+
+        assert "FROM tracer_eval_logger AS e FINAL" in query
+        assert "e._peerdb_is_deleted = 0" in query
+        assert "(e.deleted = 0 OR e.deleted IS NULL)" in query
 
     def test_build_without_preaggregated(self):
         """When use_preaggregated=False, should query tracer_eval_logger directly."""
@@ -5839,7 +5885,7 @@ class TestEvalMetricsQueryBuilderExtended:
         query, _ = builder.build()
         assert "tracer_eval_logger" in query
         assert "FINAL" in query
-        assert "avg(output_float)" in query
+        assert "avg(e.output_float)" in query
 
     def test_pass_fail_agg_query_uses_correct_columns(self):
         """Pass/fail agg query should use bool_pass and bool_fail columns."""
@@ -5896,8 +5942,8 @@ class TestEvalMetricsQueryBuilderExtended:
         )
         query, params = builder.build()
         assert "countIf" in query
-        assert "has(JSONExtract(output_str_list, 'Array(String)')" in query
-        assert "OR output_str =" in query
+        assert "has(JSONExtract(e.output_str_list, 'Array(String)')" in query
+        assert "OR e.output_str =" in query
         assert "choice_0" in params
         assert "choice_1" in params
         assert "choice_2" in params
@@ -5913,7 +5959,7 @@ class TestEvalMetricsQueryBuilderExtended:
             choices=[],
         )
         query, _ = builder.build()
-        assert "avg(output_float)" in query
+        assert "avg(e.output_float)" in query
 
     def test_agg_query_filters_by_config_id(self):
         """Agg queries should filter by custom_eval_config_id."""
@@ -5976,7 +6022,7 @@ class TestEvalMetricsQueryBuilderExtended:
             use_preaggregated=False,
         )
         query, _ = builder.build()
-        assert "avg(output_float)" in query
+        assert "avg(e.output_float)" in query
 
 
 # ============================================================================


### PR DESCRIPTION
## What changed

Fixes #2184.

Eval graph queries were using `eval_metrics_hourly`, which is populated by a CDC materialized view. Updates to one eval row were added to the rollup without removing the previous version, so scores and pass rates could be overstated.

This PR switches the graph path to the configured eval logger with `FINAL` and applies the appropriate delete filter for both the legacy and v2 tables. Project IDs are resolved through the trace dictionaries because the eval logger tables do not store them directly.

The hourly table is still available when `use_preaggregated=True`, but it is no longer the default.

## Tests

- `25 passed` for `TestEvalMetricsQueryBuilder`
- `551 passed` across the ClickHouse, query-builder, MV, eval-config, and evaluation-detail tests
- Python compilation and `git diff --check` passed
