### PR TITLE
chore(frontend): gate React Query devtools behind VITE_REACT_QUERY_DEVTOOLS_ENABLED

### DIFF
--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -56,5 +56,9 @@ VITE_TWITTER_PIXEL_ID=XXXXX
 VITE_AD_CONVERSION_VALUE=75.0
 VITE_AD_CONVERSION_CURRENCY=USD
 
+# React Query devtools floating widget. Enabled unless set to exactly "false".
+# Only ever rendered in dev builds — the devtools package no-ops in production.
+VITE_REACT_QUERY_DEVTOOLS_ENABLED=true
+
 # Disable ESLint errors in dev overlay
 ESLINT_NO_DEV_ERRORS=true

--- a/frontend/src/app.jsx
+++ b/frontend/src/app.jsx
@@ -29,7 +29,10 @@ import {
 import { ReactQueryDevtools } from "@tanstack/react-query-devtools";
 import { BrowserAgent } from "@newrelic/browser-agent/loaders/browser-agent";
 import { devTracing, prodTracing } from "./newrelic";
-import { CURRENT_ENVIRONMENT } from "./config-global";
+import {
+  CURRENT_ENVIRONMENT,
+  REACT_QUERY_DEVTOOLS_ENABLED,
+} from "./config-global";
 import { ErrorBoundary } from "react-error-boundary";
 import ErrorFallback from "./pages/ErrorFallback";
 import UploadLimitNotification from "./components/rate-limit-modal/RateLimitModal";
@@ -60,7 +63,8 @@ const _extractParts = (result) => {
   return String(result);
 };
 
-const extractErrorMessage = (result) => _extractParts(result) || "Something went wrong";
+const extractErrorMessage = (result) =>
+  _extractParts(result) || "Something went wrong";
 
 const handleError = (error, variable, context, mutation) => {
   if (error?.statusCode == RESPONSE_CODES.LIMIT_REACHED) return;
@@ -214,7 +218,9 @@ export default function App() {
           </WorkspaceProvider>
         </OrganizationProvider>
       </AuthProvider>
-      <ReactQueryDevtools initialIsOpen={false} />
+      {REACT_QUERY_DEVTOOLS_ENABLED && (
+        <ReactQueryDevtools initialIsOpen={false} />
+      )}
     </QueryClientProvider>
   );
 }

--- a/frontend/src/config-global.js
+++ b/frontend/src/config-global.js
@@ -35,6 +35,8 @@ export const HELP_LINK = resolveHelpLink();
 export const GENERATE_LINK = import.meta.env.VITE_GENERATE_LINK;
 export const ASSETS_API = import.meta.env.VITE_ASSETS_API;
 export const CURRENT_ENVIRONMENT = import.meta.env.VITE_ENVIRONMENT;
+export const REACT_QUERY_DEVTOOLS_ENABLED =
+  import.meta.env.VITE_REACT_QUERY_DEVTOOLS_ENABLED !== "false";
 export const GOOGLE_SITE_KEY = import.meta.env.VITE_GOOGLE_SITE_KEY;
 export const SENTRY_DSN = import.meta.env.VITE_SENTRY_DSN;
 export const MIXPANEL_HOST = import.meta.env.VITE_MIXPANEL_HOST;


### PR DESCRIPTION
## Why

The React Query devtools floating widget (bottom-left icon) is rendered unconditionally in `app.jsx`, so anyone running the frontend locally gets it on screen with no way to turn it off short of editing the file and remembering not to commit the edit. TanStack v5 devtools have no runtime/localStorage toggle of their own, so the only opt-out has to come from our side.

## What

Adds `VITE_REACT_QUERY_DEVTOOLS_ENABLED`, an opt-out flag:

| Value | Devtools |
|---|---|
| unset | rendered (unchanged default) |
| `true` (or anything else) | rendered |
| `false` | not rendered |

- `frontend/src/config-global.js` — `REACT_QUERY_DEVTOOLS_ENABLED = import.meta.env.VITE_REACT_QUERY_DEVTOOLS_ENABLED !== "false"`, alongside the other `VITE_*` exports.
- `frontend/src/app.jsx` — `<ReactQueryDevtools />` is now gated on that constant.
- `frontend/.env.example` — documents the flag.

No behaviour change for anyone who doesn't set the variable, and nothing changes in production: the `@tanstack/react-query-devtools` package already compiles to a no-op in production builds.

## Tests

**New tests:** none. This follows the existing precedent for the sibling build-time flags in `config-global.js` (`VITE_GOOGLE_ADS_ENABLED`, `VITE_REDDIT_ADS_ENABLED`, `VITE_TWITTER_ADS_ENABLED`), none of which carry unit tests — a test here would assert `!== "false"` against a stubbed `import.meta.env` and prove nothing the type of the expression doesn't already. Verified end-to-end against a running dev server instead (below).

**Existing tests:** no existing suite touches `app.jsx` render or `config-global.js` exports, so nothing was affected. ESLint was run over both changed source files, and the repo's `lint-staged` pre-commit chain (eslint + prettier) ran clean on commit.

## Test scenarios

All three exercised against `vite` dev server on port 4173, checking the live DOM for the devtools trigger (`button[aria-label="Open Tanstack query devtools"]`) and its container (`.tsqd-parent-container`):

1. **Variable unset** — devtools present (the default must not regress).
2. **`VITE_REACT_QUERY_DEVTOOLS_ENABLED=false`** — devtools absent.
3. **`VITE_REACT_QUERY_DEVTOOLS_ENABLED=true`** — devtools present.

## Commands

```bash
cd frontend
npx eslint src/app.jsx src/config-global.js
npx vite --port 4173 --strictPort        # once per scenario, restarted between env changes
```

## How to test locally

```bash
cd frontend
npm run dev                    # devtools icon visible, bottom-left
echo 'VITE_REACT_QUERY_DEVTOOLS_ENABLED=false' >> .env
npm run dev                    # icon gone
```

Vite only reads `.env` at startup, so the dev server has to be restarted after changing the value.

## Evidence

ESLint on the changed files (no output = clean):

```
$ npx eslint src/app.jsx src/config-global.js
$
```

DOM probe per scenario:

```
# 1. unset
{ "devtoolsButtons": ["Open Tanstack query devtools"], "hasTanstackContainer": true }

# 2. VITE_REACT_QUERY_DEVTOOLS_ENABLED=false
{ "devtoolsButtons": [], "hasTanstackContainer": false }

# 3. VITE_REACT_QUERY_DEVTOOLS_ENABLED=true
{ "devtoolsButtons": ["Open Tanstack query devtools"], "hasTanstackContainer": true }
```

Pre-commit chain:

```
[COMPLETED] node scripts/lint-staged-frontend.mjs
[COMPLETED] node scripts/lint-staged-root-format.mjs
[chore/query-devtools-env-toggle 8443721b0] chore(frontend): gate React Query devtools behind an env flag
 3 files changed, 15 insertions(+), 3 deletions(-)
```

## Architectural rationale

- **Opt-out, not opt-in.** Default-on keeps today's behaviour for everyone who has not asked for a change, so no one loses a tool they were relying on because they didn't see this PR.
- **Exact-match `!== "false"`.** Only the literal string `false` disables it. Any other value — a typo, an empty string, an unset var in a partially-populated `.env` — leaves the devtools on, which is the safe direction for a dev-only widget. This mirrors the `=== "true"` idiom used by the ads flags, inverted to match the opt-out default.
- **Build-time (`import.meta.env`), not runtime (`window.__FUTURE_AGI_CONFIG__`).** The runtime-config path in `docker-entrypoint.sh` exists for values that differ per deployed container. The devtools are stripped from production builds regardless, so a runtime knob would be unreachable code and one more variable for operators to carry.
- **Constant in `config-global.js`, not `import.meta.env` inline in `app.jsx`.** Every other `VITE_*` read in the app goes through `config-global.js`; keeping this one there means the full set of frontend env vars stays discoverable in one file.
