### PR TITLE
fix: restore demo data seeding on new user signup

### DIFF
--- a/futureagi/accounts/tests/test_post_registration.py
+++ b/futureagi/accounts/tests/test_post_registration.py
@@ -43,6 +43,7 @@ class TestProcessPostRegistration:
 class TestRunPostRegistration:
     """Tests for _run_post_registration implementation function."""
 
+    @patch("accounts.utils.get_user_organization", return_value=None)
     @patch("accounts.utils.send_slack_notification")
     @patch("accounts.utils.send_hubspot_notification")
     @patch("accounts.utils.send_signup_email")
@@ -54,6 +55,7 @@ class TestRunPostRegistration:
         mock_send_email,
         mock_hubspot,
         mock_slack,
+        mock_get_org,
     ):
         """Test that all post-registration steps are executed."""
         from accounts.utils import _run_post_registration
@@ -102,6 +104,7 @@ class TestRunPostRegistration:
         with pytest.raises(Exception, match="SMTP error"):
             _run_post_registration("user-123", "password")
 
+    @patch("accounts.utils.get_user_organization", return_value=None)
     @patch("accounts.utils.send_signup_email")
     @patch("accounts.models.User.objects.get")
     @patch.dict("os.environ", {"ENV_TYPE": "local"})
@@ -109,6 +112,7 @@ class TestRunPostRegistration:
         self,
         mock_user_get,
         mock_send_email,
+        mock_get_org,
     ):
         """Test that hubspot/slack notifications are skipped in local env."""
         from accounts.utils import _run_post_registration

--- a/futureagi/accounts/utils.py
+++ b/futureagi/accounts/utils.py
@@ -616,6 +616,16 @@ def _run_post_registration(user_id, generated_password):
             updated, err = send_hubspot_notification(user)
             send_slack_notification(user, updated=updated, err=err)
 
+        org = get_user_organization(user)
+        if org:
+            from accounts.user_onboard import (
+                create_demo_traces_and_spans,
+                upload_demo_dataset,
+            )
+
+            upload_demo_dataset(org.id, str(user.id))
+            create_demo_traces_and_spans(str(org.id))
+
 
 def existing_member_access_will_change(
     existing_user, organization, org_level, workspace_access


### PR DESCRIPTION
Restores demo dataset and trace seeding in the post-registration flow for new user signups. This was accidentally removed in commit 72cfb81ed ("Deepen simulation agent definition coverage") as a side-cleanup. Without it, new accounts get an empty datasets page and no sample Observe projects. The import is done inline inside `_run_post_registration()` to avoid a circular import chain (utils → user_onboard → develop_annotations → utils).

Closes TH-7099

**Test checklist**
- [x] Signed up with a new account locally — Demo-dataset, Image-Demo-dataset, and Demo SQL Agent projects all created
- [x] Worker picks up the Temporal activity and completes without errors
- [x] No circular import errors on backend or worker startup

**Type of change**
- [x] Bug fix (non-breaking change which fixes an issue)

**Checklist**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] New and existing unit tests pass locally with my changes