### PR TITLE
docs: align BRANCH_NAMING_CONVENTION.md with CONTRIBUTING.md (target dev)

### DIFF
--- a/BRANCH_NAMING_CONVENTION.md
+++ b/BRANCH_NAMING_CONVENTION.md
@@ -89,12 +89,12 @@ feat/TICKET-123-implement-comprehensive-user-authentication-system-with-oauth-an
 ## 🚀 Branch Lifecycle
 
 ### Main Branch
-- `main` — production-ready code; PRs target this directly (see `CONTRIBUTING.md`).
+- `main` — production-ready code; PRs target `dev` (see `CONTRIBUTING.md`).
 
 ### Workflow
-1. Branch from `main` using a valid `type/short-description` name.
+1. Branch from `dev` using a valid `type/short-description` name.
 2. Make focused changes — keep the diff small.
-3. Open a PR against `main`.
+3. Open a PR against `dev`.
 4. After review and merge, delete the branch.
 
 ## 🛠️ Enforcement


### PR DESCRIPTION
## Summary

`BRANCH_NAMING_CONVENTION.md` told contributors to branch from and open PRs against `main`, while `CONTRIBUTING.md` says to use `dev`. That contradiction is what prompted issue #2374 — and in practice it has pushed some contributors (myself included) to open PRs against the wrong base, which then needed a maintainer rebase/retarget.

This PR updates the convention doc to match `CONTRIBUTING.md`: branch from `dev`, open PRs against `dev`.

## Changes

- **Branch Lifecycle → Main Branch:** clarify that `main` is production-ready and PRs target `dev`.
- **Branch Lifecycle → Workflow:** "Branch from `main`" → "Branch from `dev`"; "Open a PR against `main`" → "Open a PR against `dev`".

No code or workflow changes.

## Related

Fixes #2374
