### PR TITLE
fix(dashboards): show widget descriptions on cards and make them readable [TH-7678]

### DIFF
--- a/frontend/src/sections/dashboards/DashboardDetailView.jsx
+++ b/frontend/src/sections/dashboards/DashboardDetailView.jsx
@@ -49,7 +49,6 @@ import {
   MIN_WIDGET_HEIGHT,
   DEFAULT_WIDGET_HEIGHT,
   DATE_CHIP_SX,
-  DESCRIPTION_TOOLTIP_SX,
 } from "./constants";
 import CustomDateRangePicker from "src/components/custom-datepicker/DatePicker";
 import { ConfirmDialog } from "src/components/custom-dialog";
@@ -58,7 +57,7 @@ import CustomTooltip from "src/components/tooltip/CustomTooltip";
 import WidgetChart from "./WidgetChart";
 import { resolveGlobalDateRange } from "./dashboardDateRange";
 import useCanEditDashboard from "./hooks/useCanEditDashboard";
-import useIsTruncated from "./hooks/useIsTruncated";
+import TruncatedTooltipText from "./TruncatedTooltipText";
 import {
   DndContext,
   DragOverlay,
@@ -452,7 +451,7 @@ function DraggableWidgetCard({
     data: { widget },
     disabled: isReadOnly,
   });
-  const [descRef, isDescTruncated] = useIsTruncated(widget.description);
+  const description = widget.description?.trim();
 
   const widgetHeight =
     rowHeight ||
@@ -579,28 +578,25 @@ function DraggableWidgetCard({
               )}
             </div>
 
-            {widget.description && (
-              <CustomTooltip
-                show={isDescTruncated}
-                title={widget.description}
-                size="small"
-                placement="bottom-start"
-                slotProps={{ tooltip: { sx: DESCRIPTION_TOOLTIP_SX } }}
-              >
-                <Typography
-                  ref={descRef}
-                  variant="caption"
-                  noWrap
-                  sx={{
-                    color: "text.secondary",
-                    pl: isReadOnly ? 0 : "20px",
-                    pr: 1,
-                    mt: 0.25,
-                  }}
-                >
-                  {widget.description}
-                </Typography>
-              </CustomTooltip>
+            {description && (
+              <TruncatedTooltipText text={description}>
+                {(measureRef) => (
+                  <Typography
+                    ref={measureRef}
+                    variant="caption"
+                    noWrap
+                    onPointerDown={(e) => e.stopPropagation()}
+                    sx={{
+                      color: "text.secondary",
+                      pl: isReadOnly ? 0 : "20px",
+                      pr: 1,
+                      mt: 0.25,
+                    }}
+                  >
+                    {description}
+                  </Typography>
+                )}
+              </TruncatedTooltipText>
             )}
           </div>
 

--- a/frontend/src/sections/dashboards/DashboardDetailView.jsx
+++ b/frontend/src/sections/dashboards/DashboardDetailView.jsx
@@ -49,6 +49,7 @@ import {
   MIN_WIDGET_HEIGHT,
   DEFAULT_WIDGET_HEIGHT,
   DATE_CHIP_SX,
+  DESCRIPTION_TOOLTIP_SX,
 } from "./constants";
 import CustomDateRangePicker from "src/components/custom-datepicker/DatePicker";
 import { ConfirmDialog } from "src/components/custom-dialog";
@@ -57,6 +58,7 @@ import CustomTooltip from "src/components/tooltip/CustomTooltip";
 import WidgetChart from "./WidgetChart";
 import { resolveGlobalDateRange } from "./dashboardDateRange";
 import useCanEditDashboard from "./hooks/useCanEditDashboard";
+import useIsTruncated from "./hooks/useIsTruncated";
 import {
   DndContext,
   DragOverlay,
@@ -450,6 +452,7 @@ function DraggableWidgetCard({
     data: { widget },
     disabled: isReadOnly,
   });
+  const [descRef, isDescTruncated] = useIsTruncated(widget.description);
 
   const widgetHeight =
     rowHeight ||
@@ -497,76 +500,107 @@ function DraggableWidgetCard({
             overflow: "hidden",
           }}
         >
-          {/* Header row — entire bar is the drag activator */}
+          {/* Header — title row plus description; the block is the drag activator */}
           <div
             {...(isReadOnly ? {} : { ...attributes, ...listeners })}
             style={{
               display: "flex",
-              flexDirection: "row",
-              alignItems: "center",
+              flexDirection: "column",
               marginBottom: 4,
-              minHeight: 24,
               cursor: isReadOnly ? "default" : "grab",
             }}
           >
-            {!isReadOnly && (
-              <Iconify
-                icon="mdi:drag"
-                width={16}
-                sx={{ color: "text.disabled", mr: 0.5, flexShrink: 0 }}
-              />
-            )}
-
-            <Typography
-              variant="subtitle2"
-              fontWeight="fontWeightSemiBold"
-              noWrap
-              sx={{
-                flex: 1,
-                cursor: "pointer",
-                "&:hover": { textDecoration: "underline" },
+            <div
+              style={{
+                display: "flex",
+                flexDirection: "row",
+                alignItems: "center",
+                minHeight: 24,
               }}
-              onPointerDown={(e) => e.stopPropagation()}
-              onClick={() =>
-                navigate(
-                  `/dashboard/dashboards/${dashboardId}/widget/${widget.id}${datePreset ? `?timePreset=${datePreset}` : ""}`,
-                )
-              }
             >
-              {widget.name}
-            </Typography>
+              {!isReadOnly && (
+                <Iconify
+                  icon="mdi:drag"
+                  width={16}
+                  sx={{ color: "text.disabled", mr: 0.5, flexShrink: 0 }}
+                />
+              )}
 
-            {/* Actions */}
-            {!isReadOnly && (
-              <Stack
-                className="widget-actions"
-                direction="row"
-                spacing={0}
+              <Typography
+                variant="subtitle2"
+                fontWeight="fontWeightSemiBold"
+                noWrap
+                sx={{
+                  flex: 1,
+                  cursor: "pointer",
+                  "&:hover": { textDecoration: "underline" },
+                }}
                 onPointerDown={(e) => e.stopPropagation()}
-                sx={{ opacity: 0, transition: "opacity 0.15s" }}
+                onClick={() =>
+                  navigate(
+                    `/dashboard/dashboards/${dashboardId}/widget/${widget.id}${datePreset ? `?timePreset=${datePreset}` : ""}`,
+                  )
+                }
               >
-                <Tooltip title="Edit">
-                  <IconButton
-                    size="small"
-                    onClick={() =>
-                      navigate(
-                        `/dashboard/dashboards/${dashboardId}/widget/${widget.id}${datePreset ? `?timePreset=${datePreset}` : ""}`,
-                      )
-                    }
-                  >
-                    <Iconify icon="mdi:pencil-outline" width={16} />
-                  </IconButton>
-                </Tooltip>
-                <Tooltip title="More">
-                  <IconButton
-                    size="small"
-                    aria-label="Widget options"
-                    onClick={(e) => onMenuOpen(e, widget)}
-                  >
-                    <Iconify icon="mdi:dots-vertical" width={16} />
-                  </IconButton>
-                </Tooltip>
-              </Stack>
+                {widget.name}
+              </Typography>
+
+              {/* Actions */}
+              {!isReadOnly && (
+                <Stack
+                  className="widget-actions"
+                  direction="row"
+                  spacing={0}
+                  onPointerDown={(e) => e.stopPropagation()}
+                  sx={{ opacity: 0, transition: "opacity 0.15s" }}
+                >
+                  <Tooltip title="Edit">
+                    <IconButton
+                      size="small"
+                      onClick={() =>
+                        navigate(
+                          `/dashboard/dashboards/${dashboardId}/widget/${widget.id}${datePreset ? `?timePreset=${datePreset}` : ""}`,
+                        )
+                      }
+                    >
+                      <Iconify icon="mdi:pencil-outline" width={16} />
+                    </IconButton>
+                  </Tooltip>
+                  <Tooltip title="More">
+                    <IconButton
+                      size="small"
+                      aria-label="Widget options"
+                      onClick={(e) => onMenuOpen(e, widget)}
+                    >
+                      <Iconify icon="mdi:dots-vertical" width={16} />
+                    </IconButton>
+                  </Tooltip>
+                </Stack>
+              )}
+            </div>
+
+            {widget.description && (
+              <CustomTooltip
+                show={isDescTruncated}
+                title={widget.description}
+                size="small"
+                placement="bottom-start"
+                slotProps={{ tooltip: { sx: DESCRIPTION_TOOLTIP_SX } }}
+              >
+                <Typography
+                  ref={descRef}
+                  variant="caption"
+                  noWrap
+                  sx={{
+                    color: "text.secondary",
+                    pl: isReadOnly ? 0 : "20px",
+                    pr: 1,
+                    mt: 0.25,
+                  }}
+                >
+                  {widget.description}
+                </Typography>
+              </CustomTooltip>
             )}
           </div>
 
@@ -1025,9 +1059,7 @@ export default function DashboardDetailView() {
   // --- Render ---
 
   if (isLoading) {
-    return (
-      <LoadingScreen sx={{ height: "60vh" }} />
-    );
+    return <LoadingScreen sx={{ height: "60vh" }} />;
   }
 
   if (!dashboard) {
@@ -1203,6 +1235,7 @@ export default function DashboardDetailView() {
               fontWeight: 700,
               color: "text.primary",
               lineHeight: 1.3,
+              wordBreak: "break-word",
             },
           }}
         />
@@ -1218,6 +1251,8 @@ export default function DashboardDetailView() {
               color: dashboard.description ? "text.secondary" : "text.disabled",
               mt: 0.5,
               fontSize: "14px",
+              whiteSpace: "pre-wrap",
+              wordBreak: "break-word",
             },
           }}
         />

--- a/frontend/src/sections/dashboards/TruncatedTooltipText.jsx
+++ b/frontend/src/sections/dashboards/TruncatedTooltipText.jsx
@@ -1,0 +1,28 @@
+import PropTypes from "prop-types";
+import CustomTooltip from "src/components/tooltip/CustomTooltip";
+import { DESCRIPTION_TOOLTIP_SX } from "./constants";
+import useIsTruncated from "./hooks/useIsTruncated";
+
+/** Reveals a description in a tooltip only once its single line is clipped.
+ *  Children is a render prop taking the ref to measure, so each caller keeps
+ *  its own markup while the measure-and-reveal wiring stays in one place. */
+export default function TruncatedTooltipText({ text, children }) {
+  const [measureRef, isTruncated] = useIsTruncated(text);
+
+  return (
+    <CustomTooltip
+      show={isTruncated}
+      title={text}
+      size="small"
+      placement="bottom-start"
+      slotProps={{ tooltip: { sx: DESCRIPTION_TOOLTIP_SX } }}
+    >
+      {children(measureRef)}
+    </CustomTooltip>
+  );
+}
+
+TruncatedTooltipText.propTypes = {
+  text: PropTypes.string.isRequired,
+  children: PropTypes.func.isRequired,
+};

--- a/frontend/src/sections/dashboards/WidgetDescriptionPopover.jsx
+++ b/frontend/src/sections/dashboards/WidgetDescriptionPopover.jsx
@@ -1,8 +1,10 @@
 import PropTypes from "prop-types";
+import { useEffect, useState } from "react";
 import { Button, Popover, Stack, TextField, Typography } from "@mui/material";
 
-/** Editor for a widget's description. The value is held by the caller and
- *  persists with the widget on save, so closing here only dismisses. */
+/** Editor for a widget's description. Edits are held here and only handed to
+ *  the caller on Done, so dismissing the popover leaves the widget as it was.
+ *  The committed value persists with the widget on save, not here. */
 export default function WidgetDescriptionPopover({
   open,
   anchorEl,
@@ -10,10 +12,28 @@ export default function WidgetDescriptionPopover({
   onChange,
   onClose,
 }) {
+  const [draft, setDraft] = useState(value);
+
+  // Reopening starts from what the widget currently holds, so a dismissed edit
+  // does not linger in the field. The popover outlives its own contents.
+  useEffect(() => {
+    if (open) setDraft(value);
+  }, [open, value]);
+
+  const commit = () => {
+    onChange(draft);
+    onClose();
+  };
+
   const handleKeyDown = (e) => {
     // Enter inserts a line break, so the shortcut is modifier+Enter. Escape is
-    // already handled by the Popover's own modal.
-    if (e.key === "Enter" && (e.metaKey || e.ctrlKey)) onClose();
+    // already handled by the Popover's own modal, and discards the edit.
+    if (e.key === "Enter" && (e.metaKey || e.ctrlKey)) {
+      // Ctrl+Enter still inserts a newline on Windows/Linux; suppress it so
+      // the shortcut cannot edit the text on its way out.
+      e.preventDefault();
+      commit();
+    }
   };
 
   return (
@@ -36,8 +56,8 @@ export default function WidgetDescriptionPopover({
         Description
       </Typography>
       <TextField
-        value={value}
-        onChange={(e) => onChange(e.target.value)}
+        value={draft}
+        onChange={(e) => setDraft(e.target.value)}
         onKeyDown={handleKeyDown}
         placeholder="What does this widget measure?"
         multiline
@@ -54,7 +74,7 @@ export default function WidgetDescriptionPopover({
         }}
       />
       <Stack direction="row" justifyContent="flex-end" sx={{ mt: 1.5 }}>
-        <Button size="small" variant="contained" onClick={onClose}>
+        <Button size="small" variant="contained" onClick={commit}>
           Done
         </Button>
       </Stack>

--- a/frontend/src/sections/dashboards/WidgetDescriptionPopover.jsx
+++ b/frontend/src/sections/dashboards/WidgetDescriptionPopover.jsx
@@ -1,0 +1,71 @@
+import PropTypes from "prop-types";
+import { Button, Popover, Stack, TextField, Typography } from "@mui/material";
+
+/** Editor for a widget's description. The value is held by the caller and
+ *  persists with the widget on save, so closing here only dismisses. */
+export default function WidgetDescriptionPopover({
+  open,
+  anchorEl,
+  value,
+  onChange,
+  onClose,
+}) {
+  const handleKeyDown = (e) => {
+    // Enter inserts a line break, so the shortcut is modifier+Enter. Escape is
+    // already handled by the Popover's own modal.
+    if (e.key === "Enter" && (e.metaKey || e.ctrlKey)) onClose();
+  };
+
+  return (
+    <Popover
+      open={open}
+      anchorEl={anchorEl}
+      onClose={onClose}
+      anchorOrigin={{ vertical: "bottom", horizontal: "left" }}
+      transformOrigin={{ vertical: "top", horizontal: "left" }}
+      slotProps={{ paper: { sx: { width: 380, p: 2, mt: 0.5 } } }}
+    >
+      <Typography
+        sx={{
+          fontSize: "12px",
+          fontWeight: 600,
+          color: "text.secondary",
+          mb: 1,
+        }}
+      >
+        Description
+      </Typography>
+      <TextField
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        onKeyDown={handleKeyDown}
+        placeholder="What does this widget measure?"
+        multiline
+        minRows={3}
+        maxRows={8}
+        fullWidth
+        autoFocus
+        sx={{
+          "& .MuiOutlinedInput-root": { p: 1.25 },
+          "& .MuiOutlinedInput-input": {
+            fontSize: "13px",
+            lineHeight: 1.6,
+          },
+        }}
+      />
+      <Stack direction="row" justifyContent="flex-end" sx={{ mt: 1.5 }}>
+        <Button size="small" variant="contained" onClick={onClose}>
+          Done
+        </Button>
+      </Stack>
+    </Popover>
+  );
+}
+
+WidgetDescriptionPopover.propTypes = {
+  open: PropTypes.bool.isRequired,
+  anchorEl: PropTypes.object,
+  value: PropTypes.string.isRequired,
+  onChange: PropTypes.func.isRequired,
+  onClose: PropTypes.func.isRequired,
+};

--- a/frontend/src/sections/dashboards/WidgetEditorView.jsx
+++ b/frontend/src/sections/dashboards/WidgetEditorView.jsx
@@ -35,7 +35,6 @@ import {
   Typography,
   useTheme,
   InputAdornment,
-  InputBase,
   CircularProgress,
 } from "@mui/material";
 import { useNavigate, useParams, useSearchParams } from "react-router-dom";
@@ -65,6 +64,8 @@ import FilterValueLabel, {
 import { useSnackbar } from "src/components/snackbar";
 import { ConfirmDialog } from "src/components/custom-dialog";
 import CustomTooltip from "src/components/tooltip/CustomTooltip";
+import WidgetDescriptionPopover from "./WidgetDescriptionPopover";
+import useIsTruncated from "./hooks/useIsTruncated";
 import { format } from "date-fns";
 import CustomDateRangePicker from "src/components/custom-datepicker/DatePicker";
 import useCanEditDashboard from "./hooks/useCanEditDashboard";
@@ -96,6 +97,7 @@ import {
   ALL_AGGREGATIONS,
   PERCENTILE_OPTIONS,
   DATE_PRESETS,
+  DESCRIPTION_TOOLTIP_SX,
 } from "./constants";
 
 const escapeCsvField = (field) => {
@@ -1105,7 +1107,9 @@ export default function WidgetEditorView() {
   const [chartName, setChartName] = useState("");
   const [chartDescription, setChartDescription] = useState("");
   const [editingName, setEditingName] = useState(false);
-  const [editingDesc, setEditingDesc] = useState(false);
+  const [descOpen, setDescOpen] = useState(false);
+  const descSlotRef = useRef(null);
+  const [descRef, isDescTruncated] = useIsTruncated(chartDescription);
   const [moreMenuAnchor, setMoreMenuAnchor] = useState(null);
   const [confirmDeleteOpen, setConfirmDeleteOpen] = useState(false);
 
@@ -2072,7 +2076,7 @@ export default function WidgetEditorView() {
     // rejects unknown fields.
     const data = {
       name: chartName.trim() || "Untitled widget",
-      description: chartDescription,
+      description: chartDescription.trim(),
       query_config: buildQueryConfig(),
       chart_config: {
         chart_type: chartType,
@@ -2906,29 +2910,91 @@ export default function WidgetEditorView() {
           </Typography>
         )}
 
-        {/* Inline editable description */}
-        <InputBase
+        {/* Description — a capped preview in the bar; the full text is read
+            and edited in a popover, so the bar can't be blown out by length. */}
+        <Box ref={descSlotRef} sx={{ display: "flex", minWidth: 0 }}>
+          {chartDescription ? (
+            <CustomTooltip
+              show={isDescTruncated}
+              title={chartDescription}
+              size="small"
+              placement="bottom-start"
+              slotProps={{ tooltip: { sx: DESCRIPTION_TOOLTIP_SX } }}
+            >
+              <Stack
+                direction="row"
+                alignItems="center"
+                gap={0.5}
+                role={isReadOnly ? undefined : "button"}
+                tabIndex={isReadOnly ? undefined : 0}
+                aria-label={isReadOnly ? undefined : "Edit description"}
+                onClick={() => !isReadOnly && setDescOpen(true)}
+                onKeyDown={(e) => {
+                  if (isReadOnly) return;
+                  if (e.key === "Enter" || e.key === " ") {
+                    e.preventDefault();
+                    setDescOpen(true);
+                  }
+                }}
+                sx={{
+                  minWidth: 0,
+                  maxWidth: 260,
+                  px: 0.75,
+                  py: 0.25,
+                  borderRadius: 1,
+                  color: "text.secondary",
+                  cursor: isReadOnly ? "default" : "pointer",
+                  transition: "background-color 0.15s, color 0.15s",
+                  "&:hover": isReadOnly
+                    ? undefined
+                    : { bgcolor: "action.hover", color: "text.primary" },
+                  "&:focus-visible": {
+                    outline: "2px solid",
+                    outlineColor: "primary.main",
+                    outlineOffset: 2,
+                  },
+                }}
+              >
+                <Iconify
+                  icon="mdi:text-box-outline"
+                  width={14}
+                  sx={{ flexShrink: 0 }}
+                />
+                <Typography
+                  ref={descRef}
+                  noWrap
+                  sx={{ fontSize: "13px", minWidth: 0 }}
+                >
+                  {chartDescription}
+                </Typography>
+              </Stack>
+            </CustomTooltip>
+          ) : (
+            !isReadOnly && (
+              <Button
+                size="small"
+                startIcon={<Iconify icon="mdi:plus" width={14} />}
+                onClick={() => setDescOpen(true)}
+                sx={{
+                  flexShrink: 0,
+                  fontSize: "13px",
+                  fontWeight: 400,
+                  color: "text.disabled",
+                  "&:hover": { color: "text.secondary" },
+                }}
+              >
+                Add description
+              </Button>
+            )
+          )}
+        </Box>
+
+        <WidgetDescriptionPopover
+          open={descOpen}
+          anchorEl={descSlotRef.current}
           value={chartDescription}
-          onChange={(e) => setChartDescription(e.target.value)}
-          onClick={() => !isReadOnly && !editingDesc && setEditingDesc(true)}
-          onBlur={() => setEditingDesc(false)}
-          onKeyDown={(e) => {
-            if (e.key === "Enter") setEditingDesc(false);
-          }}
-          readOnly={isReadOnly || !editingDesc}
-          autoFocus={editingDesc}
-          placeholder="+ Add desc..."
-          sx={{
-            minWidth: 140,
-            maxWidth: 200,
-            fontSize: "13px",
-            color: chartDescription ? "text.secondary" : "text.disabled",
-            cursor: isReadOnly ? "default" : editingDesc ? "text" : "pointer",
-            "&:hover": { color: "text.secondary" },
-            "& .MuiInputBase-input": {
-              padding: 0,
-            },
-          }}
+          onChange={setChartDescription}
+          onClose={() => setDescOpen(false)}
         />
 
         {/* Spacer */}

--- a/frontend/src/sections/dashboards/WidgetEditorView.jsx
+++ b/frontend/src/sections/dashboards/WidgetEditorView.jsx
@@ -97,6 +97,7 @@ import {
   ALL_AGGREGATIONS,
   PERCENTILE_OPTIONS,
   DATE_PRESETS,
+  DEFAULT_WIDGET_HEIGHT,
 } from "./constants";
 
 const escapeCsvField = (field) => {
@@ -3053,11 +3054,19 @@ export default function WidgetEditorView() {
             <MenuItem
               onClick={() => {
                 setMoreMenuAnchor(null);
+                const source = dashboard?.widgets?.find(
+                  (w) => w.id === widgetId,
+                );
                 const dupData = {
                   name: `${chartName || "Untitled widget"} (copy)`,
-                  width: 12,
-                  height: 1,
-                  position: 0,
+                  description: trimmedDescription,
+                  // Carry the source widget's own layout and sit the copy next
+                  // to it, as the backend's duplicate endpoint does. The
+                  // hardcoded height of 1 fell under the card's >50 guard, so
+                  // it silently rendered at the default height instead.
+                  width: source?.width || 12,
+                  height: source?.height || DEFAULT_WIDGET_HEIGHT,
+                  position: (source?.position ?? 0) + 1,
                   query_config: buildQueryConfig(),
                   chart_config: {
                     chart_type: chartType,

--- a/frontend/src/sections/dashboards/WidgetEditorView.jsx
+++ b/frontend/src/sections/dashboards/WidgetEditorView.jsx
@@ -65,7 +65,7 @@ import { useSnackbar } from "src/components/snackbar";
 import { ConfirmDialog } from "src/components/custom-dialog";
 import CustomTooltip from "src/components/tooltip/CustomTooltip";
 import WidgetDescriptionPopover from "./WidgetDescriptionPopover";
-import useIsTruncated from "./hooks/useIsTruncated";
+import TruncatedTooltipText from "./TruncatedTooltipText";
 import { format } from "date-fns";
 import CustomDateRangePicker from "src/components/custom-datepicker/DatePicker";
 import useCanEditDashboard from "./hooks/useCanEditDashboard";
@@ -97,7 +97,6 @@ import {
   ALL_AGGREGATIONS,
   PERCENTILE_OPTIONS,
   DATE_PRESETS,
-  DESCRIPTION_TOOLTIP_SX,
 } from "./constants";
 
 const escapeCsvField = (field) => {
@@ -1109,7 +1108,7 @@ export default function WidgetEditorView() {
   const [editingName, setEditingName] = useState(false);
   const [descOpen, setDescOpen] = useState(false);
   const descSlotRef = useRef(null);
-  const [descRef, isDescTruncated] = useIsTruncated(chartDescription);
+  const trimmedDescription = (chartDescription || "").trim();
   const [moreMenuAnchor, setMoreMenuAnchor] = useState(null);
   const [confirmDeleteOpen, setConfirmDeleteOpen] = useState(false);
 
@@ -2913,62 +2912,62 @@ export default function WidgetEditorView() {
         {/* Description — a capped preview in the bar; the full text is read
             and edited in a popover, so the bar can't be blown out by length. */}
         <Box ref={descSlotRef} sx={{ display: "flex", minWidth: 0 }}>
-          {chartDescription ? (
-            <CustomTooltip
-              show={isDescTruncated}
-              title={chartDescription}
-              size="small"
-              placement="bottom-start"
-              slotProps={{ tooltip: { sx: DESCRIPTION_TOOLTIP_SX } }}
-            >
-              <Stack
-                direction="row"
-                alignItems="center"
-                gap={0.5}
-                role={isReadOnly ? undefined : "button"}
-                tabIndex={isReadOnly ? undefined : 0}
-                aria-label={isReadOnly ? undefined : "Edit description"}
-                onClick={() => !isReadOnly && setDescOpen(true)}
-                onKeyDown={(e) => {
-                  if (isReadOnly) return;
-                  if (e.key === "Enter" || e.key === " ") {
-                    e.preventDefault();
-                    setDescOpen(true);
+          {trimmedDescription ? (
+            <TruncatedTooltipText text={trimmedDescription}>
+              {(measureRef) => (
+                <Stack
+                  direction="row"
+                  alignItems="center"
+                  gap={0.5}
+                  role={isReadOnly ? undefined : "button"}
+                  tabIndex={isReadOnly ? undefined : 0}
+                  aria-label={
+                    isReadOnly
+                      ? undefined
+                      : `Edit description: ${trimmedDescription}`
                   }
-                }}
-                sx={{
-                  minWidth: 0,
-                  maxWidth: 260,
-                  px: 0.75,
-                  py: 0.25,
-                  borderRadius: 1,
-                  color: "text.secondary",
-                  cursor: isReadOnly ? "default" : "pointer",
-                  transition: "background-color 0.15s, color 0.15s",
-                  "&:hover": isReadOnly
-                    ? undefined
-                    : { bgcolor: "action.hover", color: "text.primary" },
-                  "&:focus-visible": {
-                    outline: "2px solid",
-                    outlineColor: "primary.main",
-                    outlineOffset: 2,
-                  },
-                }}
-              >
-                <Iconify
-                  icon="mdi:text-box-outline"
-                  width={14}
-                  sx={{ flexShrink: 0 }}
-                />
-                <Typography
-                  ref={descRef}
-                  noWrap
-                  sx={{ fontSize: "13px", minWidth: 0 }}
+                  onClick={() => !isReadOnly && setDescOpen(true)}
+                  onKeyDown={(e) => {
+                    if (isReadOnly) return;
+                    if (e.key === "Enter" || e.key === " ") {
+                      e.preventDefault();
+                      setDescOpen(true);
+                    }
+                  }}
+                  sx={{
+                    minWidth: 0,
+                    maxWidth: 260,
+                    px: 0.75,
+                    py: 0.25,
+                    borderRadius: 1,
+                    color: "text.secondary",
+                    cursor: isReadOnly ? "default" : "pointer",
+                    transition: "background-color 0.15s, color 0.15s",
+                    "&:hover": isReadOnly
+                      ? undefined
+                      : { bgcolor: "action.hover", color: "text.primary" },
+                    "&:focus-visible": {
+                      outline: "2px solid",
+                      outlineColor: "primary.main",
+                      outlineOffset: 2,
+                    },
+                  }}
                 >
-                  {chartDescription}
-                </Typography>
-              </Stack>
-            </CustomTooltip>
+                  <Iconify
+                    icon="mdi:text-box-outline"
+                    width={14}
+                    sx={{ flexShrink: 0 }}
+                  />
+                  <Typography
+                    ref={measureRef}
+                    noWrap
+                    sx={{ fontSize: "13px", minWidth: 0 }}
+                  >
+                    {trimmedDescription}
+                  </Typography>
+                </Stack>
+              )}
+            </TruncatedTooltipText>
           ) : (
             !isReadOnly && (
               <Button

--- a/frontend/src/sections/dashboards/__tests__/DashboardDetailView.test.jsx
+++ b/frontend/src/sections/dashboards/__tests__/DashboardDetailView.test.jsx
@@ -244,4 +244,21 @@ describe("DashboardDetailView — widget description (TH-7678)", () => {
     );
     expect(header.children).toHaveLength(1);
   });
+
+  it("treats a whitespace-only description as no description", () => {
+    h.widgets = [
+      {
+        id: "w-1",
+        name: "Tokens",
+        description: "   ",
+        position: 0,
+        width: 12,
+      },
+    ];
+    const { container } = render(<DashboardDetailView />);
+    const header = container.querySelector(
+      '[data-widget-id="w-1"] .MuiCardContent-root > div',
+    );
+    expect(header.children).toHaveLength(1);
+  });
 });

--- a/frontend/src/sections/dashboards/__tests__/DashboardDetailView.test.jsx
+++ b/frontend/src/sections/dashboards/__tests__/DashboardDetailView.test.jsx
@@ -194,3 +194,54 @@ describe("DashboardDetailView — RBAC gating", () => {
     expect(screen.getByTestId("widget-chart")).toBeInTheDocument();
   });
 });
+
+describe("DashboardDetailView — widget description (TH-7678)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    h.canEdit = { ...WRITER };
+  });
+
+  it("renders the description on the widget card", () => {
+    h.widgets = [
+      {
+        id: "w-1",
+        name: "Tokens",
+        description: "Total tokens consumed per day",
+        position: 0,
+        width: 12,
+      },
+    ];
+    render(<DashboardDetailView />);
+    expect(screen.getByText("Tokens")).toBeInTheDocument();
+    expect(
+      screen.getByText("Total tokens consumed per day"),
+    ).toBeInTheDocument();
+  });
+
+  it("renders the description for a read-only viewer too", () => {
+    h.canEdit = { ...VIEWER };
+    h.widgets = [
+      {
+        id: "w-1",
+        name: "Tokens",
+        description: "Total tokens consumed per day",
+        position: 0,
+        width: 12,
+      },
+    ];
+    render(<DashboardDetailView />);
+    expect(
+      screen.getByText("Total tokens consumed per day"),
+    ).toBeInTheDocument();
+  });
+
+  it("renders no description line when the widget has none", () => {
+    h.widgets = [{ id: "w-1", name: "Tokens", position: 0, width: 12 }];
+    const { container } = render(<DashboardDetailView />);
+    // The card header holds the title row and nothing else.
+    const header = container.querySelector(
+      '[data-widget-id="w-1"] .MuiCardContent-root > div',
+    );
+    expect(header.children).toHaveLength(1);
+  });
+});

--- a/frontend/src/sections/dashboards/__tests__/WidgetDescriptionPopover.test.jsx
+++ b/frontend/src/sections/dashboards/__tests__/WidgetDescriptionPopover.test.jsx
@@ -1,0 +1,64 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent } from "src/utils/test-utils";
+import WidgetDescriptionPopover from "../WidgetDescriptionPopover";
+
+const setup = (props = {}) => {
+  const onChange = vi.fn();
+  const onClose = vi.fn();
+  const anchor = document.createElement("div");
+  document.body.appendChild(anchor);
+  render(
+    <WidgetDescriptionPopover
+      open
+      anchorEl={anchor}
+      value=""
+      onChange={onChange}
+      onClose={onClose}
+      {...props}
+    />,
+  );
+  return { onChange, onClose };
+};
+
+describe("WidgetDescriptionPopover", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("shows the current description", () => {
+    setup({ value: "p95 latency across production calls" });
+    expect(
+      screen.getByDisplayValue("p95 latency across production calls"),
+    ).toBeInTheDocument();
+  });
+
+  it("reports edits as a plain string, not an event", () => {
+    const { onChange } = setup();
+    fireEvent.change(screen.getByRole("textbox"), {
+      target: { value: "Error rate by model" },
+    });
+    expect(onChange).toHaveBeenCalledWith("Error rate by model");
+  });
+
+  it("closes on Done", () => {
+    const { onClose } = setup({ value: "Anything" });
+    fireEvent.click(screen.getByRole("button", { name: "Done" }));
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("closes on modifier+Enter but not on a bare Enter, which inserts a line break", () => {
+    const { onClose } = setup({ value: "Line one" });
+    const field = screen.getByRole("textbox");
+
+    fireEvent.keyDown(field, { key: "Enter" });
+    expect(onClose).not.toHaveBeenCalled();
+
+    fireEvent.keyDown(field, { key: "Enter", metaKey: true });
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("renders nothing while closed", () => {
+    setup({ open: false, value: "Hidden" });
+    expect(screen.queryByRole("textbox")).toBeNull();
+  });
+});

--- a/frontend/src/sections/dashboards/__tests__/WidgetDescriptionPopover.test.jsx
+++ b/frontend/src/sections/dashboards/__tests__/WidgetDescriptionPopover.test.jsx
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen, fireEvent } from "src/utils/test-utils";
+import { createEvent } from "@testing-library/react";
 import WidgetDescriptionPopover from "../WidgetDescriptionPopover";
 
 const setup = (props = {}) => {
@@ -7,7 +8,7 @@ const setup = (props = {}) => {
   const onClose = vi.fn();
   const anchor = document.createElement("div");
   document.body.appendChild(anchor);
-  render(
+  const ui = (extra) => (
     <WidgetDescriptionPopover
       open
       anchorEl={anchor}
@@ -15,9 +16,11 @@ const setup = (props = {}) => {
       onChange={onChange}
       onClose={onClose}
       {...props}
-    />,
+      {...extra}
+    />
   );
-  return { onChange, onClose };
+  const view = render(ui());
+  return { onChange, onClose, rerender: (extra) => view.rerender(ui(extra)) };
 };
 
 describe("WidgetDescriptionPopover", () => {
@@ -32,11 +35,15 @@ describe("WidgetDescriptionPopover", () => {
     ).toBeInTheDocument();
   });
 
-  it("reports edits as a plain string, not an event", () => {
+  it("holds edits until Done, then reports a plain string, not an event", () => {
     const { onChange } = setup();
     fireEvent.change(screen.getByRole("textbox"), {
       target: { value: "Error rate by model" },
     });
+    // Typing must not reach the widget — the toolbar preview would follow it.
+    expect(onChange).not.toHaveBeenCalled();
+
+    fireEvent.click(screen.getByRole("button", { name: "Done" }));
     expect(onChange).toHaveBeenCalledWith("Error rate by model");
   });
 
@@ -46,15 +53,69 @@ describe("WidgetDescriptionPopover", () => {
     expect(onClose).toHaveBeenCalledTimes(1);
   });
 
+  it("discards the edit when dismissed without Done", () => {
+    const { onChange, onClose } = setup({ value: "Original" });
+    fireEvent.change(screen.getByRole("textbox"), {
+      target: { value: "Half-typed thought" },
+    });
+
+    fireEvent.keyDown(screen.getByRole("textbox"), { key: "Escape" });
+
+    expect(onClose).toHaveBeenCalled();
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it("reopens on the widget's value, not the discarded draft", () => {
+    const { rerender } = setup({ value: "Original" });
+    fireEvent.change(screen.getByRole("textbox"), {
+      target: { value: "Half-typed thought" },
+    });
+
+    rerender({ open: false });
+    rerender({ open: true });
+
+    expect(screen.getByRole("textbox")).toHaveValue("Original");
+  });
+
   it("closes on modifier+Enter but not on a bare Enter, which inserts a line break", () => {
     const { onClose } = setup({ value: "Line one" });
     const field = screen.getByRole("textbox");
 
-    fireEvent.keyDown(field, { key: "Enter" });
+    const bare = createEvent.keyDown(field, { key: "Enter" });
+    fireEvent(field, bare);
     expect(onClose).not.toHaveBeenCalled();
+    // The line break is the whole point of a bare Enter — leave it alone.
+    expect(bare.defaultPrevented).toBe(false);
+
+    const shortcut = createEvent.keyDown(field, {
+      key: "Enter",
+      metaKey: true,
+    });
+    fireEvent(field, shortcut);
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("commits the edit on modifier+Enter, as Done does", () => {
+    const { onChange } = setup({ value: "Line one" });
+    const field = screen.getByRole("textbox");
+    fireEvent.change(field, { target: { value: "Line one and two" } });
 
     fireEvent.keyDown(field, { key: "Enter", metaKey: true });
-    expect(onClose).toHaveBeenCalledTimes(1);
+
+    expect(onChange).toHaveBeenCalledWith("Line one and two");
+  });
+
+  it("does not let the close shortcut insert a line break of its own", () => {
+    setup({ value: "Line one" });
+    const field = screen.getByRole("textbox");
+
+    // Ctrl+Enter still inserts a newline on Windows/Linux unless suppressed.
+    const shortcut = createEvent.keyDown(field, {
+      key: "Enter",
+      ctrlKey: true,
+    });
+    fireEvent(field, shortcut);
+    expect(shortcut.defaultPrevented).toBe(true);
   });
 
   it("renders nothing while closed", () => {

--- a/frontend/src/sections/dashboards/__tests__/useIsTruncated.test.jsx
+++ b/frontend/src/sections/dashboards/__tests__/useIsTruncated.test.jsx
@@ -1,0 +1,119 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { act, render, screen } from "@testing-library/react";
+import PropTypes from "prop-types";
+import useIsTruncated from "../hooks/useIsTruncated";
+
+// Widths jsdom cannot produce on its own; every element reports these.
+let widths = { scroll: 0, client: 0 };
+let observers = [];
+
+class RecordingResizeObserver {
+  constructor(callback) {
+    this.callback = callback;
+    this.observed = [];
+    this.disconnected = false;
+    observers.push(this);
+  }
+
+  observe(node) {
+    this.observed.push(node);
+  }
+
+  disconnect() {
+    this.disconnected = true;
+  }
+}
+
+// Mirrors CustomTooltip: a bare fragment until the text is clipped, a real
+// wrapper element after. The element type at that slot changes, so React
+// remounts the measured node underneath it.
+function Harness({ text }) {
+  const [measureRef, isTruncated] = useIsTruncated(text);
+  const child = (
+    <span ref={measureRef} data-testid="text">
+      {text}
+    </span>
+  );
+
+  return isTruncated ? <em data-testid="wrapper">{child}</em> : <>{child}</>;
+}
+
+Harness.propTypes = {
+  text: PropTypes.string.isRequired,
+};
+
+const overflow = () => {
+  widths = { scroll: 200, client: 100 };
+};
+const fits = () => {
+  widths = { scroll: 100, client: 100 };
+};
+
+describe("useIsTruncated", () => {
+  beforeEach(() => {
+    observers = [];
+    fits();
+    vi.stubGlobal("ResizeObserver", RecordingResizeObserver);
+    ["scrollWidth", "clientWidth"].forEach((prop) => {
+      Object.defineProperty(HTMLElement.prototype, prop, {
+        configurable: true,
+        get() {
+          return prop === "scrollWidth" ? widths.scroll : widths.client;
+        },
+      });
+    });
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    ["scrollWidth", "clientWidth"].forEach((prop) => {
+      delete HTMLElement.prototype[prop];
+    });
+  });
+
+  it("reports no truncation while the text fits", () => {
+    render(<Harness text="Short" />);
+    expect(screen.queryByTestId("wrapper")).toBeNull();
+  });
+
+  it("reports truncation when the text is clipped", () => {
+    overflow();
+    render(<Harness text="A description far too long for one line" />);
+    expect(screen.getByTestId("wrapper")).toBeInTheDocument();
+  });
+
+  // Regression: revealing the tooltip remounts the measured node. A ref object
+  // would leave the observer on the detached original and freeze the result.
+  it("observes the replacement node after the wrapper remounts it", () => {
+    overflow();
+    render(<Harness text="A description far too long for one line" />);
+
+    const live = screen.getByTestId("text");
+    const active = observers.filter((o) => !o.disconnected);
+
+    expect(active.some((o) => o.observed.includes(live))).toBe(true);
+    expect(document.contains(live)).toBe(true);
+  });
+
+  it("disconnects the observer left on the replaced node", () => {
+    overflow();
+    render(<Harness text="A description far too long for one line" />);
+
+    expect(observers.length).toBeGreaterThan(1);
+    expect(observers[0].disconnected).toBe(true);
+  });
+
+  // The point of re-observing: resizing the card wider must clear the tooltip.
+  it("clears truncation when the element grows back", () => {
+    overflow();
+    render(<Harness text="A description far too long for one line" />);
+    expect(screen.getByTestId("wrapper")).toBeInTheDocument();
+
+    fits();
+    act(() => {
+      observers.filter((o) => !o.disconnected).forEach((o) => o.callback());
+    });
+
+    expect(screen.queryByTestId("wrapper")).toBeNull();
+  });
+});

--- a/frontend/src/sections/dashboards/constants.js
+++ b/frontend/src/sections/dashboards/constants.js
@@ -54,3 +54,10 @@ export const DATE_CHIP_SX = {
 // the editor preview and the saved widget cannot answer that case differently.
 export const NO_DATA_FOR_RANGE_MESSAGE =
   "No data available for this time period. Try a broader range.";
+
+export const DESCRIPTION_TOOLTIP_SX = {
+  maxHeight: 260,
+  overflowY: "auto",
+  whiteSpace: "pre-wrap",
+  wordBreak: "break-word",
+};

--- a/frontend/src/sections/dashboards/hooks/useIsTruncated.js
+++ b/frontend/src/sections/dashboards/hooks/useIsTruncated.js
@@ -1,0 +1,25 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+
+/** Reports whether a single-line element is clipping its own text, so callers
+ *  can offer a tooltip only when there is hidden text to reveal. */
+export default function useIsTruncated(text) {
+  const ref = useRef(null);
+  const [isTruncated, setIsTruncated] = useState(false);
+
+  const measure = useCallback(() => {
+    const el = ref.current;
+    if (el) setIsTruncated(el.scrollWidth > el.clientWidth);
+  }, []);
+
+  useEffect(() => {
+    const el = ref.current;
+    if (!el) return undefined;
+
+    measure();
+    const observer = new ResizeObserver(measure);
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, [measure, text]);
+
+  return [ref, isTruncated];
+}

--- a/frontend/src/sections/dashboards/hooks/useIsTruncated.js
+++ b/frontend/src/sections/dashboards/hooks/useIsTruncated.js
@@ -1,25 +1,28 @@
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 
 /** Reports whether a single-line element is clipping its own text, so callers
- *  can offer a tooltip only when there is hidden text to reveal. */
+ *  can offer a tooltip only when there is hidden text to reveal.
+ *
+ *  The measured node is held in state and handed back as a callback ref, not a
+ *  ref object: revealing the tooltip swaps the wrapper around the text, which
+ *  remounts the node underneath it. A ref object would leave the observer
+ *  watching the detached node and freeze the result at whatever it read first. */
 export default function useIsTruncated(text) {
-  const ref = useRef(null);
+  const [node, setNode] = useState(null);
   const [isTruncated, setIsTruncated] = useState(false);
 
   const measure = useCallback(() => {
-    const el = ref.current;
-    if (el) setIsTruncated(el.scrollWidth > el.clientWidth);
-  }, []);
+    if (node) setIsTruncated(node.scrollWidth > node.clientWidth);
+  }, [node]);
 
   useEffect(() => {
-    const el = ref.current;
-    if (!el) return undefined;
+    if (!node) return undefined;
 
     measure();
     const observer = new ResizeObserver(measure);
-    observer.observe(el);
+    observer.observe(node);
     return () => observer.disconnect();
-  }, [measure, text]);
+  }, [measure, node, text]);
 
-  return [ref, isTruncated];
+  return [setNode, isTruncated];
 }


### PR DESCRIPTION
**Ticket:** [TH-7678](https://linear.app/future-agi/issue/TH-7678/dashboard-widget-description-entered-is-not-shown-on-individual) — Closes TH-7678

## What was the bug

Reported by Whatfix while building their Quickread dashboard: *"The description when I enter is not being seen in individual Widgets."*

Two separate problems:

1. A description entered on a widget was saved and returned by the API, but **never rendered on the widget card** in the dashboard grid.
2. On the widget page the description was **clipped and unreadable** — a single-line input capped at 200px.

This is frontend-only. `DashboardWidget.description` is a `TextField` with no `max_length`, it is in `DashboardWidgetSerializer.Meta.fields`, and the editor already sent and hydrated it correctly. The public share page (`SharedView.jsx`) was already rendering it — only the owner-facing views were missing it.

## What changes have been done

- `sections/dashboards/DashboardDetailView.jsx` — widget card header is now a flex column: the existing title row, plus a description line beneath it (rendered only when the widget has one). Also added wrap rules to the dashboard title and description.
- `sections/dashboards/WidgetEditorView.jsx` — the description no longer lives inline in the top bar. It is a capped 260px preview that opens a popover editor; an "Add description" button takes its place when empty. Description is now trimmed on save.
- `sections/dashboards/WidgetDescriptionPopover.jsx` *(new)* — controlled popover with a multiline field, Done button, and Cmd/Ctrl+Enter to close.
- `sections/dashboards/hooks/useIsTruncated.js` *(new)* — measures `scrollWidth > clientWidth` so a tooltip is offered only when text is actually clipped.
- `sections/dashboards/constants.js` — shared `DESCRIPTION_TOOLTIP_SX` for both description tooltips.
- Tests — 8 new across `DashboardDetailView.test.jsx` and `WidgetDescriptionPopover.test.jsx`.

## Why the changes

- **Card never rendered it.** `DraggableWidgetCard` drew `widget.name` and went straight to `<WidgetChart>`. The description line is gated on a non-empty value so existing cards keep their exact layout and chart height.
- **200px single-line input.** Widening it wasn't enough — text inside an `<input>` clips with no ellipsis and no tooltip. The top bar is an identity + actions strip; a free-text paragraph of any length can't live there. The preview keeps the bar fixed-width at any description length, and the popover gives the text a surface sized for prose.
- **Tooltip could run off-screen.** `CustomTooltip` sets `maxWidth: 400px` but no `maxHeight`, so a long description grew past the viewport with the overflow unreachable. Now capped and scrollable, preserving the author's line breaks.
- **Popover anchoring.** The popover is anchored to a wrapper that never unmounts — anchoring it to the preview meant clearing the description detached the anchor and threw the popover to the top-left corner.
- **Untrimmed save.** `name` was trimmed and `description` wasn't; a whitespace-only description is truthy and rendered a blank line on the card.
- **Keyboard access.** The old input was focusable; the new preview needed `role`/`tabIndex`/Enter-Space handling so keyboard users don't lose the ability to edit.

## Test cases — what each scenario covers

| # | Scenario | Expected |
|---|----------|----------|
| 1 | Widget with a description on the dashboard | Description renders under the widget name |
| 2 | Same, as a read-only viewer | Description still renders; no edit affordances |
| 3 | Widget with no description | No description line; card layout unchanged |
| 4 | Popover opened with an existing description | Field shows the current text |
| 5 | Typing in the popover | Reports a plain string to the caller |
| 6 | Done button | Closes the popover |
| 7 | Enter vs Cmd/Ctrl+Enter | Bare Enter inserts a line break; modifier+Enter closes |
| 8 | Popover closed | Nothing rendered |

Verified the card tests fail without the fix (stubbing the render red-lights exactly those two and nothing else). Full dashboards suite: 123 passing.

## How to reproduce (original bug)

1. Open a dashboard and add a widget.
2. On the widget page, enter a description and save.
3. Go back to the dashboard — the description is nowhere on the widget card.
4. Reopen the widget and enter a long description — it is clipped at 200px with no way to read it.

## Commands

```bash
cd frontend && npx vitest run src/sections/dashboards/__tests__/
```

## Videos and screenshots

https://github.com/user-attachments/assets/7838e993-beba-4be2-8d2d-fd971a7e7852

## Notes for the reviewer

- The dashboard title/description wrap fix is slightly outside the ticket's scope — long unspaced strings overflowed the container and could push horizontal scroll onto the page. Easy to drop if you'd rather keep this tight.
- The trim fix has no test: it lives in `handleSave` inside `WidgetEditorView`, which no existing test mounts. Verified by reading, not execution.
