### PR TITLE
fix(install): always keep VITE_HOST_API in sync when BACKEND_PORT auto-switches (#2340)

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -460,11 +460,14 @@ for entry in "${PORTS_TO_CHECK[@]}"; do
     ok "  $var=$suggestion  written to .env"
     # Keep VITE_HOST_API in sync when BACKEND_PORT moves. The frontend
     # bundle bakes the URL at build time; if .env still has the old
-    # localhost:8000 default after we switch BACKEND_PORT, the bundle
-    # would call a port that's no longer ours.
-    if [[ "$var" == "BACKEND_PORT" ]] && \
-       grep -Eq '^VITE_HOST_API=https?://localhost:[0-9]+/?$' .env; then
-      sed_inplace -E "s|^VITE_HOST_API=.*|VITE_HOST_API=http://localhost:${suggestion}|" .env
+    # localhost:8000 default (or none at all) after we switch BACKEND_PORT,
+    # the bundle would call a port that's no longer ours (#2340).
+    if [[ "$var" == "BACKEND_PORT" ]]; then
+      if grep -q '^VITE_HOST_API=' .env; then
+        sed_inplace -E "s|^VITE_HOST_API=.*|VITE_HOST_API=http://localhost:${suggestion}|" .env
+      else
+        echo "VITE_HOST_API=http://localhost:${suggestion}" >> .env
+      fi
       ok "  VITE_HOST_API=http://localhost:${suggestion}  (kept in sync)"
     fi
   else


### PR DESCRIPTION
The sync only fired when VITE_HOST_API already matched the `^https?://localhost:[0-9]+$` shape, so an absent, empty, or differently formatted value was left stale after the port switch — the built frontend kept calling the old localhost:8000 and the UI was dead after a 'successful' install. The variable is now written (or appended) with the new port whenever BACKEND_PORT changes.