### PR TITLE
fix(docs): backup command greps futureagi not future-agi

### DIFF
--- a/INSTALLATION.md
+++ b/INSTALLATION.md
@@ -386,11 +386,11 @@ Backend migrations run automatically on startup. Downtime is ~30 seconds for the
 Named Docker volumes hold all state:
 
 ```bash
-docker volume ls | grep future-agi
-# future-agi_postgres-data
-# future-agi_clickhouse-data
-# future-agi_redis-data
-# future-agi_minio-data
+docker volume ls | grep futureagi
+# futureagi_postgres-data
+# futureagi_clickhouse-data
+# futureagi_redis-data
+# futureagi_minio-data
 ```
 
 To back up Postgres:


### PR DESCRIPTION
## Summary

The backup instructions in `INSTALLATION.md` grep for `future-agi` (with a hyphen), but the Docker Compose project name is pinned to `futureagi` (no hyphen) — see `docker-compose.yml:42` (`name: futureagi`). As a result, the documented command lists **no volumes**:

```bash
docker volume ls | grep future-agi   # matches nothing
```

The actual volumes are `futureagi_postgres-data`, `futureagi_clickhouse-data`, `futureagi_redis-data`, and `futureagi_minio-data`. A user following the docs sees an empty list and may wrongly conclude there is nothing to back up.

## What changed

In the **Backups** section of `INSTALLATION.md`:
- Changed the filter from `grep future-agi` to `grep futureagi`.
- Updated the four example volume names to the correct `futureagi_*` prefix.

This is a documentation-only change with no code or runtime impact. No regression test applies (there is no docs/markdown test harness in the repo, and the fix is a literal string correction).

## Verification

```bash
# Actual volumes on a running install
docker volume ls | grep futureagi
# futureagi_postgres-data
# futureagi_clickhouse-data
# futureagi_redis-data
# futureagi_minio-data
```

Closes #2343