### PR TITLE
fix(frontend): bundle pdf.js worker locally instead of unpkg CDN (#2339)

### DIFF
--- a/frontend/src/components/PdfPreviewDrawer.jsx
+++ b/frontend/src/components/PdfPreviewDrawer.jsx
@@ -12,7 +12,7 @@ import { Viewer, Worker } from "@react-pdf-viewer/core";
 import { defaultLayoutPlugin } from "@react-pdf-viewer/default-layout";
 // pdfjs-dist is a pinned local dependency — bundle its worker instead of
 // loading it from the unpkg CDN (breaks offline self-host and CSP) (#2339).
-import pdfWorkerUrl from "pdfjs-dist/build/pdf.worker.min.mjs?url";
+import pdfWorkerUrl from "pdfjs-dist/build/pdf.worker.min.js?url";
 import { usePdfPreviewStoreShallow } from "src/utils/CommonStores/pdfPreviewStore";
 import Iconify from "./iconify";
 import SvgColor from "./svg-color";

--- a/frontend/src/components/PdfPreviewDrawer.jsx
+++ b/frontend/src/components/PdfPreviewDrawer.jsx
@@ -10,6 +10,9 @@ import { LoadingScreen } from "src/components/loading-screen";
 import React, { useState, useEffect, useRef } from "react";
 import { Viewer, Worker } from "@react-pdf-viewer/core";
 import { defaultLayoutPlugin } from "@react-pdf-viewer/default-layout";
+// pdfjs-dist is a pinned local dependency — bundle its worker instead of
+// loading it from the unpkg CDN (breaks offline self-host and CSP) (#2339).
+import pdfWorkerUrl from "pdfjs-dist/build/pdf.worker.min.mjs?url";
 import { usePdfPreviewStoreShallow } from "src/utils/CommonStores/pdfPreviewStore";
 import Iconify from "./iconify";
 import SvgColor from "./svg-color";
@@ -114,7 +117,7 @@ const PdfPreviewDrawer = () => {
       case "pdf":
         return (
           <Box sx={{ height: "100%", backgroundColor: "background.paper" }}>
-            <Worker workerUrl="https://unpkg.com/pdfjs-dist@3.11.174/build/pdf.worker.min.js">
+            <Worker workerUrl={pdfWorkerUrl}>
               <Viewer
                 fileUrl={fileUrl}
                 plugins={[defaultLayoutPluginInstance]}


### PR DESCRIPTION
PdfPreviewDrawer loaded the pdf.js worker from unpkg.com, breaking offline self-hosted installs and CSP. pdfjs-dist 3.11.174 is already a pinned local dependency — imported the worker via Vite `?url` so it ships in the bundle.