### PR TITLE
fix(agents): use env-aware host for Retell webhook URL

### DIFF
--- a/frontend/src/sections/agents/AgentConfiguration/EditAgentDetails.jsx
+++ b/frontend/src/sections/agents/AgentConfiguration/EditAgentDetails.jsx
@@ -47,6 +47,7 @@ import { PROVIDER_CHOICES } from "../constants";
 import Iconify from "src/components/iconify";
 import { enqueueSnackbar } from "notistack";
 import { copyToClipboard } from "src/utils/utils";
+import { HOST_API } from "src/config-global";
 import SvgColor from "src/components/svg-color";
 import { useMutation } from "@tanstack/react-query";
 import axios, { endpoints } from "src/utils/axios";
@@ -443,9 +444,7 @@ const EditAgentDetails = ({
                   <Typography
                     typography={"s2_1"}
                     onClick={() => {
-                      copyToClipboard(
-                        "https://api.futureagi.com/tracer/webhook",
-                      );
+                      copyToClipboard(`${HOST_API}/tracer/webhook`);
                       enqueueSnackbar({
                         message: "Copied to clipboard",
                         variant: "success",
@@ -459,7 +458,7 @@ const EditAgentDetails = ({
                       },
                     }}
                   >
-                    https://api.futureagi.com/tracer/webhook
+                    {`${HOST_API}/tracer/webhook`}
                   </Typography>
                   <Typography typography={"s2_1"} color={"blue.500"}>
                     to the Agent Level Webhook URL on Retell

--- a/frontend/src/sections/agents/CreateNewAgent/AgentConfigurationStep/AgentConfigurationStepRightSection.jsx
+++ b/frontend/src/sections/agents/CreateNewAgent/AgentConfigurationStep/AgentConfigurationStepRightSection.jsx
@@ -13,6 +13,7 @@ import {
 } from "../../constants";
 import { enqueueSnackbar } from "notistack";
 import { copyToClipboard } from "src/utils/utils";
+import { HOST_API } from "src/config-global";
 
 const AgentConfigurationStepRightSection = ({ control, getValues }) => {
   const [open, setOpen] = useState(false);
@@ -217,9 +218,7 @@ const AgentConfigurationStepRightSection = ({ control, getValues }) => {
                     color="text.primary"
                     component={"span"}
                     onClick={() => {
-                      copyToClipboard(
-                        "https://api.futureagi.com/tracer/webhook",
-                      );
+                      copyToClipboard(`${HOST_API}/tracer/webhook`);
                       enqueueSnackbar({
                         message: "Copied to clipboard",
                         variant: "success",
@@ -232,7 +231,7 @@ const AgentConfigurationStepRightSection = ({ control, getValues }) => {
                       },
                     }}
                   >
-                    https://api.futureagi.com/tracer/webhook
+                    {`${HOST_API}/tracer/webhook`}
                   </Typography>
                   {` to the Agent Level Webhook URL on Retell`}
                 </Typography>


### PR DESCRIPTION
## Summary

The "Add this to the Agent Level Webhook URL on Retell" prompt (Create New Agent flow and Edit Agent Details, for Retell-provider agents) always showed and copied `https://api.futureagi.com/tracer/webhook` — the production API host — even when the app itself was running on dev. Users on dev would end up pointing their Retell agent's webhook at prod.

## Why the changes are done — what is the problem

Both display strings were literal hardcoded constants instead of being derived from the app's actual API host, so they never reflected the environment the user was actually testing in.

## What changed

- `frontend/src/sections/agents/CreateNewAgent/AgentConfigurationStep/AgentConfigurationStepRightSection.jsx`: import `HOST_API` from `src/config-global`, replace the hardcoded `https://api.futureagi.com/tracer/webhook` string (both the `copyToClipboard` call and the displayed text) with `` `${HOST_API}/tracer/webhook` ``.
- `frontend/src/sections/agents/AgentConfiguration/EditAgentDetails.jsx`: same fix, same pattern.

`HOST_API` is the existing environment-aware API host used throughout the app (`utils/axios.js`, `auth/context/jwt/auth-provider.jsx`, etc.) — it resolves via runtime config, build-time env, or a hostname map (`dev.futureagi.com` → `https://dev.api.futureagi.com`, `app.futureagi.com` → `https://api.futureagi.com`, etc.), falling back to `http://localhost:8000` locally.

## Tests included

No test coverage exists for these two components (large form components with heavy `react-hook-form`/mutation setup); this is a copy-paste display string swapped for an existing, already-tested constant, so no new tests were added per the change's scope.

## Commands to run tests

N/A — no test suite covers this UI string; verified manually (see below).

## Backwards compatibility

- Purely a frontend display/copy string — no schema, API, or migration changes.
- On production (`app.futureagi.com`), `HOST_API` resolves to the exact same `https://api.futureagi.com`, so prod behavior is unchanged.

## Manual verification (UI)

- [x] Confirmed `HOST_API` resolves to a bare origin (no trailing slash) in all cases, so `${HOST_API}/tracer/webhook` never produces a double slash.
- [ ] On a dev deployment, open Create New Agent → Retell provider (or Edit Agent Details for an existing Retell agent) and confirm the webhook URL shown/copied is the dev API host, not `api.futureagi.com`.
- [ ] On prod, confirm the URL is unchanged (`https://api.futureagi.com/tracer/webhook`).

## Type of change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📖 Documentation only
- [ ] 🧹 Chore / refactor (no user-visible change)
- [ ] 🚀 Performance improvement
- [ ] 🧪 Test-only change

## Checklist

- [x] My code follows the style guide
- [ ] I've added tests that prove my fix is effective — N/A, see Tests section
- [x] No hardcoded secrets, URLs, or PII

## Backout / rollback

- Single-purpose string change in two files; reverting restores the old hardcoded prod URL with no data loss or side effects.

## Linear

Closes TH-6542
