### PR TITLE
fix(falcon-ai): refuse a tool-permission write that would empty the list [TH-7673]

### DIFF
--- a/frontend/src/sections/falcon-ai/components/__tests__/customize-connector-tools.test.jsx
+++ b/frontend/src/sections/falcon-ai/components/__tests__/customize-connector-tools.test.jsx
@@ -247,6 +247,43 @@ describe("Customize panel — connector tools", () => {
     );
   });
 
+  it("refuses to deny the last enabled tool, which would grant every tool", async () => {
+    // [] is the all-enabled sentinel on both sides (mcp_tools.py:207), so
+    // emptying the list inverts the permission and persists. TH-7673.
+    mocks.getConnector.mockResolvedValue({
+      ...DETAIL,
+      enabled_tool_names: ["ask_question"],
+    });
+
+    await openConnector();
+    await screen.findByText("ask_question");
+
+    fireEvent.click(screen.getAllByTitle("Allowed")[0]);
+
+    expect(await screen.findByRole("alert")).toHaveTextContent(
+      /Keep at least one tool enabled/i,
+    );
+    expect(mocks.updateConnectorTools).not.toHaveBeenCalled();
+  });
+
+  it("still allows denying a tool when others remain enabled", async () => {
+    mocks.getConnector.mockResolvedValue({
+      ...DETAIL,
+      enabled_tool_names: ["ask_question", "read_wiki_contents"],
+    });
+
+    await openConnector();
+    await screen.findByText("ask_question");
+
+    fireEvent.click(screen.getAllByTitle("Allowed")[0]);
+
+    await waitFor(() =>
+      expect(mocks.updateConnectorTools).toHaveBeenCalledWith("conn-1", [
+        "read_wiki_contents",
+      ]),
+    );
+  });
+
   it("surfaces a failed write instead of leaving the toggle silently stuck", async () => {
     mocks.updateConnectorTools.mockRejectedValue({
       response: { data: { detail: "Connector is not verified." } },

--- a/frontend/src/sections/falcon-ai/hooks/useConnectorToolPermissions.js
+++ b/frontend/src/sections/falcon-ai/hooks/useConnectorToolPermissions.js
@@ -69,6 +69,18 @@ export function useConnectorToolPermissions({
         ? enabled.filter((n) => n !== tool.name)
         : [...enabled, tool.name];
 
+      // An empty list is the "all tools enabled" sentinel on both sides
+      // (mcp_tools.py:207), so denying the last remaining tool would grant
+      // every tool instead of none — and it persists. Refuse the write until
+      // the schema can express "none enabled" (TH-7673).
+      if (next.length === 0) {
+        setToolError(
+          "Keep at least one tool enabled. An empty selection is stored as " +
+            '"all tools allowed" — use Disconnect to revoke the connector.',
+        );
+        return;
+      }
+
       await applyEnabledToolNames(connectorId, next);
     },
     [selectedItem, applyEnabledToolNames],


### PR DESCRIPTION
## 🐛 Bug

Denying a connector's **last** enabled tool grants Falcon **every** tool.

`enabled_tool_names: []` is the all-tools-enabled sentinel on both sides, so emptying the list inverts the permission — and it persists across a reload. Reproduced on dev with a real HuggingFace MCP connector: three denials behave correctly, the fourth flips all four back to allowed.

Three denied, only `hf_fs` left allowed:

![before](https://github.com/user-attachments/assets/a1d5e61f-9b90-4096-9bc0-1a18be64c6b2)

One frame later, after denying it:

![after](https://github.com/user-attachments/assets/f20b5962-d7aa-4402-a756-e3419b955c7c)

The request, and the state after a full page reload:

![payload](https://github.com/user-attachments/assets/2656569a-1585-4eb5-b2db-9350a6c57646)

![after reload](https://github.com/user-attachments/assets/4d1332f8-42b3-4db0-93f2-f57279e80c18)

Root cause — `futureagi/ee/falcon_ai/mcp_tools.py:207`:

```python
# If enabled list is empty, all tools are enabled
if enabled and tool_name not in enabled:
    continue
```

`resolveEnabledNames` applies the same rule client-side, which is why the toggles flip before the server even answers.

## 🔧 What changed

`handleToolToggle` refuses the write when `next` would be empty, and surfaces a message pointing at Disconnect.

## 🤔 Why

**This is a stopgap, not the fix.** There is no representable "none enabled" state in the schema, so a user still cannot deny every tool — they just can no longer *grant* every tool by trying to. The proper fix is a schema decision (null vs `[]` vs an explicit `all_enabled` flag), which also needs `get_tool_count` updated since it reports the sentinel as 0.

That is tracked in **TH-7673**, assigned to @cdileep23 — happy to close this PR instead if you would rather wait for the schema change and not carry a temporary guard.

cc @cdileep23 — you raised this in review on #2164.

## 🧪 Tests

- Denying the last enabled tool is blocked, surfaces the message, and issues no PATCH
- Denying a tool while others remain enabled still writes the expected list

Both verified failing before the guard.

## ▶️ How to verify

1. Falcon AI → Customize → Connectors → a connector with discovered tools
2. Deny tools until one remains, then deny that one
3. Before: all toggles flip back to allowed and `PATCH {"enabled_tool_names": []}` goes out. After: the write is refused with an explanation.

## 💻 Commands

```bash
yarn vitest run src/sections/falcon-ai
```

## 📝 Note on the base branch

Targets `fix/th-7571-falcon-customize-connector-tools` rather than `dev`, because `useConnectorToolPermissions.js` only exists on that branch. Rebase onto `dev` once #2164 merges.