### PR TITLE
feat: add Kubernetes Helm deployment

### DIFF
--- a/.github/workflows/helm-chart.yml
+++ b/.github/workflows/helm-chart.yml
@@ -1,0 +1,26 @@
+name: Helm chart
+
+on:
+  pull_request:
+    paths:
+      - deploy/helm/**
+      - .github/workflows/helm-chart.yml
+  push:
+    branches: [main]
+    paths:
+      - deploy/helm/**
+      - .github/workflows/helm-chart.yml
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: azure/setup-helm@v4
+        with:
+          version: v3.17.3
+      - name: Lint, render, and package chart
+        run: ./deploy/helm/test-chart.sh

--- a/INSTALLATION.md
+++ b/INSTALLATION.md
@@ -14,6 +14,7 @@ If you just want to try it on your laptop, jump to [Quick start](#quick-start).
   - [Full OSS stack (default)](#mode-1-full-oss-stack)
   - [Development mode (hot reload)](#mode-2-development-mode)
   - [Frontend-only deploy](#mode-3-frontend-only)
+  - [Kubernetes with Helm](#mode-4-kubernetes-with-helm)
 - [Configuration](#configuration)
   - [The `.env` file](#the-env-file)
   - [Secrets that must be changed](#secrets-that-must-be-changed)
@@ -189,6 +190,21 @@ VITE_HOST_API=https://api.your-backend.example.com \
 ```
 
 Or set `VITE_HOST_API` in `.env` and run without the inline variable. Restart the container to pick up changes — no rebuild required (the entrypoint regenerates `/config.js` from `VITE_HOST_API` on each start).
+
+### Mode 4 — Kubernetes with Helm
+
+The chart under `deploy/helm/futureagi` installs the application and bundled datastores, or connects each component to an external managed service. For a local Minikube smoke test:
+
+```bash
+minikube start --cpus=4 --memory=8192 --disk-size=30g
+helm upgrade --install futureagi ./deploy/helm/futureagi \
+  --namespace futureagi --create-namespace \
+  --values deploy/helm/futureagi/examples/minikube-values.yaml \
+  --wait --timeout 20m
+helm test futureagi --namespace futureagi --logs
+```
+
+See the [Helm chart guide](deploy/helm/futureagi/README.md) for secrets, ingress, external datastores, sizing, upgrades, and production guidance.
 
 ---
 

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -100,7 +100,7 @@ TLS proxy (Caddy/nginx)
 
 Set `VITE_HOST_API=/api` and let the proxy do the routing. Backend doesn't need CORS for cross-origin since SPA calls same origin.
 
-Official Kubernetes manifests and Helm charts are coming soon. Until then, this production overlay is the supported self-hosting path.
+For Kubernetes, use the [Future AGI Helm chart](helm/futureagi/README.md). The production Compose overlay remains the simplest supported path for a single host.
 
 ## Reverse proxy + TLS
 

--- a/deploy/helm/futureagi/.helmignore
+++ b/deploy/helm/futureagi/.helmignore
@@ -1,0 +1,10 @@
+.DS_Store
+.git/
+.github/
+.idea/
+.project
+.tmp/
+.vscode/
+*.swp
+*.tmp
+*.tgz

--- a/deploy/helm/futureagi/Chart.yaml
+++ b/deploy/helm/futureagi/Chart.yaml
@@ -1,0 +1,21 @@
+apiVersion: v2
+name: futureagi
+description: A Helm chart for self-hosting the Future AGI evaluation and observability platform
+type: application
+version: 0.1.0
+appVersion: "1.23.1"
+kubeVersion: ">=1.24.0-0"
+home: https://futureagi.com
+icon: https://raw.githubusercontent.com/future-agi/future-agi/main/frontend/public/favicon/logo.svg
+sources:
+  - https://github.com/future-agi/future-agi
+keywords:
+  - ai
+  - evaluation
+  - observability
+  - opentelemetry
+maintainers:
+  - name: Future AGI
+    url: https://github.com/future-agi
+annotations:
+  artifacthub.io/license: Apache-2.0

--- a/deploy/helm/futureagi/README.md
+++ b/deploy/helm/futureagi/README.md
@@ -1,0 +1,199 @@
+# Future AGI Helm chart
+
+This chart deploys Future AGI and its core services on Kubernetes. It mirrors the repository's Docker Compose topology while exposing Kubernetes-native configuration for persistence, probes, resources, ingress, secrets, and external datastores. Bundled MinIO is provided only for development and Minikube; production mode requires AWS S3 or GCS object storage.
+
+## Prerequisites
+
+- Kubernetes 1.24+
+- Helm 3.11+
+- A default `ReadWriteOnce` StorageClass when persistence is enabled
+- About 10 CPU cores and 10–16 GiB RAM for the default stack; use the Minikube profile below for a smaller smoke test
+- At least 15 GiB of free container-runtime disk for the published backend image and the bundled services
+
+## Install
+
+```bash
+helm install futureagi ./deploy/helm/futureagi \
+  --namespace futureagi --create-namespace
+kubectl get pods --namespace futureagi --watch
+```
+
+The default `deploymentMode: development` installs MinIO and generates random credentials on first install, preserving them during upgrades. For production, set `deploymentMode: production`, disable MinIO, configure AWS S3 or GCS, and provide `secrets.existingSecret`. The chart rejects production values that retain bundled MinIO or chart-generated credentials.
+
+Access the services locally:
+
+```bash
+kubectl port-forward --namespace futureagi svc/futureagi-futureagi-frontend 3000:80
+kubectl port-forward --namespace futureagi svc/futureagi-futureagi-backend 8000:80
+kubectl port-forward --namespace futureagi svc/futureagi-futureagi-minio 9005:9000
+```
+
+Open <http://localhost:3000>; the API health endpoint is <http://localhost:8000/health/>.
+
+## Minikube smoke test
+
+```bash
+minikube start --cpus=4 --memory=8192 --disk-size=30g
+helm upgrade --install futureagi ./deploy/helm/futureagi \
+  --namespace futureagi --create-namespace \
+  --values deploy/helm/futureagi/examples/minikube-values.yaml \
+  --wait --timeout 20m
+kubectl get pods --namespace futureagi
+helm test futureagi --namespace futureagi --logs
+```
+
+The local values disable serving, code execution, persistence, and backend gRPC, and reduce requests. They are not production sizing.
+
+On Docker Desktop, Minikube shares Docker's global disk image; `--disk-size` does not create free host capacity. Check `docker system df` first. On Apple Silicon, the backend release image is currently `linux/amd64` and requires emulation, while the other platform images are multi-architecture.
+
+## Secrets
+
+With `secrets.existingSecret` set, the referenced Secret must contain:
+
+| Key | Consumer |
+|---|---|
+| `django-secret-key` | Backend and workers |
+| `integration-encryption-key` | Encrypted integration credentials |
+| `agentcc-internal-api-key` | Backend and AgentCC gateway |
+| `agentcc-admin-token` | Backend and AgentCC gateway |
+| `postgresql-password` | Application, collector, PostgreSQL, and Temporal |
+| `clickhouse-password` | Application and collector (empty for bundled ClickHouse) |
+| `rabbitmq-password` | Application and RabbitMQ |
+| `object-storage-access-key` | Application access to AWS S3 or GCS HMAC |
+| `object-storage-secret-key` | Application access to AWS S3 or GCS HMAC |
+| `minio-root-user` | Bundled development MinIO only |
+| `minio-root-password` | Bundled development MinIO only |
+
+Example:
+
+```bash
+kubectl create secret generic futureagi-production-secrets \
+  --namespace futureagi \
+  --from-literal=django-secret-key="$(openssl rand -hex 32)" \
+  --from-literal=integration-encryption-key="$(openssl rand -base64 32)" \
+  --from-literal=agentcc-internal-api-key="$(openssl rand -hex 32)" \
+  --from-literal=agentcc-admin-token="$(openssl rand -hex 32)" \
+  --from-literal=postgresql-password="$(openssl rand -hex 16)" \
+  --from-literal=clickhouse-password= \
+  --from-literal=rabbitmq-password="$(openssl rand -hex 16)" \
+  --from-literal=object-storage-access-key="$OBJECT_STORAGE_ACCESS_KEY" \
+  --from-literal=object-storage-secret-key="$OBJECT_STORAGE_SECRET_KEY"
+```
+
+For a development install with bundled MinIO, also provide `minio-root-user` and `minio-root-password`; generated chart Secrets populate all four storage keys automatically. Secret values passed directly with `--set` are retained in Helm release history, so production mode requires an existing Secret. Prefer an external secret controller when one is available.
+
+## External datastores
+
+Disable a bundled service and provide its external endpoint. Credentials continue to come from the Secret described above.
+
+```yaml
+postgresql:
+  enabled: false
+  database: futureagi
+  username: futureagi
+  external:
+    host: postgres.example.internal
+    port: 5432
+
+clickhouse:
+  enabled: false
+  external:
+    host: clickhouse.example.internal
+    tcpPort: 9000
+    httpPort: 8123
+    username: default
+
+redis:
+  enabled: false
+  external: {host: redis.example.internal, port: 6379}
+
+rabbitmq:
+  enabled: false
+  external: {host: rabbitmq.example.internal, port: 5672, username: futureagi}
+
+temporal:
+  enabled: false
+  external: {host: temporal.example.internal, port: 7233}
+```
+
+Object storage is configured separately below. MinIO has no external production mode in this chart.
+
+## Production object storage
+
+Bundled MinIO is a development convenience, not a production datastore. Start with [examples/production-s3-values.yaml](examples/production-s3-values.yaml):
+
+```yaml
+deploymentMode: production
+secrets:
+  existingSecret: futureagi-production-secrets
+config:
+  storageBackend: s3
+  s3Bucket: futureagi-production
+  s3Endpoint: https://s3.amazonaws.com
+  s3Region: us-east-2
+  s3Secure: true
+minio:
+  enabled: false
+```
+
+The bucket must exist and the configured access key must have the required object and bucket permissions. For GCS S3 interoperability, use `storageBackend: gcs`, keep `minio.enabled: false`, and store the GCS HMAC access ID and secret in the `object-storage-access-key` and `object-storage-secret-key` Secret keys. When `s3Endpoint` is empty, the chart defaults to `https://s3.amazonaws.com` for S3 and `https://storage.googleapis.com` for GCS.
+
+## Ingress
+
+Ingress is disabled by default. The frontend calls the URL in `config.backendUrl` from the user's browser, so it must be publicly reachable. A split-domain example:
+
+```yaml
+config:
+  frontendUrl: https://app.example.com
+  backendUrl: https://api.example.com
+ingress:
+  enabled: true
+  className: nginx
+  hosts:
+    - host: app.example.com
+      paths: [{path: /, pathType: Prefix, service: frontend}]
+    - host: api.example.com
+      paths: [{path: /, pathType: Prefix, service: backend}]
+  tls:
+    - secretName: futureagi-tls
+      hosts: [app.example.com, api.example.com]
+```
+
+TLS certificates and DNS records are intentionally managed outside this chart.
+
+## Production guidance
+
+- Pin all application images to immutable release tags or digests before upgrading.
+- Use an existing Secret or an external secret controller; do not keep production credentials in a values file.
+- Set `deploymentMode: production`, disable bundled MinIO, and use AWS S3 or GCS object storage.
+- Use managed or highly available PostgreSQL, ClickHouse, Redis, RabbitMQ, object storage, and Temporal for critical installations.
+- Configure backups and test restores before sending production data.
+- Set realistic requests/limits from observed workload usage.
+- The code executor needs a privileged container for `nsjail`; it is disabled by default and will not run on clusters that prohibit privileged workloads.
+- The bundled StatefulSets are single-instance and do not claim high availability.
+
+## Validate and upgrade
+
+```bash
+helm lint deploy/helm/futureagi
+./deploy/helm/test-chart.sh
+helm template futureagi deploy/helm/futureagi --namespace futureagi >/tmp/futureagi.yaml
+helm upgrade futureagi ./deploy/helm/futureagi \
+  --namespace futureagi --values values.production.yaml \
+  --wait --timeout 20m
+helm test futureagi --namespace futureagi --logs
+```
+
+See [TESTING.md](TESTING.md) for the initial Minikube validation record and the
+environment limitations encountered during that run.
+
+Review image and schema migration notes for each Future AGI release. Stateful data is retained when a release is uninstalled if it lives in StatefulSet PVCs; confirm your cluster's reclaim policy and backup process.
+
+## Uninstall
+
+```bash
+helm uninstall futureagi --namespace futureagi
+kubectl delete namespace futureagi
+```
+
+Deleting the namespace also deletes PVCs in that namespace and is destructive. Back up data first.

--- a/deploy/helm/futureagi/REQUIREMENTS.md
+++ b/deploy/helm/futureagi/REQUIREMENTS.md
@@ -1,0 +1,39 @@
+# Helm deployment feature requirements
+
+## Problem
+
+Future AGI supports self-hosting through Docker Compose, but has no native Kubernetes deployment path. Operators must translate a multi-service topology, secret wiring, probes, and persistent storage by hand. The chart should provide a repeatable starting point for local evaluation and production customization without changing application images.
+
+## Goals
+
+- Install the complete core platform with one Helm release on Kubernetes 1.24+.
+- Keep the default deployment self-contained for development, evaluation, and Minikube.
+- Allow PostgreSQL, ClickHouse, Redis, RabbitMQ, MinIO/S3, and Temporal to be replaced independently by externally managed services.
+- Reject bundled MinIO in production mode; production installations must use AWS S3 or GCS object storage with externally managed credentials.
+- Configure every application image, tag, pull policy, replica count, resources, placement, persistence, and ingress through values.
+- Keep credentials in a Kubernetes Secret, support a pre-created Secret, and preserve chart-generated credentials across upgrades.
+- Provide startup, readiness, and liveness probes for network-facing workloads.
+- Provide a Helm test and a documented Minikube validation workflow.
+
+## Non-goals for the initial chart
+
+- Deploying the legacy optional PeerDB CDC profile. The default fi-collector path writes directly to ClickHouse.
+- Installing a Kubernetes operator or cloud-specific infrastructure.
+- Automatically configuring TLS, DNS, backups, or highly available datastores.
+- Enabling the privileged code-executor by default.
+- Deploying the hosted voice simulation runner, which requires external credentials and telephony infrastructure.
+
+## Acceptance criteria
+
+1. `helm lint deploy/helm/futureagi` succeeds.
+2. Default, external-datastore, ingress, and Minikube value sets render valid Kubernetes resources.
+3. `helm install` creates the core application and bundled datastore workloads without embedded static passwords.
+4. A second `helm upgrade` preserves generated Secret values.
+5. Backend and frontend become reachable through port-forwarding on Minikube.
+6. `helm test` verifies the frontend and unauthenticated backend health endpoint.
+7. Documentation covers install, configuration, external services, security constraints, upgrades, backups, and uninstall.
+8. `deploymentMode=production` fails rendering when bundled MinIO is enabled or a pre-created Secret is not configured.
+
+## Design notes
+
+The Langfuse chart informed three choices: a self-contained development default, independent switches for external datastores, and first-class Minikube instructions. This chart deliberately avoids external subcharts in its first version so rendering and contribution tests do not require a chart-repository network fetch. Bundled datastores are single-instance and intended for evaluation or modest installations. Bundled MinIO is development-only; production mode requires AWS S3 or GCS. Production users should also use managed/HA services or add backup and disruption procedures appropriate to their cluster.

--- a/deploy/helm/futureagi/TESTING.md
+++ b/deploy/helm/futureagi/TESTING.md
@@ -1,0 +1,38 @@
+# Helm chart validation record
+
+This file records the validation performed while introducing the chart. It is
+not a substitute for the repeatable CI checks in `deploy/helm/test-chart.sh`.
+
+## Static validation
+
+The chart passes strict Helm linting and rendering for:
+
+- the default bundled installation;
+- the reduced Minikube profile;
+- the production AWS S3 profile;
+- ingress enabled;
+- the privileged code executor with a pre-created Secret; and
+- all datastores configured as external services.
+
+Negative rendering verifies that production mode cannot use bundled MinIO.
+
+The test script also renders and packages the chart. CI runs the same checks for
+every pull request that changes the chart.
+
+## Minikube validation
+
+Tested on 2026-08-26 with Minikube 1.38.1, Kubernetes 1.34.0, the Docker driver,
+and containerd. Kubernetes admitted the release resources. The frontend,
+AgentCC gateway, PostgreSQL, ClickHouse, Redis, RabbitMQ, and MinIO reached their
+ready state. A no-op `helm upgrade` preserved every generated Secret value.
+
+The complete smoke test could not finish on the test machine because Docker
+Desktop's shared 50 GB virtual disk filled while containerd unpacked the backend
+image. Temporal also encountered DNS upstream timeouts in the rootless Docker
+network. These were host-runtime constraints rather than manifest admission
+errors. Re-run the commands in the chart README on a Minikube runtime with at
+least 15 GB free before installation and working cluster DNS; the backend image
+is the dominant disk consumer.
+
+The disposable test profile was removed after validation. No pre-existing
+Minikube profiles, Docker images, or Docker volumes were deleted.

--- a/deploy/helm/futureagi/examples/minikube-values.yaml
+++ b/deploy/helm/futureagi/examples/minikube-values.yaml
@@ -1,0 +1,47 @@
+# Reduced local footprint for Minikube smoke tests. Do not use these resource
+# settings for production. The chart generates and preserves random secrets.
+deploymentMode: development
+
+config:
+  frontendUrl: http://localhost:3000
+  backendUrl: http://localhost:8000
+  minioUrl: http://localhost:9005
+  telemetryDisabled: true
+
+global:
+  storageClass: standard
+
+backend:
+  enableGrpc: false
+  resources:
+    requests: {cpu: 100m, memory: 384Mi}
+    limits: {cpu: "1", memory: 1Gi}
+
+worker:
+  maxConcurrentActivities: 10
+  maxConcurrentWorkflowTasks: 10
+  resources:
+    requests: {cpu: 100m, memory: 384Mi}
+    limits: {cpu: "1", memory: 768Mi}
+
+serving:
+  enabled: false
+
+codeExecutor:
+  enabled: false
+
+postgresql:
+  persistence: {enabled: false, size: 1Gi}
+clickhouse:
+  persistence: {enabled: false, size: 2Gi}
+  resources:
+    requests: {cpu: 100m, memory: 384Mi}
+    limits: {cpu: "1", memory: 2Gi}
+redis:
+  persistence: {enabled: false, size: 1Gi}
+rabbitmq:
+  persistence: {enabled: false, size: 1Gi}
+minio:
+  persistence: {enabled: false, size: 1Gi}
+fiCollector:
+  persistence: {enabled: false, size: 1Gi}

--- a/deploy/helm/futureagi/examples/production-s3-values.yaml
+++ b/deploy/helm/futureagi/examples/production-s3-values.yaml
@@ -1,0 +1,19 @@
+# Production object-storage example. Create the referenced Secret first and
+# replace the bucket, region, and public application URLs.
+deploymentMode: production
+
+secrets:
+  existingSecret: futureagi-production-secrets
+
+config:
+  frontendUrl: https://app.example.com
+  backendUrl: https://api.example.com
+  storageBackend: s3
+  s3Bucket: futureagi-production
+  s3Endpoint: https://s3.amazonaws.com
+  s3Region: us-east-2
+  s3Secure: true
+  telemetryDisabled: true
+
+minio:
+  enabled: false

--- a/deploy/helm/futureagi/templates/NOTES.txt
+++ b/deploy/helm/futureagi/templates/NOTES.txt
@@ -1,0 +1,16 @@
+Future AGI is being deployed into namespace {{ .Release.Namespace }}.
+
+Watch the rollout:
+  kubectl get pods -n {{ .Release.Namespace }} -w
+
+Access the UI locally:
+  kubectl port-forward -n {{ .Release.Namespace }} svc/{{ include "futureagi.fullname" . }}-frontend 3000:80
+
+Access the API locally:
+  kubectl port-forward -n {{ .Release.Namespace }} svc/{{ include "futureagi.fullname" . }}-backend 8000:80
+
+Run the chart smoke test after all workloads are ready:
+  helm test {{ .Release.Name }} -n {{ .Release.Namespace }}
+
+For production, pin every image tag, use an existing Secret, configure external
+managed datastores or backups, and expose the services through TLS ingress.

--- a/deploy/helm/futureagi/templates/_helpers.tpl
+++ b/deploy/helm/futureagi/templates/_helpers.tpl
@@ -1,0 +1,80 @@
+{{- define "futureagi.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{- define "futureagi.fullname" -}}
+{{- if .Values.fullnameOverride }}{{ .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}{{- else }}{{ printf "%s-%s" .Release.Name (include "futureagi.name" .) | trunc 63 | trimSuffix "-" }}{{- end }}
+{{- end }}
+
+{{- define "futureagi.chart" -}}
+{{ printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{- define "futureagi.labels" -}}
+helm.sh/chart: {{ include "futureagi.chart" . }}
+app.kubernetes.io/name: {{ include "futureagi.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{- define "futureagi.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "futureagi.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{- define "futureagi.componentLabels" -}}
+{{ include "futureagi.selectorLabels" .root }}
+app.kubernetes.io/component: {{ .component }}
+{{- end }}
+
+{{- define "futureagi.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}{{ default (include "futureagi.fullname" .) .Values.serviceAccount.name }}{{- else }}{{ default "default" .Values.serviceAccount.name }}{{- end }}
+{{- end }}
+
+{{- define "futureagi.secretName" -}}
+{{- default (printf "%s-secrets" (include "futureagi.fullname" .)) .Values.secrets.existingSecret }}
+{{- end }}
+
+{{- define "futureagi.image" -}}
+{{- $registry := .root.Values.global.imageRegistry -}}
+{{- if $registry }}{{ printf "%s/%s:%s" ($registry | trimSuffix "/") .image.repository .image.tag }}{{- else }}{{ printf "%s:%s" .image.repository .image.tag }}{{- end }}
+{{- end }}
+
+{{- define "futureagi.postgresqlHost" -}}{{- if .Values.postgresql.enabled }}{{ printf "%s-postgresql" (include "futureagi.fullname" .) }}{{ else }}{{ required "postgresql.external.host is required when postgresql.enabled=false" .Values.postgresql.external.host }}{{ end }}{{- end }}
+{{- define "futureagi.clickhouseHost" -}}{{- if .Values.clickhouse.enabled }}{{ printf "%s-clickhouse" (include "futureagi.fullname" .) }}{{ else }}{{ required "clickhouse.external.host is required when clickhouse.enabled=false" .Values.clickhouse.external.host }}{{ end }}{{- end }}
+{{- define "futureagi.redisHost" -}}{{- if .Values.redis.enabled }}{{ printf "%s-redis" (include "futureagi.fullname" .) }}{{ else }}{{ required "redis.external.host is required when redis.enabled=false" .Values.redis.external.host }}{{ end }}{{- end }}
+{{- define "futureagi.rabbitmqHost" -}}{{- if .Values.rabbitmq.enabled }}{{ printf "%s-rabbitmq" (include "futureagi.fullname" .) }}{{ else }}{{ required "rabbitmq.external.host is required when rabbitmq.enabled=false" .Values.rabbitmq.external.host }}{{ end }}{{- end }}
+{{- define "futureagi.minioHost" -}}{{ printf "%s-minio" (include "futureagi.fullname" .) }}{{- end }}
+{{- define "futureagi.objectStorageEndpoint" -}}
+{{- if .Values.minio.enabled -}}
+{{ printf "http://%s-minio:9000" (include "futureagi.fullname" .) }}
+{{- else if .Values.config.s3Endpoint -}}
+{{ .Values.config.s3Endpoint }}
+{{- else if eq .Values.config.storageBackend "gcs" -}}
+https://storage.googleapis.com
+{{- else -}}
+https://s3.amazonaws.com
+{{- end -}}
+{{- end }}
+{{- define "futureagi.temporalHost" -}}{{- if .Values.temporal.enabled }}{{ printf "%s-temporal" (include "futureagi.fullname" .) }}{{ else }}{{ required "temporal.external.host is required when temporal.enabled=false" .Values.temporal.external.host }}{{ end }}{{- end }}
+
+{{- define "futureagi.podPlacement" -}}
+{{- with .Values.global.nodeSelector }}
+nodeSelector: {{- toYaml . | nindent 2 }}
+{{- end }}
+
+{{- with .Values.global.affinity }}
+affinity: {{- toYaml . | nindent 2 }}
+{{- end }}
+{{- with .Values.global.tolerations }}
+tolerations: {{- toYaml . | nindent 2 }}
+{{- end }}
+{{- end }}
+
+{{- define "futureagi.imagePullSecrets" -}}
+{{- with .Values.global.imagePullSecrets }}
+imagePullSecrets:
+  {{- toYaml . | nindent 2 }}
+{{- end }}
+{{- end }}

--- a/deploy/helm/futureagi/templates/application.yaml
+++ b/deploy/helm/futureagi/templates/application.yaml
@@ -1,0 +1,137 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "futureagi.fullname" . }}-backend
+  labels:
+    {{- include "futureagi.labels" . | nindent 4 }}
+    app.kubernetes.io/component: backend
+spec:
+  replicas: {{ .Values.backend.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "futureagi.componentLabels" (dict "root" . "component" "backend") | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "futureagi.componentLabels" (dict "root" . "component" "backend") | nindent 8 }}
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        checksum/secret: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
+        {{- with .Values.global.podAnnotations }}{{ toYaml . | nindent 8 }}{{- end }}
+    spec:
+      serviceAccountName: {{ include "futureagi.serviceAccountName" . }}
+      {{- include "futureagi.imagePullSecrets" . | nindent 6 }}
+      securityContext: {{ toYaml .Values.backend.podSecurityContext | nindent 8 }}
+      containers:
+        - name: backend
+          image: {{ include "futureagi.image" (dict "root" . "image" .Values.backend.image) }}
+          imagePullPolicy: {{ .Values.backend.image.pullPolicy }}
+          securityContext: {{ toYaml .Values.backend.containerSecurityContext | nindent 12 }}
+          ports:
+            - {name: http, containerPort: 80, protocol: TCP}
+            - {name: grpc, containerPort: 50051, protocol: TCP}
+          envFrom:
+            - configMapRef: {name: {{ include "futureagi.fullname" . }}-env}
+          env:
+            - {name: SERVICE_TYPE, value: backend}
+            - {name: GRANIAN_WORKERS, value: {{ .Values.backend.granianWorkers | quote }}}
+            - {name: GRANIAN_THREADS, value: {{ .Values.backend.granianThreads | quote }}}
+            - {name: ENABLE_GRPC, value: {{ .Values.backend.enableGrpc | quote }}}
+            - {name: ENABLE_HTTP, value: "true"}
+            - name: SECRET_KEY
+              valueFrom: {secretKeyRef: {name: {{ include "futureagi.secretName" . }}, key: django-secret-key}}
+            - name: INTEGRATION_ENCRYPTION_KEY
+              valueFrom: {secretKeyRef: {name: {{ include "futureagi.secretName" . }}, key: integration-encryption-key}}
+            - name: AGENTCC_INTERNAL_API_KEY
+              valueFrom: {secretKeyRef: {name: {{ include "futureagi.secretName" . }}, key: agentcc-internal-api-key}}
+            - name: AGENTCC_ADMIN_TOKEN
+              valueFrom: {secretKeyRef: {name: {{ include "futureagi.secretName" . }}, key: agentcc-admin-token}}
+            - name: PG_PASSWORD
+              valueFrom: {secretKeyRef: {name: {{ include "futureagi.secretName" . }}, key: postgresql-password}}
+            - name: CH_PASSWORD
+              valueFrom: {secretKeyRef: {name: {{ include "futureagi.secretName" . }}, key: clickhouse-password}}
+            - name: RABBITMQ_PASSWORD
+              valueFrom: {secretKeyRef: {name: {{ include "futureagi.secretName" . }}, key: rabbitmq-password}}
+            - name: S3_ACCESS_KEY
+              valueFrom: {secretKeyRef: {name: {{ include "futureagi.secretName" . }}, key: object-storage-access-key}}
+            - name: S3_SECRET_KEY
+              valueFrom: {secretKeyRef: {name: {{ include "futureagi.secretName" . }}, key: object-storage-secret-key}}
+            - name: GCS_HMAC_ACCESS_KEY
+              valueFrom: {secretKeyRef: {name: {{ include "futureagi.secretName" . }}, key: object-storage-access-key}}
+            - name: GCS_HMAC_SECRET_KEY
+              valueFrom: {secretKeyRef: {name: {{ include "futureagi.secretName" . }}, key: object-storage-secret-key}}
+            - name: CELERY_BROKER_URL
+              value: {{ printf "amqp://%s:$(RABBITMQ_PASSWORD)@%s:%v//" (ternary .Values.rabbitmq.username .Values.rabbitmq.external.username .Values.rabbitmq.enabled) (include "futureagi.rabbitmqHost" .) (ternary 5672 .Values.rabbitmq.external.port .Values.rabbitmq.enabled) | quote }}
+            {{- with .Values.config.providerEnv }}{{ toYaml . | nindent 12 }}{{- end }}
+            {{- with .Values.config.extraEnv }}{{ toYaml . | nindent 12 }}{{- end }}
+          startupProbe: {httpGet: {path: /health/, port: http}, failureThreshold: 60, periodSeconds: 5, timeoutSeconds: 3}
+          readinessProbe: {httpGet: {path: /health/, port: http}, periodSeconds: 10, timeoutSeconds: 3, failureThreshold: 6}
+          livenessProbe: {httpGet: {path: /health/, port: http}, periodSeconds: 20, timeoutSeconds: 5, failureThreshold: 3}
+          resources: {{ toYaml .Values.backend.resources | nindent 12 }}
+      {{- include "futureagi.podPlacement" . | nindent 6 }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "futureagi.fullname" . }}-backend
+  labels:
+    {{- include "futureagi.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.backend.service.type }}
+  selector:
+    {{- include "futureagi.componentLabels" (dict "root" . "component" "backend") | nindent 4 }}
+  ports:
+    - {name: http, port: {{ .Values.backend.service.httpPort }}, targetPort: http}
+    - {name: grpc, port: {{ .Values.backend.service.grpcPort }}, targetPort: grpc}
+{{- if .Values.frontend.enabled }}
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "futureagi.fullname" . }}-frontend
+  labels:
+    {{- include "futureagi.labels" . | nindent 4 }}
+    app.kubernetes.io/component: frontend
+spec:
+  replicas: {{ .Values.frontend.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "futureagi.componentLabels" (dict "root" . "component" "frontend") | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "futureagi.componentLabels" (dict "root" . "component" "frontend") | nindent 8 }}
+      {{- with .Values.global.podAnnotations }}
+      annotations: {{ toYaml . | nindent 8 }}
+      {{- end }}
+    spec:
+      serviceAccountName: {{ include "futureagi.serviceAccountName" . }}
+      {{- include "futureagi.imagePullSecrets" . | nindent 6 }}
+      securityContext: {{ toYaml .Values.frontend.podSecurityContext | nindent 8 }}
+      containers:
+        - name: frontend
+          image: {{ include "futureagi.image" (dict "root" . "image" .Values.frontend.image) }}
+          imagePullPolicy: {{ .Values.frontend.image.pullPolicy }}
+          securityContext: {{ toYaml .Values.frontend.containerSecurityContext | nindent 12 }}
+          ports: [{name: http, containerPort: 80}]
+          env:
+            - {name: VITE_HOST_API, value: {{ .Values.config.backendUrl | quote }}}
+            - {name: VITE_HELP_LINK, value: {{ .Values.config.helpLink | quote }}}
+          startupProbe: {httpGet: {path: /, port: http}, failureThreshold: 30, periodSeconds: 5}
+          readinessProbe: {httpGet: {path: /, port: http}, periodSeconds: 10}
+          livenessProbe: {httpGet: {path: /, port: http}, periodSeconds: 20}
+          resources: {{ toYaml .Values.frontend.resources | nindent 12 }}
+      {{- include "futureagi.podPlacement" . | nindent 6 }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "futureagi.fullname" . }}-frontend
+  labels:
+    {{- include "futureagi.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.frontend.service.type }}
+  selector:
+    {{- include "futureagi.componentLabels" (dict "root" . "component" "frontend") | nindent 4 }}
+  ports: [{name: http, port: {{ .Values.frontend.service.port }}, targetPort: http}]
+{{- end }}

--- a/deploy/helm/futureagi/templates/clickhouse-minio.yaml
+++ b/deploy/helm/futureagi/templates/clickhouse-minio.yaml
@@ -1,0 +1,114 @@
+{{- if .Values.clickhouse.enabled }}
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: {{ include "futureagi.fullname" . }}-clickhouse
+  labels:
+    {{- include "futureagi.labels" . | nindent 4 }}
+spec:
+  serviceName: {{ include "futureagi.fullname" . }}-clickhouse
+  replicas: 1
+  selector:
+    matchLabels: {{ include "futureagi.componentLabels" (dict "root" . "component" "clickhouse") | nindent 6 }}
+  template:
+    metadata:
+      labels: {{ include "futureagi.componentLabels" (dict "root" . "component" "clickhouse") | nindent 8 }}
+    spec:
+      {{- include "futureagi.imagePullSecrets" . | nindent 6 }}
+      containers:
+        - name: clickhouse
+          image: {{ include "futureagi.image" (dict "root" . "image" .Values.clickhouse.image) }}
+          imagePullPolicy: {{ .Values.clickhouse.image.pullPolicy }}
+          ports: [{name: http, containerPort: 8123}, {name: native, containerPort: 9000}]
+          env:
+            - {name: CLICKHOUSE_SKIP_USER_SETUP, value: "1"}
+            - {name: CLICKHOUSE_DB, value: {{ .Values.config.clickhouseDatabase | quote }}}
+          volumeMounts:
+            - {name: data, mountPath: /var/lib/clickhouse}
+            - {name: config, mountPath: /etc/clickhouse-server/config.d/storage-policy.xml, subPath: storage-policy.xml, readOnly: true}
+          startupProbe: {httpGet: {path: /ping, port: http}, failureThreshold: 60, periodSeconds: 5}
+          readinessProbe: {httpGet: {path: /ping, port: http}, periodSeconds: 10}
+          livenessProbe: {httpGet: {path: /ping, port: http}, periodSeconds: 20}
+          resources: {{ toYaml .Values.clickhouse.resources | nindent 12 }}
+      volumes:
+        - {name: config, configMap: {name: {{ include "futureagi.fullname" . }}-clickhouse-config}}
+        {{- if not .Values.clickhouse.persistence.enabled }}
+        - {name: data, emptyDir: {}}
+        {{- end }}
+      {{- include "futureagi.podPlacement" . | nindent 6 }}
+  {{- if .Values.clickhouse.persistence.enabled }}
+  volumeClaimTemplates:
+    - metadata: {name: data}
+      spec:
+        accessModes: [ReadWriteOnce]
+        {{- if .Values.global.storageClass }}storageClassName: {{ .Values.global.storageClass | quote }}{{- end }}
+        resources: {requests: {storage: {{ .Values.clickhouse.persistence.size }}}}
+  {{- end }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "futureagi.fullname" . }}-clickhouse
+  labels:
+    {{- include "futureagi.labels" . | nindent 4 }}
+spec:
+  clusterIP: None
+  selector: {{ include "futureagi.componentLabels" (dict "root" . "component" "clickhouse") | nindent 4 }}
+  ports: [{name: http, port: 8123}, {name: native, port: 9000}]
+{{- end }}
+{{- if .Values.minio.enabled }}
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: {{ include "futureagi.fullname" . }}-minio
+  labels:
+    {{- include "futureagi.labels" . | nindent 4 }}
+spec:
+  serviceName: {{ include "futureagi.fullname" . }}-minio
+  replicas: 1
+  selector:
+    matchLabels: {{ include "futureagi.componentLabels" (dict "root" . "component" "minio") | nindent 6 }}
+  template:
+    metadata:
+      labels: {{ include "futureagi.componentLabels" (dict "root" . "component" "minio") | nindent 8 }}
+    spec:
+      {{- include "futureagi.imagePullSecrets" . | nindent 6 }}
+      containers:
+        - name: minio
+          image: {{ include "futureagi.image" (dict "root" . "image" .Values.minio.image) }}
+          imagePullPolicy: {{ .Values.minio.image.pullPolicy }}
+          args: [server, /data, --console-address, ":9001"]
+          ports: [{name: api, containerPort: 9000}, {name: console, containerPort: 9001}]
+          env:
+            - name: MINIO_ROOT_USER
+              valueFrom: {secretKeyRef: {name: {{ include "futureagi.secretName" . }}, key: minio-root-user}}
+            - name: MINIO_ROOT_PASSWORD
+              valueFrom: {secretKeyRef: {name: {{ include "futureagi.secretName" . }}, key: minio-root-password}}
+          volumeMounts: [{name: data, mountPath: /data}]
+          readinessProbe: {httpGet: {path: /minio/health/ready, port: api}, periodSeconds: 10}
+          livenessProbe: {httpGet: {path: /minio/health/live, port: api}, periodSeconds: 20}
+          resources: {{ toYaml .Values.minio.resources | nindent 12 }}
+      {{- include "futureagi.podPlacement" . | nindent 6 }}
+  {{- if .Values.minio.persistence.enabled }}
+  volumeClaimTemplates:
+    - metadata: {name: data}
+      spec:
+        accessModes: [ReadWriteOnce]
+        {{- if .Values.global.storageClass }}storageClassName: {{ .Values.global.storageClass | quote }}{{- end }}
+        resources: {requests: {storage: {{ .Values.minio.persistence.size }}}}
+  {{- else }}
+      volumes: [{name: data, emptyDir: {}}]
+  {{- end }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "futureagi.fullname" . }}-minio
+  labels:
+    {{- include "futureagi.labels" . | nindent 4 }}
+spec:
+  clusterIP: None
+  selector: {{ include "futureagi.componentLabels" (dict "root" . "component" "minio") | nindent 4 }}
+  ports: [{name: api, port: 9000}, {name: console, port: 9001}]
+{{- end }}

--- a/deploy/helm/futureagi/templates/collector.yaml
+++ b/deploy/helm/futureagi/templates/collector.yaml
@@ -1,0 +1,75 @@
+{{- if .Values.fiCollector.enabled }}
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: {{ include "futureagi.fullname" . }}-fi-collector
+  labels:
+    {{- include "futureagi.labels" . | nindent 4 }}
+    app.kubernetes.io/component: fi-collector
+spec:
+  serviceName: {{ include "futureagi.fullname" . }}-fi-collector
+  replicas: {{ .Values.fiCollector.replicaCount }}
+  selector:
+    matchLabels: {{ include "futureagi.componentLabels" (dict "root" . "component" "fi-collector") | nindent 6 }}
+  template:
+    metadata:
+      labels: {{ include "futureagi.componentLabels" (dict "root" . "component" "fi-collector") | nindent 8 }}
+    spec:
+      serviceAccountName: {{ include "futureagi.serviceAccountName" . }}
+      {{- include "futureagi.imagePullSecrets" . | nindent 6 }}
+      securityContext: {{ toYaml .Values.fiCollector.podSecurityContext | nindent 8 }}
+      containers:
+        - name: fi-collector
+          image: {{ include "futureagi.image" (dict "root" . "image" .Values.fiCollector.image) }}
+          imagePullPolicy: {{ .Values.fiCollector.image.pullPolicy }}
+          securityContext: {{ toYaml .Values.fiCollector.containerSecurityContext | nindent 12 }}
+          ports:
+            - {name: grpc, containerPort: 4317}
+            - {name: http, containerPort: 4318}
+            - {name: admin, containerPort: 9464}
+          env:
+            - {name: FI_CH_URL, value: {{ printf "http://%s:%v" (include "futureagi.clickhouseHost" .) (ternary 8123 .Values.clickhouse.external.httpPort .Values.clickhouse.enabled) | quote }}}
+            - {name: FI_CH_DATABASE, value: {{ .Values.config.clickhouseDatabase | quote }}}
+            - {name: FI_CH_USERNAME, value: {{ .Values.clickhouse.external.username | quote }}}
+            - name: FI_CH_PASSWORD
+              valueFrom: {secretKeyRef: {name: {{ include "futureagi.secretName" . }}, key: clickhouse-password}}
+            - name: PG_PASSWORD
+              valueFrom: {secretKeyRef: {name: {{ include "futureagi.secretName" . }}, key: postgresql-password}}
+            - name: FI_PG_WRITE
+              value: {{ printf "postgres://%s:$(PG_PASSWORD)@%s:%v/%s?sslmode=disable" .Values.postgresql.username (include "futureagi.postgresqlHost" .) (ternary 5432 .Values.postgresql.external.port .Values.postgresql.enabled) .Values.postgresql.database | quote }}
+            - name: FI_PG_READ
+              value: {{ printf "postgres://%s:$(PG_PASSWORD)@%s:%v/%s?sslmode=disable" .Values.postgresql.username (include "futureagi.postgresqlHost" .) (ternary 5432 .Values.postgresql.external.port .Values.postgresql.enabled) .Values.postgresql.database | quote }}
+            - {name: FI_AUTH_REDIS_ADDR, value: {{ printf "%s:%v" (include "futureagi.redisHost" .) (ternary 6379 .Values.redis.external.port .Values.redis.enabled) | quote }}}
+            - {name: FI_GRPC_ADDR, value: ":4317"}
+            - {name: FI_HTTP_ADDR, value: ":4318"}
+            - {name: FI_ADMIN_ADDR, value: ":9464"}
+            - {name: FI_DEAD_LETTER_FILE, value: /var/lib/fi-collector/dead_letter.jsonl}
+          volumeMounts: [{name: data, mountPath: /var/lib/fi-collector}]
+          startupProbe: {httpGet: {path: /healthz, port: admin}, failureThreshold: 30, periodSeconds: 5}
+          readinessProbe: {httpGet: {path: /healthz, port: admin}, periodSeconds: 10}
+          livenessProbe: {httpGet: {path: /healthz, port: admin}, periodSeconds: 20}
+          resources: {{ toYaml .Values.fiCollector.resources | nindent 12 }}
+      {{- include "futureagi.podPlacement" . | nindent 6 }}
+  {{- if .Values.fiCollector.persistence.enabled }}
+  volumeClaimTemplates:
+    - metadata: {name: data}
+      spec:
+        accessModes: [ReadWriteOnce]
+        {{- if .Values.global.storageClass }}storageClassName: {{ .Values.global.storageClass | quote }}{{- end }}
+        resources: {requests: {storage: {{ .Values.fiCollector.persistence.size }}}}
+  {{- else }}
+      volumes: [{name: data, emptyDir: {}}]
+  {{- end }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "futureagi.fullname" . }}-fi-collector
+  labels: {{ include "futureagi.labels" . | nindent 4 }}
+spec:
+  selector: {{ include "futureagi.componentLabels" (dict "root" . "component" "fi-collector") | nindent 4 }}
+  ports:
+    - {name: grpc, port: {{ .Values.fiCollector.service.grpcPort }}, targetPort: grpc}
+    - {name: http, port: {{ .Values.fiCollector.service.httpPort }}, targetPort: http}
+    - {name: admin, port: {{ .Values.fiCollector.service.adminPort }}, targetPort: admin}
+{{- end }}

--- a/deploy/helm/futureagi/templates/configmap.yaml
+++ b/deploy/helm/futureagi/templates/configmap.yaml
@@ -1,0 +1,119 @@
+{{- if not (has .Values.deploymentMode (list "development" "production")) }}
+{{- fail "deploymentMode must be development or production" }}
+{{- end }}
+{{- if not (has .Values.config.storageBackend (list "minio" "s3" "gcs")) }}
+{{- fail "config.storageBackend must be minio, s3, or gcs" }}
+{{- end }}
+{{- if and .Values.minio.enabled (ne .Values.config.storageBackend "minio") }}
+{{- fail "config.storageBackend must be minio when bundled MinIO is enabled" }}
+{{- end }}
+{{- if and (not .Values.minio.enabled) (eq .Values.config.storageBackend "minio") }}
+{{- fail "minio.enabled=false requires config.storageBackend=s3 or gcs" }}
+{{- end }}
+{{- if and (eq .Values.deploymentMode "production") .Values.minio.enabled }}
+{{- fail "production mode requires minio.enabled=false and external S3 or GCS object storage" }}
+{{- end }}
+{{- if and (eq .Values.deploymentMode "production") (not .Values.secrets.existingSecret) }}
+{{- fail "production mode requires secrets.existingSecret" }}
+{{- end }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "futureagi.fullname" . }}-env
+  labels:
+    {{- include "futureagi.labels" . | nindent 4 }}
+data:
+  ENV_TYPE: prod
+  DJANGO_SETTINGS_MODULE: tfc.settings.settings
+  FUTURE_AGI_VERSION: {{ .Values.backend.image.tag | quote }}
+  FUTURE_AGI_DEPLOYMENT_TYPE: helm
+  FUTURE_AGI_TELEMETRY_DISABLED: {{ .Values.config.telemetryDisabled | quote }}
+  FUTURE_AGI_TELEMETRY_JITTER_SECONDS: {{ .Values.config.telemetryJitterSeconds | quote }}
+  FRONTEND_URL: {{ .Values.config.frontendUrl | quote }}
+  BASE_URL: {{ .Values.config.backendUrl | quote }}
+  ALK_RUNNER_API_URL: {{ printf "http://%s-backend" (include "futureagi.fullname" .) | quote }}
+  PG_HOST: {{ include "futureagi.postgresqlHost" . | quote }}
+  PG_PORT: {{ ternary 5432 .Values.postgresql.external.port .Values.postgresql.enabled | quote }}
+  PGBOUNCER_HOST: {{ include "futureagi.postgresqlHost" . | quote }}
+  PGBOUNCER_PORT: {{ ternary 5432 .Values.postgresql.external.port .Values.postgresql.enabled | quote }}
+  PG_USER: {{ ternary .Values.postgresql.username .Values.postgresql.username .Values.postgresql.enabled | quote }}
+  PG_DB: {{ .Values.postgresql.database | quote }}
+  CH_HOST: {{ include "futureagi.clickhouseHost" . | quote }}
+  CH_PORT: {{ ternary 9000 .Values.clickhouse.external.tcpPort .Values.clickhouse.enabled | quote }}
+  CH_HTTP_PORT: {{ ternary 8123 .Values.clickhouse.external.httpPort .Values.clickhouse.enabled | quote }}
+  CH_USER: {{ .Values.clickhouse.external.username | quote }}
+  CH_USERNAME: {{ .Values.clickhouse.external.username | quote }}
+  CH_ENABLED: "true"
+  CH_DATABASE: {{ .Values.config.clickhouseDatabase | quote }}
+  CH25_DATABASE: {{ .Values.config.clickhouseDatabase | quote }}
+  CH_USE_REPLICATED_ENGINES: "false"
+  CH25_DROP_LEGACY_CDC_CHAIN: "true"
+  REDIS_HOST: {{ include "futureagi.redisHost" . | quote }}
+  REDIS_PORT: {{ ternary 6379 .Values.redis.external.port .Values.redis.enabled | quote }}
+  REDIS_URL: {{ printf "redis://%s:%v/0" (include "futureagi.redisHost" .) (ternary 6379 .Values.redis.external.port .Values.redis.enabled) | quote }}
+  REDIS_CACHE_URL: {{ printf "redis://%s:%v/1" (include "futureagi.redisHost" .) (ternary 6379 .Values.redis.external.port .Values.redis.enabled) | quote }}
+  REDIS_LOCK_URL: {{ printf "redis://%s:%v/2" (include "futureagi.redisHost" .) (ternary 6379 .Values.redis.external.port .Values.redis.enabled) | quote }}
+  REDIS_STATE_URL: {{ printf "redis://%s:%v/2" (include "futureagi.redisHost" .) (ternary 6379 .Values.redis.external.port .Values.redis.enabled) | quote }}
+  STORAGE_BACKEND: {{ .Values.config.storageBackend | quote }}
+  S3_ENDPOINT_URL: {{ include "futureagi.objectStorageEndpoint" . | quote }}
+  S3_SECURE: {{ ternary false .Values.config.s3Secure .Values.minio.enabled | quote }}
+  S3_REGION: {{ .Values.config.s3Region | quote }}
+  AWS_DEFAULT_REGION: {{ .Values.config.s3Region | quote }}
+  MINIO_REGION: {{ .Values.config.s3Region | quote }}
+  MINIO_URL: {{ default (include "futureagi.objectStorageEndpoint" .) .Values.config.minioUrl | quote }}
+  S3_BUCKET: {{ .Values.config.s3Bucket | quote }}
+  UPLOAD_BUCKET_NAME: {{ .Values.config.s3Bucket | quote }}
+  MINIO_BUCKET_NAME: {{ .Values.config.s3Bucket | quote }}
+  TEMPORAL_HOST: {{ printf "%s:%v" (include "futureagi.temporalHost" .) (ternary 7233 .Values.temporal.external.port .Values.temporal.enabled) | quote }}
+  TEMPORAL_NAMESPACE: {{ .Values.config.temporalNamespace | quote }}
+  AGENTCC_INTERNAL_URL: {{ printf "http://%s-agentcc-gateway:8080" (include "futureagi.fullname" .) | quote }}
+  AGENTCC_GATEWAY_INTERNAL_URL: {{ printf "http://%s-agentcc-gateway:8080" (include "futureagi.fullname" .) | quote }}
+  SERVING_URL: {{ printf "http://%s-serving:8080" (include "futureagi.fullname" .) | quote }}
+  CODE_EXECUTOR_URL: {{ printf "http://%s-code-executor:8060" (include "futureagi.fullname" .) | quote }}
+---
+{{- if .Values.agentccGateway.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "futureagi.fullname" . }}-agentcc-config
+  labels:
+    {{- include "futureagi.labels" . | nindent 4 }}
+data:
+  config.yaml: |
+    {{- .Values.agentccGateway.config | nindent 4 }}
+{{- end }}
+---
+{{- if .Values.clickhouse.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "futureagi.fullname" . }}-clickhouse-config
+  labels:
+    {{- include "futureagi.labels" . | nindent 4 }}
+data:
+  storage-policy.xml: |-
+    <clickhouse>
+      <storage_configuration>
+        <disks>
+          <cold_local>
+            <path>/var/lib/clickhouse/cold/</path>
+            <keep_free_space_bytes>536870912</keep_free_space_bytes>
+          </cold_local>
+        </disks>
+        <policies>
+          <tiered>
+            <volumes>
+              <hot>
+                <disk>default</disk>
+                <max_data_part_size_bytes>10737418240</max_data_part_size_bytes>
+              </hot>
+              <cold>
+                <disk>cold_local</disk>
+              </cold>
+            </volumes>
+            <move_factor>0.05</move_factor>
+          </tiered>
+        </policies>
+      </storage_configuration>
+    </clickhouse>
+{{- end }}

--- a/deploy/helm/futureagi/templates/datastores.yaml
+++ b/deploy/helm/futureagi/templates/datastores.yaml
@@ -1,0 +1,159 @@
+{{- if .Values.postgresql.enabled }}
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: {{ include "futureagi.fullname" . }}-postgresql
+  labels: {{ include "futureagi.labels" . | nindent 4 }}
+spec:
+  serviceName: {{ include "futureagi.fullname" . }}-postgresql
+  replicas: 1
+  selector:
+    matchLabels: {{ include "futureagi.componentLabels" (dict "root" . "component" "postgresql") | nindent 6 }}
+  template:
+    metadata:
+      labels: {{ include "futureagi.componentLabels" (dict "root" . "component" "postgresql") | nindent 8 }}
+    spec:
+      {{- include "futureagi.imagePullSecrets" . | nindent 6 }}
+      containers:
+        - name: postgresql
+          image: {{ include "futureagi.image" (dict "root" . "image" .Values.postgresql.image) }}
+          imagePullPolicy: {{ .Values.postgresql.image.pullPolicy }}
+          args: ["-c", "wal_level=logical", "-c", "max_wal_senders=25", "-c", "max_replication_slots=25"]
+          ports: [{name: postgresql, containerPort: 5432}]
+          env:
+            - {name: POSTGRES_USER, value: {{ .Values.postgresql.username | quote }}}
+            - {name: POSTGRES_DB, value: {{ .Values.postgresql.database | quote }}}
+            - name: POSTGRES_PASSWORD
+              valueFrom: {secretKeyRef: {name: {{ include "futureagi.secretName" . }}, key: postgresql-password}}
+          volumeMounts: [{name: data, mountPath: /var/lib/postgresql/data}]
+          readinessProbe: {exec: {command: [sh, -c, "pg_isready -U $POSTGRES_USER -d $POSTGRES_DB"]}, periodSeconds: 10}
+          livenessProbe: {exec: {command: [sh, -c, "pg_isready -U $POSTGRES_USER -d $POSTGRES_DB"]}, periodSeconds: 20}
+          resources: {{ toYaml .Values.postgresql.resources | nindent 12 }}
+      {{- include "futureagi.podPlacement" . | nindent 6 }}
+  {{- if .Values.postgresql.persistence.enabled }}
+  volumeClaimTemplates:
+    - metadata: {name: data}
+      spec:
+        accessModes: [ReadWriteOnce]
+        {{- if .Values.global.storageClass }}storageClassName: {{ .Values.global.storageClass | quote }}{{- end }}
+        resources: {requests: {storage: {{ .Values.postgresql.persistence.size }}}}
+  {{- else }}
+      volumes: [{name: data, emptyDir: {}}]
+  {{- end }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "futureagi.fullname" . }}-postgresql
+  labels:
+    {{- include "futureagi.labels" . | nindent 4 }}
+spec:
+  clusterIP: None
+  selector: {{ include "futureagi.componentLabels" (dict "root" . "component" "postgresql") | nindent 4 }}
+  ports: [{name: postgresql, port: 5432}]
+{{- end }}
+{{- if .Values.redis.enabled }}
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: {{ include "futureagi.fullname" . }}-redis
+  labels:
+    {{- include "futureagi.labels" . | nindent 4 }}
+spec:
+  serviceName: {{ include "futureagi.fullname" . }}-redis
+  replicas: 1
+  selector:
+    matchLabels: {{ include "futureagi.componentLabels" (dict "root" . "component" "redis") | nindent 6 }}
+  template:
+    metadata:
+      labels: {{ include "futureagi.componentLabels" (dict "root" . "component" "redis") | nindent 8 }}
+    spec:
+      {{- include "futureagi.imagePullSecrets" . | nindent 6 }}
+      containers:
+        - name: redis
+          image: {{ include "futureagi.image" (dict "root" . "image" .Values.redis.image) }}
+          imagePullPolicy: {{ .Values.redis.image.pullPolicy }}
+          args: [redis-server, --appendonly, "yes"]
+          ports: [{name: redis, containerPort: 6379}]
+          volumeMounts: [{name: data, mountPath: /data}]
+          readinessProbe: {exec: {command: [redis-cli, ping]}, periodSeconds: 10}
+          livenessProbe: {exec: {command: [redis-cli, ping]}, periodSeconds: 20}
+          resources: {{ toYaml .Values.redis.resources | nindent 12 }}
+      {{- include "futureagi.podPlacement" . | nindent 6 }}
+  {{- if .Values.redis.persistence.enabled }}
+  volumeClaimTemplates:
+    - metadata: {name: data}
+      spec:
+        accessModes: [ReadWriteOnce]
+        {{- if .Values.global.storageClass }}storageClassName: {{ .Values.global.storageClass | quote }}{{- end }}
+        resources: {requests: {storage: {{ .Values.redis.persistence.size }}}}
+  {{- else }}
+      volumes: [{name: data, emptyDir: {}}]
+  {{- end }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "futureagi.fullname" . }}-redis
+  labels:
+    {{- include "futureagi.labels" . | nindent 4 }}
+spec:
+  clusterIP: None
+  selector: {{ include "futureagi.componentLabels" (dict "root" . "component" "redis") | nindent 4 }}
+  ports: [{name: redis, port: 6379}]
+{{- end }}
+{{- if .Values.rabbitmq.enabled }}
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: {{ include "futureagi.fullname" . }}-rabbitmq
+  labels:
+    {{- include "futureagi.labels" . | nindent 4 }}
+spec:
+  serviceName: {{ include "futureagi.fullname" . }}-rabbitmq
+  replicas: 1
+  selector:
+    matchLabels: {{ include "futureagi.componentLabels" (dict "root" . "component" "rabbitmq") | nindent 6 }}
+  template:
+    metadata:
+      labels: {{ include "futureagi.componentLabels" (dict "root" . "component" "rabbitmq") | nindent 8 }}
+    spec:
+      {{- include "futureagi.imagePullSecrets" . | nindent 6 }}
+      containers:
+        - name: rabbitmq
+          image: {{ include "futureagi.image" (dict "root" . "image" .Values.rabbitmq.image) }}
+          imagePullPolicy: {{ .Values.rabbitmq.image.pullPolicy }}
+          ports: [{name: amqp, containerPort: 5672}, {name: management, containerPort: 15672}]
+          env:
+            - {name: RABBITMQ_DEFAULT_USER, value: {{ .Values.rabbitmq.username | quote }}}
+            - name: RABBITMQ_DEFAULT_PASS
+              valueFrom: {secretKeyRef: {name: {{ include "futureagi.secretName" . }}, key: rabbitmq-password}}
+          volumeMounts: [{name: data, mountPath: /var/lib/rabbitmq}]
+          readinessProbe: {exec: {command: [rabbitmq-diagnostics, -q, check_running]}, periodSeconds: 10}
+          livenessProbe: {exec: {command: [rabbitmq-diagnostics, -q, ping]}, periodSeconds: 20}
+          resources: {{ toYaml .Values.rabbitmq.resources | nindent 12 }}
+      {{- include "futureagi.podPlacement" . | nindent 6 }}
+  {{- if .Values.rabbitmq.persistence.enabled }}
+  volumeClaimTemplates:
+    - metadata: {name: data}
+      spec:
+        accessModes: [ReadWriteOnce]
+        {{- if .Values.global.storageClass }}storageClassName: {{ .Values.global.storageClass | quote }}{{- end }}
+        resources: {requests: {storage: {{ .Values.rabbitmq.persistence.size }}}}
+  {{- else }}
+      volumes: [{name: data, emptyDir: {}}]
+  {{- end }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "futureagi.fullname" . }}-rabbitmq
+  labels:
+    {{- include "futureagi.labels" . | nindent 4 }}
+spec:
+  clusterIP: None
+  selector: {{ include "futureagi.componentLabels" (dict "root" . "component" "rabbitmq") | nindent 4 }}
+  ports: [{name: amqp, port: 5672}, {name: management, port: 15672}]
+{{- end }}

--- a/deploy/helm/futureagi/templates/ingress.yaml
+++ b/deploy/helm/futureagi/templates/ingress.yaml
@@ -1,0 +1,30 @@
+{{- if .Values.ingress.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "futureagi.fullname" . }}
+  labels:
+    {{- include "futureagi.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations: {{ toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- with .Values.ingress.className }}ingressClassName: {{ . }}{{- end }}
+  rules:
+    {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            pathType: {{ .pathType }}
+            backend:
+              service:
+                name: {{ include "futureagi.fullname" $ }}-{{ .service }}
+                port: {name: http}
+          {{- end }}
+    {{- end }}
+  {{- with .Values.ingress.tls }}
+  tls: {{ toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/deploy/helm/futureagi/templates/minio-init.yaml
+++ b/deploy/helm/futureagi/templates/minio-init.yaml
@@ -1,0 +1,46 @@
+{{- if .Values.minio.enabled }}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ include "futureagi.fullname" . }}-minio-init
+  labels:
+    {{- include "futureagi.labels" . | nindent 4 }}
+    app.kubernetes.io/component: minio-init
+  annotations:
+    helm.sh/hook: post-install,post-upgrade
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+    helm.sh/hook-weight: "5"
+spec:
+  activeDeadlineSeconds: 300
+  backoffLimit: 5
+  ttlSecondsAfterFinished: 300
+  template:
+    metadata:
+      labels:
+        {{- include "futureagi.componentLabels" (dict "root" . "component" "minio-init") | nindent 8 }}
+    spec:
+      restartPolicy: Never
+      serviceAccountName: {{ include "futureagi.serviceAccountName" . }}
+      {{- include "futureagi.imagePullSecrets" . | nindent 6 }}
+      containers:
+        - name: create-bucket
+          image: {{ include "futureagi.image" (dict "root" . "image" .Values.minio.image) }}
+          imagePullPolicy: {{ .Values.minio.image.pullPolicy }}
+          command: [/bin/sh, -ec]
+          args:
+            - |-
+              until mc alias set futureagi http://{{ include "futureagi.fullname" . }}-minio:9000 "$MINIO_ROOT_USER" "$MINIO_ROOT_PASSWORD"; do
+                sleep 2
+              done
+              mc mb --ignore-existing "futureagi/$S3_BUCKET"
+          env:
+            - name: MINIO_ROOT_USER
+              valueFrom: {secretKeyRef: {name: {{ include "futureagi.secretName" . }}, key: minio-root-user}}
+            - name: MINIO_ROOT_PASSWORD
+              valueFrom: {secretKeyRef: {name: {{ include "futureagi.secretName" . }}, key: minio-root-password}}
+            - {name: S3_BUCKET, value: {{ .Values.config.s3Bucket | quote }}}
+          resources:
+            requests: {cpu: 10m, memory: 32Mi}
+            limits: {cpu: 100m, memory: 128Mi}
+      {{- include "futureagi.podPlacement" . | nindent 6 }}
+{{- end }}

--- a/deploy/helm/futureagi/templates/secret.yaml
+++ b/deploy/helm/futureagi/templates/secret.yaml
@@ -1,0 +1,25 @@
+{{- if not .Values.secrets.existingSecret }}
+{{- $current := lookup "v1" "Secret" .Release.Namespace (printf "%s-secrets" (include "futureagi.fullname" .)) -}}
+{{- $data := (default dict $current.data) -}}
+{{- $minioUser := default (default "futureagi" (get $data "minio-root-user" | b64dec)) .Values.secrets.minioRootUser -}}
+{{- $minioPassword := default (default (randAlphaNum 32) (get $data "minio-root-password" | b64dec)) .Values.secrets.minioRootPassword -}}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "futureagi.fullname" . }}-secrets
+  labels:
+    {{- include "futureagi.labels" . | nindent 4 }}
+type: Opaque
+stringData:
+  django-secret-key: {{ default (default (randAlphaNum 64) (get $data "django-secret-key" | b64dec)) .Values.secrets.djangoSecretKey | quote }}
+  integration-encryption-key: {{ default (default (randBytes 32) (get $data "integration-encryption-key" | b64dec)) .Values.secrets.integrationEncryptionKey | quote }}
+  agentcc-internal-api-key: {{ default (default (randAlphaNum 48) (get $data "agentcc-internal-api-key" | b64dec)) .Values.secrets.agentccInternalApiKey | quote }}
+  agentcc-admin-token: {{ default (default (randAlphaNum 48) (get $data "agentcc-admin-token" | b64dec)) .Values.secrets.agentccAdminToken | quote }}
+  postgresql-password: {{ default (default (randAlphaNum 32) (get $data "postgresql-password" | b64dec)) .Values.secrets.postgresqlPassword | quote }}
+  clickhouse-password: {{ default (get $data "clickhouse-password" | b64dec) .Values.secrets.clickhousePassword | quote }}
+  rabbitmq-password: {{ default (default (randAlphaNum 32) (get $data "rabbitmq-password" | b64dec)) .Values.secrets.rabbitmqPassword | quote }}
+  minio-root-user: {{ $minioUser | quote }}
+  minio-root-password: {{ $minioPassword | quote }}
+  object-storage-access-key: {{ default (default $minioUser (get $data "object-storage-access-key" | b64dec)) .Values.secrets.objectStorageAccessKey | quote }}
+  object-storage-secret-key: {{ default (default $minioPassword (get $data "object-storage-secret-key" | b64dec)) .Values.secrets.objectStorageSecretKey | quote }}
+{{- end }}

--- a/deploy/helm/futureagi/templates/serviceaccount.yaml
+++ b/deploy/helm/futureagi/templates/serviceaccount.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "futureagi.serviceAccountName" . }}
+  labels:
+    {{- include "futureagi.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+automountServiceAccountToken: false
+{{- end }}

--- a/deploy/helm/futureagi/templates/supporting-apps.yaml
+++ b/deploy/helm/futureagi/templates/supporting-apps.yaml
@@ -1,0 +1,162 @@
+{{- if .Values.agentccGateway.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "futureagi.fullname" . }}-agentcc-gateway
+  labels:
+    {{- include "futureagi.labels" . | nindent 4 }}
+    app.kubernetes.io/component: agentcc-gateway
+spec:
+  replicas: {{ .Values.agentccGateway.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "futureagi.componentLabels" (dict "root" . "component" "agentcc-gateway") | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "futureagi.componentLabels" (dict "root" . "component" "agentcc-gateway") | nindent 8 }}
+      annotations:
+        checksum/config: {{ .Values.agentccGateway.config | sha256sum }}
+    spec:
+      serviceAccountName: {{ include "futureagi.serviceAccountName" . }}
+      {{- include "futureagi.imagePullSecrets" . | nindent 6 }}
+      securityContext: {{ toYaml .Values.agentccGateway.podSecurityContext | nindent 8 }}
+      containers:
+        - name: agentcc-gateway
+          image: {{ include "futureagi.image" (dict "root" . "image" .Values.agentccGateway.image) }}
+          imagePullPolicy: {{ .Values.agentccGateway.image.pullPolicy }}
+          securityContext: {{ toYaml .Values.agentccGateway.containerSecurityContext | nindent 12 }}
+          args: ["--config", "/app/config.yaml"]
+          ports: [{name: http, containerPort: 8080}]
+          env:
+            - name: AGENTCC_INTERNAL_API_KEY
+              valueFrom: {secretKeyRef: {name: {{ include "futureagi.secretName" . }}, key: agentcc-internal-api-key}}
+            - name: AGENTCC_ADMIN_TOKEN
+              valueFrom: {secretKeyRef: {name: {{ include "futureagi.secretName" . }}, key: agentcc-admin-token}}
+            {{- with .Values.config.providerEnv }}{{ toYaml . | nindent 12 }}{{- end }}
+          volumeMounts: [{name: config, mountPath: /app/config.yaml, subPath: config.yaml, readOnly: true}]
+          startupProbe: {httpGet: {path: /livez, port: http}, failureThreshold: 30, periodSeconds: 5}
+          readinessProbe: {httpGet: {path: /readyz, port: http}, periodSeconds: 10}
+          livenessProbe: {httpGet: {path: /livez, port: http}, periodSeconds: 20}
+          resources: {{ toYaml .Values.agentccGateway.resources | nindent 12 }}
+      volumes: [{name: config, configMap: {name: {{ include "futureagi.fullname" . }}-agentcc-config}}]
+      {{- include "futureagi.podPlacement" . | nindent 6 }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "futureagi.fullname" . }}-agentcc-gateway
+  labels: {{ include "futureagi.labels" . | nindent 4 }}
+spec:
+  selector: {{ include "futureagi.componentLabels" (dict "root" . "component" "agentcc-gateway") | nindent 4 }}
+  ports: [{name: http, port: {{ .Values.agentccGateway.service.port }}, targetPort: http}]
+{{- end }}
+{{- if .Values.serving.enabled }}
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "futureagi.fullname" . }}-serving
+  labels:
+    {{- include "futureagi.labels" . | nindent 4 }}
+    app.kubernetes.io/component: serving
+spec:
+  replicas: {{ .Values.serving.replicaCount }}
+  selector:
+    matchLabels: {{ include "futureagi.componentLabels" (dict "root" . "component" "serving") | nindent 6 }}
+  template:
+    metadata:
+      labels: {{ include "futureagi.componentLabels" (dict "root" . "component" "serving") | nindent 8 }}
+    spec:
+      serviceAccountName: {{ include "futureagi.serviceAccountName" . }}
+      {{- include "futureagi.imagePullSecrets" . | nindent 6 }}
+      securityContext: {{ toYaml .Values.serving.podSecurityContext | nindent 8 }}
+      containers:
+        - name: serving
+          image: {{ include "futureagi.image" (dict "root" . "image" .Values.serving.image) }}
+          imagePullPolicy: {{ .Values.serving.image.pullPolicy }}
+          securityContext: {{ toYaml .Values.serving.containerSecurityContext | nindent 12 }}
+          ports: [{name: http, containerPort: 8080}]
+          envFrom: [{configMapRef: {name: {{ include "futureagi.fullname" . }}-env}}]
+          env:
+            - name: SECRET_KEY
+              valueFrom: {secretKeyRef: {name: {{ include "futureagi.secretName" . }}, key: django-secret-key}}
+            - name: INTEGRATION_ENCRYPTION_KEY
+              valueFrom: {secretKeyRef: {name: {{ include "futureagi.secretName" . }}, key: integration-encryption-key}}
+            - name: AGENTCC_INTERNAL_API_KEY
+              valueFrom: {secretKeyRef: {name: {{ include "futureagi.secretName" . }}, key: agentcc-internal-api-key}}
+            - name: AGENTCC_ADMIN_TOKEN
+              valueFrom: {secretKeyRef: {name: {{ include "futureagi.secretName" . }}, key: agentcc-admin-token}}
+            - name: PG_PASSWORD
+              valueFrom: {secretKeyRef: {name: {{ include "futureagi.secretName" . }}, key: postgresql-password}}
+            - name: CH_PASSWORD
+              valueFrom: {secretKeyRef: {name: {{ include "futureagi.secretName" . }}, key: clickhouse-password}}
+            - name: RABBITMQ_PASSWORD
+              valueFrom: {secretKeyRef: {name: {{ include "futureagi.secretName" . }}, key: rabbitmq-password}}
+            - name: S3_ACCESS_KEY
+              valueFrom: {secretKeyRef: {name: {{ include "futureagi.secretName" . }}, key: object-storage-access-key}}
+            - name: S3_SECRET_KEY
+              valueFrom: {secretKeyRef: {name: {{ include "futureagi.secretName" . }}, key: object-storage-secret-key}}
+            - name: GCS_HMAC_ACCESS_KEY
+              valueFrom: {secretKeyRef: {name: {{ include "futureagi.secretName" . }}, key: object-storage-access-key}}
+            - name: GCS_HMAC_SECRET_KEY
+              valueFrom: {secretKeyRef: {name: {{ include "futureagi.secretName" . }}, key: object-storage-secret-key}}
+            - name: CELERY_BROKER_URL
+              value: {{ printf "amqp://%s:$(RABBITMQ_PASSWORD)@%s:%v//" (ternary .Values.rabbitmq.username .Values.rabbitmq.external.username .Values.rabbitmq.enabled) (include "futureagi.rabbitmqHost" .) (ternary 5672 .Values.rabbitmq.external.port .Values.rabbitmq.enabled) | quote }}
+            {{- with .Values.config.providerEnv }}{{ toYaml . | nindent 12 }}{{- end }}
+            {{- with .Values.config.extraEnv }}{{ toYaml . | nindent 12 }}{{- end }}
+          startupProbe: {tcpSocket: {port: http}, failureThreshold: 30, periodSeconds: 5}
+          readinessProbe: {tcpSocket: {port: http}, periodSeconds: 10}
+          livenessProbe: {tcpSocket: {port: http}, periodSeconds: 20}
+          resources: {{ toYaml .Values.serving.resources | nindent 12 }}
+      {{- include "futureagi.podPlacement" . | nindent 6 }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "futureagi.fullname" . }}-serving
+  labels: {{ include "futureagi.labels" . | nindent 4 }}
+spec:
+  selector: {{ include "futureagi.componentLabels" (dict "root" . "component" "serving") | nindent 4 }}
+  ports: [{name: http, port: {{ .Values.serving.service.port }}, targetPort: http}]
+{{- end }}
+{{- if .Values.codeExecutor.enabled }}
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "futureagi.fullname" . }}-code-executor
+  labels:
+    {{- include "futureagi.labels" . | nindent 4 }}
+    app.kubernetes.io/component: code-executor
+spec:
+  replicas: {{ .Values.codeExecutor.replicaCount }}
+  selector:
+    matchLabels: {{ include "futureagi.componentLabels" (dict "root" . "component" "code-executor") | nindent 6 }}
+  template:
+    metadata:
+      labels: {{ include "futureagi.componentLabels" (dict "root" . "component" "code-executor") | nindent 8 }}
+    spec:
+      serviceAccountName: {{ include "futureagi.serviceAccountName" . }}
+      {{- include "futureagi.imagePullSecrets" . | nindent 6 }}
+      containers:
+        - name: code-executor
+          image: {{ include "futureagi.image" (dict "root" . "image" .Values.codeExecutor.image) }}
+          imagePullPolicy: {{ .Values.codeExecutor.image.pullPolicy }}
+          securityContext: {privileged: {{ .Values.codeExecutor.privileged }}}
+          ports: [{name: http, containerPort: 8060}]
+          startupProbe: {httpGet: {path: /health, port: http}, failureThreshold: 30, periodSeconds: 5}
+          readinessProbe: {httpGet: {path: /health, port: http}, periodSeconds: 10}
+          livenessProbe: {httpGet: {path: /health, port: http}, periodSeconds: 20}
+          resources: {{ toYaml .Values.codeExecutor.resources | nindent 12 }}
+      {{- include "futureagi.podPlacement" . | nindent 6 }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "futureagi.fullname" . }}-code-executor
+  labels: {{ include "futureagi.labels" . | nindent 4 }}
+spec:
+  selector: {{ include "futureagi.componentLabels" (dict "root" . "component" "code-executor") | nindent 4 }}
+  ports: [{name: http, port: {{ .Values.codeExecutor.service.port }}, targetPort: http}]
+{{- end }}

--- a/deploy/helm/futureagi/templates/temporal.yaml
+++ b/deploy/helm/futureagi/templates/temporal.yaml
@@ -1,0 +1,48 @@
+{{- if .Values.temporal.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "futureagi.fullname" . }}-temporal
+  labels:
+    {{- include "futureagi.labels" . | nindent 4 }}
+    app.kubernetes.io/component: temporal
+spec:
+  replicas: 1
+  selector:
+    matchLabels: {{ include "futureagi.componentLabels" (dict "root" . "component" "temporal") | nindent 6 }}
+  template:
+    metadata:
+      labels: {{ include "futureagi.componentLabels" (dict "root" . "component" "temporal") | nindent 8 }}
+    spec:
+      {{- include "futureagi.imagePullSecrets" . | nindent 6 }}
+      containers:
+        - name: temporal
+          image: {{ include "futureagi.image" (dict "root" . "image" .Values.temporal.image) }}
+          imagePullPolicy: {{ .Values.temporal.image.pullPolicy }}
+          ports: [{name: grpc, containerPort: 7233}]
+          env:
+            - {name: DB, value: postgres12}
+            - {name: DB_PORT, value: "5432"}
+            - {name: POSTGRES_USER, value: {{ .Values.postgresql.username | quote }}}
+            - name: POSTGRES_PWD
+              valueFrom: {secretKeyRef: {name: {{ include "futureagi.secretName" . }}, key: postgresql-password}}
+            - {name: POSTGRES_SEEDS, value: {{ include "futureagi.postgresqlHost" . | quote }}}
+            - {name: DBNAME, value: {{ .Values.postgresql.database | quote }}}
+            - {name: ENABLE_ES, value: "false"}
+            - {name: LOG_LEVEL, value: info}
+          startupProbe: {tcpSocket: {port: grpc}, failureThreshold: 60, periodSeconds: 5}
+          readinessProbe: {tcpSocket: {port: grpc}, periodSeconds: 10}
+          livenessProbe: {tcpSocket: {port: grpc}, periodSeconds: 20}
+          resources: {{ toYaml .Values.temporal.resources | nindent 12 }}
+      {{- include "futureagi.podPlacement" . | nindent 6 }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "futureagi.fullname" . }}-temporal
+  labels:
+    {{- include "futureagi.labels" . | nindent 4 }}
+spec:
+  selector: {{ include "futureagi.componentLabels" (dict "root" . "component" "temporal") | nindent 4 }}
+  ports: [{name: grpc, port: 7233, targetPort: grpc}]
+{{- end }}

--- a/deploy/helm/futureagi/templates/tests/test-connection.yaml
+++ b/deploy/helm/futureagi/templates/tests/test-connection.yaml
@@ -1,0 +1,21 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: {{ include "futureagi.fullname" . }}-test-connection
+  labels:
+    {{- include "futureagi.labels" . | nindent 4 }}
+  annotations:
+    helm.sh/hook: test
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+spec:
+  restartPolicy: Never
+  containers:
+    - name: wget
+      image: busybox:1.36
+      command: [sh, -ec]
+      args:
+        - >-
+          wget -qO- http://{{ include "futureagi.fullname" . }}-backend/health/;
+          {{- if .Values.frontend.enabled }}
+          wget -qO- http://{{ include "futureagi.fullname" . }}-frontend/;
+          {{- end }}

--- a/deploy/helm/futureagi/templates/worker.yaml
+++ b/deploy/helm/futureagi/templates/worker.yaml
@@ -1,0 +1,66 @@
+{{- if .Values.worker.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "futureagi.fullname" . }}-worker
+  labels:
+    {{- include "futureagi.labels" . | nindent 4 }}
+    app.kubernetes.io/component: worker
+spec:
+  replicas: {{ .Values.worker.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "futureagi.componentLabels" (dict "root" . "component" "worker") | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "futureagi.componentLabels" (dict "root" . "component" "worker") | nindent 8 }}
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        checksum/secret: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
+    spec:
+      serviceAccountName: {{ include "futureagi.serviceAccountName" . }}
+      {{- include "futureagi.imagePullSecrets" . | nindent 6 }}
+      securityContext: {{ toYaml .Values.worker.podSecurityContext | nindent 8 }}
+      containers:
+        - name: worker
+          image: {{ include "futureagi.image" (dict "root" . "image" .Values.backend.image) }}
+          imagePullPolicy: {{ .Values.backend.image.pullPolicy }}
+          securityContext: {{ toYaml .Values.worker.containerSecurityContext | nindent 12 }}
+          envFrom: [{configMapRef: {name: {{ include "futureagi.fullname" . }}-env}}]
+          env:
+            - {name: SERVICE_TYPE, value: temporal-worker}
+            - {name: TEMPORAL_ALL_QUEUES, value: {{ .Values.worker.allQueues | quote }}}
+            - {name: TEMPORAL_EXCLUDED_QUEUES, value: {{ .Values.worker.excludedQueues | quote }}}
+            - {name: TEMPORAL_MAX_CONCURRENT_ACTIVITIES, value: {{ .Values.worker.maxConcurrentActivities | quote }}}
+            - {name: TEMPORAL_MAX_CONCURRENT_WORKFLOW_TASKS, value: {{ .Values.worker.maxConcurrentWorkflowTasks | quote }}}
+            - {name: REGISTER_TEMPORAL_SCHEDULES, value: "false"}
+            - name: SECRET_KEY
+              valueFrom: {secretKeyRef: {name: {{ include "futureagi.secretName" . }}, key: django-secret-key}}
+            - name: INTEGRATION_ENCRYPTION_KEY
+              valueFrom: {secretKeyRef: {name: {{ include "futureagi.secretName" . }}, key: integration-encryption-key}}
+            - name: AGENTCC_INTERNAL_API_KEY
+              valueFrom: {secretKeyRef: {name: {{ include "futureagi.secretName" . }}, key: agentcc-internal-api-key}}
+            - name: AGENTCC_ADMIN_TOKEN
+              valueFrom: {secretKeyRef: {name: {{ include "futureagi.secretName" . }}, key: agentcc-admin-token}}
+            - name: PG_PASSWORD
+              valueFrom: {secretKeyRef: {name: {{ include "futureagi.secretName" . }}, key: postgresql-password}}
+            - name: CH_PASSWORD
+              valueFrom: {secretKeyRef: {name: {{ include "futureagi.secretName" . }}, key: clickhouse-password}}
+            - name: RABBITMQ_PASSWORD
+              valueFrom: {secretKeyRef: {name: {{ include "futureagi.secretName" . }}, key: rabbitmq-password}}
+            - name: S3_ACCESS_KEY
+              valueFrom: {secretKeyRef: {name: {{ include "futureagi.secretName" . }}, key: object-storage-access-key}}
+            - name: S3_SECRET_KEY
+              valueFrom: {secretKeyRef: {name: {{ include "futureagi.secretName" . }}, key: object-storage-secret-key}}
+            - name: GCS_HMAC_ACCESS_KEY
+              valueFrom: {secretKeyRef: {name: {{ include "futureagi.secretName" . }}, key: object-storage-access-key}}
+            - name: GCS_HMAC_SECRET_KEY
+              valueFrom: {secretKeyRef: {name: {{ include "futureagi.secretName" . }}, key: object-storage-secret-key}}
+            - name: CELERY_BROKER_URL
+              value: {{ printf "amqp://%s:$(RABBITMQ_PASSWORD)@%s:%v//" (ternary .Values.rabbitmq.username .Values.rabbitmq.external.username .Values.rabbitmq.enabled) (include "futureagi.rabbitmqHost" .) (ternary 5672 .Values.rabbitmq.external.port .Values.rabbitmq.enabled) | quote }}
+            {{- with .Values.config.providerEnv }}{{ toYaml . | nindent 12 }}{{- end }}
+            {{- with .Values.config.extraEnv }}{{ toYaml . | nindent 12 }}{{- end }}
+          resources: {{ toYaml .Values.worker.resources | nindent 12 }}
+      {{- include "futureagi.podPlacement" . | nindent 6 }}
+{{- end }}

--- a/deploy/helm/futureagi/values.yaml
+++ b/deploy/helm/futureagi/values.yaml
@@ -1,0 +1,267 @@
+nameOverride: ""
+fullnameOverride: ""
+
+# Development installs may use the bundled MinIO service. Production mode
+# requires external S3 or GCS object storage and a pre-created Secret.
+deploymentMode: development
+
+global:
+  imagePullSecrets: []
+  imageRegistry: ""
+  storageClass: ""
+  podAnnotations: {}
+  nodeSelector: {}
+  tolerations: []
+  affinity: {}
+
+serviceAccount:
+  create: true
+  annotations: {}
+  name: ""
+
+secrets:
+  # Use an existing Secret to keep credentials outside Helm release values.
+  # Required keys are documented in README.md.
+  existingSecret: ""
+  djangoSecretKey: ""
+  integrationEncryptionKey: ""
+  agentccInternalApiKey: ""
+  agentccAdminToken: ""
+  postgresqlPassword: ""
+  clickhousePassword: ""
+  rabbitmqPassword: ""
+  minioRootUser: futureagi
+  minioRootPassword: ""
+  objectStorageAccessKey: ""
+  objectStorageSecretKey: ""
+
+config:
+  frontendUrl: http://localhost:3000
+  backendUrl: http://localhost:8000
+  helpLink: ""
+  telemetryDisabled: false
+  telemetryJitterSeconds: 1800
+  storageBackend: minio
+  s3Bucket: futureagi
+  # Used when minio.enabled=false. Empty defaults to the provider endpoint.
+  s3Endpoint: ""
+  s3Region: us-east-2
+  s3Secure: true
+  # Browser-facing object-storage URL. Empty uses the internal MinIO service.
+  minioUrl: ""
+  temporalNamespace: default
+  clickhouseDatabase: default
+  extraEnv: []
+  providerEnv: []
+
+frontend:
+  enabled: true
+  replicaCount: 1
+  image:
+    repository: futureagi/frontend
+    tag: v1.23.1
+    pullPolicy: IfNotPresent
+  service:
+    type: ClusterIP
+    port: 80
+  resources:
+    requests: {cpu: 50m, memory: 64Mi}
+    limits: {cpu: 500m, memory: 256Mi}
+  # The published nginx image binds port 80 and writes config.js at startup.
+  # Keep its image-defined user; enforce a non-root profile only with a
+  # compatible custom image/listen port.
+  podSecurityContext: {}
+  containerSecurityContext:
+    allowPrivilegeEscalation: false
+    readOnlyRootFilesystem: false
+
+backend:
+  replicaCount: 1
+  image:
+    repository: futureagi/future-agi
+    tag: v1.23.1
+    pullPolicy: IfNotPresent
+  service:
+    type: ClusterIP
+    httpPort: 80
+    grpcPort: 50051
+  granianWorkers: 1
+  granianThreads: 2
+  enableGrpc: true
+  resources:
+    requests: {cpu: 250m, memory: 512Mi}
+    limits: {cpu: "2", memory: 2Gi}
+  podSecurityContext: {}
+  containerSecurityContext:
+    allowPrivilegeEscalation: false
+
+worker:
+  enabled: true
+  replicaCount: 1
+  allQueues: true
+  excludedQueues: simulation_runner
+  maxConcurrentActivities: 50
+  maxConcurrentWorkflowTasks: 50
+  resources:
+    requests: {cpu: 200m, memory: 512Mi}
+    limits: {cpu: "1", memory: 1Gi}
+  podSecurityContext: {}
+  containerSecurityContext:
+    allowPrivilegeEscalation: false
+
+agentccGateway:
+  enabled: true
+  replicaCount: 1
+  image:
+    repository: futureagi/agentcc-gateway
+    tag: v1.23.1
+    pullPolicy: IfNotPresent
+  service:
+    port: 8080
+  config: |-
+    server:
+      port: 8080
+      host: "0.0.0.0"
+      read_timeout: 5s
+      write_timeout: 300s
+      idle_timeout: 120s
+      shutdown_timeout: 30s
+      max_request_body_size: 10485760
+      default_request_timeout: 60s
+    providers:
+      openai:
+        base_url: "https://api.openai.com"
+        api_key: "${OPENAI_API_KEY}"
+        api_format: "openai"
+        models: [gpt-4o, gpt-4o-mini]
+  resources:
+    requests: {cpu: 50m, memory: 64Mi}
+    limits: {cpu: 500m, memory: 256Mi}
+  podSecurityContext: {}
+  containerSecurityContext:
+    allowPrivilegeEscalation: false
+
+serving:
+  enabled: true
+  replicaCount: 1
+  image:
+    repository: futureagi/serving
+    tag: v1.23.1
+    pullPolicy: IfNotPresent
+  service:
+    port: 8080
+  resources:
+    requests: {cpu: 100m, memory: 256Mi}
+    limits: {cpu: "1", memory: 1Gi}
+  podSecurityContext: {}
+  containerSecurityContext:
+    allowPrivilegeEscalation: false
+
+codeExecutor:
+  enabled: false
+  replicaCount: 1
+  image:
+    repository: futureagi/code-executor
+    tag: v1.23.1
+    pullPolicy: IfNotPresent
+  service:
+    port: 8060
+  privileged: true
+  resources:
+    requests: {cpu: 100m, memory: 256Mi}
+    limits: {cpu: "2", memory: 1Gi}
+
+fiCollector:
+  enabled: true
+  replicaCount: 1
+  image:
+    repository: futureagi/fi-collector
+    tag: v1.23.1
+    pullPolicy: IfNotPresent
+  service:
+    grpcPort: 4317
+    httpPort: 4318
+    adminPort: 9464
+  persistence:
+    enabled: true
+    size: 1Gi
+  resources:
+    requests: {cpu: 50m, memory: 64Mi}
+    limits: {cpu: 500m, memory: 512Mi}
+  podSecurityContext:
+    runAsNonRoot: true
+    runAsUser: 65532
+    runAsGroup: 65532
+    fsGroup: 65532
+  containerSecurityContext:
+    allowPrivilegeEscalation: false
+    capabilities: {drop: [ALL]}
+    readOnlyRootFilesystem: true
+
+postgresql:
+  enabled: true
+  image: {repository: postgres, tag: "16", pullPolicy: IfNotPresent}
+  database: futureagi
+  username: futureagi
+  external: {host: "", port: 5432}
+  persistence: {enabled: true, size: 8Gi}
+  resources:
+    requests: {cpu: 100m, memory: 256Mi}
+    limits: {cpu: "1", memory: 1Gi}
+
+clickhouse:
+  enabled: true
+  image: {repository: clickhouse/clickhouse-server, tag: 25.3-alpine, pullPolicy: IfNotPresent}
+  external: {host: "", tcpPort: 9000, httpPort: 8123, username: default}
+  persistence: {enabled: true, size: 10Gi}
+  resources:
+    requests: {cpu: 250m, memory: 512Mi}
+    limits: {cpu: "2", memory: 4Gi}
+
+redis:
+  enabled: true
+  image: {repository: redis, tag: 7-alpine, pullPolicy: IfNotPresent}
+  external: {host: "", port: 6379}
+  persistence: {enabled: true, size: 2Gi}
+  resources:
+    requests: {cpu: 50m, memory: 64Mi}
+    limits: {cpu: 500m, memory: 256Mi}
+
+rabbitmq:
+  enabled: true
+  image: {repository: rabbitmq, tag: 3-management, pullPolicy: IfNotPresent}
+  username: futureagi
+  external: {host: "", port: 5672, username: futureagi}
+  persistence: {enabled: true, size: 2Gi}
+  resources:
+    requests: {cpu: 100m, memory: 256Mi}
+    limits: {cpu: "1", memory: 1Gi}
+
+minio:
+  # Development and Minikube convenience only. Production mode rejects this.
+  enabled: true
+  image: {repository: minio/minio, tag: RELEASE.2025-02-07T23-21-09Z, pullPolicy: IfNotPresent}
+  persistence: {enabled: true, size: 5Gi}
+  resources:
+    requests: {cpu: 100m, memory: 128Mi}
+    limits: {cpu: "1", memory: 1Gi}
+
+temporal:
+  enabled: true
+  image: {repository: temporalio/auto-setup, tag: 1.29.1, pullPolicy: IfNotPresent}
+  external: {host: "", port: 7233}
+  resources:
+    requests: {cpu: 100m, memory: 256Mi}
+    limits: {cpu: "1", memory: 1Gi}
+
+ingress:
+  enabled: false
+  className: ""
+  annotations: {}
+  hosts:
+    - host: futureagi.local
+      paths:
+        - path: /
+          pathType: Prefix
+          service: frontend
+  tls: []

--- a/deploy/helm/test-chart.sh
+++ b/deploy/helm/test-chart.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env sh
+set -eu
+
+script_dir=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+chart_dir="$script_dir/futureagi"
+minikube_values="$chart_dir/examples/minikube-values.yaml"
+production_s3_values="$chart_dir/examples/production-s3-values.yaml"
+package_dir=$(mktemp -d)
+trap 'rm -rf "$package_dir"' EXIT HUP INT TERM
+
+helm lint "$chart_dir" --strict
+helm lint "$chart_dir" --strict --values "$minikube_values"
+helm lint "$chart_dir" --strict --values "$production_s3_values"
+helm lint "$chart_dir" --strict --values "$production_s3_values" \
+  --set config.storageBackend=gcs \
+  --set-string config.s3Endpoint=
+helm lint "$chart_dir" --strict --set ingress.enabled=true
+helm lint "$chart_dir" --strict \
+  --set codeExecutor.enabled=true \
+  --set secrets.existingSecret=futureagi-production-secrets
+helm lint "$chart_dir" --strict \
+  --set deploymentMode=production \
+  --set secrets.existingSecret=futureagi-production-secrets \
+  --set postgresql.enabled=false \
+  --set postgresql.external.host=postgres.example.internal \
+  --set clickhouse.enabled=false \
+  --set clickhouse.external.host=clickhouse.example.internal \
+  --set redis.enabled=false \
+  --set redis.external.host=redis.example.internal \
+  --set rabbitmq.enabled=false \
+  --set rabbitmq.external.host=rabbitmq.example.internal \
+  --set minio.enabled=false \
+  --set config.storageBackend=s3 \
+  --set config.s3Endpoint=https://s3.amazonaws.com \
+  --set temporal.enabled=false \
+  --set temporal.external.host=temporal.example.internal
+
+helm template futureagi "$chart_dir" --namespace futureagi >/dev/null
+helm template futureagi "$chart_dir" --namespace futureagi \
+  --values "$minikube_values" >/dev/null
+helm template futureagi "$chart_dir" --namespace futureagi \
+  --values "$production_s3_values" >/dev/null
+helm template futureagi "$chart_dir" --namespace futureagi \
+  --set ingress.enabled=true >/dev/null
+
+if helm template futureagi "$chart_dir" --namespace futureagi \
+  --set deploymentMode=production \
+  --set secrets.existingSecret=futureagi-production-secrets >/dev/null 2>&1; then
+  echo "production mode unexpectedly accepted bundled MinIO" >&2
+  exit 1
+fi
+helm package "$chart_dir" --destination "$package_dir" >/dev/null
+
+echo "Helm chart lint, render, and package checks passed."


### PR DESCRIPTION
## Summary

Adds a first-party Helm chart for repeatable Future AGI deployment on Kubernetes.
The chart provides a self-contained development/Minikube profile, externally
managed datastore options, and an enforced production path using AWS S3 or GCS
instead of bundled MinIO.

## Linked issues

Closes #2382

## Type of change

- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🐛 Bug fix
- [ ] 💥 Breaking change
- [ ] 📖 Documentation only
- [ ] 🧹 Chore / refactor

## 1) What changes were done

**A. Kubernetes deployment**

- Adds application Deployments/Services for frontend, backend, Temporal worker,
  AgentCC gateway, serving, fi-collector, and optional code executor.
- Adds development StatefulSets for PostgreSQL, ClickHouse, Redis, RabbitMQ,
  MinIO, and Temporal, with independent external-service switches.
- Adds configurable probes, resources, persistence, ingress, placement, service
  accounts, private registries, and image pull secrets.

**B. Secrets and production storage**

- Generates upgrade-stable development credentials or consumes a pre-created
  Secret.
- Adds dedicated AWS S3/GCS endpoint, region, TLS, bucket, and credential wiring.
- Rejects `deploymentMode=production` when bundled MinIO is enabled or when a
  pre-created Secret is not configured.

**C. Validation and documentation**

- Adds strict lint/render/package checks and a path-filtered GitHub Actions job.
- Adds Minikube and production S3 examples, feature requirements, operator
  guidance, and an initial validation record.

## 2) Why the changes were done

- **Product/UX:** Self-hosters can deploy Future AGI using one documented Helm
  release rather than maintaining a private set of Kubernetes manifests.
- **Technical:** A dependency-free first chart keeps contribution and CI
  validation deterministic while allowing every datastore to be externalized.
- **Architecture:** MinIO is confined to development; production storage is an
  explicit AWS S3 or GCS contract backed by externally managed credentials.

## 3) Tests written + scenarios each covers

**`deploy/helm/test-chart.sh`** — strict chart validation covering:

- bundled development defaults;
- reduced Minikube configuration;
- production AWS S3 and GCS configurations;
- ingress;
- optional privileged code executor with an existing Secret;
- all external datastores; and
- negative validation preventing bundled MinIO in production.

> Run result: all seven strict Helm lint configurations, render checks, and
> packaging passed. Shell syntax, YAML parsing, and whitespace checks also pass.

## 4) How to run / test

```bash
./deploy/helm/test-chart.sh

minikube start --cpus=4 --memory=8192 --disk-size=30g
helm upgrade --install futureagi ./deploy/helm/futureagi \
  --namespace futureagi --create-namespace \
  --values deploy/helm/futureagi/examples/minikube-values.yaml \
  --wait --timeout 20m
helm test futureagi --namespace futureagi --logs
```

The initial Minikube run admitted the release and brought the frontend,
AgentCC, PostgreSQL, ClickHouse, Redis, RabbitMQ, and MinIO to ready state. The
complete backend smoke test was constrained by the test host's full Docker
Desktop disk and rootless Docker DNS; details are recorded in the chart's
`TESTING.md`.

## 5) Screenshots / recordings

Not applicable; this contribution adds deployment infrastructure and
documentation rather than a UI change.

## 6) Edge cases & considerations

- Chart-generated credentials are preserved across upgrades.
- Existing Secrets keep production credentials outside Helm release values.
- Production rendering fails closed when MinIO or generated credentials remain.
- The code executor remains disabled because it requires privileged containers.
- Bundled datastores are deliberately single-instance and not advertised as HA.

## 7) Pre-existing issues (NOT introduced by this PR)

- The published backend image is large and currently requires substantial
  container-runtime disk during unpacking.
- Rootless Docker DNS on the test host prevented Temporal from resolving its
  PostgreSQL service during the bounded Minikube run.

## 8) Architectural / important decisions

- **No datastore subchart dependencies:** keeps linting deterministic and lets
  production operators connect managed services without installing duplicates.
- **Explicit deployment mode:** enforces the MinIO development-only boundary at
  render time.

## Checklist

- [x] My code follows the style guide
- [x] I've added tests for the feature
- [x] I've updated the documentation
- [x] No hardcoded secrets, URLs, or PII
- [x] PR title follows Conventional Commits
- [ ] CLA signed (will complete when prompted)
- [ ] Linear issue linked (not available for this community contribution)

Backend/frontend unit suites and contract generation are not applicable because
the change contains Helm templates, shell validation, CI configuration, and
documentation only.
