### PR TITLE
feat(observe): add a free-text search box to the traces toolbar

### DIFF
--- a/api_contracts/openapi/swagger.json
+++ b/api_contracts/openapi/swagger.json
@@ -63161,6 +63161,12 @@
                         "in": "query",
                         "required": false,
                         "type": "string"
+                    },
+                    {
+                        "name": "search",
+                        "in": "query",
+                        "required": false,
+                        "type": "string"
                     }
                 ],
                 "responses": {

--- a/frontend/src/api/contracts/openapi-contract.generated.js
+++ b/frontend/src/api/contracts/openapi-contract.generated.js
@@ -36089,6 +36089,12 @@ export const OPENAPI_CONTRACT = Object.freeze({
             "schema": {
               "type": "string"
             }
+          },
+          "search": {
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
           }
         },
         "responses": {

--- a/frontend/src/generated/api-contracts/api.schemas.ts
+++ b/frontend/src/generated/api-contracts/api.schemas.ts
@@ -27544,6 +27544,7 @@ page_number?: number;
  */
 page_size?: number;
 interval?: string;
+search?: string;
 };
 
 export type TracerTraceListVoiceCallsParams = {

--- a/frontend/src/generated/api-contracts/api.zod.ts
+++ b/frontend/src/generated/api-contracts/api.zod.ts
@@ -42714,7 +42714,8 @@ export const TracerTraceListTracesOfSessionQueryParams = zod.object({
   "filters": zod.string().min(1).default(tracerTraceListTracesOfSessionQueryFiltersDefault),
   "page_number": zod.number().min(tracerTraceListTracesOfSessionQueryPageNumberMin).default(tracerTraceListTracesOfSessionQueryPageNumberDefault),
   "page_size": zod.number().min(1).max(tracerTraceListTracesOfSessionQueryPageSizeMax).default(tracerTraceListTracesOfSessionQueryPageSizeDefault),
-  "interval": zod.string().optional()
+  "interval": zod.string().optional(),
+  "search": zod.string().optional()
 })
 
 

--- a/frontend/src/sections/projects/LLMTracing/FilterChips.jsx
+++ b/frontend/src/sections/projects/LLMTracing/FilterChips.jsx
@@ -75,6 +75,8 @@ const FilterChips = ({
   onAddFilter,
   onChipClick,
   fieldLabelMap,
+  searchTerm,
+  onRemoveSearch,
 }) => {
   const chips = useMemo(
     () =>
@@ -88,7 +90,7 @@ const FilterChips = ({
     [extraFilters, fieldLabelMap],
   );
 
-  if (chips.length === 0) return null;
+  if (chips.length === 0 && !searchTerm) return null;
 
   return (
     <Box
@@ -121,6 +123,30 @@ const FilterChips = ({
           overflow: "hidden",
         }}
       >
+        {searchTerm && (
+          <Tooltip title={`Search contains ${searchTerm}`} placement="top">
+            <Chip
+              size="small"
+              variant="outlined"
+              data-filter-chip-column="search"
+              onDelete={onRemoveSearch}
+              label={
+                <Box sx={{ display: "flex", alignItems: "center", gap: 0.5 }}>
+                  <Typography variant="caption" color="text.secondary">
+                    Search
+                  </Typography>
+                  <Typography variant="caption" color="text.secondary">
+                    contains
+                  </Typography>
+                  <Typography variant="caption" fontWeight={600}>
+                    {searchTerm}
+                  </Typography>
+                </Box>
+              }
+              sx={{ maxWidth: 260 }}
+            />
+          </Tooltip>
+        )}
         {chips.map((chip) => (
           <Tooltip
             key={chip._idx}
@@ -318,6 +344,10 @@ FilterChips.propTypes = {
   // { [columnId]: { [value]: label } } — resolves chip display labels for
   // enum-like fields (e.g. Project UUID → project name).
   fieldLabelMap: PropTypes.object,
+  // Applied free-text search term — renders as a removable chip ahead of
+  // the field filters.
+  searchTerm: PropTypes.string,
+  onRemoveSearch: PropTypes.func,
 };
 
 export default React.memo(FilterChips);

--- a/frontend/src/sections/projects/LLMTracing/LLMTracingView.jsx
+++ b/frontend/src/sections/projects/LLMTracing/LLMTracingView.jsx
@@ -689,6 +689,8 @@ const LLMTracingView = ({ mode = "project", userIdForUserMode = null }) => {
   const [openCustomColumn, setOpenCustomColumn] = useState(false);
   const [extraFilters, setExtraFiltersRaw] = useState([]);
   const [compareExtraFilters, setCompareExtraFiltersRaw] = useState([]);
+  // Applied free-text search over the trace list (name/input/output).
+  const [traceSearch, setTraceSearch] = useState("");
   const [filterChipsSaved, setFilterChipsSaved] = useState(false);
   // Track which graph the filter panel targets in compare mode: "primary" | "compare"
   const [filterTarget, setFilterTarget] = useState("primary");
@@ -2082,6 +2084,7 @@ const LLMTracingView = ({ mode = "project", userIdForUserMode = null }) => {
     setExtraFilters(
       hydrateStoredFilterList(activeViewConfig.extra_filters, getRandomId),
     );
+    setTraceSearch(activeViewConfig.display?.search ?? "");
 
     // Compare state — always replace, regardless of current showCompare state.
     const nextCompareFilters = hydrateStoredFilterList(
@@ -2242,6 +2245,7 @@ const LLMTracingView = ({ mode = "project", userIdForUserMode = null }) => {
   // `filtersStorageKey` restores any non-empty extraFilters it finds.
   const clearPrimaryExtraFilters = useCallback(() => {
     setExtraFilters([]);
+    setTraceSearch("");
     localStorage.removeItem(filtersStorageKey);
   }, [setExtraFilters, filtersStorageKey]);
   const clearCompareExtraFilters = useCallback(() => {
@@ -2332,6 +2336,9 @@ const LLMTracingView = ({ mode = "project", userIdForUserMode = null }) => {
           setExtraFiltersRaw(extraFiltersWithIds);
           setFilterChipsSaved(true);
         }
+      }
+      if (saved.search) {
+        setTraceSearch(saved.search);
       }
       if (saved.showCompare) {
         if (saved.compare_filters?.length > 0) {
@@ -2436,6 +2443,8 @@ const LLMTracingView = ({ mode = "project", userIdForUserMode = null }) => {
         selectedTab === "trace"
           ? primaryTraceDateFilter
           : primarySpanDateFilter,
+      // search rides inside display for the same whitelist reason.
+      ...(traceSearch ? { search: traceSearch } : {}),
       ...(columnState ? { columnState } : {}),
     };
     const mapFilters = (filters) =>
@@ -2480,6 +2489,7 @@ const LLMTracingView = ({ mode = "project", userIdForUserMode = null }) => {
     compareSpansDateFilter,
     extraFilters,
     compareExtraFilters,
+    traceSearch,
     projectSource,
     columns,
     columnKey,
@@ -2579,6 +2589,7 @@ const LLMTracingView = ({ mode = "project", userIdForUserMode = null }) => {
     setCellHeight(DEFAULT_DISPLAY_CONFIG.cellHeight);
     setShowErrors(DEFAULT_DISPLAY_CONFIG.showErrors);
     setShowNonAnnotated(DEFAULT_DISPLAY_CONFIG.showNonAnnotated);
+    setTraceSearch("");
     // Remove custom columns
     const ck = `${selectedGraph}-${selectedTab === "spans" ? "spans" : "trace"}`;
     setColumns((prev) => ({
@@ -2677,6 +2688,8 @@ const LLMTracingView = ({ mode = "project", userIdForUserMode = null }) => {
 
     if (!filtersContentEqual(extraFilters, baselineExtraFilters)) return true;
 
+    if ((baselineDisplay.search ?? "") !== traceSearch) return true;
+
     const currentDate =
       viewTabType === "trace" ? primaryTraceDateFilter : primarySpanDateFilter;
     if ((currentDate?.dateOption ?? null) !== baselineDateOption) return true;
@@ -2750,6 +2763,7 @@ const LLMTracingView = ({ mode = "project", userIdForUserMode = null }) => {
   }, [
     activeViewConfig,
     extraFilters,
+    traceSearch,
     selectedTab,
     primaryTraceDateFilter,
     primarySpanDateFilter,
@@ -3142,8 +3156,10 @@ const LLMTracingView = ({ mode = "project", userIdForUserMode = null }) => {
         </Box>
       </Box>
       {/* Active filter chips — in compare mode, only show Clear/Save at top (chips are inline on each graph) */}
-      {!filterChipsSaved && !showCompare && (
+      {(!filterChipsSaved || !!traceSearch) && !showCompare && (
         <FilterChips
+          searchTerm={traceSearch}
+          onRemoveSearch={() => setTraceSearch("")}
           extraFilters={extraFilters.map((f) => ({
             ...f,
             display_name:
@@ -3162,6 +3178,7 @@ const LLMTracingView = ({ mode = "project", userIdForUserMode = null }) => {
           onClearAll={() => {
             setExternalFilterAnchor(null);
             setExtraFilters([]);
+            setTraceSearch("");
             try {
               localStorage.removeItem(filtersStorageKey);
             } catch {
@@ -3202,6 +3219,7 @@ const LLMTracingView = ({ mode = "project", userIdForUserMode = null }) => {
                         : primarySpanFilters,
                     ),
                     extra_filters: extraFilters || [],
+                    ...(traceSearch ? { search: traceSearch } : {}),
                   }),
                 );
               } catch {
@@ -3666,6 +3684,8 @@ const LLMTracingView = ({ mode = "project", userIdForUserMode = null }) => {
                 setIsPrimaryFilterOpen(!isPrimaryFilterOpen);
               }}
               onApplyExtraFilters={setExtraFilters}
+              searchTerm={traceSearch}
+              onSearchApply={setTraceSearch}
               onClearExtraFilters={clearPrimaryExtraFilters}
               graphFilters={selectPanelGraphFilters(
                 filterTarget,
@@ -4587,6 +4607,7 @@ const LLMTracingView = ({ mode = "project", userIdForUserMode = null }) => {
                     }
                     filters={primaryTraceValidatedFilters}
                     extraFilters={extraFilters}
+                    search={showCompare ? "" : traceSearch}
                     ref={primaryTraceGridRef}
                     setFilters={setPrimaryTraceFilters}
                     setExtraFilters={setExtraFilters}

--- a/frontend/src/sections/projects/LLMTracing/ObserveToolbar.jsx
+++ b/frontend/src/sections/projects/LLMTracing/ObserveToolbar.jsx
@@ -1,7 +1,14 @@
 import React, { useCallback, useEffect, useRef, useState } from "react";
 import { createPortal } from "react-dom";
 import PropTypes from "prop-types";
-import { Badge, Button, MenuItem, Popover, Stack } from "@mui/material";
+import {
+  Badge,
+  Button,
+  MenuItem,
+  Popover,
+  Stack,
+  TextField,
+} from "@mui/material";
 import { startOfToday, startOfTomorrow, startOfYesterday, sub } from "date-fns";
 import Iconify from "src/components/iconify";
 import DisplayPanel from "./DisplayPanel";
@@ -36,6 +43,9 @@ const ObserveToolbar = ({
   dateLabel,
   dateFilter,
   setDateFilter,
+  // Free-text search (traces mode only) — Enter applies the draft
+  searchTerm = "",
+  onSearchApply,
   // Filter
   hasActiveFilter,
   canSaveView,
@@ -112,11 +122,16 @@ const ObserveToolbar = ({
   const [panelFilters, setPanelFilters] = useState(null); // stores raw panel-format filters
   const [dateAnchor, setDateAnchor] = useState(null);
   const [customDateOpen, setCustomDateOpen] = useState(false);
+  const [searchDraft, setSearchDraft] = useState(searchTerm);
   const dateButtonRef = useRef(null);
   const setFilterButtonNode = useCallback((node) => {
     filterButtonRef.current = node;
     setFilterButtonEl(node);
   }, []);
+
+  // Keep the draft in sync when the applied term changes outside the input
+  // (chip removal, clear all, saved-view load).
+  useEffect(() => setSearchDraft(searchTerm), [searchTerm]);
 
   const handleDateOptionChange = (option) => {
     setDateAnchor(null);
@@ -295,6 +310,23 @@ const ObserveToolbar = ({
 
   const toolbarContent = (
     <Stack direction="row" alignItems="center" gap={1}>
+      {/* Free-text search — traces mode only, hidden in compare mode */}
+      {mode === "traces" && !isCompareActive && onSearchApply && (
+        <TextField
+          size="small"
+          value={searchDraft}
+          onChange={(event) => setSearchDraft(event.target.value)}
+          onKeyDown={(event) => {
+            if (event.key === "Enter") onSearchApply(searchDraft.trim());
+          }}
+          placeholder="Search traces"
+          inputProps={{ "aria-label": "Search traces" }}
+          sx={{
+            width: 190,
+            "& .MuiInputBase-root": { height: 26, fontSize: 13 },
+          }}
+        />
+      )}
       {/* Date picker — hidden in compare mode (each graph has its own) */}
       {dateLabel && !isCompareActive && (
         <>
@@ -542,6 +574,8 @@ ObserveToolbar.propTypes = {
   dateLabel: PropTypes.string,
   dateFilter: PropTypes.object,
   setDateFilter: PropTypes.func,
+  searchTerm: PropTypes.string,
+  onSearchApply: PropTypes.func,
   hasActiveFilter: PropTypes.bool,
   canSaveView: PropTypes.bool,
   onSaveView: PropTypes.func,

--- a/frontend/src/sections/projects/LLMTracing/TraceGrid.jsx
+++ b/frontend/src/sections/projects/LLMTracing/TraceGrid.jsx
@@ -60,6 +60,7 @@ const TraceGrid = React.forwardRef(
       canonicalOrderRef,
       enabled = true,
       showErrors = false,
+      search = "",
     },
     gridRef,
   ) => {
@@ -109,6 +110,7 @@ const TraceGrid = React.forwardRef(
           extraFilters: extraFilters || EMPTY_EXTRA_FILTERS,
           metricFilters: metricFilters || [],
           hasEvalFilter,
+          search,
           dateInterval,
           projectId,
           enabled,
@@ -118,6 +120,7 @@ const TraceGrid = React.forwardRef(
         extraFilters,
         metricFilters,
         hasEvalFilter,
+        search,
         dateInterval,
         projectId,
         enabled,
@@ -235,6 +238,7 @@ const TraceGrid = React.forwardRef(
                   ]),
                 ),
                 ...(dateInterval && { interval: dateInterval }),
+                ...(search ? { search } : {}),
               });
 
               // Use prefetched data if available, otherwise fetch
@@ -366,6 +370,7 @@ const TraceGrid = React.forwardRef(
         projectId,
         setLoading,
         hasEvalFilter,
+        search,
         enabled,
         dateInterval,
       ],
@@ -641,6 +646,7 @@ TraceGrid.propTypes = {
   metricFilters: PropTypes.array,
   enabled: PropTypes.bool,
   showErrors: PropTypes.bool,
+  search: PropTypes.string,
 };
 
 export default TraceGrid;

--- a/frontend/src/sections/projects/LLMTracing/__tests__/FilterChips.test.jsx
+++ b/frontend/src/sections/projects/LLMTracing/__tests__/FilterChips.test.jsx
@@ -151,6 +151,76 @@ describe("FilterChips", () => {
     expect(onAddFilter.mock.calls[0][0]).toBeInstanceOf(HTMLElement);
   });
 
+  describe("free-text search chip", () => {
+    it("renders the strip with only a search term and no filters", () => {
+      const { container } = render(
+        <FilterChips
+          extraFilters={[]}
+          searchTerm="timeout"
+          onRemoveSearch={vi.fn()}
+          onRemoveFilter={vi.fn()}
+          onClearAll={vi.fn()}
+        />,
+      );
+      expect(container.firstChild).not.toBeNull();
+      expect(screen.getByText("Search")).toBeInTheDocument();
+      expect(screen.getByText("contains")).toBeInTheDocument();
+      expect(screen.getByText("timeout")).toBeInTheDocument();
+    });
+
+    it("renders the search chip alongside field filter chips", () => {
+      render(
+        <FilterChips
+          extraFilters={[
+            {
+              column_id: "latency",
+              filter_config: { filter_op: "more_than", filter_value: 7 },
+            },
+          ]}
+          searchTerm="timeout"
+          onRemoveSearch={vi.fn()}
+          onRemoveFilter={vi.fn()}
+          onClearAll={vi.fn()}
+        />,
+      );
+      expect(screen.getByText("timeout")).toBeInTheDocument();
+      expect(screen.getByText("Latency")).toBeInTheDocument();
+    });
+
+    it("calls onRemoveSearch (not onRemoveFilter) when the search chip is deleted", async () => {
+      const user = userEvent.setup();
+      const onRemoveSearch = vi.fn();
+      const onRemoveFilter = vi.fn();
+      const { container } = render(
+        <FilterChips
+          extraFilters={[]}
+          searchTerm="timeout"
+          onRemoveSearch={onRemoveSearch}
+          onRemoveFilter={onRemoveFilter}
+          onClearAll={vi.fn()}
+        />,
+      );
+      const deleteIcon = container.querySelector(".MuiChip-deleteIcon");
+      expect(deleteIcon).not.toBeNull();
+      await user.click(deleteIcon);
+      expect(onRemoveSearch).toHaveBeenCalledTimes(1);
+      expect(onRemoveFilter).not.toHaveBeenCalled();
+    });
+
+    it("still renders nothing with no filters and no search term", () => {
+      const { container } = render(
+        <FilterChips
+          extraFilters={[]}
+          searchTerm=""
+          onRemoveSearch={vi.fn()}
+          onRemoveFilter={vi.fn()}
+          onClearAll={vi.fn()}
+        />,
+      );
+      expect(container.firstChild).toBeNull();
+    });
+  });
+
   describe("UUID column_id fallback", () => {
     const UUID = "f701b069-6224-46e8-900f-60cc5af4dd20";
 

--- a/frontend/src/sections/projects/LLMTracing/__tests__/ObserveToolbar.search.test.jsx
+++ b/frontend/src/sections/projects/LLMTracing/__tests__/ObserveToolbar.search.test.jsx
@@ -1,0 +1,78 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, userEvent } from "src/utils/test-utils";
+
+vi.mock("src/components/iconify", () => ({ default: () => null }));
+vi.mock("../TraceFilterPanel", () => ({ default: () => null }));
+vi.mock("../DisplayPanel", () => ({ default: () => null }));
+vi.mock("src/components/custom-datepicker/DatePicker", () => ({
+  default: () => null,
+}));
+vi.mock("../tabStore", () => ({
+  useTabStoreShallow: (selector) => selector({ openCreateModal: vi.fn() }),
+}));
+
+import ObserveToolbar from "../ObserveToolbar";
+
+const baseProps = {
+  inline: true,
+  mode: "traces",
+  onSearchApply: vi.fn(),
+};
+
+describe("ObserveToolbar free-text search", () => {
+  it("renders the search input in traces mode", () => {
+    render(<ObserveToolbar {...baseProps} />);
+    expect(screen.getByPlaceholderText(/search traces/i)).toBeInTheDocument();
+  });
+
+  it("applies the trimmed draft on Enter", async () => {
+    const user = userEvent.setup();
+    const onSearchApply = vi.fn();
+    render(<ObserveToolbar {...baseProps} onSearchApply={onSearchApply} />);
+
+    const input = screen.getByPlaceholderText(/search traces/i);
+    await user.type(input, "  timeout  {Enter}");
+    expect(onSearchApply).toHaveBeenCalledTimes(1);
+    expect(onSearchApply).toHaveBeenCalledWith("timeout");
+  });
+
+  it("does not apply while typing without Enter", async () => {
+    const user = userEvent.setup();
+    const onSearchApply = vi.fn();
+    render(<ObserveToolbar {...baseProps} onSearchApply={onSearchApply} />);
+
+    await user.type(screen.getByPlaceholderText(/search traces/i), "timeout");
+    expect(onSearchApply).not.toHaveBeenCalled();
+  });
+
+  it("syncs the draft when the applied term changes externally", () => {
+    const { rerender } = render(
+      <ObserveToolbar {...baseProps} searchTerm="first" />,
+    );
+    expect(screen.getByPlaceholderText(/search traces/i)).toHaveValue("first");
+
+    rerender(<ObserveToolbar {...baseProps} searchTerm="" />);
+    expect(screen.getByPlaceholderText(/search traces/i)).toHaveValue("");
+  });
+
+  it("hides the search input outside traces mode", () => {
+    render(<ObserveToolbar {...baseProps} mode="sessions" />);
+    expect(
+      screen.queryByPlaceholderText(/search traces/i),
+    ).not.toBeInTheDocument();
+  });
+
+  it("hides the search input in compare mode", () => {
+    render(<ObserveToolbar {...baseProps} isCompareActive />);
+    expect(
+      screen.queryByPlaceholderText(/search traces/i),
+    ).not.toBeInTheDocument();
+  });
+
+  it("hides the search input when no onSearchApply handler is wired", () => {
+    render(<ObserveToolbar inline mode="traces" />);
+    expect(
+      screen.queryByPlaceholderText(/search traces/i),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/futureagi/tracer/serializers/trace.py
+++ b/futureagi/tracer/serializers/trace.py
@@ -166,6 +166,7 @@ class TraceObserveListQuerySerializer(StrictInputSerializer):
         required=False, default=30, min_value=1, max_value=500
     )
     interval = serializers.CharField(required=False, allow_blank=True)
+    search = serializers.CharField(required=False, allow_blank=True)
 
 
 class TraceObserveListMetadataSerializer(serializers.Serializer):

--- a/futureagi/tracer/services/clickhouse/query_builders/trace_list.py
+++ b/futureagi/tracer/services/clickhouse/query_builders/trace_list.py
@@ -28,6 +28,15 @@ from tracer.services.clickhouse.query_builders.filters import ClickHouseFilterBu
 # nothing and scans the whole project.
 TIME_FILTER_COLUMN = "start_time"  # Options: "created_at" | "start_time"
 
+# Free-text search covers the fields shown in the trace table. All queries
+# using it are already scoped to root spans, so input/output here are the
+# root span's content — matching what the grid renders.
+SEARCH_FRAGMENT = (
+    "AND (trace_name ILIKE %(search)s"
+    " OR input ILIKE %(search)s"
+    " OR output ILIKE %(search)s)"
+)
+
 
 class TraceListQueryBuilder(BaseQueryBuilder):
     """Build queries for the paginated trace list view.
@@ -185,10 +194,11 @@ class TraceListQueryBuilder(BaseQueryBuilder):
             pv_fragment = "AND project_version_id = %(project_version_id)s"
             self.params["project_version_id"] = self.project_version_id
 
-        # Search filter on trace_name
+        # Free-text search over the root span's name and content. Lives in the
+        # root query so pagination and totals stay aligned with the page rows.
         search_fragment = ""
         if self.search:
-            search_fragment = "AND trace_name ILIKE %(search)s"
+            search_fragment = SEARCH_FRAGMENT
             self.params["search"] = f"%{self.search}%"
 
         # Configurable columns — only SELECT requested columns.
@@ -311,7 +321,7 @@ class TraceListQueryBuilder(BaseQueryBuilder):
 
         search_fragment = ""
         if self.search:
-            search_fragment = "AND trace_name ILIKE %(search)s"
+            search_fragment = SEARCH_FRAGMENT
             self.params["search"] = f"%{self.search}%"
 
         query = f"""
@@ -424,7 +434,7 @@ class TraceListQueryBuilder(BaseQueryBuilder):
         # Search filter (reuse from build())
         search_fragment = ""
         if self.search:
-            search_fragment = "AND trace_name ILIKE %(search)s"
+            search_fragment = SEARCH_FRAGMENT
             params["search"] = f"%{self.search}%"
 
         query = f"""

--- a/futureagi/tracer/tests/test_ch25_query_builders_sweep.py
+++ b/futureagi/tracer/tests/test_ch25_query_builders_sweep.py
@@ -118,6 +118,21 @@ def test_trace_list_v2_build_no_legacy():
     _assert_no_legacy(sql, "TraceList.build")
 
 
+def test_trace_list_v2_search_survives_rewrite():
+    builder = TraceListQueryBuilderV2(
+        project_id=PROJECT_ID, page_number=0, page_size=10,
+        filters=[], sort_params=[],
+        eval_config_ids=[], annotation_label_ids=[],
+        search="boom",
+    )
+    sql, params = builder.build()
+    _assert_no_legacy(sql, "TraceList.build(search)")
+    assert "trace_name ILIKE %(search)s" in sql
+    assert "input ILIKE %(search)s" in sql
+    assert "output ILIKE %(search)s" in sql
+    assert params["search"] == "%boom%"
+
+
 def test_trace_list_v2_count_no_legacy():
     sql, _ = _trace_list_builder().build_count_query()
     _assert_no_legacy(sql, "TraceList.build_count_query")

--- a/futureagi/tracer/tests/test_filter_serializer_contracts.py
+++ b/futureagi/tracer/tests/test_filter_serializer_contracts.py
@@ -500,6 +500,17 @@ class TestFilterSerializerContracts:
         assert serializer.is_valid(), serializer.errors
         assert serializer.validated_data["filters"][0]["column_id"] == "customer_tier"
 
+    def test_trace_observe_list_query_accepts_search(self):
+        serializer = TraceObserveListQuerySerializer(
+            data={
+                "project_id": "1372e742-a10b-4d98-9ca4-31ef4d67115f",
+                "search": "timeout",
+            }
+        )
+
+        assert serializer.is_valid(), serializer.errors
+        assert serializer.validated_data["search"] == "timeout"
+
     def test_trace_observe_list_query_rejects_camel_case_aliases(self):
         serializer = TraceObserveListQuerySerializer(
             data={

--- a/futureagi/tracer/tests/test_trace_list_builder_comprehensive.py
+++ b/futureagi/tracer/tests/test_trace_list_builder_comprehensive.py
@@ -479,6 +479,8 @@ class TestBuildCountQuery:
         builder.build()
         query, params = builder.build_count_query()
         assert "trace_name ILIKE %(search)s" in query
+        assert "input ILIKE %(search)s" in query
+        assert "output ILIKE %(search)s" in query
         assert params["search"] == "%boom%"
 
     def test_start_time_window_no_created_at_skew(self, project_id):

--- a/futureagi/tracer/tests/test_trace_list_ch.py
+++ b/futureagi/tracer/tests/test_trace_list_ch.py
@@ -24,7 +24,9 @@ class TestSearch:
             search="hello world",
         )
         query, params = builder.build()
-        assert "ILIKE %(search)s" in query
+        assert "trace_name ILIKE %(search)s" in query
+        assert "input ILIKE %(search)s" in query
+        assert "output ILIKE %(search)s" in query
         assert params["search"] == "%hello world%"
 
     def test_search_none_omits_filter(self, project_id):
@@ -46,7 +48,22 @@ class TestSearch:
         # Must call build() first to set start_date/end_date
         builder.build()
         count_query, count_params = builder.build_count_query()
-        assert "ILIKE %(search)s" in count_query
+        assert "trace_name ILIKE %(search)s" in count_query
+        assert "input ILIKE %(search)s" in count_query
+        assert "output ILIKE %(search)s" in count_query
+
+    def test_search_included_in_id_query(self, project_id):
+        builder = TraceListQueryBuilder(
+            project_id=project_id,
+            search="test",
+        )
+        # Must call build() first to set start_date/end_date
+        builder.build()
+        id_query, id_params = builder.build_id_query()
+        assert "trace_name ILIKE %(search)s" in id_query
+        assert "input ILIKE %(search)s" in id_query
+        assert "output ILIKE %(search)s" in id_query
+        assert id_params["search"] == "%test%"
 
 
 class TestConfigurableColumns:

--- a/futureagi/tracer/views/trace.py
+++ b/futureagi/tracer/views/trace.py
@@ -3436,6 +3436,7 @@ class TraceView(BaseModelViewSetMixin, ModelViewSet):
 
         org_scope = bool(org_project_ids)
         filters = list(validated_data.get("filters", []) or [])
+        search = validated_data.get("search") or None
         page_number = validated_data["page_number"]
         page_size = validated_data["page_size"]
         session_id = (
@@ -3523,6 +3524,7 @@ class TraceView(BaseModelViewSetMixin, ModelViewSet):
             page_size=page_size,
             eval_config_ids=eval_config_ids,
             annotation_label_ids=annotation_label_ids,
+            search=search,
         )
 
         # Phase 1: Paginated traces (light columns only — no input/output)


### PR DESCRIPTION
## Summary

Finding a trace by its content meant opening the filter drawer, picking a field from the property picker, choosing the "contains" operator and typing a value. This adds a free-text search box to the traces toolbar: typing a term and pressing Enter filters the trace list to rows whose trace name, input or output matches, and the active term renders as a removable chip in the existing filter-chip strip. It composes with existing filters, survives saved views, and is scoped to the traces toolbar.

## Linked issues

Closes #1579
Linear: -

## Type of change

- [x] ✨ New feature (non-breaking change which adds functionality)

## 1) What changes were done

**A. Widen the trace-list search predicate (backend)**
- `futureagi/tracer/services/clickhouse/query_builders/trace_list.py`: the search predicate only covered `trace_name`. Extracted a shared `SEARCH_FRAGMENT` matching `trace_name`, `input` and `output`, and used it in all three places that build it — `build()`, `build_id_query()` and `build_count_query()` — so the page, the id query and the totals stay aligned.
- The v2 (CH 25.3) builder inherits these methods and its SQL rewriter leaves `trace_name`/`input`/`output` untouched, so both routing modes get the widened predicate from one change. Its count fast-path already falls back to the raw scan whenever `search` is set, so counts stay correct.

**B. Accept the param on the endpoint (backend)**
- `futureagi/tracer/serializers/trace.py`: added an optional `search` field to `TraceObserveListQuerySerializer`. It is a strict serializer, so `?search=` was rejected outright before this and the builder was never handed a term.
- `futureagi/tracer/views/trace.py`: `_list_traces_of_session_clickhouse` reads `search` from the validated data and forwards it to the builder (which already normalises/strips it).

**C. Regenerated API contracts**
- `api_contracts/openapi/swagger.json` plus `openapi-contract.generated.js`, `api.schemas.ts` and `api.zod.ts` — the frontend validates outgoing query params against a strict zod schema built from the generated contract, so the request would be rejected client-side without this.

**D. Search box on the traces toolbar (frontend)**
- `ObserveToolbar.jsx`: a search `TextField` alongside the Date/Filter/Save view buttons. It holds a local draft and only applies on Enter, and re-syncs when the applied term changes elsewhere (chip removal, Clear all, saved-view load). Rendered only in traces mode, hidden in compare mode, and only when a handler is wired — so the sessions/users toolbars are untouched.
- `FilterChips.jsx`: renders the applied term as a removable chip ahead of the field chips, reusing the existing chip pattern. The strip's empty-state guard now accounts for a search-only state.
- `TraceGrid.jsx`: sends `search` with the trace-list request (page fetch and prefetch share one param builder) and includes it in the refetch key, so pressing Enter actually refreshes the grid.
- `LLMTracingView.jsx`: owns the applied term and threads it through. It rides inside the saved-view `display` config (the same place `dateFilter` lives, for backend-whitelist compatibility), is part of the "Save view" dirty check, is persisted with the filter chips in localStorage and rehydrated on mount, and is cleared by Clear all, the chip's delete and Reset view.

## 2) Why the changes were done

- **Product/UX:** the issue's "Done when" — typing in a search box on the traces toolbar and pressing Enter filters the list by span input, output or name; the term appears as a removable chip like any other filter; it works alongside existing filters and with saved views.
- **Technical:** the search plumbing was half-built — the builder had a `search` kwarg and a `trace_name`-only predicate, but no caller could reach it because the strict serializer rejected the param. This connects the two ends and widens the predicate to the fields the grid actually renders.
- **Architecture:** the search term is deliberately *not* modelled as another entry in `extraFilters`. `input`/`output` aren't in `BASE_TRACE_FILTER_FIELDS` and the filter pipeline compiles per-field predicates joined with AND, whereas search is one OR across three columns. Keeping it a sibling of `extraFilters` avoids inventing a pseudo-field in the filter contract, and the chip reuse keeps it looking like one filter to the user.

## 3) Tests written + scenarios each covers

**`futureagi/tracer/tests/test_trace_list_ch.py`** — builder SQL
- `TestSearch::test_search_adds_ilike_filter` — the page query matches name, input and output.
- `TestSearch::test_search_included_in_count_query` — same predicate in the count query, so totals match the rows.
- `TestSearch::test_search_included_in_id_query` — new: same predicate in the id query, with the param bound.
- `test_search_none_omits_filter` / `test_search_empty_string_omits_filter` — no search, no predicate (unchanged).

**`futureagi/tracer/tests/test_trace_list_builder_comprehensive.py`**
- `TestBuildCountQuery::test_search_fragment` — extended from the `trace_name`-only assertion to cover input/output.

**`futureagi/tracer/tests/test_ch25_query_builders_sweep.py`**
- `test_trace_list_v2_search_survives_rewrite` — new: the v2 rewriter passes the widened predicate through untouched and emits no legacy SQL.

**`futureagi/tracer/tests/test_filter_serializer_contracts.py`**
- `test_trace_observe_list_query_accepts_search` — new: the strict serializer accepts `search` (the camelCase-rejection test alongside it still guards the strictness).

**`frontend/src/sections/projects/LLMTracing/__tests__/ObserveToolbar.search.test.jsx`** (new file)
- renders the input in traces mode; applies the **trimmed** draft on Enter; does **not** apply while typing; re-syncs the draft when the applied term changes externally; hidden outside traces mode, in compare mode, and when no handler is wired.

**`frontend/src/sections/projects/LLMTracing/__tests__/FilterChips.test.jsx`**
- search-only state renders the strip (previously it returned null with no filters); the search chip renders alongside field chips; deleting it calls `onRemoveSearch` and **not** `onRemoveFilter`; empty search with no filters still renders nothing.

> Run result: backend **201 passed** across the four touched files; frontend **194 passed** across the full `LLMTracing/__tests__` directory (22 in the two search-related files). `yarn contracts:check` clean.

## 4) How to run / test

```bash
# Backend
cd futureagi
bin/test tracer/tests/test_trace_list_ch.py tracer/tests/test_trace_list_builder_comprehensive.py \
         tracer/tests/test_ch25_query_builders_sweep.py tracer/tests/test_filter_serializer_contracts.py

# Frontend
cd frontend
yarn vitest run src/sections/projects/LLMTracing/__tests__/

# Contracts
cd frontend && yarn contracts:check
```

Manually: open Observe → LLM Tracing, type a string that appears in a trace's input or output, press Enter. The list narrows, a "Search contains …" chip appears, and removing the chip restores the list while leaving any other filters in place.

## 5) Screenshots / recordings

### Backend test output (search-specific cases)

```
collecting ... collected 176 items / 168 deselected / 8 selected
tracer/tests/test_trace_list_ch.py::TestSearch::test_search_adds_ilike_filter PASSED [ 12%]
tracer/tests/test_trace_list_ch.py::TestSearch::test_search_none_omits_filter PASSED [ 25%]
tracer/tests/test_trace_list_ch.py::TestSearch::test_search_empty_string_omits_filter PASSED [ 37%]
tracer/tests/test_trace_list_ch.py::TestSearch::test_search_included_in_count_query PASSED [ 50%]
tracer/tests/test_trace_list_ch.py::TestSearch::test_search_included_in_id_query PASSED [ 62%]
tracer/tests/test_trace_list_builder_comprehensive.py::TestBuildCountQuery::test_search_fragment PASSED [ 75%]
tracer/tests/test_ch25_query_builders_sweep.py::test_trace_list_v2_search_survives_rewrite PASSED [ 87%]
tracer/tests/test_filter_serializer_contracts.py::TestFilterSerializerContracts::test_trace_observe_list_query_accepts_search PASSED [100%]
====================== 8 passed, 168 deselected in 6.09s =======================
```

### Frontend test output

```
 ✓ src/sections/projects/LLMTracing/__tests__/FilterChips.test.jsx (15 tests)
 ✓ src/sections/projects/LLMTracing/__tests__/ObserveToolbar.search.test.jsx (7 tests)

 Test Files  18 passed (18)
      Tests  194 passed (194)
```

## 6) Edge cases & considerations

- **Search + existing filters:** ANDed together; removing the search chip leaves the field filters (and vice versa).
- **Compare mode:** the input is hidden and the primary grid is passed an empty term, matching how the Date and Filter pills already behave there (each graph carries its own filters).
- **Saved views:** the term is part of `display`, so switching views applies that view's term, and editing it lights up "Save view".
- **Whitespace-only input:** trimmed before applying, so it clears rather than searching for spaces.
- **Empty search:** the param is omitted entirely, so the request is byte-identical to today's.
- **Root-span scope:** all three queries are already constrained to root spans, so the matched `input`/`output` are the root span's — the same content the grid renders. Text that only exists on a nested LLM span won't match; worth a follow-up if it turns out users expect otherwise.
- **Performance:** `input`/`output` are the large ZSTD-compressed columns and have no substring index, so a search is a scan over the date window (the count query already took the raw-scan path whenever search was set). It is bounded by the active date filter and only runs when the user types a term.

## 7) Pre-existing issues (NOT introduced by this PR)

- `params["search"] = f"%{self.search}%"` doesn't escape user-supplied `%`/`_`, so a term containing `%` matches broadly. Pre-existing in all three fragments; left as-is to keep this PR scoped, but happy to fold in an escape (or a switch to `positionCaseInsensitive`) if you'd prefer.

## 8) Architectural / important decisions

- **One shared `SEARCH_FRAGMENT`** instead of three copies of the predicate — the three sites had already drifted into identical duplicates, and they must stay identical or totals and rows disagree.
- **Widen v1 only:** the v2 builder inherits the methods and its rewriter passes these column names through, so a second implementation would have been dead code. Added a v2 test to lock that in.
- **Search kept outside `extraFilters`:** see the architecture note above — it's one OR across three columns, not a per-field predicate, and `input`/`output` aren't filter-panel fields.
- **Term stored inside `display`** in the saved-view config, following the existing comment that the backend whitelists `display` for arbitrary sub-keys (the same reason `dateFilter` lives there).

## Checklist

- [x] CLA signed
- [x] Backend tests passing
- [x] Frontend tests passing
- [x] API contracts regenerated and `yarn contracts:check` clean
- [x] No secrets, keys or internal URLs
- [x] PR title follows Conventional Commits
- [x] Targets `dev`
- [ ] Linear ticket linked (external contribution — no Linear access)
