### PR TITLE
fix(gateway): actually cancel the running job on DELETE /v1/async (#2335)

### DIFF
--- a/agentcc-gateway/internal/async/store.go
+++ b/agentcc-gateway/internal/async/store.go
@@ -140,6 +140,26 @@ func (s *Store) Update(id string, fn func(job *Job)) bool {
 	return true
 }
 
+// Cancel cancels a live job under the write lock, invoking its real CancelFn.
+// Returns false if the job was not found.
+func (s *Store) Cancel(id string) bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	job := s.jobs[id]
+	if job == nil {
+		return false
+	}
+	if job.Status == StatusQueued || job.Status == StatusProcessing {
+		now := time.Now()
+		job.Status = StatusCancelled
+		job.CompletedAt = &now
+		if job.CancelFn != nil {
+			job.CancelFn()
+		}
+	}
+	return true
+}
+
 // Delete removes a job.
 func (s *Store) Delete(id string) bool {
 	s.mu.Lock()

--- a/agentcc-gateway/internal/async/store_test.go
+++ b/agentcc-gateway/internal/async/store_test.go
@@ -118,3 +118,43 @@ func TestStore_Count(t *testing.T) {
 		t.Errorf("Count = %d, want 2", s.Count())
 	}
 }
+
+func TestStore_Cancel(t *testing.T) {
+	s := NewStore()
+
+	cancelled := false
+	s.Put(&Job{
+		ID:        "job-1",
+		Status:    StatusProcessing,
+		CreatedAt: time.Now(),
+		ExpiresAt: time.Now().Add(time.Hour),
+		CancelFn: func() {
+			cancelled = true
+		},
+	})
+
+	if !s.Cancel("job-1") {
+		t.Fatal("expected Cancel to return true for existing job")
+	}
+	if !cancelled {
+		t.Error("expected CancelFn to be invoked on the live job")
+	}
+
+	job := s.Get("job-1")
+	if job == nil {
+		t.Fatal("expected job to still exist after Cancel")
+	}
+	if job.Status != StatusCancelled {
+		t.Errorf("Status = %q, want %q", job.Status, StatusCancelled)
+	}
+	if job.CompletedAt == nil {
+		t.Error("expected CompletedAt to be set")
+	}
+	if job.CancelFn != nil {
+		t.Error("expected snapshot to keep CancelFn nil")
+	}
+
+	if s.Cancel("missing") {
+		t.Error("expected Cancel to return false for unknown job")
+	}
+}

--- a/agentcc-gateway/internal/server/handlers_async.go
+++ b/agentcc-gateway/internal/server/handlers_async.go
@@ -138,15 +138,10 @@ func (h *Handlers) DeleteAsyncJob(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Cancel if still running.
-	if job.Status == async.StatusQueued || job.Status == async.StatusProcessing {
-		now := time.Now()
-		job.Status = async.StatusCancelled
-		job.CompletedAt = &now
-		if job.CancelFn != nil {
-			job.CancelFn()
-		}
-	}
+	// Cancel if still running. Get() returns a snapshot whose CancelFn is
+	// deliberately stripped and whose mutations never touch the stored job,
+	// so cancel the REAL stored job under the write lock via Cancel() (#2335).
+	h.asyncStore.Cancel(jobID)
 
 	// Delete from store.
 	h.asyncStore.Delete(jobID)


### PR DESCRIPTION
DeleteAsyncJob used asyncStore.Get(), which returns a snapshot whose CancelFn is deliberately stripped (and whose mutations don't touch the stored job), so the cancel never fired and the goroutine kept running after the handler reported 'cancelled'. Mutate the real stored job under the write lock via asyncStore.Update() so CancelFn runs.