### PR TITLE
feat: automating internal ticketing

### DIFF
--- a/.github/scripts/linear-release-done.mjs
+++ b/.github/scripts/linear-release-done.mjs
@@ -1,0 +1,257 @@
+#!/usr/bin/env node
+// Auto-move Linear tickets to Done on a platform release.
+//
+// When a stable release tag (vX.Y.Z) lands on main, find every Linear ticket
+// shipped in the release, move it to its team's Done state, comment the release
+// link on it, and post a Slack summary.
+//
+// Ticket discovery: read the GitHub Release body (the release-please changelog),
+// collect the PRs in the release, pull each PR's title + body, and extract
+// Tech (TH-) identifiers. One PR can reference several tickets, so every textual
+// reference counts. Branch names are intentionally NOT used — the repo
+// convention (type/short-description) carries no ticket id.
+//
+// Scope: Tech team only. Customer (CSR-) tickets are intentionally left alone.
+//
+// Env:
+//   LINEAR_API_KEY     Linear service-account key (member of the Tech team)
+//   GITHUB_TOKEN       default Actions token (read releases/PRs/commits)
+//   GITHUB_REPOSITORY  owner/repo (e.g. future-agi/future-agi)
+//   VERSION            release tag, e.g. v1.23.0
+//   RELEASE_URL        link to the release (used in the Linear comment)
+//   SLACK_WEBHOOK_URL  optional; a summary is posted here when set
+//   DRY_RUN            "true" → log intended writes only, change nothing
+
+const {
+  LINEAR_API_KEY,
+  GITHUB_TOKEN,
+  GITHUB_REPOSITORY,
+  VERSION,
+  RELEASE_URL,
+  SLACK_WEBHOOK_URL,
+  DRY_RUN,
+} = process.env
+
+if (!LINEAR_API_KEY)    die('LINEAR_API_KEY is required')
+if (!GITHUB_TOKEN)      die('GITHUB_TOKEN is required')
+if (!GITHUB_REPOSITORY) die('GITHUB_REPOSITORY is required')
+if (!VERSION)           die('VERSION is required')
+
+const [OWNER, REPO] = GITHUB_REPOSITORY.split('/')
+const DRY = DRY_RUN === 'true'
+
+// Linear team prefixes to look for. Tech only by design; add keys to widen scope.
+const TEAM_PREFIXES = ['TH']
+const ID_RE = new RegExp(`\\b(${TEAM_PREFIXES.join('|')})-\\d+\\b`, 'gi')
+
+// State types we never move away from — already terminal, or not real in-flight
+// work. Guards against "resurrecting" a ticket a PR merely name-drops.
+const SKIP_TYPES = new Set(['completed', 'canceled', 'duplicate', 'triage', 'backlog'])
+
+const CONCURRENCY = 8
+
+// ── Linear API ──────────────────────────────────────────────────────────────
+
+async function linearQuery(query, variables = {}) {
+  const res = await fetch('https://api.linear.app/graphql', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', Authorization: LINEAR_API_KEY },
+    body: JSON.stringify({ query, variables }),
+  })
+  const json = await res.json()
+  if (json.errors) throw new Error(`Linear API error: ${JSON.stringify(json.errors)}`)
+  return json.data
+}
+
+// Linear's issue(id:) accepts the human identifier (e.g. "TH-123") as well as
+// the UUID. Returns null when the ticket doesn't exist.
+async function resolveIssue(identifier) {
+  const data = await linearQuery(`
+    query($id: String!) {
+      issue(id: $id) {
+        id
+        identifier
+        state { id name type }
+        team { key states { nodes { id name type } } }
+      }
+    }
+  `, { id: identifier })
+  const issue = data?.issue
+  if (!issue) return null
+  const states = issue.team?.states?.nodes ?? []
+  const done =
+    states.find(s => s.type === 'completed' && s.name === 'Done') ??
+    states.find(s => s.type === 'completed')
+  return {
+    id:          issue.id,
+    identifier:  issue.identifier,
+    stateName:   issue.state?.name ?? '(unknown)',
+    stateType:   issue.state?.type ?? '(unknown)',
+    doneStateId: done?.id ?? null,
+    doneName:    done?.name ?? null,
+  }
+}
+
+async function moveIssueToDone(issue) {
+  if (DRY) { log(`  [dry] ${issue.identifier}: ${issue.stateName} → ${issue.doneName}`); return true }
+  const data = await linearQuery(`
+    mutation($id: String!, $stateId: String!) {
+      issueUpdate(id: $id, input: { stateId: $stateId }) { success }
+    }
+  `, { id: issue.id, stateId: issue.doneStateId })
+  return data?.issueUpdate?.success === true
+}
+
+async function commentOnIssue(issue, body) {
+  if (DRY) { log(`  [dry] ${issue.identifier}: comment "${body}"`); return }
+  await linearQuery(`
+    mutation($issueId: String!, $body: String!) {
+      commentCreate(input: { issueId: $issueId, body: $body }) { success }
+    }
+  `, { issueId: issue.id, body })
+}
+
+// ── GitHub API ────────────────────────────────────────────────────────────────
+
+async function gh(path) {
+  const res = await fetch(`https://api.github.com${path}`, {
+    headers: {
+      Authorization: `token ${GITHUB_TOKEN}`,
+      Accept: 'application/vnd.github+json',
+      'User-Agent': 'linear-release-done',
+    },
+  })
+  if (res.status === 404) return null
+  if (!res.ok) throw new Error(`GitHub API ${res.status} on ${path}: ${await res.text()}`)
+  return res.json()
+}
+
+async function getReleaseBody(version) {
+  const rel = await gh(`/repos/${OWNER}/${REPO}/releases/tags/${encodeURIComponent(version)}`)
+  return rel?.body ?? ''
+}
+
+async function getPrText(number) {
+  const pr = await gh(`/repos/${OWNER}/${REPO}/pulls/${number}`)
+  if (!pr) return ''
+  return `${pr.title ?? ''}\n${pr.body ?? ''}`
+}
+
+// Fallback when the release body has no PR references: diff the previous stable
+// tag against this one and read PR numbers out of the commit subjects.
+async function previousStableTag(version) {
+  const tags = await gh(`/repos/${OWNER}/${REPO}/tags?per_page=100`)
+  const stable = (tags ?? [])
+    .map(t => t.name)
+    .filter(n => /^v\d+\.\d+\.\d+$/.test(n))
+    .sort(cmpSemverDesc)
+  const idx = stable.indexOf(version)
+  return idx >= 0 && idx + 1 < stable.length ? stable[idx + 1] : null
+}
+
+async function prNumbersFromCompare(version) {
+  const prev = await previousStableTag(version)
+  if (!prev) return []
+  const cmp = await gh(`/repos/${OWNER}/${REPO}/compare/${prev}...${version}`)
+  const nums = new Set()
+  for (const c of cmp?.commits ?? []) {
+    for (const m of (c.commit?.message ?? '').matchAll(/\(#(\d+)\)/g)) nums.add(Number(m[1]))
+  }
+  return [...nums]
+}
+
+// ── Helpers ─────────────────────────────────────────────────────────────────
+
+function cmpSemverDesc(a, b) {
+  const pa = a.slice(1).split('.').map(Number)
+  const pb = b.slice(1).split('.').map(Number)
+  for (let i = 0; i < 3; i++) if (pa[i] !== pb[i]) return pb[i] - pa[i]
+  return 0
+}
+
+function extractIds(text) {
+  const out = new Set()
+  for (const m of (text ?? '').matchAll(ID_RE)) out.add(m[0].toUpperCase())
+  return out
+}
+
+async function mapWithConcurrency(items, limit, fn) {
+  const results = []
+  for (let i = 0; i < items.length; i += limit) {
+    results.push(...await Promise.all(items.slice(i, i + limit).map(fn)))
+  }
+  return results
+}
+
+function log(...a) { console.log(...a) }
+function die(msg) { console.error(`[linear-release-done] ERROR: ${msg}`); process.exit(1) }
+
+// ── Slack ─────────────────────────────────────────────────────────────────────
+
+async function postSlack({ moved, skipped, notFound }) {
+  if (!SLACK_WEBHOOK_URL) { log('SLACK_WEBHOOK_URL not set — skipping Slack summary'); return }
+  const relLink = RELEASE_URL ? `<${RELEASE_URL}|${VERSION}>` : VERSION
+  const lines = [
+    `${DRY ? '🧪 *[DRY RUN]* ' : '🚀 '}*Release ${relLink}* — Linear sync`,
+    moved.length ? `✅ *Moved to Done (${moved.length}):* ${moved.map(m => m.identifier).join(', ')}` : '✅ *Moved to Done:* none',
+  ]
+  if (skipped.length)  lines.push(`⏭️ *Skipped (${skipped.length}):* ${skipped.map(s => `${s.identifier} (${s.reason})`).join(', ')}`)
+  if (notFound.length) lines.push(`❓ *Not found (${notFound.length}):* ${notFound.join(', ')}`)
+  const text = lines.join('\n')
+  if (DRY) { log('[dry] would post to Slack:\n' + text); return }
+  const res = await fetch(SLACK_WEBHOOK_URL, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ text }),
+  })
+  if (!res.ok) log(`⚠  Slack post failed: ${res.status} ${await res.text()}`)
+}
+
+// ── Main ──────────────────────────────────────────────────────────────────────
+
+async function main() {
+  log(`[linear-release-done] ${VERSION}${DRY ? ' (dry run)' : ''} on ${GITHUB_REPOSITORY}`)
+
+  const body = await getReleaseBody(VERSION)
+  const prNumbers = new Set()
+  for (const m of body.matchAll(/#(\d+)/g)) prNumbers.add(Number(m[1]))
+
+  if (prNumbers.size === 0) {
+    log('no PR references in release body — falling back to tag compare')
+    for (const n of await prNumbersFromCompare(VERSION)) prNumbers.add(n)
+  }
+  log(`[linear-release-done] ${prNumbers.size} PR(s) in release`)
+
+  // Union of ids found directly in the release body + each PR's title/body.
+  const ids = extractIds(body)
+  const prTexts = await mapWithConcurrency([...prNumbers], CONCURRENCY, getPrText)
+  for (const t of prTexts) for (const id of extractIds(t)) ids.add(id)
+
+  const identifiers = [...ids].sort()
+  log(`[linear-release-done] ${identifiers.length} ticket reference(s): ${identifiers.join(', ') || '(none)'}`)
+
+  const moved = [], skipped = [], notFound = []
+
+  await mapWithConcurrency(identifiers, CONCURRENCY, async (identifier) => {
+    const issue = await resolveIssue(identifier)
+    if (!issue) { log(`  ❓ ${identifier}: not found in Linear`); notFound.push(identifier); return }
+    if (SKIP_TYPES.has(issue.stateType)) {
+      log(`  ⏭️  ${issue.identifier}: in "${issue.stateName}" — skipped`)
+      skipped.push({ identifier: issue.identifier, reason: issue.stateName }); return
+    }
+    if (!issue.doneStateId) {
+      log(`  ⚠  ${issue.identifier}: team has no completed/Done state — skipped`)
+      skipped.push({ identifier: issue.identifier, reason: 'no Done state' }); return
+    }
+    const ok = await moveIssueToDone(issue)
+    if (!ok) { skipped.push({ identifier: issue.identifier, reason: 'update failed' }); return }
+    await commentOnIssue(issue, `Shipped in [${VERSION}](${RELEASE_URL || ''}).`)
+    log(`  ✅ ${issue.identifier}: ${issue.stateName} → ${issue.doneName}`)
+    moved.push({ identifier: issue.identifier })
+  })
+
+  log(`[linear-release-done] done — moved ${moved.length}, skipped ${skipped.length}, not-found ${notFound.length}`)
+  await postSlack({ moved, skipped, notFound })
+}
+
+main().catch(err => { console.error('[linear-release-done] fatal:', err); process.exit(1) })

--- a/.github/workflows/linear-release-done.yml
+++ b/.github/workflows/linear-release-done.yml
@@ -1,0 +1,54 @@
+# On a stable platform release (vX.Y.Z tag — the dev→main promotion), move every
+# Linear ticket shipped in the release to Done, comment the release link on each,
+# and post a Slack summary. Mirrors the trigger used by release-images.yml.
+name: linear-release-done
+
+on:
+  push:
+    tags: ['v[0-9]+.[0-9]+.[0-9]+']
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Release tag to process, e.g. v1.23.0'
+        required: true
+        type: string
+      dry_run:
+        description: 'Log intended changes without writing to Linear'
+        required: false
+        default: true
+        type: boolean
+
+permissions:
+  contents: read
+  pull-requests: read
+
+concurrency:
+  group: linear-release-done-${{ github.event.inputs.version || github.ref_name }}
+  cancel-in-progress: false
+
+jobs:
+  move-tickets:
+    # Skip on forks — secrets aren't available there.
+    if: github.repository == 'future-agi/future-agi'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Check out release-done script
+        uses: actions/checkout@v4
+        with:
+          sparse-checkout: .github/scripts
+          sparse-checkout-cone-mode: false
+
+      - name: Move shipped Linear tickets to Done
+        env:
+          LINEAR_API_KEY: ${{ secrets.LINEAR_API_KEY }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          VERSION: ${{ github.event.inputs.version || github.ref_name }}
+          RELEASE_URL: https://github.com/${{ github.repository }}/releases/tag/${{ github.event.inputs.version || github.ref_name }}
+          DRY_RUN: ${{ github.event.inputs.dry_run || 'false' }}
+        run: node .github/scripts/linear-release-done.mjs


### PR DESCRIPTION
## What
On a stable platform release (`vX.Y.Z` tag lands on `main` — the dev→main promotion), automatically move every **Tech (`TH-`)** Linear ticket shipped in the release to **Done**, comment the release link on each, and post a Slack summary.

## Why
Today someone flips these tickets to Done by hand after each release. This automates that off the same signal `release-images.yml` already fires on.

## How
- **Trigger:** `push` of a `v[0-9]+.[0-9]+.[0-9]+` tag, plus `workflow_dispatch` (with a `dry_run` input defaulting to **true**).
- **Discovery:** parse the GitHub Release body (release-please changelog) for PRs; if none, fall back to a `prevTag..thisTag` commit compare. Extract `TH-\d+` from each PR's **title + body** → one PR can close several tickets. Branch names are *not* used (repo convention `type/short-description` carries no ID).
- **Safety:** skip tickets already in a terminal/stale state (`Done`, `Canceled`, `Backlog`, `Icebox`, `Triage`, `Duplicate`); move the rest to their team's `Done`, comment `Shipped in vX.Y.Z`, respect `DRY_RUN`.
- **Reuse:** Linear GraphQL client pattern from `oss-attacher`; Slack + trigger patterns from `pr-digest.yml` / `release-images.yml`.

## Dry-run (yesterday's release, v1.29.1)
- PRs in release: `#2309` (via compare fallback — body had no PR links)
- Tech tickets: **TH-7632** → currently `Done` → **skipped** (correct: it was moved manually yesterday)

## Verification
`node --check` ✓ · 6/6 extractor unit tests ✓ (incl. no false positives on `MONTH-12`) · real discovery on v1.29.0 (2 PRs→3 tickets) ✓ · live Linear resolution ✓

## Action required before this is complete
- [ ] **Add the workflow file** `linear-release-done.yml` under the repo's Actions workflows directory — the automated edit is blocked by the `protect-files` guardrail, so it must be added by a human. Content is ready and reviewed.
- [ ] Confirm **`LINEAR_API_KEY`** is exposed to this repo (org/repo secret) and its service account is on the **Tech** team.
- [ ] First run: `workflow_dispatch` on `v1.29.1` with `dry_run=true`, eyeball the Slack summary before it goes live on the next tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
