### PR TITLE
feat: resolve nudge owners from reviewer-config.json

### DIFF
--- a/.github/reviewer-config.json
+++ b/.github/reviewer-config.json
@@ -128,17 +128,17 @@
     }
   },
   "users": {
-    "khushalsonawat":      { "slack_id": "U087FCUQ77E", "display_name": "Khushal" },
-    "atharva-bhange":      { "slack_id": "U071K8LUQE5", "display_name": "Atharva" },
-    "definitelynotchirag": { "slack_id": "U0ACG3CS7EY", "display_name": "Chirag" },
-    "cdileep23":           { "slack_id": "U099M4FQV97", "display_name": "Dileep" },
-    "KarthikAvinashFI":    { "slack_id": "U09808798MU", "display_name": "Karthik Avinash" },
-    "hadarishav":          { "slack_id": "U07UPK1NZGA", "display_name": "Rishav" },
-    "JayaSurya-27":        { "slack_id": "U083MBRARTL", "display_name": "Jaya" },
-    "commitPirate":        { "slack_id": "U09LC0C8NKE", "display_name": "Nosang" },
-    "sarthakFuture":       { "slack_id": "U07V82HJ17H", "display_name": "Sarthak" },
-    "azain-commits":       { "slack_id": "U09GEEBEATS", "display_name": "Azain" },
-    "NVJKKartik":          { "slack_id": "U0851KZFTV4", "display_name": "Kartik" },
-    "Tanmaycode1":         { "slack_id": "U0ARCAND0R1", "display_name": "Tanmay" }
+    "khushalsonawat":      { "slack_id": "U087FCUQ77E", "display_name": "Khushal",         "email": "khushal.sonawat@futureagi.com" },
+    "atharva-bhange":      { "slack_id": "U071K8LUQE5", "display_name": "Atharva",         "email": "atharva@futureagi.com" },
+    "definitelynotchirag": { "slack_id": "U0ACG3CS7EY", "display_name": "Chirag",          "email": "chintan@futureagi.com" },
+    "cdileep23":           { "slack_id": "U099M4FQV97", "display_name": "Dileep",          "email": "dileep.kumar@futureagi.com" },
+    "KarthikAvinashFI":    { "slack_id": "U09808798MU", "display_name": "Karthik Avinash", "email": "karthik.avinash@futureagi.com" },
+    "hadarishav":          { "slack_id": "U07UPK1NZGA", "display_name": "Rishav",          "email": "rishav@futureagi.com" },
+    "JayaSurya-27":        { "slack_id": "U083MBRARTL", "display_name": "Jaya",            "email": "jayasurya@futureagi.com" },
+    "commitPirate":        { "slack_id": "U09LC0C8NKE", "display_name": "Nosang",          "email": "nosang.s@futureagi.com" },
+    "sarthakFuture":       { "slack_id": "U07V82HJ17H", "display_name": "Sarthak",         "email": "sarthak@futureagi.com" },
+    "azain-commits":       { "slack_id": "U09GEEBEATS", "display_name": "Azain",           "email": "azain@futureagi.com" },
+    "NVJKKartik":          { "slack_id": "U0851KZFTV4", "display_name": "Kartik",          "email": "kartik.nvj@futureagi.com" },
+    "Tanmaycode1":         { "slack_id": "U0ARCAND0R1", "display_name": "Tanmay",          "email": "tanmay@futureagi.com" }
   }
 }

--- a/.github/scripts/linear-release-done.mjs
+++ b/.github/scripts/linear-release-done.mjs
@@ -26,11 +26,17 @@
 //   GITHUB_REPOSITORY  owner/repo (e.g. future-agi/future-agi)
 //   VERSION            release tag, e.g. v1.23.0
 //   RELEASE_URL        link to the release (used in comments/messages)
-//   SLACK_BOT_TOKEN    bot token (chat:write, users:read.email, im:write) — needed
-//                      for owner DMs, the #tech fallback, and the summary
+//   SLACK_BOT_TOKEN    bot token (chat:write) — owner DMs, #tech fallback, summary.
+//                      Owner Slack ids come from .github/reviewer-config.json, so
+//                      the users:read.email scope is optional (used only as a
+//                      fallback for people missing from that map).
 //   SLACK_TECH_CHANNEL channel id for unassigned nudges + the summary (e.g. C06...)
 //   SLACK_WEBHOOK_URL  optional summary fallback when SLACK_BOT_TOKEN is unset
 //   DRY_RUN            "true" → log intended writes only, change nothing
+
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { dirname, resolve } from 'node:path'
 
 const {
   LINEAR_API_KEY,
@@ -64,6 +70,25 @@ const SKIP_TYPES = new Set(['completed', 'canceled', 'duplicate', 'triage', 'bac
 const SKIP_STATE_NAMES = new Set(['On hold'])
 
 const CONCURRENCY = 8
+
+// Owner → Slack resolution reuses .github/reviewer-config.json (the repo's
+// canonical people map, also used by reviewer-assigner). We build email → slack_id
+// from it so a Linear assignee can be DMed without needing the Slack
+// `users:read.email` scope. People not in the map fall back to #tech.
+const EMAIL_TO_SLACK = (() => {
+  try {
+    const __dirname = dirname(fileURLToPath(import.meta.url))
+    const cfg = JSON.parse(readFileSync(resolve(__dirname, '..', 'reviewer-config.json'), 'utf8'))
+    const out = {}
+    for (const u of Object.values(cfg.users ?? {})) {
+      if (u.email && u.slack_id) out[u.email.toLowerCase()] = u.slack_id
+    }
+    return out
+  } catch (e) {
+    log(`⚠  could not load reviewer-config.json (${e.message}) — owner DMs will fall back to #tech`)
+    return {}
+  }
+})()
 
 // ── Linear API ──────────────────────────────────────────────────────────────
 
@@ -249,7 +274,12 @@ async function slackPost(channel, text) {
 // the ticket is unassigned or the owner can't be resolved on Slack.
 async function nudgeOnSlack(issue) {
   if (!SLACK_BOT_TOKEN) { log(`  ⚠  SLACK_BOT_TOKEN unset — cannot Slack-nudge ${issue.identifier}`); return 'no-slack' }
-  const owner = issue.assigneeEmail ? await lookupSlackUserId(issue.assigneeEmail).catch(() => null) : null
+  // Resolve the owner's Slack id from reviewer-config.json first (no scope
+  // needed); only fall back to the email lookup if the map misses and the token
+  // happens to have users:read.email.
+  const email = issue.assigneeEmail?.toLowerCase() ?? null
+  const owner = (email && EMAIL_TO_SLACK[email])
+    || (email ? await lookupSlackUserId(issue.assigneeEmail).catch(() => null) : null)
   if (owner) {
     await slackPost(owner, `Hi ${firstName(issue.assigneeName)} — Linear ticket ${issue.identifier} ("${issue.title}") shipped in release ${VERSION} but is still "${issue.stateName}". If it's complete, please close it in Linear. ${issue.url}`)
     return 'owner'


### PR DESCRIPTION
## What
Make the release ticket-sync's **owner nudges reach people via DM without needing a Slack scope**, by reusing `.github/reviewer-config.json` (the same people-map `reviewer-assigner` uses).

## Why
A dry-run on v1.30.0 proved the CI `SLACK_BOT_TOKEN` lacks `users:read.email` — both assigned in-flight tickets (TH-7247, TH-7617) fell back to `#tech` instead of DMing the owner, because `users.lookupByEmail` returns nothing.

## Change
- `reviewer-config.json`: add an `email` field to each user (additive; reviewer-assigner ignores it).
- `linear-release-done.mjs`: build an `email → slack_id` map from that config and resolve the Linear assignee against it first. Owners in the map get a DM; anyone missing (e.g. non-reviewers like a PM) falls back to `#tech`. `users.lookupByEmail` is kept only as a secondary fallback if the scope is ever granted.
- Workflow: sparse-checkout now also pulls `.github/reviewer-config.json` (**this file is guardrail-protected — added by a human, see checklist**).

## Verified
- `reviewer-config.json` valid; all 12 users have `email`. `node --check` ✓.
- Resolution test: `atharva@futureagi.com → U071K8LUQE5` ✓ (so TH-7617 would DM correctly); `nikhil@` (not a reviewer) → `#tech` fallback as expected.

## Checklist before merge
- [ ] Update the workflow to sparse-checkout `.github/reviewer-config.json` (content ready; guardrail-protected).

## Note
For full owner coverage (including non-reviewers), the alternative is granting the Slack app `users:read.email`; then the email lookup covers everyone and the map becomes optional.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
