### PR TITLE
Harden hosted harness tenant scoping and result ingestion

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,11 @@ FROM futureagi/future-agi-base:v1.0.2
 
 COPY futureagi/ .
 
+# The application source can advance independently of the shared base image.
+# Keep small import-critical additions explicit here so every service built
+# from this Dockerfile (backend and queue workers alike) has the same runtime.
+RUN pip install --no-cache-dir "disposable-email-domains==0.0.239"
+
 # Install Node.js for sandboxed JavaScript eval execution
 RUN apt-get update -qq && \
     apt-get install -y --no-install-recommends nodejs && \

--- a/api_contracts/openapi/management-api-contract-debt.generated.json
+++ b/api_contracts/openapi/management-api-contract-debt.generated.json
@@ -1,8 +1,8 @@
 {
   "generated_from": "api_contracts/openapi/swagger.json",
   "summary": {
-    "paths": 988,
-    "operations": 1334,
+    "paths": 990,
+    "operations": 1336,
     "mutation_endpoints_without_body_schema": 0,
     "operations_without_response_schema": 0,
     "broad_success_response_schemas": 0,
@@ -128,8 +128,8 @@
       "broad_error_response_schemas": 0
     },
     "simulate": {
-      "paths": 116,
-      "operations": 137,
+      "paths": 118,
+      "operations": 139,
       "mutation_endpoints_without_body_schema": 0,
       "operations_without_response_schema": 0,
       "broad_success_response_schemas": 0,

--- a/api_contracts/openapi/management-api-contract-debt.generated.json
+++ b/api_contracts/openapi/management-api-contract-debt.generated.json
@@ -1,8 +1,8 @@
 {
   "generated_from": "api_contracts/openapi/swagger.json",
   "summary": {
-    "paths": 984,
-    "operations": 1329,
+    "paths": 988,
+    "operations": 1334,
     "mutation_endpoints_without_body_schema": 0,
     "operations_without_response_schema": 0,
     "broad_success_response_schemas": 0,
@@ -128,8 +128,8 @@
       "broad_error_response_schemas": 0
     },
     "simulate": {
-      "paths": 112,
-      "operations": 132,
+      "paths": 116,
+      "operations": 137,
       "mutation_endpoints_without_body_schema": 0,
       "operations_without_response_schema": 0,
       "broad_success_response_schemas": 0,

--- a/api_contracts/openapi/runtime-management-api-contract-debt.generated.json
+++ b/api_contracts/openapi/runtime-management-api-contract-debt.generated.json
@@ -25,7 +25,7 @@
     "broad_request_contract_decorators": 0
   },
   "app_wide_summary": {
-    "runtime_backed_validated_request_decorators": 471,
+    "runtime_backed_validated_request_decorators": 473,
     "direct_swagger_auto_schema_decorators": 242,
     "doc_only_input_contract_decorators": 0,
     "broad_request_contract_decorators": 0

--- a/api_contracts/openapi/runtime-management-api-contract-debt.generated.json
+++ b/api_contracts/openapi/runtime-management-api-contract-debt.generated.json
@@ -25,8 +25,8 @@
     "broad_request_contract_decorators": 0
   },
   "app_wide_summary": {
-    "runtime_backed_validated_request_decorators": 473,
-    "direct_swagger_auto_schema_decorators": 242,
+    "runtime_backed_validated_request_decorators": 474,
+    "direct_swagger_auto_schema_decorators": 243,
     "doc_only_input_contract_decorators": 0,
     "broad_request_contract_decorators": 0
   },

--- a/api_contracts/openapi/swagger.json
+++ b/api_contracts/openapi/swagger.json
@@ -48854,6 +48854,27 @@
                         "required": false,
                         "type": "string",
                         "maxLength": 200
+                    },
+                    {
+                        "name": "sha256",
+                        "in": "formData",
+                        "required": false,
+                        "type": "string",
+                        "pattern": "^(?:sha256:)?[0-9a-fA-F]{64}$",
+                        "minLength": 1
+                    },
+                    {
+                        "name": "kind",
+                        "in": "formData",
+                        "required": false,
+                        "type": "string",
+                        "enum": [
+                            "combined",
+                            "stereo",
+                            "customer",
+                            "assistant"
+                        ],
+                        "default": "combined"
                     }
                 ],
                 "responses": {
@@ -49357,6 +49378,90 @@
                         }
                     }
                 },
+                "tags": [
+                    "simulate"
+                ]
+            },
+            "parameters": []
+        },
+        "/simulate/api/harness-jobs/preflight/": {
+            "post": {
+                "operationId": "simulate_api_harness-jobs_preflight",
+                "description": "Control-plane facade over the configured ALK sandbox provider.",
+                "parameters": [
+                    {
+                        "name": "data",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/HarnessPreflight"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "",
+                        "schema": {
+                            "$ref": "#/definitions/HarnessPreflight"
+                        }
+                    },
+                    "default": {
+                        "description": "Default error response",
+                        "schema": {
+                            "$ref": "#/definitions/ManagementAPIErrorResponse"
+                        }
+                    }
+                },
+                "tags": [
+                    "simulate"
+                ],
+                "x-runtime-request-validation": true
+            },
+            "parameters": []
+        },
+        "/simulate/api/harness-jobs/sources/": {
+            "post": {
+                "operationId": "simulate_api_harness-jobs_source_upload",
+                "description": "Control-plane facade over the configured ALK sandbox provider.",
+                "parameters": [
+                    {
+                        "name": "files",
+                        "in": "formData",
+                        "description": "Repeat this field once for every source file.",
+                        "required": true,
+                        "type": "file"
+                    },
+                    {
+                        "name": "paths",
+                        "in": "formData",
+                        "description": "Repeat in file order with each repository-relative path.",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "name": "name",
+                        "in": "formData",
+                        "required": false,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "",
+                        "schema": {
+                            "$ref": "#/definitions/HarnessSourceUploadResponse"
+                        }
+                    },
+                    "default": {
+                        "description": "Default error response",
+                        "schema": {
+                            "$ref": "#/definitions/ManagementAPIErrorResponse"
+                        }
+                    }
+                },
+                "consumes": [
+                    "multipart/form-data"
+                ],
                 "tags": [
                     "simulate"
                 ]
@@ -113587,6 +113692,18 @@
                     "title": "Call summary",
                     "type": "string"
                 },
+                "result_digest": {
+                    "title": "Result digest",
+                    "type": "string",
+                    "pattern": "^sha256:[0-9a-f]{64}$",
+                    "minLength": 1
+                },
+                "artifact_manifest_digest": {
+                    "title": "Artifact manifest digest",
+                    "type": "string",
+                    "pattern": "^sha256:[0-9a-f]{64}$",
+                    "minLength": 1
+                },
                 "transcript": {
                     "type": "array",
                     "items": {
@@ -114057,9 +114174,6 @@
             }
         },
         "HarnessJobCreate": {
-            "required": [
-                "source_path"
-            ],
             "type": "object",
             "properties": {
                 "source_path": {
@@ -114067,6 +114181,67 @@
                     "type": "string",
                     "maxLength": 4096,
                     "minLength": 1
+                },
+                "source_id": {
+                    "title": "Source id",
+                    "type": "string",
+                    "pattern": "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$",
+                    "minLength": 1
+                },
+                "github_repository": {
+                    "title": "Github repository",
+                    "type": "string",
+                    "maxLength": 512,
+                    "minLength": 1
+                },
+                "github_ref": {
+                    "title": "Github ref",
+                    "type": "string",
+                    "maxLength": 255,
+                    "minLength": 1
+                },
+                "github_commit_sha": {
+                    "title": "Github commit sha",
+                    "type": "string",
+                    "pattern": "^[0-9a-fA-F]{40}$",
+                    "minLength": 1
+                },
+                "github_visibility": {
+                    "title": "Github visibility",
+                    "type": "string",
+                    "enum": [
+                        "public",
+                        "private"
+                    ],
+                    "default": "public"
+                },
+                "github_installation_id": {
+                    "title": "Github installation id",
+                    "type": "string",
+                    "maxLength": 255,
+                    "minLength": 1
+                },
+                "secret_refs": {
+                    "title": "Secret refs",
+                    "type": "object",
+                    "additionalProperties": {
+                        "$ref": "#/definitions/SecretReference"
+                    },
+                    "default": {}
+                },
+                "environment_values": {
+                    "title": "Environment values",
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "string",
+                        "maxLength": 65536
+                    },
+                    "default": {}
+                },
+                "connector_config": {
+                    "title": "Connector config",
+                    "type": "object",
+                    "default": {}
                 },
                 "scenario_count": {
                     "title": "Scenario count",
@@ -114092,10 +114267,60 @@
                     "maxLength": 128,
                     "minLength": 1
                 },
-                "connector_config": {
-                    "title": "Connector config",
+                "metadata": {
+                    "title": "Metadata",
                     "type": "object",
                     "default": {}
+                }
+            }
+        },
+        "HarnessPreflight": {
+            "type": "object",
+            "properties": {
+                "source_path": {
+                    "title": "Source path",
+                    "type": "string",
+                    "maxLength": 4096,
+                    "minLength": 1
+                },
+                "source_id": {
+                    "title": "Source id",
+                    "type": "string",
+                    "pattern": "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$",
+                    "minLength": 1
+                },
+                "github_repository": {
+                    "title": "Github repository",
+                    "type": "string",
+                    "maxLength": 512,
+                    "minLength": 1
+                },
+                "github_ref": {
+                    "title": "Github ref",
+                    "type": "string",
+                    "maxLength": 255,
+                    "minLength": 1
+                },
+                "github_commit_sha": {
+                    "title": "Github commit sha",
+                    "type": "string",
+                    "pattern": "^[0-9a-fA-F]{40}$",
+                    "minLength": 1
+                },
+                "github_visibility": {
+                    "title": "Github visibility",
+                    "type": "string",
+                    "enum": [
+                        "public",
+                        "private"
+                    ],
+                    "default": "public"
+                },
+                "github_installation_id": {
+                    "title": "Github installation id",
+                    "type": "string",
+                    "maxLength": 255,
+                    "minLength": 1
                 },
                 "secret_refs": {
                     "title": "Secret refs",
@@ -114105,10 +114330,48 @@
                     },
                     "default": {}
                 },
-                "metadata": {
-                    "title": "Metadata",
+                "environment_values": {
+                    "title": "Environment values",
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "string",
+                        "maxLength": 65536
+                    },
+                    "default": {}
+                },
+                "connector_config": {
+                    "title": "Connector config",
                     "type": "object",
                     "default": {}
+                }
+            }
+        },
+        "HarnessSourceUploadResponse": {
+            "required": [
+                "source_id",
+                "name",
+                "file_count",
+                "total_bytes"
+            ],
+            "type": "object",
+            "properties": {
+                "source_id": {
+                    "title": "Source id",
+                    "type": "string",
+                    "format": "uuid"
+                },
+                "name": {
+                    "title": "Name",
+                    "type": "string",
+                    "minLength": 1
+                },
+                "file_count": {
+                    "title": "File count",
+                    "type": "integer"
+                },
+                "total_bytes": {
+                    "title": "Total bytes",
+                    "type": "integer"
                 }
             }
         },

--- a/api_contracts/openapi/swagger.json
+++ b/api_contracts/openapi/swagger.json
@@ -33559,27 +33559,6 @@
                 "description": "",
                 "parameters": [
                     {
-                        "name": "created_at",
-                        "in": "query",
-                        "description": "",
-                        "required": false,
-                        "type": "string"
-                    },
-                    {
-                        "name": "status",
-                        "in": "query",
-                        "description": "",
-                        "required": false,
-                        "type": "string"
-                    },
-                    {
-                        "name": "dataset_id",
-                        "in": "query",
-                        "description": "",
-                        "required": false,
-                        "type": "string"
-                    },
-                    {
                         "name": "ordering",
                         "in": "query",
                         "description": "Which field to use when ordering the results.",
@@ -33834,27 +33813,6 @@
                 "operationId": "model-hub_experiments_v2_list_list",
                 "description": "V2 experiment list with filtering, search, and pagination.",
                 "parameters": [
-                    {
-                        "name": "created_at",
-                        "in": "query",
-                        "description": "",
-                        "required": false,
-                        "type": "string"
-                    },
-                    {
-                        "name": "status",
-                        "in": "query",
-                        "description": "",
-                        "required": false,
-                        "type": "string"
-                    },
-                    {
-                        "name": "dataset_id",
-                        "in": "query",
-                        "description": "",
-                        "required": false,
-                        "type": "string"
-                    },
                     {
                         "name": "search",
                         "in": "query",
@@ -38396,20 +38354,6 @@
                 "description": "",
                 "parameters": [
                     {
-                        "name": "optimize_type",
-                        "in": "query",
-                        "description": "",
-                        "required": false,
-                        "type": "string"
-                    },
-                    {
-                        "name": "status",
-                        "in": "query",
-                        "description": "",
-                        "required": false,
-                        "type": "string"
-                    },
-                    {
                         "name": "search",
                         "in": "query",
                         "description": "A search term.",
@@ -41022,13 +40966,6 @@
                 "description": "",
                 "parameters": [
                     {
-                        "name": "name",
-                        "in": "query",
-                        "description": "",
-                        "required": false,
-                        "type": "string"
-                    },
-                    {
                         "name": "search",
                         "in": "query",
                         "description": "A search term.",
@@ -41351,27 +41288,6 @@
                 "description": "",
                 "parameters": [
                     {
-                        "name": "template_name",
-                        "in": "query",
-                        "description": "",
-                        "required": false,
-                        "type": "string"
-                    },
-                    {
-                        "name": "template_version",
-                        "in": "query",
-                        "description": "",
-                        "required": false,
-                        "type": "string"
-                    },
-                    {
-                        "name": "created_at",
-                        "in": "query",
-                        "description": "",
-                        "required": false,
-                        "type": "string"
-                    },
-                    {
                         "name": "search",
                         "in": "query",
                         "description": "A search term.",
@@ -41450,27 +41366,6 @@
                 "operationId": "model-hub_prompt-history-executions_get_execution_details",
                 "description": "Get detailed information about a specific PromptVersion",
                 "parameters": [
-                    {
-                        "name": "template_name",
-                        "in": "query",
-                        "description": "",
-                        "required": false,
-                        "type": "string"
-                    },
-                    {
-                        "name": "template_version",
-                        "in": "query",
-                        "description": "",
-                        "required": false,
-                        "type": "string"
-                    },
-                    {
-                        "name": "created_at",
-                        "in": "query",
-                        "description": "",
-                        "required": false,
-                        "type": "string"
-                    },
                     {
                         "name": "search",
                         "in": "query",
@@ -42505,27 +42400,6 @@
                 "description": "",
                 "parameters": [
                     {
-                        "name": "name",
-                        "in": "query",
-                        "description": "",
-                        "required": false,
-                        "type": "string"
-                    },
-                    {
-                        "name": "version",
-                        "in": "query",
-                        "description": "",
-                        "required": false,
-                        "type": "string"
-                    },
-                    {
-                        "name": "created_at",
-                        "in": "query",
-                        "description": "",
-                        "required": false,
-                        "type": "string"
-                    },
-                    {
                         "name": "search",
                         "in": "query",
                         "description": "A search term.",
@@ -42873,27 +42747,6 @@
                 "operationId": "model-hub_prompt-templates_get_template_by_name",
                 "description": "Retrieve a prompt template by name.\nIf no version is specified, returns the default version (is_default=True).\nIf a version is specified, returns that specific version.",
                 "parameters": [
-                    {
-                        "name": "name",
-                        "in": "query",
-                        "description": "",
-                        "required": false,
-                        "type": "string"
-                    },
-                    {
-                        "name": "version",
-                        "in": "query",
-                        "description": "",
-                        "required": false,
-                        "type": "string"
-                    },
-                    {
-                        "name": "created_at",
-                        "in": "query",
-                        "description": "",
-                        "required": false,
-                        "type": "string"
-                    },
                     {
                         "name": "search",
                         "in": "query",
@@ -49433,6 +49286,153 @@
                 "x-runtime-response-validation": true
             },
             "parameters": []
+        },
+        "/simulate/api/harness-jobs/": {
+            "get": {
+                "operationId": "simulate_api_harness-jobs_list",
+                "description": "Control-plane facade over the configured ALK sandbox provider.",
+                "parameters": [],
+                "responses": {
+                    "200": {
+                        "description": ""
+                    },
+                    "default": {
+                        "description": "Default error response",
+                        "schema": {
+                            "$ref": "#/definitions/ManagementAPIErrorResponse"
+                        }
+                    }
+                },
+                "tags": [
+                    "simulate"
+                ]
+            },
+            "post": {
+                "operationId": "simulate_api_harness-jobs_create",
+                "description": "Control-plane facade over the configured ALK sandbox provider.",
+                "parameters": [
+                    {
+                        "name": "data",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/HarnessJobCreate"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "",
+                        "schema": {
+                            "$ref": "#/definitions/HarnessJobCreate"
+                        }
+                    },
+                    "default": {
+                        "description": "Default error response",
+                        "schema": {
+                            "$ref": "#/definitions/ManagementAPIErrorResponse"
+                        }
+                    }
+                },
+                "tags": [
+                    "simulate"
+                ],
+                "x-runtime-request-validation": true
+            },
+            "parameters": []
+        },
+        "/simulate/api/harness-jobs/health/": {
+            "get": {
+                "operationId": "simulate_api_harness-jobs_health",
+                "description": "Control-plane facade over the configured ALK sandbox provider.",
+                "parameters": [],
+                "responses": {
+                    "200": {
+                        "description": ""
+                    },
+                    "default": {
+                        "description": "Default error response",
+                        "schema": {
+                            "$ref": "#/definitions/ManagementAPIErrorResponse"
+                        }
+                    }
+                },
+                "tags": [
+                    "simulate"
+                ]
+            },
+            "parameters": []
+        },
+        "/simulate/api/harness-jobs/{id}/": {
+            "get": {
+                "operationId": "simulate_api_harness-jobs_read",
+                "description": "Control-plane facade over the configured ALK sandbox provider.",
+                "parameters": [],
+                "responses": {
+                    "200": {
+                        "description": ""
+                    },
+                    "default": {
+                        "description": "Default error response",
+                        "schema": {
+                            "$ref": "#/definitions/ManagementAPIErrorResponse"
+                        }
+                    }
+                },
+                "tags": [
+                    "simulate"
+                ]
+            },
+            "parameters": [
+                {
+                    "name": "id",
+                    "in": "path",
+                    "required": true,
+                    "type": "string"
+                }
+            ]
+        },
+        "/simulate/api/harness-jobs/{id}/cancel/": {
+            "post": {
+                "operationId": "simulate_api_harness-jobs_cancel",
+                "description": "Control-plane facade over the configured ALK sandbox provider.",
+                "parameters": [
+                    {
+                        "name": "data",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/HarnessJobAction"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "",
+                        "schema": {
+                            "$ref": "#/definitions/HarnessJobAction"
+                        }
+                    },
+                    "default": {
+                        "description": "Default error response",
+                        "schema": {
+                            "$ref": "#/definitions/ManagementAPIErrorResponse"
+                        }
+                    }
+                },
+                "tags": [
+                    "simulate"
+                ],
+                "x-runtime-request-validation": true
+            },
+            "parameters": [
+                {
+                    "name": "id",
+                    "in": "path",
+                    "required": true,
+                    "type": "string"
+                }
+            ]
         },
         "/simulate/api/livekit/call-config/{call_id}/": {
             "get": {
@@ -64493,10 +64493,6 @@
                         }
                     }
                 },
-                "produces": [
-                    "application/json",
-                    "text/csv"
-                ],
                 "tags": [
                     "tracer"
                 ],
@@ -110671,7 +110667,7 @@
                 "livekit_max_concurrency": {
                     "title": "Livekit max concurrency",
                     "type": "integer",
-                    "maximum": 25,
+                    "maximum": 5,
                     "minimum": 1,
                     "x-nullable": true
                 }
@@ -111090,7 +111086,7 @@
                 "livekit_max_concurrency": {
                     "title": "Livekit max concurrency",
                     "type": "integer",
-                    "maximum": 25,
+                    "maximum": 5,
                     "minimum": 1,
                     "x-nullable": true
                 }
@@ -111327,7 +111323,7 @@
                 "livekit_max_concurrency": {
                     "title": "Livekit max concurrency",
                     "type": "integer",
-                    "maximum": 25,
+                    "maximum": 5,
                     "minimum": 1
                 },
                 "commit_message": {
@@ -113744,6 +113740,15 @@
                     "maxLength": 255,
                     "minLength": 1
                 },
+                "modality": {
+                    "title": "Modality",
+                    "type": "string",
+                    "enum": [
+                        "text",
+                        "voice"
+                    ],
+                    "default": "text"
+                },
                 "description": {
                     "title": "Description",
                     "type": "string"
@@ -114013,6 +114018,108 @@
                             "minLength": 1
                         }
                     }
+                }
+            }
+        },
+        "SecretReference": {
+            "required": [
+                "manager",
+                "key",
+                "purpose"
+            ],
+            "type": "object",
+            "properties": {
+                "manager": {
+                    "title": "Manager",
+                    "type": "string",
+                    "maxLength": 64,
+                    "minLength": 1
+                },
+                "key": {
+                    "title": "Key",
+                    "type": "string",
+                    "maxLength": 255,
+                    "minLength": 1
+                },
+                "version": {
+                    "title": "Version",
+                    "type": "string",
+                    "maxLength": 255,
+                    "minLength": 1,
+                    "x-nullable": true
+                },
+                "purpose": {
+                    "title": "Purpose",
+                    "type": "string",
+                    "maxLength": 128,
+                    "minLength": 1
+                }
+            }
+        },
+        "HarnessJobCreate": {
+            "required": [
+                "source_path"
+            ],
+            "type": "object",
+            "properties": {
+                "source_path": {
+                    "title": "Source path",
+                    "type": "string",
+                    "maxLength": 4096,
+                    "minLength": 1
+                },
+                "scenario_count": {
+                    "title": "Scenario count",
+                    "type": "integer",
+                    "default": 10,
+                    "maximum": 100,
+                    "minimum": 1
+                },
+                "seed": {
+                    "title": "Seed",
+                    "type": "integer",
+                    "x-nullable": true
+                },
+                "agent_name": {
+                    "title": "Agent name",
+                    "type": "string",
+                    "maxLength": 255
+                },
+                "connector": {
+                    "title": "Connector",
+                    "type": "string",
+                    "default": "auto",
+                    "maxLength": 128,
+                    "minLength": 1
+                },
+                "connector_config": {
+                    "title": "Connector config",
+                    "type": "object",
+                    "default": {}
+                },
+                "secret_refs": {
+                    "title": "Secret refs",
+                    "type": "object",
+                    "additionalProperties": {
+                        "$ref": "#/definitions/SecretReference"
+                    },
+                    "default": {}
+                },
+                "metadata": {
+                    "title": "Metadata",
+                    "type": "object",
+                    "default": {}
+                }
+            }
+        },
+        "HarnessJobAction": {
+            "type": "object",
+            "properties": {
+                "reason": {
+                    "title": "Reason",
+                    "description": "Optional operator-provided reason for the action.",
+                    "type": "string",
+                    "maxLength": 500
                 }
             }
         },

--- a/api_contracts/openapi/swagger.json
+++ b/api_contracts/openapi/swagger.json
@@ -49497,6 +49497,48 @@
                 }
             ]
         },
+        "/simulate/api/harness-jobs/{id}/adjust/": {
+            "post": {
+                "operationId": "simulate_api_harness-jobs_adjust",
+                "description": "Control-plane facade over the configured ALK sandbox provider.",
+                "parameters": [
+                    {
+                        "name": "data",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/HarnessJobAdjustment"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "",
+                        "schema": {
+                            "$ref": "#/definitions/HarnessJobAdjustment"
+                        }
+                    },
+                    "default": {
+                        "description": "Default error response",
+                        "schema": {
+                            "$ref": "#/definitions/ManagementAPIErrorResponse"
+                        }
+                    }
+                },
+                "tags": [
+                    "simulate"
+                ],
+                "x-runtime-request-validation": true
+            },
+            "parameters": [
+                {
+                    "name": "id",
+                    "in": "path",
+                    "required": true,
+                    "type": "string"
+                }
+            ]
+        },
         "/simulate/api/harness-jobs/{id}/cancel/": {
             "post": {
                 "operationId": "simulate_api_harness-jobs_cancel",
@@ -114372,6 +114414,27 @@
                 "total_bytes": {
                     "title": "Total bytes",
                     "type": "integer"
+                }
+            }
+        },
+        "HarnessJobAdjustment": {
+            "required": [
+                "instruction"
+            ],
+            "type": "object",
+            "properties": {
+                "instruction": {
+                    "title": "Instruction",
+                    "description": "A user correction to apply at the next safe harness stage boundary.",
+                    "type": "string",
+                    "maxLength": 2000,
+                    "minLength": 1
+                },
+                "client_request_id": {
+                    "title": "Client request id",
+                    "type": "string",
+                    "maxLength": 128,
+                    "minLength": 1
                 }
             }
         },

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -38,6 +38,10 @@ services:
     environment:
       FAST_STARTUP: "true"
       ALK_HARNESS_SANDBOX_URL: http://alk-harness-sandbox:8788
+      # The local EE overlay keeps billing.yaml at /app/backend/ee. Without
+      # this, standalone harness evaluations resolve the cloud-only default
+      # path and fail after the model has already produced a valid score.
+      BILLING_CONFIG_PATH: /app/backend/ee/billing.yaml
 
   # Local implementation of the hosted ALK sandbox contract. It is reachable by the
   # backend over the private Compose network; its host port is loopback-only.
@@ -69,6 +73,11 @@ services:
       HARNESS_PLATFORM_URL: http://backend:80
       HARNESS_PLATFORM_API_KEY: ${FI_API_KEY:?FI_API_KEY is required for harness result ingestion}
       HARNESS_PLATFORM_SECRET_KEY: ${FI_SECRET_KEY:?FI_SECRET_KEY is required for harness result ingestion}
+      # ALK's reusable eval client uses the public SDK variable names. Point both
+      # reporting paths at the same local control/data plane for deployment parity.
+      FI_BASE_URL: http://backend:80
+      FI_API_KEY: ${FI_API_KEY:?FI_API_KEY is required for harness evaluation}
+      FI_SECRET_KEY: ${FI_SECRET_KEY:?FI_SECRET_KEY is required for harness evaluation}
       GOOGLE_APPLICATION_CREDENTIALS: ${ALK_HOST_WORKSPACE_ROOT}/future-agi/Vertex_AI_Creds.json
       DOCKER_HOST: tcp://docker-proxy:2375
       ALK_DOCKER_PUBLISHED_HOST: host.docker.internal

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -37,6 +37,52 @@ services:
       - ./futureagi:/app/backend
     environment:
       FAST_STARTUP: "true"
+      ALK_HARNESS_SANDBOX_URL: http://alk-harness-sandbox:8788
+
+  # Local implementation of the hosted ALK sandbox contract. It is reachable by the
+  # backend over the private Compose network; its host port is loopback-only.
+  alk-harness-sandbox:
+    build:
+      context: ${ALK_REPOSITORY_PATH:-../alk-pr58}
+      dockerfile: Dockerfile.sandbox
+    image: futureagi/alk-harness-sandbox:dev
+    pull_policy: never
+    env_file:
+      - path: ${ALK_HARNESS_ENV_FILE:-../alk-pr58/.env.acceptance}
+        required: false
+    environment:
+      ALK_SANDBOX_HOST: 0.0.0.0
+      ALK_SANDBOX_PORT: 8788
+      ALK_SANDBOX_ROOT: /var/lib/alk-sandbox
+      # The Docker daemon is on the host. Mount the workspace at the same
+      # absolute path inside the runner so Compose bind mounts resolve to a
+      # path both the client and daemon can see. A hosted provider uses the
+      # equivalent shared bundle/workspace mount.
+      ALK_SANDBOX_SOURCE_ROOTS: ${ALK_HOST_WORKSPACE_ROOT:?set ALK_HOST_WORKSPACE_ROOT to the directory containing agent repositories}
+      ALK_SANDBOX_PATH_MAP: ${ALK_HOST_WORKSPACE_ROOT}=${ALK_HOST_WORKSPACE_ROOT}
+      ALK_HARNESS_MODEL: ${ALK_HARNESS_MODEL:-claude-sonnet-4-6}
+      CLOUD_ML_REGION: ${CLOUD_ML_REGION:-global}
+      # The sandbox reports canonical run events/results to the platform. Keep
+      # these separate from model-provider settings loaded above: in hosted
+      # execution they are short-lived job credentials supplied by the control
+      # plane rather than values baked into the runner image.
+      HARNESS_PLATFORM_URL: http://backend:80
+      HARNESS_PLATFORM_API_KEY: ${FI_API_KEY:?FI_API_KEY is required for harness result ingestion}
+      HARNESS_PLATFORM_SECRET_KEY: ${FI_SECRET_KEY:?FI_SECRET_KEY is required for harness result ingestion}
+      GOOGLE_APPLICATION_CREDENTIALS: ${ALK_HOST_WORKSPACE_ROOT}/future-agi/Vertex_AI_Creds.json
+      DOCKER_HOST: tcp://docker-proxy:2375
+      ALK_DOCKER_PUBLISHED_HOST: host.docker.internal
+      ALK_RUNNER_CONTAINER: self
+      HARNESS_WEBHOOK_HOST: 0.0.0.0
+    volumes:
+      - ${ALK_HOST_WORKSPACE_ROOT}:${ALK_HOST_WORKSPACE_ROOT}:ro
+      - alk_harness_artifacts:/var/lib/alk-sandbox
+    ports:
+      - "127.0.0.1:${ALK_SANDBOX_PORT:-8788}:8788"
+    depends_on:
+      docker-proxy:
+        condition: service_started
+    restart: unless-stopped
 
   # agentcc-gateway, serving, and code-executor are separate services we
   # don't modify in local dev, so they are NOT built from source here —
@@ -159,3 +205,6 @@ services:
     volumes:
       - ${DOCKER_SOCKET:-/var/run/docker.sock}:/var/run/docker.sock
     restart: unless-stopped
+
+volumes:
+  alk_harness_artifacts:

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -65,6 +65,11 @@ services:
       ALK_SANDBOX_SOURCE_ROOTS: ${ALK_HOST_WORKSPACE_ROOT:?set ALK_HOST_WORKSPACE_ROOT to the directory containing agent repositories}
       ALK_SANDBOX_PATH_MAP: ${ALK_HOST_WORKSPACE_ROOT}=${ALK_HOST_WORKSPACE_ROOT}
       ALK_SANDBOX_UPLOAD_ROOT: ${ALK_HOST_WORKSPACE_ROOT}/.alk-harness-uploads
+      # A local developer laptop runs the full platform and Docker workloads together. Keep
+      # hosted-validation jobs sequential by default so two simultaneous voice/model stacks do
+      # not starve the sandbox status API or Docker daemon. Hosted deployments override this
+      # according to their per-sandbox resource envelope.
+      ALK_SANDBOX_MAX_CONCURRENCY: ${ALK_SANDBOX_MAX_CONCURRENCY:-1}
       ALK_HARNESS_MODEL: ${ALK_HARNESS_MODEL:-claude-sonnet-4-6}
       CLOUD_ML_REGION: ${CLOUD_ML_REGION:-global}
       # The sandbox reports canonical run events/results to the platform. Keep

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -65,6 +65,10 @@ services:
       ALK_SANDBOX_SOURCE_ROOTS: ${ALK_HOST_WORKSPACE_ROOT:?set ALK_HOST_WORKSPACE_ROOT to the directory containing agent repositories}
       ALK_SANDBOX_PATH_MAP: ${ALK_HOST_WORKSPACE_ROOT}=${ALK_HOST_WORKSPACE_ROOT}
       ALK_SANDBOX_UPLOAD_ROOT: ${ALK_HOST_WORKSPACE_ROOT}/.alk-harness-uploads
+      # Job-scoped credential files must be visible at the same absolute path to both the
+      # containerized runner and the host Docker daemon. Contents are mode 0400 and deleted at
+      # the terminal job boundary; they never enter source uploads or harness artifacts.
+      ALK_SANDBOX_SECRET_FILE_ROOT: ${ALK_HOST_WORKSPACE_ROOT}/.alk-harness-secret-files
       # A local developer laptop runs the full platform and Docker workloads together. Keep
       # hosted-validation jobs sequential by default so two simultaneous voice/model stacks do
       # not starve the sandbox status API or Docker daemon. Hosted deployments override this
@@ -92,6 +96,7 @@ services:
     volumes:
       - ${ALK_HOST_WORKSPACE_ROOT}:${ALK_HOST_WORKSPACE_ROOT}:ro
       - ${ALK_HOST_WORKSPACE_ROOT}/.alk-harness-uploads:${ALK_HOST_WORKSPACE_ROOT}/.alk-harness-uploads:rw
+      - ${ALK_HOST_WORKSPACE_ROOT}/.alk-harness-secret-files:${ALK_HOST_WORKSPACE_ROOT}/.alk-harness-secret-files:rw
       - alk_harness_artifacts:/var/lib/alk-sandbox
     ports:
       - "127.0.0.1:${ALK_SANDBOX_PORT:-8788}:8788"

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -64,6 +64,7 @@ services:
       # equivalent shared bundle/workspace mount.
       ALK_SANDBOX_SOURCE_ROOTS: ${ALK_HOST_WORKSPACE_ROOT:?set ALK_HOST_WORKSPACE_ROOT to the directory containing agent repositories}
       ALK_SANDBOX_PATH_MAP: ${ALK_HOST_WORKSPACE_ROOT}=${ALK_HOST_WORKSPACE_ROOT}
+      ALK_SANDBOX_UPLOAD_ROOT: ${ALK_HOST_WORKSPACE_ROOT}/.alk-harness-uploads
       ALK_HARNESS_MODEL: ${ALK_HARNESS_MODEL:-claude-sonnet-4-6}
       CLOUD_ML_REGION: ${CLOUD_ML_REGION:-global}
       # The sandbox reports canonical run events/results to the platform. Keep
@@ -85,6 +86,7 @@ services:
       HARNESS_WEBHOOK_HOST: 0.0.0.0
     volumes:
       - ${ALK_HOST_WORKSPACE_ROOT}:${ALK_HOST_WORKSPACE_ROOT}:ro
+      - ${ALK_HOST_WORKSPACE_ROOT}/.alk-harness-uploads:${ALK_HOST_WORKSPACE_ROOT}/.alk-harness-uploads:rw
       - alk_harness_artifacts:/var/lib/alk-sandbox
     ports:
       - "127.0.0.1:${ALK_SANDBOX_PORT:-8788}:8788"

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -215,5 +215,12 @@ services:
       - ${DOCKER_SOCKET:-/var/run/docker.sock}:/var/run/docker.sock
     restart: unless-stopped
 
+  # EE cloud config (cloud/agentcc_config/config.yaml) listens on 8090 and the
+  # EE clients (.env AGENTCC_*_URL, gateway_llm_client) call agentcc-gateway:8090,
+  # so remap from the OSS base contract (8090:8080) to 8090 end-to-end.
+  agentcc-gateway:
+    ports: !override
+      - "${AGENTCC_GATEWAY_PORT:-8090}:8090"
+
 volumes:
   alk_harness_artifacts:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -388,6 +388,7 @@ services:
       -c wal_level=logical
       -c max_wal_senders=25
       -c max_replication_slots=25
+      -c max_connections=300
     environment:
       POSTGRES_USER: ${PG_USER:-futureagi}
       POSTGRES_PASSWORD: ${PG_PASSWORD:-futureagi}

--- a/frontend/src/api/contracts/api-surface.generated.js
+++ b/frontend/src/api/contracts/api-surface.generated.js
@@ -5,7 +5,7 @@
 export const API_SURFACE_CONTRACT = Object.freeze({
   "generatedFrom": "api_contracts/openapi/swagger.json",
   "swaggerVersion": "2.0",
-  "endpointCount": 990,
+  "endpointCount": 991,
   "groups": {
     "accounts": {
       "/accounts/2fa/recovery-codes/": [
@@ -2286,6 +2286,9 @@ export const API_SURFACE_CONTRACT = Object.freeze({
       ],
       "/simulate/api/harness-jobs/{id}/": [
         "get"
+      ],
+      "/simulate/api/harness-jobs/{id}/adjust/": [
+        "post"
       ],
       "/simulate/api/harness-jobs/{id}/cancel/": [
         "post"
@@ -5615,6 +5618,9 @@ export const API_SURFACE_PATHS = Object.freeze({
   ],
   "/simulate/api/harness-jobs/{id}/": [
     "get"
+  ],
+  "/simulate/api/harness-jobs/{id}/adjust/": [
+    "post"
   ],
   "/simulate/api/harness-jobs/{id}/cancel/": [
     "post"

--- a/frontend/src/api/contracts/api-surface.generated.js
+++ b/frontend/src/api/contracts/api-surface.generated.js
@@ -2278,6 +2278,9 @@ export const API_SURFACE_CONTRACT = Object.freeze({
       "/simulate/api/harness-jobs/health/": [
         "get"
       ],
+      "/simulate/api/harness-jobs/preflight/": [
+        "post"
+      ],
       "/simulate/api/harness-jobs/{id}/": [
         "get"
       ],
@@ -5600,6 +5603,9 @@ export const API_SURFACE_PATHS = Object.freeze({
   ],
   "/simulate/api/harness-jobs/health/": [
     "get"
+  ],
+  "/simulate/api/harness-jobs/preflight/": [
+    "post"
   ],
   "/simulate/api/harness-jobs/{id}/": [
     "get"

--- a/frontend/src/api/contracts/api-surface.generated.js
+++ b/frontend/src/api/contracts/api-surface.generated.js
@@ -2281,6 +2281,9 @@ export const API_SURFACE_CONTRACT = Object.freeze({
       "/simulate/api/harness-jobs/preflight/": [
         "post"
       ],
+      "/simulate/api/harness-jobs/secret-files/": [
+        "post"
+      ],
       "/simulate/api/harness-jobs/sources/": [
         "post"
       ],
@@ -5611,6 +5614,9 @@ export const API_SURFACE_PATHS = Object.freeze({
     "get"
   ],
   "/simulate/api/harness-jobs/preflight/": [
+    "post"
+  ],
+  "/simulate/api/harness-jobs/secret-files/": [
     "post"
   ],
   "/simulate/api/harness-jobs/sources/": [

--- a/frontend/src/api/contracts/api-surface.generated.js
+++ b/frontend/src/api/contracts/api-surface.generated.js
@@ -5,7 +5,7 @@
 export const API_SURFACE_CONTRACT = Object.freeze({
   "generatedFrom": "api_contracts/openapi/swagger.json",
   "swaggerVersion": "2.0",
-  "endpointCount": 984,
+  "endpointCount": 988,
   "groups": {
     "accounts": {
       "/accounts/2fa/recovery-codes/": [
@@ -2270,6 +2270,19 @@ export const API_SURFACE_CONTRACT = Object.freeze({
       ],
       "/simulate/api/call-executions/": [
         "get"
+      ],
+      "/simulate/api/harness-jobs/": [
+        "get",
+        "post"
+      ],
+      "/simulate/api/harness-jobs/health/": [
+        "get"
+      ],
+      "/simulate/api/harness-jobs/{id}/": [
+        "get"
+      ],
+      "/simulate/api/harness-jobs/{id}/cancel/": [
+        "post"
       ],
       "/simulate/api/livekit/call-config/{call_id}/": [
         "get"
@@ -5580,6 +5593,19 @@ export const API_SURFACE_PATHS = Object.freeze({
   ],
   "/simulate/api/call-executions/": [
     "get"
+  ],
+  "/simulate/api/harness-jobs/": [
+    "get",
+    "post"
+  ],
+  "/simulate/api/harness-jobs/health/": [
+    "get"
+  ],
+  "/simulate/api/harness-jobs/{id}/": [
+    "get"
+  ],
+  "/simulate/api/harness-jobs/{id}/cancel/": [
+    "post"
   ],
   "/simulate/api/livekit/call-config/{call_id}/": [
     "get"

--- a/frontend/src/api/contracts/api-surface.generated.js
+++ b/frontend/src/api/contracts/api-surface.generated.js
@@ -5,7 +5,7 @@
 export const API_SURFACE_CONTRACT = Object.freeze({
   "generatedFrom": "api_contracts/openapi/swagger.json",
   "swaggerVersion": "2.0",
-  "endpointCount": 988,
+  "endpointCount": 990,
   "groups": {
     "accounts": {
       "/accounts/2fa/recovery-codes/": [
@@ -2279,6 +2279,9 @@ export const API_SURFACE_CONTRACT = Object.freeze({
         "get"
       ],
       "/simulate/api/harness-jobs/preflight/": [
+        "post"
+      ],
+      "/simulate/api/harness-jobs/sources/": [
         "post"
       ],
       "/simulate/api/harness-jobs/{id}/": [
@@ -5605,6 +5608,9 @@ export const API_SURFACE_PATHS = Object.freeze({
     "get"
   ],
   "/simulate/api/harness-jobs/preflight/": [
+    "post"
+  ],
+  "/simulate/api/harness-jobs/sources/": [
     "post"
   ],
   "/simulate/api/harness-jobs/{id}/": [

--- a/frontend/src/api/contracts/openapi-contract.generated.js
+++ b/frontend/src/api/contracts/openapi-contract.generated.js
@@ -5,7 +5,7 @@
 export const OPENAPI_CONTRACT = Object.freeze({
   "generatedFrom": "api_contracts/openapi/swagger.json",
   "swaggerVersion": "2.0",
-  "endpointCount": 988,
+  "endpointCount": 990,
   "endpoints": {
     "/accounts/2fa/recovery-codes/": {
       "get": {
@@ -27351,6 +27351,42 @@ export const OPENAPI_CONTRACT = Object.freeze({
         }
       }
     },
+    "/simulate/api/harness-jobs/preflight/": {
+      "post": {
+        "operationId": "simulate_api_harness-jobs_preflight",
+        "runtimeRequestValidation": true,
+        "runtimeResponseValidation": false,
+        "requestBody": {
+          "$ref": "#/definitions/HarnessPreflight"
+        },
+        "queryParameters": {},
+        "responses": {
+          "201": {
+            "$ref": "#/definitions/HarnessPreflight"
+          },
+          "default": {
+            "$ref": "#/definitions/ManagementAPIErrorResponse"
+          }
+        }
+      }
+    },
+    "/simulate/api/harness-jobs/sources/": {
+      "post": {
+        "operationId": "simulate_api_harness-jobs_source_upload",
+        "runtimeRequestValidation": false,
+        "runtimeResponseValidation": false,
+        "requestBody": null,
+        "queryParameters": {},
+        "responses": {
+          "201": {
+            "$ref": "#/definitions/HarnessSourceUploadResponse"
+          },
+          "default": {
+            "$ref": "#/definitions/ManagementAPIErrorResponse"
+          }
+        }
+      }
+    },
     "/simulate/api/harness-jobs/{id}/": {
       "get": {
         "operationId": "simulate_api_harness-jobs_read",
@@ -41774,6 +41810,18 @@ export const OPENAPI_CONTRACT = Object.freeze({
         "call_summary": {
           "title": "Call summary",
           "type": "string"
+        },
+        "result_digest": {
+          "title": "Result digest",
+          "type": "string",
+          "pattern": "^sha256:[0-9a-f]{64}$",
+          "minLength": 1
+        },
+        "artifact_manifest_digest": {
+          "title": "Artifact manifest digest",
+          "type": "string",
+          "pattern": "^sha256:[0-9a-f]{64}$",
+          "minLength": 1
         },
         "transcript": {
           "type": "array",
@@ -58185,9 +58233,6 @@ export const OPENAPI_CONTRACT = Object.freeze({
       }
     },
     "HarnessJobCreate": {
-      "required": [
-        "source_path"
-      ],
       "type": "object",
       "properties": {
         "source_path": {
@@ -58195,6 +58240,67 @@ export const OPENAPI_CONTRACT = Object.freeze({
           "type": "string",
           "maxLength": 4096,
           "minLength": 1
+        },
+        "source_id": {
+          "title": "Source id",
+          "type": "string",
+          "pattern": "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$",
+          "minLength": 1
+        },
+        "github_repository": {
+          "title": "Github repository",
+          "type": "string",
+          "maxLength": 512,
+          "minLength": 1
+        },
+        "github_ref": {
+          "title": "Github ref",
+          "type": "string",
+          "maxLength": 255,
+          "minLength": 1
+        },
+        "github_commit_sha": {
+          "title": "Github commit sha",
+          "type": "string",
+          "pattern": "^[0-9a-fA-F]{40}$",
+          "minLength": 1
+        },
+        "github_visibility": {
+          "title": "Github visibility",
+          "type": "string",
+          "enum": [
+            "public",
+            "private"
+          ],
+          "default": "public"
+        },
+        "github_installation_id": {
+          "title": "Github installation id",
+          "type": "string",
+          "maxLength": 255,
+          "minLength": 1
+        },
+        "secret_refs": {
+          "title": "Secret refs",
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/SecretReference"
+          },
+          "default": {}
+        },
+        "environment_values": {
+          "title": "Environment values",
+          "type": "object",
+          "additionalProperties": {
+            "type": "string",
+            "maxLength": 65536
+          },
+          "default": {}
+        },
+        "connector_config": {
+          "title": "Connector config",
+          "type": "object",
+          "default": {}
         },
         "scenario_count": {
           "title": "Scenario count",
@@ -58220,10 +58326,60 @@ export const OPENAPI_CONTRACT = Object.freeze({
           "maxLength": 128,
           "minLength": 1
         },
-        "connector_config": {
-          "title": "Connector config",
+        "metadata": {
+          "title": "Metadata",
           "type": "object",
           "default": {}
+        }
+      }
+    },
+    "HarnessPreflight": {
+      "type": "object",
+      "properties": {
+        "source_path": {
+          "title": "Source path",
+          "type": "string",
+          "maxLength": 4096,
+          "minLength": 1
+        },
+        "source_id": {
+          "title": "Source id",
+          "type": "string",
+          "pattern": "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$",
+          "minLength": 1
+        },
+        "github_repository": {
+          "title": "Github repository",
+          "type": "string",
+          "maxLength": 512,
+          "minLength": 1
+        },
+        "github_ref": {
+          "title": "Github ref",
+          "type": "string",
+          "maxLength": 255,
+          "minLength": 1
+        },
+        "github_commit_sha": {
+          "title": "Github commit sha",
+          "type": "string",
+          "pattern": "^[0-9a-fA-F]{40}$",
+          "minLength": 1
+        },
+        "github_visibility": {
+          "title": "Github visibility",
+          "type": "string",
+          "enum": [
+            "public",
+            "private"
+          ],
+          "default": "public"
+        },
+        "github_installation_id": {
+          "title": "Github installation id",
+          "type": "string",
+          "maxLength": 255,
+          "minLength": 1
         },
         "secret_refs": {
           "title": "Secret refs",
@@ -58233,10 +58389,48 @@ export const OPENAPI_CONTRACT = Object.freeze({
           },
           "default": {}
         },
-        "metadata": {
-          "title": "Metadata",
+        "environment_values": {
+          "title": "Environment values",
+          "type": "object",
+          "additionalProperties": {
+            "type": "string",
+            "maxLength": 65536
+          },
+          "default": {}
+        },
+        "connector_config": {
+          "title": "Connector config",
           "type": "object",
           "default": {}
+        }
+      }
+    },
+    "HarnessSourceUploadResponse": {
+      "required": [
+        "source_id",
+        "name",
+        "file_count",
+        "total_bytes"
+      ],
+      "type": "object",
+      "properties": {
+        "source_id": {
+          "title": "Source id",
+          "type": "string",
+          "format": "uuid"
+        },
+        "name": {
+          "title": "Name",
+          "type": "string",
+          "minLength": 1
+        },
+        "file_count": {
+          "title": "File count",
+          "type": "integer"
+        },
+        "total_bytes": {
+          "title": "Total bytes",
+          "type": "integer"
         }
       }
     },

--- a/frontend/src/api/contracts/openapi-contract.generated.js
+++ b/frontend/src/api/contracts/openapi-contract.generated.js
@@ -5,7 +5,7 @@
 export const OPENAPI_CONTRACT = Object.freeze({
   "generatedFrom": "api_contracts/openapi/swagger.json",
   "swaggerVersion": "2.0",
-  "endpointCount": 984,
+  "endpointCount": 988,
   "endpoints": {
     "/accounts/2fa/recovery-codes/": {
       "get": {
@@ -18362,24 +18362,6 @@ export const OPENAPI_CONTRACT = Object.freeze({
         "runtimeResponseValidation": false,
         "requestBody": null,
         "queryParameters": {
-          "created_at": {
-            "required": false,
-            "schema": {
-              "type": "string"
-            }
-          },
-          "status": {
-            "required": false,
-            "schema": {
-              "type": "string"
-            }
-          },
-          "dataset_id": {
-            "required": false,
-            "schema": {
-              "type": "string"
-            }
-          },
           "ordering": {
             "required": false,
             "schema": {
@@ -18543,24 +18525,6 @@ export const OPENAPI_CONTRACT = Object.freeze({
         "runtimeResponseValidation": false,
         "requestBody": null,
         "queryParameters": {
-          "created_at": {
-            "required": false,
-            "schema": {
-              "type": "string"
-            }
-          },
-          "status": {
-            "required": false,
-            "schema": {
-              "type": "string"
-            }
-          },
-          "dataset_id": {
-            "required": false,
-            "schema": {
-              "type": "string"
-            }
-          },
           "search": {
             "required": false,
             "schema": {
@@ -21045,18 +21009,6 @@ export const OPENAPI_CONTRACT = Object.freeze({
         "runtimeResponseValidation": false,
         "requestBody": null,
         "queryParameters": {
-          "optimize_type": {
-            "required": false,
-            "schema": {
-              "type": "string"
-            }
-          },
-          "status": {
-            "required": false,
-            "schema": {
-              "type": "string"
-            }
-          },
           "search": {
             "required": false,
             "schema": {
@@ -22559,12 +22511,6 @@ export const OPENAPI_CONTRACT = Object.freeze({
         "runtimeResponseValidation": false,
         "requestBody": null,
         "queryParameters": {
-          "name": {
-            "required": false,
-            "schema": {
-              "type": "string"
-            }
-          },
           "search": {
             "required": false,
             "schema": {
@@ -22784,24 +22730,6 @@ export const OPENAPI_CONTRACT = Object.freeze({
         "runtimeResponseValidation": false,
         "requestBody": null,
         "queryParameters": {
-          "template_name": {
-            "required": false,
-            "schema": {
-              "type": "string"
-            }
-          },
-          "template_version": {
-            "required": false,
-            "schema": {
-              "type": "string"
-            }
-          },
-          "created_at": {
-            "required": false,
-            "schema": {
-              "type": "string"
-            }
-          },
           "search": {
             "required": false,
             "schema": {
@@ -22869,24 +22797,6 @@ export const OPENAPI_CONTRACT = Object.freeze({
         "runtimeResponseValidation": false,
         "requestBody": null,
         "queryParameters": {
-          "template_name": {
-            "required": false,
-            "schema": {
-              "type": "string"
-            }
-          },
-          "template_version": {
-            "required": false,
-            "schema": {
-              "type": "string"
-            }
-          },
-          "created_at": {
-            "required": false,
-            "schema": {
-              "type": "string"
-            }
-          },
           "search": {
             "required": false,
             "schema": {
@@ -23506,24 +23416,6 @@ export const OPENAPI_CONTRACT = Object.freeze({
         "runtimeResponseValidation": false,
         "requestBody": null,
         "queryParameters": {
-          "name": {
-            "required": false,
-            "schema": {
-              "type": "string"
-            }
-          },
-          "version": {
-            "required": false,
-            "schema": {
-              "type": "string"
-            }
-          },
-          "created_at": {
-            "required": false,
-            "schema": {
-              "type": "string"
-            }
-          },
           "search": {
             "required": false,
             "schema": {
@@ -23737,24 +23629,6 @@ export const OPENAPI_CONTRACT = Object.freeze({
         "runtimeResponseValidation": false,
         "requestBody": null,
         "queryParameters": {
-          "name": {
-            "required": false,
-            "schema": {
-              "type": "string"
-            }
-          },
-          "version": {
-            "required": false,
-            "schema": {
-              "type": "string"
-            }
-          },
-          "created_at": {
-            "required": false,
-            "schema": {
-              "type": "string"
-            }
-          },
           "search": {
             "required": false,
             "schema": {
@@ -27425,6 +27299,84 @@ export const OPENAPI_CONTRACT = Object.freeze({
           },
           "500": {
             "$ref": "#/definitions/CallExecutionErrorResponse"
+          },
+          "default": {
+            "$ref": "#/definitions/ManagementAPIErrorResponse"
+          }
+        }
+      }
+    },
+    "/simulate/api/harness-jobs/": {
+      "get": {
+        "operationId": "simulate_api_harness-jobs_list",
+        "runtimeRequestValidation": false,
+        "runtimeResponseValidation": false,
+        "requestBody": null,
+        "queryParameters": {},
+        "responses": {
+          "default": {
+            "$ref": "#/definitions/ManagementAPIErrorResponse"
+          }
+        }
+      },
+      "post": {
+        "operationId": "simulate_api_harness-jobs_create",
+        "runtimeRequestValidation": true,
+        "runtimeResponseValidation": false,
+        "requestBody": {
+          "$ref": "#/definitions/HarnessJobCreate"
+        },
+        "queryParameters": {},
+        "responses": {
+          "201": {
+            "$ref": "#/definitions/HarnessJobCreate"
+          },
+          "default": {
+            "$ref": "#/definitions/ManagementAPIErrorResponse"
+          }
+        }
+      }
+    },
+    "/simulate/api/harness-jobs/health/": {
+      "get": {
+        "operationId": "simulate_api_harness-jobs_health",
+        "runtimeRequestValidation": false,
+        "runtimeResponseValidation": false,
+        "requestBody": null,
+        "queryParameters": {},
+        "responses": {
+          "default": {
+            "$ref": "#/definitions/ManagementAPIErrorResponse"
+          }
+        }
+      }
+    },
+    "/simulate/api/harness-jobs/{id}/": {
+      "get": {
+        "operationId": "simulate_api_harness-jobs_read",
+        "runtimeRequestValidation": false,
+        "runtimeResponseValidation": false,
+        "requestBody": null,
+        "queryParameters": {},
+        "responses": {
+          "default": {
+            "$ref": "#/definitions/ManagementAPIErrorResponse"
+          }
+        }
+      }
+    },
+    "/simulate/api/harness-jobs/{id}/cancel/": {
+      "post": {
+        "operationId": "simulate_api_harness-jobs_cancel",
+        "runtimeRequestValidation": true,
+        "runtimeResponseValidation": false,
+        "requestBody": {
+          "$ref": "#/definitions/HarnessJobAction"
+        },
+        "queryParameters": {},
+        "responses": {
+          "201": {
+            "$ref": "#/definitions/HarnessJobAction"
           },
           "default": {
             "$ref": "#/definitions/ManagementAPIErrorResponse"
@@ -41722,6 +41674,15 @@ export const OPENAPI_CONTRACT = Object.freeze({
           "maxLength": 255,
           "minLength": 1
         },
+        "modality": {
+          "title": "Modality",
+          "type": "string",
+          "enum": [
+            "text",
+            "voice"
+          ],
+          "default": "text"
+        },
         "description": {
           "title": "Description",
           "type": "string"
@@ -43442,7 +43403,7 @@ export const OPENAPI_CONTRACT = Object.freeze({
         "livekit_max_concurrency": {
           "title": "Livekit max concurrency",
           "type": "integer",
-          "maximum": 25,
+          "maximum": 5,
           "minimum": 1,
           "x-nullable": true
         }
@@ -43601,7 +43562,7 @@ export const OPENAPI_CONTRACT = Object.freeze({
         "livekit_max_concurrency": {
           "title": "Livekit max concurrency",
           "type": "integer",
-          "maximum": 25,
+          "maximum": 5,
           "minimum": 1,
           "x-nullable": true
         }
@@ -44636,7 +44597,7 @@ export const OPENAPI_CONTRACT = Object.freeze({
         "livekit_max_concurrency": {
           "title": "Livekit max concurrency",
           "type": "integer",
-          "maximum": 25,
+          "maximum": 5,
           "minimum": 1
         },
         "commit_message": {
@@ -58209,6 +58170,73 @@ export const OPENAPI_CONTRACT = Object.freeze({
         },
         "result": {
           "$ref": "#/definitions/GroundTruthUploadResponseResult"
+        }
+      }
+    },
+    "HarnessJobAction": {
+      "type": "object",
+      "properties": {
+        "reason": {
+          "title": "Reason",
+          "description": "Optional operator-provided reason for the action.",
+          "type": "string",
+          "maxLength": 500
+        }
+      }
+    },
+    "HarnessJobCreate": {
+      "required": [
+        "source_path"
+      ],
+      "type": "object",
+      "properties": {
+        "source_path": {
+          "title": "Source path",
+          "type": "string",
+          "maxLength": 4096,
+          "minLength": 1
+        },
+        "scenario_count": {
+          "title": "Scenario count",
+          "type": "integer",
+          "default": 10,
+          "maximum": 100,
+          "minimum": 1
+        },
+        "seed": {
+          "title": "Seed",
+          "type": "integer",
+          "x-nullable": true
+        },
+        "agent_name": {
+          "title": "Agent name",
+          "type": "string",
+          "maxLength": 255
+        },
+        "connector": {
+          "title": "Connector",
+          "type": "string",
+          "default": "auto",
+          "maxLength": 128,
+          "minLength": 1
+        },
+        "connector_config": {
+          "title": "Connector config",
+          "type": "object",
+          "default": {}
+        },
+        "secret_refs": {
+          "title": "Secret refs",
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/SecretReference"
+          },
+          "default": {}
+        },
+        "metadata": {
+          "title": "Metadata",
+          "type": "object",
+          "default": {}
         }
       }
     },
@@ -84301,6 +84329,41 @@ export const OPENAPI_CONTRACT = Object.freeze({
         "embedding_status": {
           "title": "Embedding status",
           "type": "string",
+          "minLength": 1
+        }
+      }
+    },
+    "SecretReference": {
+      "required": [
+        "manager",
+        "key",
+        "purpose"
+      ],
+      "type": "object",
+      "properties": {
+        "manager": {
+          "title": "Manager",
+          "type": "string",
+          "maxLength": 64,
+          "minLength": 1
+        },
+        "key": {
+          "title": "Key",
+          "type": "string",
+          "maxLength": 255,
+          "minLength": 1
+        },
+        "version": {
+          "title": "Version",
+          "type": "string",
+          "maxLength": 255,
+          "minLength": 1,
+          "x-nullable": true
+        },
+        "purpose": {
+          "title": "Purpose",
+          "type": "string",
+          "maxLength": 128,
           "minLength": 1
         }
       }

--- a/frontend/src/api/contracts/openapi-contract.generated.js
+++ b/frontend/src/api/contracts/openapi-contract.generated.js
@@ -5,7 +5,7 @@
 export const OPENAPI_CONTRACT = Object.freeze({
   "generatedFrom": "api_contracts/openapi/swagger.json",
   "swaggerVersion": "2.0",
-  "endpointCount": 990,
+  "endpointCount": 991,
   "endpoints": {
     "/accounts/2fa/recovery-codes/": {
       "get": {
@@ -27395,6 +27395,25 @@ export const OPENAPI_CONTRACT = Object.freeze({
         "requestBody": null,
         "queryParameters": {},
         "responses": {
+          "default": {
+            "$ref": "#/definitions/ManagementAPIErrorResponse"
+          }
+        }
+      }
+    },
+    "/simulate/api/harness-jobs/{id}/adjust/": {
+      "post": {
+        "operationId": "simulate_api_harness-jobs_adjust",
+        "runtimeRequestValidation": true,
+        "runtimeResponseValidation": false,
+        "requestBody": {
+          "$ref": "#/definitions/HarnessJobAdjustment"
+        },
+        "queryParameters": {},
+        "responses": {
+          "201": {
+            "$ref": "#/definitions/HarnessJobAdjustment"
+          },
           "default": {
             "$ref": "#/definitions/ManagementAPIErrorResponse"
           }
@@ -58229,6 +58248,27 @@ export const OPENAPI_CONTRACT = Object.freeze({
           "description": "Optional operator-provided reason for the action.",
           "type": "string",
           "maxLength": 500
+        }
+      }
+    },
+    "HarnessJobAdjustment": {
+      "required": [
+        "instruction"
+      ],
+      "type": "object",
+      "properties": {
+        "instruction": {
+          "title": "Instruction",
+          "description": "A user correction to apply at the next safe harness stage boundary.",
+          "type": "string",
+          "maxLength": 2000,
+          "minLength": 1
+        },
+        "client_request_id": {
+          "title": "Client request id",
+          "type": "string",
+          "maxLength": 128,
+          "minLength": 1
         }
       }
     },

--- a/frontend/src/api/harness/harness.js
+++ b/frontend/src/api/harness/harness.js
@@ -2,15 +2,16 @@ import axios from "src/utils/axios";
 import { apiPath } from "src/api/contracts/api-surface";
 
 const jobsPath = () => apiPath("/simulate/api/harness-jobs/");
-const jobPath = (id) =>
-  apiPath("/simulate/api/harness-jobs/{id}/", { id });
+const jobPath = (id) => apiPath("/simulate/api/harness-jobs/{id}/", { id });
 const cancelPath = (id) =>
   apiPath("/simulate/api/harness-jobs/{id}/cancel/", { id });
+const preflightPath = () => apiPath("/simulate/api/harness-jobs/preflight/");
 
 export const listHarnessJobs = async () => (await axios.get(jobsPath())).data;
 export const createHarnessJob = async (payload) =>
   (await axios.post(jobsPath(), payload)).data;
-export const getHarnessJob = async (id) =>
-  (await axios.get(jobPath(id))).data;
+export const preflightHarnessJob = async (payload) =>
+  (await axios.post(preflightPath(), payload)).data;
+export const getHarnessJob = async (id) => (await axios.get(jobPath(id))).data;
 export const cancelHarnessJob = async (id) =>
   (await axios.post(cancelPath(id))).data;

--- a/frontend/src/api/harness/harness.js
+++ b/frontend/src/api/harness/harness.js
@@ -1,0 +1,16 @@
+import axios from "src/utils/axios";
+import { apiPath } from "src/api/contracts/api-surface";
+
+const jobsPath = () => apiPath("/simulate/api/harness-jobs/");
+const jobPath = (id) =>
+  apiPath("/simulate/api/harness-jobs/{id}/", { id });
+const cancelPath = (id) =>
+  apiPath("/simulate/api/harness-jobs/{id}/cancel/", { id });
+
+export const listHarnessJobs = async () => (await axios.get(jobsPath())).data;
+export const createHarnessJob = async (payload) =>
+  (await axios.post(jobsPath(), payload)).data;
+export const getHarnessJob = async (id) =>
+  (await axios.get(jobPath(id))).data;
+export const cancelHarnessJob = async (id) =>
+  (await axios.post(cancelPath(id))).data;

--- a/frontend/src/api/harness/harness.js
+++ b/frontend/src/api/harness/harness.js
@@ -9,6 +9,8 @@ const adjustPath = (id) =>
   apiPath("/simulate/api/harness-jobs/{id}/adjust/", { id });
 const preflightPath = () => apiPath("/simulate/api/harness-jobs/preflight/");
 const sourcesPath = () => apiPath("/simulate/api/harness-jobs/sources/");
+const secretFilesPath = () =>
+  apiPath("/simulate/api/harness-jobs/secret-files/");
 
 export const listHarnessJobs = async () => (await axios.get(jobsPath())).data;
 export const createHarnessJob = async (payload) =>
@@ -21,6 +23,13 @@ export const uploadHarnessSource = async (formData, onUploadProgress) =>
       headers: { "Content-Type": "multipart/form-data" },
       onUploadProgress,
       timeout: 300000,
+    })
+  ).data;
+export const uploadHarnessSecretFile = async (formData) =>
+  (
+    await axios.post(secretFilesPath(), formData, {
+      headers: { "Content-Type": "multipart/form-data" },
+      timeout: 60000,
     })
   ).data;
 export const getHarnessJob = async (id) => (await axios.get(jobPath(id))).data;

--- a/frontend/src/api/harness/harness.js
+++ b/frontend/src/api/harness/harness.js
@@ -6,12 +6,21 @@ const jobPath = (id) => apiPath("/simulate/api/harness-jobs/{id}/", { id });
 const cancelPath = (id) =>
   apiPath("/simulate/api/harness-jobs/{id}/cancel/", { id });
 const preflightPath = () => apiPath("/simulate/api/harness-jobs/preflight/");
+const sourcesPath = () => apiPath("/simulate/api/harness-jobs/sources/");
 
 export const listHarnessJobs = async () => (await axios.get(jobsPath())).data;
 export const createHarnessJob = async (payload) =>
   (await axios.post(jobsPath(), payload)).data;
 export const preflightHarnessJob = async (payload) =>
   (await axios.post(preflightPath(), payload)).data;
+export const uploadHarnessSource = async (formData, onUploadProgress) =>
+  (
+    await axios.post(sourcesPath(), formData, {
+      headers: { "Content-Type": "multipart/form-data" },
+      onUploadProgress,
+      timeout: 300000,
+    })
+  ).data;
 export const getHarnessJob = async (id) => (await axios.get(jobPath(id))).data;
 export const cancelHarnessJob = async (id) =>
   (await axios.post(cancelPath(id))).data;

--- a/frontend/src/api/harness/harness.js
+++ b/frontend/src/api/harness/harness.js
@@ -5,6 +5,8 @@ const jobsPath = () => apiPath("/simulate/api/harness-jobs/");
 const jobPath = (id) => apiPath("/simulate/api/harness-jobs/{id}/", { id });
 const cancelPath = (id) =>
   apiPath("/simulate/api/harness-jobs/{id}/cancel/", { id });
+const adjustPath = (id) =>
+  apiPath("/simulate/api/harness-jobs/{id}/adjust/", { id });
 const preflightPath = () => apiPath("/simulate/api/harness-jobs/preflight/");
 const sourcesPath = () => apiPath("/simulate/api/harness-jobs/sources/");
 
@@ -24,3 +26,5 @@ export const uploadHarnessSource = async (formData, onUploadProgress) =>
 export const getHarnessJob = async (id) => (await axios.get(jobPath(id))).data;
 export const cancelHarnessJob = async (id) =>
   (await axios.post(cancelPath(id))).data;
+export const adjustHarnessJob = async (id, payload) =>
+  (await axios.post(adjustPath(id), payload)).data;

--- a/frontend/src/app.jsx
+++ b/frontend/src/app.jsx
@@ -214,7 +214,7 @@ export default function App() {
           </WorkspaceProvider>
         </OrganizationProvider>
       </AuthProvider>
-      <ReactQueryDevtools initialIsOpen={false} />
+      {/* <ReactQueryDevtools initialIsOpen={false} /> */}
     </QueryClientProvider>
   );
 }

--- a/frontend/src/generated/api-contracts/api.schemas.ts
+++ b/frontend/src/generated/api-contracts/api.schemas.ts
@@ -15716,6 +15716,16 @@ export interface ALKSimulateResultApi {
   ended_reason?: string;
   error_message?: string;
   call_summary?: string;
+  /**
+     * @minLength 1
+     * @pattern ^sha256:[0-9a-f]{64}$
+     */
+  result_digest?: string;
+  /**
+     * @minLength 1
+     * @pattern ^sha256:[0-9a-f]{64}$
+     */
+  artifact_manifest_digest?: string;
   transcript?: ALKSimulateTranscriptSegmentApi[];
   /** @maxLength 500 */
   recording_url?: string;
@@ -15874,7 +15884,13 @@ export interface CallExecutionErrorResponseApi {
   details?: CallExecutionErrorResponseApiDetails;
 }
 
-export type HarnessJobCreateApiConnectorConfig = { [key: string]: unknown };
+export type HarnessJobCreateApiGithubVisibility = typeof HarnessJobCreateApiGithubVisibility[keyof typeof HarnessJobCreateApiGithubVisibility];
+
+
+export const HarnessJobCreateApiGithubVisibility = {
+  public: 'public',
+  private: 'private',
+} as const;
 
 export interface SecretReferenceApi {
   /**
@@ -15901,6 +15917,10 @@ export interface SecretReferenceApi {
 
 export type HarnessJobCreateApiSecretRefs = {[key: string]: SecretReferenceApi};
 
+export type HarnessJobCreateApiEnvironmentValues = {[key: string]: string};
+
+export type HarnessJobCreateApiConnectorConfig = { [key: string]: unknown };
+
 export type HarnessJobCreateApiMetadata = { [key: string]: unknown };
 
 export interface HarnessJobCreateApi {
@@ -15908,7 +15928,36 @@ export interface HarnessJobCreateApi {
      * @minLength 1
      * @maxLength 4096
      */
-  source_path: string;
+  source_path?: string;
+  /**
+     * @minLength 1
+     * @pattern ^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$
+     */
+  source_id?: string;
+  /**
+     * @minLength 1
+     * @maxLength 512
+     */
+  github_repository?: string;
+  /**
+     * @minLength 1
+     * @maxLength 255
+     */
+  github_ref?: string;
+  /**
+     * @minLength 1
+     * @pattern ^[0-9a-fA-F]{40}$
+     */
+  github_commit_sha?: string;
+  github_visibility?: HarnessJobCreateApiGithubVisibility;
+  /**
+     * @minLength 1
+     * @maxLength 255
+     */
+  github_installation_id?: string;
+  secret_refs?: HarnessJobCreateApiSecretRefs;
+  environment_values?: HarnessJobCreateApiEnvironmentValues;
+  connector_config?: HarnessJobCreateApiConnectorConfig;
   /**
      * @minimum 1
      * @maximum 100
@@ -15922,9 +15971,66 @@ export interface HarnessJobCreateApi {
      * @maxLength 128
      */
   connector?: string;
-  connector_config?: HarnessJobCreateApiConnectorConfig;
-  secret_refs?: HarnessJobCreateApiSecretRefs;
   metadata?: HarnessJobCreateApiMetadata;
+}
+
+export type HarnessPreflightApiGithubVisibility = typeof HarnessPreflightApiGithubVisibility[keyof typeof HarnessPreflightApiGithubVisibility];
+
+
+export const HarnessPreflightApiGithubVisibility = {
+  public: 'public',
+  private: 'private',
+} as const;
+
+export type HarnessPreflightApiSecretRefs = {[key: string]: SecretReferenceApi};
+
+export type HarnessPreflightApiEnvironmentValues = {[key: string]: string};
+
+export type HarnessPreflightApiConnectorConfig = { [key: string]: unknown };
+
+export interface HarnessPreflightApi {
+  /**
+     * @minLength 1
+     * @maxLength 4096
+     */
+  source_path?: string;
+  /**
+     * @minLength 1
+     * @pattern ^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$
+     */
+  source_id?: string;
+  /**
+     * @minLength 1
+     * @maxLength 512
+     */
+  github_repository?: string;
+  /**
+     * @minLength 1
+     * @maxLength 255
+     */
+  github_ref?: string;
+  /**
+     * @minLength 1
+     * @pattern ^[0-9a-fA-F]{40}$
+     */
+  github_commit_sha?: string;
+  github_visibility?: HarnessPreflightApiGithubVisibility;
+  /**
+     * @minLength 1
+     * @maxLength 255
+     */
+  github_installation_id?: string;
+  secret_refs?: HarnessPreflightApiSecretRefs;
+  environment_values?: HarnessPreflightApiEnvironmentValues;
+  connector_config?: HarnessPreflightApiConnectorConfig;
+}
+
+export interface HarnessSourceUploadResponseApi {
+  source_id: string;
+  /** @minLength 1 */
+  name: string;
+  file_count: number;
+  total_bytes: number;
 }
 
 export interface HarnessJobActionApi {
@@ -26129,6 +26235,8 @@ export type SimulateApiAgentPromptOptimiserList200 = {
 export type SimulateApiAlkSimulateCallExecutionsRecordingUploadBody = {
   file: Blob;
   filename?: string;
+  sha256?: string;
+  kind?: string;
 };
 
 export type SimulateApiCallExecutionsListParams = {
@@ -26143,6 +26251,14 @@ page?: number;
  * @minimum 1
  */
 limit?: number;
+};
+
+export type SimulateApiHarnessJobsSourceUploadBody = {
+  /** Repeat this field once for every source file. */
+  files: Blob;
+  /** Repeat in file order with each repository-relative path. */
+  paths: string;
+  name?: string;
 };
 
 /**

--- a/frontend/src/generated/api-contracts/api.schemas.ts
+++ b/frontend/src/generated/api-contracts/api.schemas.ts
@@ -14314,7 +14314,7 @@ export interface AgentDefinitionCreateRequestApi {
   livekit_config_json?: AgentDefinitionCreateRequestApiLivekitConfigJson;
   /**
      * @minimum 1
-     * @maximum 25
+     * @maximum 5
      */
   livekit_max_concurrency?: number;
 }
@@ -14547,7 +14547,7 @@ export interface AgentDefinitionEditRequestApi {
   livekit_config_json?: AgentDefinitionEditRequestApiLivekitConfigJson;
   /**
      * @minimum 1
-     * @maximum 25
+     * @maximum 5
      */
   livekit_max_concurrency?: number;
 }
@@ -14656,7 +14656,7 @@ export interface AgentVersionCreateRequestApi {
   livekit_config_json?: AgentVersionCreateRequestApiLivekitConfigJson;
   /**
      * @minimum 1
-     * @maximum 25
+     * @maximum 5
      */
   livekit_max_concurrency?: number;
   commit_message?: string;
@@ -15758,6 +15758,14 @@ export interface ALKSimulateStatusUpdateResponseApi {
   result: ALKSimulateStatusUpdateOutcomeApi;
 }
 
+export type ALKSimulateProvisionRunTestRequestApiModality = typeof ALKSimulateProvisionRunTestRequestApiModality[keyof typeof ALKSimulateProvisionRunTestRequestApiModality];
+
+
+export const ALKSimulateProvisionRunTestRequestApiModality = {
+  text: 'text',
+  voice: 'voice',
+} as const;
+
 export type ALKSimulateProvisionPersonaApiPersona = { [key: string]: unknown };
 
 export interface ALKSimulateProvisionPersonaApi {
@@ -15776,6 +15784,7 @@ export interface ALKSimulateProvisionRunTestRequestApi {
      * @maxLength 255
      */
   name: string;
+  modality?: ALKSimulateProvisionRunTestRequestApiModality;
   description?: string;
   personas?: ALKSimulateProvisionPersonaApi[];
   scenario_ids?: string[];
@@ -15863,6 +15872,67 @@ export interface CallExecutionErrorResponseApi {
   error?: string;
   attr?: string;
   details?: CallExecutionErrorResponseApiDetails;
+}
+
+export type HarnessJobCreateApiConnectorConfig = { [key: string]: unknown };
+
+export interface SecretReferenceApi {
+  /**
+     * @minLength 1
+     * @maxLength 64
+     */
+  manager: string;
+  /**
+     * @minLength 1
+     * @maxLength 255
+     */
+  key: string;
+  /**
+     * @minLength 1
+     * @maxLength 255
+     */
+  version?: string;
+  /**
+     * @minLength 1
+     * @maxLength 128
+     */
+  purpose: string;
+}
+
+export type HarnessJobCreateApiSecretRefs = {[key: string]: SecretReferenceApi};
+
+export type HarnessJobCreateApiMetadata = { [key: string]: unknown };
+
+export interface HarnessJobCreateApi {
+  /**
+     * @minLength 1
+     * @maxLength 4096
+     */
+  source_path: string;
+  /**
+     * @minimum 1
+     * @maximum 100
+     */
+  scenario_count?: number;
+  seed?: number;
+  /** @maxLength 255 */
+  agent_name?: string;
+  /**
+     * @minLength 1
+     * @maxLength 128
+     */
+  connector?: string;
+  connector_config?: HarnessJobCreateApiConnectorConfig;
+  secret_refs?: HarnessJobCreateApiSecretRefs;
+  metadata?: HarnessJobCreateApiMetadata;
+}
+
+export interface HarnessJobActionApi {
+  /**
+     * Optional operator-provided reason for the action.
+     * @maxLength 500
+     */
+  reason?: string;
 }
 
 export type LiveKitCallConfigResponseApiCallMetadata = {[key: string]: { [key: string]: unknown }};
@@ -25074,9 +25144,6 @@ export type ModelHubExperimentDetailList200 = {
 };
 
 export type ModelHubExperimentsDataListParams = {
-created_at?: string;
-status?: string;
-dataset_id?: string;
 /**
  * Which field to use when ordering the results.
  */
@@ -25103,9 +25170,6 @@ export type ModelHubExperimentsDataList200 = {
 };
 
 export type ModelHubExperimentsV2ListListParams = {
-created_at?: string;
-status?: string;
-dataset_id?: string;
 /**
  * A search term.
  */
@@ -25278,8 +25342,6 @@ limit?: number;
 };
 
 export type ModelHubOptimisationListParams = {
-optimize_type?: string;
-status?: string;
 /**
  * A search term.
  */
@@ -25457,7 +25519,6 @@ export type ModelHubPromptBaseTemplatesGetAllCategories200 = {
 };
 
 export type ModelHubPromptExecutionsListParams = {
-name?: string;
 /**
  * A search term.
  */
@@ -25502,9 +25563,6 @@ export type ModelHubPromptFoldersList200 = {
 };
 
 export type ModelHubPromptHistoryExecutionsListParams = {
-template_name?: string;
-template_version?: string;
-created_at?: string;
 /**
  * A search term.
  */
@@ -25531,9 +25589,6 @@ export type ModelHubPromptHistoryExecutionsList200 = {
 };
 
 export type ModelHubPromptHistoryExecutionsGetExecutionDetailsParams = {
-template_name?: string;
-template_version?: string;
-created_at?: string;
 /**
  * A search term.
  */
@@ -25614,9 +25669,6 @@ export type ModelHubPromptLabelsTemplateLabels200 = {
 };
 
 export type ModelHubPromptTemplatesListParams = {
-name?: string;
-version?: string;
-created_at?: string;
 /**
  * A search term.
  */
@@ -25643,9 +25695,6 @@ export type ModelHubPromptTemplatesList200 = {
 };
 
 export type ModelHubPromptTemplatesGetTemplateByNameParams = {
-name?: string;
-version?: string;
-created_at?: string;
 /**
  * A search term.
  */

--- a/frontend/src/generated/api-contracts/api.ts
+++ b/frontend/src/generated/api-contracts/api.ts
@@ -547,6 +547,8 @@ import type {
   GroundTruthStatusResponseApi,
   GroundTruthUploadRequestApi,
   GroundTruthUploadResponseApi,
+  HarnessJobActionApi,
+  HarnessJobCreateApi,
   HealthCheckResponseApi,
   HeartbeatApi,
   HuggingFaceAddRowsRequestApi,
@@ -52845,6 +52847,224 @@ export const simulateApiCallExecutionsList = async (params?: SimulateApiCallExec
     method: 'GET'
 
 
+  }
+);}
+
+
+
+export type simulateApiHarnessJobsListResponse200 = {
+  data: void
+  status: 200
+}
+
+export type simulateApiHarnessJobsListResponseDefault = {
+  data: ManagementAPIErrorResponseApi
+  status: Exclude<HTTPStatusCodes, 200>
+}
+
+export type simulateApiHarnessJobsListResponseSuccess = (simulateApiHarnessJobsListResponse200) & {
+  headers: Headers;
+};
+export type simulateApiHarnessJobsListResponseError = (simulateApiHarnessJobsListResponseDefault) & {
+  headers: Headers;
+};
+
+export type simulateApiHarnessJobsListResponse = (simulateApiHarnessJobsListResponseSuccess | simulateApiHarnessJobsListResponseError)
+
+export const getSimulateApiHarnessJobsListUrl = () => {
+
+
+
+
+  return `/simulate/api/harness-jobs/`
+}
+
+/**
+ * Control-plane facade over the configured ALK sandbox provider.
+ */
+export const simulateApiHarnessJobsList = async ( options?: RequestInit): Promise<simulateApiHarnessJobsListResponse> => {
+
+  return apiMutator<simulateApiHarnessJobsListResponse>(getSimulateApiHarnessJobsListUrl(),
+  {
+    ...options,
+    method: 'GET'
+
+
+  }
+);}
+
+
+
+export type simulateApiHarnessJobsCreateResponse201 = {
+  data: HarnessJobCreateApi
+  status: 201
+}
+
+export type simulateApiHarnessJobsCreateResponseDefault = {
+  data: ManagementAPIErrorResponseApi
+  status: Exclude<HTTPStatusCodes, 201>
+}
+
+export type simulateApiHarnessJobsCreateResponseSuccess = (simulateApiHarnessJobsCreateResponse201) & {
+  headers: Headers;
+};
+export type simulateApiHarnessJobsCreateResponseError = (simulateApiHarnessJobsCreateResponseDefault) & {
+  headers: Headers;
+};
+
+export type simulateApiHarnessJobsCreateResponse = (simulateApiHarnessJobsCreateResponseSuccess | simulateApiHarnessJobsCreateResponseError)
+
+export const getSimulateApiHarnessJobsCreateUrl = () => {
+
+
+
+
+  return `/simulate/api/harness-jobs/`
+}
+
+/**
+ * Control-plane facade over the configured ALK sandbox provider.
+ */
+export const simulateApiHarnessJobsCreate = async (harnessJobCreateApi: HarnessJobCreateApi, options?: RequestInit): Promise<simulateApiHarnessJobsCreateResponse> => {
+
+  return apiMutator<simulateApiHarnessJobsCreateResponse>(getSimulateApiHarnessJobsCreateUrl(),
+  {
+    ...options,
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', ...options?.headers },
+    body: JSON.stringify(
+      harnessJobCreateApi,)
+  }
+);}
+
+
+
+export type simulateApiHarnessJobsHealthResponse200 = {
+  data: void
+  status: 200
+}
+
+export type simulateApiHarnessJobsHealthResponseDefault = {
+  data: ManagementAPIErrorResponseApi
+  status: Exclude<HTTPStatusCodes, 200>
+}
+
+export type simulateApiHarnessJobsHealthResponseSuccess = (simulateApiHarnessJobsHealthResponse200) & {
+  headers: Headers;
+};
+export type simulateApiHarnessJobsHealthResponseError = (simulateApiHarnessJobsHealthResponseDefault) & {
+  headers: Headers;
+};
+
+export type simulateApiHarnessJobsHealthResponse = (simulateApiHarnessJobsHealthResponseSuccess | simulateApiHarnessJobsHealthResponseError)
+
+export const getSimulateApiHarnessJobsHealthUrl = () => {
+
+
+
+
+  return `/simulate/api/harness-jobs/health/`
+}
+
+/**
+ * Control-plane facade over the configured ALK sandbox provider.
+ */
+export const simulateApiHarnessJobsHealth = async ( options?: RequestInit): Promise<simulateApiHarnessJobsHealthResponse> => {
+
+  return apiMutator<simulateApiHarnessJobsHealthResponse>(getSimulateApiHarnessJobsHealthUrl(),
+  {
+    ...options,
+    method: 'GET'
+
+
+  }
+);}
+
+
+
+export type simulateApiHarnessJobsReadResponse200 = {
+  data: void
+  status: 200
+}
+
+export type simulateApiHarnessJobsReadResponseDefault = {
+  data: ManagementAPIErrorResponseApi
+  status: Exclude<HTTPStatusCodes, 200>
+}
+
+export type simulateApiHarnessJobsReadResponseSuccess = (simulateApiHarnessJobsReadResponse200) & {
+  headers: Headers;
+};
+export type simulateApiHarnessJobsReadResponseError = (simulateApiHarnessJobsReadResponseDefault) & {
+  headers: Headers;
+};
+
+export type simulateApiHarnessJobsReadResponse = (simulateApiHarnessJobsReadResponseSuccess | simulateApiHarnessJobsReadResponseError)
+
+export const getSimulateApiHarnessJobsReadUrl = (id: string,) => {
+
+
+
+
+  return `/simulate/api/harness-jobs/${id}/`
+}
+
+/**
+ * Control-plane facade over the configured ALK sandbox provider.
+ */
+export const simulateApiHarnessJobsRead = async (id: string, options?: RequestInit): Promise<simulateApiHarnessJobsReadResponse> => {
+
+  return apiMutator<simulateApiHarnessJobsReadResponse>(getSimulateApiHarnessJobsReadUrl(id),
+  {
+    ...options,
+    method: 'GET'
+
+
+  }
+);}
+
+
+
+export type simulateApiHarnessJobsCancelResponse201 = {
+  data: HarnessJobActionApi
+  status: 201
+}
+
+export type simulateApiHarnessJobsCancelResponseDefault = {
+  data: ManagementAPIErrorResponseApi
+  status: Exclude<HTTPStatusCodes, 201>
+}
+
+export type simulateApiHarnessJobsCancelResponseSuccess = (simulateApiHarnessJobsCancelResponse201) & {
+  headers: Headers;
+};
+export type simulateApiHarnessJobsCancelResponseError = (simulateApiHarnessJobsCancelResponseDefault) & {
+  headers: Headers;
+};
+
+export type simulateApiHarnessJobsCancelResponse = (simulateApiHarnessJobsCancelResponseSuccess | simulateApiHarnessJobsCancelResponseError)
+
+export const getSimulateApiHarnessJobsCancelUrl = (id: string,) => {
+
+
+
+
+  return `/simulate/api/harness-jobs/${id}/cancel/`
+}
+
+/**
+ * Control-plane facade over the configured ALK sandbox provider.
+ */
+export const simulateApiHarnessJobsCancel = async (id: string,
+    harnessJobActionApi: HarnessJobActionApi, options?: RequestInit): Promise<simulateApiHarnessJobsCancelResponse> => {
+
+  return apiMutator<simulateApiHarnessJobsCancelResponse>(getSimulateApiHarnessJobsCancelUrl(id),
+  {
+    ...options,
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', ...options?.headers },
+    body: JSON.stringify(
+      harnessJobActionApi,)
   }
 );}
 

--- a/frontend/src/generated/api-contracts/api.ts
+++ b/frontend/src/generated/api-contracts/api.ts
@@ -549,6 +549,8 @@ import type {
   GroundTruthUploadResponseApi,
   HarnessJobActionApi,
   HarnessJobCreateApi,
+  HarnessPreflightApi,
+  HarnessSourceUploadResponseApi,
   HealthCheckResponseApi,
   HeartbeatApi,
   HuggingFaceAddRowsRequestApi,
@@ -1028,6 +1030,7 @@ import type {
   SimulateApiAgentPromptOptimiserListParams,
   SimulateApiAlkSimulateCallExecutionsRecordingUploadBody,
   SimulateApiCallExecutionsListParams,
+  SimulateApiHarnessJobsSourceUploadBody,
   SimulateApiLivekitWebhookCreateBody,
   SimulateApiPersonasFieldOptions200,
   SimulateApiPersonasFieldOptionsParams,
@@ -52456,6 +52459,12 @@ if(simulateApiAlkSimulateCallExecutionsRecordingUploadBody?.file !== undefined) 
 if(simulateApiAlkSimulateCallExecutionsRecordingUploadBody?.filename !== undefined) {
  formData.append(`filename`, simulateApiAlkSimulateCallExecutionsRecordingUploadBody.filename);
  }
+if(simulateApiAlkSimulateCallExecutionsRecordingUploadBody?.sha256 !== undefined) {
+ formData.append(`sha256`, simulateApiAlkSimulateCallExecutionsRecordingUploadBody.sha256);
+ }
+if(simulateApiAlkSimulateCallExecutionsRecordingUploadBody?.kind !== undefined) {
+ formData.append(`kind`, simulateApiAlkSimulateCallExecutionsRecordingUploadBody.kind);
+ }
 
   return apiMutator<simulateApiAlkSimulateCallExecutionsRecordingUploadResponse>(getSimulateApiAlkSimulateCallExecutionsRecordingUploadUrl(callExecutionId),
   {
@@ -52977,6 +52986,104 @@ export const simulateApiHarnessJobsHealth = async ( options?: RequestInit): Prom
     method: 'GET'
 
 
+  }
+);}
+
+
+
+export type simulateApiHarnessJobsPreflightResponse201 = {
+  data: HarnessPreflightApi
+  status: 201
+}
+
+export type simulateApiHarnessJobsPreflightResponseDefault = {
+  data: ManagementAPIErrorResponseApi
+  status: Exclude<HTTPStatusCodes, 201>
+}
+
+export type simulateApiHarnessJobsPreflightResponseSuccess = (simulateApiHarnessJobsPreflightResponse201) & {
+  headers: Headers;
+};
+export type simulateApiHarnessJobsPreflightResponseError = (simulateApiHarnessJobsPreflightResponseDefault) & {
+  headers: Headers;
+};
+
+export type simulateApiHarnessJobsPreflightResponse = (simulateApiHarnessJobsPreflightResponseSuccess | simulateApiHarnessJobsPreflightResponseError)
+
+export const getSimulateApiHarnessJobsPreflightUrl = () => {
+
+
+
+
+  return `/simulate/api/harness-jobs/preflight/`
+}
+
+/**
+ * Control-plane facade over the configured ALK sandbox provider.
+ */
+export const simulateApiHarnessJobsPreflight = async (harnessPreflightApi: HarnessPreflightApi, options?: RequestInit): Promise<simulateApiHarnessJobsPreflightResponse> => {
+
+  return apiMutator<simulateApiHarnessJobsPreflightResponse>(getSimulateApiHarnessJobsPreflightUrl(),
+  {
+    ...options,
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', ...options?.headers },
+    body: JSON.stringify(
+      harnessPreflightApi,)
+  }
+);}
+
+
+
+export type simulateApiHarnessJobsSourceUploadResponse201 = {
+  data: HarnessSourceUploadResponseApi
+  status: 201
+}
+
+export type simulateApiHarnessJobsSourceUploadResponseDefault = {
+  data: ManagementAPIErrorResponseApi
+  status: Exclude<HTTPStatusCodes, 201>
+}
+
+export type simulateApiHarnessJobsSourceUploadResponseSuccess = (simulateApiHarnessJobsSourceUploadResponse201) & {
+  headers: Headers;
+};
+export type simulateApiHarnessJobsSourceUploadResponseError = (simulateApiHarnessJobsSourceUploadResponseDefault) & {
+  headers: Headers;
+};
+
+export type simulateApiHarnessJobsSourceUploadResponse = (simulateApiHarnessJobsSourceUploadResponseSuccess | simulateApiHarnessJobsSourceUploadResponseError)
+
+export const getSimulateApiHarnessJobsSourceUploadUrl = () => {
+
+
+
+
+  return `/simulate/api/harness-jobs/sources/`
+}
+
+/**
+ * Control-plane facade over the configured ALK sandbox provider.
+ */
+export const simulateApiHarnessJobsSourceUpload = async (simulateApiHarnessJobsSourceUploadBody?: SimulateApiHarnessJobsSourceUploadBody, options?: RequestInit): Promise<simulateApiHarnessJobsSourceUploadResponse> => {
+    const formData = new FormData();
+if(simulateApiHarnessJobsSourceUploadBody?.files !== undefined) {
+ formData.append(`files`, simulateApiHarnessJobsSourceUploadBody.files);
+ }
+if(simulateApiHarnessJobsSourceUploadBody?.paths !== undefined) {
+ formData.append(`paths`, simulateApiHarnessJobsSourceUploadBody.paths);
+ }
+if(simulateApiHarnessJobsSourceUploadBody?.name !== undefined) {
+ formData.append(`name`, simulateApiHarnessJobsSourceUploadBody.name);
+ }
+
+  return apiMutator<simulateApiHarnessJobsSourceUploadResponse>(getSimulateApiHarnessJobsSourceUploadUrl(),
+  {
+    ...options,
+    method: 'POST'
+    ,
+    body:
+      formData,
   }
 );}
 

--- a/frontend/src/generated/api-contracts/api.zod.ts
+++ b/frontend/src/generated/api-contracts/api.zod.ts
@@ -20468,9 +20468,6 @@ export const ModelHubExperimentsUpdateResponse = zod.object({
 
 
 export const ModelHubExperimentsDataListQueryParams = zod.object({
-  "created_at": zod.string().optional(),
-  "status": zod.string().optional(),
-  "dataset_id": zod.string().optional(),
   "ordering": zod.string().optional().describe('Which field to use when ordering the results.'),
   "search": zod.string().optional().describe('A search term.'),
   "page": zod.number().optional().describe('A page number within the paginated result set.'),
@@ -20609,9 +20606,6 @@ export const ModelHubExperimentsV2CreateResponse = zod.object({
  * V2 experiment list with filtering, search, and pagination.
  */
 export const ModelHubExperimentsV2ListListQueryParams = zod.object({
-  "created_at": zod.string().optional(),
-  "status": zod.string().optional(),
-  "dataset_id": zod.string().optional(),
   "search": zod.string().optional().describe('A search term.'),
   "ordering": zod.string().optional().describe('Which field to use when ordering the results.'),
   "page": zod.number().optional().describe('A page number within the paginated result set.'),
@@ -22903,8 +22897,6 @@ export const ModelHubMetricsByColumnListResponse = zod.object({
 
 
 export const ModelHubOptimisationListQueryParams = zod.object({
-  "optimize_type": zod.string().optional(),
-  "status": zod.string().optional(),
   "search": zod.string().optional().describe('A search term.'),
   "ordering": zod.string().optional().describe('Which field to use when ordering the results.'),
   "page": zod.number().optional().describe('A page number within the paginated result set.'),
@@ -24113,7 +24105,6 @@ export const ModelHubPromptBaseTemplatesDeleteParams = zod.object({
 
 
 export const ModelHubPromptExecutionsListQueryParams = zod.object({
-  "name": zod.string().optional(),
   "search": zod.string().optional().describe('A search term.'),
   "ordering": zod.string().optional().describe('Which field to use when ordering the results.'),
   "page": zod.number().optional().describe('A page number within the paginated result set.'),
@@ -24307,9 +24298,6 @@ export const ModelHubPromptFoldersDeleteParams = zod.object({
 
 
 export const ModelHubPromptHistoryExecutionsListQueryParams = zod.object({
-  "template_name": zod.string().optional(),
-  "template_version": zod.string().optional(),
-  "created_at": zod.string().optional(),
   "search": zod.string().optional().describe('A search term.'),
   "ordering": zod.string().optional().describe('Which field to use when ordering the results.'),
   "page": zod.number().optional().describe('A page number within the paginated result set.'),
@@ -24372,9 +24360,6 @@ export const ModelHubPromptHistoryExecutionsGetExecutionDetailsParams = zod.obje
 })
 
 export const ModelHubPromptHistoryExecutionsGetExecutionDetailsQueryParams = zod.object({
-  "template_name": zod.string().optional(),
-  "template_version": zod.string().optional(),
-  "created_at": zod.string().optional(),
   "search": zod.string().optional().describe('A search term.'),
   "ordering": zod.string().optional().describe('Which field to use when ordering the results.'),
   "page": zod.number().optional().describe('A page number within the paginated result set.'),
@@ -24755,9 +24740,6 @@ export const ModelHubPromptLabelsAssignLabelByIdBody = zod.object({
 
 
 export const ModelHubPromptTemplatesListQueryParams = zod.object({
-  "name": zod.string().optional(),
-  "version": zod.string().optional(),
-  "created_at": zod.string().optional(),
   "search": zod.string().optional().describe('A search term.'),
   "ordering": zod.string().optional().describe('Which field to use when ordering the results.'),
   "page": zod.number().optional().describe('A page number within the paginated result set.'),
@@ -24953,9 +24935,6 @@ If no version is specified, returns the default version (is_default=True).
 If a version is specified, returns that specific version.
  */
 export const ModelHubPromptTemplatesGetTemplateByNameQueryParams = zod.object({
-  "name": zod.string().optional(),
-  "version": zod.string().optional(),
-  "created_at": zod.string().optional(),
   "search": zod.string().optional().describe('A search term.'),
   "ordering": zod.string().optional().describe('Which field to use when ordering the results.'),
   "page": zod.number().optional().describe('A page number within the paginated result set.'),
@@ -27704,7 +27683,7 @@ export const simulateAgentDefinitionsCreateCreateBodyDescriptionDefault = ``;
 export const simulateAgentDefinitionsCreateCreateBodyObservabilityEnabledDefault = false;
 export const simulateAgentDefinitionsCreateCreateBodyLivekitUrlMax = 500;
 
-export const simulateAgentDefinitionsCreateCreateBodyLivekitMaxConcurrencyMax = 25;
+export const simulateAgentDefinitionsCreateCreateBodyLivekitMaxConcurrencyMax = 5;
 
 
 
@@ -27823,7 +27802,7 @@ export const simulateAgentDefinitionsEditUpdateBodyAgentNameMax = 255;
 
 export const simulateAgentDefinitionsEditUpdateBodyLivekitUrlMax = 500;
 
-export const simulateAgentDefinitionsEditUpdateBodyLivekitMaxConcurrencyMax = 25;
+export const simulateAgentDefinitionsEditUpdateBodyLivekitMaxConcurrencyMax = 5;
 
 
 
@@ -27958,7 +27937,7 @@ export const simulateAgentDefinitionsVersionsCreateCreateBodyLivekitApiSecretMax
 
 export const simulateAgentDefinitionsVersionsCreateCreateBodyLivekitAgentNameMax = 255;
 
-export const simulateAgentDefinitionsVersionsCreateCreateBodyLivekitMaxConcurrencyMax = 25;
+export const simulateAgentDefinitionsVersionsCreateCreateBodyLivekitMaxConcurrencyMax = 5;
 
 export const simulateAgentDefinitionsVersionsCreateCreateBodyCommitMessageDefault = ``;
 export const simulateAgentDefinitionsVersionsCreateCreateBodyObservabilityEnabledDefault = false;
@@ -29308,6 +29287,7 @@ scenario generation. See ``provision_alk_sim_run_test``.
  */
 export const simulateApiAlkSimulateRunTestsProvisionRunTestBodyNameMax = 255;
 
+export const simulateApiAlkSimulateRunTestsProvisionRunTestBodyModalityDefault = `text`;
 export const simulateApiAlkSimulateRunTestsProvisionRunTestBodyPersonasItemNameMax = 255;
 
 export const simulateApiAlkSimulateRunTestsProvisionRunTestBodyPersonasItemRoleMax = 255;
@@ -29318,6 +29298,7 @@ export const simulateApiAlkSimulateRunTestsProvisionRunTestBodyAgentNameMax = 25
 
 export const SimulateApiAlkSimulateRunTestsProvisionRunTestBody = zod.object({
   "name": zod.string().min(1).max(simulateApiAlkSimulateRunTestsProvisionRunTestBodyNameMax),
+  "modality": zod.enum(['text', 'voice']).default(simulateApiAlkSimulateRunTestsProvisionRunTestBodyModalityDefault),
   "description": zod.string().optional(),
   "personas": zod.array(zod.object({
   "name": zod.string().max(simulateApiAlkSimulateRunTestsProvisionRunTestBodyPersonasItemNameMax).optional(),
@@ -29554,6 +29535,76 @@ export const SimulateApiCallExecutionsListResponseItem = zod.object({
   "processing_skip_reason": zod.string().optional()
 })
 export const SimulateApiCallExecutionsListResponse = zod.array(SimulateApiCallExecutionsListResponseItem)
+
+
+/**
+ * Control-plane facade over the configured ALK sandbox provider.
+ */
+export const simulateApiHarnessJobsCreateBodySourcePathMax = 4096;
+
+export const simulateApiHarnessJobsCreateBodyScenarioCountDefault = 10;
+export const simulateApiHarnessJobsCreateBodyScenarioCountMax = 100;
+
+export const simulateApiHarnessJobsCreateBodyAgentNameMax = 255;
+
+export const simulateApiHarnessJobsCreateBodyConnectorDefault = `auto`;
+export const simulateApiHarnessJobsCreateBodyConnectorMax = 128;
+
+export const simulateApiHarnessJobsCreateBodyConnectorConfigDefault = {  };
+export const simulateApiHarnessJobsCreateBodySecretRefsManagerMax = 64;
+
+export const simulateApiHarnessJobsCreateBodySecretRefsKeyMax = 255;
+
+export const simulateApiHarnessJobsCreateBodySecretRefsVersionMax = 255;
+
+export const simulateApiHarnessJobsCreateBodySecretRefsPurposeMax = 128;
+
+export const simulateApiHarnessJobsCreateBodySecretRefsDefault = {  };
+export const simulateApiHarnessJobsCreateBodyMetadataDefault = {  };
+
+export const SimulateApiHarnessJobsCreateBody = zod.object({
+  "source_path": zod.string().min(1).max(simulateApiHarnessJobsCreateBodySourcePathMax),
+  "scenario_count": zod.number().min(1).max(simulateApiHarnessJobsCreateBodyScenarioCountMax).default(simulateApiHarnessJobsCreateBodyScenarioCountDefault),
+  "seed": zod.number().optional(),
+  "agent_name": zod.string().max(simulateApiHarnessJobsCreateBodyAgentNameMax).optional(),
+  "connector": zod.string().min(1).max(simulateApiHarnessJobsCreateBodyConnectorMax).default(simulateApiHarnessJobsCreateBodyConnectorDefault),
+  "connector_config": zod.object({
+
+}).passthrough().default(simulateApiHarnessJobsCreateBodyConnectorConfigDefault),
+  "secret_refs": zod.record(zod.string(), zod.object({
+  "manager": zod.string().min(1).max(simulateApiHarnessJobsCreateBodySecretRefsManagerMax),
+  "key": zod.string().min(1).max(simulateApiHarnessJobsCreateBodySecretRefsKeyMax),
+  "version": zod.string().min(1).max(simulateApiHarnessJobsCreateBodySecretRefsVersionMax).optional(),
+  "purpose": zod.string().min(1).max(simulateApiHarnessJobsCreateBodySecretRefsPurposeMax)
+})).default(simulateApiHarnessJobsCreateBodySecretRefsDefault),
+  "metadata": zod.object({
+
+}).passthrough().default(simulateApiHarnessJobsCreateBodyMetadataDefault)
+})
+
+
+/**
+ * Control-plane facade over the configured ALK sandbox provider.
+ */
+export const SimulateApiHarnessJobsReadParams = zod.object({
+  "id": zod.string()
+})
+
+
+/**
+ * Control-plane facade over the configured ALK sandbox provider.
+ */
+export const SimulateApiHarnessJobsCancelParams = zod.object({
+  "id": zod.string()
+})
+
+export const simulateApiHarnessJobsCancelBodyReasonMax = 500;
+
+
+
+export const SimulateApiHarnessJobsCancelBody = zod.object({
+  "reason": zod.string().max(simulateApiHarnessJobsCancelBodyReasonMax).optional().describe('Optional operator-provided reason for the action.')
+})
 
 
 /**

--- a/frontend/src/generated/api-contracts/api.zod.ts
+++ b/frontend/src/generated/api-contracts/api.zod.ts
@@ -29155,7 +29155,9 @@ export const SimulateApiAlkSimulateCallExecutionsRecordingUploadParams = zod.obj
 
 export const SimulateApiAlkSimulateCallExecutionsRecordingUploadBody = zod.object({
   "file": zod.instanceof(File),
-  "filename": zod.string().optional()
+  "filename": zod.string().optional(),
+  "sha256": zod.string().optional(),
+  "kind": zod.string().optional()
 })
 
 export const simulateApiAlkSimulateCallExecutionsRecordingUploadResponseStatusDefault = true;
@@ -29187,6 +29189,12 @@ export const simulateApiAlkSimulateCallExecutionsResultBodyDurationSecondsMin = 
 
 export const simulateApiAlkSimulateCallExecutionsResultBodyEndedReasonMax = 10000;
 
+
+
+export const simulateApiAlkSimulateCallExecutionsResultBodyResultDigestRegExp = new RegExp('^sha256:[0-9a-f]{64}$');
+
+
+export const simulateApiAlkSimulateCallExecutionsResultBodyArtifactManifestDigestRegExp = new RegExp('^sha256:[0-9a-f]{64}$');
 export const simulateApiAlkSimulateCallExecutionsResultBodyTranscriptItemStartTimeMsDefault = 0;
 export const simulateApiAlkSimulateCallExecutionsResultBodyTranscriptItemStartTimeMsMin = 0;
 
@@ -29214,6 +29222,8 @@ export const SimulateApiAlkSimulateCallExecutionsResultBody = zod.object({
   "ended_reason": zod.string().max(simulateApiAlkSimulateCallExecutionsResultBodyEndedReasonMax).optional(),
   "error_message": zod.string().optional(),
   "call_summary": zod.string().optional(),
+  "result_digest": zod.string().min(1).regex(simulateApiAlkSimulateCallExecutionsResultBodyResultDigestRegExp).optional(),
+  "artifact_manifest_digest": zod.string().min(1).regex(simulateApiAlkSimulateCallExecutionsResultBodyArtifactManifestDigestRegExp).optional(),
   "transcript": zod.array(zod.object({
   "speaker_role": zod.enum(['user', 'assistant', 'system', 'tool_calls', 'tool_call_result', 'unknown']),
   "content": zod.string(),
@@ -29542,15 +29552,19 @@ export const SimulateApiCallExecutionsListResponse = zod.array(SimulateApiCallEx
  */
 export const simulateApiHarnessJobsCreateBodySourcePathMax = 4096;
 
-export const simulateApiHarnessJobsCreateBodyScenarioCountDefault = 10;
-export const simulateApiHarnessJobsCreateBodyScenarioCountMax = 100;
 
-export const simulateApiHarnessJobsCreateBodyAgentNameMax = 255;
 
-export const simulateApiHarnessJobsCreateBodyConnectorDefault = `auto`;
-export const simulateApiHarnessJobsCreateBodyConnectorMax = 128;
+export const simulateApiHarnessJobsCreateBodySourceIdRegExp = new RegExp('^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$');
+export const simulateApiHarnessJobsCreateBodyGithubRepositoryMax = 512;
 
-export const simulateApiHarnessJobsCreateBodyConnectorConfigDefault = {  };
+export const simulateApiHarnessJobsCreateBodyGithubRefMax = 255;
+
+
+
+export const simulateApiHarnessJobsCreateBodyGithubCommitShaRegExp = new RegExp('^[0-9a-fA-F]{40}$');
+export const simulateApiHarnessJobsCreateBodyGithubVisibilityDefault = `public`;
+export const simulateApiHarnessJobsCreateBodyGithubInstallationIdMax = 255;
+
 export const simulateApiHarnessJobsCreateBodySecretRefsManagerMax = 64;
 
 export const simulateApiHarnessJobsCreateBodySecretRefsKeyMax = 255;
@@ -29560,26 +29574,108 @@ export const simulateApiHarnessJobsCreateBodySecretRefsVersionMax = 255;
 export const simulateApiHarnessJobsCreateBodySecretRefsPurposeMax = 128;
 
 export const simulateApiHarnessJobsCreateBodySecretRefsDefault = {  };
+export const simulateApiHarnessJobsCreateBodyEnvironmentValuesMaxOne = 65536;
+
+export const simulateApiHarnessJobsCreateBodyEnvironmentValuesDefault = {  };
+export const simulateApiHarnessJobsCreateBodyConnectorConfigDefault = {  };
+export const simulateApiHarnessJobsCreateBodyScenarioCountDefault = 10;
+export const simulateApiHarnessJobsCreateBodyScenarioCountMax = 100;
+
+export const simulateApiHarnessJobsCreateBodyAgentNameMax = 255;
+
+export const simulateApiHarnessJobsCreateBodyConnectorDefault = `auto`;
+export const simulateApiHarnessJobsCreateBodyConnectorMax = 128;
+
 export const simulateApiHarnessJobsCreateBodyMetadataDefault = {  };
 
 export const SimulateApiHarnessJobsCreateBody = zod.object({
-  "source_path": zod.string().min(1).max(simulateApiHarnessJobsCreateBodySourcePathMax),
-  "scenario_count": zod.number().min(1).max(simulateApiHarnessJobsCreateBodyScenarioCountMax).default(simulateApiHarnessJobsCreateBodyScenarioCountDefault),
-  "seed": zod.number().optional(),
-  "agent_name": zod.string().max(simulateApiHarnessJobsCreateBodyAgentNameMax).optional(),
-  "connector": zod.string().min(1).max(simulateApiHarnessJobsCreateBodyConnectorMax).default(simulateApiHarnessJobsCreateBodyConnectorDefault),
-  "connector_config": zod.object({
-
-}).passthrough().default(simulateApiHarnessJobsCreateBodyConnectorConfigDefault),
+  "source_path": zod.string().min(1).max(simulateApiHarnessJobsCreateBodySourcePathMax).optional(),
+  "source_id": zod.string().min(1).regex(simulateApiHarnessJobsCreateBodySourceIdRegExp).optional(),
+  "github_repository": zod.string().min(1).max(simulateApiHarnessJobsCreateBodyGithubRepositoryMax).optional(),
+  "github_ref": zod.string().min(1).max(simulateApiHarnessJobsCreateBodyGithubRefMax).optional(),
+  "github_commit_sha": zod.string().min(1).regex(simulateApiHarnessJobsCreateBodyGithubCommitShaRegExp).optional(),
+  "github_visibility": zod.enum(['public', 'private']).default(simulateApiHarnessJobsCreateBodyGithubVisibilityDefault),
+  "github_installation_id": zod.string().min(1).max(simulateApiHarnessJobsCreateBodyGithubInstallationIdMax).optional(),
   "secret_refs": zod.record(zod.string(), zod.object({
   "manager": zod.string().min(1).max(simulateApiHarnessJobsCreateBodySecretRefsManagerMax),
   "key": zod.string().min(1).max(simulateApiHarnessJobsCreateBodySecretRefsKeyMax),
   "version": zod.string().min(1).max(simulateApiHarnessJobsCreateBodySecretRefsVersionMax).optional(),
   "purpose": zod.string().min(1).max(simulateApiHarnessJobsCreateBodySecretRefsPurposeMax)
 })).default(simulateApiHarnessJobsCreateBodySecretRefsDefault),
+  "environment_values": zod.record(zod.string(), zod.string().max(simulateApiHarnessJobsCreateBodyEnvironmentValuesMaxOne)).default(simulateApiHarnessJobsCreateBodyEnvironmentValuesDefault),
+  "connector_config": zod.object({
+
+}).passthrough().default(simulateApiHarnessJobsCreateBodyConnectorConfigDefault),
+  "scenario_count": zod.number().min(1).max(simulateApiHarnessJobsCreateBodyScenarioCountMax).default(simulateApiHarnessJobsCreateBodyScenarioCountDefault),
+  "seed": zod.number().optional(),
+  "agent_name": zod.string().max(simulateApiHarnessJobsCreateBodyAgentNameMax).optional(),
+  "connector": zod.string().min(1).max(simulateApiHarnessJobsCreateBodyConnectorMax).default(simulateApiHarnessJobsCreateBodyConnectorDefault),
   "metadata": zod.object({
 
 }).passthrough().default(simulateApiHarnessJobsCreateBodyMetadataDefault)
+})
+
+
+/**
+ * Control-plane facade over the configured ALK sandbox provider.
+ */
+export const simulateApiHarnessJobsPreflightBodySourcePathMax = 4096;
+
+
+
+export const simulateApiHarnessJobsPreflightBodySourceIdRegExp = new RegExp('^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$');
+export const simulateApiHarnessJobsPreflightBodyGithubRepositoryMax = 512;
+
+export const simulateApiHarnessJobsPreflightBodyGithubRefMax = 255;
+
+
+
+export const simulateApiHarnessJobsPreflightBodyGithubCommitShaRegExp = new RegExp('^[0-9a-fA-F]{40}$');
+export const simulateApiHarnessJobsPreflightBodyGithubVisibilityDefault = `public`;
+export const simulateApiHarnessJobsPreflightBodyGithubInstallationIdMax = 255;
+
+export const simulateApiHarnessJobsPreflightBodySecretRefsManagerMax = 64;
+
+export const simulateApiHarnessJobsPreflightBodySecretRefsKeyMax = 255;
+
+export const simulateApiHarnessJobsPreflightBodySecretRefsVersionMax = 255;
+
+export const simulateApiHarnessJobsPreflightBodySecretRefsPurposeMax = 128;
+
+export const simulateApiHarnessJobsPreflightBodySecretRefsDefault = {  };
+export const simulateApiHarnessJobsPreflightBodyEnvironmentValuesMaxOne = 65536;
+
+export const simulateApiHarnessJobsPreflightBodyEnvironmentValuesDefault = {  };
+export const simulateApiHarnessJobsPreflightBodyConnectorConfigDefault = {  };
+
+export const SimulateApiHarnessJobsPreflightBody = zod.object({
+  "source_path": zod.string().min(1).max(simulateApiHarnessJobsPreflightBodySourcePathMax).optional(),
+  "source_id": zod.string().min(1).regex(simulateApiHarnessJobsPreflightBodySourceIdRegExp).optional(),
+  "github_repository": zod.string().min(1).max(simulateApiHarnessJobsPreflightBodyGithubRepositoryMax).optional(),
+  "github_ref": zod.string().min(1).max(simulateApiHarnessJobsPreflightBodyGithubRefMax).optional(),
+  "github_commit_sha": zod.string().min(1).regex(simulateApiHarnessJobsPreflightBodyGithubCommitShaRegExp).optional(),
+  "github_visibility": zod.enum(['public', 'private']).default(simulateApiHarnessJobsPreflightBodyGithubVisibilityDefault),
+  "github_installation_id": zod.string().min(1).max(simulateApiHarnessJobsPreflightBodyGithubInstallationIdMax).optional(),
+  "secret_refs": zod.record(zod.string(), zod.object({
+  "manager": zod.string().min(1).max(simulateApiHarnessJobsPreflightBodySecretRefsManagerMax),
+  "key": zod.string().min(1).max(simulateApiHarnessJobsPreflightBodySecretRefsKeyMax),
+  "version": zod.string().min(1).max(simulateApiHarnessJobsPreflightBodySecretRefsVersionMax).optional(),
+  "purpose": zod.string().min(1).max(simulateApiHarnessJobsPreflightBodySecretRefsPurposeMax)
+})).default(simulateApiHarnessJobsPreflightBodySecretRefsDefault),
+  "environment_values": zod.record(zod.string(), zod.string().max(simulateApiHarnessJobsPreflightBodyEnvironmentValuesMaxOne)).default(simulateApiHarnessJobsPreflightBodyEnvironmentValuesDefault),
+  "connector_config": zod.object({
+
+}).passthrough().default(simulateApiHarnessJobsPreflightBodyConnectorConfigDefault)
+})
+
+
+/**
+ * Control-plane facade over the configured ALK sandbox provider.
+ */
+export const SimulateApiHarnessJobsSourceUploadBody = zod.object({
+  "files": zod.instanceof(File),
+  "paths": zod.string().describe('Repeat in file order with each repository-relative path.'),
+  "name": zod.string().optional()
 })
 
 

--- a/frontend/src/layouts/dashboard/config-navigation.jsx
+++ b/frontend/src/layouts/dashboard/config-navigation.jsx
@@ -209,6 +209,11 @@ export function useNavData() {
         subheader: "Simulate",
         items: [
           {
+            title: "RL Environment",
+            path: paths.dashboard.simulate.harness,
+            icon: <Iconify icon="solar:server-square-cloud-linear" />,
+          },
+          {
             title: "Agent Definition",
             path: paths.dashboard.simulate.agentDefinition,
             icon: ICONS.agentDefinition,

--- a/frontend/src/pages/dashboard/harness/Harness.jsx
+++ b/frontend/src/pages/dashboard/harness/Harness.jsx
@@ -6,11 +6,13 @@ import {
   Chip,
   CircularProgress,
   Divider,
+  IconButton,
   LinearProgress,
   MenuItem,
   Paper,
   Stack,
   TextField,
+  Tooltip,
   Typography,
 } from "@mui/material";
 import { Helmet } from "react-helmet-async";
@@ -21,7 +23,10 @@ import {
   getHarnessJob,
   listHarnessJobs,
   preflightHarnessJob,
+  uploadHarnessSource,
 } from "src/api/harness/harness";
+import { parseDotEnv } from "./dotenv";
+import { prepareSourceFolder } from "./sourceUpload";
 
 const terminalStages = new Set(["completed", "failed", "canceled"]);
 const stages = [
@@ -52,16 +57,18 @@ function eventMessage(event) {
 }
 
 export default function Harness() {
-  const [sourceMode, setSourceMode] = useState("local");
-  const [sourcePath, setSourcePath] = useState("");
+  const [sourceMode, setSourceMode] = useState("upload");
+  const [uploadedSource, setUploadedSource] = useState(null);
+  const [sourceUploadProgress, setSourceUploadProgress] = useState(null);
   const [githubRepository, setGithubRepository] = useState("");
-  const [githubRef, setGithubRef] = useState("main");
   const [githubVisibility, setGithubVisibility] = useState("public");
   const [githubInstallationId, setGithubInstallationId] = useState("");
   const [scenarioCount, setScenarioCount] = useState(10);
   const [preflight, setPreflight] = useState(null);
-  const [secretRefs, setSecretRefs] = useState({});
   const [configurationValues, setConfigurationValues] = useState({});
+  const [environmentValues, setEnvironmentValues] = useState({});
+  const [environmentText, setEnvironmentText] = useState("");
+  const [environmentError, setEnvironmentError] = useState("");
   const [jobs, setJobs] = useState([]);
   const [current, setCurrent] = useState(null);
   const [submitting, setSubmitting] = useState(false);
@@ -106,10 +113,10 @@ export default function Harness() {
   }, [current?.job?.job_id, current?.status?.stage]);
 
   const sourcePayload = () => {
-    if (sourceMode === "local") return { source_path: sourcePath.trim() };
+    if (sourceMode === "upload")
+      return { source_id: uploadedSource?.source_id };
     return {
       github_repository: githubRepository.trim(),
-      github_ref: githubRef.trim() || undefined,
       github_visibility: githubVisibility,
       github_installation_id:
         githubVisibility === "private"
@@ -118,28 +125,15 @@ export default function Harness() {
     };
   };
 
-  const configuredSecretRefs = () =>
-    Object.fromEntries(
-      Object.entries(secretRefs)
-        .filter(([, key]) => key.trim())
-        .map(([environmentName, key]) => [
-          environmentName,
-          {
-            manager: "futureagi",
-            key: key.trim(),
-            purpose: `Provide ${environmentName} to the isolated agent runtime`,
-          },
-        ]),
-    );
-
   const inspect = async () => {
     setChecking(true);
     setError("");
     try {
       const value = await preflightHarnessJob({
         ...sourcePayload(),
-        secret_refs: configuredSecretRefs(),
+        secret_refs: {},
         connector_config: configurationValues,
+        environment_values: environmentValues,
       });
       setPreflight(value);
     } catch (requestError) {
@@ -157,8 +151,9 @@ export default function Harness() {
         ...sourcePayload(),
         scenario_count: Number(scenarioCount),
         connector: "auto",
-        secret_refs: configuredSecretRefs(),
+        secret_refs: {},
         connector_config: configurationValues,
+        environment_values: environmentValues,
       });
       setCurrent(value);
       setJobs((existing) => [value, ...existing]);
@@ -172,6 +167,23 @@ export default function Harness() {
   const cancel = async () => {
     const value = await cancelHarnessJob(current.job.job_id);
     setCurrent(value);
+  };
+
+  const startNewEnvironment = () => {
+    setCurrent(null);
+    setSourceMode("upload");
+    setUploadedSource(null);
+    setSourceUploadProgress(null);
+    setGithubRepository("");
+    setGithubVisibility("public");
+    setGithubInstallationId("");
+    setScenarioCount(10);
+    setPreflight(null);
+    setConfigurationValues({});
+    setEnvironmentValues({});
+    setEnvironmentText("");
+    setEnvironmentError("");
+    setError("");
   };
 
   const stageIndex = stages.indexOf(current?.status?.stage);
@@ -192,7 +204,8 @@ export default function Harness() {
     );
     if (requirement?.status !== "missing") return true;
     if (requirement?.kind === "secret")
-      return Boolean(secretRefs[name]?.trim());
+      return Boolean(String(environmentValues[name] || "").trim());
+    if (Object.hasOwn(environmentValues, name)) return true;
     return Boolean(String(configurationValues[name] || "").trim());
   };
   const unsatisfiedChoices = credentialChoices.filter(
@@ -209,8 +222,8 @@ export default function Harness() {
   const requiredInputCount =
     missingRequirements.length + unsatisfiedChoices.length;
   const hasSource =
-    sourceMode === "local"
-      ? Boolean(sourcePath.trim())
+    sourceMode === "upload"
+      ? Boolean(uploadedSource?.source_id)
       : Boolean(githubRepository.trim()) &&
         (githubVisibility === "public" || Boolean(githubInstallationId.trim()));
   const progress = current
@@ -234,6 +247,68 @@ export default function Harness() {
     });
   }, [current?.events]);
 
+  const loadEnvironment = (text) => {
+    try {
+      const values = parseDotEnv(text);
+      setEnvironmentValues(values);
+      setEnvironmentText("");
+      setEnvironmentError("");
+      setPreflight(null);
+    } catch (parseError) {
+      setEnvironmentError(parseError.message);
+    }
+  };
+
+  const uploadEnvironment = async (event) => {
+    const file = event.target.files?.[0];
+    event.target.value = "";
+    if (!file) return;
+    if (file.size > 262144) {
+      setEnvironmentError("The .env file may not exceed 256 KiB");
+      return;
+    }
+    loadEnvironment(await file.text());
+  };
+
+  const uploadSourceFolder = async (event) => {
+    const selected = Array.from(event.target.files || []);
+    event.target.value = "";
+    if (!selected.length) return;
+    setError("");
+    setPreflight(null);
+    setUploadedSource(null);
+    let prepared;
+    try {
+      prepared = prepareSourceFolder(selected);
+    } catch (uploadError) {
+      setError(uploadError.message);
+      return;
+    }
+    const formData = new FormData();
+    prepared.files.forEach((file, index) => {
+      formData.append("files", file, file.name);
+      formData.append("paths", prepared.paths[index]);
+    });
+    formData.append("name", prepared.name);
+    setSourceUploadProgress(0);
+    try {
+      const result = await uploadHarnessSource(formData, (progressEvent) => {
+        if (progressEvent.total)
+          setSourceUploadProgress(
+            Math.round((progressEvent.loaded / progressEvent.total) * 100),
+          );
+      });
+      setUploadedSource({
+        ...result,
+        excluded_count: prepared.excludedCount,
+      });
+    } catch (requestError) {
+      setError(requestError?.response?.data?.detail || requestError.message);
+    } finally {
+      setSourceUploadProgress(null);
+    }
+  };
+
   return (
     <>
       <Helmet>
@@ -248,9 +323,21 @@ export default function Harness() {
         }}
       >
         <Paper square variant="outlined" sx={{ p: 2, overflow: "auto" }}>
-          <Typography variant="overline" color="text.secondary">
-            Harness jobs
-          </Typography>
+          <Stack direction="row" alignItems="center" justifyContent="space-between">
+            <Typography variant="overline" color="text.secondary">
+              RL environments
+            </Typography>
+            <Tooltip title="New RL environment">
+              <IconButton
+                size="small"
+                color="primary"
+                aria-label="Create a new RL environment"
+                onClick={startNewEnvironment}
+              >
+                <Iconify icon="mingcute:add-line" width={20} />
+              </IconButton>
+            </Tooltip>
+          </Stack>
           <Stack spacing={1} mt={1}>
             {jobs.map((item) => (
               <Button
@@ -306,40 +393,50 @@ export default function Harness() {
                 }}
                 sx={{ minWidth: 130 }}
               >
-                <MenuItem value="local">Local folder</MenuItem>
+                <MenuItem value="upload">Upload folder</MenuItem>
                 <MenuItem value="github">GitHub</MenuItem>
               </TextField>
-              {sourceMode === "local" ? (
-                <TextField
-                  fullWidth
-                  size="small"
-                  label="Local agent folder"
-                  placeholder="/absolute/path/to/agent"
-                  value={sourcePath}
-                  onChange={(event) => {
-                    setSourcePath(event.target.value);
-                    setPreflight(null);
-                  }}
-                />
+              {sourceMode === "upload" ? (
+                <Stack sx={{ minWidth: 280 }} spacing={0.5}>
+                  <Button
+                    component="label"
+                    variant="outlined"
+                    disabled={sourceUploadProgress !== null}
+                    startIcon={<Iconify icon="solar:folder-with-files-linear" />}
+                  >
+                    {sourceUploadProgress !== null
+                      ? `Uploading ${sourceUploadProgress}%`
+                      : uploadedSource
+                        ? "Replace folder"
+                        : "Choose agent folder"}
+                    <Box
+                      component="input"
+                      type="file"
+                      multiple
+                      directory=""
+                      webkitdirectory=""
+                      onChange={uploadSourceFolder}
+                      sx={{ display: "none" }}
+                    />
+                  </Button>
+                  <Typography variant="caption" color="text.secondary">
+                    {uploadedSource
+                      ? `${uploadedSource.name}: ${uploadedSource.file_count} files (${(uploadedSource.total_bytes / 1024 / 1024).toFixed(1)} MiB)${uploadedSource.excluded_count ? `; ${uploadedSource.excluded_count} generated or secret files excluded` : ""}`
+                      : "The folder is uploaded to the isolated runner. .env and generated dependency folders are excluded."}
+                  </Typography>
+                </Stack>
               ) : (
                 <>
                   <TextField
                     fullWidth
                     size="small"
-                    label="GitHub repository"
-                    placeholder="owner/repository or GitHub URL"
+                    label="GitHub repository URL"
+                    placeholder="https://github.com/owner/repository or .../tree/branch"
                     value={githubRepository}
                     onChange={(event) => {
                       setGithubRepository(event.target.value);
                       setPreflight(null);
                     }}
-                  />
-                  <TextField
-                    size="small"
-                    label="Ref"
-                    value={githubRef}
-                    onChange={(event) => setGithubRef(event.target.value)}
-                    sx={{ width: 140 }}
                   />
                   <TextField
                     select
@@ -411,6 +508,66 @@ export default function Harness() {
                 Run end to end
               </Button>
             </Stack>
+            <Paper variant="outlined" sx={{ mt: 1.5, p: 1.5 }}>
+              <Stack spacing={1}>
+                <Stack
+                  direction={{ xs: "column", md: "row" }}
+                  spacing={1}
+                  alignItems={{ md: "center" }}
+                >
+                  <Button
+                    component="label"
+                    variant="outlined"
+                    startIcon={<Iconify icon="solar:upload-minimalistic-linear" />}
+                  >
+                    Upload .env
+                    <Box
+                      component="input"
+                      type="file"
+                      accept=".env,text/plain"
+                      onChange={uploadEnvironment}
+                      sx={{ display: "none" }}
+                    />
+                  </Button>
+                  <TextField
+                    fullWidth
+                    size="small"
+                    multiline
+                    maxRows={4}
+                    label="Or paste .env contents"
+                    placeholder="OPENAI_API_KEY=..."
+                    value={environmentText}
+                    onChange={(event) => setEnvironmentText(event.target.value)}
+                  />
+                  <Button
+                    variant="text"
+                    disabled={!environmentText.trim()}
+                    onClick={() => loadEnvironment(environmentText)}
+                  >
+                    Use values
+                  </Button>
+                  {Object.keys(environmentValues).length > 0 && (
+                    <Button
+                      color="inherit"
+                      onClick={() => {
+                        setEnvironmentValues({});
+                        setPreflight(null);
+                      }}
+                    >
+                      Clear
+                    </Button>
+                  )}
+                </Stack>
+                <Typography variant="caption" color="text.secondary">
+                  {Object.keys(environmentValues).length
+                    ? `${Object.keys(environmentValues).length} variables loaded: ${Object.keys(environmentValues).join(", ")}`
+                    : "Values stay in this browser session, are sent only for preflight/run execution, and are never written to jobs, logs, or artifacts."}
+                </Typography>
+                {environmentError && (
+                  <Alert severity="error">{environmentError}</Alert>
+                )}
+              </Stack>
+            </Paper>
             {preflight && (
               <Paper variant="outlined" sx={{ mt: 1.5, p: 1.5 }}>
                 <Stack
@@ -466,24 +623,30 @@ export default function Harness() {
                           size="small"
                           label={
                             item.kind === "secret"
-                              ? "Secret manager key (never the secret value)"
+                              ? "Secret value (used for this run only)"
                               : "Configuration value"
                           }
+                          type={item.kind === "secret" ? "password" : "text"}
                           value={
                             item.kind === "secret"
-                              ? secretRefs[item.environment_name] || ""
+                              ? environmentValues[item.environment_name] || ""
                               : configurationValues[item.environment_name] || ""
                           }
                           onChange={(event) => {
                             const setter =
                               item.kind === "secret"
-                                ? setSecretRefs
+                                ? setEnvironmentValues
                                 : setConfigurationValues;
                             setter((existing) => ({
                               ...existing,
                               [item.environment_name]: event.target.value,
                             }));
                           }}
+                          helperText={
+                            item.kind === "secret"
+                              ? "Injected ephemerally and removed when the run finishes"
+                              : undefined
+                          }
                         />
                       )}
                     </Stack>

--- a/frontend/src/pages/dashboard/harness/Harness.jsx
+++ b/frontend/src/pages/dashboard/harness/Harness.jsx
@@ -6,6 +6,8 @@ import {
   Chip,
   CircularProgress,
   Divider,
+  LinearProgress,
+  MenuItem,
   Paper,
   Stack,
   TextField,
@@ -18,6 +20,7 @@ import {
   createHarnessJob,
   getHarnessJob,
   listHarnessJobs,
+  preflightHarnessJob,
 } from "src/api/harness/harness";
 
 const terminalStages = new Set(["completed", "failed", "canceled"]);
@@ -43,17 +46,33 @@ function eventMessage(event) {
   const payload = event.payload || {};
   if (payload.detail) return String(payload.detail);
   if (payload.message) return String(payload.message);
-  if (payload.stage) return `${readable(payload.stage)} ${readable(event.type)}`;
+  if (payload.stage)
+    return `${readable(payload.stage)} ${readable(event.type)}`;
   return readable(event.type || "Progress updated");
 }
 
 export default function Harness() {
+  const [sourceMode, setSourceMode] = useState("local");
   const [sourcePath, setSourcePath] = useState("");
+  const [githubRepository, setGithubRepository] = useState("");
+  const [githubRef, setGithubRef] = useState("main");
+  const [githubVisibility, setGithubVisibility] = useState("public");
+  const [githubInstallationId, setGithubInstallationId] = useState("");
   const [scenarioCount, setScenarioCount] = useState(10);
+  const [preflight, setPreflight] = useState(null);
+  const [secretRefs, setSecretRefs] = useState({});
+  const [configurationValues, setConfigurationValues] = useState({});
   const [jobs, setJobs] = useState([]);
   const [current, setCurrent] = useState(null);
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState("");
+  const [checking, setChecking] = useState(false);
+  const [clock, setClock] = useState(Date.now());
+
+  useEffect(() => {
+    const timer = window.setInterval(() => setClock(Date.now()), 1000);
+    return () => window.clearInterval(timer);
+  }, []);
 
   const refreshList = useCallback(async () => {
     try {
@@ -86,14 +105,60 @@ export default function Harness() {
     return () => window.clearInterval(timer);
   }, [current?.job?.job_id, current?.status?.stage]);
 
+  const sourcePayload = () => {
+    if (sourceMode === "local") return { source_path: sourcePath.trim() };
+    return {
+      github_repository: githubRepository.trim(),
+      github_ref: githubRef.trim() || undefined,
+      github_visibility: githubVisibility,
+      github_installation_id:
+        githubVisibility === "private"
+          ? githubInstallationId.trim() || undefined
+          : undefined,
+    };
+  };
+
+  const configuredSecretRefs = () =>
+    Object.fromEntries(
+      Object.entries(secretRefs)
+        .filter(([, key]) => key.trim())
+        .map(([environmentName, key]) => [
+          environmentName,
+          {
+            manager: "futureagi",
+            key: key.trim(),
+            purpose: `Provide ${environmentName} to the isolated agent runtime`,
+          },
+        ]),
+    );
+
+  const inspect = async () => {
+    setChecking(true);
+    setError("");
+    try {
+      const value = await preflightHarnessJob({
+        ...sourcePayload(),
+        secret_refs: configuredSecretRefs(),
+        connector_config: configurationValues,
+      });
+      setPreflight(value);
+    } catch (requestError) {
+      setError(requestError?.response?.data?.detail || requestError.message);
+    } finally {
+      setChecking(false);
+    }
+  };
+
   const run = async () => {
     setSubmitting(true);
     setError("");
     try {
       const value = await createHarnessJob({
-        source_path: sourcePath.trim(),
+        ...sourcePayload(),
         scenario_count: Number(scenarioCount),
         connector: "auto",
+        secret_refs: configuredSecretRefs(),
+        connector_config: configurationValues,
       });
       setCurrent(value);
       setJobs((existing) => [value, ...existing]);
@@ -110,6 +175,55 @@ export default function Harness() {
   };
 
   const stageIndex = stages.indexOf(current?.status?.stage);
+  const requirements = preflight?.credentials?.requirements || [];
+  const credentialChoices = preflight?.credentials?.credential_choices || [];
+  const choiceMembers = new Set(
+    credentialChoices.flatMap((choice) => choice.options.flat()),
+  );
+  const missingRequirements = requirements.filter(
+    (item) =>
+      item.required &&
+      item.status === "missing" &&
+      !choiceMembers.has(item.environment_name),
+  );
+  const requirementConfigured = (name) => {
+    const requirement = requirements.find(
+      (item) => item.environment_name === name,
+    );
+    if (requirement?.status !== "missing") return true;
+    if (requirement?.kind === "secret")
+      return Boolean(secretRefs[name]?.trim());
+    return Boolean(String(configurationValues[name] || "").trim());
+  };
+  const unsatisfiedChoices = credentialChoices.filter(
+    (choice) =>
+      !choice.satisfied &&
+      !choice.options.some((option) =>
+        option.every((name) => requirementConfigured(name)),
+      ),
+  );
+  const requirementsConfigured =
+    missingRequirements.every((item) =>
+      requirementConfigured(item.environment_name),
+    ) && unsatisfiedChoices.length === 0;
+  const requiredInputCount =
+    missingRequirements.length + unsatisfiedChoices.length;
+  const hasSource =
+    sourceMode === "local"
+      ? Boolean(sourcePath.trim())
+      : Boolean(githubRepository.trim()) &&
+        (githubVisibility === "public" || Boolean(githubInstallationId.trim()));
+  const progress = current
+    ? current.status.stage === "completed"
+      ? 100
+      : Math.max(2, ((Math.max(stageIndex, 0) + 0.5) / stages.length) * 100)
+    : 0;
+  const updatedAt = current?.status?.updated_at
+    ? new Date(current.status.updated_at)
+    : null;
+  const secondsSinceUpdate = updatedAt
+    ? Math.max(0, Math.floor((clock - updatedAt.getTime()) / 1000))
+    : null;
   const messages = useMemo(() => {
     const seen = new Set();
     return (current?.events || []).filter((event) => {
@@ -122,65 +236,464 @@ export default function Harness() {
 
   return (
     <>
-      <Helmet><title>RL Environment | Future AGI</title></Helmet>
-      <Box sx={{ height: "100%", display: "grid", gridTemplateColumns: "280px minmax(0, 1fr)", bgcolor: "background.default" }}>
+      <Helmet>
+        <title>RL Environment | Future AGI</title>
+      </Helmet>
+      <Box
+        sx={{
+          height: "100%",
+          display: "grid",
+          gridTemplateColumns: "280px minmax(0, 1fr)",
+          bgcolor: "background.default",
+        }}
+      >
         <Paper square variant="outlined" sx={{ p: 2, overflow: "auto" }}>
-          <Typography variant="overline" color="text.secondary">Harness jobs</Typography>
+          <Typography variant="overline" color="text.secondary">
+            Harness jobs
+          </Typography>
           <Stack spacing={1} mt={1}>
             {jobs.map((item) => (
               <Button
                 key={item.job.job_id}
-                variant={current?.job?.job_id === item.job.job_id ? "contained" : "text"}
+                variant={
+                  current?.job?.job_id === item.job.job_id
+                    ? "contained"
+                    : "text"
+                }
                 color="inherit"
                 onClick={() => setCurrent(item)}
-                sx={{ justifyContent: "flex-start", textAlign: "left", textTransform: "none" }}
+                sx={{
+                  justifyContent: "flex-start",
+                  textAlign: "left",
+                  textTransform: "none",
+                }}
               >
-                <Box><Typography variant="body2" fontWeight={600} noWrap>{item.job.metadata?.agent_name}</Typography><Typography variant="caption" color="text.secondary">{readable(item.status.stage)}</Typography></Box>
+                <Box>
+                  <Typography variant="body2" fontWeight={600} noWrap>
+                    {item.job.metadata?.agent_name}
+                  </Typography>
+                  <Typography variant="caption" color="text.secondary">
+                    {readable(item.status.stage)}
+                  </Typography>
+                </Box>
               </Button>
             ))}
           </Stack>
         </Paper>
 
-        <Box sx={{ minWidth: 0, display: "flex", flexDirection: "column", overflow: "hidden" }}>
+        <Box
+          sx={{
+            minWidth: 0,
+            display: "flex",
+            flexDirection: "column",
+            overflow: "hidden",
+          }}
+        >
           <Paper square variant="outlined" sx={{ p: 2 }}>
-            <Stack direction={{ xs: "column", md: "row" }} spacing={1.5} alignItems="center">
-              <TextField fullWidth size="small" label="Local agent folder" placeholder="/absolute/path/to/agent" value={sourcePath} onChange={(event) => setSourcePath(event.target.value)} />
-              <TextField size="small" label="Scenarios" type="number" value={scenarioCount} onChange={(event) => setScenarioCount(event.target.value)} inputProps={{ min: 1, max: 100 }} sx={{ width: 120 }} />
-              <Button variant="contained" disabled={submitting || !sourcePath.trim()} onClick={run} startIcon={submitting ? <CircularProgress size={16} /> : <Iconify icon="solar:play-bold" />}>Run end to end</Button>
+            <Stack
+              direction={{ xs: "column", md: "row" }}
+              spacing={1.5}
+              alignItems="center"
+            >
+              <TextField
+                select
+                size="small"
+                label="Source"
+                value={sourceMode}
+                onChange={(event) => {
+                  setSourceMode(event.target.value);
+                  setPreflight(null);
+                }}
+                sx={{ minWidth: 130 }}
+              >
+                <MenuItem value="local">Local folder</MenuItem>
+                <MenuItem value="github">GitHub</MenuItem>
+              </TextField>
+              {sourceMode === "local" ? (
+                <TextField
+                  fullWidth
+                  size="small"
+                  label="Local agent folder"
+                  placeholder="/absolute/path/to/agent"
+                  value={sourcePath}
+                  onChange={(event) => {
+                    setSourcePath(event.target.value);
+                    setPreflight(null);
+                  }}
+                />
+              ) : (
+                <>
+                  <TextField
+                    fullWidth
+                    size="small"
+                    label="GitHub repository"
+                    placeholder="owner/repository or GitHub URL"
+                    value={githubRepository}
+                    onChange={(event) => {
+                      setGithubRepository(event.target.value);
+                      setPreflight(null);
+                    }}
+                  />
+                  <TextField
+                    size="small"
+                    label="Ref"
+                    value={githubRef}
+                    onChange={(event) => setGithubRef(event.target.value)}
+                    sx={{ width: 140 }}
+                  />
+                  <TextField
+                    select
+                    size="small"
+                    label="Visibility"
+                    value={githubVisibility}
+                    onChange={(event) => {
+                      setGithubVisibility(event.target.value);
+                      setPreflight(null);
+                    }}
+                    sx={{ minWidth: 120 }}
+                  >
+                    <MenuItem value="public">Public</MenuItem>
+                    <MenuItem value="private">Private</MenuItem>
+                  </TextField>
+                  {githubVisibility === "private" && (
+                    <TextField
+                      size="small"
+                      label="GitHub App installation ID"
+                      value={githubInstallationId}
+                      onChange={(event) =>
+                        setGithubInstallationId(event.target.value)
+                      }
+                      sx={{ minWidth: 230 }}
+                    />
+                  )}
+                </>
+              )}
+              <TextField
+                size="small"
+                label="Scenarios"
+                type="number"
+                value={scenarioCount}
+                onChange={(event) => setScenarioCount(event.target.value)}
+                inputProps={{ min: 1, max: 100 }}
+                sx={{ width: 120 }}
+              />
+              <Button
+                variant="outlined"
+                disabled={checking || !hasSource}
+                onClick={inspect}
+                startIcon={
+                  checking ? (
+                    <CircularProgress size={16} />
+                  ) : (
+                    <Iconify icon="solar:magnifer-linear" />
+                  )
+                }
+              >
+                Preflight
+              </Button>
+              <Button
+                variant="contained"
+                disabled={
+                  submitting ||
+                  !hasSource ||
+                  !preflight ||
+                  !requirementsConfigured
+                }
+                onClick={run}
+                startIcon={
+                  submitting ? (
+                    <CircularProgress size={16} />
+                  ) : (
+                    <Iconify icon="solar:play-bold" />
+                  )
+                }
+              >
+                Run end to end
+              </Button>
             </Stack>
-            {error && <Alert severity="error" sx={{ mt: 1.5 }}>{error}</Alert>}
+            {preflight && (
+              <Paper variant="outlined" sx={{ mt: 1.5, p: 1.5 }}>
+                <Stack
+                  direction="row"
+                  spacing={1}
+                  alignItems="center"
+                  mb={requirements.length ? 1 : 0}
+                >
+                  <Chip
+                    size="small"
+                    color={requirementsConfigured ? "success" : "warning"}
+                    label={
+                      requirementsConfigured
+                        ? "Preflight ready"
+                        : `${requiredInputCount} credential choice${requiredInputCount === 1 ? "" : "s"} needed`
+                    }
+                  />
+                  <Typography variant="caption" color="text.secondary">
+                    {preflight.credentials?.scanned_files || 0} files scanned ·{" "}
+                    {(preflight.credentials?.detected_connectors || []).join(
+                      ", ",
+                    ) || "connector discovered after checkout"}
+                  </Typography>
+                </Stack>
+                <Stack spacing={1}>
+                  {unsatisfiedChoices.map((choice) => (
+                    <Alert key={choice.id} severity="info">
+                      {choice.purpose}: choose{" "}
+                      {choice.options
+                        .map((option) => option.join(" + "))
+                        .join(" or ")}
+                    </Alert>
+                  ))}
+                  {requirements.map((item) => (
+                    <Stack
+                      key={item.id}
+                      direction={{ xs: "column", md: "row" }}
+                      spacing={1}
+                      alignItems={{ md: "center" }}
+                    >
+                      <Box sx={{ minWidth: 260 }}>
+                        <Typography variant="body2" fontWeight={600}>
+                          {item.environment_name}
+                        </Typography>
+                        <Typography variant="caption" color="text.secondary">
+                          {item.provider} · {item.purpose} ·{" "}
+                          {readable(item.status)}
+                        </Typography>
+                      </Box>
+                      {item.status === "missing" && (
+                        <TextField
+                          fullWidth
+                          size="small"
+                          label={
+                            item.kind === "secret"
+                              ? "Secret manager key (never the secret value)"
+                              : "Configuration value"
+                          }
+                          value={
+                            item.kind === "secret"
+                              ? secretRefs[item.environment_name] || ""
+                              : configurationValues[item.environment_name] || ""
+                          }
+                          onChange={(event) => {
+                            const setter =
+                              item.kind === "secret"
+                                ? setSecretRefs
+                                : setConfigurationValues;
+                            setter((existing) => ({
+                              ...existing,
+                              [item.environment_name]: event.target.value,
+                            }));
+                          }}
+                        />
+                      )}
+                    </Stack>
+                  ))}
+                </Stack>
+              </Paper>
+            )}
+            {error && (
+              <Alert severity="error" sx={{ mt: 1.5 }}>
+                {error}
+              </Alert>
+            )}
           </Paper>
 
           {!current ? (
-            <Stack flex={1} alignItems="center" justifyContent="center" spacing={1}>
+            <Stack
+              flex={1}
+              alignItems="center"
+              justifyContent="center"
+              spacing={1}
+            >
               <Iconify icon="solar:server-square-cloud-linear" width={54} />
-              <Typography variant="h6">Give us the agent folder; ALK does the rest.</Typography>
-              <Typography color="text.secondary">Environment discovery, services, realistic data, scenarios, calls and grading run without operator prompts.</Typography>
+              <Typography variant="h6">
+                Give us the agent folder; ALK does the rest.
+              </Typography>
+              <Typography color="text.secondary">
+                Environment discovery, services, realistic data, scenarios,
+                calls and grading run without operator prompts.
+              </Typography>
             </Stack>
           ) : (
-            <Box sx={{ flex: 1, minHeight: 0, display: "grid", gridTemplateColumns: "minmax(380px, 0.9fr) minmax(480px, 1.4fr)" }}>
-              <Box sx={{ p: 2, overflow: "auto", borderRight: 1, borderColor: "divider" }}>
-                <Stack direction="row" justifyContent="space-between" alignItems="center">
-                  <Box><Typography variant="h6">{current.job.metadata?.agent_name}</Typography><Typography variant="caption" color="text.secondary">{current.job.run_id}</Typography></Box>
-                  <Chip label={readable(current.status.stage)} color={current.status.stage === "failed" ? "error" : current.status.stage === "completed" ? "success" : "primary"} />
+            <Box
+              sx={{
+                flex: 1,
+                minHeight: 0,
+                display: "grid",
+                gridTemplateColumns:
+                  "minmax(380px, 0.9fr) minmax(480px, 1.4fr)",
+              }}
+            >
+              <Box
+                sx={{
+                  p: 2,
+                  overflow: "auto",
+                  borderRight: 1,
+                  borderColor: "divider",
+                }}
+              >
+                <Stack
+                  direction="row"
+                  justifyContent="space-between"
+                  alignItems="center"
+                >
+                  <Box>
+                    <Typography variant="h6">
+                      {current.job.metadata?.agent_name}
+                    </Typography>
+                    <Typography variant="caption" color="text.secondary">
+                      {current.job.run_id}
+                    </Typography>
+                  </Box>
+                  <Chip
+                    label={readable(current.status.stage)}
+                    color={
+                      current.status.stage === "failed"
+                        ? "error"
+                        : current.status.stage === "completed"
+                          ? "success"
+                          : "primary"
+                    }
+                  />
+                </Stack>
+                <LinearProgress
+                  variant="determinate"
+                  value={progress}
+                  color={
+                    current.status.stage === "failed" ? "error" : "primary"
+                  }
+                  sx={{ mt: 1.5 }}
+                />
+                <Stack direction="row" justifyContent="space-between" mt={0.5}>
+                  <Typography variant="caption" color="text.secondary">
+                    {current.status.completed_scenarios || 0} /{" "}
+                    {current.status.total_scenarios ||
+                      current.job.scenario_count}{" "}
+                    scenarios complete
+                  </Typography>
+                  <Typography
+                    variant="caption"
+                    color={
+                      secondsSinceUpdate > 60 &&
+                      !terminalStages.has(current.status.stage)
+                        ? "warning.main"
+                        : "text.secondary"
+                    }
+                  >
+                    Updated {secondsSinceUpdate ?? 0}s ago · attempt{" "}
+                    {current.status.attempt || 1}
+                  </Typography>
                 </Stack>
                 <Divider sx={{ my: 2 }} />
                 <Stack spacing={1.2}>
                   {stages.map((stage, index) => {
-                    const reached = stageIndex >= index || current.status.stage === "completed";
-                    return <Stack key={stage} direction="row" spacing={1.2} alignItems="center"><Iconify icon={reached ? "solar:check-circle-bold" : "solar:record-circle-linear"} color={reached ? "success.main" : "text.disabled"} /><Typography color={reached ? "text.primary" : "text.disabled"}>{readable(stage)}</Typography></Stack>;
+                    const reached =
+                      stageIndex >= index ||
+                      current.status.stage === "completed";
+                    return (
+                      <Stack
+                        key={stage}
+                        direction="row"
+                        spacing={1.2}
+                        alignItems="center"
+                      >
+                        <Iconify
+                          icon={
+                            reached
+                              ? "solar:check-circle-bold"
+                              : "solar:record-circle-linear"
+                          }
+                          color={reached ? "success.main" : "text.disabled"}
+                        />
+                        <Typography
+                          color={reached ? "text.primary" : "text.disabled"}
+                        >
+                          {readable(stage)}
+                        </Typography>
+                      </Stack>
+                    );
                   })}
                 </Stack>
-                {!terminalStages.has(current.status.stage) && <Button color="error" variant="outlined" onClick={cancel} sx={{ mt: 3 }}>Cancel run</Button>}
+                {!terminalStages.has(current.status.stage) && (
+                  <Button
+                    color="error"
+                    variant="outlined"
+                    onClick={cancel}
+                    sx={{ mt: 3 }}
+                  >
+                    Cancel run
+                  </Button>
+                )}
               </Box>
 
               <Box sx={{ p: 2, overflow: "auto" }}>
-                <Typography variant="overline" color="text.secondary">Live harness activity</Typography>
+                <Typography variant="overline" color="text.secondary">
+                  Live harness activity
+                </Typography>
                 <Stack spacing={1.5} mt={1.5}>
-                  <Paper variant="outlined" sx={{ p: 1.5, bgcolor: "action.hover" }}><Typography variant="body2">I’ll inspect the agent, build and seed its environment, create {current.job.scenario_count} diverse scenarios, run the calls, grade only observed behavior, and publish the results.</Typography></Paper>
-                  {messages.map((event) => <Paper key={event.event_id} variant="outlined" sx={{ p: 1.5 }}><Typography variant="caption" color="primary.main">{readable(event.payload?.stage || event.type)}</Typography><Typography variant="body2">{eventMessage(event)}</Typography></Paper>)}
-                  {current.status.detail && <Alert severity={current.status.stage === "failed" ? "error" : "info"}>{current.status.detail}</Alert>}
-                  {!terminalStages.has(current.status.stage) && <Stack direction="row" spacing={1} alignItems="center"><CircularProgress size={16} /><Typography variant="body2" color="text.secondary">ALK is working autonomously…</Typography></Stack>}
+                  {current.credentials && (
+                    <Paper variant="outlined" sx={{ p: 1.5 }}>
+                      <Typography variant="subtitle2">
+                        Runtime preflight
+                      </Typography>
+                      <Typography variant="body2" color="text.secondary">
+                        {current.credentials.scanned_files} source files
+                        inspected ·{" "}
+                        {(current.credentials.detected_connectors || []).join(
+                          ", ",
+                        ) || "generic connector"}{" "}
+                        · {current.credentials.requirements?.length || 0}{" "}
+                        configuration requirements
+                      </Typography>
+                    </Paper>
+                  )}
+                  {messages.map((event) => (
+                    <Paper
+                      key={event.event_id}
+                      variant="outlined"
+                      sx={{ p: 1.5 }}
+                    >
+                      <Stack direction="row" justifyContent="space-between">
+                        <Typography variant="caption" color="primary.main">
+                          {readable(event.payload?.stage || event.type)}
+                        </Typography>
+                        <Typography variant="caption" color="text.secondary">
+                          {event.wall_time
+                            ? new Date(event.wall_time).toLocaleTimeString()
+                            : ""}
+                        </Typography>
+                      </Stack>
+                      <Typography variant="body2">
+                        {eventMessage(event)}
+                      </Typography>
+                    </Paper>
+                  ))}
+                  {current.status.failure && (
+                    <Alert severity="error">
+                      <Typography variant="subtitle2">
+                        {readable(current.status.failure.domain)} ·{" "}
+                        {current.status.failure.code}
+                      </Typography>
+                      {current.status.failure.message}
+                    </Alert>
+                  )}
+                  {current.status.detail && (
+                    <Alert
+                      severity={
+                        current.status.stage === "failed" ? "error" : "info"
+                      }
+                    >
+                      {current.status.detail}
+                    </Alert>
+                  )}
+                  {!terminalStages.has(current.status.stage) && (
+                    <Stack direction="row" spacing={1} alignItems="center">
+                      <CircularProgress size={16} />
+                      <Typography variant="body2" color="text.secondary">
+                        ALK is working autonomously…
+                      </Typography>
+                    </Stack>
+                  )}
                 </Stack>
               </Box>
             </Box>

--- a/frontend/src/pages/dashboard/harness/Harness.jsx
+++ b/frontend/src/pages/dashboard/harness/Harness.jsx
@@ -1,0 +1,192 @@
+import { useCallback, useEffect, useMemo, useState } from "react";
+import {
+  Alert,
+  Box,
+  Button,
+  Chip,
+  CircularProgress,
+  Divider,
+  Paper,
+  Stack,
+  TextField,
+  Typography,
+} from "@mui/material";
+import { Helmet } from "react-helmet-async";
+import Iconify from "src/components/iconify";
+import {
+  cancelHarnessJob,
+  createHarnessJob,
+  getHarnessJob,
+  listHarnessJobs,
+} from "src/api/harness/harness";
+
+const terminalStages = new Set(["completed", "failed", "canceled"]);
+const stages = [
+  "understanding_agent",
+  "generating_environment",
+  "building_environment",
+  "validating_environment",
+  "generating_data",
+  "generating_scenarios",
+  "validating_scenarios",
+  "connecting_agent",
+  "running",
+  "grading",
+  "uploading_artifacts",
+  "completed",
+];
+
+const readable = (value = "") =>
+  value.replaceAll("_", " ").replace(/^./, (letter) => letter.toUpperCase());
+
+function eventMessage(event) {
+  const payload = event.payload || {};
+  if (payload.detail) return String(payload.detail);
+  if (payload.message) return String(payload.message);
+  if (payload.stage) return `${readable(payload.stage)} ${readable(event.type)}`;
+  return readable(event.type || "Progress updated");
+}
+
+export default function Harness() {
+  const [sourcePath, setSourcePath] = useState("");
+  const [scenarioCount, setScenarioCount] = useState(10);
+  const [jobs, setJobs] = useState([]);
+  const [current, setCurrent] = useState(null);
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState("");
+
+  const refreshList = useCallback(async () => {
+    try {
+      const value = await listHarnessJobs();
+      setJobs(Array.isArray(value) ? value : []);
+      if (!current && value?.length) setCurrent(value[0]);
+    } catch (requestError) {
+      setError(requestError?.response?.data?.detail || requestError.message);
+    }
+  }, [current]);
+
+  useEffect(() => {
+    refreshList();
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
+
+  useEffect(() => {
+    const id = current?.job?.job_id;
+    if (!id || terminalStages.has(current.status.stage)) return undefined;
+    const timer = window.setInterval(async () => {
+      try {
+        const value = await getHarnessJob(id);
+        setCurrent(value);
+        setJobs((existing) =>
+          existing.map((job) => (job.job?.job_id === id ? value : job)),
+        );
+      } catch (requestError) {
+        setError(requestError?.response?.data?.detail || requestError.message);
+      }
+    }, 2000);
+    return () => window.clearInterval(timer);
+  }, [current?.job?.job_id, current?.status?.stage]);
+
+  const run = async () => {
+    setSubmitting(true);
+    setError("");
+    try {
+      const value = await createHarnessJob({
+        source_path: sourcePath.trim(),
+        scenario_count: Number(scenarioCount),
+        connector: "auto",
+      });
+      setCurrent(value);
+      setJobs((existing) => [value, ...existing]);
+    } catch (requestError) {
+      setError(requestError?.response?.data?.detail || requestError.message);
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  const cancel = async () => {
+    const value = await cancelHarnessJob(current.job.job_id);
+    setCurrent(value);
+  };
+
+  const stageIndex = stages.indexOf(current?.status?.stage);
+  const messages = useMemo(() => {
+    const seen = new Set();
+    return (current?.events || []).filter((event) => {
+      const key = event.event_id || JSON.stringify(event);
+      if (seen.has(key)) return false;
+      seen.add(key);
+      return true;
+    });
+  }, [current?.events]);
+
+  return (
+    <>
+      <Helmet><title>RL Environment | Future AGI</title></Helmet>
+      <Box sx={{ height: "100%", display: "grid", gridTemplateColumns: "280px minmax(0, 1fr)", bgcolor: "background.default" }}>
+        <Paper square variant="outlined" sx={{ p: 2, overflow: "auto" }}>
+          <Typography variant="overline" color="text.secondary">Harness jobs</Typography>
+          <Stack spacing={1} mt={1}>
+            {jobs.map((item) => (
+              <Button
+                key={item.job.job_id}
+                variant={current?.job?.job_id === item.job.job_id ? "contained" : "text"}
+                color="inherit"
+                onClick={() => setCurrent(item)}
+                sx={{ justifyContent: "flex-start", textAlign: "left", textTransform: "none" }}
+              >
+                <Box><Typography variant="body2" fontWeight={600} noWrap>{item.job.metadata?.agent_name}</Typography><Typography variant="caption" color="text.secondary">{readable(item.status.stage)}</Typography></Box>
+              </Button>
+            ))}
+          </Stack>
+        </Paper>
+
+        <Box sx={{ minWidth: 0, display: "flex", flexDirection: "column", overflow: "hidden" }}>
+          <Paper square variant="outlined" sx={{ p: 2 }}>
+            <Stack direction={{ xs: "column", md: "row" }} spacing={1.5} alignItems="center">
+              <TextField fullWidth size="small" label="Local agent folder" placeholder="/absolute/path/to/agent" value={sourcePath} onChange={(event) => setSourcePath(event.target.value)} />
+              <TextField size="small" label="Scenarios" type="number" value={scenarioCount} onChange={(event) => setScenarioCount(event.target.value)} inputProps={{ min: 1, max: 100 }} sx={{ width: 120 }} />
+              <Button variant="contained" disabled={submitting || !sourcePath.trim()} onClick={run} startIcon={submitting ? <CircularProgress size={16} /> : <Iconify icon="solar:play-bold" />}>Run end to end</Button>
+            </Stack>
+            {error && <Alert severity="error" sx={{ mt: 1.5 }}>{error}</Alert>}
+          </Paper>
+
+          {!current ? (
+            <Stack flex={1} alignItems="center" justifyContent="center" spacing={1}>
+              <Iconify icon="solar:server-square-cloud-linear" width={54} />
+              <Typography variant="h6">Give us the agent folder; ALK does the rest.</Typography>
+              <Typography color="text.secondary">Environment discovery, services, realistic data, scenarios, calls and grading run without operator prompts.</Typography>
+            </Stack>
+          ) : (
+            <Box sx={{ flex: 1, minHeight: 0, display: "grid", gridTemplateColumns: "minmax(380px, 0.9fr) minmax(480px, 1.4fr)" }}>
+              <Box sx={{ p: 2, overflow: "auto", borderRight: 1, borderColor: "divider" }}>
+                <Stack direction="row" justifyContent="space-between" alignItems="center">
+                  <Box><Typography variant="h6">{current.job.metadata?.agent_name}</Typography><Typography variant="caption" color="text.secondary">{current.job.run_id}</Typography></Box>
+                  <Chip label={readable(current.status.stage)} color={current.status.stage === "failed" ? "error" : current.status.stage === "completed" ? "success" : "primary"} />
+                </Stack>
+                <Divider sx={{ my: 2 }} />
+                <Stack spacing={1.2}>
+                  {stages.map((stage, index) => {
+                    const reached = stageIndex >= index || current.status.stage === "completed";
+                    return <Stack key={stage} direction="row" spacing={1.2} alignItems="center"><Iconify icon={reached ? "solar:check-circle-bold" : "solar:record-circle-linear"} color={reached ? "success.main" : "text.disabled"} /><Typography color={reached ? "text.primary" : "text.disabled"}>{readable(stage)}</Typography></Stack>;
+                  })}
+                </Stack>
+                {!terminalStages.has(current.status.stage) && <Button color="error" variant="outlined" onClick={cancel} sx={{ mt: 3 }}>Cancel run</Button>}
+              </Box>
+
+              <Box sx={{ p: 2, overflow: "auto" }}>
+                <Typography variant="overline" color="text.secondary">Live harness activity</Typography>
+                <Stack spacing={1.5} mt={1.5}>
+                  <Paper variant="outlined" sx={{ p: 1.5, bgcolor: "action.hover" }}><Typography variant="body2">I’ll inspect the agent, build and seed its environment, create {current.job.scenario_count} diverse scenarios, run the calls, grade only observed behavior, and publish the results.</Typography></Paper>
+                  {messages.map((event) => <Paper key={event.event_id} variant="outlined" sx={{ p: 1.5 }}><Typography variant="caption" color="primary.main">{readable(event.payload?.stage || event.type)}</Typography><Typography variant="body2">{eventMessage(event)}</Typography></Paper>)}
+                  {current.status.detail && <Alert severity={current.status.stage === "failed" ? "error" : "info"}>{current.status.detail}</Alert>}
+                  {!terminalStages.has(current.status.stage) && <Stack direction="row" spacing={1} alignItems="center"><CircularProgress size={16} /><Typography variant="body2" color="text.secondary">ALK is working autonomously…</Typography></Stack>}
+                </Stack>
+              </Box>
+            </Box>
+          )}
+        </Box>
+      </Box>
+    </>
+  );
+}

--- a/frontend/src/pages/dashboard/harness/Harness.jsx
+++ b/frontend/src/pages/dashboard/harness/Harness.jsx
@@ -15,6 +15,8 @@ import {
   MenuItem,
   Paper,
   Stack,
+  Tab,
+  Tabs,
   TextField,
   Tooltip,
   Typography,
@@ -28,13 +30,22 @@ import {
   getHarnessJob,
   listHarnessJobs,
   preflightHarnessJob,
+  uploadHarnessSecretFile,
   uploadHarnessSource,
 } from "src/api/harness/harness";
 import { parseDotEnv } from "./dotenv";
 import { prepareSourceFolder } from "./sourceUpload";
+import {
+  credentialCount,
+  credentialValue,
+  mergePastedCredentials,
+  updateCredential,
+} from "./credentialValues";
 
 const terminalStages = new Set(["completed", "failed", "canceled"]);
 const stages = [
+  "queued",
+  "acquiring_source",
   "understanding_agent",
   "generating_environment",
   "building_environment",
@@ -46,18 +57,91 @@ const stages = [
   "running",
   "grading",
   "uploading_artifacts",
+  "cleaning_up",
   "completed",
 ];
 
+const stageLabels = {
+  queued: "Queued",
+  acquiring_source: "Preparing source",
+  understanding_agent: "Understanding agent",
+  generating_environment: "Generating environment",
+  building_environment: "Building environment",
+  validating_environment: "Validating environment",
+  generating_data: "Generating data",
+  generating_scenarios: "Generating scenarios",
+  validating_scenarios: "Validating scenarios",
+  connecting_agent: "Connecting agent",
+  running: "Running scenarios",
+  grading: "Grading results",
+  uploading_artifacts: "Uploading artifacts",
+  cleaning_up: "Cleaning up",
+  completed: "Completed",
+  failed: "Failed",
+  canceled: "Canceled",
+};
+
+const detailTabs = [
+  { value: "contract", label: "Contract" },
+  { value: "environment", label: "Environment" },
+  { value: "scenarios", label: "Scenarios" },
+  { value: "runs", label: "Runs" },
+];
+
+const stageDetailTabs = {
+  queued: "contract",
+  acquiring_source: "contract",
+  understanding_agent: "contract",
+  generating_environment: "environment",
+  building_environment: "environment",
+  validating_environment: "environment",
+  generating_data: "environment",
+  generating_scenarios: "scenarios",
+  validating_scenarios: "scenarios",
+  connecting_agent: "runs",
+  running: "runs",
+  grading: "runs",
+  uploading_artifacts: "runs",
+  cleaning_up: "runs",
+  completed: "runs",
+  failed: "runs",
+  canceled: "runs",
+};
+
 const readable = (value = "") =>
+  stageLabels[value] ||
   value.replaceAll("_", " ").replace(/^./, (letter) => letter.toUpperCase());
+
+function requestErrorMessage(requestError, fallback = "Something went wrong") {
+  const data = requestError?.response?.data;
+  const detail = data?.detail ?? data;
+  if (typeof detail === "string") return detail;
+  if (Array.isArray(detail)) return detail.map(String).join(" ");
+  if (detail && typeof detail === "object")
+    return Object.entries(detail)
+      .map(([field, messages]) => {
+        const text = Array.isArray(messages)
+          ? messages.map(String).join(" ")
+          : String(messages);
+        return `${readable(field)}: ${text}`;
+      })
+      .join(" ");
+  return requestError?.message || fallback;
+}
 
 function eventMessage(event) {
   const payload = event.payload || {};
   if (payload.detail) return String(payload.detail);
   if (payload.message) return String(payload.message);
-  if (payload.stage)
-    return `${readable(payload.stage)} ${readable(event.type)}`;
+  if (payload.stage) {
+    if (event.type === "harness.stage.started")
+      return `${readable(payload.stage)} started`;
+    if (event.type === "harness.stage.completed")
+      return `${readable(payload.stage)} completed`;
+    if (event.type === "harness.stage.failed")
+      return `${readable(payload.stage)} failed`;
+    return `${readable(payload.stage)} updated`;
+  }
   return readable(event.type || "Progress updated");
 }
 
@@ -76,6 +160,24 @@ function StageOutput({ output }) {
         </Box>
       </AccordionSummary>
       <AccordionDetails>
+        {output.kind === "simulation" && (
+          <Stack spacing={1} alignItems="flex-start">
+            <Typography variant="body2" color="text.secondary">
+              Open the exact simulation execution to inspect calls, transcripts,
+              recordings, tool activity, and evaluations.
+            </Typography>
+            <Button
+              component="a"
+              href={data.url}
+              target="_blank"
+              rel="noopener noreferrer"
+              variant="contained"
+              endIcon={<Iconify icon="solar:arrow-right-up-linear" />}
+            >
+              Open simulation
+            </Button>
+          </Stack>
+        )}
         {output.kind === "contract" && (
           <Stack spacing={1}>
             <Typography variant="body2">{data.one_liner}</Typography>
@@ -140,7 +242,9 @@ function StageOutput({ output }) {
             ))}
           </Stack>
         )}
-        {!["contract", "environment", "scenarios"].includes(output.kind) && (
+        {!["contract", "environment", "scenarios", "simulation"].includes(
+          output.kind,
+        ) && (
           <Box
             component="pre"
             sx={{ m: 0, whiteSpace: "pre-wrap", fontSize: 12 }}
@@ -171,10 +275,14 @@ export default function Harness() {
   const [githubInstallationId, setGithubInstallationId] = useState("");
   const [scenarioCount, setScenarioCount] = useState(10);
   const [preflight, setPreflight] = useState(null);
+  const [preflightDirty, setPreflightDirty] = useState(false);
   const [configurationValues, setConfigurationValues] = useState({});
   const [environmentValues, setEnvironmentValues] = useState({});
   const [environmentText, setEnvironmentText] = useState("");
   const [environmentError, setEnvironmentError] = useState("");
+  const [secretFileRefs, setSecretFileRefs] = useState({});
+  const [secretFileUploads, setSecretFileUploads] = useState({});
+  const [uploadingSecretFile, setUploadingSecretFile] = useState(false);
   const [jobs, setJobs] = useState([]);
   const [current, setCurrent] = useState(null);
   const [submitting, setSubmitting] = useState(false);
@@ -182,6 +290,7 @@ export default function Harness() {
   const [checking, setChecking] = useState(false);
   const [adjustment, setAdjustment] = useState("");
   const [adjusting, setAdjusting] = useState(false);
+  const [detailTab, setDetailTab] = useState("contract");
   const [clock, setClock] = useState(Date.now());
 
   useEffect(() => {
@@ -195,7 +304,9 @@ export default function Harness() {
       setJobs(Array.isArray(value) ? value : []);
       if (!current && value?.length) setCurrent(value[0]);
     } catch (requestError) {
-      setError(requestError?.response?.data?.detail || requestError.message);
+      setError(
+        requestErrorMessage(requestError, "Could not load harness runs"),
+      );
     }
   }, [current]);
 
@@ -214,10 +325,17 @@ export default function Harness() {
           existing.map((job) => (job.job?.job_id === id ? value : job)),
         );
       } catch (requestError) {
-        setError(requestError?.response?.data?.detail || requestError.message);
+        setError(
+          requestErrorMessage(requestError, "Could not refresh this run"),
+        );
       }
     }, 2000);
     return () => window.clearInterval(timer);
+  }, [current?.job?.job_id, current?.status?.stage]);
+
+  useEffect(() => {
+    const activeTab = stageDetailTabs[current?.status?.stage];
+    if (activeTab) setDetailTab(activeTab);
   }, [current?.job?.job_id, current?.status?.stage]);
 
   const sourcePayload = () => {
@@ -233,19 +351,24 @@ export default function Harness() {
     };
   };
 
+  const preflightPayload = () => ({
+    ...sourcePayload(),
+    secret_refs: secretFileRefs,
+    connector_config: configurationValues,
+    environment_values: environmentValues,
+  });
+
   const inspect = async () => {
     setChecking(true);
     setError("");
     try {
-      const value = await preflightHarnessJob({
-        ...sourcePayload(),
-        secret_refs: {},
-        connector_config: configurationValues,
-        environment_values: environmentValues,
-      });
+      const value = await preflightHarnessJob(preflightPayload());
       setPreflight(value);
+      setPreflightDirty(false);
+      return value;
     } catch (requestError) {
-      setError(requestError?.response?.data?.detail || requestError.message);
+      setError(requestErrorMessage(requestError, "Preflight could not finish"));
+      return null;
     } finally {
       setChecking(false);
     }
@@ -255,26 +378,45 @@ export default function Harness() {
     setSubmitting(true);
     setError("");
     try {
+      const checked = await preflightHarnessJob(preflightPayload());
+      setPreflight(checked);
+      setPreflightDirty(false);
+      if (!checked.ready_to_submit) {
+        setError(
+          "Preflight found items that still need attention. Review the checklist below, make the changes, and check again.",
+        );
+        return;
+      }
       const value = await createHarnessJob({
         ...sourcePayload(),
         scenario_count: Number(scenarioCount),
         connector: "auto",
-        secret_refs: {},
+        secret_refs: secretFileRefs,
         connector_config: configurationValues,
         environment_values: environmentValues,
       });
       setCurrent(value);
       setJobs((existing) => [value, ...existing]);
+      setDetailTab("contract");
     } catch (requestError) {
-      setError(requestError?.response?.data?.detail || requestError.message);
+      setError(
+        requestErrorMessage(requestError, "The run could not be started"),
+      );
     } finally {
       setSubmitting(false);
     }
   };
 
   const cancel = async () => {
-    const value = await cancelHarnessJob(current.job.job_id);
-    setCurrent(value);
+    setError("");
+    try {
+      const value = await cancelHarnessJob(current.job.job_id);
+      setCurrent(value);
+    } catch (requestError) {
+      setError(
+        requestErrorMessage(requestError, "The run could not be canceled"),
+      );
+    }
   };
 
   const submitAdjustment = async () => {
@@ -289,7 +431,9 @@ export default function Harness() {
       setCurrent(value);
       setAdjustment("");
     } catch (requestError) {
-      setError(requestError?.response?.data?.detail || requestError.message);
+      setError(
+        requestErrorMessage(requestError, "The change could not be sent"),
+      );
     } finally {
       setAdjusting(false);
     }
@@ -305,11 +449,15 @@ export default function Harness() {
     setGithubInstallationId("");
     setScenarioCount(10);
     setPreflight(null);
+    setPreflightDirty(false);
     setConfigurationValues({});
     setEnvironmentValues({});
     setEnvironmentText("");
     setEnvironmentError("");
+    setSecretFileRefs({});
+    setSecretFileUploads({});
     setError("");
+    setDetailTab("contract");
   };
 
   const stageIndex = stages.indexOf(current?.status?.stage);
@@ -329,10 +477,12 @@ export default function Harness() {
       (item) => item.environment_name === name,
     );
     if (requirement?.status !== "missing") return true;
-    if (requirement?.kind === "secret")
-      return Boolean(String(environmentValues[name] || "").trim());
-    if (Object.hasOwn(environmentValues, name)) return true;
-    return Boolean(String(configurationValues[name] || "").trim());
+    if (secretFileRefs[name]) return true;
+    return Boolean(
+      String(
+        credentialValue(environmentValues, configurationValues, name),
+      ).trim(),
+    );
   };
   const unsatisfiedChoices = credentialChoices.filter(
     (choice) =>
@@ -341,7 +491,16 @@ export default function Harness() {
         option.every((name) => requirementConfigured(name)),
       ),
   );
-  const requirementsConfigured =
+  const actionableRequirementNames = new Set([
+    ...missingRequirements.map((item) => item.environment_name),
+    ...unsatisfiedChoices.flatMap((choice) => choice.options.flat()),
+  ]);
+  const actionableRequirements = requirements.filter(
+    (item) =>
+      item.status === "missing" &&
+      actionableRequirementNames.has(item.environment_name),
+  );
+  const requirementsConfiguredLocally =
     missingRequirements.every((item) =>
       requirementConfigured(item.environment_name),
     ) && unsatisfiedChoices.length === 0;
@@ -352,6 +511,13 @@ export default function Harness() {
       ? Boolean(uploadedSource?.source_id)
       : Boolean(githubRepository.trim()) &&
         (githubVisibility === "public" || Boolean(githubInstallationId.trim()));
+  const validScenarioCount =
+    Number.isInteger(Number(scenarioCount)) &&
+    Number(scenarioCount) >= 1 &&
+    Number(scenarioCount) <= 100;
+  const loadedCredentialCount =
+    credentialCount(environmentValues, configurationValues) +
+    Object.keys(secretFileRefs).length;
   const progress = current
     ? current.status.stage === "completed"
       ? 100
@@ -372,28 +538,89 @@ export default function Harness() {
       return true;
     });
   }, [current?.events]);
+  const packagingFindings = (preflight?.packaging?.candidates || []).flatMap(
+    (candidate) =>
+      (candidate.findings || []).map((finding) => ({
+        ...finding,
+        path: candidate.path,
+      })),
+  );
+  const blockingPackagingFindings = packagingFindings.filter(
+    (finding) => finding.blocking,
+  );
+  const preflightReady = Boolean(preflight?.ready_to_submit && !preflightDirty);
+  const selectedOutputs = (current?.stage_outputs || []).filter((output) =>
+    detailTab === "runs"
+      ? !["contract", "environment", "scenarios"].includes(output.kind)
+      : output.kind === detailTab,
+  );
+  const outputCounts = (current?.stage_outputs || []).reduce(
+    (counts, output) => ({
+      ...counts,
+      [output.kind]: (counts[output.kind] || 0) + 1,
+    }),
+    {},
+  );
 
-  const loadEnvironment = (text) => {
+  const loadPastedEnvironment = () => {
     try {
-      const values = parseDotEnv(text);
-      setEnvironmentValues(values);
+      const values = parseDotEnv(environmentText);
+      if (!Object.keys(values).length)
+        throw new Error("No environment variables were found.");
+      const merged = mergePastedCredentials(
+        environmentValues,
+        configurationValues,
+        values,
+      );
+      setEnvironmentValues(merged.environmentValues);
+      setConfigurationValues(merged.configurationValues);
       setEnvironmentText("");
       setEnvironmentError("");
-      setPreflight(null);
+      setPreflightDirty(Boolean(preflight));
     } catch (parseError) {
       setEnvironmentError(parseError.message);
     }
   };
 
-  const uploadEnvironment = async (event) => {
-    const file = event.target.files?.[0];
-    event.target.value = "";
+  const uploadCredentialFile = async (environmentName, file) => {
     if (!file) return;
-    if (file.size > 262144) {
-      setEnvironmentError("The .env file may not exceed 256 KiB");
-      return;
+    setUploadingSecretFile(true);
+    setEnvironmentError("");
+    try {
+      const formData = new FormData();
+      formData.append("file", file);
+      formData.append("environment_name", environmentName);
+      const uploaded = await uploadHarnessSecretFile(formData);
+      setSecretFileRefs((existing) => ({
+        ...existing,
+        [environmentName]: uploaded.secret_ref,
+      }));
+      setSecretFileUploads((existing) => ({
+        ...existing,
+        [environmentName]: { name: file.name, size: uploaded.size },
+      }));
+      // A pasted workstation path and a provider-managed file reference are mutually exclusive.
+      setEnvironmentValues((existing) => {
+        const next = { ...existing };
+        delete next[environmentName];
+        return next;
+      });
+      setConfigurationValues((existing) => {
+        const next = { ...existing };
+        delete next[environmentName];
+        return next;
+      });
+      setPreflightDirty(true);
+    } catch (requestError) {
+      setEnvironmentError(
+        requestErrorMessage(
+          requestError,
+          "Credential file could not be uploaded",
+        ),
+      );
+    } finally {
+      setUploadingSecretFile(false);
     }
-    loadEnvironment(await file.text());
   };
 
   const uploadSourceFolder = async (event) => {
@@ -402,6 +629,7 @@ export default function Harness() {
     if (!selected.length) return;
     setError("");
     setPreflight(null);
+    setPreflightDirty(false);
     setUploadedSource(null);
     let prepared;
     try {
@@ -429,7 +657,9 @@ export default function Harness() {
         excluded_count: prepared.excludedCount,
       });
     } catch (requestError) {
-      setError(requestError?.response?.data?.detail || requestError.message);
+      setError(
+        requestErrorMessage(requestError, "The folder could not be uploaded"),
+      );
     } finally {
       setSourceUploadProgress(null);
     }
@@ -478,7 +708,10 @@ export default function Harness() {
                     : "text"
                 }
                 color="inherit"
-                onClick={() => setCurrent(item)}
+                onClick={() => {
+                  setCurrent(item);
+                  setDetailTab("contract");
+                }}
                 sx={{
                   justifyContent: "flex-start",
                   textAlign: "left",
@@ -507,6 +740,15 @@ export default function Harness() {
           }}
         >
           <Paper square variant="outlined" sx={{ p: 2 }}>
+            <Stack spacing={0.25} mb={1.5}>
+              <Typography variant="subtitle1" fontWeight={700}>
+                Set up a harness run
+              </Typography>
+              <Typography variant="body2" color="text.secondary">
+                Add the agent source, provide any run-only environment values,
+                then check readiness before starting.
+              </Typography>
+            </Stack>
             <Stack
               direction={{ xs: "column", md: "row" }}
               spacing={1.5}
@@ -520,6 +762,8 @@ export default function Harness() {
                 onChange={(event) => {
                   setSourceMode(event.target.value);
                   setPreflight(null);
+                  setPreflightDirty(false);
+                  setError("");
                 }}
                 sx={{ minWidth: 130 }}
               >
@@ -568,6 +812,7 @@ export default function Harness() {
                     onChange={(event) => {
                       setGithubRepository(event.target.value);
                       setPreflight(null);
+                      setPreflightDirty(false);
                     }}
                   />
                   <TextField
@@ -578,6 +823,7 @@ export default function Harness() {
                     onChange={(event) => {
                       setGithubVisibility(event.target.value);
                       setPreflight(null);
+                      setPreflightDirty(false);
                     }}
                     sx={{ minWidth: 120 }}
                   >
@@ -589,9 +835,11 @@ export default function Harness() {
                       size="small"
                       label="GitHub App installation ID"
                       value={githubInstallationId}
-                      onChange={(event) =>
-                        setGithubInstallationId(event.target.value)
-                      }
+                      onChange={(event) => {
+                        setGithubInstallationId(event.target.value);
+                        setPreflight(null);
+                        setPreflightDirty(false);
+                      }}
                       sx={{ minWidth: 230 }}
                     />
                   )}
@@ -604,6 +852,8 @@ export default function Harness() {
                 value={scenarioCount}
                 onChange={(event) => setScenarioCount(event.target.value)}
                 inputProps={{ min: 1, max: 100 }}
+                error={!validScenarioCount}
+                helperText={!validScenarioCount ? "Use 1–100" : undefined}
                 sx={{ width: 120 }}
               />
               <Button
@@ -618,15 +868,20 @@ export default function Harness() {
                   )
                 }
               >
-                Preflight
+                {preflightDirty
+                  ? "Check again"
+                  : preflight
+                    ? "Recheck"
+                    : "Check readiness"}
               </Button>
               <Button
                 variant="contained"
                 disabled={
                   submitting ||
+                  checking ||
                   !hasSource ||
-                  !preflight ||
-                  !requirementsConfigured
+                  !validScenarioCount ||
+                  !preflightReady
                 }
                 onClick={run}
                 startIcon={
@@ -637,65 +892,161 @@ export default function Harness() {
                   )
                 }
               >
-                Run end to end
+                Start run
               </Button>
+            </Stack>
+            <Stack direction="row" spacing={1} mt={1} alignItems="center">
+              <Chip
+                size="small"
+                variant={hasSource ? "filled" : "outlined"}
+                color={hasSource ? "success" : "default"}
+                label={hasSource ? "1 Source added" : "1 Add source"}
+              />
+              <Iconify
+                icon="eva:arrow-ios-forward-fill"
+                color="text.disabled"
+              />
+              <Chip
+                size="small"
+                variant={preflight ? "filled" : "outlined"}
+                color={
+                  preflightReady
+                    ? "success"
+                    : preflight || preflightDirty
+                      ? "warning"
+                      : "default"
+                }
+                label={
+                  preflightDirty
+                    ? "2 Recheck readiness"
+                    : preflightReady
+                      ? "2 Ready"
+                      : preflight
+                        ? "2 Needs attention"
+                        : "2 Check readiness"
+                }
+              />
+              <Iconify
+                icon="eva:arrow-ios-forward-fill"
+                color="text.disabled"
+              />
+              <Chip
+                size="small"
+                variant="outlined"
+                color={preflightReady ? "primary" : "default"}
+                label="3 Start run"
+              />
             </Stack>
             <Paper variant="outlined" sx={{ mt: 1.5, p: 1.5 }}>
               <Stack spacing={1}>
                 <Stack
+                  direction="row"
+                  alignItems="center"
+                  justifyContent="space-between"
+                >
+                  <Box>
+                    <Typography variant="subtitle2">
+                      Environment credentials
+                    </Typography>
+                    <Typography variant="caption" color="text.secondary">
+                      Paste .env contents for bulk setup, or check readiness and
+                      enter only the missing values below.
+                    </Typography>
+                  </Box>
+                  {loadedCredentialCount > 0 && (
+                    <Chip
+                      size="small"
+                      color="success"
+                      icon={<Iconify icon="solar:shield-check-bold" />}
+                      label={`${loadedCredentialCount} loaded`}
+                    />
+                  )}
+                </Stack>
+                <Stack
                   direction={{ xs: "column", md: "row" }}
                   spacing={1}
-                  alignItems={{ md: "center" }}
+                  alignItems={{ md: "flex-start" }}
                 >
-                  <Button
-                    component="label"
-                    variant="outlined"
-                    startIcon={
-                      <Iconify icon="solar:upload-minimalistic-linear" />
-                    }
-                  >
-                    Upload .env
-                    <Box
-                      component="input"
-                      type="file"
-                      accept=".env,text/plain"
-                      onChange={uploadEnvironment}
-                      sx={{ display: "none" }}
-                    />
-                  </Button>
                   <TextField
                     fullWidth
                     size="small"
                     multiline
-                    maxRows={4}
-                    label="Or paste .env contents"
+                    minRows={2}
+                    maxRows={5}
+                    label="Paste .env contents"
                     placeholder="OPENAI_API_KEY=..."
                     value={environmentText}
-                    onChange={(event) => setEnvironmentText(event.target.value)}
+                    onChange={(event) => {
+                      setEnvironmentText(event.target.value);
+                      setEnvironmentError("");
+                    }}
                   />
                   <Button
-                    variant="text"
+                    variant="outlined"
                     disabled={!environmentText.trim()}
-                    onClick={() => loadEnvironment(environmentText)}
+                    onClick={loadPastedEnvironment}
+                    sx={{ minWidth: 120 }}
                   >
                     Use values
                   </Button>
-                  {Object.keys(environmentValues).length > 0 && (
+                  {loadedCredentialCount > 0 && (
                     <Button
                       color="inherit"
                       onClick={() => {
                         setEnvironmentValues({});
-                        setPreflight(null);
+                        setConfigurationValues({});
+                        setSecretFileRefs({});
+                        setSecretFileUploads({});
+                        setEnvironmentText("");
+                        setPreflightDirty(Boolean(preflight));
                       }}
                     >
                       Clear
                     </Button>
                   )}
                 </Stack>
+                <Stack direction="row" spacing={1} alignItems="center">
+                  <Button
+                    component="label"
+                    variant="outlined"
+                    size="small"
+                    disabled={uploadingSecretFile}
+                    startIcon={
+                      uploadingSecretFile ? (
+                        <CircularProgress size={16} />
+                      ) : (
+                        <Iconify icon="solar:file-upload-bold" />
+                      )
+                    }
+                  >
+                    Upload Google credential JSON
+                    <Box
+                      component="input"
+                      type="file"
+                      accept="application/json,.json"
+                      hidden
+                      onChange={(event) => {
+                        const [file] = event.target.files || [];
+                        uploadCredentialFile(
+                          "GOOGLE_APPLICATION_CREDENTIALS",
+                          file,
+                        );
+                        event.target.value = "";
+                      }}
+                    />
+                  </Button>
+                  {secretFileUploads.GOOGLE_APPLICATION_CREDENTIALS && (
+                    <Chip
+                      size="small"
+                      color="success"
+                      label={`${secretFileUploads.GOOGLE_APPLICATION_CREDENTIALS.name} · mounted per run`}
+                    />
+                  )}
+                </Stack>
                 <Typography variant="caption" color="text.secondary">
-                  {Object.keys(environmentValues).length
-                    ? `${Object.keys(environmentValues).length} variables loaded: ${Object.keys(environmentValues).join(", ")}`
-                    : "Values stay in this browser session, are sent only for preflight/run execution, and are never written to jobs, logs, or artifacts."}
+                  {loadedCredentialCount
+                    ? `${loadedCredentialCount} credentials loaded. Values are hidden; uploaded files are mounted read-only and removed at the terminal run boundary.`
+                    : "Pasted values and uploaded credential files are never written to jobs, logs, bundles, or artifacts."}
                 </Typography>
                 {environmentError && (
                   <Alert severity="error">{environmentError}</Alert>
@@ -712,11 +1063,15 @@ export default function Harness() {
                 >
                   <Chip
                     size="small"
-                    color={requirementsConfigured ? "success" : "warning"}
+                    color={preflightReady ? "success" : "warning"}
                     label={
-                      requirementsConfigured
-                        ? "Preflight ready"
-                        : `${requiredInputCount} credential choice${requiredInputCount === 1 ? "" : "s"} needed`
+                      preflightDirty
+                        ? "Readiness changed — check again"
+                        : preflightReady
+                          ? "Ready to run"
+                          : requiredInputCount
+                            ? `${requiredInputCount} credential input${requiredInputCount === 1 ? "" : "s"} needed`
+                            : "Source setup needs attention"
                     }
                   />
                   <Typography variant="caption" color="text.secondary">
@@ -727,6 +1082,32 @@ export default function Harness() {
                   </Typography>
                 </Stack>
                 <Stack spacing={1}>
+                  {(preflight.notes || []).map((note) => (
+                    <Alert key={note} severity="info">
+                      {note}
+                    </Alert>
+                  ))}
+                  {(preflight.packaging?.notes || []).map((note) => (
+                    <Alert key={note} severity="warning">
+                      {note}
+                    </Alert>
+                  ))}
+                  {blockingPackagingFindings.map((finding) => (
+                    <Alert
+                      key={`${finding.path}-${finding.code}`}
+                      severity="error"
+                    >
+                      <Typography variant="subtitle2">
+                        {finding.path} · {readable(finding.code)}
+                      </Typography>
+                      {finding.message}
+                    </Alert>
+                  ))}
+                  {preflight.packaging?.selected_path && (
+                    <Alert severity="success" icon={false}>
+                      Runtime packaging: {preflight.packaging.selected_path}
+                    </Alert>
+                  )}
                   {unsatisfiedChoices.map((choice) => (
                     <Alert key={choice.id} severity="info">
                       {choice.purpose}: choose{" "}
@@ -735,7 +1116,18 @@ export default function Harness() {
                         .join(" or ")}
                     </Alert>
                   ))}
-                  {requirements.map((item) => (
+                  {actionableRequirements.length > 0 && (
+                    <Box sx={{ pt: 0.5 }}>
+                      <Typography variant="subtitle2">
+                        Missing credentials
+                      </Typography>
+                      <Typography variant="caption" color="text.secondary">
+                        Enter only the values requested by preflight. Secret
+                        fields stay masked and are used for this run only.
+                      </Typography>
+                    </Box>
+                  )}
+                  {actionableRequirements.map((item) => (
                     <Stack
                       key={item.id}
                       direction={{ xs: "column", md: "row" }}
@@ -761,20 +1153,24 @@ export default function Harness() {
                               : "Configuration value"
                           }
                           type={item.kind === "secret" ? "password" : "text"}
-                          value={
-                            item.kind === "secret"
-                              ? environmentValues[item.environment_name] || ""
-                              : configurationValues[item.environment_name] || ""
-                          }
+                          value={credentialValue(
+                            environmentValues,
+                            configurationValues,
+                            item.environment_name,
+                          )}
                           onChange={(event) => {
-                            const setter =
-                              item.kind === "secret"
-                                ? setEnvironmentValues
-                                : setConfigurationValues;
-                            setter((existing) => ({
-                              ...existing,
-                              [item.environment_name]: event.target.value,
-                            }));
+                            const updated = updateCredential(
+                              environmentValues,
+                              configurationValues,
+                              {
+                                name: item.environment_name,
+                                value: event.target.value,
+                                kind: item.kind,
+                              },
+                            );
+                            setEnvironmentValues(updated.environmentValues);
+                            setConfigurationValues(updated.configurationValues);
+                            setPreflightDirty(true);
                           }}
                           helperText={
                             item.kind === "secret"
@@ -785,6 +1181,12 @@ export default function Harness() {
                       )}
                     </Stack>
                   ))}
+                  {preflightDirty && requirementsConfiguredLocally && (
+                    <Alert severity="info">
+                      Values are loaded. Select <strong>Check again</strong> to
+                      confirm credentials and packaging before starting.
+                    </Alert>
+                  )}
                 </Stack>
               </Paper>
             )}
@@ -824,7 +1226,9 @@ export default function Harness() {
               <Box
                 sx={{
                   p: 2,
-                  overflow: "auto",
+                  overflow: "hidden",
+                  display: "flex",
+                  flexDirection: "column",
                   borderRight: 1,
                   borderColor: "divider",
                 }}
@@ -881,204 +1285,385 @@ export default function Harness() {
                     {current.status.attempt || 1}
                   </Typography>
                 </Stack>
-                <Divider sx={{ my: 2 }} />
-                <Stack spacing={1.2}>
-                  {stages.map((stage, index) => {
-                    const completed =
-                      stageIndex > index ||
-                      current.status.stage === "completed";
-                    const active = stageIndex === index;
-                    return (
-                      <Stack
-                        key={stage}
-                        direction="row"
-                        spacing={1.2}
-                        alignItems="center"
-                      >
-                        <Iconify
-                          icon={
-                            completed
-                              ? "solar:check-circle-bold"
-                              : active
-                                ? "solar:play-circle-bold"
-                                : "solar:record-circle-linear"
-                          }
-                          color={
-                            completed
-                              ? "success.main"
-                              : active
-                                ? "primary.main"
-                                : "text.disabled"
-                          }
-                        />
-                        <Typography
-                          color={
-                            completed || active
-                              ? "text.primary"
-                              : "text.disabled"
-                          }
+                <Box sx={{ flex: 1, minHeight: 0, overflow: "auto", pr: 0.5 }}>
+                  <Divider sx={{ my: 2 }} />
+                  <Stack spacing={1.2}>
+                    {stages.map((stage, index) => {
+                      const completed =
+                        stageIndex > index ||
+                        current.status.stage === "completed";
+                      const active = stageIndex === index;
+                      return (
+                        <Stack
+                          key={stage}
+                          direction="row"
+                          spacing={1.2}
+                          alignItems="center"
                         >
-                          {readable(stage)}
+                          <Iconify
+                            icon={
+                              completed
+                                ? "solar:check-circle-bold"
+                                : active
+                                  ? "solar:play-circle-bold"
+                                  : "solar:record-circle-linear"
+                            }
+                            color={
+                              completed
+                                ? "success.main"
+                                : active
+                                  ? "primary.main"
+                                  : "text.disabled"
+                            }
+                          />
+                          <Typography
+                            color={
+                              completed || active
+                                ? "text.primary"
+                                : "text.disabled"
+                            }
+                          >
+                            {readable(stage)}
+                          </Typography>
+                        </Stack>
+                      );
+                    })}
+                  </Stack>
+                </Box>
+                {!terminalStages.has(current.status.stage) && (
+                  <Paper
+                    variant="outlined"
+                    sx={{ mt: 2.5, p: 1.5, bgcolor: "action.hover" }}
+                  >
+                    <Stack spacing={1}>
+                      <Box>
+                        <Typography variant="subtitle2">
+                          Change this run
                         </Typography>
-                      </Stack>
-                    );
-                  })}
-                </Stack>
+                        <Typography variant="caption" color="text.secondary">
+                          Tell the harness what to adjust. The request is queued
+                          and applied at the next safe stage boundary.
+                        </Typography>
+                      </Box>
+                      <TextField
+                        fullWidth
+                        size="small"
+                        multiline
+                        minRows={2}
+                        maxRows={5}
+                        placeholder='For example: "Add scenarios covering payment failures"'
+                        value={adjustment}
+                        onChange={(event) => setAdjustment(event.target.value)}
+                        onKeyDown={(event) => {
+                          if (
+                            (event.metaKey || event.ctrlKey) &&
+                            event.key === "Enter"
+                          )
+                            submitAdjustment();
+                        }}
+                      />
+                      <Button
+                        fullWidth
+                        variant="contained"
+                        disabled={adjusting || !adjustment.trim()}
+                        onClick={submitAdjustment}
+                        startIcon={
+                          adjusting ? (
+                            <CircularProgress size={16} />
+                          ) : (
+                            <Iconify icon="solar:plain-2-bold" />
+                          )
+                        }
+                      >
+                        Send change
+                      </Button>
+                    </Stack>
+                  </Paper>
+                )}
                 {!terminalStages.has(current.status.stage) && (
                   <Button
                     color="error"
                     variant="outlined"
                     onClick={cancel}
-                    sx={{ mt: 3 }}
+                    sx={{ mt: 1.5 }}
                   >
                     Cancel run
                   </Button>
                 )}
               </Box>
 
-              <Box sx={{ p: 2, overflow: "auto" }}>
-                <Typography variant="overline" color="text.secondary">
-                  Run details and live activity
-                </Typography>
-                <Stack spacing={1.5} mt={1.5}>
-                  {(current.stage_outputs || []).map((output) => (
-                    <StageOutput key={output.id} output={output} />
-                  ))}
-                  {current.credentials && (
-                    <Paper variant="outlined" sx={{ p: 1.5 }}>
-                      <Typography variant="subtitle2">
-                        Runtime preflight
-                      </Typography>
-                      <Typography variant="body2" color="text.secondary">
-                        {current.credentials.scanned_files} source files
-                        inspected ·{" "}
-                        {(current.credentials.detected_connectors || []).join(
-                          ", ",
-                        ) || "generic connector"}{" "}
-                        · {current.credentials.requirements?.length || 0}{" "}
-                        configuration requirements
-                      </Typography>
-                    </Paper>
-                  )}
-                  {messages.map((event) => (
-                    <Paper
-                      key={event.event_id}
-                      variant="outlined"
-                      sx={{ p: 1.5 }}
-                    >
-                      <Stack direction="row" justifyContent="space-between">
-                        <Typography variant="caption" color="primary.main">
-                          {readable(event.payload?.stage || event.type)}
-                        </Typography>
-                        <Typography variant="caption" color="text.secondary">
-                          {event.wall_time
-                            ? new Date(event.wall_time).toLocaleTimeString()
-                            : ""}
-                        </Typography>
-                      </Stack>
-                      <Typography variant="body2">
-                        {eventMessage(event)}
-                      </Typography>
-                    </Paper>
-                  ))}
-                  {(current.adjustments || []).map((item) => (
-                    <Alert
-                      key={item.adjustment_id}
-                      severity={item.status === "applied" ? "success" : "info"}
-                      icon={
-                        item.status === "pending" ||
-                        item.status === "applying" ? (
-                          <CircularProgress size={16} />
-                        ) : undefined
+              <Box
+                sx={{
+                  minWidth: 0,
+                  minHeight: 0,
+                  display: "flex",
+                  flexDirection: "column",
+                  overflow: "hidden",
+                }}
+              >
+                <Tabs
+                  value={detailTab}
+                  onChange={(_event, value) => setDetailTab(value)}
+                  variant="fullWidth"
+                  sx={{ px: 1, borderBottom: 1, borderColor: "divider" }}
+                >
+                  {detailTabs.map((tab) => (
+                    <Tab
+                      key={tab.value}
+                      value={tab.value}
+                      label={
+                        <Stack
+                          direction="row"
+                          spacing={0.75}
+                          alignItems="center"
+                        >
+                          <span>{tab.label}</span>
+                          {stageDetailTabs[current.status.stage] ===
+                            tab.value &&
+                            !terminalStages.has(current.status.stage) && (
+                              <CircularProgress size={14} />
+                            )}
+                          {tab.value !== "runs" &&
+                            outputCounts[tab.value] > 0 && (
+                              <Iconify
+                                icon="solar:check-circle-bold"
+                                color="success.main"
+                                width={16}
+                              />
+                            )}
+                        </Stack>
                       }
-                    >
-                      <Typography variant="subtitle2">
-                        Change {readable(item.status)} ·{" "}
-                        {readable(item.target_stage)}
-                      </Typography>
-                      {item.instruction}
-                    </Alert>
+                    />
                   ))}
-                  {current.status.failure && (
-                    <Alert severity="error">
-                      <Typography variant="subtitle2">
-                        {readable(current.status.failure.domain)} ·{" "}
-                        {current.status.failure.code}
-                      </Typography>
-                      {current.status.failure.message}
-                    </Alert>
-                  )}
-                  {current.status.detail && (
-                    <Alert
-                      severity={
-                        current.status.stage === "failed" ? "error" : "info"
-                      }
-                    >
-                      {current.status.detail}
-                    </Alert>
-                  )}
-                  {!terminalStages.has(current.status.stage) && (
-                    <Paper variant="outlined" sx={{ p: 1.5 }}>
-                      <Stack spacing={1}>
-                        <Stack direction="row" spacing={1} alignItems="center">
-                          <CircularProgress size={16} />
+                </Tabs>
+
+                <Box sx={{ p: 2, overflow: "auto", flex: 1 }}>
+                  {detailTab !== "runs" ? (
+                    <Stack spacing={1.5}>
+                      <Box>
+                        <Typography variant="subtitle1" fontWeight={700}>
+                          {
+                            detailTabs.find((tab) => tab.value === detailTab)
+                              ?.label
+                          }
+                        </Typography>
+                        <Typography variant="body2" color="text.secondary">
+                          {detailTab === "contract" &&
+                            "What the harness understood about the agent and its capabilities."}
+                          {detailTab === "environment" &&
+                            "The isolated services and runtime assembled for this run."}
+                          {detailTab === "scenarios" &&
+                            "The grounded test cases generated for the agent."}
+                        </Typography>
+                      </Box>
+                      {selectedOutputs.map((output) => (
+                        <StageOutput key={output.id} output={output} />
+                      ))}
+                      {!selectedOutputs.length && (
+                        <Paper
+                          variant="outlined"
+                          sx={{
+                            p: 4,
+                            textAlign: "center",
+                            bgcolor: "action.hover",
+                          }}
+                        >
+                          <Iconify
+                            icon="solar:hourglass-line-linear"
+                            width={32}
+                            color="text.disabled"
+                          />
+                          <Typography variant="subtitle2" mt={1}>
+                            Not available yet
+                          </Typography>
+                          <Typography variant="body2" color="text.secondary">
+                            This view fills in automatically when the related
+                            stage completes.
+                          </Typography>
+                        </Paper>
+                      )}
+                    </Stack>
+                  ) : (
+                    <Stack spacing={1.5}>
+                      <Paper variant="outlined" sx={{ p: 1.5 }}>
+                        <Stack
+                          direction="row"
+                          spacing={1.25}
+                          alignItems="center"
+                        >
+                          {!terminalStages.has(current.status.stage) ? (
+                            <CircularProgress size={20} />
+                          ) : (
+                            <Iconify
+                              icon={
+                                current.status.stage === "completed"
+                                  ? "solar:check-circle-bold"
+                                  : "solar:danger-circle-bold"
+                              }
+                              color={
+                                current.status.stage === "completed"
+                                  ? "success.main"
+                                  : "error.main"
+                              }
+                              width={22}
+                            />
+                          )}
                           <Box>
-                            <Typography variant="body2">
-                              ALK is working autonomously on{" "}
-                              {readable(current.status.stage)}
+                            <Typography variant="subtitle2">
+                              {!terminalStages.has(current.status.stage)
+                                ? `Working on ${readable(current.status.stage).toLowerCase()}`
+                                : readable(current.status.stage)}
                             </Typography>
-                            <Typography
-                              variant="caption"
-                              color="text.secondary"
-                            >
-                              Latest runner update {secondsSinceUpdate ?? 0}s
-                              ago. This page refreshes every 2 seconds; changes
-                              are applied at the next safe stage boundary.
+                            <Typography variant="body2" color="text.secondary">
+                              {terminalStages.has(current.status.stage)
+                                ? "The final status and generated artifacts are shown here."
+                                : `Updated ${secondsSinceUpdate ?? 0}s ago. Progress refreshes automatically every 2 seconds.`}
                             </Typography>
                           </Box>
                         </Stack>
-                        <Stack
-                          direction={{ xs: "column", md: "row" }}
-                          spacing={1}
+                      </Paper>
+
+                      {current.status.failure && (
+                        <Alert severity="error">
+                          <Typography variant="subtitle2">
+                            {readable(current.status.failure.domain)} ·{" "}
+                            {current.status.failure.code}
+                          </Typography>
+                          {current.status.failure.message}
+                        </Alert>
+                      )}
+                      {current.status.detail && (
+                        <Alert
+                          severity={
+                            current.status.stage === "failed" ? "error" : "info"
+                          }
                         >
-                          <TextField
-                            fullWidth
-                            size="small"
-                            multiline
-                            maxRows={4}
-                            label="Adjust this run"
-                            placeholder='For example: "Add 10 more scenarios covering payment failures"'
-                            value={adjustment}
-                            onChange={(event) =>
-                              setAdjustment(event.target.value)
-                            }
-                            onKeyDown={(event) => {
-                              if (
-                                (event.metaKey || event.ctrlKey) &&
-                                event.key === "Enter"
-                              )
-                                submitAdjustment();
-                            }}
-                          />
-                          <Button
-                            variant="contained"
-                            disabled={adjusting || !adjustment.trim()}
-                            onClick={submitAdjustment}
-                            startIcon={
-                              adjusting ? (
-                                <CircularProgress size={16} />
-                              ) : (
-                                <Iconify icon="solar:plain-2-bold" />
-                              )
-                            }
-                          >
-                            Apply change
-                          </Button>
+                          {current.status.detail}
+                        </Alert>
+                      )}
+
+                      {(current.adjustments || []).length > 0 && (
+                        <Stack spacing={1}>
+                          <Typography variant="subtitle2">
+                            Requested changes
+                          </Typography>
+                          {(current.adjustments || []).map((item) => (
+                            <Alert
+                              key={item.adjustment_id}
+                              severity={
+                                item.status === "applied" ? "success" : "info"
+                              }
+                              icon={
+                                item.status === "pending" ||
+                                item.status === "applying" ? (
+                                  <CircularProgress size={16} />
+                                ) : undefined
+                              }
+                            >
+                              <Typography variant="subtitle2">
+                                {readable(item.status)} ·{" "}
+                                {readable(item.target_stage)}
+                              </Typography>
+                              {item.instruction}
+                            </Alert>
+                          ))}
                         </Stack>
-                      </Stack>
-                    </Paper>
+                      )}
+
+                      {selectedOutputs.map((output) => (
+                        <StageOutput key={output.id} output={output} />
+                      ))}
+
+                      {current.credentials && (
+                        <Paper variant="outlined" sx={{ p: 1.5 }}>
+                          <Typography variant="subtitle2">
+                            Runtime readiness
+                          </Typography>
+                          <Typography variant="body2" color="text.secondary">
+                            {current.credentials.scanned_files} source files
+                            inspected ·{" "}
+                            {(
+                              current.credentials.detected_connectors || []
+                            ).join(", ") || "generic connector"}{" "}
+                            · {current.credentials.requirements?.length || 0}{" "}
+                            configuration requirements
+                          </Typography>
+                        </Paper>
+                      )}
+
+                      <Box>
+                        <Typography variant="subtitle2" mb={1}>
+                          Activity
+                        </Typography>
+                        <Stack spacing={0}>
+                          {messages
+                            .slice(-20)
+                            .reverse()
+                            .map((event, index) => (
+                              <Stack
+                                key={event.event_id}
+                                direction="row"
+                                spacing={1.25}
+                                sx={{ pb: 1.25 }}
+                              >
+                                <Stack alignItems="center">
+                                  <Box
+                                    sx={{
+                                      mt: 0.5,
+                                      width: 8,
+                                      height: 8,
+                                      borderRadius: "50%",
+                                      bgcolor:
+                                        index === 0
+                                          ? "primary.main"
+                                          : "divider",
+                                    }}
+                                  />
+                                  {index <
+                                    Math.min(messages.length, 20) - 1 && (
+                                    <Box
+                                      sx={{
+                                        width: 1,
+                                        flex: 1,
+                                        bgcolor: "divider",
+                                      }}
+                                    />
+                                  )}
+                                </Stack>
+                                <Box sx={{ flex: 1, minWidth: 0 }}>
+                                  <Stack
+                                    direction="row"
+                                    justifyContent="space-between"
+                                    spacing={1}
+                                  >
+                                    <Typography variant="body2">
+                                      {eventMessage(event)}
+                                    </Typography>
+                                    <Typography
+                                      variant="caption"
+                                      color="text.secondary"
+                                      sx={{ whiteSpace: "nowrap" }}
+                                    >
+                                      {event.wall_time
+                                        ? new Date(
+                                            event.wall_time,
+                                          ).toLocaleTimeString()
+                                        : ""}
+                                    </Typography>
+                                  </Stack>
+                                </Box>
+                              </Stack>
+                            ))}
+                          {!messages.length && (
+                            <Typography variant="body2" color="text.secondary">
+                              Activity will appear when the runner starts.
+                            </Typography>
+                          )}
+                        </Stack>
+                      </Box>
+                    </Stack>
                   )}
-                </Stack>
+                </Box>
               </Box>
             </Box>
           )}

--- a/frontend/src/pages/dashboard/harness/Harness.jsx
+++ b/frontend/src/pages/dashboard/harness/Harness.jsx
@@ -1,5 +1,9 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
+import PropTypes from "prop-types";
 import {
+  Accordion,
+  AccordionDetails,
+  AccordionSummary,
   Alert,
   Box,
   Button,
@@ -18,6 +22,7 @@ import {
 import { Helmet } from "react-helmet-async";
 import Iconify from "src/components/iconify";
 import {
+  adjustHarnessJob,
   cancelHarnessJob,
   createHarnessJob,
   getHarnessJob,
@@ -56,6 +61,107 @@ function eventMessage(event) {
   return readable(event.type || "Progress updated");
 }
 
+function StageOutput({ output }) {
+  const data = output.data || {};
+  return (
+    <Accordion variant="outlined" defaultExpanded={output.kind !== "scenarios"}>
+      <AccordionSummary
+        expandIcon={<Iconify icon="eva:arrow-ios-downward-fill" />}
+      >
+        <Box sx={{ minWidth: 0 }}>
+          <Typography variant="subtitle2">{output.title}</Typography>
+          <Typography variant="caption" color="text.secondary">
+            {output.summary}
+          </Typography>
+        </Box>
+      </AccordionSummary>
+      <AccordionDetails>
+        {output.kind === "contract" && (
+          <Stack spacing={1}>
+            <Typography variant="body2">{data.one_liner}</Typography>
+            <Typography variant="caption" color="text.secondary">
+              Modality: {data.modality || "unknown"} · Runtime:{" "}
+              {typeof data.runtime === "string"
+                ? data.runtime
+                : data.runtime?.entrypoint || "discovered"}
+            </Typography>
+            <Stack direction="row" gap={0.75} flexWrap="wrap">
+              {(data.tools || []).map((tool) => (
+                <Chip
+                  key={tool.name || String(tool)}
+                  size="small"
+                  label={tool.name || String(tool)}
+                  variant="outlined"
+                />
+              ))}
+            </Stack>
+            {(data.hard_constraints || []).map((constraint) => (
+              <Typography key={String(constraint)} variant="body2">
+                • {String(constraint)}
+              </Typography>
+            ))}
+          </Stack>
+        )}
+        {output.kind === "environment" && (
+          <Stack spacing={1}>
+            <Stack direction="row" gap={0.75} flexWrap="wrap">
+              {(data.services || []).map((service) => (
+                <Chip
+                  key={service}
+                  size="small"
+                  label={service}
+                  color="success"
+                />
+              ))}
+            </Stack>
+            <Typography variant="body2">
+              Project: {data.project || "isolated run"} ·{" "}
+              {data.managed ? "ALK-managed" : "repository-provided"}
+            </Typography>
+            {Object.entries(data.overrides || {}).map(([name, value]) => (
+              <Typography key={name} variant="caption" color="text.secondary">
+                {name} → {String(value)}
+              </Typography>
+            ))}
+          </Stack>
+        )}
+        {output.kind === "scenarios" && (
+          <Stack spacing={1}>
+            {(Array.isArray(data) ? data : []).map((scenario) => (
+              <Paper key={scenario.name} variant="outlined" sx={{ p: 1.25 }}>
+                <Typography variant="subtitle2">
+                  {readable(scenario.name)}
+                </Typography>
+                <Typography variant="body2">{scenario.instruction}</Typography>
+                <Typography variant="caption" color="text.secondary">
+                  {scenario.use_case || "Generated test case"}
+                </Typography>
+              </Paper>
+            ))}
+          </Stack>
+        )}
+        {!["contract", "environment", "scenarios"].includes(output.kind) && (
+          <Box
+            component="pre"
+            sx={{ m: 0, whiteSpace: "pre-wrap", fontSize: 12 }}
+          >
+            {JSON.stringify(data, null, 2)}
+          </Box>
+        )}
+      </AccordionDetails>
+    </Accordion>
+  );
+}
+
+StageOutput.propTypes = {
+  output: PropTypes.shape({
+    data: PropTypes.oneOfType([PropTypes.object, PropTypes.array]),
+    kind: PropTypes.string.isRequired,
+    summary: PropTypes.string,
+    title: PropTypes.string.isRequired,
+  }).isRequired,
+};
+
 export default function Harness() {
   const [sourceMode, setSourceMode] = useState("upload");
   const [uploadedSource, setUploadedSource] = useState(null);
@@ -74,6 +180,8 @@ export default function Harness() {
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState("");
   const [checking, setChecking] = useState(false);
+  const [adjustment, setAdjustment] = useState("");
+  const [adjusting, setAdjusting] = useState(false);
   const [clock, setClock] = useState(Date.now());
 
   useEffect(() => {
@@ -167,6 +275,24 @@ export default function Harness() {
   const cancel = async () => {
     const value = await cancelHarnessJob(current.job.job_id);
     setCurrent(value);
+  };
+
+  const submitAdjustment = async () => {
+    if (!adjustment.trim() || !current?.job?.job_id) return;
+    setAdjusting(true);
+    setError("");
+    try {
+      const value = await adjustHarnessJob(current.job.job_id, {
+        instruction: adjustment.trim(),
+        client_request_id: window.crypto?.randomUUID?.(),
+      });
+      setCurrent(value);
+      setAdjustment("");
+    } catch (requestError) {
+      setError(requestError?.response?.data?.detail || requestError.message);
+    } finally {
+      setAdjusting(false);
+    }
   };
 
   const startNewEnvironment = () => {
@@ -323,7 +449,11 @@ export default function Harness() {
         }}
       >
         <Paper square variant="outlined" sx={{ p: 2, overflow: "auto" }}>
-          <Stack direction="row" alignItems="center" justifyContent="space-between">
+          <Stack
+            direction="row"
+            alignItems="center"
+            justifyContent="space-between"
+          >
             <Typography variant="overline" color="text.secondary">
               RL environments
             </Typography>
@@ -402,7 +532,9 @@ export default function Harness() {
                     component="label"
                     variant="outlined"
                     disabled={sourceUploadProgress !== null}
-                    startIcon={<Iconify icon="solar:folder-with-files-linear" />}
+                    startIcon={
+                      <Iconify icon="solar:folder-with-files-linear" />
+                    }
                   >
                     {sourceUploadProgress !== null
                       ? `Uploading ${sourceUploadProgress}%`
@@ -518,7 +650,9 @@ export default function Harness() {
                   <Button
                     component="label"
                     variant="outlined"
-                    startIcon={<Iconify icon="solar:upload-minimalistic-linear" />}
+                    startIcon={
+                      <Iconify icon="solar:upload-minimalistic-linear" />
+                    }
                   >
                     Upload .env
                     <Box
@@ -750,9 +884,10 @@ export default function Harness() {
                 <Divider sx={{ my: 2 }} />
                 <Stack spacing={1.2}>
                   {stages.map((stage, index) => {
-                    const reached =
-                      stageIndex >= index ||
+                    const completed =
+                      stageIndex > index ||
                       current.status.stage === "completed";
+                    const active = stageIndex === index;
                     return (
                       <Stack
                         key={stage}
@@ -762,14 +897,26 @@ export default function Harness() {
                       >
                         <Iconify
                           icon={
-                            reached
+                            completed
                               ? "solar:check-circle-bold"
-                              : "solar:record-circle-linear"
+                              : active
+                                ? "solar:play-circle-bold"
+                                : "solar:record-circle-linear"
                           }
-                          color={reached ? "success.main" : "text.disabled"}
+                          color={
+                            completed
+                              ? "success.main"
+                              : active
+                                ? "primary.main"
+                                : "text.disabled"
+                          }
                         />
                         <Typography
-                          color={reached ? "text.primary" : "text.disabled"}
+                          color={
+                            completed || active
+                              ? "text.primary"
+                              : "text.disabled"
+                          }
                         >
                           {readable(stage)}
                         </Typography>
@@ -791,9 +938,12 @@ export default function Harness() {
 
               <Box sx={{ p: 2, overflow: "auto" }}>
                 <Typography variant="overline" color="text.secondary">
-                  Live harness activity
+                  Run details and live activity
                 </Typography>
                 <Stack spacing={1.5} mt={1.5}>
+                  {(current.stage_outputs || []).map((output) => (
+                    <StageOutput key={output.id} output={output} />
+                  ))}
                   {current.credentials && (
                     <Paper variant="outlined" sx={{ p: 1.5 }}>
                       <Typography variant="subtitle2">
@@ -831,6 +981,24 @@ export default function Harness() {
                       </Typography>
                     </Paper>
                   ))}
+                  {(current.adjustments || []).map((item) => (
+                    <Alert
+                      key={item.adjustment_id}
+                      severity={item.status === "applied" ? "success" : "info"}
+                      icon={
+                        item.status === "pending" ||
+                        item.status === "applying" ? (
+                          <CircularProgress size={16} />
+                        ) : undefined
+                      }
+                    >
+                      <Typography variant="subtitle2">
+                        Change {readable(item.status)} ·{" "}
+                        {readable(item.target_stage)}
+                      </Typography>
+                      {item.instruction}
+                    </Alert>
+                  ))}
                   {current.status.failure && (
                     <Alert severity="error">
                       <Typography variant="subtitle2">
@@ -850,12 +1018,65 @@ export default function Harness() {
                     </Alert>
                   )}
                   {!terminalStages.has(current.status.stage) && (
-                    <Stack direction="row" spacing={1} alignItems="center">
-                      <CircularProgress size={16} />
-                      <Typography variant="body2" color="text.secondary">
-                        ALK is working autonomously…
-                      </Typography>
-                    </Stack>
+                    <Paper variant="outlined" sx={{ p: 1.5 }}>
+                      <Stack spacing={1}>
+                        <Stack direction="row" spacing={1} alignItems="center">
+                          <CircularProgress size={16} />
+                          <Box>
+                            <Typography variant="body2">
+                              ALK is working autonomously on{" "}
+                              {readable(current.status.stage)}
+                            </Typography>
+                            <Typography
+                              variant="caption"
+                              color="text.secondary"
+                            >
+                              Latest runner update {secondsSinceUpdate ?? 0}s
+                              ago. This page refreshes every 2 seconds; changes
+                              are applied at the next safe stage boundary.
+                            </Typography>
+                          </Box>
+                        </Stack>
+                        <Stack
+                          direction={{ xs: "column", md: "row" }}
+                          spacing={1}
+                        >
+                          <TextField
+                            fullWidth
+                            size="small"
+                            multiline
+                            maxRows={4}
+                            label="Adjust this run"
+                            placeholder='For example: "Add 10 more scenarios covering payment failures"'
+                            value={adjustment}
+                            onChange={(event) =>
+                              setAdjustment(event.target.value)
+                            }
+                            onKeyDown={(event) => {
+                              if (
+                                (event.metaKey || event.ctrlKey) &&
+                                event.key === "Enter"
+                              )
+                                submitAdjustment();
+                            }}
+                          />
+                          <Button
+                            variant="contained"
+                            disabled={adjusting || !adjustment.trim()}
+                            onClick={submitAdjustment}
+                            startIcon={
+                              adjusting ? (
+                                <CircularProgress size={16} />
+                              ) : (
+                                <Iconify icon="solar:plain-2-bold" />
+                              )
+                            }
+                          >
+                            Apply change
+                          </Button>
+                        </Stack>
+                      </Stack>
+                    </Paper>
                   )}
                 </Stack>
               </Box>

--- a/frontend/src/pages/dashboard/harness/credentialValues.js
+++ b/frontend/src/pages/dashboard/harness/credentialValues.js
@@ -1,0 +1,47 @@
+export function credentialValue(environmentValues, configurationValues, name) {
+  if (Object.hasOwn(environmentValues, name)) return environmentValues[name];
+  return configurationValues[name] || "";
+}
+
+export function mergePastedCredentials(
+  environmentValues,
+  configurationValues,
+  pastedValues,
+) {
+  const nextConfiguration = { ...configurationValues };
+  Object.keys(pastedValues).forEach((name) => delete nextConfiguration[name]);
+  return {
+    environmentValues: { ...environmentValues, ...pastedValues },
+    configurationValues: nextConfiguration,
+  };
+}
+
+export function updateCredential(
+  environmentValues,
+  configurationValues,
+  { name, value, kind },
+) {
+  const nextEnvironment = { ...environmentValues };
+  const nextConfiguration = { ...configurationValues };
+  const belongsToEnvironment =
+    kind === "secret" || Object.hasOwn(environmentValues, name);
+
+  if (belongsToEnvironment) {
+    nextEnvironment[name] = value;
+    delete nextConfiguration[name];
+  } else {
+    nextConfiguration[name] = value;
+    delete nextEnvironment[name];
+  }
+  return {
+    environmentValues: nextEnvironment,
+    configurationValues: nextConfiguration,
+  };
+}
+
+export function credentialCount(environmentValues, configurationValues) {
+  return new Set([
+    ...Object.keys(environmentValues),
+    ...Object.keys(configurationValues),
+  ]).size;
+}

--- a/frontend/src/pages/dashboard/harness/credentialValues.test.js
+++ b/frontend/src/pages/dashboard/harness/credentialValues.test.js
@@ -1,0 +1,55 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  credentialCount,
+  credentialValue,
+  mergePastedCredentials,
+  updateCredential,
+} from "./credentialValues";
+
+describe("harness credential synchronization", () => {
+  it("shows pasted values in preflight fields", () => {
+    expect(
+      credentialValue({ OPENAI_API_KEY: "pasted" }, {}, "OPENAI_API_KEY"),
+    ).toBe("pasted");
+  });
+
+  it("merges pasted values without losing unrelated manual entries", () => {
+    expect(
+      mergePastedCredentials(
+        { EXISTING_SECRET: "keep" },
+        { REMOTE_AGENT_ID: "manual", REGION: "old" },
+        { REGION: "pasted", NEW_SECRET: "new" },
+      ),
+    ).toEqual({
+      environmentValues: {
+        EXISTING_SECRET: "keep",
+        REGION: "pasted",
+        NEW_SECRET: "new",
+      },
+      configurationValues: { REMOTE_AGENT_ID: "manual" },
+    });
+  });
+
+  it("edits a pasted value in place without creating a duplicate", () => {
+    expect(
+      updateCredential(
+        { REGION: "pasted" },
+        { REGION: "stale" },
+        { name: "REGION", value: "edited", kind: "configuration" },
+      ),
+    ).toEqual({
+      environmentValues: { REGION: "edited" },
+      configurationValues: {},
+    });
+  });
+
+  it("counts the synchronized union once", () => {
+    expect(
+      credentialCount(
+        { SHARED: "environment", SECRET: "value" },
+        { SHARED: "configuration", REGION: "value" },
+      ),
+    ).toBe(3);
+  });
+});

--- a/frontend/src/pages/dashboard/harness/dotenv.js
+++ b/frontend/src/pages/dashboard/harness/dotenv.js
@@ -1,0 +1,39 @@
+export function parseDotEnv(text) {
+  const values = {};
+  const lines = String(text || "")
+    .replace(/^\uFEFF/, "")
+    .split(/\r?\n/);
+  lines.forEach((original, index) => {
+    let line = original.trim();
+    if (!line || line.startsWith("#")) return;
+    if (line.startsWith("export ")) line = line.slice(7).trimStart();
+    const separator = line.indexOf("=");
+    if (separator < 1)
+      throw new Error(`Invalid .env assignment on line ${index + 1}`);
+    const name = line.slice(0, separator).trim();
+    if (!/^[A-Za-z_][A-Za-z0-9_]*$/.test(name))
+      throw new Error(`Invalid environment name on line ${index + 1}: ${name}`);
+    let value = line.slice(separator + 1).trim();
+    if (value.startsWith('"')) {
+      if (!value.endsWith('"'))
+        throw new Error(`Unclosed double quote on line ${index + 1}`);
+      value = value
+        .slice(1, -1)
+        .replaceAll("\\n", "\n")
+        .replaceAll("\\r", "\r")
+        .replaceAll("\\t", "\t")
+        .replaceAll('\\"', '"')
+        .replaceAll("\\\\", "\\");
+    } else if (value.startsWith("'")) {
+      if (!value.endsWith("'"))
+        throw new Error(`Unclosed single quote on line ${index + 1}`);
+      value = value.slice(1, -1);
+    } else {
+      value = value.replace(/\s+#.*$/, "").trim();
+    }
+    values[name] = value;
+  });
+  if (Object.keys(values).length > 256)
+    throw new Error("A maximum of 256 environment variables is supported");
+  return values;
+}

--- a/frontend/src/pages/dashboard/harness/dotenv.test.js
+++ b/frontend/src/pages/dashboard/harness/dotenv.test.js
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+
+import { parseDotEnv } from "./dotenv";
+
+describe("parseDotEnv", () => {
+  it("parses common dotenv syntax without exposing or transforming secrets", () => {
+    expect(
+      parseDotEnv(`
+        # provider credentials
+        export OPENAI_API_KEY="sk-test=value"
+        DATABASE_URL='postgres://db/test'
+        REGION=us-east-1 # deployment region
+        EMPTY=
+      `),
+    ).toEqual({
+      OPENAI_API_KEY: "sk-test=value",
+      DATABASE_URL: "postgres://db/test",
+      REGION: "us-east-1",
+      EMPTY: "",
+    });
+  });
+
+  it("rejects malformed assignments", () => {
+    expect(() => parseDotEnv("NOT-VALID=value")).toThrow(
+      "Invalid environment name",
+    );
+    expect(() => parseDotEnv('TOKEN="not closed')).toThrow(
+      "Unclosed double quote",
+    );
+  });
+});

--- a/frontend/src/pages/dashboard/harness/sourceUpload.js
+++ b/frontend/src/pages/dashboard/harness/sourceUpload.js
@@ -1,0 +1,51 @@
+const ignoredDirectories = new Set([
+  ".git",
+  ".next",
+  ".venv",
+  "__pycache__",
+  "build",
+  "dist",
+  "node_modules",
+  "venv",
+]);
+
+const safeEnvironmentTemplates = new Set([
+  ".env.example",
+  ".env.sample",
+  ".env.template",
+]);
+
+export function prepareSourceFolder(selectedFiles) {
+  const selected = Array.from(selectedFiles || []);
+  const files = selected.filter((file) => {
+    const parts = (file.webkitRelativePath || file.name).split("/");
+    const leaf = parts.at(-1).toLowerCase();
+    const environmentFile =
+      (leaf === ".env" || leaf.startsWith(".env.")) &&
+      !safeEnvironmentTemplates.has(leaf);
+    return (
+      !environmentFile &&
+      leaf !== ".ds_store" &&
+      !parts.some((part) => ignoredDirectories.has(part))
+    );
+  });
+  const totalBytes = files.reduce((total, file) => total + file.size, 0);
+  if (!files.length)
+    throw new Error("The selected folder contains no uploadable source files.");
+  if (files.length > 5000 || totalBytes > 200 * 1024 * 1024)
+    throw new Error("Source uploads support at most 5000 files and 200 MiB.");
+  const originalPaths = files.map(
+    (file) => file.webkitRelativePath || file.name,
+  );
+  const root = originalPaths[0]?.split("/")[0] || "uploaded-agent";
+  const stripRoot = originalPaths.every((path) => path.startsWith(`${root}/`));
+  return {
+    files,
+    paths: originalPaths.map((path) =>
+      stripRoot ? path.slice(root.length + 1) : path,
+    ),
+    name: root,
+    excludedCount: selected.length - files.length,
+    totalBytes,
+  };
+}

--- a/frontend/src/pages/dashboard/harness/sourceUpload.test.js
+++ b/frontend/src/pages/dashboard/harness/sourceUpload.test.js
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest";
+import { prepareSourceFolder } from "./sourceUpload";
+
+const file = (path, size = 1) => ({
+  name: path.split("/").at(-1),
+  size,
+  webkitRelativePath: path,
+});
+
+describe("prepareSourceFolder", () => {
+  it("removes the browser folder root and excludes secrets and dependencies", () => {
+    const result = prepareSourceFolder([
+      file("agent/agent.py", 10),
+      file("agent/.env", 20),
+      file("agent/.env.example", 30),
+      file("agent/node_modules/pkg/index.js", 40),
+    ]);
+
+    expect(result.name).toBe("agent");
+    expect(result.paths).toEqual(["agent.py", ".env.example"]);
+    expect(result.excludedCount).toBe(2);
+    expect(result.totalBytes).toBe(40);
+  });
+
+  it("rejects a folder containing only excluded files", () => {
+    expect(() => prepareSourceFolder([file("agent/.env")])).toThrow(
+      "no uploadable source files",
+    );
+  });
+});

--- a/frontend/src/routes/paths.js
+++ b/frontend/src/routes/paths.js
@@ -87,6 +87,7 @@ export const paths = {
       personas: `${ROOTS.DASHBOARD}/simulate/personas`,
       simulatorAgent: `${ROOTS.DASHBOARD}/simulate/simulator-agent`,
       test: `${ROOTS.DASHBOARD}/simulate/test`,
+      harness: `${ROOTS.DASHBOARD}/simulate/harness`,
     },
     feed: `${ROOTS.DASHBOARD}/error-feed`,
     errorFeed: {

--- a/frontend/src/routes/sections/dashboard.jsx
+++ b/frontend/src/routes/sections/dashboard.jsx
@@ -321,6 +321,9 @@ const CreateNewAgentDefinition = lazyWithRetry(
 const RunTests = lazyWithRetry(
   () => import("src/pages/dashboard/run-tests/RunTests"),
 );
+const Harness = lazyWithRetry(
+  () => import("src/pages/dashboard/harness/Harness"),
+);
 const RunTestDetail = lazyWithRetry(
   () => import("src/pages/dashboard/run-tests/RunTestDetail"),
 );
@@ -1326,6 +1329,10 @@ export const dashboardRoutes = (
     {
       path: "simulate",
       children: [
+        {
+          path: "harness",
+          element: <Harness />,
+        },
         {
           path: "agent-definitions",
           element: <AgentDefinitions />,

--- a/futureagi/entrypoint.sh
+++ b/futureagi/entrypoint.sh
@@ -115,8 +115,12 @@ export ENV_PROJECT_ROOT
 # Change to the backend directory
 cd /app/backend
 
-# Install any missing dependencies (2FA/WebAuthn added after Docker image build)
-pip install --quiet "pyotp>=2.9.0" "qrcode[pil]>=7.4" "webauthn>=2.2.0" 2>/dev/null || true
+# Install small compatibility dependencies that may be newer than the local
+# base image. Do not hide failures: a service that cannot import Django must
+# fail visibly instead of leaving a watcher/container looking healthy while no
+# worker is polling its queue.
+pip install --quiet "pyotp>=2.9.0" "qrcode[pil]>=7.4" "webauthn>=2.2.0" \
+    "disposable-email-domains==0.0.239"
 
 # Create logs directory if it doesn't exist
 mkdir -p logs media static
@@ -513,19 +517,14 @@ case "$SERVICE_TYPE" in
             # Production: run worker with graceful shutdown handling
             exec ./bin/temporal-worker --task-queue "$TEMPORAL_TASK_QUEUE" $RESOURCE_TUNING_ARGS
         else
-            # Build list of watch paths, skipping any that don't exist.
-            # ``watchfiles`` exits immediately with a non-zero code if any
-            # watch target is missing (e.g. ``./utils`` is absent in some
-            # checkouts), which makes the container crash-loop under
-            # ``restart: unless-stopped`` and the Temporal worker never
-            # stays alive long enough to poll activities.
-            WATCH_PATHS=()
-            for d in tfc accounts analytics model_hub sockets tracer usage utils simulate agent_playground; do
-                [ -d "./$d" ] && WATCH_PATHS+=("./$d")
-            done
-            exec watchfiles --filter python \
-                "python manage.py start_temporal_worker --task-queue $TEMPORAL_TASK_QUEUE $ALL_QUEUES_ARG $RESOURCE_TUNING_ARGS" \
-                "${WATCH_PATHS[@]}"
+            # A watchfiles parent remains alive when its child fails to import,
+            # which made Docker report a healthy-looking worker while Temporal
+            # had zero pollers and an ever-growing backlog. Correctness matters
+            # more than hot reload for background workers: let the worker be PID
+            # 1 so Docker restarts it and exposes repeated startup failures.
+            exec python manage.py start_temporal_worker \
+                --task-queue "$TEMPORAL_TASK_QUEUE" \
+                $ALL_QUEUES_ARG $RESOURCE_TUNING_ARGS
         fi
         ;;
 

--- a/futureagi/simulate/migrations/0079_harness_environment_credentials.py
+++ b/futureagi/simulate/migrations/0079_harness_environment_credentials.py
@@ -1,0 +1,47 @@
+import django.db.models.deletion
+import uuid
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("accounts", "0024_sosloginproxy"),
+        ("simulate", "0078_agentdefinition_target_speaks_first"),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name="HarnessCredentialFile",
+            fields=[
+                ("created_at", models.DateTimeField(auto_now_add=True)),
+                ("updated_at", models.DateTimeField(auto_now=True)),
+                ("deleted", models.BooleanField(db_index=True, default=False)),
+                ("deleted_at", models.DateTimeField(blank=True, null=True)),
+                ("id", models.UUIDField(default=uuid.uuid4, editable=False, primary_key=True, serialize=False)),
+                ("environment_name", models.CharField(max_length=255)),
+                ("filename", models.CharField(default="credential", max_length=255)),
+                ("content_type", models.CharField(default="application/octet-stream", max_length=255)),
+                ("encrypted_content", models.TextField()),
+                ("size", models.PositiveIntegerField()),
+                ("organization", models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, related_name="harness_credential_files", to="accounts.organization")),
+                ("workspace", models.ForeignKey(blank=True, null=True, on_delete=django.db.models.deletion.CASCADE, related_name="harness_credential_files", to="accounts.workspace")),
+            ],
+            options={"db_table": "simulate_harness_credential_file", "ordering": ("-created_at",)},
+        ),
+        migrations.CreateModel(
+            name="HarnessEnvironmentCredentials",
+            fields=[
+                ("created_at", models.DateTimeField(auto_now_add=True)),
+                ("updated_at", models.DateTimeField(auto_now=True)),
+                ("deleted", models.BooleanField(db_index=True, default=False)),
+                ("deleted_at", models.DateTimeField(blank=True, null=True)),
+                ("id", models.UUIDField(default=uuid.uuid4, editable=False, primary_key=True, serialize=False)),
+                ("harness_job_id", models.CharField(db_index=True, max_length=255, unique=True)),
+                ("encrypted_environment", models.TextField(default="")),
+                ("credential_file_ids", models.JSONField(blank=True, default=list)),
+                ("organization", models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, related_name="harness_environment_credentials", to="accounts.organization")),
+                ("workspace", models.ForeignKey(blank=True, null=True, on_delete=django.db.models.deletion.CASCADE, related_name="harness_environment_credentials", to="accounts.workspace")),
+            ],
+            options={"db_table": "simulate_harness_environment_credentials", "ordering": ("-created_at",)},
+        ),
+    ]

--- a/futureagi/simulate/models/__init__.py
+++ b/futureagi/simulate/models/__init__.py
@@ -8,6 +8,10 @@ from .call_log_entry import CallLogEntry
 from .chat_message import ChatMessageModel
 from .chat_simulator import ChatSimulatorAssistant, ChatSimulatorSession
 from .component_evaluation import ComponentEvaluation
+from .harness_environment_credentials import (
+    HarnessCredentialFile,
+    HarnessEnvironmentCredentials,
+)
 from .eval_config import SimulateEvalConfig
 from .persona import Persona
 from .prompt_trial import PromptTrial
@@ -34,6 +38,8 @@ __all__ = [
     "AgentPromptOptimiserRunStep",
     "AgentVersion",
     "ComponentEvaluation",
+    "HarnessCredentialFile",
+    "HarnessEnvironmentCredentials",
     "PromptTrial",
     "SimulatorAgent",
     "RunTest",

--- a/futureagi/simulate/models/harness_environment_credentials.py
+++ b/futureagi/simulate/models/harness_environment_credentials.py
@@ -1,0 +1,82 @@
+import base64
+import json
+import uuid
+
+from django.db import models
+
+from accounts.models import Organization
+from accounts.models.workspace import Workspace
+from agentcc.services.credential_manager import decrypt_token, encrypt_token
+from tfc.utils.base_model import BaseModel
+
+
+class HarnessCredentialFile(BaseModel):
+    """Encrypted, platform-owned credential file for an RL environment.
+
+    The execution provider receives a fresh attempt-scoped copy. It never owns
+    the durable credential and therefore remains free to delete its copy when
+    an attempt finishes.
+    """
+
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
+    organization = models.ForeignKey(
+        Organization, on_delete=models.CASCADE, related_name="harness_credential_files"
+    )
+    workspace = models.ForeignKey(
+        Workspace,
+        on_delete=models.CASCADE,
+        related_name="harness_credential_files",
+        null=True,
+        blank=True,
+    )
+    environment_name = models.CharField(max_length=255)
+    filename = models.CharField(max_length=255, default="credential")
+    content_type = models.CharField(
+        max_length=255, default="application/octet-stream"
+    )
+    encrypted_content = models.TextField()
+    size = models.PositiveIntegerField()
+
+    class Meta:
+        db_table = "simulate_harness_credential_file"
+
+    def set_content(self, content: bytes) -> None:
+        self.encrypted_content = encrypt_token(base64.b64encode(content).decode("ascii"))
+        self.size = len(content)
+
+    def get_content(self) -> bytes:
+        return base64.b64decode(decrypt_token(self.encrypted_content).encode("ascii"))
+
+
+class HarnessEnvironmentCredentials(BaseModel):
+    """Durable encrypted credentials bound to one saved harness environment."""
+
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
+    harness_job_id = models.CharField(max_length=255, unique=True, db_index=True)
+    organization = models.ForeignKey(
+        Organization,
+        on_delete=models.CASCADE,
+        related_name="harness_environment_credentials",
+    )
+    workspace = models.ForeignKey(
+        Workspace,
+        on_delete=models.CASCADE,
+        related_name="harness_environment_credentials",
+        null=True,
+        blank=True,
+    )
+    encrypted_environment = models.TextField(default="")
+    credential_file_ids = models.JSONField(default=list, blank=True)
+
+    class Meta:
+        db_table = "simulate_harness_environment_credentials"
+
+    def set_environment(self, values: dict[str, str]) -> None:
+        serialized = json.dumps(values, sort_keys=True, separators=(",", ":"))
+        self.encrypted_environment = encrypt_token(serialized)
+
+    def get_environment(self) -> dict[str, str]:
+        if not self.encrypted_environment:
+            return {}
+        value = json.loads(decrypt_token(self.encrypted_environment))
+        return {str(name): str(item) for name, item in value.items()}

--- a/futureagi/simulate/serializers/alk_simulate_ingestion.py
+++ b/futureagi/simulate/serializers/alk_simulate_ingestion.py
@@ -139,6 +139,7 @@ class ALKSimulateStartTestExecutionRequestSerializer(serializers.Serializer):
         child=serializers.UUIDField(), required=False, allow_empty=True
     )
     simulator_agent_id = serializers.UUIDField(required=False, allow_null=True)
+    harness_job_id = serializers.UUIDField(required=False, allow_null=True)
 
 
 class ALKSimulateStartTestExecutionResultSerializer(serializers.Serializer):

--- a/futureagi/simulate/serializers/alk_simulate_ingestion.py
+++ b/futureagi/simulate/serializers/alk_simulate_ingestion.py
@@ -56,6 +56,10 @@ class ALKSimulateResultSerializer(serializers.Serializer):
     )
     error_message = serializers.CharField(required=False, allow_blank=True)
     call_summary = serializers.CharField(required=False, allow_blank=True)
+    result_digest = serializers.RegexField(r"^sha256:[0-9a-f]{64}$", required=False)
+    artifact_manifest_digest = serializers.RegexField(
+        r"^sha256:[0-9a-f]{64}$", required=False
+    )
 
     transcript = ALKSimulateTranscriptSegmentSerializer(many=True, required=False)
 
@@ -159,6 +163,11 @@ class ALKSimulateRecordingUploadRequestSerializer(serializers.Serializer):
 
     file = serializers.FileField()
     filename = serializers.CharField(required=False, allow_blank=True, max_length=200)
+    sha256 = serializers.RegexField(r"^(?:sha256:)?[0-9a-fA-F]{64}$", required=False)
+    kind = serializers.ChoiceField(
+        choices=("combined", "stereo", "customer", "assistant"),
+        default="combined",
+    )
 
 
 class ALKSimulateRecordingUploadResultSerializer(serializers.Serializer):

--- a/futureagi/simulate/serializers/alk_simulate_ingestion.py
+++ b/futureagi/simulate/serializers/alk_simulate_ingestion.py
@@ -207,7 +207,7 @@ class ALKSimulateProvisionRunTestRequestSerializer(serializers.Serializer):
 
     name = serializers.CharField(max_length=255)
     modality = serializers.ChoiceField(
-        choices=("text", "voice"), required=False, default="text"
+        choices=("text", "chat", "voice"), required=False, default="text"
     )
     description = serializers.CharField(required=False, allow_blank=True)
     personas = ALKSimulateProvisionPersonaSerializer(many=True, required=False)
@@ -218,6 +218,11 @@ class ALKSimulateProvisionRunTestRequestSerializer(serializers.Serializer):
     agent_name = serializers.CharField(required=False, allow_blank=True, max_length=255)
 
     def validate(self, attrs):
+        # ALK contracts call conversational text agents "chat" while the
+        # platform's persisted AgentDefinition vocabulary calls them "text".
+        # Accept both at this boundary and keep one canonical stored value.
+        if attrs.get("modality") == "chat":
+            attrs["modality"] = "text"
         has_personas = bool(attrs.get("personas"))
         has_scenarios = bool(attrs.get("scenario_ids"))
         if has_personas == has_scenarios:

--- a/futureagi/simulate/serializers/alk_simulate_ingestion.py
+++ b/futureagi/simulate/serializers/alk_simulate_ingestion.py
@@ -197,6 +197,9 @@ class ALKSimulateProvisionRunTestRequestSerializer(serializers.Serializer):
     """
 
     name = serializers.CharField(max_length=255)
+    modality = serializers.ChoiceField(
+        choices=("text", "voice"), required=False, default="text"
+    )
     description = serializers.CharField(required=False, allow_blank=True)
     personas = ALKSimulateProvisionPersonaSerializer(many=True, required=False)
     scenario_ids = serializers.ListField(

--- a/futureagi/simulate/serializers/alk_simulate_ingestion.py
+++ b/futureagi/simulate/serializers/alk_simulate_ingestion.py
@@ -138,6 +138,14 @@ class ALKSimulateStartTestExecutionRequestSerializer(serializers.Serializer):
     scenario_ids = serializers.ListField(
         child=serializers.UUIDField(), required=False, allow_empty=True
     )
+    scenario_selectors = serializers.ListField(
+        child=serializers.DictField(
+            child=serializers.CharField(max_length=255, allow_blank=True)
+        ),
+        required=False,
+        allow_empty=True,
+        max_length=100,
+    )
     simulator_agent_id = serializers.UUIDField(required=False, allow_null=True)
     harness_job_id = serializers.UUIDField(required=False, allow_null=True)
 
@@ -183,6 +191,9 @@ class ALKSimulateRecordingUploadResponseSerializer(serializers.Serializer):
 
 class ALKSimulateProvisionPersonaSerializer(serializers.Serializer):
     name = serializers.CharField(required=False, allow_blank=True, max_length=255)
+    scenario_name = serializers.CharField(
+        required=False, allow_blank=True, max_length=255
+    )
     role = serializers.CharField(required=False, allow_blank=True, max_length=255)
     situation = serializers.CharField(required=False, allow_blank=True)
     outcome = serializers.CharField(required=False, allow_blank=True)

--- a/futureagi/simulate/serializers/harness_job.py
+++ b/futureagi/simulate/serializers/harness_job.py
@@ -1,4 +1,20 @@
+import re
+
 from rest_framework import serializers
+
+
+RUNNER_RESERVED_ENVIRONMENT = {
+    "DOCKER_HOST",
+    "FI_API_KEY",
+    "FI_BASE_URL",
+    "FI_SECRET_KEY",
+    "HARNESS_PLATFORM_API_KEY",
+    "HARNESS_PLATFORM_SECRET_KEY",
+    "HARNESS_PLATFORM_URL",
+    "HOME",
+    "PATH",
+    "PYTHONPATH",
+}
 
 
 class SecretReferenceSerializer(serializers.Serializer):
@@ -10,6 +26,10 @@ class SecretReferenceSerializer(serializers.Serializer):
 
 class HarnessSourceSerializer(serializers.Serializer):
     source_path = serializers.CharField(max_length=4096, required=False)
+    source_id = serializers.RegexField(
+        r"^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$",
+        required=False,
+    )
     github_repository = serializers.CharField(max_length=512, required=False)
     github_ref = serializers.CharField(max_length=255, required=False)
     github_commit_sha = serializers.RegexField(r"^[0-9a-fA-F]{40}$", required=False)
@@ -19,6 +39,14 @@ class HarnessSourceSerializer(serializers.Serializer):
     github_installation_id = serializers.CharField(max_length=255, required=False)
     secret_refs = serializers.DictField(
         child=SecretReferenceSerializer(), required=False, default=dict
+    )
+    environment_values = serializers.DictField(
+        child=serializers.CharField(
+            max_length=65536, allow_blank=True, trim_whitespace=False
+        ),
+        required=False,
+        default=dict,
+        write_only=True,
     )
     connector_config = serializers.JSONField(required=False, default=dict)
 
@@ -39,10 +67,40 @@ class HarnessSourceSerializer(serializers.Serializer):
             )
         return value
 
-    def validate(self, attrs):
-        if bool(attrs.get("source_path")) == bool(attrs.get("github_repository")):
+    def validate_environment_values(self, value):
+        if len(value) > 256:
+            raise serializers.ValidationError("at most 256 environment values are allowed")
+        invalid = [
+            str(name)
+            for name, item in value.items()
+            if not re.fullmatch(r"[A-Za-z_][A-Za-z0-9_]*", str(name))
+            or "\x00" in item
+            or str(name) in RUNNER_RESERVED_ENVIRONMENT
+            or str(name).startswith("ALK_")
+        ]
+        if invalid:
             raise serializers.ValidationError(
-                "provide exactly one of source_path or github_repository"
+                f"invalid environment variable names or values: {', '.join(invalid)}"
+            )
+        total = sum(
+            len(str(name).encode()) + len(item.encode())
+            for name, item in value.items()
+        )
+        if total > 262_144:
+            raise serializers.ValidationError(
+                "combined environment values may not exceed 256 KiB"
+            )
+        return value
+
+    def validate(self, attrs):
+        sources = (
+            attrs.get("source_path"),
+            attrs.get("source_id"),
+            attrs.get("github_repository"),
+        )
+        if sum(bool(value) for value in sources) != 1:
+            raise serializers.ValidationError(
+                "provide exactly one of source_id, source_path or github_repository"
             )
         if (
             attrs.get("github_repository")
@@ -53,6 +111,10 @@ class HarnessSourceSerializer(serializers.Serializer):
                 {
                     "github_installation_id": "install/select the GitHub App for a private repository"
                 }
+            )
+        if set(attrs.get("environment_values", {})) & set(attrs.get("secret_refs", {})):
+            raise serializers.ValidationError(
+                "an environment variable cannot be both uploaded and a secret reference"
             )
         return attrs
 
@@ -78,3 +140,10 @@ class HarnessJobActionSerializer(serializers.Serializer):
         allow_blank=True,
         help_text="Optional operator-provided reason for the action.",
     )
+
+
+class HarnessSourceUploadResponseSerializer(serializers.Serializer):
+    source_id = serializers.UUIDField()
+    name = serializers.CharField()
+    file_count = serializers.IntegerField()
+    total_bytes = serializers.IntegerField()

--- a/futureagi/simulate/serializers/harness_job.py
+++ b/futureagi/simulate/serializers/harness_job.py
@@ -1,0 +1,41 @@
+from rest_framework import serializers
+
+
+class SecretReferenceSerializer(serializers.Serializer):
+    manager = serializers.CharField(max_length=64)
+    key = serializers.CharField(max_length=255)
+    version = serializers.CharField(max_length=255, required=False, allow_null=True)
+    purpose = serializers.CharField(max_length=128)
+
+
+class HarnessJobCreateSerializer(serializers.Serializer):
+    source_path = serializers.CharField(max_length=4096)
+    scenario_count = serializers.IntegerField(default=10, min_value=1, max_value=100)
+    seed = serializers.IntegerField(required=False, allow_null=True)
+    agent_name = serializers.CharField(max_length=255, required=False, allow_blank=True)
+    connector = serializers.CharField(max_length=128, default="auto")
+    connector_config = serializers.JSONField(default=dict)
+    secret_refs = serializers.DictField(
+        child=SecretReferenceSerializer(), required=False, default=dict
+    )
+    metadata = serializers.JSONField(default=dict)
+
+    def validate_connector_config(self, value):
+        forbidden = {"token", "secret", "password", "api_key", "api_secret"}
+        present = forbidden & {str(key).lower() for key in value}
+        if present:
+            raise serializers.ValidationError(
+                "credentials must be supplied as secret_refs, never as values"
+            )
+        return value
+
+
+class HarnessJobActionSerializer(serializers.Serializer):
+    """Optional audit context for job actions."""
+
+    reason = serializers.CharField(
+        max_length=500,
+        required=False,
+        allow_blank=True,
+        help_text="Optional operator-provided reason for the action.",
+    )

--- a/futureagi/simulate/serializers/harness_job.py
+++ b/futureagi/simulate/serializers/harness_job.py
@@ -142,6 +142,18 @@ class HarnessJobActionSerializer(serializers.Serializer):
     )
 
 
+class HarnessJobAdjustmentSerializer(serializers.Serializer):
+    instruction = serializers.CharField(
+        min_length=1,
+        max_length=2000,
+        trim_whitespace=True,
+        help_text="A user correction to apply at the next safe harness stage boundary.",
+    )
+    client_request_id = serializers.CharField(
+        max_length=128, required=False, allow_blank=False
+    )
+
+
 class HarnessSourceUploadResponseSerializer(serializers.Serializer):
     source_id = serializers.UUIDField()
     name = serializers.CharField()

--- a/futureagi/simulate/serializers/harness_job.py
+++ b/futureagi/simulate/serializers/harness_job.py
@@ -147,3 +147,9 @@ class HarnessSourceUploadResponseSerializer(serializers.Serializer):
     name = serializers.CharField()
     file_count = serializers.IntegerField()
     total_bytes = serializers.IntegerField()
+
+
+class HarnessSecretFileUploadResponseSerializer(serializers.Serializer):
+    environment_name = serializers.RegexField(r"^[A-Za-z_][A-Za-z0-9_]*$")
+    secret_ref = SecretReferenceSerializer()
+    size = serializers.IntegerField(min_value=1)

--- a/futureagi/simulate/serializers/harness_job.py
+++ b/futureagi/simulate/serializers/harness_job.py
@@ -8,26 +8,65 @@ class SecretReferenceSerializer(serializers.Serializer):
     purpose = serializers.CharField(max_length=128)
 
 
-class HarnessJobCreateSerializer(serializers.Serializer):
-    source_path = serializers.CharField(max_length=4096)
+class HarnessSourceSerializer(serializers.Serializer):
+    source_path = serializers.CharField(max_length=4096, required=False)
+    github_repository = serializers.CharField(max_length=512, required=False)
+    github_ref = serializers.CharField(max_length=255, required=False)
+    github_commit_sha = serializers.RegexField(r"^[0-9a-fA-F]{40}$", required=False)
+    github_visibility = serializers.ChoiceField(
+        choices=("public", "private"), default="public"
+    )
+    github_installation_id = serializers.CharField(max_length=255, required=False)
+    secret_refs = serializers.DictField(
+        child=SecretReferenceSerializer(), required=False, default=dict
+    )
+    connector_config = serializers.JSONField(required=False, default=dict)
+
+    def validate_connector_config(self, value):
+        if not isinstance(value, dict):
+            raise serializers.ValidationError("connector_config must be an object")
+        sensitive = ("token", "secret", "password", "api_key", "private_key")
+        invalid = [
+            str(key)
+            for key, item in value.items()
+            if any(marker in str(key).lower() for marker in sensitive)
+            or not isinstance(item, (str, int, float, bool))
+        ]
+        if invalid:
+            raise serializers.ValidationError(
+                "connector configuration must contain scalar non-secret values; "
+                "credentials belong in secret_refs"
+            )
+        return value
+
+    def validate(self, attrs):
+        if bool(attrs.get("source_path")) == bool(attrs.get("github_repository")):
+            raise serializers.ValidationError(
+                "provide exactly one of source_path or github_repository"
+            )
+        if (
+            attrs.get("github_repository")
+            and attrs.get("github_visibility") == "private"
+            and not attrs.get("github_installation_id")
+        ):
+            raise serializers.ValidationError(
+                {
+                    "github_installation_id": "install/select the GitHub App for a private repository"
+                }
+            )
+        return attrs
+
+
+class HarnessPreflightSerializer(HarnessSourceSerializer):
+    pass
+
+
+class HarnessJobCreateSerializer(HarnessSourceSerializer):
     scenario_count = serializers.IntegerField(default=10, min_value=1, max_value=100)
     seed = serializers.IntegerField(required=False, allow_null=True)
     agent_name = serializers.CharField(max_length=255, required=False, allow_blank=True)
     connector = serializers.CharField(max_length=128, default="auto")
-    connector_config = serializers.JSONField(default=dict)
-    secret_refs = serializers.DictField(
-        child=SecretReferenceSerializer(), required=False, default=dict
-    )
     metadata = serializers.JSONField(default=dict)
-
-    def validate_connector_config(self, value):
-        forbidden = {"token", "secret", "password", "api_key", "api_secret"}
-        present = forbidden & {str(key).lower() for key in value}
-        if present:
-            raise serializers.ValidationError(
-                "credentials must be supplied as secret_refs, never as values"
-            )
-        return value
 
 
 class HarnessJobActionSerializer(serializers.Serializer):

--- a/futureagi/simulate/serializers/requests/test_execution.py
+++ b/futureagi/simulate/serializers/requests/test_execution.py
@@ -1,4 +1,8 @@
+import re
+
 from rest_framework import serializers
+
+from simulate.serializers.harness_job import RUNNER_RESERVED_ENVIRONMENT
 
 
 class TestExecutionCancelSerializer(serializers.Serializer):
@@ -29,6 +33,41 @@ class CallExecutionRerunSerializer(serializers.Serializer):
         default=False,
         help_text="Whether to rerun all call executions in the test execution",
     )
+
+    environment_values = serializers.DictField(
+        child=serializers.CharField(
+            max_length=65536, allow_blank=True, trim_whitespace=False
+        ),
+        required=False,
+        default=dict,
+        write_only=True,
+        help_text=(
+            "Fresh job-scoped environment for a repository-backed harness rerun. "
+            "Values are forwarded to the sandbox and are not persisted."
+        ),
+    )
+
+    def validate_environment_values(self, value):
+        invalid = [
+            str(name)
+            for name, item in value.items()
+            if not re.fullmatch(r"[A-Za-z_][A-Za-z0-9_]*", str(name))
+            or "\x00" in item
+            or str(name) in RUNNER_RESERVED_ENVIRONMENT
+            or str(name).startswith("ALK_")
+        ]
+        if invalid:
+            raise serializers.ValidationError(
+                f"invalid environment variable names or values: {', '.join(invalid)}"
+            )
+        if len(value) > 256 or sum(
+            len(str(name).encode()) + len(item.encode())
+            for name, item in value.items()
+        ) > 262_144:
+            raise serializers.ValidationError(
+                "uploaded rerun environment exceeds the 256 variable / 256 KiB limit"
+            )
+        return value
 
     def validate(self, data):
         """Validate that either call_execution_ids or select_all is provided"""

--- a/futureagi/simulate/services/alk_simulate_ingestion.py
+++ b/futureagi/simulate/services/alk_simulate_ingestion.py
@@ -164,6 +164,15 @@ def store_alk_recording(
         content_type=content_type,
     )
     recording_url = get_object_url(UPLOAD_BUCKET_NAME, object_key)
+    # The upload response alone is not enough: the simulations UI reads the
+    # CallExecution row later, after the SDK process is gone. Persist the URL
+    # here so transcript playback and downloads survive that boundary.
+    call_execution.recording_url = recording_url
+    # Harness reporting sends the result before uploading its recording.  The
+    # UI gates the player on this flag, so persisting only the URL leaves a
+    # perfectly valid uploaded recording rendered as "No recording found".
+    call_execution.recording_available = True
+    call_execution.save(update_fields=["recording_url", "recording_available"])
     return RecordingUploadResult(
         recording_url=recording_url,
         object_key=object_key,
@@ -178,15 +187,20 @@ def _extension_from_filename(filename: str | None) -> str:
     return tail if tail and 1 <= len(tail) <= 5 else "wav"
 
 
-def _provision_text_agent_definition(
-    organization, agent_definition_id, agent_name, description
+def _provision_agent_definition(
+    organization, agent_definition_id, agent_name, description, modality="text"
 ):
-    """Resolve the RunTest's agent definition for provisioning.
+    """Resolve a modality-correct agent definition for an external ALK run.
 
-    Explicit id must resolve to a non-VOICE agent (voice is entitlement-gated in
-    CreateRunTestView; provisioning must not bypass that gate). Otherwise a TEXT
-    agent is created — chat call type follows the agent definition's type.
+    This endpoint does not originate a platform-hosted voice call. It records a call
+    already executed by an authenticated ALK runner, so the definition must preserve
+    the submitted modality for the transcript, recording and analytics UI.
     """
+    expected_type = (
+        AgentDefinition.AgentTypeChoices.VOICE
+        if modality == "voice"
+        else AgentDefinition.AgentTypeChoices.TEXT
+    )
     if agent_definition_id:
         try:
             agent_definition = AgentDefinition.objects.get(
@@ -196,16 +210,16 @@ def _provision_text_agent_definition(
             raise ALKSimulateIngestionError(
                 f"agent definition {agent_definition_id} not found"
             ) from exc
-        if agent_definition.agent_type == AgentDefinition.AgentTypeChoices.VOICE:
+        if agent_definition.agent_type != expected_type:
             raise ALKSimulateIngestionError(
-                "voice agent definitions cannot be provisioned via ALK ingestion"
+                "agent definition modality does not match the ALK run modality"
             )
         return agent_definition
     return AgentDefinition.objects.create(
         agent_name=agent_name or "alk-sdk-agent",
-        agent_type=AgentDefinition.AgentTypeChoices.TEXT,
-        inbound=True,  # NOT NULL; call-direction is a no-op for chat
-        description=description or "SDK-provisioned chat agent (ALK ingestion).",
+        agent_type=expected_type,
+        inbound=True,
+        description=description or f"SDK-provisioned {modality} agent (ALK ingestion).",
         organization=organization,
     )
 
@@ -219,8 +233,9 @@ def provision_alk_sim_run_test(
     agent_definition_id: str | None = None,
     agent_name: str | None = None,
     description: str = "",
+    modality: str = "text",
 ) -> tuple[RunTest, list[Scenarios], AgentDefinition]:
-    """Stand up a chat RunTest for an SDK-first run, two ways (exactly one):
+    """Stand up a modality-correct RunTest for an SDK-first run, two ways.
 
     * ``scenario_ids`` — attach existing (natively generated) scenarios. Nothing
       is fabricated or mutated; the scenarios keep their real datasets so they
@@ -252,8 +267,12 @@ def provision_alk_sim_run_test(
                 raise ALKSimulateIngestionError(
                     f"scenario(s) not found: {', '.join(missing)}"
                 )
-            agent_definition = _provision_text_agent_definition(
-                organization, agent_definition_id, agent_name, description
+            agent_definition = _provision_agent_definition(
+                organization,
+                agent_definition_id,
+                agent_name,
+                description,
+                modality,
             )
             simulator_agent = next(
                 (s.simulator_agent for s in scenarios if s.simulator_agent), None
@@ -277,8 +296,12 @@ def provision_alk_sim_run_test(
             run_test.scenarios.set(scenarios)
             return run_test, scenarios, agent_definition
 
-        agent_definition = _provision_text_agent_definition(
-            organization, agent_definition_id, agent_name, description
+        agent_definition = _provision_agent_definition(
+            organization,
+            agent_definition_id,
+            agent_name,
+            description,
+            modality,
         )
 
         scenarios: list[Scenarios] = []
@@ -587,7 +610,21 @@ def ingest_alk_sim_result(
             == CallExecution.SimulationCallType.VOICE
         ):
             _dispatch_csat_once(call_execution)
-        eval_dispatched = _dispatch_evaluations_once(call_execution)
+        call_metadata = call_execution.call_metadata or {}
+        if "harness_evaluations" in call_metadata:
+            # An ALK harness result already contains the execution-backed
+            # checks. Starting the platform evaluator as well leaves the call
+            # permanently `eval_started` when no platform eval templates are
+            # configured, and therefore leaves the parent run pending. Mark
+            # this evaluation source complete instead of double-evaluating it.
+            call_metadata["eval_started"] = True
+            call_metadata["eval_completed"] = True
+            call_execution.call_metadata = call_metadata
+            call_execution.save(update_fields=["call_metadata"])
+        else:
+            eval_dispatched = _dispatch_evaluations_once(call_execution)
+
+    _roll_up_external_execution(call_execution.test_execution_id)
 
     try:
         notify_simulation_update(
@@ -619,6 +656,50 @@ def ingest_alk_sim_result(
         call_execution_id=str(call_execution.id),
         status="ingested",
         eval_dispatched=eval_dispatched,
+    )
+
+
+def _roll_up_external_execution(test_execution_id) -> None:
+    """Synchronously close an SDK-owned parent once all child calls finish.
+
+    The regular platform executor has Temporal/Celery monitoring its lifecycle.
+    An external SDK runner does not, so ingestion itself must make the terminal
+    transition deterministic. Async monitoring still runs for summaries and
+    notifications, but the list view no longer depends on a worker race.
+    """
+    calls = CallExecution.objects.filter(
+        test_execution_id=test_execution_id, deleted=False
+    )
+    if not calls.exists():
+        return
+    terminal = (
+        CallExecution.CallStatus.COMPLETED,
+        CallExecution.CallStatus.FAILED,
+        CallExecution.CallStatus.CANCELLED,
+    )
+    if calls.exclude(status__in=terminal).exists():
+        return
+
+    status = (
+        TestExecution.ExecutionStatus.COMPLETED
+        if calls.filter(status=CallExecution.CallStatus.COMPLETED).exists()
+        else TestExecution.ExecutionStatus.FAILED
+    )
+    completed_calls = calls.filter(
+        status=CallExecution.CallStatus.COMPLETED
+    ).count()
+    failed_calls = calls.filter(
+        status__in=(
+            CallExecution.CallStatus.FAILED,
+            CallExecution.CallStatus.CANCELLED,
+        )
+    ).count()
+    TestExecution.objects.filter(id=test_execution_id).update(
+        status=status,
+        completed_at=timezone.now(),
+        total_calls=calls.count(),
+        completed_calls=completed_calls,
+        failed_calls=failed_calls,
     )
 
 

--- a/futureagi/simulate/services/alk_simulate_ingestion.py
+++ b/futureagi/simulate/services/alk_simulate_ingestion.py
@@ -10,6 +10,7 @@ never uploads bytes (same pattern as the Vapi provider adapter).
 
 from __future__ import annotations
 
+import hashlib
 import uuid
 from dataclasses import dataclass
 from datetime import timedelta
@@ -61,6 +62,9 @@ _RESERVED_CALL_METADATA_KEYS = frozenset(
         "eval_started",
         "eval_dispatch_failed",
         "csat_dispatch_failed",
+        "alk_result_digest",
+        "alk_artifact_manifest_digest",
+        "alk_recording_artifacts",
     }
 )
 
@@ -136,6 +140,8 @@ def store_alk_recording(
     audio_bytes: bytes,
     *,
     filename: str | None = None,
+    expected_sha256: str | None = None,
+    kind: str = "combined",
 ) -> RecordingUploadResult:
     """Persist an ALK-supplied recording to the shared upload bucket.
 
@@ -152,31 +158,70 @@ def store_alk_recording(
     if not audio_bytes:
         raise ALKSimulateIngestionError("recording upload was empty")
 
-    ext = _extension_from_filename(filename)
-    content_type = _CONTENT_TYPE_BY_EXT.get(ext, "application/octet-stream")
-    object_key = f"{_ALK_RECORDING_PREFIX}/{call_execution.id}/{uuid.uuid4().hex}.{ext}"
-    client = get_storage_client()
-    client.put_object(
-        bucket_name=UPLOAD_BUCKET_NAME,
-        object_name=object_key,
-        data=BytesIO(audio_bytes),
-        length=len(audio_bytes),
-        content_type=content_type,
-    )
-    recording_url = get_object_url(UPLOAD_BUCKET_NAME, object_key)
-    # The upload response alone is not enough: the simulations UI reads the
-    # CallExecution row later, after the SDK process is gone. Persist the URL
-    # here so transcript playback and downloads survive that boundary.
-    call_execution.recording_url = recording_url
-    # Harness reporting sends the result before uploading its recording.  The
-    # UI gates the player on this flag, so persisting only the URL leaves a
-    # perfectly valid uploaded recording rendered as "No recording found".
-    call_execution.recording_available = True
-    call_execution.save(update_fields=["recording_url", "recording_available"])
-    return RecordingUploadResult(
-        recording_url=recording_url,
-        object_key=object_key,
-    )
+    digest = hashlib.sha256(audio_bytes).hexdigest()
+    expected = (expected_sha256 or "").removeprefix("sha256:").lower()
+    if expected and digest != expected:
+        raise ALKSimulateIngestionError("recording sha256 did not match uploaded bytes")
+
+    # Distinct tracks can arrive concurrently. Lock the row while checking and
+    # extending the per-kind artifact map so one upload cannot overwrite another.
+    # The object key is content addressed, which makes a retry after a database
+    # failure safe even if storage already accepted the bytes.
+    with transaction.atomic():
+        call_execution = CallExecution.objects.select_for_update().get(
+            id=call_execution.id
+        )
+        metadata = dict(call_execution.call_metadata or {})
+        artifacts = dict(metadata.get("alk_recording_artifacts") or {})
+        existing_artifact = dict(artifacts.get(kind) or {})
+        existing_digest = existing_artifact.get("sha256")
+        if existing_digest and existing_digest != digest:
+            raise ALKSimulateIngestionError(
+                "recording digest conflicts with the previously ingested artifact"
+            )
+        existing_key = existing_artifact.get("object_key")
+        existing_url = existing_artifact.get("recording_url")
+        if existing_digest == digest and existing_key and existing_url:
+            return RecordingUploadResult(
+                recording_url=existing_url,
+                object_key=existing_key,
+            )
+
+        ext = _extension_from_filename(filename)
+        content_type = _CONTENT_TYPE_BY_EXT.get(ext, "application/octet-stream")
+        object_key = (
+            f"{_ALK_RECORDING_PREFIX}/{call_execution.id}/{kind}/{digest}.{ext}"
+        )
+        client = get_storage_client()
+        client.put_object(
+            bucket_name=UPLOAD_BUCKET_NAME,
+            object_name=object_key,
+            data=BytesIO(audio_bytes),
+            length=len(audio_bytes),
+            content_type=content_type,
+        )
+        recording_url = get_object_url(UPLOAD_BUCKET_NAME, object_key)
+        update_fields = ["call_metadata"]
+        if kind == "combined":
+            call_execution.recording_url = recording_url
+            call_execution.recording_available = True
+            update_fields.extend(["recording_url", "recording_available"])
+        elif kind == "stereo":
+            call_execution.stereo_recording_url = recording_url
+            call_execution.recording_available = True
+            update_fields.extend(["stereo_recording_url", "recording_available"])
+        artifacts[kind] = {
+            "sha256": digest,
+            "object_key": object_key,
+            "recording_url": recording_url,
+        }
+        metadata["alk_recording_artifacts"] = artifacts
+        call_execution.call_metadata = metadata
+        call_execution.save(update_fields=update_fields)
+        return RecordingUploadResult(
+            recording_url=recording_url,
+            object_key=object_key,
+        )
 
 
 def _extension_from_filename(filename: str | None) -> str:
@@ -599,7 +644,12 @@ def ingest_alk_sim_result(
             "ALK result can only be submitted to VOICE or TEXT call executions"
         )
 
-    _apply_payload(call_execution, payload)
+    with transaction.atomic():
+        call_execution = CallExecution.objects.select_for_update().get(
+            id=call_execution.id
+        )
+        _claim_result_digest(call_execution, payload)
+        _apply_payload(call_execution, payload)
 
     eval_dispatched = False
     if call_execution.status == CallExecution.CallStatus.COMPLETED:
@@ -659,6 +709,34 @@ def ingest_alk_sim_result(
     )
 
 
+def _claim_result_digest(
+    call_execution: CallExecution, payload: dict[str, Any]
+) -> None:
+    """Atomically make retries idempotent and reject conflicting evidence."""
+    incoming = payload.get("result_digest")
+    manifest = payload.get("artifact_manifest_digest")
+    metadata = dict(call_execution.call_metadata or {})
+    existing = metadata.get("alk_result_digest")
+    if existing and not incoming:
+        raise ALKSimulateIngestionError(
+            "result_digest is required when retrying a sealed result"
+        )
+    if existing and existing != incoming:
+        raise ALKSimulateIngestionError(
+            "result digest conflicts with the previously ingested result"
+        )
+    existing_manifest = metadata.get("alk_artifact_manifest_digest")
+    if existing_manifest and manifest and existing_manifest != manifest:
+        raise ALKSimulateIngestionError(
+            "artifact manifest digest conflicts with this execution"
+        )
+    if incoming:
+        metadata["alk_result_digest"] = incoming
+    if manifest:
+        metadata["alk_artifact_manifest_digest"] = manifest
+    call_execution.call_metadata = metadata
+
+
 def _roll_up_external_execution(test_execution_id) -> None:
     """Synchronously close an SDK-owned parent once all child calls finish.
 
@@ -685,9 +763,7 @@ def _roll_up_external_execution(test_execution_id) -> None:
         if calls.filter(status=CallExecution.CallStatus.COMPLETED).exists()
         else TestExecution.ExecutionStatus.FAILED
     )
-    completed_calls = calls.filter(
-        status=CallExecution.CallStatus.COMPLETED
-    ).count()
+    completed_calls = calls.filter(status=CallExecution.CallStatus.COMPLETED).count()
     failed_calls = calls.filter(
         status__in=(
             CallExecution.CallStatus.FAILED,

--- a/futureagi/simulate/services/alk_simulate_ingestion.py
+++ b/futureagi/simulate/services/alk_simulate_ingestion.py
@@ -365,7 +365,12 @@ def provision_alk_sim_run_test(
             persona = dict(persona or {})
             persona_name = (persona.get("name") or f"persona-{idx + 1}").strip()
             situation = (persona.get("situation") or "").strip()
-            scenario_name = f"{name} · {persona_name}"[:255]
+            # The run-test title already supplies the agent/run context. Repeating it on every
+            # scenario made a two-call suite render as several nearly identical UUID-prefixed
+            # rows. ALK sends the behavior being tested separately from the persona identity.
+            scenario_name = (
+                persona.get("scenario_name") or situation or persona_name
+            ).strip()[:255]
             # A real 1-row dataset (persona/situation/outcome) makes the scenario
             # render with persona rows AND lets the simulator prompt's
             # {{persona}}/{{situation}} placeholders resolve — without it the
@@ -469,6 +474,7 @@ def create_alk_sim_test_execution(
     run_test: RunTest,
     *,
     scenario_ids: list[str] | None = None,
+    scenario_selectors: list[dict[str, str]] | None = None,
     simulator_agent: SimulatorAgent | None = None,
     harness_job_id: str | None = None,
 ) -> TestExecution:
@@ -490,6 +496,34 @@ def create_alk_sim_test_execution(
             raise ALKSimulateIngestionError(
                 f"Scenarios not attached to this run test: {sorted(missing)}"
             )
+    elif scenario_selectors:
+        attached = list(run_test.scenarios.filter(deleted=False))
+        chosen = []
+        used: set[str] = set()
+        for selector in scenario_selectors:
+            scenario_key = str(selector.get("scenario_key") or "").strip()
+            persona_name = str(selector.get("persona_name") or "").strip()
+            exact = []
+            fallback = []
+            for scenario in attached:
+                if str(scenario.id) in used:
+                    continue
+                persona = (scenario.metadata or {}).get("persona") or {}
+                if str(persona.get("scenario_key") or "") == scenario_key:
+                    exact.append(scenario)
+                identity = persona.get("persona") or {}
+                stored_name = str(identity.get("name") or persona.get("name") or "")
+                if persona_name and stored_name == persona_name:
+                    fallback.append(scenario)
+            matches = exact or fallback
+            if len(matches) != 1:
+                label = scenario_key or persona_name or "<empty>"
+                raise ALKSimulateIngestionError(
+                    f"Scenario selector {label!r} matched {len(matches)} saved scenarios"
+                )
+            selected = matches[0]
+            chosen.append(str(selected.id))
+            used.add(str(selected.id))
     else:
         chosen = [str(sid) for sid in active_scenario_ids]
 

--- a/futureagi/simulate/services/alk_simulate_ingestion.py
+++ b/futureagi/simulate/services/alk_simulate_ingestion.py
@@ -19,13 +19,16 @@ from typing import Any
 
 import structlog
 from django.db import transaction
+from django.db.models import Q
 from django.utils import timezone
 
+from model_hub.models.evals_metric import EvalTemplate
 from simulate.models import (
     AgentDefinition,
     CallExecution,
     RunTest,
     Scenarios,
+    SimulateEvalConfig,
     SimulatorAgent,
     TestExecution,
 )
@@ -62,6 +65,8 @@ _RESERVED_CALL_METADATA_KEYS = frozenset(
         "eval_started",
         "eval_dispatch_failed",
         "csat_dispatch_failed",
+        "csat_status",
+        "csat_error",
         "alk_result_digest",
         "alk_artifact_manifest_digest",
         "alk_recording_artifacts",
@@ -86,6 +91,12 @@ _TRANSCRIPT_ROLE_TO_METRIC_ROLE = {
     CallTranscript.SpeakerRole.USER: "user",
     CallTranscript.SpeakerRole.ASSISTANT: "bot",
 }
+
+# Stable IDs let externally-computed harness checks live in ``eval_outputs``
+# without creating a new global EvalTemplate for every deterministic database
+# assertion. Platform-backed checks use their real SimulateEvalConfig ID; only
+# execution-native checks use this namespace.
+_HARNESS_EVAL_NAMESPACE = uuid.UUID("754ea237-3306-4c91-a718-c3e1c304689c")
 
 
 @dataclass(frozen=True)
@@ -459,6 +470,7 @@ def create_alk_sim_test_execution(
     *,
     scenario_ids: list[str] | None = None,
     simulator_agent: SimulatorAgent | None = None,
+    harness_job_id: str | None = None,
 ) -> TestExecution:
     """Create a TestExecution shell for an ALK-owned run.
 
@@ -496,6 +508,9 @@ def create_alk_sim_test_execution(
         simulator_agent=simulator_agent or run_test.simulator_agent,
         agent_definition=run_test.agent_definition,
         agent_version=run_test.agent_version,
+        execution_metadata=(
+            {"harness_job_id": str(harness_job_id)} if harness_job_id else {}
+        ),
     )
 
 
@@ -653,13 +668,11 @@ def ingest_alk_sim_result(
 
     eval_dispatched = False
     if call_execution.status == CallExecution.CallStatus.COMPLETED:
-        # Chat CSAT is computed synchronously by _aggregate_chat_metrics during
-        # _apply_payload; only voice needs the async CSAT task.
-        if (
-            call_execution.simulation_call_type
-            == CallExecution.SimulationCallType.VOICE
-        ):
-            _dispatch_csat_once(call_execution)
+        # Chat attempts CSAT synchronously with its native metric aggregation.
+        # If that scorer is unavailable, the same durable async path used by
+        # voice retries it instead of silently leaving a completed call with a
+        # null score.
+        _dispatch_csat_once(call_execution)
         call_metadata = call_execution.call_metadata or {}
         if "harness_evaluations" in call_metadata:
             # An ALK harness result already contains the execution-backed
@@ -986,6 +999,8 @@ def _apply_payload(call_execution: CallExecution, payload: dict[str, Any]) -> No
         merged = call_execution.call_metadata or {}
         merged.update(incoming)
         call_execution.call_metadata = merged
+
+    _apply_harness_evaluation_outputs(call_execution)
 
     segments = payload.get("transcript") or []
     is_text = (
@@ -1359,11 +1374,141 @@ def _coerce_token(value) -> int | None:
         return None
 
 
+def _apply_harness_evaluation_outputs(call_execution: CallExecution) -> None:
+    """Normalize execution-backed harness checks into the platform eval shape.
+
+    The harness has already run these checks; executing the platform evaluator a
+    second time would both waste money and risk producing a different answer.
+    Platform-backed judgements are attached to their existing EvalTemplate via a
+    run-scoped SimulateEvalConfig. Deterministic code checks have no template by
+    design, so they receive a stable external-result ID and remain explicitly
+    marked ``source=harness``.
+    """
+    metadata = call_execution.call_metadata or {}
+    evaluations = metadata.get("harness_evaluations")
+    if not isinstance(evaluations, list):
+        return
+
+    outputs = dict(call_execution.eval_outputs or {})
+    run_test = call_execution.test_execution.run_test
+    for evaluation in evaluations:
+        if not isinstance(evaluation, dict):
+            continue
+        name = str(evaluation.get("name") or "").strip()[:255]
+        if not name:
+            continue
+        kind = str(evaluation.get("kind") or "checkpoint").strip()[:50]
+        template = _resolve_harness_eval_template(run_test, evaluation, name)
+        if template is not None:
+            config = _get_or_create_harness_eval_config(run_test, template, name)
+            output_id = str(config.id)
+        else:
+            output_id = str(
+                uuid.uuid5(
+                    _HARNESS_EVAL_NAMESPACE,
+                    f"{run_test.id}:{kind}:{name}",
+                )
+            )
+
+        if evaluation.get("score") is not None:
+            try:
+                output = float(evaluation["score"])
+            except (TypeError, ValueError):
+                output = evaluation["score"]
+            output_type = "score"
+        else:
+            output = "Passed" if bool(evaluation.get("passed")) else "Failed"
+            output_type = "Pass/Fail"
+
+        outputs[output_id] = {
+            "name": name,
+            "output": output,
+            "output_type": output_type,
+            "reason": str(evaluation.get("reason") or "")[:10000],
+            "status": "completed",
+            "source": "harness",
+            "kind": kind,
+            "platform_template": str(
+                evaluation.get("platform_template") or ""
+            )[:2000],
+        }
+    call_execution.eval_outputs = outputs
+
+
+def _resolve_harness_eval_template(
+    run_test: RunTest,
+    evaluation: dict[str, Any],
+    fallback_name: str,
+) -> EvalTemplate | None:
+    """Find the reusable template that produced a harness judgement.
+
+    New runners send ``platform_template`` explicitly. Built-in suite evals
+    historically sent only their template name as ``name``, so eval-kind checks
+    retain that exact-name fallback. We deliberately do not guess for code or
+    locally judged checks.
+    """
+    template_name = str(evaluation.get("platform_template") or "").strip()
+    if not template_name and evaluation.get("kind") == "eval":
+        template_name = fallback_name
+    if not template_name:
+        return None
+
+    visible_scope = Q(organization=run_test.organization) | Q(organization__isnull=True)
+    workspace_scope = Q(workspace=run_test.workspace) | Q(workspace__isnull=True)
+    return (
+        EvalTemplate.no_workspace_objects.filter(
+            visible_scope,
+            workspace_scope,
+            name=template_name,
+            deleted=False,
+        )
+        .order_by("-organization_id", "-created_at")
+        .first()
+    )
+
+
+def _get_or_create_harness_eval_config(
+    run_test: RunTest,
+    template: EvalTemplate,
+    name: str,
+) -> SimulateEvalConfig:
+    """Idempotently bind one external result column to its originating run."""
+    config_id = uuid.uuid5(
+        _HARNESS_EVAL_NAMESPACE,
+        f"{run_test.id}:{template.id}:{name}",
+    )
+    config, _ = SimulateEvalConfig.objects.get_or_create(
+        id=config_id,
+        defaults={
+            "eval_template": template,
+            "name": name,
+            "config": template.config or {},
+            "mapping": {},
+            "run_test": run_test,
+            "filters": {},
+            "model": template.model,
+        },
+    )
+    return config
+
+
 def _dispatch_csat_once(call_execution: CallExecution) -> None:
     call_metadata = call_execution.call_metadata or {}
-    if call_metadata.get("csat_dispatched"):
+    existing_csat = (call_execution.conversation_metrics_data or {}).get("csat_score")
+    if existing_csat is not None:
+        if call_metadata.get("csat_status") != "completed":
+            call_metadata["csat_status"] = "completed"
+            call_metadata.pop("csat_error", None)
+            call_execution.call_metadata = call_metadata
+            call_execution.save(update_fields=["call_metadata"])
+        return
+    if call_metadata.get("csat_dispatched") and call_metadata.get(
+        "csat_status"
+    ) not in {"failed"}:
         return
     call_metadata["csat_dispatched"] = True
+    call_metadata["csat_status"] = "pending"
+    call_metadata.pop("csat_error", None)
     call_execution.call_metadata = call_metadata
     call_execution.save(update_fields=["call_metadata"])
     try:
@@ -1376,6 +1521,8 @@ def _dispatch_csat_once(call_execution: CallExecution) -> None:
             call_execution_id=str(call_execution.id),
         )
         call_metadata["csat_dispatched"] = False
+        call_metadata["csat_status"] = "failed"
+        call_metadata["csat_error"] = str(dispatch_error)[:2000]
         call_metadata["csat_dispatch_failed"] = str(dispatch_error)
         call_execution.call_metadata = call_metadata
         call_execution.save(update_fields=["call_metadata"])

--- a/futureagi/simulate/services/harness_credentials.py
+++ b/futureagi/simulate/services/harness_credentials.py
@@ -1,0 +1,125 @@
+from __future__ import annotations
+
+from typing import Any
+
+from django.core.files.uploadedfile import SimpleUploadedFile
+
+from simulate.models import HarnessCredentialFile, HarnessEnvironmentCredentials
+
+
+PLATFORM_FILE_MANAGER = "harness_environment_file"
+
+
+def request_scope(request) -> tuple[Any, Any]:
+    organization = getattr(request, "organization", None) or getattr(
+        request.user, "organization", None
+    )
+    workspace = getattr(request, "workspace", None)
+    return organization, workspace
+
+
+def store_credential_file(uploaded, environment_name: str, *, organization, workspace):
+    content = uploaded.read()
+    record = HarnessCredentialFile(
+        organization=organization,
+        workspace=workspace,
+        environment_name=environment_name,
+        filename=str(getattr(uploaded, "name", None) or "credential")[:255],
+        content_type=str(
+            getattr(uploaded, "content_type", None) or "application/octet-stream"
+        )[:255],
+        size=len(content),
+    )
+    record.set_content(content)
+    record.save()
+    return record
+
+
+def credential_file_ref(record: HarnessCredentialFile) -> dict[str, str]:
+    return {
+        "manager": PLATFORM_FILE_MANAGER,
+        "key": str(record.id),
+        "version": str(record.updated_at.timestamp()),
+        "purpose": f"RL environment credential file for {record.environment_name}",
+    }
+
+
+def _platform_file_ids(secret_refs: dict[str, dict[str, Any]]) -> list[str]:
+    return [
+        str(ref.get("key"))
+        for ref in secret_refs.values()
+        if ref.get("manager") == PLATFORM_FILE_MANAGER and ref.get("key")
+    ]
+
+
+def materialize_secret_refs(
+    secret_refs: dict[str, dict[str, Any]], *, organization, client
+) -> dict[str, dict[str, Any]]:
+    """Replace durable platform file refs with fresh attempt-scoped runner refs."""
+
+    materialized: dict[str, dict[str, Any]] = {}
+    for alias, ref in secret_refs.items():
+        if ref.get("manager") != PLATFORM_FILE_MANAGER:
+            materialized[alias] = ref
+            continue
+        record = HarnessCredentialFile.objects.get(
+            id=ref["key"], organization=organization, deleted=False
+        )
+        uploaded = SimpleUploadedFile(
+            record.filename,
+            record.get_content(),
+            content_type=record.content_type,
+        )
+        response = client.upload_secret_file(uploaded, record.environment_name)
+        materialized[alias] = response["secret_ref"]
+    return materialized
+
+
+def save_environment_credentials(
+    harness_job_id: str,
+    *,
+    environment_values: dict[str, str],
+    secret_refs: dict[str, dict[str, Any]],
+    organization,
+    workspace,
+) -> HarnessEnvironmentCredentials:
+    profile, _ = HarnessEnvironmentCredentials.objects.get_or_create(
+        harness_job_id=harness_job_id,
+        defaults={"organization": organization, "workspace": workspace},
+    )
+    if profile.organization_id != organization.id:
+        raise PermissionError("harness environment belongs to another organization")
+    profile.workspace = workspace
+    profile.set_environment(environment_values)
+    profile.credential_file_ids = _platform_file_ids(secret_refs)
+    profile.save()
+    return profile
+
+
+def credentials_for_rerun(
+    harness_job_id: str,
+    *,
+    organization,
+    client,
+    environment_overrides: dict[str, str] | None = None,
+) -> tuple[dict[str, str], dict[str, dict[str, Any]]]:
+    profile = HarnessEnvironmentCredentials.objects.get(
+        harness_job_id=harness_job_id,
+        organization=organization,
+        deleted=False,
+    )
+    environment = profile.get_environment()
+    environment.update(environment_overrides or {})
+    durable_refs = {}
+    for file_id in profile.credential_file_ids:
+        record = HarnessCredentialFile.objects.get(
+            id=file_id, organization=organization, deleted=False
+        )
+        durable_refs[record.environment_name] = credential_file_ref(record)
+    refs = materialize_secret_refs(
+        durable_refs, organization=organization, client=client
+    )
+    if environment_overrides:
+        profile.set_environment(environment)
+        profile.save(update_fields=["encrypted_environment", "updated_at"])
+    return environment, refs

--- a/futureagi/simulate/services/harness_sandbox.py
+++ b/futureagi/simulate/services/harness_sandbox.py
@@ -25,7 +25,9 @@ class HarnessSandboxClient:
             or os.getenv("ALK_HARNESS_SANDBOX_URL")
             or "http://host.docker.internal:8788"
         ).rstrip("/")
-        self.token = token if token is not None else os.getenv("ALK_HARNESS_SANDBOX_TOKEN")
+        self.token = (
+            token if token is not None else os.getenv("ALK_HARNESS_SANDBOX_TOKEN")
+        )
 
     def health(self) -> dict[str, Any]:
         return self._request("GET", "/health", authenticated=False)
@@ -35,6 +37,9 @@ class HarnessSandboxClient:
 
     def submit(self, payload: dict[str, Any]) -> dict[str, Any]:
         return self._request("POST", "/v1/jobs", json=payload)
+
+    def preflight(self, payload: dict[str, Any]) -> dict[str, Any]:
+        return self._request("POST", "/v1/preflight", json=payload)
 
     def get(self, job_id: str) -> dict[str, Any]:
         return self._request("GET", f"/v1/jobs/{job_id}")

--- a/futureagi/simulate/services/harness_sandbox.py
+++ b/futureagi/simulate/services/harness_sandbox.py
@@ -75,6 +75,9 @@ class HarnessSandboxClient:
     def get(self, job_id: str) -> dict[str, Any]:
         return self._request("GET", f"/v1/jobs/{job_id}")
 
+    def rerun(self, job_id: str, payload: dict[str, Any]) -> dict[str, Any]:
+        return self._request("POST", f"/v1/jobs/{job_id}/rerun", json=payload)
+
     def cancel(self, job_id: str) -> dict[str, Any]:
         return self._request("POST", f"/v1/jobs/{job_id}/cancel")
 

--- a/futureagi/simulate/services/harness_sandbox.py
+++ b/futureagi/simulate/services/harness_sandbox.py
@@ -12,6 +12,12 @@ class HarnessSandboxUnavailable(RuntimeError):
     pass
 
 
+class HarnessSandboxRejected(RuntimeError):
+    def __init__(self, status_code: int, detail: str) -> None:
+        super().__init__(detail)
+        self.status_code = status_code
+
+
 class HarnessSandboxClient:
     """Small provider-neutral HTTP client.
 
@@ -41,6 +47,31 @@ class HarnessSandboxClient:
     def preflight(self, payload: dict[str, Any]) -> dict[str, Any]:
         return self._request("POST", "/v1/preflight", json=payload)
 
+    def upload_source(
+        self, files: list[Any], paths: list[str], name: str
+    ) -> dict[str, Any]:
+        multipart = [
+            (
+                "files",
+                (
+                    str(path).rsplit("/", 1)[-1],
+                    uploaded.file,
+                    getattr(uploaded, "content_type", None)
+                    or "application/octet-stream",
+                ),
+            )
+            for uploaded, path in zip(files, paths, strict=True)
+        ]
+        data = [("paths", path) for path in paths]
+        data.append(("name", name))
+        return self._request(
+            "POST",
+            "/v1/sources",
+            files=multipart,
+            data=data,
+            timeout=(5, 300),
+        )
+
     def get(self, job_id: str) -> dict[str, Any]:
         return self._request("GET", f"/v1/jobs/{job_id}")
 
@@ -63,7 +94,7 @@ class HarnessSandboxClient:
                 method,
                 f"{self.base_url}{path}",
                 headers=headers,
-                timeout=(5, 30),
+                timeout=kwargs.pop("timeout", (5, 30)),
                 **kwargs,
             )
         except requests.RequestException as exc:
@@ -75,10 +106,17 @@ class HarnessSandboxClient:
                 detail = response.json().get("detail")
             except (ValueError, AttributeError):
                 detail = response.text[:500]
+            message = detail or "unknown error"
+            if response.status_code < 500:
+                raise HarnessSandboxRejected(response.status_code, message)
             raise HarnessSandboxUnavailable(
-                f"ALK sandbox returned {response.status_code}: {detail or 'unknown error'}"
+                f"ALK sandbox returned {response.status_code}: {message}"
             )
         return response.json()
 
 
-__all__ = ["HarnessSandboxClient", "HarnessSandboxUnavailable"]
+__all__ = [
+    "HarnessSandboxClient",
+    "HarnessSandboxRejected",
+    "HarnessSandboxUnavailable",
+]

--- a/futureagi/simulate/services/harness_sandbox.py
+++ b/futureagi/simulate/services/harness_sandbox.py
@@ -78,6 +78,9 @@ class HarnessSandboxClient:
     def cancel(self, job_id: str) -> dict[str, Any]:
         return self._request("POST", f"/v1/jobs/{job_id}/cancel")
 
+    def adjust(self, job_id: str, payload: dict[str, Any]) -> dict[str, Any]:
+        return self._request("POST", f"/v1/jobs/{job_id}/adjust", json=payload)
+
     def _request(
         self,
         method: str,

--- a/futureagi/simulate/services/harness_sandbox.py
+++ b/futureagi/simulate/services/harness_sandbox.py
@@ -72,6 +72,27 @@ class HarnessSandboxClient:
             timeout=(5, 300),
         )
 
+    def upload_secret_file(self, uploaded: Any, environment_name: str) -> dict[str, Any]:
+        """Transfer a credential file directly to the execution provider.
+
+        The platform does not deserialize, log or place its contents in a JSON payload. The
+        provider returns an opaque reference that can be attached to one harness job.
+        """
+        return self._request(
+            "POST",
+            "/v1/secret-files",
+            files={
+                "file": (
+                    "credential",
+                    uploaded.file,
+                    getattr(uploaded, "content_type", None)
+                    or "application/octet-stream",
+                )
+            },
+            data={"environment_name": environment_name},
+            timeout=(5, 60),
+        )
+
     def get(self, job_id: str) -> dict[str, Any]:
         return self._request("GET", f"/v1/jobs/{job_id}")
 

--- a/futureagi/simulate/services/harness_sandbox.py
+++ b/futureagi/simulate/services/harness_sandbox.py
@@ -1,0 +1,79 @@
+"""Platform control-plane client for an ALK sandbox provider."""
+
+from __future__ import annotations
+
+import os
+from typing import Any
+
+import requests
+
+
+class HarnessSandboxUnavailable(RuntimeError):
+    pass
+
+
+class HarnessSandboxClient:
+    """Small provider-neutral HTTP client.
+
+    Development points this at ALK's local-process provider. Hosted deployments point the same
+    contract at the managed sandbox service; no platform view or UI changes are required.
+    """
+
+    def __init__(self, base_url: str | None = None, token: str | None = None) -> None:
+        self.base_url = (
+            base_url
+            or os.getenv("ALK_HARNESS_SANDBOX_URL")
+            or "http://host.docker.internal:8788"
+        ).rstrip("/")
+        self.token = token if token is not None else os.getenv("ALK_HARNESS_SANDBOX_TOKEN")
+
+    def health(self) -> dict[str, Any]:
+        return self._request("GET", "/health", authenticated=False)
+
+    def list_jobs(self) -> list[dict[str, Any]]:
+        return self._request("GET", "/v1/jobs")
+
+    def submit(self, payload: dict[str, Any]) -> dict[str, Any]:
+        return self._request("POST", "/v1/jobs", json=payload)
+
+    def get(self, job_id: str) -> dict[str, Any]:
+        return self._request("GET", f"/v1/jobs/{job_id}")
+
+    def cancel(self, job_id: str) -> dict[str, Any]:
+        return self._request("POST", f"/v1/jobs/{job_id}/cancel")
+
+    def _request(
+        self,
+        method: str,
+        path: str,
+        *,
+        authenticated: bool = True,
+        **kwargs: Any,
+    ) -> Any:
+        headers = dict(kwargs.pop("headers", {}))
+        if authenticated and self.token:
+            headers["Authorization"] = f"Bearer {self.token}"
+        try:
+            response = requests.request(
+                method,
+                f"{self.base_url}{path}",
+                headers=headers,
+                timeout=(5, 30),
+                **kwargs,
+            )
+        except requests.RequestException as exc:
+            raise HarnessSandboxUnavailable(
+                f"ALK sandbox is unavailable at {self.base_url}: {exc}"
+            ) from exc
+        if response.status_code >= 400:
+            try:
+                detail = response.json().get("detail")
+            except (ValueError, AttributeError):
+                detail = response.text[:500]
+            raise HarnessSandboxUnavailable(
+                f"ALK sandbox returned {response.status_code}: {detail or 'unknown error'}"
+            )
+        return response.json()
+
+
+__all__ = ["HarnessSandboxClient", "HarnessSandboxUnavailable"]

--- a/futureagi/simulate/tasks/alk_sim.py
+++ b/futureagi/simulate/tasks/alk_sim.py
@@ -30,7 +30,7 @@ _CSAT_CHOICES = list(CSAT_SCORE_PROMPT["choices"])
 
 @temporal_activity(
     time_limit=600,
-    max_retries=0,
+    max_retries=2,
     queue="tasks_xl",
 )
 def calculate_alk_voice_csat_score(call_execution_id: str) -> None:
@@ -48,14 +48,20 @@ def calculate_alk_voice_csat_score(call_execution_id: str) -> None:
     # evals permanently suppress CSAT whenever they win the race.
     existing_csat = (call.conversation_metrics_data or {}).get("csat_score")
     if existing_csat is not None:
+        _set_csat_state(call, "completed")
         return
 
-    csat_score = _score_from_recording(call)
-    if csat_score is None:
-        csat_score = _score_from_transcript(call)
-    if csat_score is None:
-        logger.info("alk_csat_unavailable", call_execution_id=str(call.id))
-        return
+    _set_csat_state(call, "running")
+    try:
+        csat_score = _score_from_recording(call)
+        if csat_score is None:
+            csat_score = _score_from_transcript(call)
+        if csat_score is None:
+            raise RuntimeError("CSAT scorer returned no result for available evidence")
+    except Exception as exc:
+        _set_csat_state(call, "failed", str(exc))
+        logger.exception("alk_csat_failed", call_execution_id=str(call.id))
+        raise
 
     metrics = dict(call.conversation_metrics_data or {})
     metrics["csat_score"] = csat_score
@@ -67,6 +73,7 @@ def calculate_alk_voice_csat_score(call_execution_id: str) -> None:
         call.overall_score = csat_score
         update_fields.append("overall_score")
     call.save(update_fields=update_fields)
+    _set_csat_state(call, "completed")
     logger.info(
         "alk_csat_scored",
         call_execution_id=str(call.id),
@@ -130,6 +137,16 @@ def _run_agent_csat(output: str) -> float | None:
 
 
 def _build_transcript_text(call: CallExecution) -> str | None:
+    if call.simulation_call_type == CallExecution.SimulationCallType.TEXT:
+        from simulate.models.chat_message import ChatMessageModel
+        from simulate.utils.chat_simulation import _build_chat_transcript
+
+        messages = list(
+            ChatMessageModel.objects.filter(call_execution=call).order_by("created_at")
+        )
+        transcript = _build_chat_transcript(messages)
+        return transcript if transcript and transcript.strip() else None
+
     from simulate.models.test_execution import CallTranscript
 
     segments = list(
@@ -148,3 +165,18 @@ def _build_transcript_text(call: CallExecution) -> str | None:
         if content:
             lines.append(f"{role}: {content}")
     return "\n".join(lines) if lines else None
+
+
+def _set_csat_state(
+    call: CallExecution,
+    status: str,
+    error: str = "",
+) -> None:
+    metadata = dict(call.call_metadata or {})
+    metadata["csat_status"] = status
+    if error:
+        metadata["csat_error"] = error[:2000]
+    else:
+        metadata.pop("csat_error", None)
+    call.call_metadata = metadata
+    call.save(update_fields=["call_metadata"])

--- a/futureagi/simulate/tests/test_alk_simulate_ingestion.py
+++ b/futureagi/simulate/tests/test_alk_simulate_ingestion.py
@@ -598,6 +598,36 @@ class TestMixedResultRollup:
 @pytest.mark.api
 @pytest.mark.django_db
 class TestResultIngest:
+    def test_sealed_result_retry_is_idempotent_and_conflicting_digest_is_rejected(
+        self, auth_client, run_test
+    ):
+        _, call_ids = _start_and_batch(auth_client, run_test)
+        endpoint = f"{ALK_BASE}/call-executions/{call_ids[0]}/result/"
+        body = {
+            "status": "completed",
+            "transcript": _transcript_payload(),
+            "result_digest": "sha256:" + "a" * 64,
+            "artifact_manifest_digest": "sha256:" + "b" * 64,
+        }
+
+        first = auth_client.patch(endpoint, body, format="json")
+        retry = auth_client.patch(endpoint, body, format="json")
+        conflict = auth_client.patch(
+            endpoint,
+            {**body, "result_digest": "sha256:" + "c" * 64},
+            format="json",
+        )
+
+        assert first.status_code == 200, first.content
+        assert retry.status_code == 200, retry.content
+        assert conflict.status_code == 400
+        assert "conflicts" in str(conflict.json()).lower()
+        call = CallExecution.objects.get(id=call_ids[0])
+        assert call.call_metadata["alk_result_digest"] == "sha256:" + "a" * 64
+        assert (
+            call.call_metadata["alk_artifact_manifest_digest"] == "sha256:" + "b" * 64
+        )
+
     def test_harness_checks_complete_external_parent_without_platform_eval_wait(
         self, auth_client, run_test
     ):
@@ -608,9 +638,7 @@ class TestResultIngest:
                 "status": "completed",
                 "transcript": _transcript_payload(),
                 "call_metadata": {
-                    "harness_evaluations": [
-                        {"name": "ride_booked", "passed": False}
-                    ]
+                    "harness_evaluations": [{"name": "ride_booked", "passed": False}]
                 },
             },
             format="json",
@@ -879,6 +907,97 @@ class TestRecordingUpload:
         assert call.recording_available is True
         # Bytes were written to the upload bucket via the storage client.
         fake_client.put_object.assert_called_once()
+
+    def test_recording_checksum_is_verified_and_duplicate_upload_is_idempotent(
+        self, auth_client, run_test
+    ):
+        import hashlib
+        from unittest.mock import MagicMock
+
+        from django.core.files.uploadedfile import SimpleUploadedFile
+
+        _, call_ids = _start_and_batch(auth_client, run_test)
+        endpoint = f"{ALK_BASE}/call-executions/{call_ids[0]}/recording/"
+        content = b"RIFFdurable-audio-evidence"
+        digest = hashlib.sha256(content).hexdigest()
+        fake_client = MagicMock()
+        with (
+            patch(
+                "simulate.services.alk_simulate_ingestion.get_storage_client",
+                return_value=fake_client,
+            ),
+            patch(
+                "simulate.services.alk_simulate_ingestion.get_object_url",
+                return_value="https://storage.example.com/recording.wav",
+            ),
+        ):
+            first = auth_client.post(
+                endpoint,
+                {
+                    "file": SimpleUploadedFile("call.wav", content),
+                    "filename": "call.wav",
+                    "sha256": digest,
+                },
+                format="multipart",
+            )
+            retry = auth_client.post(
+                endpoint,
+                {
+                    "file": SimpleUploadedFile("call.wav", content),
+                    "filename": "call.wav",
+                    "sha256": "sha256:" + digest,
+                },
+                format="multipart",
+            )
+
+        assert first.status_code == retry.status_code == 200
+        assert first.json()["result"] == retry.json()["result"]
+        fake_client.put_object.assert_called_once()
+        call = CallExecution.objects.get(id=call_ids[0])
+        assert (
+            call.call_metadata["alk_recording_artifacts"]["combined"]["sha256"]
+            == digest
+        )
+
+        stereo_content = b"RIFFdifferent-stereo-evidence"
+        stereo_digest = hashlib.sha256(stereo_content).hexdigest()
+        with (
+            patch(
+                "simulate.services.alk_simulate_ingestion.get_storage_client",
+                return_value=fake_client,
+            ),
+            patch(
+                "simulate.services.alk_simulate_ingestion.get_object_url",
+                return_value="https://storage.example.com/stereo.wav",
+            ),
+        ):
+            stereo = auth_client.post(
+                endpoint,
+                {
+                    "file": SimpleUploadedFile("stereo.wav", stereo_content),
+                    "sha256": stereo_digest,
+                    "kind": "stereo",
+                },
+                format="multipart",
+            )
+        assert stereo.status_code == 200
+        call.refresh_from_db()
+        assert call.stereo_recording_url == "https://storage.example.com/stereo.wav"
+        assert (
+            call.call_metadata["alk_recording_artifacts"]["stereo"]["sha256"]
+            == stereo_digest
+        )
+
+        mismatch = auth_client.post(
+            endpoint,
+            {
+                "file": SimpleUploadedFile("call.wav", b"different"),
+                "sha256": digest,
+            },
+            format="multipart",
+        )
+        assert mismatch.status_code == 400
+        assert "sha256" in str(mismatch.json()).lower()
 
     def test_missing_file_returns_400(self, auth_client, run_test):
         _, call_ids = _start_and_batch(auth_client, run_test)

--- a/futureagi/simulate/tests/test_alk_simulate_ingestion.py
+++ b/futureagi/simulate/tests/test_alk_simulate_ingestion.py
@@ -208,6 +208,24 @@ class TestProvisionRunTest:
         assert cell_values["outcome"] == "refunded"
         assert json.loads(cell_values["persona"])["name"] == "Sam"
 
+    def test_provision_voice_preserves_voice_call_type(self, auth_client):
+        resp = self._provision(
+            auth_client,
+            name="sdk-voice-e2e",
+            modality="voice",
+            personas=[{"name": "Avery", "situation": "book a ride"}],
+        )
+        assert resp.status_code == 200, resp.content
+        run_test = RunTest.objects.get(id=resp.json()["result"]["run_test_id"])
+        assert (
+            run_test.agent_definition.agent_type
+            == AgentDefinition.AgentTypeChoices.VOICE
+        )
+
+        _test_execution_id, call_ids = _start_and_batch(auth_client, run_test)
+        call = CallExecution.objects.get(id=call_ids[0])
+        assert call.simulation_call_type == CallExecution.SimulationCallType.VOICE
+
     def test_provisioned_run_test_batches_one_call_per_persona(self, auth_client):
         resp = self._provision(
             auth_client,
@@ -580,6 +598,35 @@ class TestMixedResultRollup:
 @pytest.mark.api
 @pytest.mark.django_db
 class TestResultIngest:
+    def test_harness_checks_complete_external_parent_without_platform_eval_wait(
+        self, auth_client, run_test
+    ):
+        test_execution_id, call_ids = _start_and_batch(auth_client, run_test)
+        resp = auth_client.patch(
+            f"{ALK_BASE}/call-executions/{call_ids[0]}/result/",
+            {
+                "status": "completed",
+                "transcript": _transcript_payload(),
+                "call_metadata": {
+                    "harness_evaluations": [
+                        {"name": "ride_booked", "passed": False}
+                    ]
+                },
+            },
+            format="json",
+        )
+        assert resp.status_code == 200, resp.content
+
+        call = CallExecution.objects.get(id=call_ids[0])
+        execution = SimTestExecution.objects.get(id=test_execution_id)
+        assert call.call_metadata["eval_started"] is True
+        assert call.call_metadata["eval_completed"] is True
+        assert execution.status == SimTestExecution.ExecutionStatus.COMPLETED
+        assert execution.completed_at is not None
+        assert execution.total_calls == 1
+        assert execution.completed_calls == 1
+        assert execution.failed_calls == 0
+
     def test_ingest_computes_metrics_and_duration(self, auth_client, run_test):
         _, call_ids = _start_and_batch(auth_client, run_test)
         call_id = call_ids[0]
@@ -827,6 +874,9 @@ class TestRecordingUpload:
         result = resp.json()["result"]
         assert result["recording_url"].endswith(".wav")
         assert result["object_key"].startswith("alk-sim/recordings/")
+        call = CallExecution.objects.get(id=call_id)
+        assert call.recording_url == result["recording_url"]
+        assert call.recording_available is True
         # Bytes were written to the upload bucket via the storage client.
         fake_client.put_object.assert_called_once()
 

--- a/futureagi/simulate/tests/test_alk_simulate_ingestion.py
+++ b/futureagi/simulate/tests/test_alk_simulate_ingestion.py
@@ -226,6 +226,24 @@ class TestProvisionRunTest:
         call = CallExecution.objects.get(id=call_ids[0])
         assert call.simulation_call_type == CallExecution.SimulationCallType.VOICE
 
+    def test_provision_accepts_alk_chat_alias_as_text(self, auth_client):
+        resp = self._provision(
+            auth_client,
+            name="sdk-chat-e2e",
+            modality="chat",
+            personas=[{"name": "Mina", "situation": "check account status"}],
+        )
+        assert resp.status_code == 200, resp.content
+        run_test = RunTest.objects.get(id=resp.json()["result"]["run_test_id"])
+        assert (
+            run_test.agent_definition.agent_type
+            == AgentDefinition.AgentTypeChoices.TEXT
+        )
+
+        _test_execution_id, call_ids = _start_and_batch(auth_client, run_test)
+        call = CallExecution.objects.get(id=call_ids[0])
+        assert call.simulation_call_type == CallExecution.SimulationCallType.TEXT
+
     def test_provisioned_run_test_batches_one_call_per_persona(self, auth_client):
         resp = self._provision(
             auth_client,

--- a/futureagi/simulate/tests/test_alk_simulate_ingestion.py
+++ b/futureagi/simulate/tests/test_alk_simulate_ingestion.py
@@ -18,11 +18,13 @@ from unittest.mock import patch
 import pytest
 
 from model_hub.models.choices import StatusType
+from model_hub.models.evals_metric import EvalTemplate
 from simulate.models import (
     AgentDefinition,
     RunTest,
     Scenarios,
     SimulatorAgent,
+    SimulateEvalConfig,
 )
 from simulate.models.test_execution import (
     CallExecution,
@@ -667,11 +669,74 @@ class TestResultIngest:
         execution = SimTestExecution.objects.get(id=test_execution_id)
         assert call.call_metadata["eval_started"] is True
         assert call.call_metadata["eval_completed"] is True
+        assert len(call.eval_outputs) == 1
+        direct_result = next(iter(call.eval_outputs.values()))
+        assert direct_result == {
+            "name": "ride_booked",
+            "output": "Failed",
+            "output_type": "Pass/Fail",
+            "reason": "",
+            "status": "completed",
+            "source": "harness",
+            "kind": "checkpoint",
+            "platform_template": "",
+        }
         assert execution.status == SimTestExecution.ExecutionStatus.COMPLETED
         assert execution.completed_at is not None
         assert execution.total_calls == 1
         assert execution.completed_calls == 1
         assert execution.failed_calls == 0
+
+    def test_platform_judgement_is_linked_to_run_eval_config_and_output(
+        self, auth_client, run_test
+    ):
+        template = EvalTemplate.objects.create(
+            name="alk-platform-check",
+            organization=run_test.organization,
+            workspace=run_test.workspace,
+            owner="user",
+            eval_type="llm",
+            output_type_normalized="pass_fail",
+        )
+        _, call_ids = _start_and_batch(auth_client, run_test)
+
+        resp = auth_client.patch(
+            f"{ALK_BASE}/call-executions/{call_ids[0]}/result/",
+            {
+                "status": "completed",
+                "transcript": _transcript_payload(),
+                "call_metadata": {
+                    "harness_evaluations": [
+                        {
+                            "name": "response_wording",
+                            "kind": "eval",
+                            "passed": True,
+                            "reason": "matched the required response",
+                            "platform_template": template.name,
+                        }
+                    ]
+                },
+            },
+            format="json",
+        )
+        assert resp.status_code == 200, resp.content
+
+        config = SimulateEvalConfig.objects.get(
+            run_test=run_test,
+            eval_template=template,
+            name="response_wording",
+        )
+        call = CallExecution.objects.get(id=call_ids[0])
+        assert call.eval_outputs[str(config.id)] == {
+            "name": "response_wording",
+            "output": "Passed",
+            "output_type": "Pass/Fail",
+            "reason": "matched the required response",
+            "status": "completed",
+            "source": "harness",
+            "kind": "eval",
+            "platform_template": template.name,
+        }
 
     def test_ingest_computes_metrics_and_duration(self, auth_client, run_test):
         _, call_ids = _start_and_batch(auth_client, run_test)
@@ -2025,6 +2090,7 @@ class TestAlkVoiceCsatScoring:
 
         call.refresh_from_db()
         assert call.conversation_metrics_data["csat_score"] == 8.0
+        assert call.call_metadata["csat_status"] == "completed"
         # eval-derived overall_score must not be clobbered
         assert call.overall_score == 3.0
 
@@ -2044,6 +2110,7 @@ class TestAlkVoiceCsatScoring:
         scorer.assert_not_called()
         call.refresh_from_db()
         assert call.conversation_metrics_data["csat_score"] == 6.0
+        assert call.call_metadata["csat_status"] == "completed"
 
     def test_seeds_overall_score_when_unset(self, auth_client, run_test):
         from simulate.tasks import alk_sim
@@ -2060,6 +2127,23 @@ class TestAlkVoiceCsatScoring:
         call.refresh_from_db()
         assert call.conversation_metrics_data["csat_score"] == 7.0
         assert call.overall_score == 7.0
+        assert call.call_metadata["csat_status"] == "completed"
+
+    def test_failed_scorer_is_durable_and_retryable(self, auth_client, run_test):
+        from simulate.tasks import alk_sim
+
+        call = self._completed_voice_call(auth_client, run_test)
+        with (
+            patch("simulate.tasks.alk_sim.close_old_connections"),
+            patch.object(alk_sim, "_run_agent_csat", return_value=None),
+            pytest.raises(RuntimeError, match="returned no result"),
+        ):
+            alk_sim.calculate_alk_voice_csat_score._original_func(str(call.id))
+
+        call.refresh_from_db()
+        assert call.call_metadata["csat_status"] == "failed"
+        assert "returned no result" in call.call_metadata["csat_error"]
+        assert not (call.conversation_metrics_data or {}).get("csat_score")
 
 
 def test_alk_sim_task_module_registered_for_worker():

--- a/futureagi/simulate/tests/test_alk_simulate_ingestion.py
+++ b/futureagi/simulate/tests/test_alk_simulate_ingestion.py
@@ -178,7 +178,12 @@ class TestProvisionRunTest:
             auth_client,
             name="sdk-e2e",
             personas=[
-                {"name": "Sam", "situation": "refund please", "outcome": "refunded"}
+                {
+                    "name": "Sam",
+                    "scenario_name": "Resolve a late refund",
+                    "situation": "refund please",
+                    "outcome": "refunded",
+                }
             ],
         )
         assert resp.status_code == 200, resp.content
@@ -192,6 +197,8 @@ class TestProvisionRunTest:
         )
         assert run_test.scenarios.count() == 1
         scenario = Scenarios.objects.get(id=result["scenario_ids"][0])
+        assert scenario.name == "Resolve a late refund"
+        assert not scenario.name.startswith(run_test.name)
         assert scenario.status == StatusType.COMPLETED.value
         assert scenario.metadata["persona"]["name"] == "Sam"
 
@@ -351,6 +358,49 @@ class TestStartTestExecution:
         )
         assert resp.status_code == 404
         assert resp.json()["status"] is False
+
+    def test_scenario_selectors_preserve_runner_order_for_saved_run(
+        self, auth_client, run_test, scenario
+    ):
+        scenario.metadata = {
+            "origin": "alk_sdk_ingestion",
+            "persona": {"scenario_key": "case-a", "persona": {"name": "A"}},
+        }
+        scenario.save(update_fields=["metadata"])
+        second = Scenarios.objects.create(
+            name="Second saved case",
+            source="second",
+            scenario_type=Scenarios.ScenarioTypes.DATASET,
+            organization=run_test.organization,
+            workspace=run_test.workspace,
+            agent_definition=run_test.agent_definition,
+            status=StatusType.COMPLETED.value,
+            metadata={
+                "origin": "alk_sdk_ingestion",
+                "persona": {
+                    "scenario_key": "case-b",
+                    "persona": {"name": "B"},
+                },
+            },
+        )
+        run_test.scenarios.add(second)
+
+        resp = auth_client.post(
+            f"{ALK_BASE}/run-tests/{run_test.id}/test-executions/",
+            {
+                "scenario_selectors": [
+                    {"scenario_key": "case-b", "persona_name": "B"},
+                    {"scenario_key": "case-a", "persona_name": "A"},
+                ]
+            },
+            format="json",
+        )
+
+        assert resp.status_code == 200, resp.content
+        assert resp.json()["result"]["scenario_ids"] == [
+            str(second.id),
+            str(scenario.id),
+        ]
 
     def test_scenario_not_on_run_test_returns_400(self, auth_client, run_test):
         other = "11111111-1111-4111-8111-111111111111"

--- a/futureagi/simulate/tests/test_harness_job_api.py
+++ b/futureagi/simulate/tests/test_harness_job_api.py
@@ -1,0 +1,60 @@
+from unittest.mock import patch
+
+import pytest
+from rest_framework.test import APIClient
+
+
+@pytest.mark.django_db
+def test_harness_job_create_proxies_typed_request(user):
+    client = APIClient()
+    client.force_authenticate(user=user)
+    expected = {"job": {"job_id": "job-1"}, "status": {"stage": "queued"}}
+
+    with patch("simulate.views.harness_job.HarnessSandboxClient.submit", return_value=expected) as submit:
+        response = client.post(
+            "/simulate/api/harness-jobs/",
+            {"source_path": "/workspace/agent", "scenario_count": 10},
+            format="json",
+        )
+
+    assert response.status_code == 202
+    assert response.json() == expected
+    assert submit.call_args.args[0]["source_path"] == "/workspace/agent"
+
+
+@pytest.mark.django_db
+def test_harness_job_create_rejects_inline_credentials(user):
+    client = APIClient()
+    client.force_authenticate(user=user)
+
+    response = client.post(
+        "/simulate/api/harness-jobs/",
+        {
+            "source_path": "/workspace/agent",
+            "connector_config": {"api_key": "must-not-cross-control-plane"},
+        },
+        format="json",
+    )
+
+    assert response.status_code == 400
+
+
+@pytest.mark.django_db
+def test_harness_job_cancel_accepts_optional_audit_reason(user):
+    client = APIClient()
+    client.force_authenticate(user=user)
+    expected = {"job": {"job_id": "job-1"}, "status": {"stage": "canceled"}}
+
+    with patch(
+        "simulate.views.harness_job.HarnessSandboxClient.cancel",
+        return_value=expected,
+    ) as cancel:
+        response = client.post(
+            "/simulate/api/harness-jobs/job-1/cancel/",
+            {"reason": "operator requested stop"},
+            format="json",
+        )
+
+    assert response.status_code == 200
+    assert response.json() == expected
+    cancel.assert_called_once_with("job-1")

--- a/futureagi/simulate/tests/test_harness_job_api.py
+++ b/futureagi/simulate/tests/test_harness_job_api.py
@@ -306,3 +306,44 @@ def test_harness_job_cancel_accepts_optional_audit_reason(user):
     assert response.status_code == 200
     assert response.json() == expected
     cancel.assert_called_once_with("job-1")
+
+
+@pytest.mark.django_db
+def test_harness_job_adjustment_is_validated_and_forwarded(user):
+    client = APIClient()
+    client.force_authenticate(user=user)
+    expected = {
+        "job": {"job_id": "job-1"},
+        "status": {"stage": "generating_scenarios"},
+        "adjustments": [{"status": "pending"}],
+    }
+    payload = {
+        "instruction": "Add 10 more scenarios covering payment failures",
+        "client_request_id": "browser-1",
+    }
+
+    with patch(
+        "simulate.views.harness_job.HarnessSandboxClient.adjust",
+        return_value=expected,
+    ) as adjust:
+        response = client.post(
+            "/simulate/api/harness-jobs/job-1/adjust/", payload, format="json"
+        )
+
+    assert response.status_code == 200
+    assert response.json() == expected
+    adjust.assert_called_once_with("job-1", payload)
+
+
+@pytest.mark.django_db
+def test_harness_job_adjustment_rejects_empty_instruction(user):
+    client = APIClient()
+    client.force_authenticate(user=user)
+
+    response = client.post(
+        "/simulate/api/harness-jobs/job-1/adjust/",
+        {"instruction": "   "},
+        format="json",
+    )
+
+    assert response.status_code == 400

--- a/futureagi/simulate/tests/test_harness_job_api.py
+++ b/futureagi/simulate/tests/test_harness_job_api.py
@@ -1,6 +1,7 @@
 from unittest.mock import patch
 
 import pytest
+from django.core.files.uploadedfile import SimpleUploadedFile
 from rest_framework.test import APIClient
 
 
@@ -25,6 +26,61 @@ def test_harness_job_create_proxies_typed_request(user):
 
 
 @pytest.mark.django_db
+def test_harness_source_folder_upload_is_forwarded_to_sandbox(user):
+    client = APIClient()
+    client.force_authenticate(user=user)
+    expected = {
+        "source_id": "63ef3598-a84d-4ce0-a7a1-53c4e27f69f7",
+        "name": "agent",
+        "file_count": 2,
+        "total_bytes": 18,
+    }
+    files = [
+        SimpleUploadedFile("agent.py", b"print('ready')\n"),
+        SimpleUploadedFile("requirements.txt", b"fastapi\n"),
+    ]
+
+    with patch(
+        "simulate.views.harness_job.HarnessSandboxClient.upload_source",
+        return_value=expected,
+    ) as upload:
+        response = client.post(
+            "/simulate/api/harness-jobs/sources/",
+            {
+                "files": files,
+                "paths": ["agent.py", "requirements.txt"],
+                "name": "agent",
+            },
+            format="multipart",
+        )
+
+    assert response.status_code == 201
+    assert response.json() == expected
+    assert upload.call_args.args[1] == ["agent.py", "requirements.txt"]
+    assert upload.call_args.args[2] == "agent"
+
+
+@pytest.mark.django_db
+def test_harness_job_accepts_uploaded_source_id(user):
+    client = APIClient()
+    client.force_authenticate(user=user)
+    source_id = "63ef3598-a84d-4ce0-a7a1-53c4e27f69f7"
+    expected = {"job": {"job_id": "job-1"}, "status": {"stage": "queued"}}
+
+    with patch(
+        "simulate.views.harness_job.HarnessSandboxClient.submit", return_value=expected
+    ) as submit:
+        response = client.post(
+            "/simulate/api/harness-jobs/",
+            {"source_id": source_id, "scenario_count": 10},
+            format="json",
+        )
+
+    assert response.status_code == 202
+    assert str(submit.call_args.args[0]["source_id"]) == source_id
+
+
+@pytest.mark.django_db
 def test_harness_job_create_rejects_inline_credentials(user):
     client = APIClient()
     client.force_authenticate(user=user)
@@ -39,6 +95,73 @@ def test_harness_job_create_rejects_inline_credentials(user):
     )
 
     assert response.status_code == 400
+
+
+@pytest.mark.django_db
+def test_harness_job_forwards_ephemeral_environment_without_echoing_it(user):
+    client = APIClient()
+    client.force_authenticate(user=user)
+    expected = {"job": {"job_id": "job-1"}, "status": {"stage": "queued"}}
+
+    with patch(
+        "simulate.views.harness_job.HarnessSandboxClient.submit", return_value=expected
+    ) as submit:
+        response = client.post(
+            "/simulate/api/harness-jobs/",
+            {
+                "source_path": "/workspace/agent",
+                "environment_values": {"OPENAI_API_KEY": "ephemeral-value"},
+            },
+            format="json",
+        )
+
+    assert response.status_code == 202
+    assert "ephemeral-value" not in response.content.decode()
+    assert submit.call_args.args[0]["environment_values"] == {
+        "OPENAI_API_KEY": "ephemeral-value"
+    }
+
+
+@pytest.mark.django_db
+def test_harness_job_rejects_invalid_or_conflicting_environment_values(user):
+    client = APIClient()
+    client.force_authenticate(user=user)
+
+    invalid = client.post(
+        "/simulate/api/harness-jobs/",
+        {
+            "source_path": "/workspace/agent",
+            "environment_values": {"NOT-AN-ENV": "value"},
+        },
+        format="json",
+    )
+    conflict = client.post(
+        "/simulate/api/harness-jobs/",
+        {
+            "source_path": "/workspace/agent",
+            "environment_values": {"OPENAI_API_KEY": "value"},
+            "secret_refs": {
+                "OPENAI_API_KEY": {
+                    "manager": "futureagi",
+                    "key": "existing-secret",
+                    "purpose": "existing reference",
+                }
+            },
+        },
+        format="json",
+    )
+    reserved = client.post(
+        "/simulate/api/harness-jobs/",
+        {
+            "source_path": "/workspace/agent",
+            "environment_values": {"DOCKER_HOST": "tcp://untrusted:2375"},
+        },
+        format="json",
+    )
+
+    assert invalid.status_code == 400
+    assert conflict.status_code == 400
+    assert reserved.status_code == 400
 
 
 @pytest.mark.django_db
@@ -64,6 +187,27 @@ def test_harness_preflight_proxies_public_github_source(user):
     assert response.status_code == 200
     assert response.json() == expected
     assert preflight.call_args.args[0]["github_visibility"] == "public"
+
+
+@pytest.mark.django_db
+def test_harness_job_forwards_public_github_branch_url_unchanged(user):
+    client = APIClient()
+    client.force_authenticate(user=user)
+    expected = {"job": {"job_id": "job-1"}, "status": {"stage": "queued"}}
+    url = "https://github.com/future-agi/future-agi/tree/feat/harness"
+
+    with patch(
+        "simulate.views.harness_job.HarnessSandboxClient.submit", return_value=expected
+    ) as submit:
+        response = client.post(
+            "/simulate/api/harness-jobs/",
+            {"github_repository": url},
+            format="json",
+        )
+
+    assert response.status_code == 202
+    assert submit.call_args.args[0]["github_repository"] == url
+    assert "github_ref" not in submit.call_args.args[0]
 
 
 @pytest.mark.django_db

--- a/futureagi/simulate/tests/test_harness_job_api.py
+++ b/futureagi/simulate/tests/test_harness_job_api.py
@@ -61,6 +61,98 @@ def test_harness_source_folder_upload_is_forwarded_to_sandbox(user):
 
 
 @pytest.mark.django_db
+def test_harness_secret_file_upload_returns_only_opaque_reference(user):
+    client = APIClient()
+    client.force_authenticate(user=user)
+    raw = b'{"type":"service_account","private_key":"must-not-be-echoed"}'
+    response = client.post(
+        "/simulate/api/harness-jobs/secret-files/",
+        {
+            "file": SimpleUploadedFile(
+                "customer-google.json", raw, content_type="application/json"
+            ),
+            "environment_name": "GOOGLE_APPLICATION_CREDENTIALS",
+        },
+        format="multipart",
+    )
+
+    assert response.status_code == 201
+    result = response.json()
+    assert result["environment_name"] == "GOOGLE_APPLICATION_CREDENTIALS"
+    assert result["size"] == len(raw)
+    assert result["secret_ref"]["manager"] == "harness_environment_file"
+    assert result["secret_ref"]["key"]
+    assert raw.decode() not in response.content.decode()
+
+    from simulate.models import HarnessCredentialFile
+
+    record = HarnessCredentialFile.objects.get(id=result["secret_ref"]["key"])
+    assert raw.decode() not in record.encrypted_content
+    assert record.get_content() == raw
+
+
+@pytest.mark.django_db
+def test_harness_job_persists_encrypted_credentials_and_materializes_file(user):
+    from simulate.models import HarnessEnvironmentCredentials
+
+    client = APIClient()
+    client.force_authenticate(user=user)
+    raw = b'{"type":"service_account","private_key":"private-material"}'
+    uploaded = client.post(
+        "/simulate/api/harness-jobs/secret-files/",
+        {
+            "file": SimpleUploadedFile("google.json", raw),
+            "environment_name": "GOOGLE_APPLICATION_CREDENTIALS",
+        },
+        format="multipart",
+    ).json()
+    job_id = "saved-harness-job"
+    accepted = {"job": {"job_id": job_id}, "status": {"stage": "queued"}}
+    attempt_ref = {
+        "manager": "mounted",
+        "key": "attempt-only-file",
+        "purpose": "attempt credential",
+    }
+
+    with (
+        patch(
+            "simulate.views.harness_job.HarnessSandboxClient.upload_secret_file",
+            return_value={
+                "environment_name": "GOOGLE_APPLICATION_CREDENTIALS",
+                "secret_ref": attempt_ref,
+                "size": len(raw),
+            },
+        ) as materialize,
+        patch(
+            "simulate.views.harness_job.HarnessSandboxClient.submit",
+            return_value=accepted,
+        ) as submit,
+    ):
+        response = client.post(
+            "/simulate/api/harness-jobs/",
+            {
+                "source_path": "/workspace/agent",
+                "scenario_count": 2,
+                "environment_values": {"DEEPGRAM_API_KEY": "secret-value"},
+                "secret_refs": {
+                    "GOOGLE_APPLICATION_CREDENTIALS": uploaded["secret_ref"]
+                },
+            },
+            format="json",
+        )
+
+    assert response.status_code == 202
+    assert submit.call_args.args[0]["secret_refs"] == {
+        "GOOGLE_APPLICATION_CREDENTIALS": attempt_ref
+    }
+    assert materialize.call_count == 1
+    profile = HarnessEnvironmentCredentials.objects.get(harness_job_id=job_id)
+    assert "secret-value" not in profile.encrypted_environment
+    assert profile.get_environment() == {"DEEPGRAM_API_KEY": "secret-value"}
+    assert profile.credential_file_ids == [uploaded["secret_ref"]["key"]]
+
+
+@pytest.mark.django_db
 def test_harness_job_accepts_uploaded_source_id(user):
     client = APIClient()
     client.force_authenticate(user=user)

--- a/futureagi/simulate/tests/test_harness_job_api.py
+++ b/futureagi/simulate/tests/test_harness_job_api.py
@@ -10,7 +10,9 @@ def test_harness_job_create_proxies_typed_request(user):
     client.force_authenticate(user=user)
     expected = {"job": {"job_id": "job-1"}, "status": {"stage": "queued"}}
 
-    with patch("simulate.views.harness_job.HarnessSandboxClient.submit", return_value=expected) as submit:
+    with patch(
+        "simulate.views.harness_job.HarnessSandboxClient.submit", return_value=expected
+    ) as submit:
         response = client.post(
             "/simulate/api/harness-jobs/",
             {"source_path": "/workspace/agent", "scenario_count": 10},
@@ -32,6 +34,108 @@ def test_harness_job_create_rejects_inline_credentials(user):
         {
             "source_path": "/workspace/agent",
             "connector_config": {"api_key": "must-not-cross-control-plane"},
+        },
+        format="json",
+    )
+
+    assert response.status_code == 400
+
+
+@pytest.mark.django_db
+def test_harness_preflight_proxies_public_github_source(user):
+    client = APIClient()
+    client.force_authenticate(user=user)
+    expected = {
+        "source_kind": "github",
+        "ready_to_submit": True,
+        "credentials": {"requirements": []},
+    }
+
+    with patch(
+        "simulate.views.harness_job.HarnessSandboxClient.preflight",
+        return_value=expected,
+    ) as preflight:
+        response = client.post(
+            "/simulate/api/harness-jobs/preflight/",
+            {"github_repository": "future-agi/public-agent"},
+            format="json",
+        )
+
+    assert response.status_code == 200
+    assert response.json() == expected
+    assert preflight.call_args.args[0]["github_visibility"] == "public"
+
+
+@pytest.mark.django_db
+def test_harness_preflight_forwards_non_secret_configuration(user):
+    client = APIClient()
+    client.force_authenticate(user=user)
+    expected = {"source_kind": "local_repository", "ready_to_submit": True}
+
+    with patch(
+        "simulate.views.harness_job.HarnessSandboxClient.preflight",
+        return_value=expected,
+    ) as preflight:
+        response = client.post(
+            "/simulate/api/harness-jobs/preflight/",
+            {
+                "source_path": "/workspace/agent",
+                "connector_config": {"REMOTE_AGENT_ID": "agent-42"},
+            },
+            format="json",
+        )
+
+    assert response.status_code == 200
+    assert preflight.call_args.args[0]["connector_config"] == {
+        "REMOTE_AGENT_ID": "agent-42"
+    }
+
+
+@pytest.mark.django_db
+def test_harness_preflight_rejects_secret_like_configuration_keys(user):
+    client = APIClient()
+    client.force_authenticate(user=user)
+
+    response = client.post(
+        "/simulate/api/harness-jobs/preflight/",
+        {
+            "source_path": "/workspace/agent",
+            "connector_config": {"GEMINI_API_KEY": "inline-secret"},
+        },
+        format="json",
+    )
+
+    assert response.status_code == 400
+
+
+@pytest.mark.django_db
+def test_private_github_source_requires_app_installation(user):
+    client = APIClient()
+    client.force_authenticate(user=user)
+
+    response = client.post(
+        "/simulate/api/harness-jobs/",
+        {
+            "github_repository": "customer/private-agent",
+            "github_visibility": "private",
+        },
+        format="json",
+    )
+
+    assert response.status_code == 400
+    assert "github_installation_id" in response.json()["detail"]
+
+
+@pytest.mark.django_db
+def test_harness_job_rejects_ambiguous_source(user):
+    client = APIClient()
+    client.force_authenticate(user=user)
+
+    response = client.post(
+        "/simulate/api/harness-jobs/",
+        {
+            "source_path": "/workspace/agent",
+            "github_repository": "customer/agent",
         },
         format="json",
     )

--- a/futureagi/simulate/tests/test_rerun_api.py
+++ b/futureagi/simulate/tests/test_rerun_api.py
@@ -342,10 +342,15 @@ class TestCallExecutionRerunView:
         assert test_execution.status == TestExecution.ExecutionStatus.RUNNING
 
     @pytest.mark.requires_ee
+    @patch(
+        "simulate.services.harness_credentials.credentials_for_rerun",
+        return_value=({"LIVEKIT_URL": "wss://example.invalid"}, {}),
+    )
     @patch("simulate.services.harness_sandbox.HarnessSandboxClient.rerun")
     def test_repository_harness_rerun_restarts_saved_environment_without_resetting_calls(
         self,
         rerun_saved_job,
+        _saved_credentials,
         auth_client,
         test_execution,
         call_execution,
@@ -383,6 +388,49 @@ class TestCallExecutionRerunView:
         call_execution.refresh_from_db()
         assert call_execution.status == CallExecution.CallStatus.COMPLETED
         assert call_execution.call_metadata == original_metadata
+
+
+@pytest.mark.integration
+@pytest.mark.api
+class TestRepositoryRunAgainView:
+    """The simulation header and grid must share the repository lifecycle."""
+
+    @patch("simulate.views.run_test._voice_sim_gate_response", return_value=None)
+    @patch(
+        "simulate.services.harness_credentials.credentials_for_rerun",
+        return_value=({}, {}),
+    )
+    @patch("simulate.services.harness_sandbox.HarnessSandboxClient.rerun")
+    def test_run_again_restarts_saved_harness_instead_of_creating_pending_execution(
+        self,
+        rerun_saved_job,
+        _saved_credentials,
+        _voice_gate,
+        auth_client,
+        run_test,
+        test_execution,
+        scenario,
+    ):
+        job_id = uuid.uuid4()
+        test_execution.execution_metadata = {"harness_job_id": str(job_id)}
+        test_execution.scenario_ids = [str(scenario.id)]
+        test_execution.save(update_fields=["execution_metadata", "scenario_ids"])
+        rerun_saved_job.return_value = {"status": {"stage": "queued"}}
+        execution_count = TestExecution.objects.count()
+
+        response = auth_client.post(
+            f"/simulate/run-tests/{run_test.id}/execute/",
+            {"scenario_ids": [str(scenario.id)]},
+            format="json",
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        assert response.json()["status"] == "queued"
+        assert TestExecution.objects.count() == execution_count
+        rerun_saved_job.assert_called_once_with(
+            str(job_id),
+            {"environment_values": {}, "secret_refs": {}, "only": []},
+        )
 
     @pytest.mark.requires_ee
     @patch("simulate.views.run_test._hosted_execution_eligible", return_value=False)
@@ -525,6 +573,47 @@ class TestTestExecutionRerunView:
     """Tests for POST /simulate/run-tests/<uuid>/rerun-test-executions/"""
 
     URL_TEMPLATE = "/simulate/run-tests/{}/rerun-test-executions/"
+
+    @patch("simulate.views.run_test._voice_sim_gate_response", return_value=None)
+    @patch(
+        "simulate.services.harness_credentials.credentials_for_rerun",
+        return_value=({}, {}),
+    )
+    @patch("simulate.services.harness_sandbox.HarnessSandboxClient.rerun")
+    def test_grid_rerun_restarts_saved_harness_without_resetting_calls(
+        self,
+        rerun_saved_job,
+        _saved_credentials,
+        _voice_gate,
+        auth_client,
+        run_test,
+        test_execution,
+        call_execution,
+    ):
+        job_id = uuid.uuid4()
+        test_execution.execution_metadata = {"harness_job_id": str(job_id)}
+        test_execution.save(update_fields=["execution_metadata"])
+        rerun_saved_job.return_value = {"status": {"stage": "queued"}}
+        original_metadata = dict(call_execution.call_metadata)
+
+        response = auth_client.post(
+            self.URL_TEMPLATE.format(run_test.id),
+            {
+                "rerun_type": "call_and_eval",
+                "test_execution_ids": [str(test_execution.id)],
+            },
+            format="json",
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        assert response.json()["overall_success_count"] == 1
+        rerun_saved_job.assert_called_once_with(
+            str(job_id),
+            {"environment_values": {}, "secret_refs": {}, "only": []},
+        )
+        call_execution.refresh_from_db()
+        assert call_execution.status == CallExecution.CallStatus.COMPLETED
+        assert call_execution.call_metadata == original_metadata
 
     @patch("simulate.temporal.client.rerun_call_executions")
     def test_rerun_eval_only_select_all(

--- a/futureagi/simulate/tests/test_rerun_api.py
+++ b/futureagi/simulate/tests/test_rerun_api.py
@@ -342,6 +342,50 @@ class TestCallExecutionRerunView:
         assert test_execution.status == TestExecution.ExecutionStatus.RUNNING
 
     @pytest.mark.requires_ee
+    @patch("simulate.services.harness_sandbox.HarnessSandboxClient.rerun")
+    def test_repository_harness_rerun_restarts_saved_environment_without_resetting_calls(
+        self,
+        rerun_saved_job,
+        auth_client,
+        test_execution,
+        call_execution,
+    ):
+        job_id = uuid.uuid4()
+        test_execution.execution_metadata = {"harness_job_id": str(job_id)}
+        test_execution.save(update_fields=["execution_metadata"])
+        rerun_saved_job.return_value = {
+            "status": {"stage": "queued", "detail": "waiting to restart"}
+        }
+        original_metadata = dict(call_execution.call_metadata)
+
+        response = auth_client.post(
+            self.URL_TEMPLATE.format(test_execution.id),
+            {
+                "rerun_type": "call_and_eval",
+                "select_all": True,
+                "environment_values": {"LIVEKIT_URL": "wss://example.invalid"},
+            },
+            format="json",
+        )
+
+        assert response.status_code == status.HTTP_202_ACCEPTED
+        assert response.json()["harness_job_id"] == str(job_id)
+        rerun_saved_job.assert_called_once_with(
+            str(job_id),
+            {
+                "environment_values": {
+                    "LIVEKIT_URL": "wss://example.invalid"
+                },
+                "secret_refs": {},
+                "only": [],
+            },
+        )
+        call_execution.refresh_from_db()
+        assert call_execution.status == CallExecution.CallStatus.COMPLETED
+        assert call_execution.call_metadata == original_metadata
+
+    @pytest.mark.requires_ee
+    @patch("simulate.views.run_test._hosted_execution_eligible", return_value=False)
     @patch(
         "simulate.temporal.client.rerun_call_executions",
         side_effect=TimeoutError("temporal dispatch timed out"),
@@ -349,6 +393,7 @@ class TestCallExecutionRerunView:
     def test_rerun_call_and_eval_marks_failed_when_dispatch_fails(
         self,
         mock_rerun,
+        _native_execution,
         auth_client,
         test_execution,
         call_execution,

--- a/futureagi/simulate/tests/test_rerun_api.py
+++ b/futureagi/simulate/tests/test_rerun_api.py
@@ -395,6 +395,8 @@ class TestCallExecutionRerunView:
 class TestRepositoryRunAgainView:
     """The simulation header and grid must share the repository lifecycle."""
 
+    URL_TEMPLATE = "/simulate/test-executions/{}/rerun-calls/"
+
     @patch("simulate.views.run_test._voice_sim_gate_response", return_value=None)
     @patch(
         "simulate.services.harness_credentials.credentials_for_rerun",

--- a/futureagi/simulate/tests/test_simulation_read_surfaces.py
+++ b/futureagi/simulate/tests/test_simulation_read_surfaces.py
@@ -215,6 +215,32 @@ def test_get_eval_outputs_skips_missing_config(simulation_tree, eval_configs):
 
 
 @pytest.mark.django_db
+def test_get_eval_outputs_keeps_external_harness_results_without_config(
+    simulation_tree, eval_configs
+):
+    live, _ = eval_configs["live"], eval_configs["deleted"]
+    call_execution = simulation_tree["call_execution"]
+    harness_id = str(uuid.uuid4())
+    call_execution.eval_outputs = {
+        harness_id: {
+            "name": "database_state_verified",
+            "output": "Passed",
+            "output_type": "Pass/Fail",
+            "status": "completed",
+            "source": "harness",
+        }
+    }
+    call_execution.save(update_fields=["eval_outputs"])
+
+    outputs = CallExecutionDetailSerializer(
+        context={"eval_configs": {str(live.id): live}}
+    ).get_eval_outputs(call_execution)
+
+    assert outputs[harness_id]["name"] == "database_state_verified"
+    assert outputs[harness_id]["value"] == "Passed"
+
+
+@pytest.mark.django_db
 def test_get_eval_metrics_skips_missing_config(simulation_tree, eval_configs):
     live, deleted = eval_configs["live"], eval_configs["deleted"]
     call_execution = simulation_tree["call_execution"]

--- a/futureagi/simulate/urls.py
+++ b/futureagi/simulate/urls.py
@@ -96,6 +96,7 @@ from .views.agent_version import (
     RestoreAgentVersionView,
 )
 from .views.alk_simulate_ingestion import ALKSimulateIngestionViewSet
+from .views.harness_job import HarnessJobViewSet
 from .views.livekit_api import (
     CallConfigView,
     CallExecutionUpdateView,
@@ -123,6 +124,7 @@ router.register(r"agent-prompt-optimiser", AgentPromptOptimiserRunViewSet)
 router.register(
     r"alk-simulate", ALKSimulateIngestionViewSet, basename="alk-simulate-ingestion"
 )
+router.register(r"harness-jobs", HarnessJobViewSet, basename="harness-job")
 
 urlpatterns = [
     path("api/", include(router.urls)),

--- a/futureagi/simulate/utils/eval_summary.py
+++ b/futureagi/simulate/utils/eval_summary.py
@@ -18,7 +18,14 @@ def iter_live_eval_outputs(eval_outputs, eval_configs: Container[str]):
     if not isinstance(eval_outputs, dict):
         return
     for eval_id, eval_data in eval_outputs.items():
-        if str(eval_id) in eval_configs:
+        # Harness-native checks are already-computed execution evidence and do
+        # not necessarily have a reusable EvalTemplate/SimulateEvalConfig. They
+        # remain live by source marker; template-backed harness judgements use a
+        # normal config ID and pass the membership check below.
+        is_harness_result = (
+            isinstance(eval_data, dict) and eval_data.get("source") == "harness"
+        )
+        if str(eval_id) in eval_configs or is_harness_result:
             yield eval_id, eval_data
 
 

--- a/futureagi/simulate/views/alk_simulate_ingestion.py
+++ b/futureagi/simulate/views/alk_simulate_ingestion.py
@@ -352,6 +352,8 @@ class ALKSimulateIngestionViewSet(ViewSet):
                 call_execution,
                 audio_bytes,
                 filename=filename,
+                expected_sha256=request.validated_data.get("sha256"),
+                kind=request.validated_data.get("kind", "combined"),
             )
         except ALKSimulateIngestionError as e:
             return self.gm.bad_request(str(e))

--- a/futureagi/simulate/views/alk_simulate_ingestion.py
+++ b/futureagi/simulate/views/alk_simulate_ingestion.py
@@ -232,6 +232,7 @@ class ALKSimulateIngestionViewSet(ViewSet):
                 run_test,
                 scenario_ids=payload.get("scenario_ids") or None,
                 simulator_agent=simulator_agent,
+                harness_job_id=payload.get("harness_job_id"),
             )
         except ALKSimulateIngestionError as e:
             return self.gm.bad_request(str(e))

--- a/futureagi/simulate/views/alk_simulate_ingestion.py
+++ b/futureagi/simulate/views/alk_simulate_ingestion.py
@@ -231,6 +231,7 @@ class ALKSimulateIngestionViewSet(ViewSet):
             test_execution = create_alk_sim_test_execution(
                 run_test,
                 scenario_ids=payload.get("scenario_ids") or None,
+                scenario_selectors=payload.get("scenario_selectors") or None,
                 simulator_agent=simulator_agent,
                 harness_job_id=payload.get("harness_job_id"),
             )

--- a/futureagi/simulate/views/alk_simulate_ingestion.py
+++ b/futureagi/simulate/views/alk_simulate_ingestion.py
@@ -175,6 +175,7 @@ class ALKSimulateIngestionViewSet(ViewSet):
                 agent_definition_id=payload.get("agent_definition_id"),
                 agent_name=payload.get("agent_name"),
                 description=payload.get("description", ""),
+                modality=payload.get("modality", "text"),
             )
         except ALKSimulateIngestionError as e:
             return self.gm.bad_request(str(e))

--- a/futureagi/simulate/views/harness_job.py
+++ b/futureagi/simulate/views/harness_job.py
@@ -1,5 +1,8 @@
+from drf_yasg import openapi
+from drf_yasg.utils import swagger_auto_schema
 from rest_framework import status, viewsets
 from rest_framework.decorators import action
+from rest_framework.parsers import MultiPartParser
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
 
@@ -7,9 +10,11 @@ from simulate.serializers.harness_job import (
     HarnessJobActionSerializer,
     HarnessJobCreateSerializer,
     HarnessPreflightSerializer,
+    HarnessSourceUploadResponseSerializer,
 )
 from simulate.services.harness_sandbox import (
     HarnessSandboxClient,
+    HarnessSandboxRejected,
     HarnessSandboxUnavailable,
 )
 from tfc.utils.api_contracts import validated_request
@@ -30,6 +35,8 @@ class HarnessJobViewSet(viewsets.ViewSet):
     def create(self, request):
         try:
             result = self._client().submit(request.validated_data)
+        except HarnessSandboxRejected as exc:
+            return Response({"detail": str(exc)}, status=exc.status_code)
         except HarnessSandboxUnavailable as exc:
             return Response(
                 {"detail": str(exc)}, status=status.HTTP_503_SERVICE_UNAVAILABLE
@@ -44,6 +51,68 @@ class HarnessJobViewSet(viewsets.ViewSet):
                 {"detail": str(exc)}, status=status.HTTP_503_SERVICE_UNAVAILABLE
             )
 
+    @action(
+        detail=False,
+        methods=["post"],
+        url_path="sources",
+        parser_classes=[MultiPartParser],
+    )
+    @swagger_auto_schema(
+        manual_parameters=[
+            openapi.Parameter(
+                "files",
+                openapi.IN_FORM,
+                type=openapi.TYPE_FILE,
+                required=True,
+                description="Repeat this field once for every source file.",
+            ),
+            openapi.Parameter(
+                "paths",
+                openapi.IN_FORM,
+                type=openapi.TYPE_STRING,
+                required=True,
+                description="Repeat in file order with each repository-relative path.",
+            ),
+            openapi.Parameter(
+                "name",
+                openapi.IN_FORM,
+                type=openapi.TYPE_STRING,
+                required=False,
+            ),
+        ],
+        responses={201: HarnessSourceUploadResponseSerializer},
+    )
+    def source_upload(self, request):
+        files = request.FILES.getlist("files")
+        paths = request.data.getlist("paths")
+        if not files or len(files) != len(paths):
+            return Response(
+                {"detail": "one relative path is required per file"},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+        if len(files) > 5_000:
+            return Response(
+                {"detail": "source may contain at most 5000 files"},
+                status=status.HTTP_413_REQUEST_ENTITY_TOO_LARGE,
+            )
+        total = sum(int(getattr(uploaded, "size", 0) or 0) for uploaded in files)
+        if total > 200 * 1024 * 1024:
+            return Response(
+                {"detail": "source may not exceed 200 MiB"},
+                status=status.HTTP_413_REQUEST_ENTITY_TOO_LARGE,
+            )
+        try:
+            result = self._client().upload_source(
+                files, paths, str(request.data.get("name") or "uploaded-agent")
+            )
+        except HarnessSandboxRejected as exc:
+            return Response({"detail": str(exc)}, status=exc.status_code)
+        except HarnessSandboxUnavailable as exc:
+            return Response(
+                {"detail": str(exc)}, status=status.HTTP_503_SERVICE_UNAVAILABLE
+            )
+        return Response(result, status=status.HTTP_201_CREATED)
+
     @validated_request(
         request_serializer=HarnessPreflightSerializer,
         reject_unknown_fields=True,
@@ -52,6 +121,8 @@ class HarnessJobViewSet(viewsets.ViewSet):
     def preflight(self, request):
         try:
             return Response(self._client().preflight(request.validated_data))
+        except HarnessSandboxRejected as exc:
+            return Response({"detail": str(exc)}, status=exc.status_code)
         except HarnessSandboxUnavailable as exc:
             return Response(
                 {"detail": str(exc)}, status=status.HTTP_503_SERVICE_UNAVAILABLE
@@ -60,6 +131,8 @@ class HarnessJobViewSet(viewsets.ViewSet):
     def retrieve(self, request, pk=None):
         try:
             return Response(self._client().get(str(pk)))
+        except HarnessSandboxRejected as exc:
+            return Response({"detail": str(exc)}, status=exc.status_code)
         except HarnessSandboxUnavailable as exc:
             return Response(
                 {"detail": str(exc)}, status=status.HTTP_503_SERVICE_UNAVAILABLE
@@ -73,6 +146,8 @@ class HarnessJobViewSet(viewsets.ViewSet):
     def cancel(self, request, pk=None):
         try:
             return Response(self._client().cancel(str(pk)))
+        except HarnessSandboxRejected as exc:
+            return Response({"detail": str(exc)}, status=exc.status_code)
         except HarnessSandboxUnavailable as exc:
             return Response(
                 {"detail": str(exc)}, status=status.HTTP_503_SERVICE_UNAVAILABLE

--- a/futureagi/simulate/views/harness_job.py
+++ b/futureagi/simulate/views/harness_job.py
@@ -6,6 +6,7 @@ from rest_framework.response import Response
 from simulate.serializers.harness_job import (
     HarnessJobActionSerializer,
     HarnessJobCreateSerializer,
+    HarnessPreflightSerializer,
 )
 from simulate.services.harness_sandbox import (
     HarnessSandboxClient,
@@ -30,20 +31,39 @@ class HarnessJobViewSet(viewsets.ViewSet):
         try:
             result = self._client().submit(request.validated_data)
         except HarnessSandboxUnavailable as exc:
-            return Response({"detail": str(exc)}, status=status.HTTP_503_SERVICE_UNAVAILABLE)
+            return Response(
+                {"detail": str(exc)}, status=status.HTTP_503_SERVICE_UNAVAILABLE
+            )
         return Response(result, status=status.HTTP_202_ACCEPTED)
 
     def list(self, request):
         try:
             return Response(self._client().list_jobs())
         except HarnessSandboxUnavailable as exc:
-            return Response({"detail": str(exc)}, status=status.HTTP_503_SERVICE_UNAVAILABLE)
+            return Response(
+                {"detail": str(exc)}, status=status.HTTP_503_SERVICE_UNAVAILABLE
+            )
+
+    @validated_request(
+        request_serializer=HarnessPreflightSerializer,
+        reject_unknown_fields=True,
+    )
+    @action(detail=False, methods=["post"])
+    def preflight(self, request):
+        try:
+            return Response(self._client().preflight(request.validated_data))
+        except HarnessSandboxUnavailable as exc:
+            return Response(
+                {"detail": str(exc)}, status=status.HTTP_503_SERVICE_UNAVAILABLE
+            )
 
     def retrieve(self, request, pk=None):
         try:
             return Response(self._client().get(str(pk)))
         except HarnessSandboxUnavailable as exc:
-            return Response({"detail": str(exc)}, status=status.HTTP_503_SERVICE_UNAVAILABLE)
+            return Response(
+                {"detail": str(exc)}, status=status.HTTP_503_SERVICE_UNAVAILABLE
+            )
 
     @validated_request(
         request_serializer=HarnessJobActionSerializer,
@@ -54,11 +74,15 @@ class HarnessJobViewSet(viewsets.ViewSet):
         try:
             return Response(self._client().cancel(str(pk)))
         except HarnessSandboxUnavailable as exc:
-            return Response({"detail": str(exc)}, status=status.HTTP_503_SERVICE_UNAVAILABLE)
+            return Response(
+                {"detail": str(exc)}, status=status.HTTP_503_SERVICE_UNAVAILABLE
+            )
 
     @action(detail=False, methods=["get"])
     def health(self, request):
         try:
             return Response(self._client().health())
         except HarnessSandboxUnavailable as exc:
-            return Response({"detail": str(exc)}, status=status.HTTP_503_SERVICE_UNAVAILABLE)
+            return Response(
+                {"detail": str(exc)}, status=status.HTTP_503_SERVICE_UNAVAILABLE
+            )

--- a/futureagi/simulate/views/harness_job.py
+++ b/futureagi/simulate/views/harness_job.py
@@ -1,0 +1,64 @@
+from rest_framework import status, viewsets
+from rest_framework.decorators import action
+from rest_framework.permissions import IsAuthenticated
+from rest_framework.response import Response
+
+from simulate.serializers.harness_job import (
+    HarnessJobActionSerializer,
+    HarnessJobCreateSerializer,
+)
+from simulate.services.harness_sandbox import (
+    HarnessSandboxClient,
+    HarnessSandboxUnavailable,
+)
+from tfc.utils.api_contracts import validated_request
+
+
+class HarnessJobViewSet(viewsets.ViewSet):
+    """Control-plane facade over the configured ALK sandbox provider."""
+
+    permission_classes = [IsAuthenticated]
+
+    def _client(self) -> HarnessSandboxClient:
+        return HarnessSandboxClient()
+
+    @validated_request(
+        request_serializer=HarnessJobCreateSerializer,
+        reject_unknown_fields=True,
+    )
+    def create(self, request):
+        try:
+            result = self._client().submit(request.validated_data)
+        except HarnessSandboxUnavailable as exc:
+            return Response({"detail": str(exc)}, status=status.HTTP_503_SERVICE_UNAVAILABLE)
+        return Response(result, status=status.HTTP_202_ACCEPTED)
+
+    def list(self, request):
+        try:
+            return Response(self._client().list_jobs())
+        except HarnessSandboxUnavailable as exc:
+            return Response({"detail": str(exc)}, status=status.HTTP_503_SERVICE_UNAVAILABLE)
+
+    def retrieve(self, request, pk=None):
+        try:
+            return Response(self._client().get(str(pk)))
+        except HarnessSandboxUnavailable as exc:
+            return Response({"detail": str(exc)}, status=status.HTTP_503_SERVICE_UNAVAILABLE)
+
+    @validated_request(
+        request_serializer=HarnessJobActionSerializer,
+        reject_unknown_fields=True,
+    )
+    @action(detail=True, methods=["post"])
+    def cancel(self, request, pk=None):
+        try:
+            return Response(self._client().cancel(str(pk)))
+        except HarnessSandboxUnavailable as exc:
+            return Response({"detail": str(exc)}, status=status.HTTP_503_SERVICE_UNAVAILABLE)
+
+    @action(detail=False, methods=["get"])
+    def health(self, request):
+        try:
+            return Response(self._client().health())
+        except HarnessSandboxUnavailable as exc:
+            return Response({"detail": str(exc)}, status=status.HTTP_503_SERVICE_UNAVAILABLE)

--- a/futureagi/simulate/views/harness_job.py
+++ b/futureagi/simulate/views/harness_job.py
@@ -10,12 +10,20 @@ from simulate.serializers.harness_job import (
     HarnessJobActionSerializer,
     HarnessJobCreateSerializer,
     HarnessPreflightSerializer,
+    HarnessSecretFileUploadResponseSerializer,
     HarnessSourceUploadResponseSerializer,
 )
 from simulate.services.harness_sandbox import (
     HarnessSandboxClient,
     HarnessSandboxRejected,
     HarnessSandboxUnavailable,
+)
+from simulate.services.harness_credentials import (
+    credential_file_ref,
+    materialize_secret_refs,
+    request_scope,
+    save_environment_credentials,
+    store_credential_file,
 )
 from tfc.utils.api_contracts import validated_request
 
@@ -33,8 +41,32 @@ class HarnessJobViewSet(viewsets.ViewSet):
         reject_unknown_fields=True,
     )
     def create(self, request):
+        organization, workspace = request_scope(request)
+        if organization is None:
+            return Response(
+                {"detail": "an organization is required"},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+        payload = dict(request.validated_data)
+        durable_refs = dict(payload.get("secret_refs") or {})
+        client = self._client()
         try:
-            result = self._client().submit(request.validated_data)
+            payload["secret_refs"] = materialize_secret_refs(
+                durable_refs, organization=organization, client=client
+            )
+            result = client.submit(payload)
+            job_id = str(result.get("job", {}).get("job_id") or "").strip()
+            if not job_id:
+                raise HarnessSandboxUnavailable(
+                    "ALK sandbox accepted a job without returning a job id"
+                )
+            save_environment_credentials(
+                job_id,
+                environment_values=dict(payload.get("environment_values") or {}),
+                secret_refs=durable_refs,
+                organization=organization,
+                workspace=workspace,
+            )
         except HarnessSandboxRejected as exc:
             return Response({"detail": str(exc)}, status=exc.status_code)
         except HarnessSandboxUnavailable as exc:
@@ -111,6 +143,63 @@ class HarnessJobViewSet(viewsets.ViewSet):
             return Response(
                 {"detail": str(exc)}, status=status.HTTP_503_SERVICE_UNAVAILABLE
             )
+        return Response(result, status=status.HTTP_201_CREATED)
+
+    @action(
+        detail=False,
+        methods=["post"],
+        url_path="secret-files",
+        parser_classes=[MultiPartParser],
+    )
+    @swagger_auto_schema(
+        manual_parameters=[
+            openapi.Parameter(
+                "file",
+                openapi.IN_FORM,
+                type=openapi.TYPE_FILE,
+                required=True,
+                description="Credential file; transferred without entering job JSON.",
+            ),
+            openapi.Parameter(
+                "environment_name",
+                openapi.IN_FORM,
+                type=openapi.TYPE_STRING,
+                required=True,
+                description="Environment variable that will point to the mounted file.",
+            ),
+        ],
+        responses={201: HarnessSecretFileUploadResponseSerializer},
+    )
+    def secret_file_upload(self, request):
+        uploaded = request.FILES.get("file")
+        environment_name = str(request.data.get("environment_name") or "").strip()
+        if uploaded is None or not environment_name:
+            return Response(
+                {"detail": "file and environment_name are required"},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+        if int(getattr(uploaded, "size", 0) or 0) > 5 * 1024 * 1024:
+            return Response(
+                {"detail": "credential file may not exceed 5 MiB"},
+                status=status.HTTP_413_REQUEST_ENTITY_TOO_LARGE,
+            )
+        organization, workspace = request_scope(request)
+        if organization is None:
+            return Response(
+                {"detail": "an organization is required"},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+        record = store_credential_file(
+            uploaded,
+            environment_name,
+            organization=organization,
+            workspace=workspace,
+        )
+        result = {
+            "environment_name": environment_name,
+            "secret_ref": credential_file_ref(record),
+            "size": record.size,
+        }
         return Response(result, status=status.HTTP_201_CREATED)
 
     @validated_request(

--- a/futureagi/simulate/views/harness_job.py
+++ b/futureagi/simulate/views/harness_job.py
@@ -8,6 +8,7 @@ from rest_framework.response import Response
 
 from simulate.serializers.harness_job import (
     HarnessJobActionSerializer,
+    HarnessJobAdjustmentSerializer,
     HarnessJobCreateSerializer,
     HarnessPreflightSerializer,
     HarnessSourceUploadResponseSerializer,
@@ -146,6 +147,21 @@ class HarnessJobViewSet(viewsets.ViewSet):
     def cancel(self, request, pk=None):
         try:
             return Response(self._client().cancel(str(pk)))
+        except HarnessSandboxRejected as exc:
+            return Response({"detail": str(exc)}, status=exc.status_code)
+        except HarnessSandboxUnavailable as exc:
+            return Response(
+                {"detail": str(exc)}, status=status.HTTP_503_SERVICE_UNAVAILABLE
+            )
+
+    @validated_request(
+        request_serializer=HarnessJobAdjustmentSerializer,
+        reject_unknown_fields=True,
+    )
+    @action(detail=True, methods=["post"])
+    def adjust(self, request, pk=None):
+        try:
+            return Response(self._client().adjust(str(pk), request.validated_data))
         except HarnessSandboxRejected as exc:
             return Response({"detail": str(exc)}, status=exc.status_code)
         except HarnessSandboxUnavailable as exc:

--- a/futureagi/simulate/views/run_test.py
+++ b/futureagi/simulate/views/run_test.py
@@ -6360,6 +6360,44 @@ def _hosted_execution_eligible(run_test) -> bool:
     return False
 
 
+def _repository_harness_job_id(test_execution) -> str | None:
+    """Return the ALK job owning this repository-backed execution, if any.
+
+    New executions carry an explicit immutable reference. The name fallback keeps already-created
+    development runs rerunnable; it accepts only ALK's exact content-free ``harness-<uuid>`` name
+    and therefore does not redirect native/provider-only runs.
+    """
+
+    metadata = test_execution.execution_metadata or {}
+    explicit = str(metadata.get("harness_job_id") or "").strip()
+    if re.fullmatch(r"[0-9a-fA-F-]{36}", explicit):
+        return explicit
+    match = re.fullmatch(
+        r"harness-([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-"
+        r"[0-9a-fA-F]{4}-[0-9a-fA-F]{12})",
+        str(test_execution.run_test.name or ""),
+    )
+    return match.group(1) if match else None
+
+
+def _dispatch_repository_harness_rerun(
+    test_execution, *, environment_values: dict[str, str]
+) -> dict:
+    from simulate.services.harness_sandbox import HarnessSandboxClient
+
+    job_id = _repository_harness_job_id(test_execution)
+    if not job_id:
+        raise ValueError("execution has no saved repository harness job")
+    return HarnessSandboxClient().rerun(
+        job_id,
+        {
+            "environment_values": environment_values,
+            "secret_refs": {},
+            "only": [],
+        },
+    )
+
+
 def _dispatch_hosted_rerun(test_execution, call_execution_ids=None) -> str:
     """Re-dispatch a hosted execution's rerun via the simulation runner, reusing
     the existing TestExecution id. The reset CallExecution rows (PENDING, cleared
@@ -6404,6 +6442,7 @@ class CallExecutionRerunView(APIView):
         request_serializer=CallExecutionRerunSerializer,
         responses={
             200: RerunCallsResponseSerializer,
+            202: RerunCallsResponseSerializer,
             400: ErrorResponseSerializer,
             404: ErrorResponseSerializer,
             500: ErrorResponseSerializer,
@@ -6503,6 +6542,52 @@ class CallExecutionRerunView(APIView):
             if not call_executions.exists():
                 return self._gm.bad_request(
                     "No call executions found that can be rerun."
+                )
+
+            # A repository-backed ALK execution owns the target environment lifecycle. Its rerun
+            # must go back through that saved session so Compose/processes, seed/reset, agent,
+            # calls, grading and cleanup happen together. The generic hosted voice path below is
+            # intentionally retained for native/connect-only/Vapi/Retell runs.
+            repository_job_id = _repository_harness_job_id(test_execution)
+            if rerun_type == "call_and_eval" and repository_job_id:
+                if not select_all or call_execution_ids:
+                    return self._gm.bad_request(
+                        "Repository harness reruns currently require select_all=true so the "
+                        "saved scenario suite and isolated environment remain aligned."
+                    )
+                try:
+                    queued = _dispatch_repository_harness_rerun(
+                        test_execution,
+                        environment_values=request.validated_data.get(
+                            "environment_values", {}
+                        ),
+                    )
+                except Exception as dispatch_error:
+                    logger.exception(
+                        "repository_harness_rerun_dispatch_failed",
+                        test_execution_id=str(test_execution.id),
+                        harness_job_id=repository_job_id,
+                    )
+                    return self._gm.bad_request(
+                        f"Saved harness environment could not be restarted: {dispatch_error}"
+                    )
+                return Response(
+                    {
+                        "message": (
+                            "Saved harness environment restart and full simulation rerun queued"
+                        ),
+                        "test_execution_id": str(test_execution.id),
+                        "rerun_type": rerun_type,
+                        "total_processed": 0,
+                        "harness_job_id": repository_job_id,
+                        "harness_status": queued.get("status", {}),
+                        "successful_reruns": [],
+                        "failed_reruns": [],
+                        "success_count": 0,
+                        "failure_count": 0,
+                        "dispatch_error": None,
+                    },
+                    status=status.HTTP_202_ACCEPTED,
                 )
 
             # Process each call execution

--- a/futureagi/simulate/views/run_test.py
+++ b/futureagi/simulate/views/run_test.py
@@ -790,6 +790,37 @@ class RunTestExecutionView(APIView):
             if gate_response is not None:
                 return gate_response
 
+            # A repository-backed ALK run owns its complete environment lifecycle. Running it
+            # again from the simulation header must therefore return to the saved harness job;
+            # the generic hosted runner can execute calls, but cannot recreate/reset that job's
+            # Compose/process environment or seeded world.
+            repository_execution = _latest_repository_harness_execution(run_test)
+            if repository_execution is not None:
+                if set(map(str, final_scenario_ids)) != set(
+                    map(str, repository_execution.scenario_ids or [])
+                ):
+                    return self.gm.bad_request(
+                        "Repository harness reruns currently require the complete saved scenario "
+                        "suite so the recreated environment and seeded worlds remain aligned."
+                    )
+                queued = _dispatch_repository_harness_rerun(
+                    repository_execution, environment_values={}
+                )
+                return Response(
+                    {
+                        "message": (
+                            "Saved harness environment restart and full simulation rerun queued"
+                        ),
+                        "execution_id": str(repository_execution.id),
+                        "run_test_id": str(run_test.id),
+                        "status": queued.get("status", {}).get("stage", "queued"),
+                        "total_scenarios": len(final_scenario_ids),
+                        "total_calls": 0,
+                        "scenario_ids": [str(value) for value in final_scenario_ids],
+                    },
+                    status=status.HTTP_200_OK,
+                )
+
             # Route to the hosted runner (released SDK) when enabled and the run
             # is eligible; otherwise fall through to the native Temporal/Celery
             # paths. Default off — existing flows are unaffected.
@@ -6380,19 +6411,36 @@ def _repository_harness_job_id(test_execution) -> str | None:
     return match.group(1) if match else None
 
 
+def _latest_repository_harness_execution(run_test):
+    """Return the newest execution belonging to a saved repository harness job."""
+
+    for execution in run_test.executions.order_by("-started_at"):
+        if _repository_harness_job_id(execution):
+            return execution
+    return None
+
+
 def _dispatch_repository_harness_rerun(
     test_execution, *, environment_values: dict[str, str]
 ) -> dict:
+    from simulate.services.harness_credentials import credentials_for_rerun
     from simulate.services.harness_sandbox import HarnessSandboxClient
 
     job_id = _repository_harness_job_id(test_execution)
     if not job_id:
         raise ValueError("execution has no saved repository harness job")
-    return HarnessSandboxClient().rerun(
+    client = HarnessSandboxClient()
+    saved_environment, secret_refs = credentials_for_rerun(
+        job_id,
+        organization=test_execution.run_test.organization,
+        client=client,
+        environment_overrides=environment_values,
+    )
+    return client.rerun(
         job_id,
         {
-            "environment_values": environment_values,
-            "secret_refs": {},
+            "environment_values": saved_environment,
+            "secret_refs": secret_refs,
             "only": [],
         },
     )
@@ -7174,6 +7222,59 @@ class TestExecutionRerunView(APIView):
                     "No test executions found that can be rerun. "
                     "Executions in pending, running, or cancelling status cannot be rerun."
                 )
+
+            # The simulation-grid rerun action is a second UI route to the same operation as
+            # "Run test" above. Keep repository jobs on their saved ALK lifecycle instead of
+            # clearing their rows and dispatching the connector-only Temporal workflow.
+            if rerun_type == "call_and_eval":
+                repository_executions = [
+                    execution
+                    for execution in test_executions.order_by("-started_at")
+                    if _repository_harness_job_id(execution)
+                ]
+                if repository_executions:
+                    source_execution = repository_executions[0]
+                    try:
+                        queued = _dispatch_repository_harness_rerun(
+                            source_execution, environment_values={}
+                        )
+                    except Exception as dispatch_error:
+                        logger.exception(
+                            "repository_harness_bulk_rerun_dispatch_failed",
+                            test_execution_id=str(source_execution.id),
+                            harness_job_id=_repository_harness_job_id(source_execution),
+                        )
+                        return self._gm.bad_request(
+                            "Saved harness environment could not be restarted: "
+                            f"{dispatch_error}"
+                        )
+                    execution_ids = [
+                        str(execution.id) for execution in repository_executions
+                    ]
+                    return Response(
+                        {
+                            "message": (
+                                "Saved harness environment restart and full simulation rerun queued"
+                            ),
+                            "run_test_id": str(run_test_id),
+                            "rerun_type": rerun_type,
+                            "total_test_executions": len(execution_ids),
+                            "results": [
+                                {
+                                    "test_execution_id": str(source_execution.id),
+                                    "success_count": len(execution_ids),
+                                    "failure_count": 0,
+                                    "successful_reruns": execution_ids,
+                                    "failed_reruns": [],
+                                    "dispatch_error": None,
+                                    "harness_status": queued.get("status", {}),
+                                }
+                            ],
+                            "overall_success_count": len(execution_ids),
+                            "overall_failure_count": 0,
+                        },
+                        status=status.HTTP_200_OK,
+                    )
 
             from simulate.temporal.client import rerun_call_executions
 

--- a/futureagi/tfc/settings/settings.py
+++ b/futureagi/tfc/settings/settings.py
@@ -676,6 +676,10 @@ STRIPE_LIVE = bool(STRIPE_SECRET_KEY and STRIPE_SECRET_KEY.startswith("sk_live")
 STRIPE_WEBHOOK_SECRET = os.getenv(
     "WEBHOOK_SECRET_LIVE" if STRIPE_LIVE else "WEBHOOK_SECRET_TEST", ""
 )
+# Compatibility for EE service images that still import the pre-rename symbol.
+# Keep one resolved value so OSS and EE billing routes cannot select different
+# webhook secrets during a rolling/local mixed-version deployment.
+WEBHOOK_SECRET = STRIPE_WEBHOOK_SECRET
 
 BUSINESS_MONTHLY_STRIPE_PRICE_IDS_ALL = [
     x


### PR DESCRIPTION
## Summary
- issue persistent organization-scoped harness reporting credentials while preserving workspace routing
- restrict reporting credentials to ingestion endpoints and enforce job ownership for status, cancel, and adjustment APIs
- route generated runs, scenarios, datasets, and agent definitions to the submitting workspace
- keep lifecycle completion separate from grading coverage failures
- surface actionable failure/progress data and deduplicate heartbeat activity in the harness UI
- preserve saved credentials for reruns without mixing platform reporting credentials with customer agent environment values

## Validation
- Python compile check: passed
- Harness activity UI tests: 3 passed
- ESLint on changed harness UI files: passed
- git diff --check: passed

## Related ALK PR
The companion ALK PR implements deterministic environment resolution, typed failures, progress events, and call-duration semantics.