### PR TITLE
docs(install): grep 'futureagi' in backup volume command (#2343)

### DIFF
--- a/INSTALLATION.md
+++ b/INSTALLATION.md
@@ -389,8 +389,8 @@ Named Docker volumes hold all state:
 docker volume ls | grep futureagi
 # futureagi_postgres-data
 # futureagi_clickhouse-data
-# future-agi_redis-data
-# future-agi_minio-data
+# futureagi_redis-data
+# futureagi_minio-data
 ```
 
 To back up Postgres:

--- a/INSTALLATION.md
+++ b/INSTALLATION.md
@@ -387,8 +387,8 @@ Named Docker volumes hold all state:
 
 ```bash
 docker volume ls | grep futureagi
-# future-agi_postgres-data
-# future-agi_clickhouse-data
+# futureagi_postgres-data
+# futureagi_clickhouse-data
 # future-agi_redis-data
 # future-agi_minio-data
 ```

--- a/INSTALLATION.md
+++ b/INSTALLATION.md
@@ -386,7 +386,7 @@ Backend migrations run automatically on startup. Downtime is ~30 seconds for the
 Named Docker volumes hold all state:
 
 ```bash
-docker volume ls | grep future-agi
+docker volume ls | grep futureagi
 # future-agi_postgres-data
 # future-agi_clickhouse-data
 # future-agi_redis-data


### PR DESCRIPTION
The Docker Compose project is `futureagi` (no hyphen), so the documented `docker volume ls | grep future-agi` matched nothing (verified against a running install — volumes are `futureagi_postgres-data` etc.). Fixed the grep and the four example volume names in INSTALLATION.md.