### PR TITLE
fix(model-hub): recover stuck run prompt cells and fix temporal retry dead-ends (TH-7120)

### DIFF
--- a/futureagi/ai_tools/tests/test_run_prompt_tools.py
+++ b/futureagi/ai_tools/tests/test_run_prompt_tools.py
@@ -516,6 +516,52 @@ class TestEditRunPromptColumnTool:
         assert result.data["name"] == "Updated"
         assert result.data["model"] == "gpt-4o-mini"
 
+    def test_edit_rerun_resets_cells_with_cell_status_enum(
+        self, tool_context, writable_dataset, mock_celery
+    ):
+        """Rerun must write CellStatus ("running") into Cell.status, not
+        StatusType ("Running") — the wrong enum makes the UI ignore the
+        cells and the stuck-run recovery unable to match them."""
+        from model_hub.models.choices import CellStatus
+        from model_hub.models.develop_dataset import Cell, Column, Row
+
+        create_result = run_tool(
+            "add_run_prompt_column",
+            {
+                "dataset_id": str(writable_dataset.id),
+                "name": "Rerun Column",
+                "model": "gpt-4o",
+                "messages": [{"role": "user", "content": "test"}],
+                "run": False,
+            },
+            tool_context,
+        )
+        column = Column.objects.get(id=create_result.data["column_id"])
+        row = Row.objects.create(dataset=writable_dataset, order=0)
+        cell = Cell.objects.create(
+            dataset=writable_dataset,
+            column=column,
+            row=row,
+            value="old value",
+            status=CellStatus.PASS.value,
+        )
+
+        result = run_tool(
+            "edit_run_prompt_column",
+            {
+                "dataset_id": str(writable_dataset.id),
+                "column_id": str(column.id),
+                "model": "gpt-4o-mini",
+                "run": True,
+            },
+            tool_context,
+        )
+        assert not result.is_error
+
+        cell.refresh_from_db()
+        assert cell.status == CellStatus.RUNNING.value  # "running", not "Running"
+        assert cell.value is None
+
     def test_edit_nonexistent_column(self, tool_context, writable_dataset):
         result = run_tool(
             "edit_run_prompt_column",

--- a/futureagi/ai_tools/tools/datasets/edit_run_prompt_column.py
+++ b/futureagi/ai_tools/tools/datasets/edit_run_prompt_column.py
@@ -107,7 +107,7 @@ class EditRunPromptColumnTool(BaseTool):
     ) -> ToolResult:
         from django.db import transaction
 
-        from model_hub.models.choices import SourceChoices, StatusType
+        from model_hub.models.choices import CellStatus, SourceChoices, StatusType
         from model_hub.models.develop_dataset import Cell, Column, Dataset
         from model_hub.models.run_prompt import RunPrompter
         from model_hub.tasks.run_prompt import process_prompts_single
@@ -231,10 +231,12 @@ class EditRunPromptColumnTool(BaseTool):
             if params.tools is not None:
                 rp.tools.set(tool_objects)
 
-            # Clear existing cells for rerun
+            # Clear existing cells for rerun. Cell.status uses the CellStatus
+            # enum ("running"), not StatusType ("Running") — the wrong enum
+            # makes the UI ignore the cells and recovery unable to match them.
             if params.run:
                 Cell.objects.filter(dataset=dataset, column=column).update(
-                    value=None, status=StatusType.RUNNING.value
+                    value=None, status=CellStatus.RUNNING.value
                 )
 
         # Trigger re-execution if requested

--- a/futureagi/model_hub/tasks/run_prompt.py
+++ b/futureagi/model_hub/tasks/run_prompt.py
@@ -1,14 +1,19 @@
-from datetime import timedelta
+import json
+import threading
+from datetime import datetime, timedelta
 
 import structlog
 from django.db import close_old_connections
+from django.db.models import CharField, Exists, OuterRef
+from django.db.models.functions import Cast
 from django.utils import timezone
 
-from model_hub.models.choices import StatusType
+from model_hub.models.choices import CellStatus, SourceChoices, StatusType
+from model_hub.models.develop_dataset import Cell
 from model_hub.models.run_prompt import RunPrompter
 from model_hub.views.run_prompt import RunPrompts
 from tfc.temporal import temporal_activity
-from tfc.utils.distributed_locks import distributed_lock_manager
+from tfc.utils.distributed_locks import LockAcquisitionError, distributed_lock_manager
 from tfc.utils.distributed_state import DistributedEvaluationTracker
 
 logger = structlog.get_logger(__name__)
@@ -17,15 +22,139 @@ logger = structlog.get_logger(__name__)
 # How long a prompt can be in RUNNING status before considered stuck
 STUCK_RUNNING_THRESHOLD_HOURS = 1
 
-# Distributed tracker for run prompts (separate key prefix from evaluations)
-run_prompt_tracker = DistributedEvaluationTracker()
+
+LEASE_RENEW_INTERVAL_SECONDS = 60
+LEASE_TTL_SECONDS = 300  # ~ Temporal heartbeat_timeout (5 min)
+LEASE_FRESH_SECONDS = 3 * LEASE_RENEW_INTERVAL_SECONDS
+LOCK_TTL_SECONDS = 600  # lock auto-expiry; renewed alongside the lease
+
+# Distributed tracker for run prompts (separate key prefix from evaluations).
+run_prompt_tracker = DistributedEvaluationTracker(default_ttl=LEASE_TTL_SECONDS)
 run_prompt_tracker.key_prefix = "running_prompt:"
+
+
+class PromptAlreadyRunningElsewhere(Exception):
+    """Another live instance holds the lease on this prompt.
+
+    Raised (not swallowed) so the Temporal attempt is recorded as failed and
+    retried later. Returning success here is a dead-end: Temporal would mark
+    the workflow complete and the prompt would never be reprocessed even
+    after the other owner dies.
+    """
+
+
+class OwnershipLease:
+    """Keeps this worker's claim on a run prompt alive while it processes.
+
+    A daemon thread renews the distributed tracker entry (liveness lease) and
+    extends the Redis lock every LEASE_RENEW_INTERVAL_SECONDS. Without
+    renewal the fixed TTLs (tracker 5 min, lock 10 min) are shorter than a
+    legitimate run, so both must be kept alive for as long as the worker
+    actually is.
+    """
+
+    def __init__(self, prompt_id, lock=None):
+        self._prompt_id = prompt_id
+        self._lock = lock
+        self._stop = threading.Event()
+        self._thread = None
+
+    def __enter__(self):
+        self._thread = threading.Thread(
+            target=self._renew_loop,
+            name=f"run-prompt-lease-{self._prompt_id}",
+            daemon=True,
+        )
+        self._thread.start()
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        self._stop.set()
+        if self._thread is not None:
+            self._thread.join(timeout=5)
+        return False
+
+    def _renew_loop(self):
+        while not self._stop.wait(LEASE_RENEW_INTERVAL_SECONDS):
+            self.renew_once()
+
+    def renew_once(self):
+        try:
+            run_prompt_tracker.refresh_running(
+                self._prompt_id, ttl=LEASE_TTL_SECONDS
+            )
+        except Exception as e:
+            logger.warning(
+                "run_prompt_lease_refresh_failed",
+                prompt_id=str(self._prompt_id),
+                error=str(e),
+            )
+        # Local threading-lock fallback has no extend(); skip it.
+        if self._lock is not None and hasattr(self._lock, "extend"):
+            try:
+                self._lock.extend(LOCK_TTL_SECONDS, replace_ttl=True)
+            except Exception as e:
+                logger.warning(
+                    "run_prompt_lock_extend_failed",
+                    prompt_id=str(self._prompt_id),
+                    error=str(e),
+                )
+
+
+def _get_fresh_lease(prompt_id):
+    """Return the tracker entry if a live worker holds it, else None.
+
+    A lease is live when its last renewal (or start) is within
+    LEASE_FRESH_SECONDS; owners renew every LEASE_RENEW_INTERVAL_SECONDS, so
+    anything older belongs to a dead worker and is reclaimable.
+    """
+    info = run_prompt_tracker.get_running_info(prompt_id)
+    if not info:
+        return None
+    stamp = (info.metadata or {}).get("renewed_at") or info.started_at
+    try:
+        renewed = datetime.fromisoformat(stamp)
+    except (TypeError, ValueError):
+        return info  # unknown age: assume live, the TTL will purge it
+    if (datetime.utcnow() - renewed).total_seconds() < LEASE_FRESH_SECONDS:
+        return info
+    return None
+
+
+def _held_by_other_live_instance(prompt_id) -> bool:
+    """True if another live instance holds a fresh lease on this prompt."""
+    lease = _get_fresh_lease(prompt_id)
+    return bool(lease and lease.instance_id != run_prompt_tracker.instance_id)
+
+
+def _claim_prompt(run_prompt_id, runner_info):
+    """Take ownership of the prompt in the tracker (caller holds the lock).
+
+    Clears any stale lease left behind by a dead worker first, so a Temporal
+    retry can reclaim a crashed run instead of dead-ending on the leftover
+    entry.
+    """
+    stale = run_prompt_tracker.get_running_info(run_prompt_id)
+    if (
+        stale
+        and stale.instance_id != run_prompt_tracker.instance_id
+        and _get_fresh_lease(run_prompt_id) is None
+    ):
+        logger.warning(
+            "run_prompt_reclaiming_stale_lease",
+            run_prompt_id=str(run_prompt_id),
+            previous_owner=stale.instance_id,
+        )
+        run_prompt_tracker.mark_completed(run_prompt_id)
+
+    run_prompt_tracker.mark_running(
+        run_prompt_id, runner_info=runner_info, ttl=LEASE_TTL_SECONDS
+    )
 
 
 def process_not_started_prompt(run_prompt_id):
     """Process a newly created run prompt with distributed tracking."""
     close_old_connections()
-    tracking_key = f"prompt_{run_prompt_id}"
 
     logger.info(
         "process_not_started_prompt_starting",
@@ -34,39 +163,31 @@ def process_not_started_prompt(run_prompt_id):
     )
 
     try:
-        # Check if already running on another instance
-        if run_prompt_tracker.is_running(run_prompt_id):
-            running_info = run_prompt_tracker.get_running_info(run_prompt_id)
-            if (
-                running_info
-                and running_info.instance_id != run_prompt_tracker.instance_id
-            ):
-                logger.warning(
-                    "process_not_started_prompt_already_running",
-                    run_prompt_id=str(run_prompt_id),
-                    running_on=running_info.instance_id,
-                    current_instance=run_prompt_tracker.instance_id,
-                )
-                return
+        # Fail fast (and retryably) if a live instance already owns this
+        # prompt. Stale leases from dead workers do not count.
+        if _held_by_other_live_instance(run_prompt_id):
+            logger.warning(
+                "process_not_started_prompt_already_running",
+                run_prompt_id=str(run_prompt_id),
+                current_instance=run_prompt_tracker.instance_id,
+            )
+            raise PromptAlreadyRunningElsewhere(str(run_prompt_id))
 
         # Use distributed lock to prevent race conditions
         with distributed_lock_manager.lock(
             f"run_prompt:{run_prompt_id}",
-            timeout=3600,  # 1 hour max
+            timeout=LOCK_TTL_SECONDS,  # renewed by OwnershipLease below
             blocking_timeout=10,
-        ):
+        ) as lock:
             # Double-check after acquiring lock
-            if run_prompt_tracker.is_running(run_prompt_id):
-                existing = run_prompt_tracker.get_running_info(run_prompt_id)
-                if existing and existing.instance_id != run_prompt_tracker.instance_id:
-                    logger.warning(
-                        "process_not_started_prompt_started_elsewhere",
-                        run_prompt_id=str(run_prompt_id),
-                    )
-                    return
+            if _held_by_other_live_instance(run_prompt_id):
+                logger.warning(
+                    "process_not_started_prompt_started_elsewhere",
+                    run_prompt_id=str(run_prompt_id),
+                )
+                raise PromptAlreadyRunningElsewhere(str(run_prompt_id))
 
-            # Mark as running in distributed tracker
-            run_prompt_tracker.mark_running(
+            _claim_prompt(
                 run_prompt_id,
                 runner_info={
                     "type": "not_started",
@@ -79,8 +200,9 @@ def process_not_started_prompt(run_prompt_id):
                     "process_not_started_prompt_executing",
                     run_prompt_id=str(run_prompt_id),
                 )
-                runner = RunPrompts(run_prompt_id=run_prompt_id)
-                runner.run_prompt()
+                with OwnershipLease(run_prompt_id, lock=lock):
+                    runner = RunPrompts(run_prompt_id=run_prompt_id)
+                    runner.run_prompt()
                 logger.info(
                     "process_not_started_prompt_completed",
                     run_prompt_id=str(run_prompt_id),
@@ -89,6 +211,11 @@ def process_not_started_prompt(run_prompt_id):
                 # Always clean up distributed tracking
                 run_prompt_tracker.mark_completed(run_prompt_id)
 
+    except (PromptAlreadyRunningElsewhere, LockAcquisitionError):
+        # Another live instance owns this prompt. Do NOT mark the prompt
+        # FAILED (it is being processed) and do NOT touch the tracker entry
+        # (we don't own it) — just fail this attempt so Temporal retries.
+        raise
     except Exception as e:
         logger.exception(
             "process_not_started_prompt_failed",
@@ -129,36 +256,29 @@ def process_editing_prompt(run_prompt_id):
     )
 
     try:
-        # Check if already running on another instance
-        if run_prompt_tracker.is_running(run_prompt_id):
-            running_info = run_prompt_tracker.get_running_info(run_prompt_id)
-            if (
-                running_info
-                and running_info.instance_id != run_prompt_tracker.instance_id
-            ):
-                logger.warning(
-                    "process_editing_prompt_already_running",
-                    run_prompt_id=str(run_prompt_id),
-                    running_on=running_info.instance_id,
-                    current_instance=run_prompt_tracker.instance_id,
-                )
-                # Request cancellation of the existing run
-                run_prompt_tracker.request_cancel(
-                    run_prompt_id, reason="Edit requested"
-                )
-                logger.info(
-                    "process_editing_prompt_cancel_requested",
-                    run_prompt_id=str(run_prompt_id),
-                )
+        # An edit preempts a live run: request cancellation, then take over
+        # once the lock is released (or expires).
+        if _held_by_other_live_instance(run_prompt_id):
+            logger.warning(
+                "process_editing_prompt_already_running",
+                run_prompt_id=str(run_prompt_id),
+                current_instance=run_prompt_tracker.instance_id,
+            )
+            run_prompt_tracker.request_cancel(
+                run_prompt_id, reason="Edit requested"
+            )
+            logger.info(
+                "process_editing_prompt_cancel_requested",
+                run_prompt_id=str(run_prompt_id),
+            )
 
         # Use distributed lock to prevent race conditions
         with distributed_lock_manager.lock(
             f"run_prompt:{run_prompt_id}",
-            timeout=3600,  # 1 hour max
+            timeout=LOCK_TTL_SECONDS,  # renewed by OwnershipLease below
             blocking_timeout=30,  # Wait longer for edit as we may be waiting for cancel
-        ):
-            # Mark as running in distributed tracker
-            run_prompt_tracker.mark_running(
+        ) as lock:
+            _claim_prompt(
                 run_prompt_id,
                 runner_info={
                     "type": "editing",
@@ -171,8 +291,9 @@ def process_editing_prompt(run_prompt_id):
                     "process_editing_prompt_executing",
                     run_prompt_id=str(run_prompt_id),
                 )
-                runner = RunPrompts(run_prompt_id=run_prompt_id)
-                runner.run_prompt(edit_mode=True)
+                with OwnershipLease(run_prompt_id, lock=lock):
+                    runner = RunPrompts(run_prompt_id=run_prompt_id)
+                    runner.run_prompt(edit_mode=True)
                 logger.info(
                     "process_editing_prompt_completed",
                     run_prompt_id=str(run_prompt_id),
@@ -181,6 +302,11 @@ def process_editing_prompt(run_prompt_id):
                 # Always clean up distributed tracking
                 run_prompt_tracker.mark_completed(run_prompt_id)
 
+    except LockAcquisitionError:
+        # The current owner did not release within blocking_timeout. Fail
+        # this attempt (Temporal retries) without marking the prompt FAILED —
+        # the owner is still processing it.
+        raise
     except Exception as e:
         logger.exception(
             "process_editing_prompt_failed",
@@ -210,7 +336,7 @@ def process_editing_prompt(run_prompt_id):
         close_old_connections()
 
 
-@temporal_activity(time_limit=3600, queue="tasks_l")
+@temporal_activity(time_limit=4 * 3600, queue="tasks_l")
 def process_prompts_single(prompt):
     """
     Process a single run prompt. This activity is triggered directly from the API
@@ -245,20 +371,16 @@ def process_prompts_single(prompt):
             )
             return
 
-        # Check if already being processed by another instance
-        if run_prompt_tracker.is_running(prompt_id):
-            running_info = run_prompt_tracker.get_running_info(prompt_id)
-            if (
-                running_info
-                and running_info.instance_id != run_prompt_tracker.instance_id
-            ):
-                logger.warning(
-                    "process_prompts_single_already_running",
-                    prompt_id=prompt_id,
-                    running_on=running_info.instance_id,
-                    current_instance=run_prompt_tracker.instance_id,
-                )
-                return
+        # If a live instance owns this prompt, fail the attempt so Temporal
+        # retries later. Returning success here would end the workflow while
+        # the prompt might still die unprocessed (retry dead-end).
+        if prompt_type != "editing" and _held_by_other_live_instance(prompt_id):
+            logger.warning(
+                "process_prompts_single_already_running",
+                prompt_id=prompt_id,
+                current_instance=run_prompt_tracker.instance_id,
+            )
+            raise PromptAlreadyRunningElsewhere(str(prompt_id))
 
         if prompt_type == "not_started":
             process_not_started_prompt(prompt_id)
@@ -283,6 +405,8 @@ def process_prompts_single(prompt):
             prompt_id=prompt_id,
             prompt_type=prompt_type,
         )
+    except (PromptAlreadyRunningElsewhere, LockAcquisitionError):
+        raise
     except Exception as e:
         logger.exception(
             "process_prompts_single_error",
@@ -314,13 +438,31 @@ def recover_stuck_run_prompts():
     try:
         threshold = timezone.now() - timedelta(hours=STUCK_RUNNING_THRESHOLD_HOURS)
 
-        # Find prompts stuck in RUNNING for too long
-        stuck_prompts = RunPrompter.objects.filter(
-            status=StatusType.RUNNING.value,
-            updated_at__lt=threshold,
-        ).values_list("id", flat=True)[
-            :20
-        ]  # Process max 20 at a time
+        # Cell-write liveness is applied in SQL, before the batch slice, so
+        # live long runs cannot crowd dead prompts out of the batch. Oldest
+        # first so the longest-dead prompts are recovered first.
+        # (RunPrompter.updated_at is not refreshed while rows are processed,
+        # so the status/updated_at filter alone would flag healthy long runs.)
+        recent_cell_writes = Cell.objects.filter(
+            column__source=SourceChoices.RUN_PROMPT.value,
+            column__source_id=Cast(OuterRef("id"), output_field=CharField()),
+            updated_at__gte=threshold,
+        )
+        candidate_prompts = list(
+            RunPrompter.objects.filter(
+                status=StatusType.RUNNING.value,
+                updated_at__lt=threshold,
+            )
+            .filter(~Exists(recent_cell_writes))
+            .order_by("updated_at")
+            .values_list("id", flat=True)[:20]  # Process max 20 at a time
+        )
+
+        # Primary liveness signal: the worker's renewed ownership lease.
+        # Cell writes above are the fallback for when Redis is unavailable.
+        stuck_prompts = [
+            p for p in candidate_prompts if _get_fresh_lease(p) is None
+        ]
 
         stuck_count = len(stuck_prompts)
         if stuck_count == 0:
@@ -338,6 +480,23 @@ def recover_stuck_run_prompts():
                 status=StatusType.FAILED.value
             )
 
+            # Also flip their cells stuck in RUNNING to ERROR so the UI stops
+            # spinning forever. "Running" (StatusType) is matched too because
+            # older reruns wrote the wrong enum into Cell.status.
+            timeout_message = (
+                "Run prompt timed out or was interrupted. Please rerun this cell."
+            )
+            stuck_cells_updated = Cell.objects.filter(
+                column__source=SourceChoices.RUN_PROMPT.value,
+                column__source_id__in=[str(p) for p in stuck_prompts],
+                status__in=[CellStatus.RUNNING.value, StatusType.RUNNING.value],
+                deleted=False,
+            ).update(
+                status=CellStatus.ERROR.value,
+                value=timeout_message,
+                value_infos=json.dumps({"reason": timeout_message}),
+            )
+
             # Clean up distributed tracker entries for stuck prompts
             for prompt_id in stuck_prompts:
                 run_prompt_tracker.mark_completed(prompt_id)
@@ -346,12 +505,14 @@ def recover_stuck_run_prompts():
             logger.info(
                 "recover_stuck_run_prompts_marked_failed",
                 count=stuck_count,
+                stuck_cells_updated=stuck_cells_updated,
             )
 
-        # Also clean up stale entries in distributed tracker
-        stale_cleaned = run_prompt_tracker.cleanup_stale(
-            max_age_hours=STUCK_RUNNING_THRESHOLD_HOURS * 2
-        )
+        # Safety net for tracker entries whose TTL somehow failed to fire.
+        # Must exceed the longest legitimate run (activity limit is 4h):
+        # cleanup keys off started_at, and deleting a live long run's lease
+        # would break both dedup and the liveness signal above.
+        stale_cleaned = run_prompt_tracker.cleanup_stale(max_age_hours=5)
         if stale_cleaned > 0:
             logger.info(
                 "recover_stuck_run_prompts_cleaned_stale_tracker_entries",

--- a/futureagi/model_hub/tests/test_run_prompt_tasks.py
+++ b/futureagi/model_hub/tests/test_run_prompt_tasks.py
@@ -24,7 +24,7 @@ class TestProcessNotStartedPrompt:
         """Test successful processing of a not-started prompt."""
         from model_hub.tasks.run_prompt import process_not_started_prompt
 
-        mock_tracker.is_running.return_value = False
+        mock_tracker.get_running_info.return_value = None
         mock_tracker.instance_id = "test-instance"
         mock_runner = MagicMock()
         mock_runner_class.return_value = mock_runner
@@ -38,22 +38,29 @@ class TestProcessNotStartedPrompt:
     @patch("model_hub.tasks.run_prompt.run_prompt_tracker")
     @patch("model_hub.tasks.run_prompt.distributed_lock_manager")
     @patch("model_hub.tasks.run_prompt.close_old_connections")
-    def test_skips_if_already_running_on_another_instance(
+    def test_raises_if_already_running_on_another_instance(
         self, mock_close, mock_lock_mgr, mock_tracker
     ):
-        """Test that processing is skipped if prompt is running on another instance."""
-        from model_hub.tasks.run_prompt import process_not_started_prompt
+        """A fresh lease held by another live instance must fail the attempt
+        (so Temporal retries) instead of returning a false success."""
+        from model_hub.tasks.run_prompt import (
+            PromptAlreadyRunningElsewhere,
+            process_not_started_prompt,
+        )
 
-        mock_tracker.is_running.return_value = True
         mock_tracker.instance_id = "current-instance"
         mock_running_info = MagicMock()
         mock_running_info.instance_id = "other-instance"
+        # metadata is a MagicMock -> renewal age unknown -> treated as live
         mock_tracker.get_running_info.return_value = mock_running_info
 
-        process_not_started_prompt("prompt-123")
+        with pytest.raises(PromptAlreadyRunningElsewhere):
+            process_not_started_prompt("prompt-123")
 
-        # Lock should never be acquired since we skip early
+        # Lock should never be acquired since we fail early
         mock_lock_mgr.lock.assert_not_called()
+        # Must not clobber the live owner's lease or mark the prompt FAILED
+        mock_tracker.mark_completed.assert_not_called()
 
     @patch("model_hub.tasks.run_prompt.run_prompt_tracker")
     @patch("model_hub.tasks.run_prompt.distributed_lock_manager")
@@ -67,7 +74,7 @@ class TestProcessNotStartedPrompt:
         from model_hub.models.choices import StatusType
         from model_hub.tasks.run_prompt import process_not_started_prompt
 
-        mock_tracker.is_running.return_value = False
+        mock_tracker.get_running_info.return_value = None
         mock_tracker.instance_id = "test-instance"
         mock_runner = MagicMock()
         mock_runner.run_prompt.side_effect = Exception("Processing failed")
@@ -85,13 +92,17 @@ class TestProcessNotStartedPrompt:
     @patch("model_hub.tasks.run_prompt.distributed_lock_manager")
     @patch("model_hub.tasks.run_prompt.RunPrompts")
     @patch("model_hub.tasks.run_prompt.close_old_connections")
-    def test_uses_correct_lock_timeout(
+    def test_uses_renewable_lock_timeout(
         self, mock_close, mock_runner_class, mock_lock_mgr, mock_tracker
     ):
-        """Test that distributed lock uses 1-hour timeout."""
-        from model_hub.tasks.run_prompt import process_not_started_prompt
+        """The lock uses the short renewable TTL (extended by the lease
+        renewer), not a fixed lifetime longer than the work."""
+        from model_hub.tasks.run_prompt import (
+            LOCK_TTL_SECONDS,
+            process_not_started_prompt,
+        )
 
-        mock_tracker.is_running.return_value = False
+        mock_tracker.get_running_info.return_value = None
         mock_tracker.instance_id = "test-instance"
         mock_runner = MagicMock()
         mock_runner_class.return_value = mock_runner
@@ -100,7 +111,7 @@ class TestProcessNotStartedPrompt:
 
         mock_lock_mgr.lock.assert_called_once()
         call_kwargs = mock_lock_mgr.lock.call_args[1]
-        assert call_kwargs["timeout"] == 3600  # 1 hour
+        assert call_kwargs["timeout"] == LOCK_TTL_SECONDS
 
 
 class TestProcessEditingPrompt:
@@ -116,7 +127,7 @@ class TestProcessEditingPrompt:
         """Test successful processing of an editing prompt."""
         from model_hub.tasks.run_prompt import process_editing_prompt
 
-        mock_tracker.is_running.return_value = False
+        mock_tracker.get_running_info.return_value = None
         mock_tracker.instance_id = "test-instance"
         mock_runner = MagicMock()
         mock_runner_class.return_value = mock_runner
@@ -137,10 +148,10 @@ class TestProcessEditingPrompt:
         """Test that cancellation is requested if prompt is running elsewhere."""
         from model_hub.tasks.run_prompt import process_editing_prompt
 
-        mock_tracker.is_running.return_value = True
         mock_tracker.instance_id = "current-instance"
         mock_running_info = MagicMock()
         mock_running_info.instance_id = "other-instance"
+        # metadata is a MagicMock -> renewal age unknown -> treated as live
         mock_tracker.get_running_info.return_value = mock_running_info
         mock_runner = MagicMock()
         mock_runner_class.return_value = mock_runner
@@ -161,7 +172,7 @@ class TestProcessEditingPrompt:
         """Test that edit mode uses longer blocking timeout (30s)."""
         from model_hub.tasks.run_prompt import process_editing_prompt
 
-        mock_tracker.is_running.return_value = False
+        mock_tracker.get_running_info.return_value = None
         mock_tracker.instance_id = "test-instance"
         mock_runner = MagicMock()
         mock_runner_class.return_value = mock_runner
@@ -188,7 +199,7 @@ class TestProcessPromptsSingle:
         from model_hub.models.choices import StatusType
         from model_hub.tasks.run_prompt import process_prompts_single
 
-        mock_tracker.is_running.return_value = False
+        mock_tracker.get_running_info.return_value = None
         mock_tracker.instance_id = "test-instance"
         mock_prompt = MagicMock()
         mock_prompt.status = StatusType.RUNNING.value
@@ -209,7 +220,7 @@ class TestProcessPromptsSingle:
         from model_hub.models.choices import StatusType
         from model_hub.tasks.run_prompt import process_prompts_single
 
-        mock_tracker.is_running.return_value = False
+        mock_tracker.get_running_info.return_value = None
         mock_tracker.instance_id = "test-instance"
         mock_prompt = MagicMock()
         mock_prompt.status = StatusType.RUNNING.value
@@ -240,27 +251,78 @@ class TestProcessPromptsSingle:
     @patch("model_hub.tasks.run_prompt.run_prompt_tracker")
     @patch("model_hub.tasks.run_prompt.RunPrompter")
     @patch("model_hub.tasks.run_prompt.close_old_connections")
-    def test_skips_if_already_running_on_another_instance(
+    def test_raises_if_already_running_on_another_instance(
         self, mock_close, mock_prompter, mock_tracker
     ):
-        """Test idempotency - skip if already running elsewhere."""
+        """A live lease elsewhere must fail the Temporal attempt (retryable),
+        never return success: a false success ends the workflow and the
+        prompt is never reprocessed if the other owner dies."""
         from model_hub.models.choices import StatusType
-        from model_hub.tasks.run_prompt import process_prompts_single
+        from model_hub.models.run_prompt import RunPrompter
+        from model_hub.tasks.run_prompt import (
+            PromptAlreadyRunningElsewhere,
+            process_prompts_single,
+        )
 
-        mock_tracker.is_running.return_value = True
+        # Keep the real exception class so `except RunPrompter.DoesNotExist`
+        # stays valid while the module attribute is mocked.
+        mock_prompter.DoesNotExist = RunPrompter.DoesNotExist
         mock_tracker.instance_id = "current-instance"
         mock_running_info = MagicMock()
         mock_running_info.instance_id = "other-instance"
+        # metadata is a MagicMock -> renewal age unknown -> treated as live
         mock_tracker.get_running_info.return_value = mock_running_info
 
         mock_prompt = MagicMock()
         mock_prompt.status = StatusType.RUNNING.value
         mock_prompter.objects.get.return_value = mock_prompt
 
-        process_prompts_single({"type": "not_started", "prompt_id": "prompt-123"})
+        with pytest.raises(PromptAlreadyRunningElsewhere):
+            process_prompts_single(
+                {"type": "not_started", "prompt_id": "prompt-123"}
+            )
 
         # Should not process
         mock_tracker.mark_running.assert_not_called()
+
+    @patch("model_hub.tasks.run_prompt.run_prompt_tracker")
+    @patch("model_hub.tasks.run_prompt.RunPrompter")
+    @patch("model_hub.tasks.run_prompt.close_old_connections")
+    def test_proceeds_when_leftover_lease_is_stale(
+        self, mock_close, mock_prompter, mock_tracker
+    ):
+        """A lease whose last renewal is old belongs to a dead worker; the
+        retry must reclaim the prompt instead of dead-ending on the entry."""
+        from datetime import datetime, timedelta as td
+
+        from model_hub.models.choices import StatusType
+        from model_hub.tasks.run_prompt import (
+            LEASE_FRESH_SECONDS,
+            process_prompts_single,
+        )
+
+        mock_tracker.instance_id = "current-instance"
+        stale_info = MagicMock()
+        stale_info.instance_id = "dead-instance"
+        stale_info.metadata = {
+            "renewed_at": (
+                datetime.utcnow() - td(seconds=LEASE_FRESH_SECONDS + 60)
+            ).isoformat()
+        }
+        mock_tracker.get_running_info.return_value = stale_info
+
+        mock_prompt = MagicMock()
+        mock_prompt.status = StatusType.RUNNING.value
+        mock_prompter.objects.get.return_value = mock_prompt
+
+        with patch(
+            "model_hub.tasks.run_prompt.process_not_started_prompt"
+        ) as mock_process:
+            process_prompts_single(
+                {"type": "not_started", "prompt_id": "prompt-123"}
+            )
+
+        mock_process.assert_called_once_with("prompt-123")
 
 
 @pytest.mark.django_db
@@ -275,13 +337,21 @@ class TestRecoverStuckRunPrompts:
         from model_hub.models.choices import StatusType
         from model_hub.tasks.run_prompt import recover_stuck_run_prompts
 
-        # Mock stuck prompts query
+        # Mock stuck prompts query:
+        # filter(...).filter(~Exists(...)).order_by(...).values_list(...)[:20]
         stuck_ids = ["prompt-1", "prompt-2"]
-        mock_prompter.objects.filter.return_value.values_list.return_value.__getitem__.return_value = (
-            stuck_ids
+        query_chain = (
+            mock_prompter.objects.filter.return_value.filter.return_value
+            .order_by.return_value.values_list.return_value
         )
+        query_chain.__getitem__.return_value = stuck_ids
+        # No lease -> candidates are dead
+        mock_tracker.get_running_info.return_value = None
 
-        recover_stuck_run_prompts()
+        # Call the undecorated function: the temporal_activity wrapper's
+        # close_old_connections() would kill pytest-django's transaction
+        # connection before the real Cell queries run.
+        recover_stuck_run_prompts._original_func()
 
         # Should mark stuck prompts as FAILED
         mock_prompter.objects.filter.return_value.update.assert_called()
@@ -298,9 +368,11 @@ class TestRecoverStuckRunPrompts:
         from model_hub.tasks.run_prompt import recover_stuck_run_prompts
 
         # No stuck prompts
-        mock_prompter.objects.filter.return_value.values_list.return_value.__getitem__.return_value = (
-            []
+        query_chain = (
+            mock_prompter.objects.filter.return_value.filter.return_value
+            .order_by.return_value.values_list.return_value
         )
+        query_chain.__getitem__.return_value = []
 
         recover_stuck_run_prompts()
 
@@ -316,14 +388,19 @@ class TestRecoverStuckRunPrompts:
         """Test that stale tracker entries are cleaned up."""
         from model_hub.tasks.run_prompt import recover_stuck_run_prompts
 
-        mock_prompter.objects.filter.return_value.values_list.return_value.__getitem__.return_value = (
-            []
+        query_chain = (
+            mock_prompter.objects.filter.return_value.filter.return_value
+            .order_by.return_value.values_list.return_value
         )
+        query_chain.__getitem__.return_value = []
         mock_tracker.cleanup_stale.return_value = 5  # 5 stale entries cleaned
 
         recover_stuck_run_prompts()
 
-        mock_tracker.cleanup_stale.assert_called_once()
+        # Cleanup age must exceed the longest legitimate run (4h activity
+        # limit): cleanup keys off started_at, and deleting a live long
+        # run's lease would break dedup and the liveness signal.
+        mock_tracker.cleanup_stale.assert_called_once_with(max_age_hours=5)
 
 
 class TestGetRunningPromptsStatus:
@@ -399,6 +476,396 @@ class TestRunPromptTrackerConfiguration:
         from model_hub.tasks.run_prompt import run_prompt_tracker
 
         assert run_prompt_tracker.key_prefix == "running_prompt:"
+
+    def test_tracker_ttl_matches_lease(self):
+        """Tracker entries are short-lived leases renewed by the worker.
+
+        A dead worker (crash/OOM/deploy) leaves its tracker entry behind;
+        with the old 2-hour TTL, Temporal retries saw "already running
+        elsewhere" and returned successfully without processing, leaving
+        cells stuck in RUNNING forever. Live workers renew the lease every
+        LEASE_RENEW_INTERVAL_SECONDS, so a short TTL only ever expires
+        entries owned by dead workers.
+        """
+        from model_hub.tasks.run_prompt import (
+            LEASE_RENEW_INTERVAL_SECONDS,
+            LEASE_TTL_SECONDS,
+            run_prompt_tracker,
+        )
+
+        assert run_prompt_tracker.default_ttl == LEASE_TTL_SECONDS
+        # TTL must comfortably outlast the renew interval, or live leases
+        # would expire between renewals.
+        assert LEASE_TTL_SECONDS >= 3 * LEASE_RENEW_INTERVAL_SECONDS
+
+
+class TestOwnershipLease:
+    """Tests for the lease renewer that keeps the tracker entry and the
+    distributed lock alive while a worker processes a prompt."""
+
+    @patch("model_hub.tasks.run_prompt.run_prompt_tracker")
+    def test_renew_refreshes_tracker_and_extends_lock(self, mock_tracker):
+        from model_hub.tasks.run_prompt import (
+            LEASE_TTL_SECONDS,
+            LOCK_TTL_SECONDS,
+            OwnershipLease,
+        )
+
+        mock_lock = MagicMock()
+        OwnershipLease("prompt-123", lock=mock_lock).renew_once()
+
+        mock_tracker.refresh_running.assert_called_once_with(
+            "prompt-123", ttl=LEASE_TTL_SECONDS
+        )
+        mock_lock.extend.assert_called_once_with(
+            LOCK_TTL_SECONDS, replace_ttl=True
+        )
+
+    @patch("model_hub.tasks.run_prompt.run_prompt_tracker")
+    def test_renew_survives_redis_errors(self, mock_tracker):
+        """A failed renewal must not kill the run; the next tick retries."""
+        from model_hub.tasks.run_prompt import OwnershipLease
+
+        mock_tracker.refresh_running.side_effect = Exception("redis down")
+        mock_lock = MagicMock()
+        mock_lock.extend.side_effect = Exception("redis down")
+
+        OwnershipLease("prompt-123", lock=mock_lock).renew_once()  # no raise
+
+    @patch("model_hub.tasks.run_prompt.run_prompt_tracker")
+    def test_local_lock_without_extend_is_skipped(self, mock_tracker):
+        """The local threading-lock fallback has no extend(); the lease must
+        still renew the tracker entry."""
+        import threading
+
+        from model_hub.tasks.run_prompt import OwnershipLease
+
+        OwnershipLease("prompt-123", lock=threading.Lock()).renew_once()
+
+        mock_tracker.refresh_running.assert_called_once()
+
+    @patch("model_hub.tasks.run_prompt.run_prompt_tracker")
+    def test_context_manager_starts_and_stops_renewer(self, mock_tracker):
+        from model_hub.tasks.run_prompt import OwnershipLease
+
+        lease = OwnershipLease("prompt-123")
+        with lease:
+            assert lease._thread.is_alive()
+        assert not lease._thread.is_alive()
+
+
+@pytest.mark.django_db
+class TestRecoverStuckRunPromptsCellCleanup:
+    """Integration tests: recovery must repair stuck cells and must not
+    kill runs that are still actively writing cells (liveness check)."""
+
+    @pytest.fixture
+    def stuck_setup(self, organization, workspace):
+        """A RUNNING RunPrompter (stale for >1h) with two stuck cells."""
+        from model_hub.models.choices import (
+            CellStatus,
+            DatasetSourceChoices,
+            DataTypeChoices,
+            SourceChoices,
+            StatusType,
+        )
+        from model_hub.models.develop_dataset import Cell, Column, Dataset, Row
+        from model_hub.models.run_prompt import RunPrompter
+
+        dataset = Dataset.objects.create(
+            name="Stuck Dataset",
+            organization=organization,
+            workspace=workspace,
+            source=DatasetSourceChoices.BUILD.value,
+        )
+        prompter = RunPrompter.objects.create(
+            name="Stuck Prompter",
+            dataset=dataset,
+            organization=organization,
+            workspace=workspace,
+            status=StatusType.RUNNING.value,
+            model="gpt-4",
+            messages=[{"role": "user", "content": "hi"}],
+            run_prompt_config={},
+        )
+        column = Column.objects.create(
+            name="Stuck Output",
+            dataset=dataset,
+            data_type=DataTypeChoices.TEXT.value,
+            source=SourceChoices.RUN_PROMPT.value,
+            source_id=str(prompter.id),
+        )
+        row1 = Row.objects.create(dataset=dataset, order=0)
+        row2 = Row.objects.create(dataset=dataset, order=1)
+        cell_running = Cell.objects.create(
+            dataset=dataset,
+            column=column,
+            row=row1,
+            value="",
+            status=CellStatus.RUNNING.value,
+        )
+        cell_legacy = Cell.objects.create(
+            dataset=dataset,
+            column=column,
+            row=row2,
+            value="",
+            status=CellStatus.RUNNING.value,
+        )
+        # Legacy rerun path bulk-wrote the wrong enum ("Running") into
+        # Cell.status via queryset.update (which bypasses full_clean);
+        # recovery must repair those too. Reproduce it the same way.
+        Cell.objects.filter(id=cell_legacy.id).update(
+            status=StatusType.RUNNING.value
+        )
+
+        # Soft-deleted cells must be left alone by recovery.
+        row3 = Row.objects.create(dataset=dataset, order=2)
+        cell_deleted = Cell.objects.create(
+            dataset=dataset,
+            column=column,
+            row=row3,
+            value="",
+            status=CellStatus.RUNNING.value,
+            deleted=True,
+        )
+
+        # Backdate everything past the stuck threshold (queryset.update
+        # bypasses auto_now).
+        stale = timezone.now() - timedelta(hours=2)
+        RunPrompter.objects.filter(id=prompter.id).update(updated_at=stale)
+        Cell.objects.filter(
+            id__in=[cell_running.id, cell_legacy.id, cell_deleted.id]
+        ).update(updated_at=stale)
+
+        return {
+            "prompter": prompter,
+            "column": column,
+            "cells": [cell_running, cell_legacy],
+            "deleted_cell": cell_deleted,
+        }
+
+    @patch("model_hub.tasks.run_prompt.close_old_connections")
+    @patch("model_hub.tasks.run_prompt.run_prompt_tracker")
+    def test_recovery_marks_stuck_cells_error(
+        self, mock_tracker, mock_close, stuck_setup
+    ):
+        """Dead run: prompt -> FAILED and its RUNNING cells -> ERROR."""
+        from model_hub.models.choices import CellStatus, StatusType
+        from model_hub.tasks.run_prompt import recover_stuck_run_prompts
+
+        mock_tracker.get_running_info.return_value = None  # no lease -> dead
+
+        recover_stuck_run_prompts._original_func()
+
+        prompter = stuck_setup["prompter"]
+        prompter.refresh_from_db()
+        assert prompter.status == StatusType.FAILED.value
+
+        for cell in stuck_setup["cells"]:
+            cell.refresh_from_db()
+            assert cell.status == CellStatus.ERROR.value
+            assert "rerun" in cell.value.lower()
+
+        # Soft-deleted cells are invisible to users; recovery must not
+        # rewrite their status/value.
+        deleted_cell = stuck_setup["deleted_cell"]
+        deleted_cell.refresh_from_db()
+        assert deleted_cell.status == CellStatus.RUNNING.value
+        assert deleted_cell.value == ""
+
+    @patch("model_hub.tasks.run_prompt.close_old_connections")
+    @patch("model_hub.tasks.run_prompt.run_prompt_tracker")
+    def test_recovery_skips_prompts_with_recent_cell_activity(
+        self, mock_tracker, mock_close, stuck_setup
+    ):
+        """Live long run: recent cell writes mean the run is alive, so the
+        prompt must NOT be failed even though RunPrompter.updated_at is stale
+        (it is never refreshed during row processing)."""
+        from model_hub.models.choices import CellStatus, StatusType
+        from model_hub.models.develop_dataset import Cell
+        from model_hub.tasks.run_prompt import recover_stuck_run_prompts
+
+        mock_tracker.get_running_info.return_value = None  # no lease
+
+        # Simulate a freshly written cell (liveness signal)
+        live_cell = stuck_setup["cells"][0]
+        Cell.objects.filter(id=live_cell.id).update(updated_at=timezone.now())
+
+        recover_stuck_run_prompts._original_func()
+
+        prompter = stuck_setup["prompter"]
+        prompter.refresh_from_db()
+        assert prompter.status == StatusType.RUNNING.value
+
+        for cell in stuck_setup["cells"]:
+            cell.refresh_from_db()
+            assert cell.status != CellStatus.ERROR.value
+
+    @patch("model_hub.tasks.run_prompt.close_old_connections")
+    @patch("model_hub.tasks.run_prompt.run_prompt_tracker")
+    def test_recovery_skips_prompts_with_fresh_lease(
+        self, mock_tracker, mock_close, stuck_setup
+    ):
+        """Live long run with no recent cell writes (e.g. one slow LLM call):
+        the worker's renewed lease is the primary liveness signal, so the
+        prompt must NOT be failed."""
+        from datetime import datetime
+
+        from model_hub.models.choices import CellStatus, StatusType
+        from model_hub.tasks.run_prompt import recover_stuck_run_prompts
+
+        lease = MagicMock()
+        lease.instance_id = "live-worker"
+        lease.metadata = {"renewed_at": datetime.utcnow().isoformat()}
+        mock_tracker.get_running_info.return_value = lease
+
+        recover_stuck_run_prompts._original_func()
+
+        prompter = stuck_setup["prompter"]
+        prompter.refresh_from_db()
+        assert prompter.status == StatusType.RUNNING.value
+
+        for cell in stuck_setup["cells"]:
+            cell.refresh_from_db()
+            assert cell.status != CellStatus.ERROR.value
+
+    @patch("model_hub.tasks.run_prompt.close_old_connections")
+    @patch("model_hub.tasks.run_prompt.run_prompt_tracker")
+    def test_recovery_treats_stale_lease_as_dead(
+        self, mock_tracker, mock_close, stuck_setup
+    ):
+        """A lease that stopped being renewed belongs to a dead worker; the
+        prompt must be recovered despite the leftover tracker entry."""
+        from datetime import datetime
+
+        from model_hub.models.choices import StatusType
+        from model_hub.tasks.run_prompt import (
+            LEASE_FRESH_SECONDS,
+            recover_stuck_run_prompts,
+        )
+
+        lease = MagicMock()
+        lease.instance_id = "dead-worker"
+        lease.metadata = {
+            "renewed_at": (
+                datetime.utcnow() - timedelta(seconds=LEASE_FRESH_SECONDS + 60)
+            ).isoformat()
+        }
+        mock_tracker.get_running_info.return_value = lease
+
+        recover_stuck_run_prompts._original_func()
+
+        prompter = stuck_setup["prompter"]
+        prompter.refresh_from_db()
+        assert prompter.status == StatusType.FAILED.value
+
+    @patch("model_hub.tasks.run_prompt.close_old_connections")
+    @patch("model_hub.tasks.run_prompt.run_prompt_tracker")
+    def test_recovery_batches_oldest_dead_prompts_first(
+        self, mock_tracker, mock_close, stuck_setup, organization, workspace
+    ):
+        """The batch slice happens after liveness filtering, oldest first, so
+        newer stale-looking prompts cannot starve older dead ones."""
+        from model_hub.models.choices import DatasetSourceChoices, StatusType
+        from model_hub.models.develop_dataset import Dataset
+        from model_hub.models.run_prompt import RunPrompter
+        from model_hub.tasks.run_prompt import recover_stuck_run_prompts
+
+        mock_tracker.get_running_info.return_value = None
+
+        dataset = Dataset.objects.create(
+            name="Starvation Dataset",
+            organization=organization,
+            workspace=workspace,
+            source=DatasetSourceChoices.BUILD.value,
+        )
+        # 25 newer stale prompts (no cells, no lease -> dead). With the old
+        # newest-first slice-then-filter, these would fill the batch of 20
+        # and the 2h-old prompt from stuck_setup could be pushed out.
+        newer_ids = []
+        for i in range(25):
+            p = RunPrompter.objects.create(
+                name=f"Newer Stale {i}",
+                dataset=dataset,
+                organization=organization,
+                workspace=workspace,
+                status=StatusType.RUNNING.value,
+                model="gpt-4",
+                messages=[{"role": "user", "content": "hi"}],
+                run_prompt_config={},
+            )
+            newer_ids.append(p.id)
+        RunPrompter.objects.filter(id__in=newer_ids).update(
+            updated_at=timezone.now() - timedelta(minutes=70)
+        )
+
+        recover_stuck_run_prompts._original_func()
+
+        # The oldest dead prompt (2h stale) must be in the recovered batch.
+        prompter = stuck_setup["prompter"]
+        prompter.refresh_from_db()
+        assert prompter.status == StatusType.FAILED.value
+
+
+@pytest.mark.django_db
+class TestRunAllPromptsTaskCellStatus:
+    """run_all_prompts_task must write the CellStatus enum ("running"),
+    not StatusType ("Running"), into Cell.status."""
+
+    def test_rerun_sets_cells_to_lowercase_running(self, organization, workspace):
+        from model_hub.models.choices import (
+            CellStatus,
+            DatasetSourceChoices,
+            DataTypeChoices,
+            SourceChoices,
+            StatusType,
+        )
+        from model_hub.models.develop_dataset import Cell, Column, Dataset, Row
+        from model_hub.models.run_prompt import RunPrompter
+        from model_hub.views.run_prompt import run_all_prompts_task
+
+        dataset = Dataset.objects.create(
+            name="Rerun Dataset",
+            organization=organization,
+            workspace=workspace,
+            source=DatasetSourceChoices.BUILD.value,
+        )
+        prompter = RunPrompter.objects.create(
+            name="Rerun Prompter",
+            dataset=dataset,
+            organization=organization,
+            workspace=workspace,
+            status=StatusType.COMPLETED.value,
+            model="gpt-4",
+            messages=[{"role": "user", "content": "hi"}],
+            run_prompt_config={},
+        )
+        column = Column.objects.create(
+            name="Rerun Output",
+            dataset=dataset,
+            data_type=DataTypeChoices.TEXT.value,
+            source=SourceChoices.RUN_PROMPT.value,
+            source_id=str(prompter.id),
+        )
+        row = Row.objects.create(dataset=dataset, order=0)
+        cell = Cell.objects.create(
+            dataset=dataset,
+            column=column,
+            row=row,
+            value="old value",
+            status=CellStatus.PASS.value,
+        )
+
+        # Stub the runner so no LLM call happens; the cell keeps the status
+        # written by the bulk reset in run_all_prompts_task. Call the
+        # undecorated function so the temporal wrapper doesn't close
+        # pytest-django's transaction connection.
+        with patch("model_hub.views.run_prompt.RunPrompts") as mock_runner_class:
+            mock_runner_class.return_value = MagicMock()
+            run_all_prompts_task._original_func([str(prompter.id)], [str(row.id)])
+
+        cell.refresh_from_db()
+        assert cell.status == CellStatus.RUNNING.value  # "running", not "Running"
 
 
 @pytest.mark.django_db

--- a/futureagi/model_hub/views/run_prompt.py
+++ b/futureagi/model_hub/views/run_prompt.py
@@ -2823,7 +2823,7 @@ class RunPromptForRowsView(APIView):
             return self._gm.internal_server_error_response(error_message)
 
 
-@temporal_activity(time_limit=3600, queue="tasks_l")
+@temporal_activity(time_limit=4 * 3600, queue="tasks_l")
 def run_all_prompts_task(run_prompt_ids, row_ids):
     try:
         for run_prompt_id in run_prompt_ids:
@@ -2839,7 +2839,7 @@ def run_all_prompts_task(run_prompt_ids, row_ids):
             Cell.objects.filter(
                 row_id__in=row_ids, column__source_id=run_prompt_id, deleted=False
             ).update(
-                status=StatusType.RUNNING.value, value=None, value_infos=json.dumps({})
+                status=CellStatus.RUNNING.value, value=None, value_infos=json.dumps({})
             )
 
             # Run the prompt for each row ID

--- a/futureagi/tfc/temporal/background_tasks/tests/test_e2e_flows.py
+++ b/futureagi/tfc/temporal/background_tasks/tests/test_e2e_flows.py
@@ -50,8 +50,8 @@ class TestRunPromptE2EFlow:
         from model_hub.models.choices import StatusType
         from model_hub.tasks.run_prompt import process_prompts_single
 
-        # Setup: Prompt exists and is in RUNNING status
-        mock_tracker.is_running.return_value = False
+        # Setup: Prompt exists and is in RUNNING status, no lease held
+        mock_tracker.get_running_info.return_value = None
         mock_tracker.instance_id = "test-instance-1"
         mock_prompt_obj = MagicMock()
         mock_prompt_obj.status = StatusType.RUNNING.value
@@ -84,7 +84,7 @@ class TestRunPromptE2EFlow:
         from model_hub.models.choices import StatusType
         from model_hub.tasks.run_prompt import process_prompts_single
 
-        mock_tracker.is_running.return_value = False
+        mock_tracker.get_running_info.return_value = None
         mock_tracker.instance_id = "test-instance-1"
         mock_prompt_obj = MagicMock()
         mock_prompt_obj.status = StatusType.RUNNING.value
@@ -107,22 +107,33 @@ class TestRunPromptE2EFlow:
     def test_prompt_already_running_on_different_instance(
         self, mock_close, mock_prompter, mock_runner_class, mock_lock_mgr, mock_tracker
     ):
-        """Test that duplicate execution is prevented across instances."""
+        """Duplicate execution across instances fails the attempt (retryable)
+        instead of returning a false success that ends the workflow."""
         from model_hub.models.choices import StatusType
-        from model_hub.tasks.run_prompt import process_prompts_single
+        from model_hub.models.run_prompt import RunPrompter
+        from model_hub.tasks.run_prompt import (
+            PromptAlreadyRunningElsewhere,
+            process_prompts_single,
+        )
 
-        # Simulate prompt already running on another instance
-        mock_tracker.is_running.return_value = True
+        # Keep the real exception class so `except RunPrompter.DoesNotExist`
+        # stays valid while the module attribute is mocked.
+        mock_prompter.DoesNotExist = RunPrompter.DoesNotExist
+        # Simulate a live lease held by another instance
         mock_tracker.instance_id = "current-instance"
         mock_running_info = MagicMock()
         mock_running_info.instance_id = "other-instance"
+        # metadata is a MagicMock -> renewal age unknown -> treated as live
         mock_tracker.get_running_info.return_value = mock_running_info
 
         mock_prompt_obj = MagicMock()
         mock_prompt_obj.status = StatusType.RUNNING.value
         mock_prompter.objects.get.return_value = mock_prompt_obj
 
-        process_prompts_single({"type": "not_started", "prompt_id": "prompt-123"})
+        with pytest.raises(PromptAlreadyRunningElsewhere):
+            process_prompts_single(
+                {"type": "not_started", "prompt_id": "prompt-123"}
+            )
 
         # Should not process - already running elsewhere
         mock_runner_class.assert_not_called()
@@ -140,7 +151,7 @@ class TestRunPromptE2EFlow:
         from model_hub.models.choices import StatusType
         from model_hub.tasks.run_prompt import process_not_started_prompt
 
-        mock_tracker.is_running.return_value = False
+        mock_tracker.get_running_info.return_value = None
         mock_tracker.instance_id = "test-instance"
         mock_runner = MagicMock()
         mock_runner.run_prompt.side_effect = Exception("LLM API Error")
@@ -409,22 +420,26 @@ class TestDistributedLockingE2E:
     @patch("model_hub.tasks.run_prompt.run_prompt_tracker")
     @patch("model_hub.tasks.run_prompt.RunPrompts")
     @patch("model_hub.tasks.run_prompt.close_old_connections")
-    def test_run_prompt_uses_one_hour_lock_timeout(
+    def test_run_prompt_uses_renewable_lock_timeout(
         self, mock_close, mock_runner_class, mock_tracker, mock_lock_mgr
     ):
-        """Verify run prompt uses 1-hour (3600s) lock timeout."""
-        from model_hub.tasks.run_prompt import process_not_started_prompt
+        """The lock uses the short renewable TTL: the OwnershipLease renewer
+        extends it while the worker is alive, so a dead worker frees the
+        lock quickly instead of holding it for a fixed hour."""
+        from model_hub.tasks.run_prompt import (
+            LOCK_TTL_SECONDS,
+            process_not_started_prompt,
+        )
 
-        mock_tracker.is_running.return_value = False
+        mock_tracker.get_running_info.return_value = None
         mock_tracker.instance_id = "test-instance"
         mock_runner_class.return_value = MagicMock()
 
         process_not_started_prompt("prompt-123")
 
-        # Verify lock was called with 3600 second timeout
         mock_lock_mgr.lock.assert_called_once()
         call_kwargs = mock_lock_mgr.lock.call_args[1]
-        assert call_kwargs["timeout"] == 3600
+        assert call_kwargs["timeout"] == LOCK_TTL_SECONDS
 
 
 # =============================================================================
@@ -516,21 +531,30 @@ class TestDistributedStateE2E:
 class TestRecoveryMechanismsE2E:
     """End-to-end tests for stuck task recovery mechanisms."""
 
+    @patch("model_hub.tasks.run_prompt.Cell")
     @patch("model_hub.tasks.run_prompt.run_prompt_tracker")
     @patch("model_hub.tasks.run_prompt.RunPrompter")
     @patch("model_hub.tasks.run_prompt.close_old_connections")
     def test_recover_stuck_prompts_finds_old_running(
-        self, mock_close, mock_prompter, mock_tracker
+        self, mock_close, mock_prompter, mock_tracker, mock_cell
     ):
         """Test that recovery finds prompts stuck in RUNNING for > 1 hour."""
         from model_hub.models.choices import StatusType
         from model_hub.tasks.run_prompt import recover_stuck_run_prompts
 
-        # Setup stuck prompts query to return some IDs
+        # Setup stuck prompts query to return some IDs:
+        # filter(...).filter(~Exists(...)).order_by(...).values_list(...)[:20]
         stuck_ids = ["prompt-1", "prompt-2", "prompt-3"]
         mock_queryset = MagicMock()
-        mock_queryset.values_list.return_value.__getitem__.return_value = stuck_ids
+        (
+            mock_queryset.filter.return_value.order_by.return_value
+            .values_list.return_value.__getitem__.return_value
+        ) = stuck_ids
         mock_prompter.objects.filter.return_value = mock_queryset
+
+        # No lease and no recent cell writes -> all candidates are truly stuck
+        mock_tracker.get_running_info.return_value = None
+        mock_cell.objects.filter.return_value.update.return_value = 0
 
         recover_stuck_run_prompts()
 
@@ -554,9 +578,11 @@ class TestRecoveryMechanismsE2E:
         from model_hub.tasks.run_prompt import recover_stuck_run_prompts
 
         # No stuck prompts
-        mock_prompter.objects.filter.return_value.values_list.return_value.__getitem__.return_value = (
-            []
-        )
+        (
+            mock_prompter.objects.filter.return_value.filter.return_value
+            .order_by.return_value.values_list.return_value
+            .__getitem__.return_value
+        ) = []
 
         # But there are stale tracker entries
         mock_tracker.cleanup_stale.return_value = 5
@@ -575,9 +601,11 @@ class TestRecoveryMechanismsE2E:
         """Test recovery gracefully handles when no prompts are stuck."""
         from model_hub.tasks.run_prompt import recover_stuck_run_prompts
 
-        mock_prompter.objects.filter.return_value.values_list.return_value.__getitem__.return_value = (
-            []
-        )
+        (
+            mock_prompter.objects.filter.return_value.filter.return_value
+            .order_by.return_value.values_list.return_value
+            .__getitem__.return_value
+        ) = []
         mock_tracker.cleanup_stale.return_value = 0
 
         # Should not raise
@@ -705,7 +733,7 @@ class TestErrorHandlingE2E:
         from model_hub.models.choices import StatusType
         from model_hub.tasks.run_prompt import process_not_started_prompt
 
-        mock_tracker.is_running.return_value = False
+        mock_tracker.get_running_info.return_value = None
         mock_tracker.instance_id = "test-instance"
 
         # Runner fails

--- a/futureagi/tfc/temporal/drop_in/runner.py
+++ b/futureagi/tfc/temporal/drop_in/runner.py
@@ -211,6 +211,7 @@ async def _start_activity_async(
                 args=safe_args,
                 kwargs=safe_kwargs,
                 queue=queue,
+                time_limit=activity_metadata.get("time_limit"),
                 max_retries=activity_metadata.get("max_retries"),
                 retry_delay=activity_metadata.get("retry_delay"),
             ),

--- a/futureagi/tfc/temporal/drop_in/tests/test_retry_policy_propagation.py
+++ b/futureagi/tfc/temporal/drop_in/tests/test_retry_policy_propagation.py
@@ -227,6 +227,9 @@ class TestRunnerInputConstruction:
         assert run_input.activity_name == "fixture_activity_for_runner"
         assert run_input.max_retries == 2
         assert run_input.retry_delay == 15
+        # time_limit must reach TaskRunnerInput so the workflow applies the
+        # decorator's start_to_close timeout instead of the 12h default.
+        assert run_input.time_limit == 3600
 
     @pytest.mark.asyncio
     async def test_runner_passes_none_when_activity_unknown(self):
@@ -259,3 +262,35 @@ class TestRunnerInputConstruction:
         run_input = captured["input"]
         assert run_input.max_retries is None
         assert run_input.retry_delay is None
+        assert run_input.time_limit is None  # falls back to workflow default
+
+    @pytest.mark.asyncio
+    async def test_runner_threads_explicit_time_limit(self):
+        """A decorator-declared time_limit must propagate to TaskRunnerInput."""
+        _decorate("fixture_activity_time_limit", time_limit=4 * 3600)
+
+        captured = {}
+
+        async def _capture_start_workflow(workflow_run, run_input, **kwargs):
+            captured["input"] = run_input
+            return MagicMock()
+
+        fake_client = MagicMock()
+        fake_client.start_workflow = AsyncMock(side_effect=_capture_start_workflow)
+        fake_client.namespace = "default"
+
+        with patch(
+            "tfc.temporal.common.client.get_client",
+            new=AsyncMock(return_value=fake_client),
+        ):
+            from tfc.temporal.drop_in.runner import _start_activity_async
+
+            await _start_activity_async(
+                activity_name="fixture_activity_time_limit",
+                args=(),
+                kwargs={},
+                queue="default",
+                task_id="t-3",
+            )
+
+        assert captured["input"].time_limit == 4 * 3600

--- a/futureagi/tfc/utils/distributed_state.py
+++ b/futureagi/tfc/utils/distributed_state.py
@@ -367,6 +367,35 @@ class DistributedEvaluationTracker(DistributedStateManager):
             )
             return False
 
+    def refresh_running(self, eval_id: int, ttl: Optional[int] = None) -> bool:
+        """
+        Renew this instance's lease on a running entry.
+
+        Re-writes the entry with a fresh TTL and stamps
+        ``metadata["renewed_at"]`` so other instances can distinguish a live
+        owner (recent renewal) from a dead one (stale renewal). Only the
+        owning instance may renew.
+
+        Args:
+            eval_id: The task ID.
+            ttl: TTL for the renewed entry; defaults to default_ttl.
+
+        Returns:
+            True if renewed, False when the entry is missing, owned by
+            another instance, or Redis is unavailable.
+        """
+        key = str(eval_id)
+        try:
+            info = self.get_running_info(eval_id)
+            if not info or info.instance_id != self._instance_id:
+                return False
+            info.metadata = dict(info.metadata or {})
+            info.metadata["renewed_at"] = datetime.utcnow().isoformat()
+            return self.set(key, info.to_dict(), ttl=ttl)
+        except Exception as e:
+            logger.warning(f"Failed to refresh running entry {eval_id}: {e}")
+            return False
+
     def is_running(self, eval_id: int) -> bool:
         """
         Check if an evaluation is currently running on any instance.

--- a/futureagi/tfc/utils/tests/test_distributed_state.py
+++ b/futureagi/tfc/utils/tests/test_distributed_state.py
@@ -1,0 +1,73 @@
+"""
+Tests for tfc/utils/distributed_state.py (lease renewal semantics).
+
+Run with: pytest tfc/utils/tests/test_distributed_state.py -v
+"""
+
+from unittest.mock import patch
+
+from tfc.utils.distributed_state import (
+    DistributedEvaluationTracker,
+    RunningTaskInfo,
+)
+
+
+def _make_tracker() -> DistributedEvaluationTracker:
+    """Build a tracker without touching Redis (methods are patched per-test)."""
+    tracker = DistributedEvaluationTracker.__new__(DistributedEvaluationTracker)
+    tracker.key_prefix = "running_eval:"
+    tracker.default_ttl = 300
+    tracker._instance_id = "this-instance"
+    tracker._redis_available = False
+    return tracker
+
+
+class TestRefreshRunning:
+    """refresh_running is the lease-renewal primitive: only the owner may
+    renew, and each renewal stamps metadata["renewed_at"] so other instances
+    can distinguish live owners from dead ones."""
+
+    def test_owner_renewal_stamps_renewed_at_and_ttl(self):
+        tracker = _make_tracker()
+        info = RunningTaskInfo(
+            task_id="1",
+            instance_id="this-instance",
+            started_at="2024-01-01T00:00:00",
+        )
+        with patch.object(tracker, "get_running_info", return_value=info), patch.object(
+            tracker, "set", return_value=True
+        ) as mock_set:
+            assert tracker.refresh_running(1, ttl=300) is True
+
+        args, kwargs = mock_set.call_args
+        assert args[0] == "1"
+        assert "renewed_at" in args[1]["metadata"]
+        assert kwargs["ttl"] == 300
+
+    def test_non_owner_cannot_renew(self):
+        tracker = _make_tracker()
+        info = RunningTaskInfo(
+            task_id="1",
+            instance_id="other-instance",
+            started_at="2024-01-01T00:00:00",
+        )
+        with patch.object(tracker, "get_running_info", return_value=info), patch.object(
+            tracker, "set"
+        ) as mock_set:
+            assert tracker.refresh_running(1) is False
+            mock_set.assert_not_called()
+
+    def test_missing_entry_returns_false(self):
+        tracker = _make_tracker()
+        with patch.object(tracker, "get_running_info", return_value=None), patch.object(
+            tracker, "set"
+        ) as mock_set:
+            assert tracker.refresh_running(1) is False
+            mock_set.assert_not_called()
+
+    def test_redis_error_returns_false(self):
+        tracker = _make_tracker()
+        with patch.object(
+            tracker, "get_running_info", side_effect=Exception("redis down")
+        ):
+            assert tracker.refresh_running(1) is False


### PR DESCRIPTION
## Summary
- Run-prompt cells were stuck in `running` forever after worker crashes: Temporal retries dead-ended on stale tracker entries, the recovery task had no liveness signal, and reruns wrote the wrong status enum into cells.
- This PR introduces a **renewable ownership lease**: while a worker processes a prompt it renews the Redis tracker entry (TTL 5 min, renewed every 60s, `renewed_at` stamped) and extends the distributed lock (TTL 10 min). Lease freshness is now the primary liveness/ownership signal for retries and recovery.
- Addresses all four review comments: retries now fail retryably (never false-success) when a live lease exists elsewhere, reclaim stale leases from dead workers; tracker/lock/activity lifetimes are aligned via renewal; recovery liveness uses the lease first with cell-writes as a Redis-outage fallback; and the recovery batch is filtered in SQL before slicing (oldest first), removing the starvation regression.

## Changes by file
- `model_hub/tasks/run_prompt.py`: New `OwnershipLease` renewer (daemon thread refreshing tracker + extending lock), `PromptAlreadyRunningElsewhere` raised instead of returning success on live leases, stale-lease reclaim under the distributed lock (`_claim_prompt`), lock timeout 3600s → 600s renewable, recovery rewritten (SQL `~Exists` cell-writes filter → oldest-first ordering → slice last → lease check), `cleanup_stale` horizon raised to 5h so it can't delete leases of legitimate long runs (activity limit is 4h), stuck-cell repair keeps `deleted=False` and both-enum matching.
- `tfc/utils/distributed_state.py`: New `DistributedEvaluationTracker.refresh_running()` — owner-only lease renewal that re-sets the entry with a fresh TTL and stamps `metadata["renewed_at"]`.
- `ai_tools/tools/datasets/edit_run_prompt_column.py`: Found while sweeping for similar issues — the rerun path wrote `StatusType.RUNNING` (`"Running"`) into `Cell.status` instead of `CellStatus.RUNNING` (`"running"`), the same enum bug this PR fixed in `run_all_prompts_task`.
- `model_hub/tests/test_run_prompt_tasks.py`: Tests for lease renewal, retryable already-running failures, stale-lease reclaim, lease-based recovery liveness, stale-lease-as-dead recovery, and a 25-prompt starvation regression test.
- `tfc/utils/tests/test_distributed_state.py`: New unit tests for `refresh_running` (owner-only, `renewed_at` stamping, error handling).
- `tfc/temporal/background_tasks/tests/test_e2e_flows.py`: Updated e2e mocks for the new lease semantics and query chain.
- `ai_tools/tests/test_run_prompt_tools.py`: Regression test that rerun resets cells with the `CellStatus` enum.

## Flows touched
- Run-prompt create/edit (Temporal `process_prompts_single`): retries after a worker crash now reclaim the prompt once the lease goes stale (≤5 min) instead of false-succeeding; a genuinely live run elsewhere fails the attempt retryably. Edits still preempt via cancel request.
- Stuck-run recovery (`recover_stuck_run_prompts`): decides liveness from the renewed lease first, recent cell writes second; recovers oldest dead prompts first; still flips prompt → FAILED and non-deleted stuck cells → ERROR.
- MCP `edit_run_prompt_column` rerun: cells now reset with the correct enum so the UI and recovery can see them.

## Test coverage
- False-success retry path, stale-lease reclaim, lease renewal (tracker + lock, error tolerance, local-lock fallback), recovery liveness from lease/cell-writes/stale-lease, starvation regression (25 newer dead prompts cannot push out an older one), soft-deleted cell exclusion, enum regression in both rerun paths.
- Known gap: cancel-flag honoring inside `RunPrompts.run_prompt` is still a follow-up (pre-existing).

## How tested
- `bin/test model_hub/tests/test_run_prompt_tasks.py tfc/utils/tests/ tfc/temporal/background_tasks/tests/ tfc/temporal/drop_in/tests/ ai_tools/tests/test_run_prompt_tools.py` → **263 passed, 1 deselected** (the deselected test is `test_cleanup_stale_handles_exception`, quarantined pre-existing failure, issue #1984 — verified it fails identically without this change).

## Media
<!-- User will attach screenshot/video manually if relevant -->
_Screenshot / video:_ (placeholder — add manually if relevant)

## Test logs
<details>
<summary>Test run output</summary>

```
$ bin/test model_hub/tests/test_run_prompt_tasks.py tfc/utils/tests/ tfc/temporal/background_tasks/tests/ tfc/temporal/drop_in/tests/ ai_tools/tests/test_run_prompt_tools.py -q --deselect "tfc/utils/tests/test_distributed_locks.py::TestDistributedStateErrorHandling::test_cleanup_stale_handles_exception"
====================== 263 passed, 1 deselected in 33.65s ======================
```

</details>