### PR TITLE
test(e2e): isolated stack profile, runner CLI, and deterministic mock LLM

### DIFF
--- a/bin/e2e
+++ b/bin/e2e
@@ -1,0 +1,145 @@
+#!/usr/bin/env bash
+# E2E stack + suite runner. See e2e/README.md.
+set -euo pipefail
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+ENV_FILE="$ROOT/e2e/stack/e2e.env"
+COMPOSE=(docker compose --env-file "$ENV_FILE"
+  -f "$ROOT/docker-compose.yml" -f "$ROOT/e2e/stack/docker-compose.e2e.yml"
+  -p futureagi-e2e)
+# Trimmed profile: no serving/code-executor, single ALL_QUEUES worker. PeerDB
+# is included — eval/annotation/dashboard reads are CDC-only. The flow workers
+# must be named (nothing depends_on them); peerdb-init is one-shot and handled
+# separately in `up` (compose --wait treats an exiting service as a failure).
+SERVICES=(frontend backend worker postgres clickhouse redis rabbitmq minio
+  temporal agentcc-gateway fi-collector mock-llm
+  peerdb-server peerdb-flow-worker peerdb-flow-snapshot-worker
+  # nothing depends_on peerdb-minio, but the CH peer validates by writing to
+  # it and every mirror sync stages through it — without it ch_dest is never
+  # created and peerdb-init "succeeds" with zero mirrors.
+  peerdb-minio)
+# Mirrors whose CH destination table is behind the PG model (PeerDB
+# validates PG columns ⊆ CH columns). Known product schema drift, ticketed;
+# their CREATE MIRROR failures are reported as warnings until the DDL is fixed.
+KNOWN_DRIFTED_MIRRORS='model_hub_score|simulate_agent_definition'
+
+backend_port() { grep '^BACKEND_PORT=' "$ENV_FILE" | cut -d= -f2; }
+ch_port() { grep '^CH_HTTP_PORT=' "$ENV_FILE" | cut -d= -f2; }
+frontend_port() { grep '^FRONTEND_PORT=' "$ENV_FILE" | cut -d= -f2; }
+
+# Runs a one-shot service to completion and returns its exit code. Recreated
+# every call so `logs` shows this run's output, not an accumulation.
+run_one_shot() {
+  local service="$1" budget="$2" state deadline
+  "${COMPOSE[@]}" up -d --force-recreate "$service"
+  # Budget starts only after up -d returns: that call itself cold-boots the
+  # peerdb substack (catalog/temporal/flow-api + temporal-init) via depends_on.
+  deadline=$((SECONDS + budget))
+  while true; do
+    state="$("${COMPOSE[@]}" ps -a "$service" --format '{{.State}} {{.ExitCode}}')"
+    case "$state" in
+      exited*) return "${state##* }" ;;
+    esac
+    ((SECONDS < deadline)) || { echo "$service not done in ${budget}s"; exit 1; }
+    sleep 3
+  done
+}
+
+# Splits peerdb-init's ERROR: lines into the ticketed schema-drift allowlist and
+# everything else. Sets PEERDB_DRIFTED/PEERDB_FATAL: bash 3.2 has no namerefs.
+classify_peerdb_errors() {
+  local errors
+  # 2>&1 is load-bearing: compose forwards the container's stderr to ours,
+  # and psql prints its ERROR: lines there.
+  errors="$("${COMPOSE[@]}" logs peerdb-init 2>&1 | grep "ERROR:" || true)"
+  PEERDB_DRIFTED="$(grep -E "$KNOWN_DRIFTED_MIRRORS" <<<"$errors" || true)"
+  PEERDB_FATAL="$(grep -vE "$KNOWN_DRIFTED_MIRRORS" <<<"$errors" || true)"
+}
+
+wait_peerdb_init() {
+  echo "Waiting for peerdb-init (CDC mirror setup) ..."
+  local attempt
+  for attempt in 1 2; do
+    if ((attempt == 2)); then
+      echo "Retrying PeerDB init ..."
+    fi
+    # Runs before EVERY attempt, not just the retry, and must stay that way.
+    # On fresh volumes the first registration of the MirrorName search
+    # attribute does not take effect (peerdb-temporal's healthcheck is a bare
+    # pgrep, so init beats the namespace being usable), and mirrors submitted
+    # without the mapping fail permanently: peerdb-setup-mirrors.sh reports a
+    # retry as MIRROR ALREADY EXISTS and skips it, so the mirror is never
+    # created. Preventing that failure is the only cure — it has no recovery.
+    # Non-zero is expected here on a re-run: the attribute already exists.
+    run_one_shot peerdb-temporal-init 180 || true
+    if ! run_one_shot peerdb-init 180; then
+      echo "peerdb-init failed:"; "${COMPOSE[@]}" logs peerdb-init || true; exit 1
+    fi
+    # The setup script is fail-open: mirror/peer failures print ERROR lines
+    # and still exit 0. Fail closed here.
+    classify_peerdb_errors
+    if [[ -z "$PEERDB_FATAL" ]]; then
+      break
+    fi
+  done
+  if [[ -n "$PEERDB_DRIFTED" ]]; then
+    echo "WARN: known schema-drift mirrors failed (ticketed):"
+    cut -c1-160 <<<"$PEERDB_DRIFTED"
+  fi
+  if [[ -n "$PEERDB_FATAL" ]]; then
+    echo "peerdb-init exited 0 but reported errors (CDC mirrors missing):"
+    head -5 <<<"$PEERDB_FATAL"
+    exit 1
+  fi
+}
+
+wait_ready() {
+  # Measured cold boot 2026-08-25: first-run migrations take ~6.5 min before
+  # /health/ answers; 300s was not enough.
+  local deadline=$((SECONDS + 600))
+  echo "Waiting for backend /health/ ..."
+  until curl -fsS "http://localhost:$(backend_port)/health/" >/dev/null 2>&1; do
+    ((SECONDS < deadline)) || { echo "backend not healthy in 600s"; "${COMPOSE[@]}" ps; exit 1; }
+    sleep 3
+  done
+  # The Django CH boot hook logs-and-continues on failure, so /health/ alone
+  # can pass with a broken CH schema. Prove the spans table exists.
+  echo "Checking ClickHouse schema ..."
+  curl -fsS -G "http://localhost:$(ch_port)/" --data-urlencode "query=SELECT count() FROM spans LIMIT 0" >/dev/null \
+    || { echo "CH spans table missing — boot-hook schema apply failed (check backend logs)"; exit 1; }
+  echo "Waiting for frontend ..."
+  until curl -fsS "http://localhost:$(frontend_port)/" >/dev/null 2>&1; do
+    ((SECONDS < deadline)) || { echo "frontend not up in 600s"; exit 1; }
+    sleep 2
+  done
+  echo "E2E stack ready: app http://localhost:$(frontend_port)  api http://localhost:$(backend_port)"
+}
+
+build_target() {
+  case "$1" in
+    backend)   docker build -t futureagi/future-agi:e2e-local -f "$ROOT/futureagi/Dockerfile.oss" "$ROOT/futureagi"
+               echo "built. run with: FUTURE_AGI_VERSION=e2e-local bin/e2e up" ;;
+    frontend)  docker build -t futureagi/frontend:e2e-local "$ROOT/frontend"
+               echo "built. run with: FRONTEND_VERSION=e2e-local bin/e2e up" ;;
+    collector) docker build -t futureagi/fi-collector:e2e-local "$ROOT/fi-collector"
+               echo "built. run with: E2E_FI_COLLECTOR_VERSION=e2e-local bin/e2e up" ;;
+    all)       build_target backend; build_target frontend; build_target collector
+               echo "run with: FUTURE_AGI_VERSION=e2e-local FRONTEND_VERSION=e2e-local E2E_FI_COLLECTOR_VERSION=e2e-local bin/e2e up" ;;
+    *) echo "usage: bin/e2e build backend|frontend|collector|all"; exit 2 ;;
+  esac
+}
+
+cmd="${1:-}"; shift || true
+case "$cmd" in
+  # wait_ready before wait_peerdb_init: mirrors can only be created once the
+  # backend has migrated the tables they replicate (fresh volumes = CI path).
+  up)      "${COMPOSE[@]}" up -d --wait --wait-timeout 300 "${SERVICES[@]}"; wait_ready; wait_peerdb_init ;;
+  down)    "${COMPOSE[@]}" down "$@" ;;
+  build)   build_target "${1:?usage: bin/e2e build backend|frontend|collector|all}" ;;
+  test)    (cd "$ROOT/e2e" && yarn playwright test "$@") ;;
+  ui)      (cd "$ROOT/e2e" && yarn playwright test --ui "$@") ;;
+  report)  (cd "$ROOT/e2e" && yarn playwright show-report) ;;
+  logs)    "${COMPOSE[@]}" logs "$@" ;;
+  ps)      "${COMPOSE[@]}" ps "$@" ;;
+  compose) "${COMPOSE[@]}" "$@" ;;
+  *) echo "usage: bin/e2e up|down [-v]|build <target>|test [pw args]|ui|report|logs|ps|compose <args>"; exit 2 ;;
+esac

--- a/e2e/stack/docker-compose.e2e.yml
+++ b/e2e/stack/docker-compose.e2e.yml
@@ -1,0 +1,27 @@
+# Overlay on the root docker-compose.yml for the futureagi-e2e stack.
+services:
+  clickhouse:
+    # Seatbelt on 16GB CI runners: CH is the first OOM-kill victim otherwise.
+    mem_limit: 3g
+  backend:
+    restart: "no"
+  worker:
+    restart: "no"
+  fi-collector:
+    # Root compose reuses FUTURE_AGI_VERSION for this image; the e2e stack
+    # decouples it so CI can retag the backend without inventing a
+    # futureagi/fi-collector:e2e-ci that was never built.
+    image: futureagi/fi-collector:${E2E_FI_COLLECTOR_VERSION:-latest}
+  peerdb-init:
+    environment:
+      # Root compose never passes the flag to peerdb-init, so the setup script
+      # attempts the retired tracer_observation_span mirror.
+      CH25_DROP_LEGACY_CDC_CHAIN: "true"
+  mock-llm:
+    image: node:22-alpine
+    command: ["node", "/srv/server.mjs"]
+    volumes:
+      # Compose resolves paths in an override file against the project
+      # directory (the first -f file's dir = repo root), not this file's dir.
+      - ./e2e/stack/mock-llm/server.mjs:/srv/server.mjs:ro
+    restart: "no"

--- a/e2e/stack/e2e.env
+++ b/e2e/stack/e2e.env
@@ -1,0 +1,37 @@
+# Isolated E2E stack: futureagi-e2e project, 3100/8100/2xxxx ports.
+# Collides with neither the default dev stack nor futureagi-test (1xxxx).
+FRONTEND_PORT=3100
+BACKEND_PORT=8100
+AGENTCC_GATEWAY_PORT=28090
+SERVING_PORT=28080
+CODE_EXECUTOR_PORT=28060
+PG_PORT=25432
+CH_HTTP_PORT=28123
+CH_PORT=29000
+REDIS_PORT=26379
+MINIO_API_PORT=29005
+MINIO_CONSOLE_PORT=29006
+TEMPORAL_PORT=27233
+FI_COLLECTOR_OTLP_PORT=24317
+FI_COLLECTOR_OTLP_HTTP_PORT=24318
+FI_COLLECTOR_ADMIN_PORT=29464
+# peerdb-server binds host 9900 by default — collides with a dev peerdb stack
+PEERDB_PORT=29900
+# not started by bin/e2e up, but `bin/e2e compose up peerdb-ui` shouldn't collide either
+PEERDB_UI_PORT=23001
+
+# Prebuilt frontend image reads the API base at runtime (docker-entrypoint.sh
+# renders window.__FUTURE_AGI_CONFIG__).
+VITE_HOST_API=http://localhost:8100
+
+# Some UI surfaces treat an empty provider key as "unconfigured"; the value is
+# never sent anywhere real — the gateway config below points at mock-llm.
+OPENAI_API_KEY=e2e-mock
+# Root compose mounts ./${AGENTCC_CONFIG_PATH}, so this is repo-root-relative.
+AGENTCC_CONFIG_PATH=e2e/stack/gateway.e2e.yaml
+
+# CDC is a load-bearing read path: eval results, annotation scores, dataset/
+# simulation dashboards reach ClickHouse ONLY via the PeerDB mirrors
+# (peerdb-setup-mirrors.sh). This activates the profile-gated peerdb services
+# so bin/e2e can start them by name.
+COMPOSE_PROFILES=peerdb

--- a/e2e/stack/gateway.e2e.yaml
+++ b/e2e/stack/gateway.e2e.yaml
@@ -1,0 +1,684 @@
+# Agentcc Gateway Configuration
+# Copy to config.yaml and update with your settings.
+
+server:
+  port: 8080
+  host: "0.0.0.0"
+  read_timeout: 5s
+  write_timeout: 300s
+  idle_timeout: 120s
+  shutdown_timeout: 30s
+  max_request_body_size: 10485760 # 10MB
+  default_request_timeout: 60s
+
+providers:
+  openai:
+    base_url: "http://mock-llm:8080"
+    api_key: "e2e-mock"
+    api_format: "openai"
+    default_timeout: 60s
+    max_concurrent: 100
+    conn_pool_size: 100
+    models:
+      - gpt-4o
+      - gpt-4o-mini
+      - gpt-4-turbo
+      - gpt-3.5-turbo
+      - o1
+      - o1-mini
+
+  # anthropic:
+  #   base_url: "https://api.anthropic.com"
+  #   api_key: "${ANTHROPIC_API_KEY}"
+  #   api_format: "anthropic"
+  #   default_timeout: 120s
+  #   max_concurrent: 50
+  #   conn_pool_size: 50
+  #   headers:
+  #     anthropic-version: "2023-06-01"
+  #   models:
+  #     - claude-sonnet-4-20250514
+  #     - claude-3-5-haiku-20241022
+  #     - claude-3-opus-20240229
+
+  # gemini:
+  #   base_url: "https://generativelanguage.googleapis.com"
+  #   api_key: "${GEMINI_API_KEY}"
+  #   api_format: "gemini"
+  #   default_timeout: 120s
+  #   max_concurrent: 50
+  #   conn_pool_size: 50
+  #   models:
+  #     - gemini-2.0-flash
+  #     - gemini-2.0-pro
+  #     - gemini-1.5-pro
+
+  # Google Vertex AI (same api_format as gemini, different base URL + Bearer auth):
+  # vertex:
+  #   base_url: "https://us-central1-aiplatform.googleapis.com"
+  #   api_key: "${GOOGLE_ACCESS_TOKEN}"        # Bearer token from gcloud/service account
+  #   api_format: "gemini"
+  #   headers:
+  #     x-gcp-project: "my-project-id"         # GCP project ID
+  #     x-gcp-location: "us-central1"          # GCP region
+  #   models:
+  #     - gemini-2.0-flash
+  #     - gemini-2.0-pro
+
+  # bedrock:
+  #   base_url: "https://bedrock-runtime.us-east-1.amazonaws.com"
+  #   api_format: "bedrock"
+  #   default_timeout: 120s
+  #   max_concurrent: 50
+  #   conn_pool_size: 50
+  #   headers:
+  #     x-aws-region: "us-east-1"
+  #   models:
+  #     - anthropic.claude-3-sonnet-20240229-v1:0
+  #     - anthropic.claude-3-haiku-20240307-v1:0
+  #   # Auth: Set AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY env vars
+
+  # Bedrock cross-region (use multiple providers + routing for failover):
+  # bedrock-east:
+  #   base_url: "https://bedrock-runtime.us-east-1.amazonaws.com"
+  #   api_format: "bedrock"
+  #   headers: { x-aws-region: "us-east-1" }
+  #   models: [anthropic.claude-3-sonnet-v1]
+  # bedrock-west:
+  #   base_url: "https://bedrock-runtime.us-west-2.amazonaws.com"
+  #   api_format: "bedrock"
+  #   headers: { x-aws-region: "us-west-2" }
+  #   models: [anthropic.claude-3-sonnet-v1]
+  # # Then configure routing targets for load balancing / failover:
+  # # routing:
+  # #   targets:
+  # #     anthropic.claude-3-sonnet-v1:
+  # #       - provider: bedrock-east
+  # #         weight: 70
+  # #       - provider: bedrock-west
+  # #         weight: 30
+
+  # cohere:
+  #   base_url: "https://api.cohere.com"
+  #   api_key: "${COHERE_API_KEY}"
+  #   api_format: "cohere"
+  #   default_timeout: 60s
+  #   max_concurrent: 50
+  #   conn_pool_size: 50
+  #   models:
+  #     - command-r-plus
+  #     - command-r
+  #     - command
+
+  # ── Self-Hosted / Custom Endpoints ──────────────────────────
+  # vLLM, Ollama, LMStudio, TGI, LocalAI — all use OpenAI-compat format.
+  # Just set api_format: "openai" and point base_url to your server.
+  # No api_key needed for local servers. Models are auto-discovered
+  # from /v1/models if not listed. Local endpoints get optimized defaults
+  # (120s timeout, 10 max_concurrent, 10 pool size).
+
+  # vllm:
+  #   base_url: "http://localhost:8000"
+  #   api_format: "openai"
+  #   type: "vllm"
+  #   # models: auto-discovered from /v1/models
+
+  # ollama:
+  #   base_url: "http://localhost:11434"
+  #   api_format: "openai"
+  #   type: "ollama"
+  #   # Ollama serves OpenAI-compat at /v1/ by default
+
+  # lmstudio:
+  #   base_url: "http://localhost:1234"
+  #   api_format: "openai"
+  #   type: "lmstudio"
+
+  # tgi:
+  #   base_url: "http://localhost:8080"
+  #   api_format: "openai"
+  #   type: "tgi"
+
+  # Custom remote OpenAI-compatible endpoint:
+  # my-server:
+  #   base_url: "https://my-inference.example.com"
+  #   api_key: "${MY_SERVER_KEY}"
+  #   api_format: "openai"
+  #   local: false          # treat as remote (cloud defaults)
+  #   skip_tls: false       # set true for self-signed certs
+  #   auto_discover: true   # fetch models from /v1/models
+  #   models:               # or list explicitly
+  #     - my-model-v1
+
+  # ── Cloud Providers (OpenAI-Compatible) ──────────────────────
+  # These providers use the OpenAI API format. Set type to auto-fill base_url,
+  # or specify base_url explicitly to override. Only api_key is required.
+
+  # azure:
+  #   base_url: "https://my-resource.openai.azure.com"
+  #   api_key: "${AZURE_OPENAI_KEY}"
+  #   type: "azure"                  # auto-sets api_format: "azure"
+  #   headers:
+  #     api-version: "2024-10-21"    # Azure API version (default: 2024-10-21)
+  #   models:
+  #     - gpt-4o                     # Azure deployment names
+  #     - gpt-4o-mini
+
+  # Azure OpenAI with Azure AD token auth (instead of api-key):
+  # azure-ad:
+  #   base_url: "https://my-resource.openai.azure.com"
+  #   api_key: "${AZURE_AD_TOKEN}"   # Bearer token from Azure AD
+  #   type: "azure"
+  #   headers:
+  #     auth-type: "bearer"          # use Authorization: Bearer instead of api-key
+  #     api-version: "2024-10-21"
+  #   models:
+  #     - gpt-4o
+
+  # groq:
+  #   api_key: "${GROQ_API_KEY}"
+  #   type: "groq"                   # auto-sets base_url + api_format
+  #   models:
+  #     - llama-3.3-70b-versatile
+  #     - mixtral-8x7b-32768
+
+  # mistral:
+  #   api_key: "${MISTRAL_API_KEY}"
+  #   type: "mistral"
+  #   models:
+  #     - mistral-large-latest
+  #     - mistral-small-latest
+
+  # together:
+  #   api_key: "${TOGETHER_API_KEY}"
+  #   type: "together"
+  #   models:
+  #     - meta-llama/Meta-Llama-3.1-70B-Instruct-Turbo
+  #     - mistralai/Mixtral-8x7B-Instruct-v0.1
+
+  # fireworks:
+  #   api_key: "${FIREWORKS_API_KEY}"
+  #   type: "fireworks"
+  #   models:
+  #     - accounts/fireworks/models/llama-v3p1-70b-instruct
+
+  # deepinfra:
+  #   api_key: "${DEEPINFRA_API_KEY}"
+  #   type: "deepinfra"
+  #   models:
+  #     - meta-llama/Meta-Llama-3.1-70B-Instruct
+
+  # Perplexity exposes two complementary APIs over the same OpenAI-compatible base URL:
+  #   * Sonar API  (chat completions) - models: sonar, sonar-pro, sonar-reasoning, sonar-reasoning-pro, sonar-deep-research
+  #   * Agent API  (responses)        - orchestrates third-party LLMs (default model: gpt-5.1)
+  # See https://docs.perplexity.ai for full reference.
+  # perplexity:
+  #   api_key: "${PERPLEXITY_API_KEY}"
+  #   type: "perplexity"
+  #   models:
+  #     - sonar-pro
+  #     - sonar
+  #     - sonar-reasoning-pro
+  #     - sonar-reasoning
+  #     - sonar-deep-research
+  #     # Agent API (third-party model via Perplexity Agent orchestration)
+  #     - gpt-5.1
+
+  # cerebras:
+  #   api_key: "${CEREBRAS_API_KEY}"
+  #   type: "cerebras"
+  #   models:
+  #     - llama3.1-70b
+
+  # xai:
+  #   api_key: "${XAI_API_KEY}"
+  #   type: "xai"
+  #   models:
+  #     - grok-2
+
+  # openrouter:
+  #   api_key: "${OPENROUTER_API_KEY}"
+  #   type: "openrouter"
+  #   models:
+  #     - openai/gpt-4o
+  #     - anthropic/claude-3.5-sonnet
+
+# Explicit model-to-provider mapping (overrides provider-level models).
+# model_map:
+#   gpt-4o: openai
+#   claude-sonnet-4-20250514: anthropic
+
+# Virtual API key authentication.
+# When enabled, all requests must include Authorization: Bearer sk-agentcc-xxx
+# Setting AGENTCC_INTERNAL_API_KEY in the environment turns this on automatically
+# and registers that key. Running with no key and no auth block leaves the
+# gateway open — only do that on a trusted, non-public network.
+# auth:
+#   enabled: true
+#   keys:
+#     - name: "dev-key"
+#       key: "sk-agentcc-dev-key-for-testing"
+#       owner: "dev-team"
+#       models:
+#         - gpt-4o
+#         - gpt-4o-mini
+#     - name: "prod-key"
+#       key: "sk-agentcc-prod-key-unrestricted"
+#       owner: "production"
+#       # no models = unrestricted access to all models
+
+# Load balancing across multiple providers for the same model.
+# routing:
+#   default_strategy: "round-robin"   # round-robin, weighted, least-latency, cost-optimized
+#   failover:
+#     enabled: true                    # Auto-failover to next provider on error (default: true)
+#     max_attempts: 3                  # Max providers to try (default: 3)
+#     on_status_codes: [429, 500, 502, 503, 504]  # HTTP codes that trigger failover
+#     on_timeout: true                 # Failover on timeout errors (default: true)
+#   circuit_breaker:
+#     enabled: true                    # Per-provider circuit breaking (default: false)
+#     failure_threshold: 5             # Consecutive failures to open circuit (default: 5)
+#     success_threshold: 2             # Successes in half-open to close (default: 2)
+#     cooldown: 30s                    # Time before half-open test (default: 30s)
+#   retry:
+#     enabled: true                    # Auto-retry on same provider (default: true when routing)
+#     max_retries: 2                   # Max retries per provider (default: 2)
+#     initial_delay: 500ms             # First retry delay (default: 500ms)
+#     max_delay: 10s                   # Max backoff cap (default: 10s)
+#     multiplier: 2.0                  # Backoff multiplier (default: 2.0)
+#   model_fallbacks:
+#     gpt-4o:                              # If gpt-4o is unavailable, try these in order
+#       - claude-sonnet-4-20250514
+#       - gemini-2.0-pro
+#     claude-sonnet-4-20250514:
+#       - gpt-4o
+#       - gemini-2.0-pro
+#   model_timeouts:                          # Per-model timeout overrides
+#     o1: 300s                               # Reasoning models need more time
+#     o1-mini: 180s
+#     claude-3-opus-20240229: 120s
+#   mirror:                                 # Traffic mirroring for shadow testing
+#     enabled: true
+#     rules:
+#       - source_model: "gpt-4o"            # Mirror gpt-4o requests
+#         target_provider: "anthropic"       # Send copy to Anthropic
+#         target_model: "claude-sonnet-4-20250514"
+#         sample_rate: 0.1                   # Mirror 10% of traffic
+#       - source_model: "*"                  # Mirror all models
+#         target_provider: "staging"
+#         sample_rate: 0.01                  # 1% of all traffic
+#   conditional_routes:
+#     - name: "enterprise-tier"           # Route enterprise users to dedicated provider
+#       priority: 10                      # Lower = higher priority, first match wins
+#       condition:
+#         field: "metadata.tier"
+#         op: "$eq"
+#         value: "enterprise"
+#       action:
+#         provider: "openai-dedicated"
+#     - name: "gpt-models-to-openai"      # Route all GPT models to OpenAI
+#       priority: 50
+#       condition:
+#         field: "model"
+#         op: "$regex"
+#         value: "^gpt-"
+#       action:
+#         provider: "openai"
+#     # Operators: $eq, $ne, $in, $nin, $regex, $gt, $lt, $gte, $lte, $exists
+#     # Combinators: $and, $or, $not (nest conditions for complex rules)
+#     # Fields: model, user, stream, provider, session_id, request_id, metadata.<key>
+#   targets:
+#     gpt-4o:
+#       - provider: openai-east
+#         weight: 50
+#       - provider: openai-west
+#         weight: 50
+
+# cache:
+#   enabled: true
+#   default_ttl: 5m                        # Default cache entry TTL
+#   max_entries: 10000                     # Max entries in LRU cache
+#   # Per-request headers:
+#   #   x-agentcc-cache-ttl: "10m"           # Override TTL for this request
+#   #   x-agentcc-cache-namespace: "prod"    # Isolate cache by namespace
+#   #   x-agentcc-cache-force-refresh: true  # Skip cache read, refresh entry
+#   #   Cache-Control: no-store            # Skip caching entirely
+
+# rate_limiting:
+#   enabled: true
+#   global_rpm: 0              # 0 = unlimited (default). Set to limit all unauthenticated requests.
+
+# cost_tracking:
+#   enabled: true
+#   custom_pricing:
+#     my-custom-model:
+#       input_per_mtok: 1.00
+#       output_per_mtok: 5.00
+
+logging:
+  level: info
+  # request_logging:
+  #   enabled: true              # Log every request (default: true)
+  #   include_bodies: false      # Include full request/response bodies (default: false)
+  #   buffer_size: 4096          # Async buffer size (default: 4096)
+  #   workers: 2                 # Number of log worker goroutines (default: 2)
+# guardrails:
+#   enabled: true
+#   fail_open: true                     # If a guardrail times out or errors, allow the request (default: true)
+#   default_timeout: 5s                 # Default per-guardrail timeout
+#   rules:
+#     - name: "pii-detection"           # Must match a registered guardrail name
+#       stage: "pre"                    # "pre" (before provider) or "post" (after provider)
+#       mode: "sync"                    # "sync" (blocks pipeline) or "async" (fire-and-forget)
+#       action: "block"                 # "block", "warn", or "log"
+#       threshold: 0.8                  # Score above this triggers the action
+#       timeout: 3s                     # Per-rule timeout override
+#       config:                         # Rule-specific config passed to the guardrail
+#         entities: ["email", "phone", "ssn"]
+#     - name: "content-moderation"
+#       stage: "post"
+#       mode: "sync"
+#       action: "warn"
+#       threshold: 0.7
+#     - name: "usage-logger"
+#       stage: "pre"
+#       mode: "async"                   # Async guardrails don't block the pipeline
+#       action: "log"
+#       threshold: 0.0
+
+# admin:
+#   token: "your-secret-admin-token"
+
+# CORS for browser-based clients hitting the gateway directly.
+# cors:
+#   enabled: true
+#   allowed_origins: ["https://app.example.com", "*"]
+#   allowed_methods: ["GET", "POST", "OPTIONS"]
+#   allowed_headers: ["Authorization", "Content-Type"]
+#   exposed_headers: []
+#   max_age: 86400
+#   allow_credentials: false
+
+# Restrict inbound traffic by IP / CIDR.
+# ip_acl:
+#   enabled: true
+#   trusted_proxies: 1                    # hops of X-Forwarded-For to trust
+#   allow: ["10.0.0.0/8", "192.168.1.0/24"]
+#   deny:  ["203.0.113.7"]                # deny takes precedence over allow
+
+# Role-based access control for teams and users.
+# rbac:
+#   enabled: true
+#   default_role: "viewer"
+#   roles:
+#     admin:
+#       permissions: ["*"]
+#     developer:
+#       permissions: ["chat.completions:create", "models:list"]
+#     viewer:
+#       permissions: ["models:list"]
+#   teams:
+#     platform:
+#       role: "admin"
+#       models: ["gpt-4o", "claude-sonnet-4-20250514"]
+#       members:
+#         alice@example.com: {}
+
+# Spend caps per org / team / user / key / tag. Requires cost_tracking enabled.
+# budgets:
+#   enabled: true
+#   default_period: "monthly"       # daily | weekly | monthly | total
+#   warn_threshold: 0.8              # notify at 80% of limit
+#   org:
+#     limit: 10000.0                 # USD
+#     hard: true                     # hard=true rejects once limit hit
+#   teams:
+#     platform:
+#       limit: 5000.0
+#       period: "monthly"
+#       per_model:
+#         gpt-4o: 2000.0
+#   users:
+#     alice@example.com:
+#       limit: 500.0
+#   keys:
+#     sk-agentcc-dev-key-for-testing:
+#       limit: 100.0
+
+# Structured audit log of security-relevant events.
+# audit:
+#   enabled: true
+#   buffer_size: 1024
+#   min_severity: "info"              # info | warn | error | critical
+#   categories: []                     # empty = all (auth, rbac, budget, admin, ...)
+#   sinks:
+#     - type: "stdout"
+#     - type: "file"
+#       path: "/var/log/agentcc/audit.jsonl"
+#     - type: "webhook"
+#       url: "https://siem.example.com/ingest"
+#       headers:
+#         Authorization: "Bearer ${SIEM_TOKEN}"
+
+# OpenTelemetry tracing. One span per request carrying model, provider,
+# latency, token counts, cost, cache status, and any caller dimensions sent in
+# the x-agentcc-metadata header. Attribute names follow the OTel GenAI semantic
+# conventions (gen_ai.*), with session.id / user.id / metadata for the rest, so
+# spans are consumable by any GenAI-aware backend without a translation layer.
+# otel:
+#   enabled: true
+#   service_name: "agentcc-gateway"
+#   exporter: "otlp"                   # stdout | otlp
+#   endpoint: "http://otel-collector:4318"   # required for otlp; /v1/traces is
+#                                            # appended when the URL has no path
+#   protocol: "http/protobuf"          # the only supported OTLP transport
+#   headers:                           # hosted collectors authenticate here;
+#     X-Api-Key: "${FI_API_KEY}"       # keep credentials in the environment,
+#     X-Secret-Key: "${FI_SECRET_KEY}" # not in this file
+#   include_bodies: false              # attach prompt + completion to each span
+#                                      # (input.value / output.value). Off by
+#                                      # default: it sends user content to the
+#                                      # collector. Redacted with the same
+#                                      # privacy config as the request log.
+#   sample_rate: 0.1                   # 10% of requests
+#   attributes:                        # emitted as OTLP resource attributes
+#     environment: "production"
+#     region: "us-east-1"
+#
+# Exporting to the FutureAGI platform: point endpoint at
+# https://api.futureagi.com/v1/traces, authenticate with X-Api-Key/X-Secret-Key,
+# and set project_name (plus project_type: "observe") under attributes — the
+# platform reads those resource attributes to decide which project the spans
+# land in, and creates it on first use.
+#
+# Spans are queued and flushed in the background, so an unreachable collector
+# never adds latency to a request. The gateway's own x-agentcc-trace-id travels
+# as the agentcc.trace_id span attribute, so a span can be matched to its
+# request-log row; agentcc.request_id and agentcc.is_stream are likewise
+# gateway facts with no conventional equivalent.
+
+# Prometheus metrics endpoint.
+# prometheus:
+#   enabled: true
+#   path: "/-/metrics"
+
+# Alerting rules evaluated against rolling metric windows.
+# alerting:
+#   enabled: true
+#   rules:
+#     - name: "high-error-rate"
+#       metric: "error_count"          # error_count | request_count | cost_total | latency_avg | tokens_total
+#       condition: ">="                # >=, >, <=, <, ==
+#       threshold: 50
+#       window: 5m
+#       cooldown: 15m
+#       channels: ["ops-slack"]
+#     - name: "daily-spend-spike"
+#       metric: "cost_total"
+#       condition: ">"
+#       threshold: 500.0
+#       window: 1h
+#       cooldown: 1h
+#       channels: ["ops-slack", "finance-webhook"]
+#   channels:
+#     - name: "ops-slack"
+#       type: "slack"
+#       url: "https://hooks.slack.com/services/XXX/YYY/ZZZ"
+#     - name: "finance-webhook"
+#       type: "webhook"
+#       url: "https://alerts.example.com/agentcc"
+#       headers:
+#         Authorization: "Bearer ${ALERT_TOKEN}"
+
+# Override model metadata (pricing, token limits, capabilities, deprecation).
+# model_database:
+#   validation_enabled: true                 # reject requests for unknown models
+#   overrides:
+#     gpt-4o:
+#       provider: "openai"
+#       max_input_tokens: 128000
+#       max_output_tokens: 16384
+#       pricing:
+#         input_per_mtok: 2.50
+#         output_per_mtok: 10.00
+#       deprecation_date: "2026-12-31"
+#       regions: ["us-east-1", "us-west-2"]
+
+# Pull API keys from external secret stores instead of env vars.
+# secrets:
+#   vault:
+#     address: "https://vault.example.com"
+#     token: "${VAULT_TOKEN}"
+#     # or AppRole:
+#     # app_role_id: "${VAULT_ROLE_ID}"
+#     # app_role_secret: "${VAULT_ROLE_SECRET}"
+#   aws:
+#     region: "us-east-1"
+#     # IAM role is preferred; static creds only for local dev:
+#     # access_key_id: "${AWS_ACCESS_KEY_ID}"
+#     # secret_access_key: "${AWS_SECRET_ACCESS_KEY}"
+#   gcp: {}
+#   azure: {}
+
+# Redact PII from requests/responses before logging.
+# privacy:
+#   enabled: true
+#   mode: "patterns"                   # full | patterns | none
+#   redact_patterns:
+#     - name: "email"
+#       pattern: '[\w.+-]+@[\w-]+\.[\w.-]+'
+#     - name: "ssn"
+#       pattern: '\d{3}-\d{2}-\d{4}'
+
+# Strip or reject tool-calling requests that don't match an allowlist.
+# tool_policy:
+#   enabled: true
+#   max_tools_per_request: 32
+#   default_action: "strip"            # strip | reject
+#   allow: ["search_*", "code_interpreter"]
+#   deny:  ["shell_exec"]
+
+# Multi-replica coordination (rate limits, budgets, circuit state via Redis).
+# cluster:
+#   enabled: true
+#   node_id: "gateway-1"               # auto-generated if empty
+#   redis_url: "redis://localhost:6379/0"
+#   heartbeat_interval: 5s
+#   heartbeat_ttl: 15s
+#   drain_timeout: 30s
+
+# Shared state across replicas. Fallback to in-memory on Redis outage.
+# redis:
+#   enabled: true
+#   address: "localhost:6379"
+#   password: "${REDIS_PASSWORD}"
+#   db: 0
+#   pool_size: 20
+#   timeout: 2s
+#   prefix: "agentcc:"
+
+# Edge / region-aware routing.
+# edge:
+#   enabled: true
+#   regions:
+#     - name: "us-east"
+#       backend: "openai-east"
+#       weight: 70
+#     - name: "us-west"
+#       backend: "openai-west"
+#       weight: 30
+#   cache:
+#     enabled: true
+#     default_ttl: 300                 # seconds
+#     max_size: 1048576                # 1MB per entry
+
+# Pull config (keys, budgets, RBAC) from a Django control plane.
+# control_plane:
+#   url: "http://localhost:8000"
+#   admin_token: "${CONTROL_PLANE_ADMIN_TOKEN}"
+#   webhook_secret: "${CONTROL_PLANE_WEBHOOK_SECRET}"
+#   sync_on_startup: true
+#   sync_interval: 5m                  # 0 = disabled
+
+# OpenAI-compatible Assistants API proxy.
+# assistants:
+#   enabled: true
+#   run_timeout: 5m
+#   stream_read_timeout: 60s
+
+# Model Context Protocol — expose tools from registered MCP servers to models.
+# mcp:
+#   enabled: true
+#   endpoint: "/mcp"
+#   max_agent_depth: 5
+#   tool_call_timeout: 30s
+#   session_ttl: 30m
+#   separator: "__"                    # server-name__tool-name
+#   servers:
+#     filesystem:
+#       transport: "stdio"
+#       command: "npx"
+#       args: ["-y", "@modelcontextprotocol/server-filesystem", "/tmp"]
+#       tools_cache_ttl: 5m
+#     search:
+#       transport: "http"
+#       url: "https://mcp.example.com"
+#       auth:
+#         type: "bearer"
+#         token: "${MCP_SEARCH_TOKEN}"
+#   guardrails:
+#     enabled: true
+#     blocked_tools: ["shell_exec"]
+#     allowed_servers: ["filesystem", "search"]
+#     validate_inputs: true
+#     validate_outputs: false
+#     tool_rate_limits:
+#       filesystem__read_file: 100     # per minute
+#   tool_versions:
+#     filesystem__read_file:
+#       version: "v2"
+#       deprecated: false
+#     filesystem__legacy_read:
+#       version: "v1"
+#       deprecated: true
+#       deprecation_message: "Use read_file instead"
+#       replaced_by: "filesystem__read_file"
+
+# Agent-to-Agent protocol: expose Agentcc as an agent and register remote agents.
+# a2a:
+#   enabled: true
+#   card:
+#     name: "agentcc"
+#     description: "LLM gateway with routing and guardrails"
+#     version: "1.0.0"
+#   agents:
+#     research-agent:
+#       url: "https://agents.example.com/research"
+#       description: "Deep research specialist"
+#       auth:
+#         type: "bearer"
+#         token: "${RESEARCH_AGENT_TOKEN}"
+#       skills:
+#         - id: "web-search"
+#           name: "Web Search"
+#           description: "Search the open web"

--- a/e2e/stack/mock-llm/server.mjs
+++ b/e2e/stack/mock-llm/server.mjs
@@ -1,0 +1,102 @@
+// OpenAI-compatible deterministic mock. Reply is a pure function of the last
+// user message so specs can assert exact output end-to-end.
+import { createServer } from "node:http";
+
+const PORT = process.env.PORT || 8080;
+const MODELS = ["gpt-4o-mini", "gpt-4o", "text-embedding-3-small"];
+
+const reply = (messages) => {
+  const last = [...(messages ?? [])].reverse().find((m) => m.role === "user");
+  return `echo: ${typeof last?.content === "string" ? last.content : JSON.stringify(last?.content ?? "")}`;
+};
+
+const json = (res, code, body) => {
+  res.writeHead(code, { "Content-Type": "application/json" });
+  res.end(JSON.stringify(body));
+};
+
+createServer((req, res) => {
+  let raw = "";
+  req.on("data", (c) => {
+    raw += c;
+  });
+  req.on("error", (err) => {
+    console.error(`request aborted: ${err.message}`);
+    res.destroy();
+  });
+  req.on("end", () => {
+    let body;
+    try {
+      body = raw ? JSON.parse(raw) : {};
+    } catch {
+      body = null;
+    }
+    // Rejects bad syntax and valid-but-non-object JSON (`null`, `42`, `"x"`)
+    // alike: the route handlers read properties off `body` unguarded.
+    if (typeof body !== "object" || body === null) {
+      return json(res, 400, {
+        error: { message: "invalid JSON body", type: "invalid_request_error" },
+      });
+    }
+    const path = req.url.split("?")[0];
+    if (path === "/v1/models") {
+      return json(res, 200, {
+        object: "list",
+        data: MODELS.map((id) => ({ id, object: "model", owned_by: "e2e" })),
+      });
+    }
+    if (path === "/v1/chat/completions") {
+      const content = reply(body.messages);
+      const model = body.model ?? "gpt-4o-mini";
+      if (body.stream) {
+        res.writeHead(200, {
+          "Content-Type": "text/event-stream",
+          "Cache-Control": "no-cache",
+        });
+        const chunk = (delta, finish = null) =>
+          res.write(
+            `data: ${JSON.stringify({
+              id: "chatcmpl-e2e",
+              object: "chat.completion.chunk",
+              model,
+              choices: [{ index: 0, delta, finish_reason: finish }],
+            })}\n\n`,
+          );
+        chunk({ role: "assistant" });
+        // Zero-width split after whitespace: the deltas concatenate back to
+        // `content` byte-for-byte, so streamed and non-streamed output match.
+        for (const part of content.split(/(?<=\s)/)) chunk({ content: part });
+        chunk({}, "stop");
+        res.write("data: [DONE]\n\n");
+        return res.end();
+      }
+      return json(res, 200, {
+        id: "chatcmpl-e2e",
+        object: "chat.completion",
+        model,
+        choices: [
+          {
+            index: 0,
+            message: { role: "assistant", content },
+            finish_reason: "stop",
+          },
+        ],
+        usage: { prompt_tokens: 7, completion_tokens: 7, total_tokens: 14 },
+      });
+    }
+    if (path === "/v1/embeddings") {
+      const inputs = Array.isArray(body.input) ? body.input : [body.input];
+      return json(res, 200, {
+        object: "list",
+        model: body.model ?? "text-embedding-3-small",
+        data: inputs.map((_, index) => ({
+          object: "embedding",
+          index,
+          embedding: Array(8).fill(0.125),
+        })),
+        usage: { prompt_tokens: 1, total_tokens: 1 },
+      });
+    }
+    json(res, 404, { error: { message: `no route ${req.url}` } });
+  });
+}).listen(PORT, () => console.log(`mock-llm on :${PORT}`));


### PR DESCRIPTION
> **Stacked PR 1 of 4** — base is `feat/e2e-testing-setup`, which merges to `dev` once the stack lands.
> Review order: **1 (this)** → [2 harness] → [3 flows] → [4 CI + docs].
> Design docs: `internal-docs/e2e-testing-setup/` (`00-master-plan.md` for the decisions, `02-architecture.md` for the spec, `05-findings-log.md` for the product bugs this surfaced).

## Why

We want to ship faster without shipping regressions, and today nothing exercises the product end to end. The backend suite mocks at the service layer, the frontend suite runs in jsdom, and the ~130 puppeteer smokes in `frontend/scripts/api-journeys/browser/` are hand-rolled scripts pointed at one engineer's laptop, never wired into CI. Nothing checks that a user action produces the right backend state.

This PR is the foundation for that: a real stack, isolated, reproducible, and bootable by one command on a laptop or a CI runner.

## What

- **`e2e/stack/e2e.env` + `docker-compose.e2e.yml`** — the stack profile. Reuses the root `docker-compose.yml` with its own compose project (`futureagi-e2e`) and shifted ports (3100/8100/2xxxx), so it runs alongside your dev stack without collision. The overlay adds only what the E2E context needs: the mock LLM, a ClickHouse memory cap, `restart: "no"` so a crash-looping service fails loudly, and a decoupled fi-collector image tag.
- **`bin/e2e`** — the CLI: `up`, `down`, `build`, `test`, `ui`, `report`, `logs`, `ps`, `compose`.
- **`e2e/stack/mock-llm/server.mjs` + `gateway.e2e.yaml`** — an OpenAI-compatible mock behind the *real* gateway, so provider responses are deterministic while routing, streaming, and cost accounting still execute.

**PeerDB is included in the profile**, which the plan originally got wrong. Eval results, annotation scores, and several dashboards reach ClickHouse *only* through the CDC mirrors — Django writes eval results to Postgres alone, and `tracer_eval_logger_v2` has no writer at all. Without PeerDB those surfaces are permanently empty and per-span eval details 400.

### The readiness contract is the interesting part

`bin/e2e up` deliberately gates on more than `/health/`:

1. compose healthchecks (`up --wait`),
2. backend `/health/`,
3. **the ClickHouse schema directly** — the Django boot hook logs-and-continues when its schema apply fails, so `/health/` can pass with no tables,
4. frontend serving,
5. **`peerdb-init` exited 0 *and* its log has no `ERROR:` lines** — the mirror setup script prints `Done! All CDC mirrors configured` even when every mirror failed.

Two cold-boot hazards are handled explicitly, both found by actually booting from empty volumes:

- **Mirrors are created only after migrations finish.** `peerdb-init` has no dependency on the backend, so on fresh volumes it runs ~6 minutes before the tables it replicates exist, and every `CREATE MIRROR` fails.
- **Temporal search attributes are re-registered before every mirror attempt.** On fresh volumes the first registration reports success but does not take effect, and a mirror that fails once reports `MIRROR ALREADY EXISTS` forever after — unrecoverable without wiping volumes.

Two mirrors still fail on any fresh install because the ClickHouse DDL is behind the Postgres models (`model_hub_score`, `simulate_agent_definition`). Those are allowlisted as warnings, ticketed in `05-findings-log.md`, and the allowlist should be deleted when the DDL is fixed.

## Tests

No new automated tests — this is infrastructure, and per our testing standards infra changes are verified end to end rather than with new test files. The verification is the boot itself, and the specs in PRs 2–3 are its real regression test.

### Scenarios covered

| Scenario | Result |
|---|---|
| Cold boot from empty volumes (the CI path) | exit 0 in 4 min 54 s |
| Second boot with volumes intact | clean, faster |
| Runs beside a dev stack | no port collision; `docker compose ls` shows both |
| CDC mirrors actually created | 18 `_peerdb_raw_*` tables incl. `tracer_eval_logger` |
| Boot with broken CDC | **fails closed** — caught a real failure that printed "Done!" |
| Gateway → mock LLM | deterministic `echo:` response through the real gateway |
| Malformed mock input | 400, process survives (compose runs it `restart: "no"`) |

## Commands

```bash
bin/e2e up          # boot and wait for the readiness contract
bin/e2e ps          # 19 containers, project futureagi-e2e
bin/e2e down -v     # tear down, wiping volumes
```

## How to verify locally

```bash
git checkout test/e2e-stack-and-runner
bin/e2e down -v && bin/e2e up     # ~5 min on a warm image cache
curl -s http://localhost:8100/health/
curl -s http://localhost:3100/config.js        # VITE_HOST_API points at :8100
docker compose ls                              # your dev stack is untouched
bin/e2e down -v
```

## Evidence

Cold boot from empty volumes:

```
=== BOOT ===
Checking ClickHouse schema ...
E2E stack ready: app http://localhost:3100  api http://localhost:8100
WARN: known schema-drift mirrors failed (ticketed):
peerdb-init-1  | ERROR: ... field value_history not found in destination table model_hub_score
peerdb-init-1  | ERROR: ... field target_speaks_first not found in destination table simulate_agent_definition
bin/e2e up  4:54.62 total
=== BOOT EXIT: 0 ===
```

CDC mirrors present afterwards:

```
$ curl -sG http://localhost:28123/ --data-urlencode \
    "query=SELECT count() FROM system.tables WHERE name LIKE '_peerdb_raw%'"
18
```

The fail-closed check earning its place — an earlier boot, before the ordering fix:

```
peerdb-init-1 | ERROR: ... Namespace default has no mapping defined for search attribute MirrorName
peerdb-init exited 0 but reported errors (CDC mirrors missing)
```

That boot printed `Done! All CDC mirrors configured` and exited 0. Without this check we would have shipped a stack where every eval and annotation assertion silently returned nothing.

## Architectural rationale

**Why reuse the root compose instead of a dedicated E2E stack.** A separate definition drifts from what we ship the moment someone changes a service. Every port in the root compose is already an env var and every image is a tag var, so an env file plus a thin overlay gets isolation for free — the same side-by-side pattern `INSTALLATION.md` documents.

**Why a trimmed service list.** No `serving`, no `code-executor`, no per-queue workers: the single `TEMPORAL_ALL_QUEUES` worker covers every queue the flows use. That keeps the profile around 9–10 GB so it fits a free public-repo GitHub runner (4 vCPU / 16 GB).

**Why mock only the LLM.** It is the one dependency that is non-deterministic, rate-limited, and costs money per run. Mocking it at the provider HTTP boundary — behind our own gateway rather than in front of it — keeps routing, streaming, and cost accounting under test. This is the same arc LibreChat went through (HTTP mock first), and matches how Dify keeps its CI deterministic.

**Why the readiness contract is so paranoid.** Every check exists because a real failure mode was observed. A stack that looks healthy but silently has no CDC produces test failures that look like product bugs and product bugs that look like test flakes; failing the boot loudly is much cheaper than debugging that later.

## Reviewer notes

- The env file is `e2e/stack/e2e.env`, not `.env.e2e`, because the pre-commit safety check blocks anything matching `.env*` — correctly, since that guard exists to stop real local env files being committed. Renaming also means the shared root `.gitignore` needs no negation entry. It contains ports and profile flags, no secrets.
- The `KNOWN_DRIFTED_MIRRORS` allowlist in `bin/e2e` is deliberately narrow and should shrink to empty once the ClickHouse DDL catches up.
