### PR TITLE
fix(evals): hide the Error Localization checkbox on OSS deployments

### DIFF
--- a/frontend/src/hooks/__tests__/useErrorLocalization.test.jsx
+++ b/frontend/src/hooks/__tests__/useErrorLocalization.test.jsx
@@ -1,0 +1,55 @@
+import React from "react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderHook } from "@testing-library/react";
+
+import { useErrorLocalizationAvailable } from "src/hooks/useErrorLocalization";
+
+const { deployment } = vi.hoisted(() => ({
+  deployment: { mode: "oss", isCloud: false, isOSS: true, isEE: false },
+}));
+vi.mock("src/hooks/useDeploymentMode", () => ({
+  useDeploymentMode: () => deployment,
+}));
+
+describe("useErrorLocalizationAvailable (TH-7177)", () => {
+  beforeEach(() => {
+    Object.assign(deployment, {
+      mode: "oss",
+      isCloud: false,
+      isOSS: true,
+      isEE: false,
+    });
+  });
+
+  it("is available on cloud", () => {
+    Object.assign(deployment, { mode: "cloud", isCloud: true, isOSS: false });
+    const { result } = renderHook(() => useErrorLocalizationAvailable());
+    expect(result.current).toBe(true);
+  });
+
+  it("is unavailable on OSS", () => {
+    const { result } = renderHook(() => useErrorLocalizationAvailable());
+    expect(result.current).toBe(false);
+  });
+
+  it("is unavailable on self-hosted EE", () => {
+    Object.assign(deployment, {
+      mode: "ee",
+      isCloud: false,
+      isOSS: false,
+      isEE: true,
+    });
+    const { result } = renderHook(() => useErrorLocalizationAvailable());
+    expect(result.current).toBe(false);
+  });
+
+  it("fails closed while deployment info is still loading (isCloud falsy)", () => {
+    Object.assign(deployment, {
+      mode: "oss",
+      isCloud: undefined,
+      isLoading: true,
+    });
+    const { result } = renderHook(() => useErrorLocalizationAvailable());
+    expect(result.current).toBeFalsy();
+  });
+});

--- a/frontend/src/hooks/__tests__/useErrorLocalization.test.jsx
+++ b/frontend/src/hooks/__tests__/useErrorLocalization.test.jsx
@@ -32,7 +32,7 @@ describe("useErrorLocalizationAvailable (TH-7177)", () => {
     expect(result.current).toBe(false);
   });
 
-  it("is unavailable on self-hosted EE", () => {
+  it("is available on licensed self-hosted EE", () => {
     Object.assign(deployment, {
       mode: "ee",
       isCloud: false,
@@ -40,10 +40,10 @@ describe("useErrorLocalizationAvailable (TH-7177)", () => {
       isEE: true,
     });
     const { result } = renderHook(() => useErrorLocalizationAvailable());
-    expect(result.current).toBe(false);
+    expect(result.current).toBe(true);
   });
 
-  it("fails closed while deployment info is still loading (isCloud falsy)", () => {
+  it("fails closed while deployment info is still loading (no mode confirmed)", () => {
     Object.assign(deployment, {
       mode: "oss",
       isCloud: undefined,

--- a/frontend/src/hooks/useErrorLocalization.js
+++ b/frontend/src/hooks/useErrorLocalization.js
@@ -1,0 +1,13 @@
+import { useDeploymentMode } from "src/hooks/useDeploymentMode";
+
+/**
+ * TH-7177: Error Localization only runs on cloud deployments, so OSS and
+ * self-hosted EE builds must not offer it at all (previously the checkbox
+ * rendered and runs failed with a generic upgrade message). Fails closed:
+ * while deployment info loads the mode defaults to "oss", so the control
+ * stays hidden until cloud is confirmed - the same "never flash an
+ * unavailable feature" convention the capabilities hooks follow.
+ */
+export function useErrorLocalizationAvailable() {
+  return useDeploymentMode().isCloud;
+}

--- a/frontend/src/hooks/useErrorLocalization.js
+++ b/frontend/src/hooks/useErrorLocalization.js
@@ -1,13 +1,17 @@
 import { useDeploymentMode } from "src/hooks/useDeploymentMode";
 
 /**
- * TH-7177: Error Localization only runs on cloud deployments, so OSS and
- * self-hosted EE builds must not offer it at all (previously the checkbox
- * rendered and runs failed with a generic upgrade message). Fails closed:
- * while deployment info loads the mode defaults to "oss", so the control
- * stays hidden until cloud is confirmed - the same "never flash an
- * unavailable feature" convention the capabilities hooks follow.
+ * TH-7177: Error Localization is not available on OSS, so OSS builds must
+ * not offer it at all (previously the checkbox rendered and runs failed
+ * with a generic upgrade message). Cloud and licensed self-hosted EE
+ * deployments keep the control; per-license entitlement on those stays
+ * with the existing AGENTIC_EVAL capability lock at the render sites.
+ * Fails closed: while deployment info loads the mode defaults to "oss",
+ * so the control stays hidden until cloud/EE is confirmed - the same
+ * "never flash an unavailable feature" convention the capabilities hooks
+ * follow.
  */
 export function useErrorLocalizationAvailable() {
-  return useDeploymentMode().isCloud;
+  const { isCloud, isEE } = useDeploymentMode();
+  return isCloud || isEE;
 }

--- a/frontend/src/hooks/useErrorLocalization.js
+++ b/frontend/src/hooks/useErrorLocalization.js
@@ -1,16 +1,8 @@
 import { useDeploymentMode } from "src/hooks/useDeploymentMode";
 
-/**
- * TH-7177: Error Localization is not available on OSS, so OSS builds must
- * not offer it at all (previously the checkbox rendered and runs failed
- * with a generic upgrade message). Cloud and licensed self-hosted EE
- * deployments keep the control; per-license entitlement on those stays
- * with the existing AGENTIC_EVAL capability lock at the render sites.
- * Fails closed: while deployment info loads the mode defaults to "oss",
- * so the control stays hidden until cloud/EE is confirmed - the same
- * "never flash an unavailable feature" convention the capabilities hooks
- * follow.
- */
+// Fails closed: `useDeploymentMode` reports "oss" until the fetch resolves, so
+// the control stays hidden until cloud/EE is confirmed rather than flashing.
+// Per-license entitlement is separate — the AGENTIC_EVAL capability lock.
 export function useErrorLocalizationAvailable() {
   const { isCloud, isEE } = useDeploymentMode();
   return isCloud || isEE;

--- a/frontend/src/sections/common/EvalPicker/EvalPickerConfigFull.jsx
+++ b/frontend/src/sections/common/EvalPicker/EvalPickerConfigFull.jsx
@@ -127,7 +127,7 @@ const EvalPickerConfigFull = ({ evalData, onBack, onSave, isSaving }) => {
     CAPABILITY.TURING_MODELS,
   );
   const { locked: agentEvalLocked } = useFeatureLocked(CAPABILITY.AGENTIC_EVAL);
-  // TH-7177: Error Localization is cloud-only; off-cloud the control is
+  // TH-7177: Error Localization is unavailable on OSS; there the control is
   // hidden entirely instead of rendering something that cannot run.
   const errorLocalizerAvailable = useErrorLocalizationAvailable();
   // Confirmed denial (loaded AND not allowed) — seed the model default raw and
@@ -1729,7 +1729,7 @@ const EvalPickerConfigFull = ({ evalData, onBack, onSave, isSaving }) => {
                 />
               )}
 
-              {/* Error Localization (cloud-only per TH-7177; single-eval concern,
+              {/* Error Localization (hidden on OSS per TH-7177; single-eval concern,
                   LLM/Agent only — code evals don't produce the model traces
                   the feature introspects). */}
               {errorLocalizerAvailable &&

--- a/frontend/src/sections/common/EvalPicker/EvalPickerConfigFull.jsx
+++ b/frontend/src/sections/common/EvalPicker/EvalPickerConfigFull.jsx
@@ -127,8 +127,6 @@ const EvalPickerConfigFull = ({ evalData, onBack, onSave, isSaving }) => {
     CAPABILITY.TURING_MODELS,
   );
   const { locked: agentEvalLocked } = useFeatureLocked(CAPABILITY.AGENTIC_EVAL);
-  // TH-7177: Error Localization is unavailable on OSS; there the control is
-  // hidden entirely instead of rendering something that cannot run.
   const errorLocalizerAvailable = useErrorLocalizationAvailable();
   // Confirmed denial (loaded AND not allowed) — seed the model default raw and
   // only strip it here, never off `locked` (true while loading), so entitled
@@ -1729,9 +1727,8 @@ const EvalPickerConfigFull = ({ evalData, onBack, onSave, isSaving }) => {
                 />
               )}
 
-              {/* Error Localization (hidden on OSS per TH-7177; single-eval concern,
-                  LLM/Agent only — code evals don't produce the model traces
-                  the feature introspects). */}
+              {/* Single-eval concern, LLM/Agent only — code evals don't produce
+                  the model traces the feature introspects. */}
               {errorLocalizerAvailable &&
                 !isComposite &&
                 evalType !== "code" && (

--- a/frontend/src/sections/common/EvalPicker/EvalPickerConfigFull.jsx
+++ b/frontend/src/sections/common/EvalPicker/EvalPickerConfigFull.jsx
@@ -17,6 +17,7 @@ import CustomTooltip from "src/components/tooltip/CustomTooltip";
 import { LoadingButton } from "@mui/lab";
 import { enqueueSnackbar } from "notistack";
 import { useFeatureLocked, CAPABILITY } from "src/hooks/useCapabilities";
+import { useErrorLocalizationAvailable } from "src/hooks/useErrorLocalization";
 import { FAGI_MODEL_VALUES } from "src/sections/evals/components/ModelSelector";
 import PropTypes from "prop-types";
 import React, {
@@ -126,6 +127,9 @@ const EvalPickerConfigFull = ({ evalData, onBack, onSave, isSaving }) => {
     CAPABILITY.TURING_MODELS,
   );
   const { locked: agentEvalLocked } = useFeatureLocked(CAPABILITY.AGENTIC_EVAL);
+  // TH-7177: Error Localization is cloud-only; off-cloud the control is
+  // hidden entirely instead of rendering something that cannot run.
+  const errorLocalizerAvailable = useErrorLocalizationAvailable();
   // Confirmed denial (loaded AND not allowed) — seed the model default raw and
   // only strip it here, never off `locked` (true while loading), so entitled
   // users keep "turing_large" through the fetch.
@@ -191,7 +195,8 @@ const EvalPickerConfigFull = ({ evalData, onBack, onSave, isSaving }) => {
   const [knowledgeBaseIds, setKnowledgeBaseIds] = useState([]);
   const [contextOptions, setContextOptions] = useState(["variables_only"]);
   const [errorLocalizerEnabled, setErrorLocalizerEnabled] = useState(false);
-  const errorLocalizerActive = errorLocalizerEnabled && !agentEvalLocked;
+  const errorLocalizerActive =
+    errorLocalizerEnabled && !agentEvalLocked && errorLocalizerAvailable;
   // Name for the UserEvalMetric — defaults to template name, user can customise
   const [evalName, setEvalName] = useState("");
   const [dataReady, setDataReady] = useState(false);
@@ -1724,47 +1729,49 @@ const EvalPickerConfigFull = ({ evalData, onBack, onSave, isSaving }) => {
                 />
               )}
 
-              {/* Error Localization (single-eval concern, LLM/Agent only).
-                  Code evals don't support error localization — the feature
-                  introspects model traces, which code evals don't produce. */}
-              {!isComposite && evalType !== "code" && (
-                <CustomTooltip
-                  show={agentEvalLocked}
-                  type=""
-                  arrow
-                  title={ERROR_LOCALIZER_LOCKED_TOOLTIP}
-                >
-                  <FormControlLabel
-                    control={
-                      <Checkbox
-                        checked={errorLocalizerActive}
-                        disabled={agentEvalLocked}
-                        onChange={(e) => {
-                          setErrorLocalizerEnabled(e.target.checked);
-                          setIsDirty(true);
-                        }}
-                        size="small"
-                      />
-                    }
-                    label={
-                      <Box>
-                        <Typography variant="body2" fontWeight={500}>
-                          Error Localization
-                        </Typography>
-                        <Typography
-                          variant="caption"
-                          color="text.secondary"
-                          sx={{ display: "block" }}
-                        >
-                          Pinpoints which parts of the input caused evaluation
-                          failures
-                        </Typography>
-                      </Box>
-                    }
-                    sx={{ alignItems: "flex-start" }}
-                  />
-                </CustomTooltip>
-              )}
+              {/* Error Localization (cloud-only per TH-7177; single-eval concern,
+                  LLM/Agent only — code evals don't produce the model traces
+                  the feature introspects). */}
+              {errorLocalizerAvailable &&
+                !isComposite &&
+                evalType !== "code" && (
+                  <CustomTooltip
+                    show={agentEvalLocked}
+                    type=""
+                    arrow
+                    title={ERROR_LOCALIZER_LOCKED_TOOLTIP}
+                  >
+                    <FormControlLabel
+                      control={
+                        <Checkbox
+                          checked={errorLocalizerActive}
+                          disabled={agentEvalLocked}
+                          onChange={(e) => {
+                            setErrorLocalizerEnabled(e.target.checked);
+                            setIsDirty(true);
+                          }}
+                          size="small"
+                        />
+                      }
+                      label={
+                        <Box>
+                          <Typography variant="body2" fontWeight={500}>
+                            Error Localization
+                          </Typography>
+                          <Typography
+                            variant="caption"
+                            color="text.secondary"
+                            sx={{ display: "block" }}
+                          >
+                            Pinpoints which parts of the input caused evaluation
+                            failures
+                          </Typography>
+                        </Box>
+                      }
+                      sx={{ alignItems: "flex-start" }}
+                    />
+                  </CustomTooltip>
+                )}
             </Box>
           }
           rightPanel={

--- a/frontend/src/sections/common/EvalPicker/EvalPickerConfigFull.test.jsx
+++ b/frontend/src/sections/common/EvalPicker/EvalPickerConfigFull.test.jsx
@@ -236,9 +236,9 @@ describe("EvalPickerConfigFull — error localization gating (TH-7177)", () => {
     expect(screen.queryByText("Error Localization")).toBeNull();
   });
 
-  it("hides the Error Localization checkbox on self-hosted EE", () => {
+  it("shows the Error Localization checkbox on licensed self-hosted EE", () => {
     Object.assign(deploymentMode, { mode: "ee", isCloud: false, isEE: true });
     renderConfigFull();
-    expect(screen.queryByText("Error Localization")).toBeNull();
+    expect(screen.getByText("Error Localization")).toBeTruthy();
   });
 });

--- a/frontend/src/sections/common/EvalPicker/EvalPickerConfigFull.test.jsx
+++ b/frontend/src/sections/common/EvalPicker/EvalPickerConfigFull.test.jsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render } from "src/utils/test-utils";
+import { screen } from "@testing-library/react";
 
 import EvalPickerProvider from "./context/EvalPickerProvider";
 import EvalPickerConfigFull from "./EvalPickerConfigFull";
@@ -133,8 +134,14 @@ vi.mock("src/hooks/useCapabilities", async (importOriginal) => {
     useCapabilities: () => ({ data: undefined, isLoading: false }),
   };
 });
+const { deploymentMode } = vi.hoisted(() => ({
+  // Mutable on purpose: TH-7177 tests flip the mode per test. Reset in the
+  // gating suite's beforeEach; default matches cloud so other suites keep
+  // seeing the pre-existing UI.
+  deploymentMode: { mode: "cloud", isCloud: true, isOSS: false, isEE: false },
+}));
 vi.mock("src/hooks/useDeploymentMode", () => ({
-  useDeploymentMode: () => ({ isOSS: false }),
+  useDeploymentMode: () => deploymentMode,
 }));
 
 vi.mock("notistack", async (importOriginal) => {
@@ -205,5 +212,33 @@ describe("EvalPickerConfigFull — task preview time window", () => {
         (f) => f.column_id === "created_at",
       ),
     ).toBe(false);
+  });
+});
+
+describe("EvalPickerConfigFull — error localization gating (TH-7177)", () => {
+  beforeEach(() => {
+    Object.assign(deploymentMode, {
+      mode: "cloud",
+      isCloud: true,
+      isOSS: false,
+      isEE: false,
+    });
+  });
+
+  it("shows the Error Localization checkbox on cloud", () => {
+    renderConfigFull();
+    expect(screen.getByText("Error Localization")).toBeTruthy();
+  });
+
+  it("hides the Error Localization checkbox on OSS", () => {
+    Object.assign(deploymentMode, { mode: "oss", isCloud: false, isOSS: true });
+    renderConfigFull();
+    expect(screen.queryByText("Error Localization")).toBeNull();
+  });
+
+  it("hides the Error Localization checkbox on self-hosted EE", () => {
+    Object.assign(deploymentMode, { mode: "ee", isCloud: false, isEE: true });
+    renderConfigFull();
+    expect(screen.queryByText("Error Localization")).toBeNull();
   });
 });

--- a/frontend/src/sections/common/EvalPicker/EvalPickerCreateNew.test.jsx
+++ b/frontend/src/sections/common/EvalPicker/EvalPickerCreateNew.test.jsx
@@ -122,7 +122,7 @@ vi.mock("src/hooks/useCapabilities", async (importOriginal) => {
   };
 });
 vi.mock("src/hooks/useDeploymentMode", () => ({
-  useDeploymentMode: () => ({ isOSS: false }),
+  useDeploymentMode: () => ({ isOSS: false, isCloud: true }),
 }));
 
 vi.mock("notistack", async (importOriginal) => {

--- a/frontend/src/sections/common/EvaluationDrawer/EvaluationMappingForm.jsx
+++ b/frontend/src/sections/common/EvaluationDrawer/EvaluationMappingForm.jsx
@@ -147,8 +147,8 @@ const EvaluationMappingFormChild = ({
 }) => {
   const { role } = useAuthContext();
   const theme = useTheme();
-  // TH-7177: the form defaults errorLocalizer to true, so gate the submitted
-  // value too - on OSS the hidden field must never post true.
+  // The form defaults errorLocalizer to true, so hiding the field is not enough —
+  // the submitted value has to be gated as well.
   const errorLocalizerAvailable = useErrorLocalizationAvailable();
 
   // Get the id for fetching JSON schemas

--- a/frontend/src/sections/common/EvaluationDrawer/EvaluationMappingForm.jsx
+++ b/frontend/src/sections/common/EvaluationDrawer/EvaluationMappingForm.jsx
@@ -34,6 +34,7 @@ import { format } from "date-fns";
 import logger from "src/utils/logger";
 import EvaluationMappingFormContent from "./EvaluationMappingFormContent";
 import { sanitizeEvalMapping } from "src/sections/common/EvalPicker/serializeEvalConfig";
+import { useErrorLocalizationAvailable } from "src/hooks/useErrorLocalization";
 
 function removeElements(array1, array2) {
   return array1.filter((element) => !array2.includes(element));
@@ -146,6 +147,9 @@ const EvaluationMappingFormChild = ({
 }) => {
   const { role } = useAuthContext();
   const theme = useTheme();
+  // TH-7177: the form defaults errorLocalizer to true, so gate the submitted
+  // value too - off-cloud the hidden field must never post true.
+  const errorLocalizerAvailable = useErrorLocalizationAvailable();
 
   // Get the id for fetching JSON schemas
   const {
@@ -556,7 +560,7 @@ const EvaluationMappingFormChild = ({
             ? false
             : run,
         template_id: selectedEval.id,
-        error_localizer: errorLocalizer,
+        error_localizer: Boolean(errorLocalizer) && errorLocalizerAvailable,
         ...(kbId ? { kb_id: kbId } : {}),
       };
       if (payload.kb_id === "") {

--- a/frontend/src/sections/common/EvaluationDrawer/EvaluationMappingForm.jsx
+++ b/frontend/src/sections/common/EvaluationDrawer/EvaluationMappingForm.jsx
@@ -148,7 +148,7 @@ const EvaluationMappingFormChild = ({
   const { role } = useAuthContext();
   const theme = useTheme();
   // TH-7177: the form defaults errorLocalizer to true, so gate the submitted
-  // value too - off-cloud the hidden field must never post true.
+  // value too - on OSS the hidden field must never post true.
   const errorLocalizerAvailable = useErrorLocalizationAvailable();
 
   // Get the id for fetching JSON schemas

--- a/frontend/src/sections/common/EvaluationDrawer/EvaluationMappingFormContent.jsx
+++ b/frontend/src/sections/common/EvaluationDrawer/EvaluationMappingFormContent.jsx
@@ -418,80 +418,82 @@ export default function EvaluationMappingFormContent({
       {(isFutureagiBuilt || alwaysShowModel) &&
         visibleModels.length > 0 &&
         !hideModel && (
-        <HeadingAndSubHeading
-          heading={
-            <FormSearchSelectFieldControl
-              control={control}
-              disabled={isViewMode}
-              options={visibleModels.map((model) => {
-                return {
-                  ...model,
-                  component: (
-                    <Box sx={{ padding: theme.spacing(0.75, 1) }}>
-                      <Box
-                        display={"flex"}
-                        flexDirection={"row"}
-                        alignItems={"center"}
-                        gap={"8px"}
-                      >
-                        <img
-                          src={"/favicon/logo.svg"}
-                          style={{
-                            height: theme.spacing(2),
-                            width: theme.spacing(2),
-                          }}
-                        />
+          <HeadingAndSubHeading
+            heading={
+              <FormSearchSelectFieldControl
+                control={control}
+                disabled={isViewMode}
+                options={visibleModels.map((model) => {
+                  return {
+                    ...model,
+                    component: (
+                      <Box sx={{ padding: theme.spacing(0.75, 1) }}>
+                        <Box
+                          display={"flex"}
+                          flexDirection={"row"}
+                          alignItems={"center"}
+                          gap={"8px"}
+                        >
+                          <img
+                            src={"/favicon/logo.svg"}
+                            style={{
+                              height: theme.spacing(2),
+                              width: theme.spacing(2),
+                            }}
+                          />
+                          <Typography
+                            typography="s1"
+                            fontWeight={"fontWeightMedium"}
+                            color={"text.primary"}
+                          >
+                            {model.label}
+                          </Typography>
+                        </Box>
                         <Typography
-                          typography="s1"
-                          fontWeight={"fontWeightMedium"}
+                          typography={"s2"}
+                          sx={{
+                            marginLeft: theme.spacing(3),
+                            wordWrap: "break-word",
+                            whiteSpace: "normal",
+                          }}
                           color={"text.primary"}
                         >
-                          {model.label}
+                          {model.description}
                         </Typography>
                       </Box>
-                      <Typography
-                        typography={"s2"}
-                        sx={{
-                          marginLeft: theme.spacing(3),
-                          wordWrap: "break-word",
-                          whiteSpace: "normal",
+                    ),
+                  };
+                })}
+                InputProps={{
+                  startAdornment: (
+                    <InputAdornment position="start">
+                      <img
+                        src={"/favicon/logo.svg"}
+                        style={{
+                          height: theme.spacing(2),
+                          width: theme.spacing(2),
                         }}
-                        color={"text.primary"}
-                      >
-                        {model.description}
-                      </Typography>
-                    </Box>
+                      />
+                    </InputAdornment>
                   ),
-                };
-              })}
-              InputProps={{
-                startAdornment: (
-                  <InputAdornment position="start">
-                    <img
-                      src={"/favicon/logo.svg"}
-                      style={{
-                        height: theme.spacing(2),
-                        width: theme.spacing(2),
-                      }}
-                    />
-                  </InputAdornment>
-                ),
-              }}
-              error={formState.errors?.model && formState.errors.model.message}
-              fieldName={"model"}
-              label={"Language Model"}
-              size={"small"}
-              fullWidth
-              required
-            />
-          }
-          subHeading={
-            modeHelpMessage
-              ? modeHelpMessage
-              : "The model to use for evaluation"
-          }
-        />
-      )}
+                }}
+                error={
+                  formState.errors?.model && formState.errors.model.message
+                }
+                fieldName={"model"}
+                label={"Language Model"}
+                size={"small"}
+                fullWidth
+                required
+              />
+            }
+            subHeading={
+              modeHelpMessage
+                ? modeHelpMessage
+                : "The model to use for evaluation"
+            }
+          />
+        )}
       <ShowComponent condition={!hideKnowledgeBase}>
         <HeadingAndSubHeading
           heading={

--- a/frontend/src/sections/common/EvaluationDrawer/EvaluationMappingFormContent.jsx
+++ b/frontend/src/sections/common/EvaluationDrawer/EvaluationMappingFormContent.jsx
@@ -118,7 +118,7 @@ export default function EvaluationMappingFormContent({
 }) {
   const [_, setSearchParams] = useSearchParams();
   const theme = useTheme();
-  // TH-7177: Error Localization is cloud-only; hide the control off-cloud.
+  // TH-7177: Error Localization is unavailable on OSS; hide the control there.
   const errorLocalizerAvailable = useErrorLocalizationAvailable();
   const navigate = useNavigate();
   const model = useWatch({

--- a/frontend/src/sections/common/EvaluationDrawer/EvaluationMappingFormContent.jsx
+++ b/frontend/src/sections/common/EvaluationDrawer/EvaluationMappingFormContent.jsx
@@ -118,7 +118,6 @@ export default function EvaluationMappingFormContent({
 }) {
   const [_, setSearchParams] = useSearchParams();
   const theme = useTheme();
-  // TH-7177: Error Localization is unavailable on OSS; hide the control there.
   const errorLocalizerAvailable = useErrorLocalizationAvailable();
   const navigate = useNavigate();
   const model = useWatch({

--- a/frontend/src/sections/common/EvaluationDrawer/EvaluationMappingFormContent.jsx
+++ b/frontend/src/sections/common/EvaluationDrawer/EvaluationMappingFormContent.jsx
@@ -24,6 +24,7 @@ import { useGetJsonColumnSchema } from "src/api/develop/develop-detail";
 import PropTypes from "prop-types";
 import { enqueueSnackbar } from "notistack";
 import { FormCheckboxField } from "../../../components/FormCheckboxField";
+import { useErrorLocalizationAvailable } from "src/hooks/useErrorLocalization";
 import { PERMISSIONS, RolePermission } from "src/utils/rolePermissionMapping";
 import { LoadingButton } from "@mui/lab";
 import { ADD_AND_RUN_BUTTON_MAPPER, ADD_BUTTON_MAPPER } from "./common";
@@ -117,6 +118,8 @@ export default function EvaluationMappingFormContent({
 }) {
   const [_, setSearchParams] = useSearchParams();
   const theme = useTheme();
+  // TH-7177: Error Localization is cloud-only; hide the control off-cloud.
+  const errorLocalizerAvailable = useErrorLocalizationAvailable();
   const navigate = useNavigate();
   const model = useWatch({
     control,
@@ -908,38 +911,40 @@ export default function EvaluationMappingFormContent({
           })}
         </Box>
       </ShowComponent>
-      <Box
-        display={"flex"}
-        py={theme.spacing(2)}
-        px={theme.spacing(1.5)}
-        border={`1px solid`}
-        borderColor={"divider"}
-        borderRadius={theme.spacing(0.5)}
-      >
-        <HeadingAndSubHeading
-          heading={
-            <FormCheckboxField
-              control={control}
-              fieldName={"errorLocalizer"}
-              label={"Error Localization"}
-              helperText={undefined}
-              disabled={isViewMode}
-              labelPlacement="end"
-              defaultValue={formState.defaultValues.errorLocalizer}
-              labelProps={{
-                gap: theme.spacing(1),
-              }}
-              checkboxSx={{
-                padding: 0,
-                "&.Mui-checked": {
-                  color: "primary.light",
-                },
-              }}
-            />
-          }
-          subHeading="Pinpoints the errors in your LLM output"
-        />
-      </Box>
+      {errorLocalizerAvailable && (
+        <Box
+          display={"flex"}
+          py={theme.spacing(2)}
+          px={theme.spacing(1.5)}
+          border={`1px solid`}
+          borderColor={"divider"}
+          borderRadius={theme.spacing(0.5)}
+        >
+          <HeadingAndSubHeading
+            heading={
+              <FormCheckboxField
+                control={control}
+                fieldName={"errorLocalizer"}
+                label={"Error Localization"}
+                helperText={undefined}
+                disabled={isViewMode}
+                labelPlacement="end"
+                defaultValue={formState.defaultValues.errorLocalizer}
+                labelProps={{
+                  gap: theme.spacing(1),
+                }}
+                checkboxSx={{
+                  padding: 0,
+                  "&.Mui-checked": {
+                    color: "primary.light",
+                  },
+                }}
+              />
+            }
+            subHeading="Pinpoints the errors in your LLM output"
+          />
+        </Box>
+      )}
       <Box display={"flex"} flexGrow={1} />
       <ShowComponent condition={!selectedEval?.isGroupEvals}>
         <Box

--- a/frontend/src/sections/evals/EvalPlayground/TopEvaluationSection/LeftInputSection.jsx
+++ b/frontend/src/sections/evals/EvalPlayground/TopEvaluationSection/LeftInputSection.jsx
@@ -25,6 +25,7 @@ import { enqueueSnackbar } from "notistack";
 import { useCreditExhaustion } from "src/hooks/use-credit-exhaustion";
 import { CreditExhaustionBanner } from "src/components/CreditExhaustionBanner";
 import { useExecuteCompositeEval } from "../../hooks/useCompositeEval";
+import { useErrorLocalizationAvailable } from "src/hooks/useErrorLocalization";
 
 const defaultValues = {
   templateType: "Futureagi",
@@ -149,6 +150,8 @@ const LeftInputSection = ({
   const navigate = useNavigate();
   const { role } = useAuthContext();
   const theme = useTheme();
+  // TH-7177: Error Localization is cloud-only; hide the control off-cloud.
+  const errorLocalizerAvailable = useErrorLocalizationAvailable();
   const evalId = evaluation?.id;
   const {
     exhaustionError,
@@ -635,28 +638,30 @@ const LeftInputSection = ({
         // borderRadius={theme.spacing(0.5)}
         paddingTop={0.5}
       >
-        <HeadingAndSubHeading
-          heading={
-            <FormCheckboxField
-              control={control}
-              fieldName={"errorLocalizer"}
-              label={"Error Localization"}
-              helperText={undefined}
-              labelPlacement="end"
-              defaultValue={formState?.defaultValues?.errorLocalizer}
-              labelProps={{
-                gap: theme.spacing(1),
-              }}
-              checkboxSx={{
-                padding: 0,
-                "&.Mui-checked": {
-                  color: "primary.light",
-                },
-              }}
-            />
-          }
-          subHeading="Pinpoints the errors in your LLM output"
-        />
+        {errorLocalizerAvailable && (
+          <HeadingAndSubHeading
+            heading={
+              <FormCheckboxField
+                control={control}
+                fieldName={"errorLocalizer"}
+                label={"Error Localization"}
+                helperText={undefined}
+                labelPlacement="end"
+                defaultValue={formState?.defaultValues?.errorLocalizer}
+                labelProps={{
+                  gap: theme.spacing(1),
+                }}
+                checkboxSx={{
+                  padding: 0,
+                  "&.Mui-checked": {
+                    color: "primary.light",
+                  },
+                }}
+              />
+            }
+            subHeading="Pinpoints the errors in your LLM output"
+          />
+        )}
         <CreditExhaustionBanner
           error={exhaustionError}
           onUpgrade={handleUpgradeClick}

--- a/frontend/src/sections/evals/EvalPlayground/TopEvaluationSection/LeftInputSection.jsx
+++ b/frontend/src/sections/evals/EvalPlayground/TopEvaluationSection/LeftInputSection.jsx
@@ -150,7 +150,7 @@ const LeftInputSection = ({
   const navigate = useNavigate();
   const { role } = useAuthContext();
   const theme = useTheme();
-  // TH-7177: Error Localization is cloud-only; hide the control off-cloud.
+  // TH-7177: Error Localization is unavailable on OSS; hide the control there.
   const errorLocalizerAvailable = useErrorLocalizationAvailable();
   const evalId = evaluation?.id;
   const {

--- a/frontend/src/sections/evals/EvalPlayground/TopEvaluationSection/LeftInputSection.jsx
+++ b/frontend/src/sections/evals/EvalPlayground/TopEvaluationSection/LeftInputSection.jsx
@@ -150,7 +150,6 @@ const LeftInputSection = ({
   const navigate = useNavigate();
   const { role } = useAuthContext();
   const theme = useTheme();
-  // TH-7177: Error Localization is unavailable on OSS; hide the control there.
   const errorLocalizerAvailable = useErrorLocalizationAvailable();
   const evalId = evaluation?.id;
   const {

--- a/frontend/src/sections/evals/components/EvalCreatePage.jsx
+++ b/frontend/src/sections/evals/components/EvalCreatePage.jsx
@@ -154,8 +154,6 @@ const EvalCreatePage = () => {
   const { locked: fagiLocked } = useFeatureLocked(CAPABILITY.TURING_MODELS);
   const { locked: agentEvalLocked, isLoading: capabilitiesLoading } =
     useFeatureLocked(CAPABILITY.AGENTIC_EVAL);
-  // TH-7177: Error Localization is unavailable on OSS; there the control is
-  // hidden entirely instead of rendering something that cannot run.
   const errorLocalizerAvailable = useErrorLocalizationAvailable();
   // Confirmed denial (loaded AND not allowed). Seed defaults raw and only
   // strip them on confirmed denial — seeding off `locked` (which is true
@@ -1125,9 +1123,8 @@ const EvalCreatePage = () => {
                     />
                   )}
 
-                  {/* Error Localization — hidden on OSS (TH-7177), LLM/Agent only. Code
-                      evals don't produce model traces for the localizer to
-                      introspect. */}
+                  {/* LLM/Agent only — code evals don't produce model traces for
+                      the localizer to introspect. */}
                   {errorLocalizerAvailable && evalType !== "code" && (
                     <Box>
                       <CustomTooltip

--- a/frontend/src/sections/evals/components/EvalCreatePage.jsx
+++ b/frontend/src/sections/evals/components/EvalCreatePage.jsx
@@ -685,7 +685,6 @@ const EvalCreatePage = () => {
   const canSave =
     canEditEvals && (mode === "single" ? canSaveSingle : canSaveComposite);
 
-
   if (capabilitiesLoading) {
     return null;
   }
@@ -946,10 +945,7 @@ const EvalCreatePage = () => {
                                   }}
                                 >
                                   {tab.label}
-                                  <Iconify
-                                    icon="mdi:lock-outline"
-                                    width={14}
-                                  />
+                                  <Iconify icon="mdi:lock-outline" width={14} />
                                 </Box>
                               </CustomTooltip>
                             ) : (

--- a/frontend/src/sections/evals/components/EvalCreatePage.jsx
+++ b/frontend/src/sections/evals/components/EvalCreatePage.jsx
@@ -154,7 +154,7 @@ const EvalCreatePage = () => {
   const { locked: fagiLocked } = useFeatureLocked(CAPABILITY.TURING_MODELS);
   const { locked: agentEvalLocked, isLoading: capabilitiesLoading } =
     useFeatureLocked(CAPABILITY.AGENTIC_EVAL);
-  // TH-7177: Error Localization is cloud-only; off-cloud the control is
+  // TH-7177: Error Localization is unavailable on OSS; there the control is
   // hidden entirely instead of rendering something that cannot run.
   const errorLocalizerAvailable = useErrorLocalizationAvailable();
   // Confirmed denial (loaded AND not allowed). Seed defaults raw and only
@@ -1125,7 +1125,7 @@ const EvalCreatePage = () => {
                     />
                   )}
 
-                  {/* Error Localization — cloud-only (TH-7177), LLM/Agent only. Code
+                  {/* Error Localization — hidden on OSS (TH-7177), LLM/Agent only. Code
                       evals don't produce model traces for the localizer to
                       introspect. */}
                   {errorLocalizerAvailable && evalType !== "code" && (

--- a/frontend/src/sections/evals/components/EvalCreatePage.jsx
+++ b/frontend/src/sections/evals/components/EvalCreatePage.jsx
@@ -20,6 +20,7 @@ import axios, { endpoints } from "src/utils/axios";
 import { useNavigate, useParams } from "react-router";
 import { useSnackbar } from "notistack";
 import { useFeatureLocked, CAPABILITY } from "src/hooks/useCapabilities";
+import { useErrorLocalizationAvailable } from "src/hooks/useErrorLocalization";
 import { FAGI_MODEL_VALUES } from "./ModelSelector";
 
 import { useCreateEval } from "../hooks/useCreateEval";
@@ -153,6 +154,9 @@ const EvalCreatePage = () => {
   const { locked: fagiLocked } = useFeatureLocked(CAPABILITY.TURING_MODELS);
   const { locked: agentEvalLocked, isLoading: capabilitiesLoading } =
     useFeatureLocked(CAPABILITY.AGENTIC_EVAL);
+  // TH-7177: Error Localization is cloud-only; off-cloud the control is
+  // hidden entirely instead of rendering something that cannot run.
+  const errorLocalizerAvailable = useErrorLocalizationAvailable();
   // Confirmed denial (loaded AND not allowed). Seed defaults raw and only
   // strip them on confirmed denial — seeding off `locked` (which is true
   // while loading) would blank the default model / flip the eval type for
@@ -187,7 +191,8 @@ const EvalCreatePage = () => {
   const [knowledgeBaseIds, setKnowledgeBaseIds] = useState([]);
   const [contextOptions, setContextOptions] = useState(["variables_only"]);
   const [errorLocalizerEnabled, setErrorLocalizerEnabled] = useState(false);
-  const errorLocalizerActive = errorLocalizerEnabled && !agentEvalLocked;
+  const errorLocalizerActive =
+    errorLocalizerEnabled && !agentEvalLocked && errorLocalizerAvailable;
   const [tags, setTags] = useState([]);
   const [fewShotExamples, setFewShotExamples] = useState([]);
   const [messages, setMessages] = useState([{ role: "system", content: "" }]);
@@ -1120,9 +1125,10 @@ const EvalCreatePage = () => {
                     />
                   )}
 
-                  {/* Error Localization — LLM/Agent only. Code evals don't
-                      produce model traces for the localizer to introspect. */}
-                  {evalType !== "code" && (
+                  {/* Error Localization — cloud-only (TH-7177), LLM/Agent only. Code
+                      evals don't produce model traces for the localizer to
+                      introspect. */}
+                  {errorLocalizerAvailable && evalType !== "code" && (
                     <Box>
                       <CustomTooltip
                         show={agentEvalLocked}

--- a/frontend/src/sections/evals/components/EvalDetailPage.jsx
+++ b/frontend/src/sections/evals/components/EvalDetailPage.jsx
@@ -137,8 +137,6 @@ const EvalDetailPage = () => {
     CAPABILITY.TURING_MODELS,
   );
   const { locked: agentEvalLocked } = useFeatureLocked(CAPABILITY.AGENTIC_EVAL);
-  // TH-7177: Error Localization is unavailable on OSS; there the control is
-  // hidden entirely instead of rendering something that cannot run.
   const errorLocalizerAvailable = useErrorLocalizationAvailable();
   // Confirmed denial (loaded AND not allowed). Seed the default model raw and
   // only strip it on confirmed denial, so entitled users don't lose the
@@ -1708,7 +1706,6 @@ const EvalDetailPage = () => {
                     />
                   ))}
 
-                {/* Error Localization — hidden on OSS (TH-7177) */}
                 {errorLocalizerAvailable &&
                   !isComposite &&
                   evalType !== "code" && (

--- a/frontend/src/sections/evals/components/EvalDetailPage.jsx
+++ b/frontend/src/sections/evals/components/EvalDetailPage.jsx
@@ -1104,9 +1104,7 @@ const EvalDetailPage = () => {
   }, [evalId, enqueueSnackbar, navigate]);
 
   if (isLoading) {
-    return (
-      <LoadingScreen sx={{ height: "100%", minHeight: "60vh" }} />
-    );
+    return <LoadingScreen sx={{ height: "100%", minHeight: "60vh" }} />;
   }
 
   if (fetchError || !evalData) {

--- a/frontend/src/sections/evals/components/EvalDetailPage.jsx
+++ b/frontend/src/sections/evals/components/EvalDetailPage.jsx
@@ -137,7 +137,7 @@ const EvalDetailPage = () => {
     CAPABILITY.TURING_MODELS,
   );
   const { locked: agentEvalLocked } = useFeatureLocked(CAPABILITY.AGENTIC_EVAL);
-  // TH-7177: Error Localization is cloud-only; off-cloud the control is
+  // TH-7177: Error Localization is unavailable on OSS; there the control is
   // hidden entirely instead of rendering something that cannot run.
   const errorLocalizerAvailable = useErrorLocalizationAvailable();
   // Confirmed denial (loaded AND not allowed). Seed the default model raw and
@@ -1708,7 +1708,7 @@ const EvalDetailPage = () => {
                     />
                   ))}
 
-                {/* Error Localization — cloud-only (TH-7177) */}
+                {/* Error Localization — hidden on OSS (TH-7177) */}
                 {errorLocalizerAvailable &&
                   !isComposite &&
                   evalType !== "code" && (

--- a/frontend/src/sections/evals/components/EvalDetailPage.jsx
+++ b/frontend/src/sections/evals/components/EvalDetailPage.jsx
@@ -29,6 +29,7 @@ import { useNavigate, useParams } from "react-router";
 import { useSearchParams } from "react-router-dom";
 import { useSnackbar } from "notistack";
 import { useFeatureLocked, CAPABILITY } from "src/hooks/useCapabilities";
+import { useErrorLocalizationAvailable } from "src/hooks/useErrorLocalization";
 import Iconify from "src/components/iconify";
 import CustomTooltip from "src/components/tooltip/CustomTooltip";
 import axios, { endpoints } from "src/utils/axios";
@@ -136,6 +137,9 @@ const EvalDetailPage = () => {
     CAPABILITY.TURING_MODELS,
   );
   const { locked: agentEvalLocked } = useFeatureLocked(CAPABILITY.AGENTIC_EVAL);
+  // TH-7177: Error Localization is cloud-only; off-cloud the control is
+  // hidden entirely instead of rendering something that cannot run.
+  const errorLocalizerAvailable = useErrorLocalizationAvailable();
   // Confirmed denial (loaded AND not allowed). Seed the default model raw and
   // only strip it on confirmed denial, so entitled users don't lose the
   // "turing_large" default while capabilities are still loading.
@@ -184,7 +188,8 @@ const EvalDetailPage = () => {
       "mustache",
   );
   const [errorLocalizerEnabled, setErrorLocalizerEnabled] = useState(false);
-  const errorLocalizerActive = errorLocalizerEnabled && !agentEvalLocked;
+  const errorLocalizerActive =
+    errorLocalizerEnabled && !agentEvalLocked && errorLocalizerAvailable;
 
   // Dataset columns for autocomplete
   const [datasetColumns, setDatasetColumns] = useState([]);
@@ -1703,47 +1708,49 @@ const EvalDetailPage = () => {
                     />
                   ))}
 
-                {/* Error Localization */}
-                {!isComposite && evalType !== "code" && (
-                  <Box>
-                    <CustomTooltip
-                      show={agentEvalLocked}
-                      type=""
-                      arrow
-                      title={ERROR_LOCALIZER_LOCKED_TOOLTIP}
-                    >
-                      <Box sx={{ display: "inline-flex" }}>
-                        <FormControlLabel
-                          control={
-                            <Checkbox
-                              checked={errorLocalizerActive}
-                              disabled={agentEvalLocked}
-                              onChange={(e) => {
-                                setErrorLocalizerEnabled(e.target.checked);
-                                markDirty();
-                              }}
-                              size="small"
-                            />
-                          }
-                          label={
-                            <Typography variant="body2" fontWeight={500}>
-                              Error Localization
-                            </Typography>
-                          }
-                          sx={{ ml: 0 }}
-                        />
-                      </Box>
-                    </CustomTooltip>
-                    <Typography
-                      variant="caption"
-                      color="text.secondary"
-                      sx={{ display: "block", ml: 3.5, mt: -0.5 }}
-                    >
-                      Pinpoints which parts of the input caused evaluation
-                      failures
-                    </Typography>
-                  </Box>
-                )}
+                {/* Error Localization — cloud-only (TH-7177) */}
+                {errorLocalizerAvailable &&
+                  !isComposite &&
+                  evalType !== "code" && (
+                    <Box>
+                      <CustomTooltip
+                        show={agentEvalLocked}
+                        type=""
+                        arrow
+                        title={ERROR_LOCALIZER_LOCKED_TOOLTIP}
+                      >
+                        <Box sx={{ display: "inline-flex" }}>
+                          <FormControlLabel
+                            control={
+                              <Checkbox
+                                checked={errorLocalizerActive}
+                                disabled={agentEvalLocked}
+                                onChange={(e) => {
+                                  setErrorLocalizerEnabled(e.target.checked);
+                                  markDirty();
+                                }}
+                                size="small"
+                              />
+                            }
+                            label={
+                              <Typography variant="body2" fontWeight={500}>
+                                Error Localization
+                              </Typography>
+                            }
+                            sx={{ ml: 0 }}
+                          />
+                        </Box>
+                      </CustomTooltip>
+                      <Typography
+                        variant="caption"
+                        color="text.secondary"
+                        sx={{ display: "block", ml: 3.5, mt: -0.5 }}
+                      >
+                        Pinpoints which parts of the input caused evaluation
+                        failures
+                      </Typography>
+                    </Box>
+                  )}
 
                 {/* Description */}
                 {!isComposite && (


### PR DESCRIPTION
## Summary

On OSS and self-hosted EE deployments the **Error Localization** checkbox rendered everywhere evals are configured, but the feature isn't available there — users who ticked it hit a generic upgrade message with a useless Retry button (TH-7177). The checkbox (and its form-field variants) now do not render at all on OSS: they require `/api/deployment-info/` to report `mode: "cloud"` **or `"ee"` (licensed self-hosted)**, and every submit path is hardened so `error_localizer(_enabled)` can never post `true` on OSS. Cloud and licensed-EE behavior is unchanged, including the existing capability lock (disabled + tooltip).

## Linked issues

Closes TH-7177
Linear: https://linear.app/future-agi/issue/TH-7177/if-a-feature-is-not-available-in-oss-it-should-not-be-an-option-to-run

## Type of change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

---

## 1) What changes were done

> Review note: the PR is two commits — the first is a pure prettier-normalize of three files that had pre-existing format drift (lint-staged would have reformatted them at commit anyway); the second is the entire logical change.

**A. New one-line policy hook — `src/hooks/useErrorLocalization.js`**

- `useErrorLocalizationAvailable()` → `isCloud || isEE` from `useDeploymentMode()`. Single place that owns "where does Error Localization exist"; reuses the existing `/api/deployment-info/` query (React Query, `staleTime: Infinity` — no new request). Fails closed: while deployment info loads, mode defaults to `"oss"` so the control stays hidden until cloud/EE is confirmed. Per-license entitlement on cloud/EE stays with the existing `AGENTIC_EVAL` capability lock at the render sites.

**B. The five surfaces that render the control now gate on it**

- `EvalCreatePage.jsx`, `EvalDetailPage.jsx`, `EvalPickerConfigFull.jsx` (this one also serves the Tasks page via `EvalPickerDrawer`): checkbox block wrapped in `errorLocalizerAvailable &&`, and the shared `errorLocalizerActive` flag gains `&& errorLocalizerAvailable`, so every payload built from it (`error_localizer_enabled`) is `false` on OSS.
- `EvaluationMappingFormContent.jsx` (evaluation drawer + sessions MapVariables): the bordered checkbox box no longer renders on OSS.
- `LeftInputSection.jsx` (Eval Playground): the checkbox block no longer renders on OSS; its payloads already default `false`.

**C. Submit-path hardening where the form default was `true`**

- `EvaluationMappingForm.jsx` defaults `errorLocalizer: evalsData?.errorLocalizer ?? true`, so hiding the field alone would still have submitted `true`. The submitted value is now `Boolean(errorLocalizer) && errorLocalizerAvailable`.

No API surface, contract, or backend change — `error_localizer_enabled` stays in the contract (additive-only rule); OSS clients simply always send `false`.

---

## 2) Why the changes were done

- **Product/UX:** offering a feature that cannot run, then failing with a no-CTA upgrade message and a Retry button, is the exact confusion TH-7177 reports. OSS users now never see the option; licensed self-hosted EE keeps it (their entitlement path already works via capabilities).
- **Technical:** `useDeploymentMode()` already exists (drives the OSS first-run flow), is cached for the session, and distinguishes `oss/ee/cloud` — no new endpoint, no new state. `mode === "ee"` means an `EE_LICENSE_KEY` is configured, so "licensed self-hosted" is exactly the `isEE` signal; per-license entitlement beyond that is the capability layer's job and is unchanged.
- **Architecture:** policy lives in one named hook with five thin consumers, so if availability later becomes entitlement-driven (a `CAPABILITY.ERROR_LOCALIZER` in `/api/capabilities/`), only the hook changes.

---

## 3) Tests written + scenarios each covers

**`src/hooks/__tests__/useErrorLocalization.test.jsx`** — unit tests for the policy hook

- `is available on cloud` — `mode: "cloud"` → `true`
- `is unavailable on OSS` — `mode: "oss"` → `false`
- `is available on licensed self-hosted EE` — `mode: "ee"` → `true`
- `fails closed while deployment info is still loading (no mode confirmed)` — no flash of the control before the fetch resolves

**`src/sections/common/EvalPicker/EvalPickerConfigFull.test.jsx`** — component-level gating (new `TH-7177` suite; existing suites unchanged and still passing)

- `shows the Error Localization checkbox on cloud` — cloud keeps today's UI
- `hides the Error Localization checkbox on OSS` — control absent from the DOM
- `shows the Error Localization checkbox on licensed self-hosted EE` — licensed EE keeps the control

Test-infra note: the file's `useDeploymentMode` mock became a hoisted **mutable, referentially-stable** object (per the file's own convention) so suites can flip the mode per test; `EvalPickerCreateNew.test.jsx`'s mock gained `isCloud: true` to preserve its pre-existing cloud behavior.

> Run result: targeted suites **10 files / 108 tests passed**; full `vitest run`: **2,693 / 2,694 passed** — the single failure is a pre-existing 30s-timeout flake in `annotations/queues/annotate-components.test.jsx` (zero imports from this change; passes in 2.7s when run in isolation). ESLint on all touched files: **0 errors** (7 pre-existing `exhaustive-deps` warnings untouched). Prettier clean; `yarn build` green.

---

## 4) How to run / test

### Frontend tests

```bash
cd frontend
yarn test:run src/hooks/__tests__/useErrorLocalization.test.jsx src/sections/common/EvalPicker
```

### UI steps (manual)

1. Start the stack and log in at **http://localhost:3031**.
2. On a **cloud** (`CLOUD_DEPLOYMENT=DEV/PROD`) or **licensed EE** (`EE_LICENSE_KEY` set) backend: open Evals → create/edit an LLM or Agent eval, the eval drawer on a task, and the Eval Playground — the Error Localization checkbox appears exactly as before.
3. On an **OSS** backend (no `CLOUD_DEPLOYMENT`, no `EE_LICENSE_KEY`): the checkbox is absent in all five places, and saved evals post `error_localizer_enabled: false`.

---

## 5) Screenshots / recordings

### Test output

Targeted run: `Test Files 10 passed (10) · Tests 108 passed (108)` — includes the 7 new TH-7177 cases.

### UI testing

Recorded live against two real backends with this PR's frontend (same account, same Create Evaluation flow). Full set also in [this comment](https://github.com/future-agi/future-agi/pull/2306#issuecomment-5407512266).

**Cloud mode (`mode: "cloud"`) — checkbox visible and tickable:**

<img width="800" alt="th7177-cloud-mode-checkbox-visible" src="https://github.com/user-attachments/assets/63d925ad-7d83-4b58-98f0-0519134ca5a0" />
<img width="800" alt="cloud-mode-zoom-checkbox-visible" src="https://github.com/user-attachments/assets/2bb87d97-4bb2-49ca-852e-3741132318de" />

**OSS mode (`mode: "oss"`, same image with `CLOUD_DEPLOYMENT`/`EE_LICENSE_KEY` stripped) — checkbox absent from the DOM (Description follows Output Type directly):**

<img width="800" alt="th7177-oss-mode-checkbox-hidden" src="https://github.com/user-attachments/assets/8c78be79-acf6-4b13-aed6-cd9cb385739a" />
<img width="800" alt="oss-mode-zoom-checkbox-hidden" src="https://github.com/user-attachments/assets/ac9f42ed-42d5-4986-9cfa-7aa84e7954ec" />

Licensed EE (`mode: "ee"`) keeps the cloud behavior — covered by the component test.

---

## 6) Edge cases & considerations

- **Deployment info still loading:** mode defaults to `"oss"` → control hidden until cloud/EE confirms (fail closed, no flash). The query is warm from login guards, so on cloud this is not user-visible in practice.
- **`EvaluationMappingForm` defaults `errorLocalizer` to `true`:** hidden field ≠ false in react-hook-form state — handled by gating the submitted value, not just the render.
- **Eval previously saved with the flag `true`, edited on OSS:** saving posts `false` (intentional downgrade — the feature cannot run there).
- **EE with an invalid/expired license key:** `deployment-info` only checks the key is non-empty, so the checkbox renders — but the `AGENTIC_EVAL` capability lock (which does validate) keeps it disabled with the existing tooltip, same as an unentitled cloud workspace.
- **Composite / code evals:** existing `!isComposite && evalType !== "code"` conditions are preserved; the new gate only ANDs onto them.
- **Result display paths** (`EvalResultDisplay`, `TaskLogsView`, `useErrorLocalizerPoll`) are deliberately untouched — they render stored results, which off-cloud deployments won't have.

## 7) Pre-existing issues (NOT introduced by this PR)

- 7 `react-hooks/exhaustive-deps` ESLint warnings in `EvalCreatePage.jsx`/`EvalDetailPage.jsx` (about `templateFormat`, `isComposite`, `enqueueSnackbar`) predate this PR.
- `annotate-components.test.jsx › keeps request actions reachable…` times out under full-suite parallel load (passes in isolation); flaked identically on unmodified `dev`.
- **Local-dev gotcha (not CI):** on Node ≥25, 34 suites fail to collect with `localStorage.getItem is not a function` — newer Node ships an experimental `localStorage` global that shadows jsdom's unless `--localstorage-file` points at a real file. CI pins Node 22.18 and is unaffected; locally use Node 22 (as the template says) or `NODE_OPTIONS=--localstorage-file=/tmp/ls.json`. Reproduced on unmodified `dev`.
- UI hiding is client-side only: the backend still accepts `error_localizer_enabled: true` from old SDKs/direct API calls off-cloud. Server-side fail-closed enforcement is a follow-up (flagged on TH-7177).

---

## 8) Architectural / important decisions

- **Deployment-mode gate over a new capability:** TH-7177's scope is "not available → not offered". `/api/capabilities/` has no `error_localizer` feature today; adding one is a backend change this UI fix doesn't need. The single hook keeps that migration a one-liner later. Licensed EE keeps the control (product decision on this PR): availability = `isCloud || isEE`, with per-license entitlement left to the existing capability lock.
- **Hide, don't disable:** disabled-with-tooltip is the existing *entitlement* treatment on cloud/EE and stays; on OSS there is no upgrade path inside the product, so showing a dead control is exactly the confusion the ticket reports.

---

## Checklist

- [x] My code follows the style guide
- [x] I've added tests that prove my fix is effective or that my feature works
- [x] `yarn test:run` passes locally (frontend)
- [ ] `bin/test` passes locally (backend) — N/A, frontend-only change
- [ ] `yarn contracts:check` — N/A, no API surface change
- [x] I've updated the documentation where relevant — N/A
- [x] No hardcoded secrets, URLs, or PII
- [x] I've signed the CLA
- [x] PR title follows Conventional Commits
- [x] Linear issue is linked and updated with status
