### PR TITLE
fix(tracer): persist failed-eval row on non-ValueError exceptions (#2334)

### DIFF
--- a/futureagi/tracer/utils/eval.py
+++ b/futureagi/tracer/utils/eval.py
@@ -1979,6 +1979,14 @@ def evaluate_observation_span(
         logger.exception(
             f"Exception during evaluation in evaluate_observation_span: {e}"
         )
+        # Non-ValueError failures must still leave a failed-eval row so the
+        # span is never left without an eval record (#2334).
+        try:
+            _create_error_eval_logger(
+                observation_span, custom_eval_config, eval_task_id, e
+            )
+        except Exception:
+            logger.exception("Failed to persist error eval logger")
         return False
 
 


### PR DESCRIPTION
evaluate_observation_span recorded a failed-eval row only on ValueError; any other exception logged and returned, leaving the span with no eval record at all. The generic except now persists an error eval logger (with the eval_task_id) just like the ValueError path.