### PR TITLE
chore: allow arbitrary fi collector release branches

### DIFF
--- a/.github/workflows/release-fi-collector.yml
+++ b/.github/workflows/release-fi-collector.yml
@@ -14,8 +14,7 @@ on:
         description: 'Branch to build from'
         required: true
         default: 'main'
-        type: choice
-        options: [main, dev]
+        type: string
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary

Adds the fi-collector release workflow to main with a free-text branch input, retaining main as the default. The workflow is absent from main but present on dev.

## Validation

- YAML parsed successfully
- git diff --check passed