### PR TITLE
fix(evals): resolve prompt field from dataset cells when RunPrompter is absent [TH-7504]

### DIFF
--- a/futureagi/model_hub/tests/test_eval_runner_uploaded_dataset_prompt.py
+++ b/futureagi/model_hub/tests/test_eval_runner_uploaded_dataset_prompt.py
@@ -1,0 +1,279 @@
+"""
+Regression tests for TH-7504: running system evals (prompt_instruction_adherence,
+tone) on user-uploaded datasets failed with "No input received for 'prompt'".
+
+The eval runner assumed every dataset column traces back to a RunPrompter
+(platform-generated output). Uploaded CSV datasets have no RunPrompter, which
+broke three code paths in model_hub/views/eval_runner.py:
+
+1. process_mapping: the prompt_instruction_adherence special handling skipped
+   normal cell resolution even when the RunPrompter lookup failed (misplaced
+   `continue`).
+2. process_mapping: the output->input auto-inference under run_prompt_column
+   had unguarded ORM lookups that raised DoesNotExist.
+3. EvaluationRunner._get_required_fields_and_mappings: broke after the first
+   mapping entry whenever run_prompt_column was set, dropping the prompt
+   column from the required fields.
+
+Each test class below pins the uploaded-dataset fallback and the unchanged
+platform-generated (RunPrompter-backed) behavior for one of those paths.
+"""
+
+import pytest
+
+from model_hub.models.choices import (
+    CellStatus,
+    DatasetSourceChoices,
+    DataTypeChoices,
+    ModelTypes,
+    OwnerChoices,
+    SourceChoices,
+)
+from model_hub.models.develop_dataset import Cell, Column, Dataset, Row
+from model_hub.models.evals_metric import EvalTemplate, UserEvalMetric
+from model_hub.models.run_prompt import RunPrompter
+from model_hub.views.eval_runner import EvaluationRunner, process_mapping
+
+SYSTEM_TEXT = "Follow the instructions exactly."
+USER_TEXT = "Summarize the document."
+
+
+class _StubRunner:
+    """Minimal runner stub for the RunPrompter-backed inference path."""
+
+    def _replace_dynamic_ids(self, text, row):
+        return text
+
+
+@pytest.fixture
+def dataset(db, user, organization, workspace):
+    return Dataset.objects.create(
+        name="TH-7504 Dataset",
+        organization=organization,
+        user=user,
+        source=DatasetSourceChoices.BUILD.value,
+        model_type=ModelTypes.GENERATIVE_LLM.value,
+        workspace=workspace,
+    )
+
+
+@pytest.fixture
+def row(db, dataset):
+    return Row.objects.create(dataset=dataset, order=0)
+
+
+@pytest.fixture
+def run_prompter(db, dataset, organization, workspace):
+    return RunPrompter.objects.create(
+        dataset=dataset,
+        model="gpt-4o",
+        name="th-7504-run-prompt",
+        organization=organization,
+        workspace=workspace,
+        messages=[
+            {"role": "system", "content": [{"type": "text", "text": SYSTEM_TEXT}]},
+            {"role": "user", "content": [{"type": "text", "text": USER_TEXT}]},
+        ],
+    )
+
+
+def _make_column(dataset, name, source_id=None, source=SourceChoices.OTHERS.value):
+    return Column.objects.create(
+        name=name,
+        dataset=dataset,
+        data_type=DataTypeChoices.TEXT.value,
+        source=source,
+        source_id=source_id,
+    )
+
+
+def _make_cell(dataset, column, row, value):
+    return Cell.objects.create(
+        dataset=dataset,
+        column=column,
+        row=row,
+        value=value,
+        status=CellStatus.PASS.value,
+    )
+
+
+@pytest.mark.django_db
+class TestProcessMappingPromptInstructionAdherence:
+    """prompt_instruction_adherence 'prompt' key resolution in process_mapping."""
+
+    def test_uploaded_dataset_prompt_falls_back_to_cell_value(self, dataset, row):
+        """Without a RunPrompter, the prompt must resolve from the dataset cell
+        instead of being silently dropped (the misplaced-continue bug)."""
+        prompt_col = _make_column(dataset, "prompt")
+        output_col = _make_column(dataset, "output")
+        _make_cell(dataset, prompt_col, row, "Answer in JSON only.")
+        _make_cell(dataset, output_col, row, '{"answer": 42}')
+
+        required_field, mapping = process_mapping(
+            {"prompt": str(prompt_col.id), "output": str(output_col.id)},
+            row,
+            eval_template_name="prompt_instruction_adherence",
+        )
+
+        assert required_field == ["prompt", "output"]
+        assert mapping == ["Answer in JSON only.", '{"answer": 42}']
+
+    def test_platform_dataset_prompt_resolves_run_prompter_messages(
+        self, dataset, row, run_prompter
+    ):
+        """With a RunPrompter, the prompt must still resolve to the structured
+        messages dict and skip normal cell resolution (no duplicate entry)."""
+        prompt_col = _make_column(
+            dataset,
+            "prompt",
+            source_id=str(run_prompter.id),
+            source=SourceChoices.RUN_PROMPT.value,
+        )
+        _make_cell(dataset, prompt_col, row, "raw cell value that must be ignored")
+
+        required_field, mapping = process_mapping(
+            {"prompt": str(prompt_col.id)},
+            row,
+            eval_template_name="prompt_instruction_adherence",
+        )
+
+        assert required_field == ["prompt"]
+        assert mapping == [
+            {
+                "system_prompt": [
+                    {
+                        "role": "system",
+                        "content": [{"type": "text", "text": SYSTEM_TEXT}],
+                    }
+                ],
+                "user_prompt": [
+                    {
+                        "role": "user",
+                        "content": [{"type": "text", "text": USER_TEXT}],
+                    }
+                ],
+            }
+        ]
+
+
+@pytest.mark.django_db
+class TestProcessMappingRunPromptColumnInference:
+    """output->input auto-inference under run_prompt_column in process_mapping."""
+
+    def test_uploaded_dataset_skips_inference_without_run_prompter(
+        self, dataset, row
+    ):
+        """Without a RunPrompter, inference must be skipped gracefully instead
+        of raising DoesNotExist (previously unguarded ORM lookups)."""
+        output_col = _make_column(dataset, "output")
+        _make_cell(dataset, output_col, row, "model output text")
+
+        required_field, mapping = process_mapping(
+            {"output": str(output_col.id)},
+            row,
+            run_prompt_column=True,
+        )
+
+        assert required_field == ["output"]
+        assert mapping == ["model output text"]
+
+    def test_platform_dataset_infers_input_from_run_prompter(
+        self, dataset, row, run_prompter
+    ):
+        """With a RunPrompter, the user prompt must still be inferred and
+        inserted as the 'input' field."""
+        output_col = _make_column(
+            dataset,
+            "output",
+            source_id=str(run_prompter.id),
+            source=SourceChoices.RUN_PROMPT.value,
+        )
+        _make_cell(dataset, output_col, row, "model output text")
+
+        required_field, mapping = process_mapping(
+            {"output": str(output_col.id)},
+            row,
+            run_prompt_column=True,
+            runner=_StubRunner(),
+        )
+
+        assert required_field == ["input", "output"]
+        assert mapping == [USER_TEXT, "model output text"]
+
+
+@pytest.mark.django_db
+class TestGetRequiredFieldsAndMappings:
+    """run_prompt_column handling in EvaluationRunner._get_required_fields_and_mappings."""
+
+    def _make_runner(self, dataset, mapping, user, organization, workspace, name):
+        template = EvalTemplate.objects.create(
+            name=name,
+            owner=OwnerChoices.SYSTEM.value,
+            config={
+                "required_keys": ["input"],
+                "eval_type_id": "OutputEvaluator",
+                "output": "Pass/Fail",
+                "run_prompt_column": True,
+            },
+        )
+        metric = UserEvalMetric.objects.create(
+            name=f"{name}-metric",
+            organization=organization,
+            workspace=workspace,
+            dataset=dataset,
+            template=template,
+            config={"mapping": mapping},
+            user=user,
+        )
+        return EvaluationRunner(user_eval_metric_id=metric.id), metric
+
+    def test_uploaded_dataset_keeps_all_mapped_columns(
+        self, dataset, user, organization, workspace
+    ):
+        """Without a RunPrompter, every mapped column must survive — the old
+        unconditional break dropped the prompt column entirely."""
+        output_col = _make_column(dataset, "output")
+        prompt_col = _make_column(dataset, "prompt")
+        runner, metric = self._make_runner(
+            dataset,
+            {"output": str(output_col.id), "prompt": str(prompt_col.id)},
+            user,
+            organization,
+            workspace,
+            name="th-7504-uploaded",
+        )
+
+        required_field, mapping = runner._get_required_fields_and_mappings(
+            user_eval_metric=metric
+        )
+
+        assert required_field == [str(output_col.id), str(prompt_col.id)]
+        assert mapping == [str(output_col.id), str(prompt_col.id)]
+
+    def test_platform_dataset_still_breaks_after_output_column(
+        self, dataset, user, organization, workspace, run_prompter
+    ):
+        """With a RunPrompter behind the first mapped column, the prompt is
+        auto-inferred later so only the output column must be kept."""
+        output_col = _make_column(
+            dataset,
+            "output",
+            source_id=str(run_prompter.id),
+            source=SourceChoices.RUN_PROMPT.value,
+        )
+        prompt_col = _make_column(dataset, "prompt")
+        runner, metric = self._make_runner(
+            dataset,
+            {"output": str(output_col.id), "prompt": str(prompt_col.id)},
+            user,
+            organization,
+            workspace,
+            name="th-7504-platform",
+        )
+
+        required_field, mapping = runner._get_required_fields_and_mappings(
+            user_eval_metric=metric
+        )
+
+        assert required_field == [str(output_col.id)]
+        assert mapping == [str(output_col.id)]

--- a/futureagi/model_hub/views/eval_runner.py
+++ b/futureagi/model_hub/views/eval_runner.py
@@ -748,13 +748,9 @@ def process_mapping(
                     }
                     mapping.append(prompt_dict)
                     required_field.append(key)
-                except (Column.DoesNotExist, RunPrompter.DoesNotExist) as e:
-                    logger.error(
-                        "failed_to_resolve_prompt_instruction_adherence_prompt",
-                        column_id=str(data),
-                        error=str(e),
-                    )
-                continue  # Skip normal cell resolution for this key
+                    continue  # Skip normal cell resolution for this key
+                except (Column.DoesNotExist, RunPrompter.DoesNotExist):
+                    pass  # Fall through to normal cell resolution below
 
             try:
                 if data:
@@ -788,24 +784,27 @@ def process_mapping(
                 if key == "output" and not mappings.get("input"):
                     # Skip if value is a KnowledgeBaseFile UUID
                     if not _is_knowledge_base_uuid(value):
-                        output_column = Column.objects.get(id=value)
-                        prompt_column = RunPrompter.objects.get(
-                            id=output_column.source_id
-                        )
-                        # Get the user prompt from messages
-                        prompt = "\n".join(
-                            [
-                                runner._replace_dynamic_ids(
-                                    content["text"], row
-                                )  # Updated to handle new content structure
-                                for message in prompt_column.messages
-                                if message["role"] == "user"
-                                for content in message["content"]
-                                if content["type"] == "text"
-                            ]
-                        )
-                        mapping.insert(0, prompt)
-                        required_field.insert(0, "input")
+                        try:
+                            output_column = Column.objects.get(id=value)
+                            prompt_column = RunPrompter.objects.get(
+                                id=output_column.source_id
+                            )
+                            # Get the user prompt from messages
+                            prompt = "\n".join(
+                                [
+                                    runner._replace_dynamic_ids(
+                                        content["text"], row
+                                    )
+                                    for message in prompt_column.messages
+                                    if message["role"] == "user"
+                                    for content in message["content"]
+                                    if content["type"] == "text"
+                                ]
+                            )
+                            mapping.insert(0, prompt)
+                            required_field.insert(0, "input")
+                        except (Column.DoesNotExist, RunPrompter.DoesNotExist):
+                            pass
     return required_field, mapping
 
 
@@ -1631,11 +1630,20 @@ class EvaluationRunner:
         final_mapping = []
         final_required_field = []
 
+        can_infer_prompt = False
+        if run_prompt_column and col_ids:
+            try:
+                output_col = Column.objects.get(id=col_ids[0])
+                RunPrompter.objects.get(id=output_col.source_id)
+                can_infer_prompt = True
+            except (Column.DoesNotExist, RunPrompter.DoesNotExist):
+                pass
+
         for key, data in enumerate(mapping):
             if data:
                 final_mapping.append(data)
                 final_required_field.append(col_ids[key])
-            if run_prompt_column:
+            if can_infer_prompt:
                 break
         if effective_config.get("eval_type_id") == "DeterministicEvaluator":
             return final_required_field, final_mapping


### PR DESCRIPTION
## Summary
- Running system evals (`prompt_instruction_adherence`, `tone`) on a user-uploaded dataset failed every row with "No input received for 'prompt'". The eval runner assumed every dataset column traces back to a `RunPrompter` (platform playground output); uploaded CSV datasets have none, so the prompt field was never resolved.
- All three fixes make the same conceptual change: when `RunPrompter` doesn't exist, fall back to resolving fields directly from the dataset's cells. Platform-generated datasets are unaffected (all lookups succeed, behavior identical).
- Adds regression tests pinning both the uploaded-dataset fallback and the unchanged RunPrompter-backed behavior for each fixed path.

Closes TH-7504

## Changes by file
- `futureagi/model_hub/views/eval_runner.py`:
  - `process_mapping` (prompt_instruction_adherence handling): moved the `continue` inside the `try` so it only skips normal cell resolution when the RunPrompter lookup succeeded; on `DoesNotExist` the code now falls through to normal cell resolution.
  - `process_mapping` (output→input inference under `run_prompt_column`): wrapped the previously unguarded `Column.objects.get` / `RunPrompter.objects.get` in try/except so uploaded datasets skip inference gracefully instead of crashing.
  - `_get_required_fields_and_mappings`: replaced the unconditional `if run_prompt_column: break` (which dropped the prompt column from required fields) with a `can_infer_prompt` probe that only breaks when the first mapped column actually resolves to a RunPrompter.
- `futureagi/model_hub/tests/test_eval_runner_uploaded_dataset_prompt.py` (new): six regression tests, one uploaded-dataset case and one platform-generated case per fixed path.

## Flows touched
- System evals on uploaded CSV datasets: previously failed every row with "No input received for 'prompt'"; now resolve prompt/output directly from dataset cells.
- System evals on platform-generated datasets (with RunPrompter): unchanged — prompt still resolves to the structured messages dict, input still auto-inferred from RunPrompter messages, required-fields still collapse to the output column.
- "Test eval" playground with manual text inputs: different code path, unaffected.

## Test coverage
- `test_uploaded_dataset_prompt_falls_back_to_cell_value`: prompt resolves from the dataset cell when no RunPrompter exists (misplaced-continue fix).
- `test_platform_dataset_prompt_resolves_run_prompter_messages`: RunPrompter-backed prompt still resolves to the `{system_prompt, user_prompt}` dict with no duplicate cell entry.
- `test_uploaded_dataset_skips_inference_without_run_prompter`: output→input inference no longer raises `DoesNotExist` on uploaded datasets.
- `test_platform_dataset_infers_input_from_run_prompter`: inference still inserts the user prompt as `input` when a RunPrompter exists.
- `test_uploaded_dataset_keeps_all_mapped_columns`: `_get_required_fields_and_mappings` keeps every mapped column when the prompt cannot be inferred.
- `test_platform_dataset_still_breaks_after_output_column`: old break-after-first behavior preserved when a RunPrompter backs the output column.
- Gap: no end-to-end test through the full eval execution pipeline (would need a live eval backend); unit coverage of the three fixed functions is where the bug lived.

## How tested
- `bin/test model_hub/tests/test_eval_runner_uploaded_dataset_prompt.py` — 6 passed
- `bin/test --no-services model_hub/tests/test_eval_runner_uploaded_dataset_prompt.py model_hub/tests/test_eval_runner.py model_hub/tests/test_eval_partial_inputs.py model_hub/tests/test_eval_versioning.py model_hub/tests/test_eval_runner_runtime_contracts.py model_hub/tests/test_eval_precheck_error_cells.py model_hub/tests/test_feedback_api.py model_hub/tests/test_experiment_v2_feedback.py` — 219 passed, 9 deselected (e2e/live markers)

## Media
_Screenshot / video:_ (placeholder — add manually if relevant)

## Test logs
<details>
<summary>Test run output</summary>

```
$ bin/test model_hub/tests/test_eval_runner_uploaded_dataset_prompt.py

model_hub/tests/test_eval_runner_uploaded_dataset_prompt.py::TestProcessMappingPromptInstructionAdherence::test_uploaded_dataset_prompt_falls_back_to_cell_value PASSED [ 16%]
model_hub/tests/test_eval_runner_uploaded_dataset_prompt.py::TestProcessMappingPromptInstructionAdherence::test_platform_dataset_prompt_resolves_run_prompter_messages PASSED [ 33%]
model_hub/tests/test_eval_runner_uploaded_dataset_prompt.py::TestProcessMappingRunPromptColumnInference::test_uploaded_dataset_skips_inference_without_run_prompter PASSED [ 50%]
model_hub/tests/test_eval_runner_uploaded_dataset_prompt.py::TestProcessMappingRunPromptColumnInference::test_platform_dataset_infers_input_from_run_prompter PASSED [ 66%]
model_hub/tests/test_eval_runner_uploaded_dataset_prompt.py::TestGetRequiredFieldsAndMappings::test_uploaded_dataset_keeps_all_mapped_columns PASSED [ 83%]
model_hub/tests/test_eval_runner_uploaded_dataset_prompt.py::TestGetRequiredFieldsAndMappings::test_platform_dataset_still_breaks_after_output_column PASSED [100%]

============================== 6 passed in 3.11s ===============================

$ bin/test --no-services model_hub/tests/test_eval_runner_uploaded_dataset_prompt.py \
    model_hub/tests/test_eval_runner.py model_hub/tests/test_eval_partial_inputs.py \
    model_hub/tests/test_eval_versioning.py model_hub/tests/test_eval_runner_runtime_contracts.py \
    model_hub/tests/test_eval_precheck_error_cells.py model_hub/tests/test_feedback_api.py \
    model_hub/tests/test_experiment_v2_feedback.py

====================== 219 passed, 9 deselected in 26.96s ======================
```

</details>

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)