### PR TITLE
fix(tracer): make span attribute-key discovery exhaustive over its window [TH-7632]

### DIFF
--- a/futureagi/tracer/services/clickhouse/query_service.py
+++ b/futureagi/tracer/services/clickhouse/query_service.py
@@ -131,7 +131,11 @@ class AnalyticsQueryService:
         include_counts: bool = False,
         order_by_count_desc: bool = False,
     ) -> list[dict]:
-        """Get distinct span attribute keys with types for one or more projects."""
+        """Get distinct span attribute keys with types for one or more projects.
+
+        ``count`` is scoped to the discovery window, so a key surfaced only by
+        the unbounded path's legacy sample lane reports 0.
+        """
         if not project_ids:
             return []
 
@@ -156,11 +160,11 @@ class AnalyticsQueryService:
                   {window_filter}
                 GROUP BY key"""
             if recent_days is None:
-                # Unbounded callers additionally keep the legacy sample, so a key
-                # visible before this change can never disappear from the picker.
+                # Visibility-only lane: window plus sample is a superset of the
+                # old sample, so the picker only gains keys. cnt 0 avoids double-count.
                 sql += f"""
                 UNION ALL
-                SELECT key, '{type_name}' AS type, count() AS cnt FROM (
+                SELECT key, '{type_name}' AS type, 0 AS cnt FROM (
                     SELECT {column}.keys AS ks FROM spans
                     WHERE project_id IN %(project_ids)s
                       AND is_deleted = 0

--- a/futureagi/tracer/services/clickhouse/query_service.py
+++ b/futureagi/tracer/services/clickhouse/query_service.py
@@ -24,6 +24,10 @@ from tracer.services.clickhouse.eval_logger_table import eval_logger_source
 
 logger = structlog.get_logger(__name__)
 
+# Attribute discovery reads a bounded window so it can stay exhaustive; the
+# partition key is `toDate(start_time)`, so this prunes to whole partitions.
+ATTRIBUTE_DISCOVERY_WINDOW_DAYS = 7
+
 
 class QueryType(StrEnum):
     """Supported query types with per-type routing."""
@@ -131,13 +135,39 @@ class AnalyticsQueryService:
         if not project_ids:
             return []
 
-        recent_filter = ""
         params: dict[str, Any] = {
             "project_ids": tuple(project_ids),
+            "window_days": (
+                ATTRIBUTE_DISCOVERY_WINDOW_DAYS
+                if recent_days is None
+                else int(recent_days)
+            ),
         }
-        if recent_days is not None:
-            params["recent_days"] = int(recent_days)
-            recent_filter = "AND start_time >= now() - toIntervalDay(%(recent_days)s)"
+        window_filter = "AND start_time >= now() - toIntervalDay(%(window_days)s)"
+
+        def lane(column: str, type_name: str) -> str:
+            # Exhaustive over the window: ARRAY JOIN on `<map>.keys` reads only
+            # that subcolumn, so no key can fall outside an arbitrary row sample.
+            sql = f"""
+                SELECT key, '{type_name}' AS type, count() AS cnt
+                FROM spans ARRAY JOIN {column}.keys AS key
+                WHERE project_id IN %(project_ids)s
+                  AND is_deleted = 0
+                  {window_filter}
+                GROUP BY key"""
+            if recent_days is None:
+                # Unbounded callers additionally keep the legacy sample, so a key
+                # visible before this change can never disappear from the picker.
+                sql += f"""
+                UNION ALL
+                SELECT key, '{type_name}' AS type, count() AS cnt FROM (
+                    SELECT {column}.keys AS ks FROM spans
+                    WHERE project_id IN %(project_ids)s
+                      AND is_deleted = 0
+                    LIMIT 10000
+                ) ARRAY JOIN ks AS key
+                GROUP BY key"""
+            return sql
 
         outer_select = "SELECT key, argMax(type, cnt) AS type"
         if include_counts:
@@ -146,35 +176,16 @@ class AnalyticsQueryService:
             "ORDER BY count DESC, key" if order_by_count_desc else "ORDER BY key"
         )
 
-        query = f"""
-            {outer_select} FROM (
-                SELECT key, 'string' AS type, count() AS cnt FROM (
-                    SELECT attrs_string.keys AS ks FROM spans
-                    WHERE project_id IN %(project_ids)s
-                      AND is_deleted = 0
-                      {recent_filter}
-                    LIMIT 10000
-                ) ARRAY JOIN ks AS key
-                GROUP BY key
-                UNION ALL
-                SELECT key, 'number' AS type, count() AS cnt FROM (
-                    SELECT attrs_number.keys AS ks FROM spans
-                    WHERE project_id IN %(project_ids)s
-                      AND is_deleted = 0
-                      {recent_filter}
-                    LIMIT 10000
-                ) ARRAY JOIN ks AS key
-                GROUP BY key
-                UNION ALL
-                SELECT key, 'boolean' AS type, count() AS cnt FROM (
-                    SELECT attrs_bool.keys AS ks FROM spans
-                    WHERE project_id IN %(project_ids)s
-                      AND is_deleted = 0
-                      {recent_filter}
-                    LIMIT 10000
-                ) ARRAY JOIN ks AS key
-                GROUP BY key
+        lanes = " UNION ALL ".join(
+            lane(column, type_name)
+            for column, type_name in (
+                ("attrs_string", "string"),
+                ("attrs_number", "number"),
+                ("attrs_bool", "boolean"),
             )
+        )
+        query = f"""
+            {outer_select} FROM ({lanes})
             GROUP BY key
             {outer_order}
             LIMIT {int(outer_limit)}
@@ -195,15 +206,6 @@ class AnalyticsQueryService:
         populated at ingest time by fi-collector, so they are the canonical
         attribute inventory — no CDC fallback needed post-CH25 close-out.
         """
-        # This is a discovery query (populate a filter dropdown), not an
-        # accounting one, so an approximate sample is semantically fine.
-        # Two bounds keep it bounded even on very large projects:
-        #   * 7-day window on `start_time` (the partition key is
-        #     `toDate(start_time)`) so CH can skip partitions and granules.
-        #   * `LIMIT 10000` inside each per-map subquery before the
-        #     ARRAY JOIN — without this, projects with millions of spans
-        #     and wide `attrs_*` maps hit Code: 307 (max_bytes_to_read)
-        #     because every row's Map gets exploded.
         return self.get_span_attribute_keys_ch_for_projects([project_id])
 
     @staticmethod

--- a/futureagi/tracer/tests/test_clickhouse.py
+++ b/futureagi/tracer/tests/test_clickhouse.py
@@ -4546,50 +4546,6 @@ class TestSpanAttributeViews:
                 pass
 
 
-@pytest.mark.unit
-class TestSpanAttributeKeyDiscoveryScope:
-    """Attribute-key discovery must be exhaustive over its time window.
-
-    The query used to sample `LIMIT 10000` rows per map before the ARRAY
-    JOIN, so a key carried by only a thin slice of spans could fall outside
-    the sample and never reach the filter picker. Each lane now ARRAY JOINs
-    the `<map>.keys` subcolumn over every span in the window instead.
-    """
-
-    PROJECT_ID = "c4de3065-12b5-488c-a814-aa1c8e3f856f"
-    WINDOW = "start_time >= now() - toIntervalDay(%(window_days)s)"
-
-    def _discovery_sql(self, **kwargs):
-        from tracer.services.clickhouse.query_service import AnalyticsQueryService
-
-        with mock.patch.object(
-            AnalyticsQueryService,
-            "execute_ch_query",
-            return_value=mock.Mock(data=[]),
-        ) as execute:
-            AnalyticsQueryService().get_span_attribute_keys_ch_for_projects(
-                [self.PROJECT_ID], **kwargs
-            )
-        return execute.call_args.args[0]
-
-    def test_each_lane_array_joins_keys_across_the_whole_window(self):
-        """No row sample: every lane reads .keys for every span in the window."""
-        sql = self._discovery_sql(recent_days=7)
-
-        for column in ("attrs_string", "attrs_number", "attrs_bool"):
-            assert f"FROM spans ARRAY JOIN {column}.keys AS key" in sql
-        assert sql.count(self.WINDOW) == 3
-        assert "LIMIT 10000" not in sql
-
-    def test_unbounded_discovery_keeps_the_legacy_sample_lane(self):
-        """recent_days=None unions the old sample in, so no key regresses."""
-        sql = self._discovery_sql(recent_days=None)
-
-        assert sql.count(self.WINDOW) == 3
-        assert sql.count("LIMIT 10000") == 3
-        assert sql.count("UNION ALL") == 5
-
-
 # ============================================================================
 # 14. Comprehensive Trace List Query Builder Tests
 # ============================================================================

--- a/futureagi/tracer/tests/test_clickhouse.py
+++ b/futureagi/tracer/tests/test_clickhouse.py
@@ -4546,6 +4546,50 @@ class TestSpanAttributeViews:
                 pass
 
 
+@pytest.mark.unit
+class TestSpanAttributeKeyDiscoveryScope:
+    """Attribute-key discovery must be exhaustive over its time window.
+
+    The query used to sample `LIMIT 10000` rows per map before the ARRAY
+    JOIN, so a key carried by only a thin slice of spans could fall outside
+    the sample and never reach the filter picker. Each lane now ARRAY JOINs
+    the `<map>.keys` subcolumn over every span in the window instead.
+    """
+
+    PROJECT_ID = "c4de3065-12b5-488c-a814-aa1c8e3f856f"
+    WINDOW = "start_time >= now() - toIntervalDay(%(window_days)s)"
+
+    def _discovery_sql(self, **kwargs):
+        from tracer.services.clickhouse.query_service import AnalyticsQueryService
+
+        with mock.patch.object(
+            AnalyticsQueryService,
+            "execute_ch_query",
+            return_value=mock.Mock(data=[]),
+        ) as execute:
+            AnalyticsQueryService().get_span_attribute_keys_ch_for_projects(
+                [self.PROJECT_ID], **kwargs
+            )
+        return execute.call_args.args[0]
+
+    def test_each_lane_array_joins_keys_across_the_whole_window(self):
+        """No row sample: every lane reads .keys for every span in the window."""
+        sql = self._discovery_sql(recent_days=7)
+
+        for column in ("attrs_string", "attrs_number", "attrs_bool"):
+            assert f"FROM spans ARRAY JOIN {column}.keys AS key" in sql
+        assert sql.count(self.WINDOW) == 3
+        assert "LIMIT 10000" not in sql
+
+    def test_unbounded_discovery_keeps_the_legacy_sample_lane(self):
+        """recent_days=None unions the old sample in, so no key regresses."""
+        sql = self._discovery_sql(recent_days=None)
+
+        assert sql.count(self.WINDOW) == 3
+        assert sql.count("LIMIT 10000") == 3
+        assert sql.count("UNION ALL") == 5
+
+
 # ============================================================================
 # 14. Comprehensive Trace List Query Builder Tests
 # ============================================================================

--- a/futureagi/tracer/tests/test_eval_attributes_list.py
+++ b/futureagi/tracer/tests/test_eval_attributes_list.py
@@ -308,20 +308,28 @@ class TestSpanAttributeKeysNormalisation:
 
 
 class TestSpanAttributeKeysPartitionPruning:
-    """The recent-window discovery query must prune by the partition key.
+    """The recent-window discovery query must prune, stay unordered, and stay
+    exhaustive.
 
     ``spans`` is partitioned by ``toDate(start_time)``; ``created_at`` is
     neither the partition key nor in the sort key. Windowing by ``created_at``
     defeats partition pruning and scans the whole project. Pin that the query
     windows by ``start_time`` and does NOT order by it: ``start_time`` sits
     behind ``observation_type``/``service_name`` in the sort key, so an ordered
-    top-N reads the whole window (materializing the fat ``attrs_*`` maps) before
-    ``LIMIT`` applies -> Code 396 / Code 159 on high-volume projects. Without the
-    ORDER BY, ``project_id`` leading the sort key lets ``LIMIT 10000`` bound the
-    scan. Also pin that only the Map ``.keys`` subcolumn is read (never values).
+    lane sorts the whole window (materializing the fat ``attrs_*`` maps) ->
+    Code 396 / Code 159 on high-volume projects.
+
+    Discovery is exhaustive over that window: each lane ARRAY JOINs the
+    ``<map>.keys`` subcolumn over every span, never a row sample, so a key
+    carried by a thin slice of spans still reaches the filter picker. The
+    unbounded path keeps the legacy ``LIMIT 10000`` sample as a visibility-only
+    superset lane that contributes no count. Also pin that only the Map
+    ``.keys`` subcolumn is read (never values).
     """
 
-    def _capture_sql(self, monkeypatch, *, recent_days=7) -> str:
+    WINDOW = "start_time >= now() - toIntervalDay(%(window_days)s)"
+
+    def _capture_sql(self, monkeypatch, *, recent_days=7, **kwargs) -> str:
         from tracer.services.clickhouse.query_service import AnalyticsQueryService
 
         captured: dict = {}
@@ -337,7 +345,9 @@ class TestSpanAttributeKeysPartitionPruning:
             AnalyticsQueryService, "execute_ch_query", _capture, raising=True
         )
         AnalyticsQueryService().get_span_attribute_keys_ch_for_projects(
-            ["c4de3065-12b5-488c-a814-aa1c8e3f856f"], recent_days=recent_days
+            ["c4de3065-12b5-488c-a814-aa1c8e3f856f"],
+            recent_days=recent_days,
+            **kwargs,
         )
         return captured["query"]
 
@@ -345,7 +355,7 @@ class TestSpanAttributeKeysPartitionPruning:
         sql = self._capture_sql(monkeypatch, recent_days=7)
         # start_time is the partition key -> CH can prune to the window.
         assert "start_time >= now() - toIntervalDay" in sql
-        # The recency ORDER BY is dropped so LIMIT 10000 bounds the scan.
+        # No recency ORDER BY: an ordered lane would sort the whole window.
         assert "ORDER BY start_time" not in sql
 
     def test_reads_keys_subcolumn_not_whole_map(self, monkeypatch):
@@ -378,6 +388,22 @@ class TestSpanAttributeKeysPartitionPruning:
         sql = self._capture_sql(monkeypatch, recent_days=None)
         assert "ORDER BY start_time" not in sql
         assert "LIMIT 10000" in sql
+
+    def test_each_lane_array_joins_keys_across_the_whole_window(self, monkeypatch):
+        # No row sample: every lane reads .keys for every span in the window, so
+        # a key on a thin slice of spans cannot fall outside it (TH-7632).
+        sql = self._capture_sql(monkeypatch, recent_days=7)
+        for column in ("attrs_string", "attrs_number", "attrs_bool"):
+            assert f"FROM spans ARRAY JOIN {column}.keys AS key" in sql
+        assert sql.count(self.WINDOW) == 3
+        assert "LIMIT 10000" not in sql
+
+    def test_unbounded_discovery_keeps_the_legacy_sample_lane(self, monkeypatch):
+        # recent_days=None unions the old sample in, so no key regresses.
+        sql = self._capture_sql(monkeypatch, recent_days=None)
+        assert sql.count(self.WINDOW) == 3
+        assert sql.count("LIMIT 10000") == 3
+        assert sql.count("UNION ALL") == 5
 
 
 @pytest.mark.integration

--- a/futureagi/tracer/tests/test_eval_attributes_list.py
+++ b/futureagi/tracer/tests/test_eval_attributes_list.py
@@ -357,10 +357,9 @@ class TestSpanAttributeKeysPartitionPruning:
         assert "attrs_bool.keys" in sql
         assert "mapKeys(" not in sql
 
-    def test_preserves_limit_and_type_labels(self, monkeypatch):
+    def test_preserves_type_labels(self, monkeypatch):
         sql = self._capture_sql(monkeypatch, recent_days=7)
-        # The per-map LIMIT and type labels are unchanged by the fix.
-        assert "LIMIT 10000" in sql
+        # The windowed lanes are exhaustive, so only the type labels survive.
         assert "'string'" in sql
         assert "'number'" in sql
         assert "'boolean'" in sql
@@ -372,11 +371,11 @@ class TestSpanAttributeKeysPartitionPruning:
         assert "ORDER BY created_at" not in sql
 
     def test_full_project_discovery_skips_order_by_to_short_circuit(self, monkeypatch):
-        # recent_days=None (dashboard/metrics filter discovery): no window, so
-        # the ORDER BY must be dropped or LIMIT 10000 can't short-circuit and
-        # CH scans the whole project (~477k rows) instead of ~15k.
+        # recent_days=None (dashboard/metrics filter discovery) unions the
+        # windowed lane with the legacy sample; the ORDER BY must stay dropped
+        # or LIMIT 10000 can't short-circuit and CH scans the whole project
+        # (~477k rows) instead of ~15k.
         sql = self._capture_sql(monkeypatch, recent_days=None)
-        assert "start_time >= now()" not in sql
         assert "ORDER BY start_time" not in sql
         assert "LIMIT 10000" in sql
 

--- a/futureagi/tracer/tests/test_eval_attributes_list.py
+++ b/futureagi/tracer/tests/test_eval_attributes_list.py
@@ -405,6 +405,14 @@ class TestSpanAttributeKeysPartitionPruning:
         assert sql.count("LIMIT 10000") == 3
         assert sql.count("UNION ALL") == 5
 
+    def test_sample_lane_contributes_no_count(self, monkeypatch):
+        # A span inside both the window and the sample would otherwise be summed
+        # twice by the outer sum(cnt) and inflate argMax(type, cnt).
+        sql = self._capture_sql(monkeypatch, recent_days=None, include_counts=True)
+        assert sql.count("0 AS cnt") == 3
+        assert sql.count("count() AS cnt") == 3
+        assert "sum(cnt) AS count" in sql
+
 
 @pytest.mark.integration
 @pytest.mark.api


### PR DESCRIPTION
## Summary

Cherry-pick of [#2301](https://github.com/future-agi/future-agi/pull/2301) from `dev` into `main` as a hotfix.

**What:** The attribute-key discovery query sampled 10k rows with no `ORDER BY`, so attribute pickers missed keys from later services/hours. The fix `ARRAY JOIN`s directly on the `.keys` subcolumn for exhaustive discovery over a 7-day window, with the legacy sample kept as a strict superset for backwards compatibility.

**Why:** Customers with rare or service-specific attributes see "No properties found" in the filter picker. This is blocking.

**Impact:** 3 commits, ~160 lines changed across `tracer/services/clickhouse/query_service.py` and `tracer/tests/test_eval_attributes_list.py`. No migration, no schema change, no API contract change. Reverting returns to the sampled behaviour exactly as it is on `main` today.

**Tests:** All 8 tests in `TestSpanAttributeKeysPartitionPruning` pass (3 new, 2 amended, 3 existing). The 3 new tests fail if the fix is reverted.

Fixes TH-7632.
