### PR TITLE
chore: allow arbitrary fi collector release branches

### DIFF
--- a/.github/workflows/release-fi-collector.yml
+++ b/.github/workflows/release-fi-collector.yml
@@ -14,8 +14,7 @@ on:
         description: 'Branch to build from'
         required: true
         default: 'main'
-        type: choice
-        options: [main, dev]
+        type: string
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary

Changes the manual fi-collector release workflow's branch input from a main/dev dropdown to a free-text string while retaining main as the default.

## Validation

- YAML parsed successfully
- git diff --check passed