### PR TITLE
fix: key reasoning toggle by source_id, not sourceId

### DIFF
--- a/frontend/src/sections/develop-detail/DataTab/common.js
+++ b/frontend/src/sections/develop-detail/DataTab/common.js
@@ -522,7 +522,7 @@ const getMainMenuItems =
       // use the underlying eval / eval_reason column ids, so the old
       // `column.id` key no longer matched what was stored and the
       // "Hide Reasoning" state was lost.
-      const key = column?.sourceId || column?.id;
+      const key = column?.source_id || column?.id;
       extraMenuItems.push({
         name: showSummary.includes(key) ? "Hide Reasoning" : "Show Reasoning",
         action: () => {


### PR DESCRIPTION
## Summary
- The Show/Hide Reasoning menu toggle keyed itself off `column?.sourceId`, which is only populated after a column passes through `enhanceCol`. Raw columns carry `source_id` (snake_case), so the toggle state could fail to match, dropping the "Hide Reasoning" state as noted in the surrounding comment.
- Switch the fallback key to `column?.source_id`.

## Test plan
- [ ] Toggle "Show Reasoning" / "Hide Reasoning" on an eval column and confirm state persists across the reasoning-children expand/collapse (group header split).