### PR TITLE
fix(dashboards): match legend swatches to line colours, keep tooltip whole [TH-7679]

### DIFF
--- a/frontend/src/sections/dashboards/WidgetChart.jsx
+++ b/frontend/src/sections/dashboards/WidgetChart.jsx
@@ -115,6 +115,35 @@ export default function WidgetChart({ widget, globalDateRange }) {
   const containerRef = useRef(null);
   const [chartHeight, setChartHeight] = useState(CHART_HEIGHT_FALLBACK);
 
+  // ApexCharts places the tooltip entirely above the cursor — `cursorY - gridTop -
+  // tooltipHeight` — and never clamps that at 0; it clamps x three ways and clamps y
+  // only against the grid's bottom. Any point in the top `tooltipHeight` px of the
+  // plot therefore gets a negative top and is drawn above the canvas, where the
+  // widget card's `overflow: hidden` slices it. On these cards that is most of the
+  // plot: 134px of tooltip against a 230px grid. The card cannot drop the overflow
+  // (the chart's ResizeObserver then loses its height constraint and the canvas
+  // grows unbounded), `tooltip.fixed` is ignored on the intersect path these charts
+  // use, and a chart-level `mouseMove` hook loses the race — Apex rewrites the style
+  // after it, even a frame later. Watching the attribute is what reliably catches
+  // the write, whenever Apex makes it.
+  useEffect(() => {
+    const el = containerRef.current;
+    if (!el) return;
+    const clampTooltips = () => {
+      el.querySelectorAll(".apexcharts-tooltip").forEach((tip) => {
+        const top = Number.parseFloat(tip.style.top);
+        if (Number.isFinite(top) && top < 0) tip.style.top = "0px";
+      });
+    };
+    const mo = new MutationObserver(clampTooltips);
+    mo.observe(el, {
+      attributes: true,
+      subtree: true,
+      attributeFilter: ["style"],
+    });
+    return () => mo.disconnect();
+  }, []);
+
   useEffect(() => {
     const el = containerRef.current;
     if (!el) return;
@@ -1148,7 +1177,7 @@ export default function WidgetChart({ widget, globalDateRange }) {
       {legendNames.length > 1 && (
         <ChartLegend
           items={legendNames}
-          colors={COLORS}
+          colors={chartSeries.map((s) => colorFor(s.name))}
           onHoverSeries={handleLegendHover}
           onLeaveSeries={handleLegendLeave}
         />

--- a/frontend/src/sections/dashboards/__tests__/WidgetChart.test.jsx
+++ b/frontend/src/sections/dashboards/__tests__/WidgetChart.test.jsx
@@ -19,6 +19,17 @@ vi.mock("react-apexcharts", () => ({
       data-testid={`apex-${props.type}`}
       data-series={JSON.stringify(props.series)}
       data-labels={JSON.stringify(props.options?.labels ?? null)}
+      data-colors={JSON.stringify(props.options?.colors ?? null)}
+    />
+  ),
+}));
+
+vi.mock("../ChartLegend", () => ({
+  default: (props) => (
+    <div
+      data-testid="chart-legend"
+      data-items={JSON.stringify(props.items)}
+      data-colors={JSON.stringify(props.colors)}
     />
   ),
 }));
@@ -389,5 +400,88 @@ describe("WidgetPieCharts — nothing to draw in any metric", () => {
     expect(
       screen.getByText(/Nothing to chart for this metric/),
     ).toBeInTheDocument();
+  });
+});
+
+
+// Regression guard for TH-7679. The legend used to be handed the raw palette and
+// index it positionally (COLORS[i]), while the lines were coloured by a hash of
+// the series name — so swatch and line agreed only by coincidence. Both must now
+// come from the same per-name lookup.
+describe("WidgetChart — legend swatches match the plotted line colours", () => {
+  const multiSeriesResult = (aggregations) => ({
+    data: {
+      result: {
+        metrics: aggregations.map((aggregation) => ({
+          name: "Latency",
+          aggregation,
+          series: [
+            {
+              name: "total",
+              data: [
+                { timestamp: "2026-07-09T00:00:00Z", value: 12 },
+                { timestamp: "2026-07-09T01:00:00Z", value: 18 },
+              ],
+            },
+          ],
+        })),
+      },
+    },
+  });
+
+  const multiWidget = (aggregations) => ({
+    ...baseWidget,
+    query_config: {
+      metrics: aggregations.map((aggregation) => ({
+        name: "Latency",
+        aggregation,
+      })),
+    },
+  });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    h.query.isPending = false;
+    h.query.isError = false;
+    h.query.data = null;
+  });
+
+  it("gives the legend exactly the colours the chart draws the lines with", () => {
+    const aggs = ["p95", "p99", "p50"];
+    h.query.data = multiSeriesResult(aggs);
+    render(<WidgetChart widget={multiWidget(aggs)} globalDateRange={null} />);
+
+    const legend = screen.getByTestId("chart-legend");
+    const chart = screen.getByTestId("apex-line");
+
+    const legendColors = JSON.parse(legend.getAttribute("data-colors"));
+    const lineColors = JSON.parse(chart.getAttribute("data-colors"));
+
+    expect(legendColors).toEqual(lineColors);
+  });
+
+  it("keeps swatch and line aligned per series name, not per position", () => {
+    const aggs = ["p95", "p99", "p50"];
+    h.query.data = multiSeriesResult(aggs);
+    render(<WidgetChart widget={multiWidget(aggs)} globalDateRange={null} />);
+
+    const legend = screen.getByTestId("chart-legend");
+    const items = JSON.parse(legend.getAttribute("data-items"));
+    const legendColors = JSON.parse(legend.getAttribute("data-colors"));
+    const lineColors = JSON.parse(
+      screen.getByTestId("apex-line").getAttribute("data-colors"),
+    );
+
+    expect(items).toEqual([
+      "Latency (p95)",
+      "Latency (p99)",
+      "Latency (p50)",
+    ]);
+    items.forEach((_, i) => {
+      expect(legendColors[i]).toBe(lineColors[i]);
+    });
+    // The names above hash away from the identity mapping, so a positional
+    // legend would disagree here — that is exactly the bug being guarded.
+    expect(new Set(legendColors).size).toBe(items.length);
   });
 });


### PR DESCRIPTION
## Summary

Two frontend fixes to the dashboard widget chart, both reported by Whatfix (Ameeth) on the Quickread dashboard.

1. **Legend swatches didn't match the lines they name.** The legend coloured its swatches *positionally* from the raw palette while the lines were coloured by a hash of the series *name* — two unrelated systems that agreed only by coincidence. On the customer's dashboard no line used the legend's third colour at all, and an orange line was labelled by nothing.
2. **The tooltip was sliced down to its last row** when hovering a data point near the top of a plot.

## Linked issues

Linear: [TH-7679](https://linear.app/future-agi/issue/TH-7679/dashboard-chart-line-colors-do-not-match-across-the-widget) (parent: [TH-7677](https://linear.app/future-agi/issue/TH-7677/dashboard-3-ux-issues-reported-by-customer))

## Type of change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

---

## 1) What changes were done

**A. Legend swatches now take their colour from the same lookup as the lines**

- `ChartLegend` picks its swatch with `colors[idx]`, indexed by position. It was being handed `COLORS` — the raw 10-colour palette — so slot 0 was always purple and slot 1 always cyan, whatever the series happened to be. The lines meanwhile used `colorFor(name)`, a hash of the series name.
- It now receives `chartSeries.map((s) => colorFor(s.name))`, built from the same list in the same order as `items={legendNames}`, so index `i` means the same series in both arrays.
- No API or storage change — colours are computed entirely client-side from series names; nothing about colour is persisted or sent by the backend.

**B. The widget tooltip is kept inside the chart**

- ApexCharts places the tooltip entirely above the cursor (`cursorY - gridTop - tooltipHeight`) and never clamps that at 0. It clamps `x` three separate ways and clamps `y` only against the grid's *bottom*.
- Any point in the top `tooltipHeight` px of the plot therefore gets a negative `top`, is drawn above the canvas, and is sliced by the widget card's `overflow: hidden`. On these cards that's most of the plot — a 134px tooltip against a 230px grid.
- A `MutationObserver` on the chart subtree watches the `style` attribute and rewrites a negative `top` to `0px`. A positive `top` is left alone, so a tooltip that already fits still follows the cursor.

---

## 2) Why the changes were done

- **Product/UX:** the legend is the only thing telling a user which line is which. When it disagrees with the plot, every reading of the chart is wrong — the customer's screenshot has the median line labelled as p95, which inverts the whole chart. The sliced tooltip hides the metric name, date and value, leaving only "±x% from previous".
- **Technical (A):** the editor already did this correctly — `WidgetEditorView` passes the same `chartColors` array to both the chart and the legend. This makes the saved widget behave like its own editor preview, which is why colours matched while configuring and changed after save.
- **Technical (B):** the three obvious fixes were tried and measured first — see §8.

---

## 3) Tests written + scenarios each covers

**`frontend/src/sections/dashboards/__tests__/WidgetChart.test.jsx`** — legend/line colour agreement

- `gives the legend exactly the colours the chart draws the lines with` — renders a 3-series widget and asserts `ChartLegend`'s `colors` prop deep-equals `options.colors` handed to ApexCharts.
- `keeps swatch and line aligned per series name, not per position` — asserts per-index equality plus all-distinct colours, using series names (`Latency (p95)/(p99)/(p50)`) chosen because they hash *away* from the identity mapping, so a positional legend fails.

Both were confirmed failing against the pre-fix code before being kept:

```
AssertionError: expected [ '#7B56DB', '#1ABCFE', …(8) ] to deeply equal [ '#1ABCFE', '#FD7E14', '#7B56DB' ]
```

> Run result: **135 passed** across `src/sections/dashboards/__tests__/`. ESLint clean on the changed file (the one `react-hooks/exhaustive-deps` warning on the query effect is pre-existing — see §7).

---

## 4) How to run / test

### Frontend tests

```bash
cd frontend
yarn test:run src/sections/dashboards/__tests__/
```

### UI steps (manual)

1. Open any dashboard with a **multi-series** line widget (2+ metrics).
2. **Legend:** each swatch should be the colour of the line it names. Open the widget in the editor and back — the colours should no longer change between the two views.
3. **Tooltip:** hover a data point near the **top** of the plot. The full tooltip (name, date, value, change) should be visible instead of just its bottom row.
4. Hover a point near the **bottom** — the tooltip should still sit next to the cursor, not jump to the top.

---

## 5) Screenshots / recordings

### A. Legend swatches

Same widget, same data — only the swatches change. Before: legend claims purple=p95, cyan=p99, coral=p50, but the lines are cyan/orange/purple and **no line is coral**. After: swatches match their lines, and the ordering now agrees with `p50 ≤ p95 ≤ p99`.

**Before**

![Legend swatches — before](https://github.com/user-attachments/assets/fb7963a5-1bc4-4a83-98e0-f4d93458ef0c)

**After**

![Legend swatches — after](https://github.com/user-attachments/assets/915bf1f3-c0ab-4465-8891-55a976ae949f)

### B. Tooltip clipping

Hovering the Tokens peak (94.43K on a 100K axis). Before: ApexCharts sets `top: -141.86px`, so the tooltip is drawn above the canvas and clipped away — only a sliver survives behind the legend row. After: `top: 0px`, fully visible.

**Before**

![Tooltip — before](https://github.com/user-attachments/assets/5fb12033-4888-408c-9d17-f3c1f1b0cd77)

**After**

![Tooltip — after](https://github.com/user-attachments/assets/fa6eb9f7-a72f-4105-b534-41c79a63404c)

---

## 6) Edge cases & considerations

- **Single-series widgets:** the legend only renders for `legendNames.length > 1`, so this path is untouched.
- **Hidden series:** `colorFor` is keyed off the full `series` list, not the filtered `chartSeries`, so a hidden series keeps its colour when re-enabled — the legend now follows that same map.
- **Tooltip already fitting:** only a *negative* `top` is rewritten, so normal cursor-following behaviour is preserved (verified: a low point keeps Apex's `top: 72.14px`).
- **Feedback loop:** writing `top = "0px"` fires the observer once more, but the `top < 0` guard then fails and it stops — one extra callback per clamp, no loop.
- **Observer cost:** metered in the browser — 0 callbacks while idle, 0 during the entry animation and a re-query, and **7 callbacks / 0.10 ms total** across a 60-step hover sweep. Apex animates via SVG attributes (`d`, `cx`, `cy`) rather than inline styles, so `attributeFilter: ["style"]` filters out nearly everything. It never calls `setState`, so it triggers no React renders.
- **Pie and table widgets:** `WidgetPieCharts` already passed `legendNames.map(colorFor)` and is unaffected.

---

## 7) Pre-existing issues (NOT introduced by this PR)

- `react-hooks/exhaustive-deps` warning on the existing query effect in `WidgetChart.jsx` (missing `queryMutation`). Present on `dev`; untouched here.

---

## 8) Architectural / important decisions

- **Legend reads the series colour map rather than lines reading the palette:** the name-hash gives colour stability across reloads, which positional indexing can't. Making the legend follow the lines keeps that property; the reverse would lose it.
- **`MutationObserver` over the three simpler options**, each ruled out by measurement rather than preference:
  - `tooltip.fixed` — ignored by ApexCharts on the intersect path these charts use. Confirmed by flipping `topRight`→`bottomLeft` and getting a byte-identical position.
  - Dropping the card's `overflow: hidden` — the chart's `ResizeObserver` loses its height constraint and the canvas grows from 312px to **4537px**.
  - A `chart.events.mouseMove` hook — fires (13× per hover) and reads `top: -67.86px`, but Apex rewrites the style afterwards, even a frame later via `requestAnimationFrame`. There is no point in the frame where an event hook wins that race.
- **Not fixed here, deliberately:** the same metric can still take a different colour in *different* widgets, because collision-resolution in `buildSeriesColorMap` runs per-widget and is order-dependent (`Latency (p95)` is cyan alone but coral when it follows `Cost (sum)`). That's a separate defect from the one the customer reported and wants its own ticket.

---

## Checklist

- [x] My code follows the [style guide](../CONTRIBUTING.md#code-style)
- [x] I've added tests that prove my fix is effective or that my feature works
- [ ] `bin/test` passes locally (backend) — n/a, frontend-only
- [x] `yarn test:run` passes locally (frontend)
- [ ] `yarn contracts:check` passes if API surface changed — n/a, no API surface change
- [x] No hardcoded secrets, URLs, or PII
- [x] PR title follows Conventional Commits
- [x] Linear issue is linked and updated with status
