### PR TITLE
feat: reconcile release tickets by state + fix discovery

### DIFF
--- a/.github/scripts/linear-release-done.mjs
+++ b/.github/scripts/linear-release-done.mjs
@@ -1,15 +1,22 @@
 #!/usr/bin/env node
-// Auto-move Linear tickets to Done on a platform release.
+// Reconcile Linear tickets against a platform release.
 //
-// When a stable release tag (vX.Y.Z) lands on main, find every Linear ticket
-// shipped in the release, move it to its team's Done state, comment the release
-// link on it, and post a Slack summary.
+// When a stable release tag (vX.Y.Z) lands on main, find every Tech (TH-) ticket
+// shipped in the release and act on it by its current state:
+//   • "Ready to Merge"        → move to Done + comment the release link (auto-close)
+//   • any other in-flight state (In Review / In Progress / Todo / …)
+//                             → do NOT close; comment on the ticket AND ping the
+//                               owner on Slack (or #tech if unassigned) to close it
+//   • terminal / not-in-flight (Done, Canceled, Backlog, Icebox, Triage, On hold)
+//                             → skip
+// Finally, post a summary to Slack.
 //
-// Ticket discovery: read the GitHub Release body (the release-please changelog),
-// collect the PRs in the release, pull each PR's title + body, and extract
-// Tech (TH-) identifiers. One PR can reference several tickets, so every textual
-// reference counts. Branch names are intentionally NOT used — the repo
-// convention (type/short-description) carries no ticket id.
+// Ticket discovery: diff the previous stable tag against this one, harvest PR
+// numbers from the commit messages (squash `(#123)` and `Merge pull request #123`),
+// and union TH- ids from the release body, commit messages, and each PR's title +
+// body — so a ticket referenced only in a PR description is still caught, and one
+// PR can close several tickets. Branch names are NOT used (repo convention
+// `type/short-description` carries no ticket id).
 //
 // Scope: Tech team only. Customer (CSR-) tickets are intentionally left alone.
 //
@@ -18,8 +25,11 @@
 //   GITHUB_TOKEN       default Actions token (read releases/PRs/commits)
 //   GITHUB_REPOSITORY  owner/repo (e.g. future-agi/future-agi)
 //   VERSION            release tag, e.g. v1.23.0
-//   RELEASE_URL        link to the release (used in the Linear comment)
-//   SLACK_WEBHOOK_URL  optional; a summary is posted here when set
+//   RELEASE_URL        link to the release (used in comments/messages)
+//   SLACK_BOT_TOKEN    bot token (chat:write, users:read.email, im:write) — needed
+//                      for owner DMs, the #tech fallback, and the summary
+//   SLACK_TECH_CHANNEL channel id for unassigned nudges + the summary (e.g. C06...)
+//   SLACK_WEBHOOK_URL  optional summary fallback when SLACK_BOT_TOKEN is unset
 //   DRY_RUN            "true" → log intended writes only, change nothing
 
 const {
@@ -28,6 +38,8 @@ const {
   GITHUB_REPOSITORY,
   VERSION,
   RELEASE_URL,
+  SLACK_BOT_TOKEN,
+  SLACK_TECH_CHANNEL,
   SLACK_WEBHOOK_URL,
   DRY_RUN,
 } = process.env
@@ -44,9 +56,12 @@ const DRY = DRY_RUN === 'true'
 const TEAM_PREFIXES = ['TH']
 const ID_RE = new RegExp(`\\b(${TEAM_PREFIXES.join('|')})-\\d+\\b`, 'gi')
 
-// State types we never move away from — already terminal, or not real in-flight
-// work. Guards against "resurrecting" a ticket a PR merely name-drops.
+// State whose tickets are auto-closed to Done (clearly shipped + approved).
+const CLOSE_STATES = new Set(['Ready to Merge'])
+// Never act on these — terminal, or explicitly not in-flight. Everything that is
+// neither a CLOSE_STATE nor skipped is treated as "in flight" → nudge the owner.
 const SKIP_TYPES = new Set(['completed', 'canceled', 'duplicate', 'triage', 'backlog'])
+const SKIP_STATE_NAMES = new Set(['On hold'])
 
 const CONCURRENCY = 8
 
@@ -71,7 +86,10 @@ async function resolveIssue(identifier) {
       issue(id: $id) {
         id
         identifier
+        title
+        url
         state { id name type }
+        assignee { email displayName }
         team { key states { nodes { id name type } } }
       }
     }
@@ -83,12 +101,16 @@ async function resolveIssue(identifier) {
     states.find(s => s.type === 'completed' && s.name === 'Done') ??
     states.find(s => s.type === 'completed')
   return {
-    id:          issue.id,
-    identifier:  issue.identifier,
-    stateName:   issue.state?.name ?? '(unknown)',
-    stateType:   issue.state?.type ?? '(unknown)',
-    doneStateId: done?.id ?? null,
-    doneName:    done?.name ?? null,
+    id:            issue.id,
+    identifier:    issue.identifier,
+    title:         issue.title ?? '',
+    url:           issue.url ?? '',
+    stateName:     issue.state?.name ?? '(unknown)',
+    stateType:     issue.state?.type ?? '(unknown)',
+    assigneeEmail: issue.assignee?.email ?? null,
+    assigneeName:  issue.assignee?.displayName ?? null,
+    doneStateId:   done?.id ?? null,
+    doneName:      done?.name ?? null,
   }
 }
 
@@ -137,8 +159,6 @@ async function getPrText(number) {
   return `${pr.title ?? ''}\n${pr.body ?? ''}`
 }
 
-// Fallback when the release body has no PR references: diff the previous stable
-// tag against this one and read PR numbers out of the commit subjects.
 async function previousStableTag(version) {
   const tags = await gh(`/repos/${OWNER}/${REPO}/tags?per_page=100`)
   const stable = (tags ?? [])
@@ -149,11 +169,10 @@ async function previousStableTag(version) {
   return idx >= 0 && idx + 1 < stable.length ? stable[idx + 1] : null
 }
 
-// Diff the previous stable tag against this one and harvest, from every commit
-// message: PR numbers (both squash `(#123)` and merge `Merge pull request #123`
-// forms — we just match any `#123`) and any ticket ids in the subject/body.
-// release-please writes commit-SHA links rather than PR refs in the release
-// body, so this compare — not the body — is the reliable source of PRs.
+// Diff the previous stable tag against this one and harvest PR numbers and ticket
+// ids from every commit message. release-please writes commit-SHA links (not PR
+// refs) into the release body, so this compare — not the body — is the reliable
+// source of PRs.
 async function compareData(version) {
   const prev = await previousStableTag(version)
   if (!prev) return { prev: null, prNumbers: [], ids: new Set() }
@@ -194,28 +213,74 @@ async function mapWithConcurrency(items, limit, fn) {
   return results
 }
 
+function firstName(name) { return (name ?? '').trim().split(/\s+/)[0] || 'there' }
 function log(...a) { console.log(...a) }
 function die(msg) { console.error(`[linear-release-done] ERROR: ${msg}`); process.exit(1) }
 
 // ── Slack ─────────────────────────────────────────────────────────────────────
 
-async function postSlack({ moved, skipped, notFound }) {
-  if (!SLACK_WEBHOOK_URL) { log('SLACK_WEBHOOK_URL not set — skipping Slack summary'); return }
+async function slackApi(method, payload) {
+  const res = await fetch(`https://slack.com/api/${method}`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json; charset=utf-8', Authorization: `Bearer ${SLACK_BOT_TOKEN}` },
+    body: JSON.stringify(payload),
+  })
+  const json = await res.json()
+  if (!json.ok) throw new Error(`Slack ${method} failed: ${json.error}`)
+  return json
+}
+
+async function lookupSlackUserId(email) {
+  if (!email) return null
+  const res = await fetch(`https://slack.com/api/users.lookupByEmail?email=${encodeURIComponent(email)}`, {
+    headers: { Authorization: `Bearer ${SLACK_BOT_TOKEN}` },
+  })
+  const json = await res.json()
+  return json.ok ? json.user.id : null
+}
+
+async function slackPost(channel, text) {
+  if (!channel) return
+  if (DRY) { log(`  [dry] slack → ${channel}: ${text}`); return }
+  await slackApi('chat.postMessage', { channel, text })
+}
+
+// Nudge the owner (DM) about a shipped-but-open ticket; fall back to #tech when
+// the ticket is unassigned or the owner can't be resolved on Slack.
+async function nudgeOnSlack(issue) {
+  if (!SLACK_BOT_TOKEN) { log(`  ⚠  SLACK_BOT_TOKEN unset — cannot Slack-nudge ${issue.identifier}`); return 'no-slack' }
+  const owner = issue.assigneeEmail ? await lookupSlackUserId(issue.assigneeEmail).catch(() => null) : null
+  if (owner) {
+    await slackPost(owner, `Hi ${firstName(issue.assigneeName)} — Linear ticket ${issue.identifier} ("${issue.title}") shipped in release ${VERSION} but is still "${issue.stateName}". If it's complete, please close it in Linear. ${issue.url}`)
+    return 'owner'
+  }
+  if (SLACK_TECH_CHANNEL) {
+    const who = issue.assigneeEmail ? `(owner ${issue.assigneeEmail} not found on Slack)` : '(unassigned)'
+    await slackPost(SLACK_TECH_CHANNEL, `Ticket ${issue.identifier} ("${issue.title}") ${who} shipped in release ${VERSION} but is still "${issue.stateName}" — if it's yours and complete, please move it to Done. ${issue.url}`)
+    return 'tech'
+  }
+  log(`  ⚠  no Slack target for ${issue.identifier} (unassigned and SLACK_TECH_CHANNEL unset)`)
+  return 'no-target'
+}
+
+async function postSummary({ moved, nudged, skipped, notFound }) {
   const relLink = RELEASE_URL ? `<${RELEASE_URL}|${VERSION}>` : VERSION
   const lines = [
     `${DRY ? '🧪 *[DRY RUN]* ' : '🚀 '}*Release ${relLink}* — Linear sync`,
-    moved.length ? `✅ *Moved to Done (${moved.length}):* ${moved.map(m => m.identifier).join(', ')}` : '✅ *Moved to Done:* none',
+    moved.length ? `✅ *Closed (${moved.length}):* ${moved.map(m => m.identifier).join(', ')}` : '✅ *Closed:* none',
   ]
+  if (nudged.length)   lines.push(`📣 *Nudged to close (${nudged.length}):* ${nudged.map(n => `${n.identifier}→${n.via}`).join(', ')}`)
   if (skipped.length)  lines.push(`⏭️ *Skipped (${skipped.length}):* ${skipped.map(s => `${s.identifier} (${s.reason})`).join(', ')}`)
   if (notFound.length) lines.push(`❓ *Not found (${notFound.length}):* ${notFound.join(', ')}`)
   const text = lines.join('\n')
-  if (DRY) { log('[dry] would post to Slack:\n' + text); return }
-  const res = await fetch(SLACK_WEBHOOK_URL, {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ text }),
-  })
-  if (!res.ok) log(`⚠  Slack post failed: ${res.status} ${await res.text()}`)
+  if (DRY) { log('[dry] would post summary to Slack:\n' + text); return }
+  if (SLACK_BOT_TOKEN && SLACK_TECH_CHANNEL) { await slackPost(SLACK_TECH_CHANNEL, text); return }
+  if (SLACK_WEBHOOK_URL) {
+    const res = await fetch(SLACK_WEBHOOK_URL, { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ text }) })
+    if (!res.ok) log(`⚠  Slack summary failed: ${res.status} ${await res.text()}`)
+    return
+  }
+  log('No Slack target configured — skipping summary')
 }
 
 // ── Main ──────────────────────────────────────────────────────────────────────
@@ -223,11 +288,9 @@ async function postSlack({ moved, skipped, notFound }) {
 async function main() {
   log(`[linear-release-done] ${VERSION}${DRY ? ' (dry run)' : ''} on ${GITHUB_REPOSITORY}`)
 
-  // PR numbers come from the tag compare (reliable) plus any that happen to be
-  // written into the release body. Ids are unioned from four sources so a ticket
-  // referenced in ANY of them is caught: release body text, commit messages,
-  // and each PR's title + body (the last covers ids that live only in the PR
-  // description — the "one PR closes several tickets" case).
+  // PR numbers from the tag compare (reliable) plus any written into the release
+  // body. Ids unioned from release body, commit messages, and each PR's title +
+  // body so a ticket referenced in ANY of them is caught.
   const body = await getReleaseBody(VERSION)
   const { prev, prNumbers: cmpPrNumbers, ids: cmpIds } = await compareData(VERSION)
 
@@ -242,28 +305,40 @@ async function main() {
   const identifiers = [...ids].sort()
   log(`[linear-release-done] ${identifiers.length} ticket reference(s): ${identifiers.join(', ') || '(none)'}`)
 
-  const moved = [], skipped = [], notFound = []
+  const moved = [], nudged = [], skipped = [], notFound = []
 
   await mapWithConcurrency(identifiers, CONCURRENCY, async (identifier) => {
     const issue = await resolveIssue(identifier)
     if (!issue) { log(`  ❓ ${identifier}: not found in Linear`); notFound.push(identifier); return }
-    if (SKIP_TYPES.has(issue.stateType)) {
+
+    // Skip terminal / not-in-flight states.
+    if (SKIP_TYPES.has(issue.stateType) || SKIP_STATE_NAMES.has(issue.stateName)) {
       log(`  ⏭️  ${issue.identifier}: in "${issue.stateName}" — skipped`)
       skipped.push({ identifier: issue.identifier, reason: issue.stateName }); return
     }
-    if (!issue.doneStateId) {
-      log(`  ⚠  ${issue.identifier}: team has no completed/Done state — skipped`)
-      skipped.push({ identifier: issue.identifier, reason: 'no Done state' }); return
+
+    // Auto-close the states that mean "shipped + approved".
+    if (CLOSE_STATES.has(issue.stateName)) {
+      if (!issue.doneStateId) {
+        log(`  ⚠  ${issue.identifier}: team has no Done state — skipped`)
+        skipped.push({ identifier: issue.identifier, reason: 'no Done state' }); return
+      }
+      const ok = await moveIssueToDone(issue)
+      if (!ok) { skipped.push({ identifier: issue.identifier, reason: 'update failed' }); return }
+      await commentOnIssue(issue, `Shipped in [${VERSION}](${RELEASE_URL || ''}). Auto-closed by the release ticket-sync.`)
+      log(`  ✅ ${issue.identifier}: ${issue.stateName} → ${issue.doneName}`)
+      moved.push({ identifier: issue.identifier }); return
     }
-    const ok = await moveIssueToDone(issue)
-    if (!ok) { skipped.push({ identifier: issue.identifier, reason: 'update failed' }); return }
-    await commentOnIssue(issue, `Shipped in [${VERSION}](${RELEASE_URL || ''}).`)
-    log(`  ✅ ${issue.identifier}: ${issue.stateName} → ${issue.doneName}`)
-    moved.push({ identifier: issue.identifier })
+
+    // In-flight but not "Ready to Merge": don't close — comment + Slack the owner.
+    await commentOnIssue(issue, `Shipped in [${VERSION}](${RELEASE_URL || ''}) but this ticket is still in "${issue.stateName}". If the work is complete, please move it to Done — it wasn't auto-closed because it wasn't in "Ready to Merge".`)
+    const via = await nudgeOnSlack(issue)
+    log(`  📣 ${issue.identifier}: in "${issue.stateName}" — nudged (${via})`)
+    nudged.push({ identifier: issue.identifier, via })
   })
 
-  log(`[linear-release-done] done — moved ${moved.length}, skipped ${skipped.length}, not-found ${notFound.length}`)
-  await postSlack({ moved, skipped, notFound })
+  log(`[linear-release-done] done — closed ${moved.length}, nudged ${nudged.length}, skipped ${skipped.length}, not-found ${notFound.length}`)
+  await postSummary({ moved, nudged, skipped, notFound })
 }
 
 main().catch(err => { console.error('[linear-release-done] fatal:', err); process.exit(1) })

--- a/.github/scripts/linear-release-done.mjs
+++ b/.github/scripts/linear-release-done.mjs
@@ -162,7 +162,10 @@ async function compareData(version) {
   const ids = new Set()
   for (const c of cmp?.commits ?? []) {
     const msg = c.commit?.message ?? ''
-    for (const m of msg.matchAll(/#(\d+)/g)) prNumbers.add(Number(m[1]))
+    // Only the two real merge formats — squash `(#123)` and merge-commit
+    // `Merge pull request #123` — so stray `#123` mentions in prose don't drag
+    // unrelated PRs (and their tickets) into the release.
+    for (const m of msg.matchAll(/(?:\(#|Merge pull request #)(\d+)/g)) prNumbers.add(Number(m[1]))
     for (const id of extractIds(msg)) ids.add(id)
   }
   return { prev, prNumbers: [...prNumbers], ids }

--- a/.github/scripts/linear-release-done.mjs
+++ b/.github/scripts/linear-release-done.mjs
@@ -149,15 +149,23 @@ async function previousStableTag(version) {
   return idx >= 0 && idx + 1 < stable.length ? stable[idx + 1] : null
 }
 
-async function prNumbersFromCompare(version) {
+// Diff the previous stable tag against this one and harvest, from every commit
+// message: PR numbers (both squash `(#123)` and merge `Merge pull request #123`
+// forms — we just match any `#123`) and any ticket ids in the subject/body.
+// release-please writes commit-SHA links rather than PR refs in the release
+// body, so this compare — not the body — is the reliable source of PRs.
+async function compareData(version) {
   const prev = await previousStableTag(version)
-  if (!prev) return []
+  if (!prev) return { prev: null, prNumbers: [], ids: new Set() }
   const cmp = await gh(`/repos/${OWNER}/${REPO}/compare/${prev}...${version}`)
-  const nums = new Set()
+  const prNumbers = new Set()
+  const ids = new Set()
   for (const c of cmp?.commits ?? []) {
-    for (const m of (c.commit?.message ?? '').matchAll(/\(#(\d+)\)/g)) nums.add(Number(m[1]))
+    const msg = c.commit?.message ?? ''
+    for (const m of msg.matchAll(/#(\d+)/g)) prNumbers.add(Number(m[1]))
+    for (const id of extractIds(msg)) ids.add(id)
   }
-  return [...nums]
+  return { prev, prNumbers: [...prNumbers], ids }
 }
 
 // ── Helpers ─────────────────────────────────────────────────────────────────
@@ -212,18 +220,19 @@ async function postSlack({ moved, skipped, notFound }) {
 async function main() {
   log(`[linear-release-done] ${VERSION}${DRY ? ' (dry run)' : ''} on ${GITHUB_REPOSITORY}`)
 
+  // PR numbers come from the tag compare (reliable) plus any that happen to be
+  // written into the release body. Ids are unioned from four sources so a ticket
+  // referenced in ANY of them is caught: release body text, commit messages,
+  // and each PR's title + body (the last covers ids that live only in the PR
+  // description — the "one PR closes several tickets" case).
   const body = await getReleaseBody(VERSION)
-  const prNumbers = new Set()
+  const { prev, prNumbers: cmpPrNumbers, ids: cmpIds } = await compareData(VERSION)
+
+  const prNumbers = new Set(cmpPrNumbers)
   for (const m of body.matchAll(/#(\d+)/g)) prNumbers.add(Number(m[1]))
+  log(`[linear-release-done] ${prNumbers.size} PR(s) since ${prev ?? '(no previous tag)'}`)
 
-  if (prNumbers.size === 0) {
-    log('no PR references in release body — falling back to tag compare')
-    for (const n of await prNumbersFromCompare(VERSION)) prNumbers.add(n)
-  }
-  log(`[linear-release-done] ${prNumbers.size} PR(s) in release`)
-
-  // Union of ids found directly in the release body + each PR's title/body.
-  const ids = extractIds(body)
+  const ids = new Set([...extractIds(body), ...cmpIds])
   const prTexts = await mapWithConcurrency([...prNumbers], CONCURRENCY, getPrText)
   for (const t of prTexts) for (const id of extractIds(t)) ids.add(id)
 

--- a/.github/workflows/linear-release-done.yml
+++ b/.github/workflows/linear-release-done.yml
@@ -1,6 +1,7 @@
-# On a stable platform release (vX.Y.Z tag — the dev→main promotion), move every
-# Linear ticket shipped in the release to Done, comment the release link on each,
-# and post a Slack summary. Mirrors the trigger used by release-images.yml.
+# On a stable platform release (vX.Y.Z tag — the dev→main promotion), reconcile
+# Tech (TH-) Linear tickets shipped in the release: auto-close "Ready to Merge"
+# ones to Done, nudge the owner (or #tech if unassigned) for still-in-flight
+# ones, and post a Slack summary. Mirrors the trigger used by release-images.yml.
 name: linear-release-done
 
 on:
@@ -13,7 +14,7 @@ on:
         required: true
         type: string
       dry_run:
-        description: 'Log intended changes without writing to Linear'
+        description: 'Log intended changes without writing to Linear/Slack'
         required: false
         default: true
         type: boolean
@@ -42,10 +43,12 @@ jobs:
           sparse-checkout: .github/scripts
           sparse-checkout-cone-mode: false
 
-      - name: Move shipped Linear tickets to Done
+      - name: Reconcile shipped Linear tickets
         env:
           LINEAR_API_KEY: ${{ secrets.LINEAR_API_KEY }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+          SLACK_TECH_CHANNEL: ${{ vars.SLACK_TECH_CHANNEL || 'C06UJCJ3NQZ' }}
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
           GITHUB_REPOSITORY: ${{ github.repository }}
           VERSION: ${{ github.event.inputs.version || github.ref_name }}


### PR DESCRIPTION
## What
Two changes to the release ticket-sync tool (script shipped in #2322):
1. **Fix discovery** so it finds all PRs in a release (not just squash-style refs).
2. **Reconcile by state** instead of force-closing every non-terminal ticket, and Slack-nudge owners for in-flight ones.

## 1 — Discovery fix (found by checking v1.29.1 / v1.30.0)
- release-please writes **commit-SHA links** into the release body, not `(#123)` PR refs.
- The old fallback matched only `(#123)`, missing **merge-commit** PRs (`Merge pull request #123`). On v1.30.0 the live run saw **1 PR / 0 tickets** and moved nothing, while the release actually shipped ~22 Tech tickets.
- Now: diff `prevTag..thisTag`; harvest PR numbers from squash + merge formats; union ticket ids from release body + commit messages + each PR's title/body. Tightened so stray `#123` in prose can't drag in unrelated tickets.

## 2 — Reconcile by state (+ owner nudges)
- `Ready to Merge` → move to **Done** + comment (auto-close).
- Other in-flight states (`In Review`/`In Progress`/`Todo`/…) → **do not close**; comment on the ticket and **Slack the owner** (`users.lookupByEmail` → DM), falling back to **#tech** (`SLACK_TECH_CHANNEL`) when unassigned or the owner isn't on Slack.
- Terminal / `On hold` / `Backlog` / `Icebox` / `Triage` → skip.
- Prevents auto-closing tickets that shipped code but aren't actually done (e.g. the on-hold parent SOS incident TH-7247).

## New config (must be added — see checklist)
- **`SLACK_BOT_TOKEN`** secret — scopes `chat:write`, `users:read.email`, `im:write`.
- **`SLACK_TECH_CHANNEL`** — repo variable (defaults to `#tech` = `C06UJCJ3NQZ` in the workflow).

## Verified
- Discovery: v1.29.1 sees `#2276/#2308/#2309/#2310`; v1.30.0 sees 29 PRs / 22 tickets; v1.29.0 unchanged (3). `node --check` ✓.
- Reconcile logic dry-run on v1.30.0: 12 close / 7 nudge / 3 skip, `not-found: 0`.

## Checklist before merge
- [ ] Update the workflow file to pass `SLACK_BOT_TOKEN` + `SLACK_TECH_CHANNEL` env (guardrail-protected — added by a human; content ready).
- [ ] Add the `SLACK_BOT_TOKEN` secret with the scopes above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
