### PR TITLE
fix(evals): treat a non-string eval mapping value as invalid instead of crashing

### DIFF
--- a/frontend/src/sections/common/EvalPicker/serializeEvalConfig.js
+++ b/frontend/src/sections/common/EvalPicker/serializeEvalConfig.js
@@ -6,6 +6,8 @@
 // backend contract consumed by normalize_eval_runtime_config and the simulation
 // runner. Edit-reopen flows should read from that canonical location instead
 // of depending on duplicate top-level payload keys.
+import { isClearedMappingValue } from "src/sections/evals/utils/evalMappingPath";
+
 const RUN_CONFIG_KEYS = [
   "model",
   "agent_mode",
@@ -22,11 +24,12 @@ const RUN_CONFIG_KEYS = [
 // A cleared auto-mapped field reaches us as "" — the eval runner treats a
 // present-but-empty path as a required attribute it can never resolve and
 // fails every row, while an absent key falls through to context injection.
+// `isClearedMappingValue` is imported rather than restated so this stays one
+// definition of what a mapping value may be.
 export function sanitizeEvalMapping(mapping) {
   return Object.fromEntries(
     Object.entries(mapping || {}).filter(
-      ([, path]) =>
-        path != null && !(typeof path === "string" && path.trim() === ""),
+      ([, path]) => !isClearedMappingValue(path),
     ),
   );
 }

--- a/frontend/src/sections/common/EvalPicker/serializeEvalConfig.test.js
+++ b/frontend/src/sections/common/EvalPicker/serializeEvalConfig.test.js
@@ -1,5 +1,8 @@
 import { describe, expect, it } from "vitest";
-import { serializeEvalConfig } from "./serializeEvalConfig";
+import {
+  sanitizeEvalMapping,
+  serializeEvalConfig,
+} from "./serializeEvalConfig";
 
 describe("serializeEvalConfig", () => {
   it("emits runtime overrides only inside config.run_config", () => {
@@ -78,5 +81,21 @@ describe("serializeEvalConfig", () => {
         filters,
       }).filters,
     ).toBe(filters);
+  });
+});
+
+describe("sanitizeEvalMapping", () => {
+  it("drops cleared fields and keeps real attribute paths", () => {
+    expect(
+      sanitizeEvalMapping({ a: "output.value", b: "", c: null, d: "   " }),
+    ).toEqual({ a: "output.value" });
+  });
+
+  it("forwards a non-string value so the API rejects it by name", () => {
+    // Dropping it here would silently delete the variable from the saved
+    // config; the write gate answers it with a message instead.
+    expect(sanitizeEvalMapping({ a: { value: "output.value" } })).toEqual({
+      a: { value: "output.value" },
+    });
   });
 });

--- a/frontend/src/sections/common/EvalsTasks/EditTaskDrawer/EditTaskDrawerV2.jsx
+++ b/frontend/src/sections/common/EvalsTasks/EditTaskDrawer/EditTaskDrawerV2.jsx
@@ -39,6 +39,7 @@ import { useGetProjectById } from "src/api/project/evals-task";
 import { useDebounce } from "src/hooks/use-debounce";
 import axios, { endpoints } from "src/utils/axios";
 import { red } from "src/theme/palette";
+import { mappingChipLabel } from "src/sections/evals/utils/evalMappingPath";
 import {
   extractAttributeFilters,
   getTaskFilterApiKey,
@@ -88,7 +89,7 @@ const ConfiguredEvalCard = ({ evalItem, onRemove, isEditing }) => {
             {mappedKeys.slice(0, 3).map((key) => (
               <Chip
                 key={key}
-                label={`${key} → ${evalItem.mapping[key]}`}
+                label={mappingChipLabel(key, evalItem.mapping[key])}
                 size="small"
                 sx={{
                   fontSize: "10px",

--- a/frontend/src/sections/common/EvalsTasks/NewTaskDrawer/NewTaskDrawerV2.jsx
+++ b/frontend/src/sections/common/EvalsTasks/NewTaskDrawer/NewTaskDrawerV2.jsx
@@ -38,6 +38,7 @@ import FormTextFieldV2 from "src/components/FormTextField/FormTextFieldV2";
 import { FormSearchSelectFieldControl } from "src/components/FromSearchSelectField";
 import { useNavigate } from "react-router";
 import FilterErrorBoundary from "src/components/ComplexFilter/FilterErrorBoundary";
+import { mappingChipLabel } from "src/sections/evals/utils/evalMappingPath";
 import { EvalPickerDrawer, serializeEvalConfig } from "../../EvalPicker";
 
 // ── Configured Eval Card ──
@@ -76,7 +77,7 @@ const ConfiguredEvalCard = ({ evalItem, onRemove }) => {
             {mappedKeys.slice(0, 3).map((key) => (
               <Chip
                 key={key}
-                label={`${key} → ${evalItem.mapping[key]}`}
+                label={mappingChipLabel(key, evalItem.mapping[key])}
                 size="small"
                 sx={{
                   fontSize: "10px",

--- a/frontend/src/sections/develop-detail/Evaluation/RunCompareEvaluation.jsx
+++ b/frontend/src/sections/develop-detail/Evaluation/RunCompareEvaluation.jsx
@@ -11,6 +11,7 @@ import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { enqueueSnackbar } from "notistack";
 import logger from "src/utils/logger";
 import { useGetJsonColumnSchema } from "src/api/develop/develop-detail";
+import { isMappingPath } from "src/sections/evals/utils/evalMappingPath";
 const RunEvaluationChild = ({
   onClose,
   allColumns,
@@ -71,7 +72,11 @@ const RunEvaluationChild = ({
     // Handle JSON paths: "uuid.path" -> "HeaderName.path"
     data.config.mapping = Object.fromEntries(
       Object.entries(data.config.mapping).map(([key, value]) => {
-        if (!value) return [key, value];
+        // A non-string mapping value has no field id to rewrite, and .match()
+        // on one throws inside this save handler — no error boundary catches an
+        // event handler, so the save button would just stop working. Forward it
+        // untouched and let the API reject it with a message.
+        if (!isMappingPath(value)) return [key, value];
 
         // Check if value contains a JSON path (UUID format followed by dot)
         const uuidPattern =

--- a/frontend/src/sections/develop-detail/Experiment/StepperComponentExperiment/EvaluationStepExperimentCreation.jsx
+++ b/frontend/src/sections/develop-detail/Experiment/StepperComponentExperiment/EvaluationStepExperimentCreation.jsx
@@ -22,6 +22,7 @@ import { EvalPickerDrawer } from "src/sections/common/EvalPicker";
 import { getVersionedEvalName } from "src/components/run-tests/common";
 import { ShowComponent } from "src/components/show";
 import { isUUID } from "src/utils/utils";
+import { mappingChipLabel } from "src/sections/evals/utils/evalMappingPath";
 
 const EvaluationStepExperimentCreation = ({
   control,
@@ -405,7 +406,7 @@ const EvaluationStepExperimentCreation = ({
                           return (
                             <Chip
                               key={key}
-                              label={`${key}: ${label}`}
+                              label={mappingChipLabel(key, label, ": ")}
                               size="small"
                               variant="outlined"
                             />

--- a/frontend/src/sections/evals/utils/__tests__/evalExecution.test.js
+++ b/frontend/src/sections/evals/utils/__tests__/evalExecution.test.js
@@ -151,6 +151,18 @@ describe("resolveMappingFromRow", () => {
     ]);
     expect(out).toEqual({ note: "from-row" });
   });
+
+  it("omits a non-string mapping value instead of throwing on it", () => {
+    // Called out as a behaviour change: this used to throw out of the walker
+    // and unmount the page. The variable is now simply absent, and the panel
+    // labels it invalid so the owner can see which one to re-map.
+    const out = resolveMappingFromRow(
+      { bad: { value: "input.value" }, good: "input.value" },
+      spanDetail,
+    );
+    expect(out).toEqual({ good: "hello" });
+    expect("bad" in out).toBe(false);
+  });
 });
 
 describe("executeEvalForRow — single eval", () => {

--- a/frontend/src/sections/evals/utils/evalMappingPath.js
+++ b/frontend/src/sections/evals/utils/evalMappingPath.js
@@ -1,0 +1,16 @@
+// An eval mapping value is an attribute path. A non-string reaches neither a
+// path walker nor a React child, so both questions are answered here only.
+export const INVALID_MAPPING_LABEL = "invalid mapping";
+
+export function isMappingPath(value) {
+  return typeof value === "string" && value !== "";
+}
+
+export function mappingPathLabel(value) {
+  if (isMappingPath(value)) return value;
+  return value == null || value === "" ? "" : INVALID_MAPPING_LABEL;
+}
+
+export function mappingChipLabel(key, value) {
+  return `${key} → ${mappingPathLabel(value)}`;
+}

--- a/frontend/src/sections/evals/utils/evalMappingPath.js
+++ b/frontend/src/sections/evals/utils/evalMappingPath.js
@@ -19,6 +19,10 @@ export function mappingPathLabel(value) {
   return value == null || value === "" ? "" : INVALID_MAPPING_LABEL;
 }
 
-export function mappingChipLabel(key, value) {
-  return `${key} → ${mappingPathLabel(value)}`;
+// A cleared value has no label, so the chip is the key alone rather than a
+// dangling separator. `separator` exists because the develop-detail chips use
+// ": " while the eval chips use " -> " — same label rule, one owner.
+export function mappingChipLabel(key, value, separator = " → ") {
+  const label = mappingPathLabel(value);
+  return label ? `${key}${separator}${label}` : key;
 }

--- a/frontend/src/sections/evals/utils/evalMappingPath.js
+++ b/frontend/src/sections/evals/utils/evalMappingPath.js
@@ -6,6 +6,14 @@ export function isMappingPath(value) {
   return typeof value === "string" && value !== "";
 }
 
+// A cleared field reaches the payload as "" or null (whitespace-only counts as
+// cleared). A non-string is deliberately NOT cleared: it is forwarded so the
+// API rejects it with a message, rather than being dropped here and taking the
+// variable down with it.
+export function isClearedMappingValue(value) {
+  return value == null || (typeof value === "string" && value.trim() === "");
+}
+
 export function mappingPathLabel(value) {
   if (isMappingPath(value)) return value;
   return value == null || value === "" ? "" : INVALID_MAPPING_LABEL;

--- a/frontend/src/sections/evals/utils/evalMappingPath.test.js
+++ b/frontend/src/sections/evals/utils/evalMappingPath.test.js
@@ -1,6 +1,7 @@
 import { describe, it, expect } from "vitest";
 import {
   INVALID_MAPPING_LABEL,
+  isClearedMappingValue,
   isMappingPath,
   mappingChipLabel,
   mappingPathLabel,
@@ -61,5 +62,24 @@ describe("mappingChipLabel", () => {
 
   it("renders a bare variable for an unmapped value", () => {
     expect(mappingChipLabel("input", null)).toBe("input → ");
+  });
+});
+
+describe("isClearedMappingValue", () => {
+  it("treats unset and blank values as cleared", () => {
+    expect(isClearedMappingValue(null)).toBe(true);
+    expect(isClearedMappingValue(undefined)).toBe(true);
+    expect(isClearedMappingValue("")).toBe(true);
+    expect(isClearedMappingValue("   ")).toBe(true);
+  });
+
+  it("does not treat a non-string as cleared, so it reaches the API gate", () => {
+    expect(isClearedMappingValue({ value: "output.value" })).toBe(false);
+    expect(isClearedMappingValue(["output", "value"])).toBe(false);
+    expect(isClearedMappingValue(0)).toBe(false);
+  });
+
+  it("keeps a real attribute path", () => {
+    expect(isClearedMappingValue("output.value")).toBe(false);
   });
 });

--- a/frontend/src/sections/evals/utils/evalMappingPath.test.js
+++ b/frontend/src/sections/evals/utils/evalMappingPath.test.js
@@ -1,0 +1,65 @@
+import { describe, it, expect } from "vitest";
+import {
+  INVALID_MAPPING_LABEL,
+  isMappingPath,
+  mappingChipLabel,
+  mappingPathLabel,
+} from "./evalMappingPath";
+
+describe("isMappingPath", () => {
+  it("accepts an attribute path string", () => {
+    expect(isMappingPath("output.value")).toBe(true);
+    expect(isMappingPath("input")).toBe(true);
+  });
+
+  it("rejects the object and array shapes a saved mapping can carry", () => {
+    expect(isMappingPath({ value: "output.value" })).toBe(false);
+    expect(isMappingPath(["output", "value"])).toBe(false);
+    expect(isMappingPath(42)).toBe(false);
+    expect(isMappingPath(true)).toBe(false);
+  });
+
+  it("rejects unset and empty values", () => {
+    expect(isMappingPath(null)).toBe(false);
+    expect(isMappingPath(undefined)).toBe(false);
+    expect(isMappingPath("")).toBe(false);
+  });
+});
+
+describe("mappingPathLabel", () => {
+  it("returns the path itself for an attribute path string", () => {
+    expect(mappingPathLabel("output.value")).toBe("output.value");
+  });
+
+  it("returns a string label instead of the value for a non-string mapping", () => {
+    const label = mappingPathLabel({ value: "output.value" });
+    expect(typeof label).toBe("string");
+    expect(label).toBe(INVALID_MAPPING_LABEL);
+    expect(mappingPathLabel(["output", "value"])).toBe(INVALID_MAPPING_LABEL);
+    expect(mappingPathLabel(42)).toBe(INVALID_MAPPING_LABEL);
+  });
+
+  it("returns an empty label for an unmapped variable", () => {
+    expect(mappingPathLabel(null)).toBe("");
+    expect(mappingPathLabel(undefined)).toBe("");
+    expect(mappingPathLabel("")).toBe("");
+  });
+});
+
+describe("mappingChipLabel", () => {
+  it("renders the variable and its attribute path", () => {
+    expect(mappingChipLabel("input", "output.value")).toBe(
+      "input → output.value",
+    );
+  });
+
+  it("never stringifies a non-string mapping into the chip", () => {
+    const label = mappingChipLabel("input", { value: "output.value" });
+    expect(label).toBe(`input → ${INVALID_MAPPING_LABEL}`);
+    expect(label).not.toContain("[object Object]");
+  });
+
+  it("renders a bare variable for an unmapped value", () => {
+    expect(mappingChipLabel("input", null)).toBe("input → ");
+  });
+});

--- a/frontend/src/sections/evals/utils/evalMappingPath.test.js
+++ b/frontend/src/sections/evals/utils/evalMappingPath.test.js
@@ -60,8 +60,21 @@ describe("mappingChipLabel", () => {
     expect(label).not.toContain("[object Object]");
   });
 
-  it("renders a bare variable for an unmapped value", () => {
-    expect(mappingChipLabel("input", null)).toBe("input → ");
+  it("renders the variable alone rather than a dangling separator", () => {
+    // mappedKeys is unfiltered Object.keys(mapping), so a cleared value in
+    // in-memory state still reaches a chip.
+    expect(mappingChipLabel("input", null)).toBe("input");
+    expect(mappingChipLabel("input", "")).toBe("input");
+  });
+
+  it("takes the separator from the call site", () => {
+    // develop-detail chips read "key: value"; the eval chips use the arrow.
+    expect(mappingChipLabel("input", "output.value", ": ")).toBe(
+      "input: output.value",
+    );
+    expect(mappingChipLabel("input", { value: "x" }, ": ")).toBe(
+      `input: ${INVALID_MAPPING_LABEL}`,
+    );
   });
 });
 

--- a/frontend/src/sections/evals/utils/rowPathWalker.js
+++ b/frontend/src/sections/evals/utils/rowPathWalker.js
@@ -7,6 +7,7 @@ import {
   canonicalKeys,
   stripAttributePathPrefix,
 } from "src/utils/utils";
+import { isMappingPath } from "./evalMappingPath";
 
 export const EAGER_DEPTH = 4;
 export const ARRAY_PEEK = 500;
@@ -146,7 +147,7 @@ export function expandPaths(root, prefixPath, { maxDepth = EAGER_DEPTH } = {}) {
 }
 
 export function resolvePath(root, path) {
-  if (!isObjectLike(root) || !path) return { status: "missing" };
+  if (!isObjectLike(root) || !isMappingPath(path)) return { status: "missing" };
   const result = descend(root, path);
   if (result.found) return { status: "resolved", value: result.value };
   return { status: result.unknown ? "unknown" : "missing" };

--- a/frontend/src/sections/evals/utils/rowPathWalker.test.js
+++ b/frontend/src/sections/evals/utils/rowPathWalker.test.js
@@ -166,6 +166,35 @@ describe("resolvePath", () => {
     expect(resolvePath(null, "x").status).toBe("missing");
     expect(resolvePath(detail, "").status).toBe("missing");
   });
+
+  it("returns missing without throwing for an object path", () => {
+    const path = { value: "input" };
+    expect(() => resolvePath(detail, path)).not.toThrow();
+    expect(resolvePath(detail, path)).toEqual({ status: "missing" });
+  });
+
+  it("returns missing without throwing for an array path", () => {
+    const path = ["input", "value"];
+    expect(() => resolvePath(detail, path)).not.toThrow();
+    expect(resolvePath(detail, path)).toEqual({ status: "missing" });
+  });
+
+  it("returns missing without throwing for a number path", () => {
+    expect(() => resolvePath(detail, 42)).not.toThrow();
+    expect(resolvePath(detail, 42)).toEqual({ status: "missing" });
+  });
+
+  it("keeps resolving string paths alongside a non-string one", () => {
+    expect(resolvePath(detail, { value: "input" }).status).toBe("missing");
+    expect(resolvePath(detail, "input")).toEqual({
+      status: "resolved",
+      value: "top-level",
+    });
+    expect(resolvePath(detail, "llm.model_name")).toEqual({
+      status: "resolved",
+      value: "gpt",
+    });
+  });
 });
 
 describe("dotted attribute keys (flat collector bags)", () => {

--- a/frontend/src/sections/tasks/components/TaskConfigPanel.jsx
+++ b/frontend/src/sections/tasks/components/TaskConfigPanel.jsx
@@ -31,6 +31,7 @@ import ModalWrapper from "src/components/ModalWrapper/ModalWrapper";
 import TaskSchedulingSection from "./TaskSchedulingSection";
 import { useGetProjectDetails } from "src/api/project/project-detail";
 import { PROJECT_SOURCE } from "src/utils/constants";
+import { mappingChipLabel } from "src/sections/evals/utils/evalMappingPath";
 import TaskFilterBar from "./TaskFilterBar";
 
 const ROW_TYPE_OPTIONS = [
@@ -229,7 +230,7 @@ const ConfiguredEvalCard = ({ evalItem, onEdit, onRemove }) => {
             {mappedKeys.slice(0, 4).map((key) => (
               <Chip
                 key={key}
-                label={`${key} → ${evalItem.mapping[key]}`}
+                label={mappingChipLabel(key, evalItem.mapping[key])}
                 size="small"
                 sx={{
                   fontSize: "10px",

--- a/frontend/src/sections/tasks/components/TaskLivePreview.jsx
+++ b/frontend/src/sections/tasks/components/TaskLivePreview.jsx
@@ -28,6 +28,10 @@ import {
   resolvePath,
   sortSpansForMapping,
 } from "src/sections/evals/utils/rowPathWalker";
+import {
+  isMappingPath,
+  mappingPathLabel,
+} from "src/sections/evals/utils/evalMappingPath";
 import Iconify from "src/components/iconify";
 import CustomTooltip from "src/components/tooltip/CustomTooltip";
 
@@ -1086,13 +1090,17 @@ const VariableMappingView = ({
                 >
                   {variables.map((variable) => {
                     const field = mapping[variable];
+                    const label = mappingPathLabel(field);
+                    const isPath = isMappingPath(field);
                     // Tri-state: `missing` warns, `unknown` (session traces
                     // whose spans weren't fetched) stays silent — the BE is
                     // the authoritative resolver at test time.
-                    const hit = spanDetail
-                      ? resolvePath(spanDetail, field)
-                      : { status: "unknown" };
-                    const showWarn = hit.status === "missing" && !!field;
+                    const hit =
+                      spanDetail && isPath
+                        ? resolvePath(spanDetail, field)
+                        : { status: "unknown" };
+                    const showNotInRow = hit.status === "missing" && isPath;
+                    const showWarn = showNotInRow || (!isPath && !!label);
                     return (
                       <Box
                         key={variable}
@@ -1121,8 +1129,8 @@ const VariableMappingView = ({
                           sx={{ color: "text.disabled" }}
                         />
                         <CustomTooltip
-                          title={field || ""}
-                          show={!!field}
+                          title={label}
+                          show={!!label}
                           type="default"
                           placement="top"
                           arrow
@@ -1139,10 +1147,10 @@ const VariableMappingView = ({
                               whiteSpace: "nowrap",
                             }}
                           >
-                            {field || "—"}
+                            {label || "—"}
                           </Typography>
                         </CustomTooltip>
-                        {showWarn && (
+                        {showNotInRow && (
                           <Typography
                             variant="caption"
                             color="warning.main"

--- a/frontend/src/sections/tasks/components/__tests__/TaskLivePreview.test.jsx
+++ b/frontend/src/sections/tasks/components/__tests__/TaskLivePreview.test.jsx
@@ -2,7 +2,9 @@ import React from "react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { render, screen } from "@testing-library/react";
 import { useForm } from "react-hook-form";
+import { ErrorBoundary } from "react-error-boundary";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { INVALID_MAPPING_LABEL } from "src/sections/evals/utils/evalMappingPath";
 import TaskLivePreview from "../TaskLivePreview";
 
 const axiosGetMock = vi.hoisted(() => vi.fn());
@@ -63,6 +65,11 @@ const renderPreview = (evalsDetails) => {
   );
 };
 
+// The saved value that crashed production was an object. Its inner shape was
+// never recoverable from the report, so these tests assert on the value being a
+// non-string — which is the whole gate — and never on a particular inner shape.
+const OBJECT_MAPPING_VALUE = { value: "output.value" };
+
 describe("TaskLivePreview — variable mapping", () => {
   beforeEach(() => {
     axiosGetMock.mockReset();
@@ -82,14 +89,14 @@ describe("TaskLivePreview — variable mapping", () => {
       {
         id: "eval-1",
         name: "Groundedness",
-        mapping: { context: { value: "output.value" }, answer: "output.value" },
+        mapping: { context: OBJECT_MAPPING_VALUE, answer: "output.value" },
       },
     ]);
 
     expect(await screen.findByText("Variable Mapping")).toBeInTheDocument();
     expect(screen.getByText("context")).toBeInTheDocument();
     expect(screen.getByText("answer")).toBeInTheDocument();
-    expect(screen.getByText("invalid mapping")).toBeInTheDocument();
+    expect(screen.getByText(INVALID_MAPPING_LABEL)).toBeInTheDocument();
     expect(screen.queryByText("[object Object]")).not.toBeInTheDocument();
   });
 
@@ -98,13 +105,71 @@ describe("TaskLivePreview — variable mapping", () => {
       {
         id: "eval-1",
         name: "Groundedness",
-        mapping: { context: { value: "output.value" }, answer: "output.value" },
+        mapping: { context: OBJECT_MAPPING_VALUE, answer: "output.value" },
       },
     ]);
 
     await screen.findByText("Variable Mapping");
     expect(screen.getByText("output.value")).toBeInTheDocument();
-    expect(screen.getByText("invalid mapping")).toBeInTheDocument();
+    expect(screen.getByText(INVALID_MAPPING_LABEL)).toBeInTheDocument();
     expect(screen.queryByText("(not in row)")).not.toBeInTheDocument();
+  });
+});
+
+describe("TaskLivePreview — app error boundary", () => {
+  beforeEach(() => {
+    axiosGetMock.mockReset();
+    axiosGetMock.mockResolvedValue({
+      data: {
+        result: {
+          table: [{ span_id: "span-1", output: { value: "hi" } }],
+          metadata: { total_rows: 1 },
+          config: [],
+        },
+      },
+    });
+  });
+
+  it("does not trip the boundary that wraps the whole app", async () => {
+    // app.jsx wraps <Router /> in this same react-error-boundary with no reset
+    // on navigation, so anything thrown while rendering a mapping takes the
+    // whole application down until a reload — that was the reported symptom.
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+
+    const Harness = () => {
+      const { control } = useForm({
+        defaultValues: {
+          filters: [],
+          startDate: null,
+          endDate: null,
+          rowType: "spans",
+          evalsDetails: [
+            {
+              id: "eval-1",
+              name: "Groundedness",
+              mapping: { context: OBJECT_MAPPING_VALUE },
+            },
+          ],
+        },
+      });
+      return <TaskLivePreview control={control} projectId="project-1" />;
+    };
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <ErrorBoundary
+          FallbackComponent={() => <div>application error boundary</div>}
+        >
+          <Harness />
+        </ErrorBoundary>
+      </QueryClientProvider>,
+    );
+
+    expect(await screen.findByText("Variable Mapping")).toBeInTheDocument();
+    expect(
+      screen.queryByText("application error boundary"),
+    ).not.toBeInTheDocument();
   });
 });

--- a/frontend/src/sections/tasks/components/__tests__/TaskLivePreview.test.jsx
+++ b/frontend/src/sections/tasks/components/__tests__/TaskLivePreview.test.jsx
@@ -1,0 +1,110 @@
+import React from "react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, screen } from "@testing-library/react";
+import { useForm } from "react-hook-form";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import TaskLivePreview from "../TaskLivePreview";
+
+const axiosGetMock = vi.hoisted(() => vi.fn());
+
+vi.mock("src/utils/axios", () => ({
+  default: { get: axiosGetMock },
+  endpoints: {
+    project: {
+      getSpansForObserveProject: () => "/tracer/observe-project-spans/",
+      getTracesForObserveProject: () => "/tracer/observe-project-traces/",
+      projectSessionList: () => "/tracer/project-session-list/",
+      getTrace: (id) => `/tracer/trace/${id}/`,
+      traceSession: "/tracer/trace-session/",
+      getCallLogs: "/tracer/call-logs/",
+      getVoiceCallDetail: "/tracer/voice-call-detail/",
+    },
+  },
+}));
+
+vi.mock("src/components/iconify", () => ({
+  default: ({ icon }) => <span data-testid="icon">{icon}</span>,
+}));
+
+vi.mock("src/sections/evals/components/DatasetTestMode", () => ({
+  JsonValueTree: () => <span>json value</span>,
+}));
+
+vi.mock("src/sections/evals/components/EvalResultDisplay", () => ({
+  default: () => <div>eval result</div>,
+}));
+
+vi.mock("src/sections/evals/components/SpanRowList", () => ({
+  default: () => <div>span rows</div>,
+}));
+
+const renderPreview = (evalsDetails) => {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+
+  const Harness = () => {
+    const { control } = useForm({
+      defaultValues: {
+        filters: [],
+        startDate: null,
+        endDate: null,
+        rowType: "spans",
+        evalsDetails,
+      },
+    });
+    return <TaskLivePreview control={control} projectId="project-1" />;
+  };
+
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <Harness />
+    </QueryClientProvider>,
+  );
+};
+
+describe("TaskLivePreview — variable mapping", () => {
+  beforeEach(() => {
+    axiosGetMock.mockReset();
+    axiosGetMock.mockResolvedValue({
+      data: {
+        result: {
+          table: [{ span_id: "span-1", output: { value: "hi" } }],
+          metadata: { total_rows: 1 },
+          config: [],
+        },
+      },
+    });
+  });
+
+  it("renders a mapping whose value is an object instead of tearing down the page", async () => {
+    renderPreview([
+      {
+        id: "eval-1",
+        name: "Groundedness",
+        mapping: { context: { value: "output.value" }, answer: "output.value" },
+      },
+    ]);
+
+    expect(await screen.findByText("Variable Mapping")).toBeInTheDocument();
+    expect(screen.getByText("context")).toBeInTheDocument();
+    expect(screen.getByText("answer")).toBeInTheDocument();
+    expect(screen.getByText("invalid mapping")).toBeInTheDocument();
+    expect(screen.queryByText("[object Object]")).not.toBeInTheDocument();
+  });
+
+  it("flags the object value as invalid while the path value stays resolved", async () => {
+    renderPreview([
+      {
+        id: "eval-1",
+        name: "Groundedness",
+        mapping: { context: { value: "output.value" }, answer: "output.value" },
+      },
+    ]);
+
+    await screen.findByText("Variable Mapping");
+    expect(screen.getByText("output.value")).toBeInTheDocument();
+    expect(screen.getByText("invalid mapping")).toBeInTheDocument();
+    expect(screen.queryByText("(not in row)")).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/sections/tasks/components/__tests__/TaskLivePreview.test.jsx
+++ b/frontend/src/sections/tasks/components/__tests__/TaskLivePreview.test.jsx
@@ -105,14 +105,23 @@ describe("TaskLivePreview — variable mapping", () => {
       {
         id: "eval-1",
         name: "Groundedness",
-        mapping: { context: OBJECT_MAPPING_VALUE, answer: "output.value" },
+        mapping: {
+          context: OBJECT_MAPPING_VALUE,
+          answer: "output.value",
+          absent: "nope.not.here",
+        },
       },
     ]);
 
-    await screen.findByText("Variable Mapping");
+    // Every hit is forced to "unknown" until spanDetail resolves, which also
+    // suppresses "(not in row)". Awaiting it therefore pins the assertions
+    // below to the post-resolution render — asserting its absence would have
+    // passed mid-fetch and proved nothing about resolution.
+    expect(await screen.findByText("(not in row)")).toBeInTheDocument();
     expect(screen.getByText("output.value")).toBeInTheDocument();
     expect(screen.getByText(INVALID_MAPPING_LABEL)).toBeInTheDocument();
-    expect(screen.queryByText("(not in row)")).not.toBeInTheDocument();
+    // Only the absent path warns, so output.value genuinely resolved.
+    expect(screen.getAllByText("(not in row)")).toHaveLength(1);
   });
 });
 

--- a/futureagi/ai_tools/tools/tracing/create_custom_eval_config.py
+++ b/futureagi/ai_tools/tools/tracing/create_custom_eval_config.py
@@ -13,6 +13,7 @@ from ai_tools.formatting import (
     section,
 )
 from ai_tools.registry import register_tool
+from model_hub.utils.eval_mapping import non_path_mapping_keys
 
 logger = structlog.get_logger(__name__)
 
@@ -187,6 +188,19 @@ class CreateCustomEvalConfigTool(BaseTool):
 
         if params.mapping:
             # --- User provided mapping: validate attribute values exist ---
+            # Fourth write path into CustomEvalConfig.mapping. The
+            # attribute-membership check below only sees truthy values, so a
+            # falsy non-string ({} or []) used to slip through and get stored;
+            # a truthy one was rejected with a misleading "not a valid span
+            # attribute". The shared predicate answers the type question first.
+            bad_mapping_keys = non_path_mapping_keys(params.mapping)
+            if bad_mapping_keys:
+                return ToolResult.error(
+                    "Mapping values must be attribute path strings. "
+                    f"Non-string values for: {', '.join(bad_mapping_keys)}.",
+                    error_code="VALIDATION_ERROR",
+                )
+
             invalid_attrs = []
             for key, attr_value in params.mapping.items():
                 if attr_value and attr_value not in available_attributes:

--- a/futureagi/model_hub/tests/test_eval_group_contracts.py
+++ b/futureagi/model_hub/tests/test_eval_group_contracts.py
@@ -3,8 +3,6 @@ import uuid
 import pytest
 from rest_framework import status
 
-from rest_framework.exceptions import ValidationError
-
 from model_hub.serializers.eval_group import ApplyEvalGroupRequestSerializer
 from model_hub.views.utils.utils import (
     fetch_specific_mapping_for_specific_eval_template,
@@ -132,7 +130,10 @@ class TestEvalGroupMappingValues:
         assert parsed == {"hypothesis": "input", "reference": "output.value"}
 
     def test_object_mapping_value_is_refused_before_it_reaches_a_config(self):
-        with pytest.raises(ValidationError) as exc:
+        # ValueError, not a DRF ValidationError: the apply-eval-group view only
+        # maps ValueError to a 400. See the endpoint test in
+        # test_function_params_surfaces.py for the status code itself.
+        with pytest.raises(ValueError) as exc:
             fetch_specific_mapping_for_specific_eval_template(
                 {"hypothesis": {"type": "span_attribute", "path": "input"}},
                 self._template(["hypothesis"]),

--- a/futureagi/model_hub/tests/test_eval_group_contracts.py
+++ b/futureagi/model_hub/tests/test_eval_group_contracts.py
@@ -3,7 +3,12 @@ import uuid
 import pytest
 from rest_framework import status
 
+from rest_framework.exceptions import ValidationError
+
 from model_hub.serializers.eval_group import ApplyEvalGroupRequestSerializer
+from model_hub.views.utils.utils import (
+    fetch_specific_mapping_for_specific_eval_template,
+)
 
 
 class TestApplyEvalGroupContracts:
@@ -109,3 +114,28 @@ def test_apply_eval_group_api_rejects_legacy_aliases(auth_client):
     )
 
     assert response.status_code == status.HTTP_400_BAD_REQUEST
+
+
+class TestEvalGroupMappingValues:
+    def _template(self, required, optional=None):
+        class _T:
+            config = {"required_keys": required, "optional_keys": optional or []}
+
+        return _T()
+
+    def test_path_string_mapping_values_are_copied_through(self):
+        parsed = fetch_specific_mapping_for_specific_eval_template(
+            {"hypothesis": "input", "reference": "output.value"},
+            self._template(["hypothesis"], ["reference"]),
+        )
+
+        assert parsed == {"hypothesis": "input", "reference": "output.value"}
+
+    def test_object_mapping_value_is_refused_before_it_reaches_a_config(self):
+        with pytest.raises(ValidationError) as exc:
+            fetch_specific_mapping_for_specific_eval_template(
+                {"hypothesis": {"type": "span_attribute", "path": "input"}},
+                self._template(["hypothesis"]),
+            )
+
+        assert "hypothesis" in str(exc.value)

--- a/futureagi/model_hub/tests/test_function_params_surfaces.py
+++ b/futureagi/model_hub/tests/test_function_params_surfaces.py
@@ -204,6 +204,45 @@ def test_apply_eval_group_dataset_propagates_shared_params(
 
 
 @pytest.mark.django_db
+def test_apply_eval_group_rejects_a_non_path_mapping_with_400(
+    auth_client, user, workspace, rag_function_template, dataset_for_eval
+):
+    """A non-path mapping value is a client error, not a server error.
+
+    The view maps ValueError to 400 and everything else to a 500 whose body is
+    the stringified exception, so raising a DRF ValidationError from the gate
+    answered 500 and leaked ErrorDetail(...) to the caller.
+    """
+    dataset, _hypothesis_col, reference_col = dataset_for_eval
+    eval_group = EvalGroup.objects.create(
+        name="dataset_bad_mapping_group",
+        organization=user.organization,
+        workspace=workspace,
+        created_by=user,
+    )
+    eval_group.eval_templates.add(rag_function_template)
+
+    response = auth_client.post(
+        "/model-hub/eval-groups/apply-eval-group/",
+        {
+            "eval_group_id": str(eval_group.id),
+            "page_id": "DATASET",
+            "filters": {"dataset_id": str(dataset.id), "model": "turing_small"},
+            "mapping": {
+                "hypothesis": {"source": "span_attribute", "column_id": "output.value"},
+                "reference": str(reference_col.id),
+            },
+        },
+        format="json",
+    )
+
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    body = str(response.json())
+    assert "attribute path strings" in body
+    assert "ErrorDetail" not in body
+
+
+@pytest.mark.django_db
 def test_apply_eval_group_prompt_propagates_shared_params(
     auth_client, user, workspace, rag_function_template, prompt_template
 ):

--- a/futureagi/model_hub/utils/eval_mapping.py
+++ b/futureagi/model_hub/utils/eval_mapping.py
@@ -1,0 +1,27 @@
+"""Single definition of what a saved eval mapping value may be.
+
+A mapping value is an attribute path string. Every resolver splits it on ".",
+so any other type reaches a walker as an unhandled TypeError.
+"""
+
+
+def is_mapping_path(value) -> bool:
+    return isinstance(value, str) and value != ""
+
+
+def non_path_mapping_keys(mapping) -> list[str]:
+    return sorted(
+        key
+        for key, path in (mapping or {}).items()
+        if path is not None and not isinstance(path, str)
+    )
+
+
+def require_mapping_paths(mapping, target: str) -> None:
+    """Raise ValueError for any mapping value that is not an attribute path."""
+    for key, attribute in (mapping or {}).items():
+        if attribute is not None and not isinstance(attribute, str):
+            raise ValueError(
+                f"Mapping value for key '{key}' must be an attribute path string, "
+                f"got {type(attribute).__name__}, on {target}"
+            )

--- a/futureagi/model_hub/utils/eval_mapping.py
+++ b/futureagi/model_hub/utils/eval_mapping.py
@@ -2,24 +2,53 @@
 
 A mapping value is an attribute path string. Every resolver splits it on ".",
 so any other type reaches a walker as an unhandled TypeError.
+
+``None`` stays admissible: it is how the UI represents a cleared field, and
+every resolver treats a falsy path as a missing attribute.
+
+The mapping itself is not guaranteed to be a dict either. The OTEL eval-tag
+path stored wire values verbatim after ``json.loads``, so a legacy row can hold
+a list. ``.items()`` on one raises AttributeError, which lands in the broad
+``except Exception`` these helpers exist to keep failures out of — so a non-dict
+mapping is invalid here rather than a crash downstream.
 """
 
+# Reported in place of a key when the mapping is not a dict at all: the whole
+# value is the invalid thing, and there are no keys to name.
+WHOLE_MAPPING_KEY = "<mapping>"
 
-def is_mapping_path(value) -> bool:
-    return isinstance(value, str) and value != ""
+
+def _as_dict(mapping):
+    """Return ``mapping`` as a dict, or ``None`` when it is not one."""
+    if mapping is None:
+        return {}
+    return mapping if isinstance(mapping, dict) else None
 
 
 def non_path_mapping_keys(mapping) -> list[str]:
+    """Keys whose value is not an attribute path.
+
+    Returns ``[WHOLE_MAPPING_KEY]`` when *mapping* is not a dict.
+    """
+    items = _as_dict(mapping)
+    if items is None:
+        return [WHOLE_MAPPING_KEY]
     return sorted(
         key
-        for key, path in (mapping or {}).items()
+        for key, path in items.items()
         if path is not None and not isinstance(path, str)
     )
 
 
 def require_mapping_paths(mapping, target: str) -> None:
     """Raise ValueError for any mapping value that is not an attribute path."""
-    for key, attribute in (mapping or {}).items():
+    items = _as_dict(mapping)
+    if items is None:
+        raise ValueError(
+            f"Mapping must be an object of attribute path strings, "
+            f"got {type(mapping).__name__}, on {target}"
+        )
+    for key, attribute in items.items():
         if attribute is not None and not isinstance(attribute, str):
             raise ValueError(
                 f"Mapping value for key '{key}' must be an attribute path string, "

--- a/futureagi/model_hub/views/utils/utils.py
+++ b/futureagi/model_hub/views/utils/utils.py
@@ -15,6 +15,8 @@ except ImportError:
 
 logger = structlog.get_logger(__name__)
 from model_hub.views.utils.constants import PLACEHOLDER_PATTERN
+from model_hub.utils.eval_mapping import non_path_mapping_keys
+from rest_framework.exceptions import ValidationError as DRFValidationError
 
 # Pattern to match UUID placeholders with optional .property suffix
 # Matches: {{uuid}}, {{uuid.property}}, {{uuid.nested.property}}
@@ -350,6 +352,12 @@ def fetch_required_keys_for_eval_template(eval_templates):
 
 
 def fetch_specific_mapping_for_specific_eval_template(mapping, eval_template):
+    bad = non_path_mapping_keys(mapping)
+    if bad:
+        raise DRFValidationError(
+            "Mapping values must be attribute path strings. "
+            f"Non-string values for: {', '.join(bad)}."
+        )
     required_keys = eval_template.config.get("required_keys", [])
     optional_keys = eval_template.config.get("optional_keys", [])
     parsed_mapping = {}

--- a/futureagi/model_hub/views/utils/utils.py
+++ b/futureagi/model_hub/views/utils/utils.py
@@ -3,6 +3,7 @@ from typing import Literal, Union
 
 import structlog
 
+from model_hub.utils.eval_mapping import non_path_mapping_keys
 from tfc.ee_stub import _ee_stub
 from tfc.utils.ssrf_guard import is_valid_url, safe_fetch
 
@@ -15,8 +16,6 @@ except ImportError:
 
 logger = structlog.get_logger(__name__)
 from model_hub.views.utils.constants import PLACEHOLDER_PATTERN
-from model_hub.utils.eval_mapping import non_path_mapping_keys
-from rest_framework.exceptions import ValidationError as DRFValidationError
 
 # Pattern to match UUID placeholders with optional .property suffix
 # Matches: {{uuid}}, {{uuid.property}}, {{uuid.nested.property}}
@@ -354,7 +353,11 @@ def fetch_required_keys_for_eval_template(eval_templates):
 def fetch_specific_mapping_for_specific_eval_template(mapping, eval_template):
     bad = non_path_mapping_keys(mapping)
     if bad:
-        raise DRFValidationError(
+        # ValueError, not DRFValidationError: the apply-eval-group view maps
+        # ValueError to a 400 and everything else to a 500 whose body is the
+        # stringified exception. A DRF ValidationError is an APIException, so it
+        # would take the 500 branch and leak ErrorDetail(...) to the caller.
+        raise ValueError(
             "Mapping values must be attribute path strings. "
             f"Non-string values for: {', '.join(bad)}."
         )

--- a/futureagi/tracer/management/commands/scan_eval_mapping_paths.py
+++ b/futureagi/tracer/management/commands/scan_eval_mapping_paths.py
@@ -19,7 +19,7 @@ Usage:
 
 from django.core.management.base import BaseCommand
 
-from model_hub.utils.eval_mapping import non_path_mapping_keys
+from model_hub.utils.eval_mapping import WHOLE_MAPPING_KEY, non_path_mapping_keys
 from tracer.models.custom_eval_config import CustomEvalConfig
 
 
@@ -52,13 +52,23 @@ class Command(BaseCommand):
 
         affected = 0
         for config in queryset.iterator():
-            bad_keys = non_path_mapping_keys(config.mapping)
+            # This sweeps legacy rows of unknown shape, so one surprising row
+            # must not cost the report on every row after it.
+            try:
+                bad_keys = non_path_mapping_keys(config.mapping)
+            except Exception as exc:  # noqa: BLE001 - a support tool, keep going
+                affected += 1
+                self.stderr.write(f"eval_config={config.id} unreadable_mapping={exc!r}")
+                continue
             if not bad_keys:
                 continue
             affected += 1
-            details = ", ".join(
-                f"{key}={type(config.mapping[key]).__name__}" for key in bad_keys
-            )
+            if bad_keys == [WHOLE_MAPPING_KEY]:
+                details = f"{WHOLE_MAPPING_KEY}={type(config.mapping).__name__}"
+            else:
+                details = ", ".join(
+                    f"{key}={type(config.mapping[key]).__name__}" for key in bad_keys
+                )
             self.stdout.write(
                 f"organization={config.project.organization_id} "
                 f"project={config.project_id} "

--- a/futureagi/tracer/management/commands/scan_eval_mapping_paths.py
+++ b/futureagi/tracer/management/commands/scan_eval_mapping_paths.py
@@ -1,0 +1,73 @@
+"""Report saved eval configs whose mapping holds a non-path value.
+
+An eval mapping value is an attribute path string; every resolver splits it on
+".". Rows written before the API refused non-strings can still hold an object
+or a list, and those rows produce no eval result. This command finds them so
+support can tell the owner which eval to re-map.
+
+It deliberately does not repair. The correct path for a broken value is only
+knowable by whoever configured the eval, and guessing one would silently
+evaluate the wrong attribute. The repair surface is the product: the mapping
+panel now renders such a value as "invalid mapping" instead of tearing the page
+down, so the owner can open the eval and set the path themselves.
+
+Usage:
+    python manage.py scan_eval_mapping_paths
+    python manage.py scan_eval_mapping_paths --project-id <uuid>
+    python manage.py scan_eval_mapping_paths --organization-id <uuid>
+"""
+
+from django.core.management.base import BaseCommand
+
+from model_hub.utils.eval_mapping import non_path_mapping_keys
+from tracer.models.custom_eval_config import CustomEvalConfig
+
+
+class Command(BaseCommand):
+    help = (
+        "List eval configs whose mapping holds a value that is not an "
+        "attribute path string. Read-only."
+    )
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--project-id",
+            help="Restrict the scan to one project.",
+        )
+        parser.add_argument(
+            "--organization-id",
+            help="Restrict the scan to one organization.",
+        )
+
+    def handle(self, *args, **options):
+        queryset = CustomEvalConfig.no_workspace_objects.select_related(
+            "project", "project__organization"
+        )
+        if options["project_id"]:
+            queryset = queryset.filter(project_id=options["project_id"])
+        if options["organization_id"]:
+            queryset = queryset.filter(
+                project__organization_id=options["organization_id"]
+            )
+
+        affected = 0
+        for config in queryset.iterator():
+            bad_keys = non_path_mapping_keys(config.mapping)
+            if not bad_keys:
+                continue
+            affected += 1
+            details = ", ".join(
+                f"{key}={type(config.mapping[key]).__name__}" for key in bad_keys
+            )
+            self.stdout.write(
+                f"organization={config.project.organization_id} "
+                f"project={config.project_id} "
+                f"eval_config={config.id} name={config.name!r} "
+                f"invalid_keys=[{details}]"
+            )
+
+        self.stdout.write(
+            self.style.SUCCESS(f"affected_eval_configs={affected}")
+            if affected == 0
+            else self.style.WARNING(f"affected_eval_configs={affected}")
+        )

--- a/futureagi/tracer/serializers/custom_eval_config.py
+++ b/futureagi/tracer/serializers/custom_eval_config.py
@@ -45,6 +45,23 @@ class CustomEvalConfigSerializer(serializers.ModelSerializer):
             return obj.eval_group.name
         return None
 
+    def validate_mapping(self, value):
+        if not value:
+            return value
+        if not isinstance(value, dict):
+            raise serializers.ValidationError("Mapping must be an object.")
+        bad = sorted(
+            key
+            for key, path in value.items()
+            if path is not None and not isinstance(path, str)
+        )
+        if bad:
+            raise serializers.ValidationError(
+                "Mapping values must be attribute path strings. "
+                f"Non-string values for: {', '.join(bad)}."
+            )
+        return value
+
     def validate(self, attrs):
         eval_template = attrs.get("eval_template") or getattr(
             self.instance, "eval_template", None

--- a/futureagi/tracer/serializers/custom_eval_config.py
+++ b/futureagi/tracer/serializers/custom_eval_config.py
@@ -2,6 +2,7 @@ from rest_framework import serializers
 
 from model_hub.models.develop_dataset import KnowledgeBaseFile
 from model_hub.models.evals_metric import EvalTemplate
+from model_hub.utils.eval_mapping import non_path_mapping_keys
 from model_hub.utils.function_eval_params import normalize_eval_runtime_config
 from tracer.models.custom_eval_config import CustomEvalConfig
 from tracer.models.project import Project
@@ -46,15 +47,11 @@ class CustomEvalConfigSerializer(serializers.ModelSerializer):
         return None
 
     def validate_mapping(self, value):
-        if not value:
+        if value is None:
             return value
         if not isinstance(value, dict):
             raise serializers.ValidationError("Mapping must be an object.")
-        bad = sorted(
-            key
-            for key, path in value.items()
-            if path is not None and not isinstance(path, str)
-        )
+        bad = non_path_mapping_keys(value)
         if bad:
             raise serializers.ValidationError(
                 "Mapping values must be attribute path strings. "

--- a/futureagi/tracer/tests/test_custom_eval_config.py
+++ b/futureagi/tracer/tests/test_custom_eval_config.py
@@ -562,6 +562,19 @@ class TestScanEvalMappingPathsCommand:
         assert "output" not in output.split("invalid_keys=")[1].split("]")[0]
         assert "affected_eval_configs=1" in output
 
+    def test_reports_a_list_valued_row_without_aborting(self, custom_eval_config):
+        # non_path_mapping_keys used to raise AttributeError on a non-dict
+        # mapping, which killed the sweep on the first such row and left every
+        # row after it unreported.
+        custom_eval_config.mapping = ["input", "output"]
+        custom_eval_config.save(update_fields=["mapping"])
+
+        output = self._scan()
+
+        assert str(custom_eval_config.id) in output
+        assert "<mapping>=list" in output
+        assert "affected_eval_configs=1" in output
+
     def test_reports_nothing_when_every_value_is_a_path(self, custom_eval_config):
         output = self._scan()
 
@@ -605,14 +618,58 @@ class TestEvalTagIngestMappingValues:
     def test_object_mapping_value_is_refused_before_a_config_is_created(
         self, project, eval_template
     ):
-        from tracer.utils.otel import _process_eval_tags
+        # Driven through get_or_create_project_version, not _process_eval_tags:
+        # creation happens in _create_custom_eval_configs, so only the caller
+        # that reaches it can show that nothing was created.
+        from tracer.utils.otel import get_or_create_project_version
 
-        with pytest.raises(ValueError, match="must be an attribute path string"):
-            _process_eval_tags(
-                self._tag({"input": {"path": "input"}, "output": "output"}, eval_template),
-                project,
+        with pytest.raises(Exception, match="must be an attribute path string"):
+            get_or_create_project_version(
+                project_id=project.id,
+                project_version_name="v1",
+                project_version_id=None,
+                eval_tags=self._tag(
+                    {"input": {"path": "input"}, "output": "output"}, eval_template
+                ),
+                metadata=None,
+                project_type="experiment",
             )
         assert not CustomEvalConfig.objects.filter(name="release-tag-eval").exists()
+
+    def test_async_ingest_keeps_the_span_batch_when_a_tag_is_malformed(
+        self, project, eval_template
+    ):
+        """The OTLP export already answered 200 before this runs.
+
+        bulk_create_observation_span_task is a max_retries=0 activity wrapping
+        the whole batch in one transaction, so raising here would drop every
+        span in it with nothing surfaced to the client. The bad tag is dropped
+        instead; the spans land.
+        """
+        from tracer.utils.otel import _bulk_get_or_create_project_versions
+
+        tags = self._tag(
+            {"input": {"path": "input"}, "output": "output"}, eval_template
+        )
+        versions = _bulk_get_or_create_project_versions(
+            [(project.name, "experiment", "v1", None, tags)],
+            {(project.name, project.organization_id, "experiment"): project},
+            project.organization_id,
+        )
+
+        assert any(
+            v is not None for v in versions.values()
+        ), "the whole span batch would have been dropped"
+        assert not CustomEvalConfig.objects.filter(name="release-tag-eval").exists()
+
+    def test_list_mapping_is_refused_as_a_value_error(self, project, eval_template):
+        # A list was storable before the write gates existed: the OTEL path
+        # stored wire values verbatim after json.loads. It must not reach
+        # ``.items()`` as an AttributeError.
+        from tracer.utils.otel import _process_eval_tags
+
+        with pytest.raises(ValueError, match="must be an object"):
+            _process_eval_tags(self._tag(["input", "output"], eval_template), project)
 
     def test_path_string_mapping_values_pass_through(self, project, eval_template):
         from tracer.utils.otel import _process_eval_tags

--- a/futureagi/tracer/tests/test_custom_eval_config.py
+++ b/futureagi/tracer/tests/test_custom_eval_config.py
@@ -101,6 +101,81 @@ class TestCustomEvalConfigCreateAPI:
         # Should fail due to unique constraint
         assert response.status_code == status.HTTP_400_BAD_REQUEST
 
+    def test_create_config_saves_only_path_string_mapping_values(
+        self, auth_client, project, eval_template
+    ):
+        """Mapping values are attribute paths — an object value is not stored."""
+        rejected = auth_client.post(
+            "/tracer/custom-eval-config/",
+            {
+                "project": str(project.id),
+                "eval_template": str(eval_template.id),
+                "name": "Object Mapping Config",
+                "mapping": {"input": {"path": "input"}, "output": "output"},
+            },
+            format="json",
+        )
+        assert rejected.status_code == status.HTTP_400_BAD_REQUEST
+        assert not CustomEvalConfig.objects.filter(
+            name="Object Mapping Config"
+        ).exists()
+
+        accepted = auth_client.post(
+            "/tracer/custom-eval-config/",
+            {
+                "project": str(project.id),
+                "eval_template": str(eval_template.id),
+                "name": "Path Mapping Config",
+                "mapping": {"input": "input.value", "output": "output"},
+            },
+            format="json",
+        )
+        assert accepted.status_code == status.HTTP_200_OK
+        saved = CustomEvalConfig.objects.get(name="Path Mapping Config")
+        assert saved.mapping == {"input": "input.value", "output": "output"}
+
+
+@pytest.mark.integration
+@pytest.mark.api
+class TestCustomEvalConfigPartialUpdateAPI:
+    """Tests for PATCH /tracer/custom-eval-config/<id>/ endpoint."""
+
+    def test_partial_update_unauthenticated(self, api_client, custom_eval_config):
+        """Unauthenticated requests should be rejected."""
+        response = api_client.patch(
+            f"/tracer/custom-eval-config/{custom_eval_config.id}/",
+            {"mapping": {"input": "input.value"}},
+            format="json",
+        )
+        assert response.status_code in AUTH_REQUIRED_STATUS_CODES
+
+    def test_partial_update_saves_only_path_string_mapping_values(
+        self, auth_client, custom_eval_config
+    ):
+        """Mapping values are attribute paths — an object value is not stored."""
+        existing_mapping = dict(custom_eval_config.mapping)
+
+        rejected = auth_client.patch(
+            f"/tracer/custom-eval-config/{custom_eval_config.id}/",
+            {"mapping": {"input": {"path": "input"}, "output": "output"}},
+            format="json",
+        )
+        assert rejected.status_code == status.HTTP_400_BAD_REQUEST
+        custom_eval_config.refresh_from_db()
+        assert custom_eval_config.mapping == existing_mapping
+
+        accepted = auth_client.patch(
+            f"/tracer/custom-eval-config/{custom_eval_config.id}/",
+            {"mapping": {"input": "input.value", "output": "output"}},
+            format="json",
+        )
+        assert accepted.status_code == status.HTTP_200_OK
+        custom_eval_config.refresh_from_db()
+        assert custom_eval_config.mapping == {
+            "input": "input.value",
+            "output": "output",
+        }
+
 
 @pytest.mark.integration
 @pytest.mark.api

--- a/futureagi/tracer/tests/test_custom_eval_config.py
+++ b/futureagi/tracer/tests/test_custom_eval_config.py
@@ -585,3 +585,51 @@ class TestScanEvalMappingPathsCommand:
         output = self._scan(project_id=str(uuid.uuid4()))
 
         assert "affected_eval_configs=0" in output
+
+
+@pytest.mark.integration
+class TestEvalTagIngestMappingValues:
+    """The OTEL eval-tag path writes CustomEvalConfig.mapping straight from the
+    wire via get_or_create, bypassing both the serializer and the eval-group
+    helper. It is the only write path a customer's SDK reaches directly."""
+
+    def _tag(self, mapping, eval_template):
+        return [
+            {
+                "custom_eval_name": "release-tag-eval",
+                "eval_name": eval_template.name,
+                "mapping": mapping,
+            }
+        ]
+
+    def test_object_mapping_value_is_refused_before_a_config_is_created(
+        self, project, eval_template
+    ):
+        from tracer.utils.otel import _process_eval_tags
+
+        with pytest.raises(ValueError, match="must be an attribute path string"):
+            _process_eval_tags(
+                self._tag({"input": {"path": "input"}, "output": "output"}, eval_template),
+                project,
+            )
+        assert not CustomEvalConfig.objects.filter(name="release-tag-eval").exists()
+
+    def test_path_string_mapping_values_pass_through(self, project, eval_template):
+        from tracer.utils.otel import _process_eval_tags
+
+        processed = _process_eval_tags(
+            self._tag({"input": "input.value", "output": "output"}, eval_template),
+            project,
+        )
+
+        assert processed[0]["mapping"] == {"input": "input.value", "output": "output"}
+
+    def test_json_string_mapping_is_parsed_then_checked(self, project, eval_template):
+        from tracer.utils.otel import _process_eval_tags
+
+        # The wire form is often a JSON string; the guard must run after the parse.
+        with pytest.raises(ValueError, match="must be an attribute path string"):
+            _process_eval_tags(
+                self._tag(json.dumps({"input": {"path": "input"}}), eval_template),
+                project,
+            )

--- a/futureagi/tracer/tests/test_custom_eval_config.py
+++ b/futureagi/tracer/tests/test_custom_eval_config.py
@@ -6,8 +6,10 @@ Tests for /tracer/custom-eval-config/ endpoints.
 
 import json
 import uuid
+from io import StringIO
 
 import pytest
+from django.core.management import call_command
 from rest_framework import status
 
 from tracer.models.custom_eval_config import CustomEvalConfig
@@ -119,6 +121,12 @@ class TestCustomEvalConfigCreateAPI:
         assert not CustomEvalConfig.objects.filter(
             name="Object Mapping Config"
         ).exists()
+        # The response names the offending key in words the caller can act on,
+        # and carries no DRF internals.
+        body = json.dumps(rejected.json())
+        assert "attribute path strings" in body
+        assert "input" in body
+        assert "ErrorDetail" not in body
 
         accepted = auth_client.post(
             "/tracer/custom-eval-config/",
@@ -163,6 +171,10 @@ class TestCustomEvalConfigPartialUpdateAPI:
         assert rejected.status_code == status.HTTP_400_BAD_REQUEST
         custom_eval_config.refresh_from_db()
         assert custom_eval_config.mapping == existing_mapping
+        body = json.dumps(rejected.json())
+        assert "attribute path strings" in body
+        assert "input" in body
+        assert "ErrorDetail" not in body
 
         accepted = auth_client.patch(
             f"/tracer/custom-eval-config/{custom_eval_config.id}/",
@@ -526,3 +538,50 @@ class TestEvalConfigBYOModel:
         config = ExternalEvalConfig(model=model_value)
         exclude = [f.name for f in ExternalEvalConfig._meta.fields if f.name != "model"]
         config.clean_fields(exclude=exclude)
+
+
+@pytest.mark.integration
+class TestScanEvalMappingPathsCommand:
+    """Tests for `manage.py scan_eval_mapping_paths` — the existing-row sweep."""
+
+    def _scan(self, **kwargs):
+        out = StringIO()
+        call_command("scan_eval_mapping_paths", stdout=out, **kwargs)
+        return out.getvalue()
+
+    def test_reports_a_row_saved_before_the_write_gate(self, custom_eval_config):
+        # Written straight through the ORM: exactly how the rows that predate
+        # the API gate exist today.
+        custom_eval_config.mapping = {"input": {"path": "input"}, "output": "output"}
+        custom_eval_config.save(update_fields=["mapping"])
+
+        output = self._scan()
+
+        assert str(custom_eval_config.id) in output
+        assert "input=dict" in output
+        assert "output" not in output.split("invalid_keys=")[1].split("]")[0]
+        assert "affected_eval_configs=1" in output
+
+    def test_reports_nothing_when_every_value_is_a_path(self, custom_eval_config):
+        output = self._scan()
+
+        assert str(custom_eval_config.id) not in output
+        assert "affected_eval_configs=0" in output
+
+    def test_leaves_the_row_untouched(self, custom_eval_config):
+        broken = {"input": {"path": "input"}, "output": "output"}
+        custom_eval_config.mapping = broken
+        custom_eval_config.save(update_fields=["mapping"])
+
+        self._scan()
+
+        custom_eval_config.refresh_from_db()
+        assert custom_eval_config.mapping == broken
+
+    def test_project_filter_scopes_the_scan(self, custom_eval_config):
+        custom_eval_config.mapping = {"input": {"path": "input"}}
+        custom_eval_config.save(update_fields=["mapping"])
+
+        output = self._scan(project_id=str(uuid.uuid4()))
+
+        assert "affected_eval_configs=0" in output

--- a/futureagi/tracer/tests/test_process_mapping.py
+++ b/futureagi/tracer/tests/test_process_mapping.py
@@ -394,6 +394,27 @@ def test_object_mapping_value_fails_session_mapping_as_value_error(
     ) == {"prompt": "Test Session"}
 
 
+# The shape the reporting customer actually saved, quoted from their own report:
+#   generated_value: {"source": "span_attribute", "column_id": "output.value"}
+# Their 31 rows all failed with "'dict' object has no attribute 'startswith'",
+# which is _heavy_span_ids_for_trace_mapping scanning raw mapping values before
+# the resolver binds to a span -- hence trace_id/span_id/session_id all null.
+CUSTOMER_MAPPING_VALUE = {"source": "span_attribute", "column_id": "output.value"}
+
+
+def test_customer_mapping_shape_fails_before_the_heavy_span_scan(
+    trace, eval_template, mocker
+):
+    mocker.patch(
+        "tracer.services.clickhouse.v2.eval_loader._read_source",
+        return_value="clickhouse",
+    )
+    with pytest.raises(ValueError, match="must be an attribute path string"):
+        resolve_trace_mapping_lean_first(
+            {"generated_value": CUSTOMER_MAPPING_VALUE}, trace, eval_template.id
+        )
+
+
 def test_object_mapping_value_fails_lean_first_trace_path(trace, eval_template, mocker):
     mocker.patch(
         "tracer.services.clickhouse.v2.eval_loader._read_source",

--- a/futureagi/tracer/tests/test_process_mapping.py
+++ b/futureagi/tracer/tests/test_process_mapping.py
@@ -372,9 +372,7 @@ def test_object_mapping_value_fails_span_mapping_as_value_error(
     ) == {"prompt": "hello"}
 
 
-def test_object_mapping_value_fails_trace_mapping_as_value_error(
-    trace, eval_template
-):
+def test_object_mapping_value_fails_trace_mapping_as_value_error(trace, eval_template):
     with pytest.raises(ValueError, match="must be an attribute path string"):
         _process_trace_mapping({"prompt": {"path": "name"}}, trace, eval_template.id)
     assert _process_trace_mapping({"prompt": "name"}, trace, eval_template.id) == {
@@ -392,6 +390,25 @@ def test_object_mapping_value_fails_session_mapping_as_value_error(
     assert _process_session_mapping(
         {"prompt": "name"}, trace_session, eval_template.id
     ) == {"prompt": "Test Session"}
+
+
+def test_list_mapping_raises_value_error_not_attribute_error(trace, eval_template):
+    # ``(mapping or {}).items()`` only absorbs an *empty* list. A populated one
+    # used to raise AttributeError, which the callers' broad ``except Exception``
+    # swallows instead of recording — the exact failure mode this set out to end.
+    with pytest.raises(ValueError, match="must be an object"):
+        _process_trace_mapping(["prompt"], trace, eval_template.id)
+
+
+def test_cleared_value_on_a_required_key_is_a_missing_attribute(
+    observation_span, eval_template
+):
+    # ``None`` is admissible (it is how a cleared field is stored) and is popped
+    # for optional keys. On a *required* key the span resolver used to reach
+    # ``None.split(".")``; it now converges on the same missing-attribute
+    # failure the trace and session resolvers already raised.
+    with pytest.raises(EvalSkippedMissingAttribute):
+        _process_mapping({"prompt": None}, observation_span, eval_template.id)
 
 
 # The shape the reporting customer actually saved, quoted from their own report:
@@ -453,12 +470,8 @@ def test_object_mapping_value_fails_lean_first_session_path(
 
 
 def test_object_mapping_value_is_recorded_not_swallowed(
-    trace, observation_span, custom_eval_config, eval_task, mocker
+    trace, observation_span, custom_eval_config, eval_task
 ):
-    mocker.patch(
-        "tracer.services.clickhouse.v2.eval_loader._read_source",
-        return_value="postgres",
-    )
     custom_eval_config.mapping = {"input": {"path": "input"}, "output": "output"}
     custom_eval_config.save(update_fields=["mapping"])
 

--- a/futureagi/tracer/tests/test_process_mapping.py
+++ b/futureagi/tracer/tests/test_process_mapping.py
@@ -4,11 +4,13 @@ import uuid
 
 import pytest
 
+from tracer.models.observation_span import EvalLogger
 from tracer.utils.eval import (
     EvalSkippedMissingAttribute,
     _process_mapping,
     _process_session_mapping,
     _process_trace_mapping,
+    evaluate_trace_observe,
     resolve_session_mapping_lean_first,
     resolve_trace_mapping_lean_first,
 )
@@ -416,3 +418,50 @@ def test_object_mapping_value_fails_lean_first_session_path(
             trace_session,
             eval_template.id,
         )
+
+
+# ───────────────────────────────────────────────────────────────────────────
+# The recorded outcome
+#
+# ``evaluate_trace_observe`` records a ValueError on EvalTask.failed_spans and
+# writes an error EvalLogger row, but its bare ``except Exception`` only logs.
+# A mapping value that used to raise TypeError out of a path walker therefore
+# produced no eval result and no trace of why. Raising ValueError instead is
+# what makes the failure visible, so that is what this asserts.
+# ───────────────────────────────────────────────────────────────────────────
+
+
+def test_object_mapping_value_is_recorded_not_swallowed(
+    trace, observation_span, custom_eval_config, eval_task, mocker
+):
+    mocker.patch(
+        "tracer.services.clickhouse.v2.eval_loader._read_source",
+        return_value="postgres",
+    )
+    custom_eval_config.mapping = {"input": {"path": "input"}, "output": "output"}
+    custom_eval_config.save(update_fields=["mapping"])
+
+    # ``._original_func`` for the same reason ``inline_temporal`` uses it: the
+    # temporal_activity wrapper's close_old_connections() drops pytest-django's
+    # test transaction. The body it wraps is the one Temporal runs.
+    result = evaluate_trace_observe._original_func(
+        trace_id=str(trace.id),
+        custom_eval_config_id=str(custom_eval_config.id),
+        eval_task_id=str(eval_task.id),
+    )
+
+    assert result is False
+
+    eval_task.refresh_from_db()
+    assert eval_task.failed_spans, "the failure was swallowed, not recorded"
+    recorded = eval_task.failed_spans[-1]
+    assert recorded["trace_id"] == str(trace.id)
+    assert "must be an attribute path string" in recorded["error"]
+
+    errored = EvalLogger.objects.filter(
+        trace_id=trace.id,
+        custom_eval_config_id=custom_eval_config.id,
+        error=True,
+    ).first()
+    assert errored is not None, "no error row was written for the failed eval"
+    assert "must be an attribute path string" in errored.error_message

--- a/futureagi/tracer/tests/test_process_mapping.py
+++ b/futureagi/tracer/tests/test_process_mapping.py
@@ -4,7 +4,14 @@ import uuid
 
 import pytest
 
-from tracer.utils.eval import EvalSkippedMissingAttribute, _process_mapping
+from tracer.utils.eval import (
+    EvalSkippedMissingAttribute,
+    _process_mapping,
+    _process_session_mapping,
+    _process_trace_mapping,
+    resolve_session_mapping_lean_first,
+    resolve_trace_mapping_lean_first,
+)
 
 
 @pytest.fixture
@@ -336,3 +343,76 @@ def test_voice_fallback_not_reached_when_literal_resolves(
         {"v": "call.duration"}, span, eval_template_id=missing_eval_template_id
     )
     assert out == {"v": "42"}
+
+
+# ───────────────────────────────────────────────────────────────────────────
+# Non-string mapping values
+#
+# A saved mapping value is an attribute path string. A resolver handed any
+# other type must fail as a ValueError — the type the eval callers catch and
+# persist as a failed EvalLogger row — rather than a TypeError/AttributeError
+# from inside a path walker.
+# ───────────────────────────────────────────────────────────────────────────
+
+
+def test_object_mapping_value_fails_span_mapping_as_value_error(
+    _span_with_attrs, missing_eval_template_id
+):
+    span = _span_with_attrs({"input": "hello"})
+    with pytest.raises(ValueError, match="must be an attribute path string"):
+        _process_mapping(
+            {"prompt": {"path": "input"}},
+            span,
+            eval_template_id=missing_eval_template_id,
+        )
+    assert _process_mapping(
+        {"prompt": "input"}, span, eval_template_id=missing_eval_template_id
+    ) == {"prompt": "hello"}
+
+
+def test_object_mapping_value_fails_trace_mapping_as_value_error(
+    trace, eval_template
+):
+    with pytest.raises(ValueError, match="must be an attribute path string"):
+        _process_trace_mapping({"prompt": {"path": "name"}}, trace, eval_template.id)
+    assert _process_trace_mapping({"prompt": "name"}, trace, eval_template.id) == {
+        "prompt": "Test Trace"
+    }
+
+
+def test_object_mapping_value_fails_session_mapping_as_value_error(
+    trace_session, eval_template
+):
+    with pytest.raises(ValueError, match="must be an attribute path string"):
+        _process_session_mapping(
+            {"prompt": {"path": "name"}}, trace_session, eval_template.id
+        )
+    assert _process_session_mapping(
+        {"prompt": "name"}, trace_session, eval_template.id
+    ) == {"prompt": "Test Session"}
+
+
+def test_object_mapping_value_fails_lean_first_trace_path(trace, eval_template, mocker):
+    mocker.patch(
+        "tracer.services.clickhouse.v2.eval_loader._read_source",
+        return_value="clickhouse",
+    )
+    with pytest.raises(ValueError, match="must be an attribute path string"):
+        resolve_trace_mapping_lean_first(
+            {"prompt": {"path": "spans.0.input"}}, trace, eval_template.id
+        )
+
+
+def test_object_mapping_value_fails_lean_first_session_path(
+    trace_session, eval_template, mocker
+):
+    mocker.patch(
+        "tracer.services.clickhouse.v2.eval_loader._read_source",
+        return_value="clickhouse",
+    )
+    with pytest.raises(ValueError, match="must be an attribute path string"):
+        resolve_session_mapping_lean_first(
+            {"prompt": {"path": "traces.0.spans.0.input"}},
+            trace_session,
+            eval_template.id,
+        )

--- a/futureagi/tracer/utils/eval.py
+++ b/futureagi/tracer/utils/eval.py
@@ -17,6 +17,7 @@ from accounts.models.workspace import Workspace
 # ClickHouse client warms up at startup. Keep it lazy.
 from agentic_eval.core_evals.fi_evals import *  # noqa: F403
 from common.utils.data_injection import normalize as _di_normalize
+from model_hub.utils.eval_mapping import require_mapping_paths
 from model_hub.models.choices import StatusType
 from model_hub.models.evals_metric import EvalTemplate
 from sdk.utils.helpers import _get_api_call_type
@@ -559,17 +560,12 @@ class EvalSkippedMissingAttribute(ValueError):
 
 
 def _require_mapping_paths(mapping, target):
-    """Raise ValueError for any mapping value that is not an attribute path.
+    """Guard the mapping before any walker touches it.
 
-    Runs before any walker touches the mapping: the heavy-id scan reads the raw
-    values first, so a per-value check inside the resolve loop never sees them.
+    The heavy-id scan reads the raw values first, so a per-value check inside
+    the resolve loop never sees them.
     """
-    for key, attribute in (mapping or {}).items():
-        if attribute is not None and not isinstance(attribute, str):
-            raise ValueError(
-                f"Mapping value for key '{key}' must be an attribute path string, "
-                f"got {type(attribute).__name__}, on {target}"
-            )
+    require_mapping_paths(mapping, target)
 
 
 def _process_mapping(

--- a/futureagi/tracer/utils/eval.py
+++ b/futureagi/tracer/utils/eval.py
@@ -17,9 +17,9 @@ from accounts.models.workspace import Workspace
 # ClickHouse client warms up at startup. Keep it lazy.
 from agentic_eval.core_evals.fi_evals import *  # noqa: F403
 from common.utils.data_injection import normalize as _di_normalize
-from model_hub.utils.eval_mapping import require_mapping_paths
 from model_hub.models.choices import StatusType
 from model_hub.models.evals_metric import EvalTemplate
+from model_hub.utils.eval_mapping import require_mapping_paths
 from sdk.utils.helpers import _get_api_call_type
 from tfc.constants.api_calls import APICallStatusChoices
 from tfc.temporal import temporal_activity
@@ -621,7 +621,9 @@ def _process_mapping(
         # shorthands (``recording_url``, ``transcript``, …) resolve to
         # one of several provider-specific attribute names via the
         # ``_ATTRIBUTE_ALIASES`` table above — first hit wins.
-        candidates = [attribute, f"{attribute}.value"]
+        # A cleared value on a required key: _resolve_attr would reach
+        # ``None.split(".")``. Falls through to the miss branch, as trace does.
+        candidates = [attribute, f"{attribute}.value"] if attribute else []
         for alias in _ATTRIBUTE_ALIASES.get(attribute, []):
             candidates.append(alias)
             candidates.append(f"{alias}.value")
@@ -644,6 +646,7 @@ def _process_mapping(
         # so non-voice spans are unaffected. See _walk_raw_log.
         if (
             resolved_value is _MISSING
+            and attribute
             and span.observation_type == ObservationType.CONVERSATION
         ):
             raw_log = span_attrs.get("raw_log")

--- a/futureagi/tracer/utils/eval.py
+++ b/futureagi/tracer/utils/eval.py
@@ -558,6 +558,20 @@ class EvalSkippedMissingAttribute(ValueError):
         )
 
 
+def _require_mapping_paths(mapping, target):
+    """Raise ValueError for any mapping value that is not an attribute path.
+
+    Runs before any walker touches the mapping: the heavy-id scan reads the raw
+    values first, so a per-value check inside the resolve loop never sees them.
+    """
+    for key, attribute in (mapping or {}).items():
+        if attribute is not None and not isinstance(attribute, str):
+            raise ValueError(
+                f"Mapping value for key '{key}' must be an attribute path string, "
+                f"got {type(attribute).__name__}, on {target}"
+            )
+
+
 def _process_mapping(
     mapping: dict | None, span: ObservationSpan, eval_template_id: int
 ) -> dict:
@@ -579,6 +593,7 @@ def _process_mapping(
 
     if not mapping:
         return {}
+    _require_mapping_paths(mapping, f"span {span.id}")
 
     parsed_mapping = {}
     # Use accessor for backward compatibility (span_attributes || eval_attributes)
@@ -2836,6 +2851,7 @@ def _process_trace_mapping(
     """
     if not mapping:
         return {}
+    _require_mapping_paths(mapping, f"trace {trace.id}")
 
     parsed: dict = {}
     is_user_custom_eval = False
@@ -2997,6 +3013,8 @@ def resolve_trace_mapping_lean_first(mapping: dict | None, trace, template_id) -
     """
     from tracer.services.clickhouse.v2.eval_loader import _read_source
 
+    _require_mapping_paths(mapping, f"trace {trace.id}")
+
     if _read_source() != "clickhouse":
         return _process_trace_mapping(mapping, trace, template_id)
 
@@ -3112,6 +3130,8 @@ def resolve_session_mapping_lean_first(
     """
     from tracer.services.clickhouse.v2.eval_loader import _read_source
 
+    _require_mapping_paths(mapping, f"session {trace_session.id}")
+
     if _read_source() != "clickhouse":
         return _process_session_mapping(mapping, trace_session, template_id)
 
@@ -3133,6 +3153,7 @@ def _process_session_mapping(
     """Resolve a saved mapping against a TraceSession."""
     if not mapping:
         return {}
+    _require_mapping_paths(mapping, f"session {trace_session.id}")
 
     parsed: dict = {}
     is_user_custom_eval = False

--- a/futureagi/tracer/utils/otel.py
+++ b/futureagi/tracer/utils/otel.py
@@ -1181,10 +1181,15 @@ def _get_eval_template(eval_template_name, project):
     return eval_template
 
 
-def _process_eval_tags(eval_tags, project):
+def _process_eval_tags(eval_tags, project, skip_invalid_mappings: bool = False):
     """
     Process and validate eval_tags.
     Returns a list of processed eval tag data ready for database operations.
+
+    ``skip_invalid_mappings`` drops a tag whose mapping is malformed instead of
+    raising. The async ingest path sets it so one bad tag cannot cost a whole
+    span batch; the synchronous span endpoint leaves it off so the caller gets
+    a 400.
     """
     if not eval_tags:
         return []
@@ -1217,11 +1222,24 @@ def _process_eval_tags(eval_tags, project):
                 logger.exception(f"Invalid JSON format for mapping: {str(e)}")
                 raise Exception(f"Invalid JSON format for mapping: {str(e)}") from e
 
-        # Third write path into CustomEvalConfig.mapping, and the only one that
-        # takes the values straight off the wire. Refuse a non-path value here
-        # rather than in _create_custom_eval_configs, so nothing is created for
-        # the whole batch when one tag is malformed.
-        require_mapping_paths(mapping, f"eval tag '{custom_eval_name}'")
+        # One of four write paths into CustomEvalConfig.mapping, and the only
+        # one that takes the values straight off the wire. Refuse a non-path
+        # value here rather than in _create_custom_eval_configs, so nothing is
+        # created for the whole batch when one tag is malformed.
+        try:
+            require_mapping_paths(mapping, f"eval tag '{custom_eval_name}'")
+        except ValueError:
+            if not skip_invalid_mappings:
+                raise
+            # Async ingest: the export already returned 200 and the activity
+            # runs with max_retries=0, so raising here would drop every span in
+            # the batch with no client-visible error. Drop the tag, keep the spans.
+            logger.exception(
+                "Skipping eval tag %r on project %s: malformed mapping",
+                custom_eval_name,
+                project.id,
+            )
+            continue
 
         processed_eval_tags.append(
             {
@@ -1298,6 +1316,7 @@ def get_or_create_project_version(
     eval_tags: list | None,
     metadata: dict | None,
     project_type: str,
+    skip_invalid_eval_tags: bool = False,
 ) -> ProjectVersion | None:
     try:
         if project_type == "observe":
@@ -1330,7 +1349,9 @@ def get_or_create_project_version(
             if not project_version_id:
                 project_version_id = uuid.uuid4()
 
-            processed_eval_tags = _process_eval_tags(eval_tags, project)
+            processed_eval_tags = _process_eval_tags(
+                eval_tags, project, skip_invalid_mappings=skip_invalid_eval_tags
+            )
             final_eval_tags = _create_custom_eval_configs(processed_eval_tags, project)
 
             versions_qs = ProjectVersion.objects.filter(project=project)
@@ -1421,6 +1442,8 @@ def _bulk_get_or_create_project_versions(version_keys, projects, organization_id
                     eval_tags=eval_tags,
                     metadata=None,
                     project_type=p_type,
+                    # Only reached from bulk_create_observation_span_task.
+                    skip_invalid_eval_tags=True,
                 )
                 project_versions[version_key] = project_version
     return project_versions

--- a/futureagi/tracer/utils/otel.py
+++ b/futureagi/tracer/utils/otel.py
@@ -21,6 +21,7 @@ from model_hub.models.ai_model import AIModel
 from model_hub.models.choices import StatusType
 from model_hub.models.custom_models import CustomAIModel
 from model_hub.models.evals_metric import EvalTemplate
+from model_hub.utils.eval_mapping import require_mapping_paths
 from tfc.utils.storage import upload_audio_to_s3, upload_image_to_s3, upload_video_to_s3
 from tracer.models.custom_eval_config import CustomEvalConfig
 from tracer.models.observation_span import ObservationSpan, UserIdType
@@ -1215,6 +1216,12 @@ def _process_eval_tags(eval_tags, project):
             except json.JSONDecodeError as e:
                 logger.exception(f"Invalid JSON format for mapping: {str(e)}")
                 raise Exception(f"Invalid JSON format for mapping: {str(e)}") from e
+
+        # Third write path into CustomEvalConfig.mapping, and the only one that
+        # takes the values straight off the wire. Refuse a non-path value here
+        # rather than in _create_custom_eval_configs, so nothing is created for
+        # the whole batch when one tag is malformed.
+        require_mapping_paths(mapping, f"eval tag '{custom_eval_name}'")
 
         processed_eval_tags.append(
             {

--- a/futureagi/tracer/views/custom_eval_config.py
+++ b/futureagi/tracer/views/custom_eval_config.py
@@ -76,7 +76,8 @@ class CustomEvalConfigView(BaseModelViewSetMixin, ModelViewSet):
                 data["config"]["choices"] = choices
 
             serializer = self.get_serializer(data=data)
-            serializer.is_valid(raise_exception=True)
+            if not serializer.is_valid():
+                return self._gm.bad_request(serializer.errors)
 
             mapping = serializer.validated_data.get("mapping", {})
 
@@ -133,7 +134,8 @@ class CustomEvalConfigView(BaseModelViewSetMixin, ModelViewSet):
             serializer = self.get_serializer(
                 custom_eval_config, data=data, partial=True
             )
-            serializer.is_valid(raise_exception=True)
+            if not serializer.is_valid():
+                return self._gm.bad_request(serializer.errors)
 
             if "mapping" in serializer.validated_data:
                 mapping = serializer.validated_data["mapping"]


### PR DESCRIPTION
## Summary

A saved `CustomEvalConfig.mapping` value is an attribute path string. When one is any other type, the eval task detail page throws `TypeError: path.split is not a function` from inside the path walker, the throw escapes to the app-level `ErrorBoundary`, and the **entire dashboard** is replaced by the "Houston, we have a problem!" page until a full reload. Reported by Whatfix on their `test-project` eval tasks, and reproducible on any org whose config carries a non-string mapping value.

This is a two-layer bug. The frontend crashes on it; the backend chokes on it in three different resolvers, none of which raises the `ValueError` the eval callers are written to catch. The fix makes a non-string value a named, visible invalid state on both layers, closes the four write gates that let one be stored in the first place, and ships a read-only sweep so rows that predate the gates can be found. Adds 48 tests. 46 are red with the fix reverted; the two exceptions are named in the test section.

## Why the changes are done — what is the problem

### Reproduce on dev / main today (before this PR)

1. Set any `tracer_custom_eval_config.mapping` value to a JSON object, for example `{"input": {"type": "span_attribute", "path": "input"}}`.
2. Open the eval task that uses that config at `/dashboard/tasks/<task_id>`.
3. The page renders for about a second. Live Preview shows `Row 1 of N` and a spinner.
4. The moment the row detail resolves, the whole app is replaced by the error page. The sidebar goes with it. Navigating away does not recover it; only a full reload does.

### Where it breaks — UI

`VariableMappingView` mounts only once `spanDetail` resolves (`TaskLivePreview.jsx:689`), which is exactly the moment the spinner clears. It then hands the raw mapping value to `resolvePath`, which calls `path.split(".")` on it:

```js
// rowPathWalker.js, before
export function resolvePath(root, path) {
  if (!isObjectLike(root) || !path) return { status: "missing" };
  const result = descend(root, path);   // -> path.split(".")
```

A second latent throw sat one line further on, rendering the value directly as a React child (`{field || "—"}`). The `ErrorBoundary` wraps the whole `<Router />` (`app.jsx:186`) with no reset on navigation, which is why one bad mapping takes the entire dashboard down rather than one panel.

Three more surfaces put the same value into a template literal, which does not throw but prints `expected_value → [object Object]`.

### Where it breaks — BE

All three resolvers assume a string and each fails differently:

| Path | Call | Raises |
|---|---|---|
| span | `_ATTRIBUTE_ALIASES.get(attribute, [])` | `TypeError: unhashable type: 'dict'` |
| trace | `path.split(".", 1)` | `AttributeError: 'dict' object has no attribute 'split'` |
| session | `path.split(".", 1)` | `AttributeError: 'dict' object has no attribute 'split'` |
| trace, ClickHouse mode | `attribute.startswith("spans.")` (`eval.py:2953`) | `AttributeError: 'dict' object has no attribute 'startswith'` |

**The last row is the one production actually hits.** The reporting customer's 31 rows all failed with exactly `'dict' object has no attribute 'startswith'`, and every row came back with `trace_id`, `span_id` and `session_id` null — because `_heavy_span_ids_for_trace_mapping` scans the raw mapping values *before* the resolver ever binds to a span. `test_customer_mapping_shape_fails_before_the_heavy_span_scan` reproduces it from their real saved shape and, with the fix reverted, fails on that exact line.

None is a `ValueError`, which is the one type the eval callers are written to catch and persist. Two callers behave differently, and it is worth being precise about which:

- `run_entry` (`tracer/services/eval_tasks/run_entry.py:44`) catches `Exception` and does mark the entry `ERRORED` with the message. So on this path the failure was already visible, but the message the customer saw was `'dict' object has no attribute 'split'`, which points at nothing actionable.
- `evaluate_trace_observe` (`tracer/utils/eval.py:3859`) has a bare `except Exception` that only logs and returns `False`. No `failed_spans` entry, no error `EvalLogger` row. On this path the run really is silent.

That second path is what `test_object_mapping_value_is_recorded_not_swallowed` pins. With the fix reverted it fails on `assert eval_task.failed_spans` and the captured log is the production stack verbatim:

```
AttributeError: 'dict' object has no attribute 'split'
  File "tracer/utils/eval.py", line 3814, in evaluate_trace_observe
  File "tracer/utils/eval.py", line 2864, in _process_trace_mapping
  File "tracer/utils/eval.py", line 2654, in _resolve_trace_path
E   AssertionError: the failure was swallowed, not recorded
E   assert [] = <EvalTask ...>.failed_spans
```

After this PR both paths raise `ValueError("Mapping value for key 'input' must be an attribute path string, got dict, on trace <id>")`, which names the key and the type, and `evaluate_trace_observe` takes its `except ValueError` branch — the one that writes `failed_spans` plus an error `EvalLogger` row.

### Why the guard sits where it does

The obvious placement, a per-value check inside each resolver's `for key, attribute in mapping.items()` loop, is **unreachable on the ClickHouse path**. `resolve_trace_mapping_lean_first` computes the heavy span set up front, and `_heavy_span_ids_for_trace_mapping` calls `attribute.startswith("spans.")` on the raw values (`eval.py:2952`) *before* the resolver ever runs. So the guard runs at the mapping entry points instead, all five of them, ahead of anything that walks a value. Two of the new tests exist specifically to pin that.

## What changed

### frontend/src/sections/evals/utils/evalMappingPath.js (new)

Why a new module: four call sites needed the same two answers — is this value a usable attribute path, and what do we render when it is not. Two of them are in `evals/`, two in `tasks/`, so there was no existing shared home. It owns `isMappingPath`, `isClearedMappingValue`, `mappingPathLabel`, `mappingChipLabel`, `INVALID_MAPPING_LABEL`, and nothing else.

### frontend/src/sections/evals/utils/rowPathWalker.js

`resolvePath` reports a non-string path as `missing` instead of calling `split` on it. One guard in the single owner of path resolution covers both call sites: `TaskLivePreview.jsx` and `evalExecution.js`'s `resolveMappingFromRow`, which the Test button uses.

### frontend/src/sections/tasks/components/TaskLivePreview.jsx

Routes the value through the helper so a non-string reaches neither `resolvePath` nor a React child. Splits the old single `showWarn` into `showNotInRow` (the path resolved to nothing) and `showWarn` (either that, or the value is not a path at all), so an invalid mapping is no longer mislabelled "(not in row)".

### frontend/src/sections/tasks/components/TaskConfigPanel.jsx, EvalsTasks/EditTaskDrawer/EditTaskDrawerV2.jsx, EvalsTasks/NewTaskDrawer/NewTaskDrawerV2.jsx

The three chips used the same copy-pasted `` `${key} → ${value}` `` literal. The whole label, arrow included, is now `mappingChipLabel(key, value)` in one place.

### frontend/src/sections/common/EvalPicker/serializeEvalConfig.js

`sanitizeEvalMapping` had its own inline notion of a droppable mapping value, which is a second definition of the same rule. It now imports `isClearedMappingValue`. **Behaviour is identical** — `""`, `null` and whitespace-only are still dropped, a non-string is still forwarded — and two tests lock both halves, because forwarding rather than dropping is a deliberate choice: dropping would silently delete the variable from the saved config, where forwarding gets a 400 that names the key.

### futureagi/model_hub/utils/eval_mapping.py (new)

Why a new module: the same rule is needed by two Django apps (`tracer` serializers and resolvers, `model_hub` views) and by the management command. Putting it in either app's utils would have one importing the other. Two functions and a constant, no state: `non_path_mapping_keys`, `require_mapping_paths`, `WHOLE_MAPPING_KEY`.

Both helpers treat a mapping that is **not a dict** as invalid rather than calling `.items()` on it. `(mapping or {})` only absorbs an *empty* list; a populated one raised `AttributeError`, which the callers' broad `except Exception` swallows instead of recording — the exact failure mode this PR exists to end, just for lists instead of dicts. Lists were storable before these gates because the OTEL path stored wire values verbatim after `json.loads`.

`None` stays admissible, deliberately: it is how the UI represents a cleared field. The crash it used to cause on a *required* key is fixed at the resolver instead — see `tracer/utils/eval.py` below.

(A third helper, `is_mapping_path`, was dead on the Python side — nothing imported it, and it disagreed with the other two about `""`. Removed. The frontend keeps its own `isMappingPath`, which is used.)

### futureagi/tracer/serializers/custom_eval_config.py

`validate_mapping` rejects any non-string value. This covers the `CustomEvalConfig` viewset: `create` and `partial_update` both go through `self.get_serializer`, and the router registers exactly one viewset (`tracer/urls.py:60`). It also matches the contract already declared, and never wired to save, at `model_hub/models/evals_metric.py:259`.

### futureagi/model_hub/views/utils/utils.py

**There is a second write path and the serializer does not cover it.** `apply-eval-group` builds configs through `fetch_specific_mapping_for_specific_eval_template` and `bulk_create`, never touching `CustomEvalConfigSerializer`. The same rejection now runs at that chokepoint, which is why this PR has two commits rather than one.

It raises **`ValueError`, not a DRF `ValidationError`.** The apply-eval-group view's handler order is `except ValueError -> bad_request(400)` then `except Exception -> internal_server_error_response(500)`, and a DRF `ValidationError` is an `APIException`, so it skipped the first branch and answered **500 with `[ErrorDetail(string=..., code='invalid')]` in the body** — the same leak the `custom_eval_config.py` change fixes for the other view. `ValueError` also matches every other validation error in `services/eval_group.py`. Test 46 drives the endpoint and asserts the status code, which the previous helper-level test did not.

### futureagi/tracer/utils/otel.py

**And a third.** The OTEL eval-tag path (`_process_eval_tags` → `_create_custom_eval_configs`) builds a config with `CustomEvalConfig.objects.get_or_create(defaults={"mapping": mapping})`, where `mapping` is `eval_tag.get("mapping")` taken straight off the request and JSON-parsed if it arrives as a string. No type check anywhere. It is also the only write path a customer's SDK reaches directly, which makes it the strongest candidate for where these values came from — see Out of scope. The same `require_mapping_paths` runs in `_process_eval_tags`, after the parse and before any config is created, so one malformed tag cannot leave a half-created batch.

**The guard is strict on the synchronous path and lenient on the async one, and that asymmetry is the point.** `bulk_create_observation_span_task` is a `@temporal_activity(max_retries=0)` activity that runs the whole batch under one `transaction.atomic()`, and the OTLP export views answer the SDK **before** enqueuing it. Raising there would abort span ingestion for the entire batch — and every later batch carrying the same tag — with nothing visible to the client, trading a loud dashboard crash for silent trace-data loss. So `_process_eval_tags` takes `skip_invalid_mappings`: `_bulk_get_or_create_project_versions` (reachable only from that activity) sets it and the malformed tag is dropped with a logged exception, while the synchronous span endpoint leaves it off and still gets its 400 via `observation_span.py`.

### futureagi/tracer/views/custom_eval_config.py

`create` and `partial_update` used `is_valid(raise_exception=True)` inside a broad `except Exception`, so a validation failure was stringified into the response as `... {'mapping': [ErrorDetail(string='...', code='invalid')]}`. They now use the pattern already in this same file at line 258 and across `dashboard.py` / `charts.py`: `if not serializer.is_valid(): return self._gm.bad_request(serializer.errors)`. Same 400, same envelope, no DRF internals in the message. The two other `raise_exception=True` calls in this file are on unrelated serializers and are deliberately untouched.

### futureagi/tracer/utils/eval.py

`_require_mapping_paths(mapping, target)` raises `ValueError` naming the key and the type. Called from all five mapping entry points: `_process_mapping`, `_process_trace_mapping`, `_process_session_mapping`, `resolve_trace_mapping_lean_first`, `resolve_session_mapping_lean_first`.

`_process_mapping` also stops building candidates from a falsy path. `_process_mapping` pops `None` only for *optional* keys, so a stored `{"required_key": null}` reached `candidates = [None, "None.value"]` and then `None.split(".")` in `_resolve_attr` — an `AttributeError` the broad handler swallowed. The trace and session resolvers already guarded falsy; the span path now converges on the same missing-attribute failure.

### futureagi/tracer/management/commands/scan_eval_mapping_paths.py (new) — existing rows

The gates stop new bad rows. Rows written before them still exist, and this reports them, scoped by project or organization or across the fleet:

```
$ python manage.py scan_eval_mapping_paths
organization=<uuid> project=<uuid> eval_config=<uuid> name='Groundedness' invalid_keys=[input=dict]
affected_eval_configs=1
```

It is read-only on purpose. The correct path for a broken value is knowable only by whoever configured the eval, and writing a guessed one would silently evaluate the wrong attribute. **The repair surface is the product itself:** before this PR the page crashed, so the owner could not open the config to fix it; after it, the value renders as `invalid mapping` and they can re-map it in the UI. The command exists so support knows who to tell. A test asserts it leaves the row untouched.

It also guards per row. A support tool sweeping legacy data of unknown shape must not let one surprising row cost the report on every row after it, so an unreadable mapping is printed to stderr and the sweep continues.

### futureagi/ai_tools/tools/tracing/create_custom_eval_config.py — the fourth write path

`CustomEvalConfig.objects.create(mapping=final_mapping, ...)`, gated only by an ad-hoc `if attr_value and attr_value not in available_attributes` membership check. That check rejected a **truthy** non-string with a misleading "not a valid span attribute" message, and a **falsy** one (`{}`, `[]`) skipped it entirely and was stored. It now answers the type question first, through the shared predicate.

### frontend/src/sections/develop-detail/Evaluation/RunCompareEvaluation.jsx

`handleFormSave` called `value.match(uuidPattern)` on the raw mapping value. A truthy non-string threw inside an event handler, where no error boundary catches it — the save button simply stopped working, with nothing on screen. It now routes through `isMappingPath` and forwards a non-string untouched so the API rejects it with a message.

### frontend/src/sections/develop-detail/Experiment/StepperComponentExperiment/EvaluationStepExperimentCreation.jsx

Rendered `` `${key}: ${label}` `` — the same `[object Object]` as the four sites above, missed by the original ` -> ` sweep because the separator is `: `. Routed through `mappingChipLabel`, which now takes the separator from the call site so there is still one owner of the label rule.

## Tests included — what each scenario covers

All 48 are new. No prior test covered a non-string mapping value on either layer.

| # | Test | Setup | Action | What it pins |
|---|---|---|---|---|
| 1 | `test_object_mapping_value_fails_span_mapping_as_value_error` | span with attrs | `_process_mapping` with a dict value | `ValueError`, not `TypeError: unhashable type` |
| 2 | `test_object_mapping_value_fails_trace_mapping_as_value_error` | trace | `_process_trace_mapping` with a dict value | `ValueError`, not `AttributeError` |
| 3 | `test_object_mapping_value_fails_session_mapping_as_value_error` | session | `_process_session_mapping` with a dict value | `ValueError`, not `AttributeError` |
| 4a | `test_customer_mapping_shape_fails_before_the_heavy_span_scan` | trace, CH mode | `resolve_trace_mapping_lean_first` with the customer's real saved value `{"source": "span_attribute", "column_id": "output.value"}` | reverted, it raises their exact `'dict' object has no attribute 'startswith'` at `eval.py:2953` |
| 4 | `test_object_mapping_value_fails_lean_first_trace_path` | trace, `_read_source` forced to `clickhouse` | `resolve_trace_mapping_lean_first` with `spans.` path as a dict | the guard runs **ahead of** the heavy-id scan, the path prod actually takes |
| 5 | `test_object_mapping_value_fails_lean_first_session_path` | session, CH mode | `resolve_session_mapping_lean_first` | same, session twin |
| 6 | `test_object_mapping_value_is_recorded_not_swallowed` | trace + span + eval task, config broken via the ORM | `evaluate_trace_observe` end to end | `failed_spans` gains an entry **and** an error `EvalLogger` row is written, both naming the key. Reverted, this is the silent path |
| 7 | `test_create_config_saves_only_path_string_mapping_values` | authed client | `POST /tracer/custom-eval-config/` with an object mapping value | 400 naming the key, no `ErrorDetail` in the body, string mapping still saves |
| 8 | `test_partial_update_saves_only_path_string_mapping_values` | existing config | `PATCH` with an object mapping value | same, and the stored mapping is unchanged |
| 9 | `test_partial_update_unauthenticated` | no auth | `PATCH` | the new class does not open an unauthenticated hole |
| 10 | `test_object_mapping_value_is_refused_before_it_reaches_a_config` | eval group | `fetch_specific_mapping_for_specific_eval_template` | the second write path rejects too |
| 11 | `test_path_string_mapping_values_are_copied_through` | eval group | same | a valid group mapping is untouched |
| 12-14 | `TestEvalTagIngestMappingValues` | project + eval template | `_process_eval_tags` with an object value, a valid one, and a JSON-string payload | the ingest path rejects before `get_or_create`, no config is created, and the guard runs **after** the JSON parse |
| 15-18 | `TestScanEvalMappingPathsCommand` | config broken via the ORM | `manage.py scan_eval_mapping_paths` | reports the row and the offending key by type, reports nothing when clean, **leaves the row untouched**, honours `--project-id` |
| 19-22 | `rowPathWalker.test.js` non-string cases | row detail object | `resolvePath` with object / array / number | returns `missing`, does not throw; string paths still resolve |
| 23-34 | `evalMappingPath.test.js` | — | `isMappingPath` / `isClearedMappingValue` / `mappingPathLabel` / `mappingChipLabel` | empty and null render blank, non-string renders `invalid mapping`, a non-string is not "cleared" |
| 35-36 | `serializeEvalConfig.test.js` | mapping with cleared and non-string values | `sanitizeEvalMapping` | cleared values still dropped, non-string still forwarded to the API gate |
| 37 | `evalExecution.test.js` omits a non-string | row detail | `resolveMappingFromRow` | the variable is omitted rather than throwing; valid ones still resolve |
| 38 | `renders a mapping whose value is an object instead of tearing down the page` | eval config with a mixed mapping | render `TaskLivePreview` | the tree renders, `[object Object]` never appears |
| 39 | `flags the object value as invalid while the path value stays resolved` | same | render | object reads `invalid mapping`, string keeps its real path, no "(not in row)" |
| 41 | `test_async_ingest_keeps_the_span_batch_when_a_tag_is_malformed` | project + eval template | `_bulk_get_or_create_project_versions`, the async entry point, with a malformed tag | a ProjectVersion is still returned, so the span batch survives; no config is created. Reverted, the version is `None` and every span in the batch is dropped |
| 42 | `test_list_mapping_is_refused_as_a_value_error` | project + eval template | `_process_eval_tags` with a **list** mapping | `ValueError`, not `AttributeError: 'list' object has no attribute 'items'` |
| 43 | `test_list_mapping_raises_value_error_not_attribute_error` | trace | `_process_trace_mapping` with a list | same, at the resolver |
| 44 | `test_cleared_value_on_a_required_key_is_a_missing_attribute` | span | `_process_mapping` with `{"key": None}` | `EvalSkippedMissingAttribute` (a `ValueError`), not `AttributeError: 'NoneType' object has no attribute 'split'` |
| 45 | `test_reports_a_list_valued_row_without_aborting` | config with a list mapping, via the ORM | `manage.py scan_eval_mapping_paths` | the row is reported as `<mapping>=list` and the sweep continues. Reverted, the first such row kills the scan |
| 46 | `test_apply_eval_group_rejects_a_non_path_mapping_with_400` | authed client, eval group, dataset | `POST /model-hub/eval-groups/apply-eval-group/` with an object mapping value | **HTTP 400** naming the key, no `ErrorDetail` in the body. Reverted, it is a 500 with the DRF internals stringified into the response |
| 47-48 | `mappingChipLabel` separator + bare-key cases | — | `mappingChipLabel(key, null)` and `(key, value, ": ")` | a cleared value renders the key alone, not `key → `; the develop-detail chips reuse the same label rule |
| 40 | `does not trip the boundary that wraps the whole app` | same | render inside the real `react-error-boundary` `app.jsx` uses | the fallback never mounts. Reverted, the fallback is the **only** thing in the DOM |

**Red-on-revert, stated precisely.** 46 of the 48 go red when the fix is reverted. **Rows 35-36 do not, and the earlier blanket claim was wrong.** The `sanitizeEvalMapping` change is an exactly behaviour-preserving refactor — the old inline predicate and `!isClearedMappingValue(path)` agree on every input class (null, undefined, `""`, whitespace, string, object, number) — so reverting the source leaves all six of that file's tests passing. They are characterization tests that pin the behaviour against future drift, not proof of this change. Thanks to @JayaSurya-27 for catching it.

Round-2 red run, all four fixes reverted at once:

```
FAILED tracer/tests/test_process_mapping.py::test_list_mapping_raises_value_error_not_attribute_error
FAILED tracer/tests/test_process_mapping.py::test_cleared_value_on_a_required_key_is_a_missing_attribute
FAILED tracer/tests/test_custom_eval_config.py::TestScanEvalMappingPathsCommand::test_reports_a_list_valued_row_without_aborting
FAILED tracer/tests/test_custom_eval_config.py::TestEvalTagIngestMappingValues::test_async_ingest_keeps_the_span_batch_when_a_tag_is_malformed
FAILED tracer/tests/test_custom_eval_config.py::TestEvalTagIngestMappingValues::test_list_mapping_is_refused_as_a_value_error
FAILED model_hub/tests/test_function_params_surfaces.py::test_apply_eval_group_rejects_a_non_path_mapping_with_400
FAILED model_hub/tests/test_eval_group_contracts.py::TestEvalGroupMappingValues::test_object_mapping_value_is_refused_before_it_reaches_a_config
======================== 7 failed, 102 passed in 14.75s ========================
```

The apply-eval-group failure captured the leak verbatim, which is the defect it pins:

```
ERROR django.request: Internal Server Error: /model-hub/eval-groups/apply-eval-group/
Error in applying eval group: [ErrorDetail(string='Mapping values must be attribute
path strings. Non-string values for: hypothesis.', code='invalid')]
```

Restored: **109 passed**.

## Commands to run tests

```bash
# backend (needs the test stack up)
cd futureagi
python -m pytest tracer/tests/test_process_mapping.py tracer/tests/test_custom_eval_config.py \
  model_hub/tests/test_eval_group_contracts.py -q

# frontend
cd frontend
npx vitest run \
  src/sections/evals/utils/rowPathWalker.test.js \
  src/sections/evals/utils/evalMappingPath.test.js \
  src/sections/evals/utils/__tests__/evalExecution.test.js \
  src/sections/common/EvalPicker/serializeEvalConfig.test.js \
  src/sections/tasks/components/__tests__/TaskLivePreview.test.jsx
```

### Local verification results

```
# fix reverted (RED)
FAILED tracer/tests/test_process_mapping.py::test_object_mapping_value_fails_span_mapping_as_value_error
FAILED tracer/tests/test_process_mapping.py::test_object_mapping_value_fails_trace_mapping_as_value_error
FAILED tracer/tests/test_process_mapping.py::test_object_mapping_value_fails_session_mapping_as_value_error
FAILED tracer/tests/test_process_mapping.py::test_object_mapping_value_fails_lean_first_trace_path
FAILED tracer/tests/test_process_mapping.py::test_object_mapping_value_fails_lean_first_session_path
FAILED tracer/tests/test_process_mapping.py::test_object_mapping_value_is_recorded_not_swallowed
FAILED tracer/tests/test_custom_eval_config.py::TestCustomEvalConfigCreateAPI::test_create_config_saves_only_path_string_mapping_values
FAILED tracer/tests/test_custom_eval_config.py::TestCustomEvalConfigPartialUpdateAPI::test_partial_update_saves_only_path_string_mapping_values
FAILED model_hub/tests/test_eval_group_contracts.py::TestEvalGroupMappingValues::test_object_mapping_value_is_refused_before_it_reaches_a_config
FAILED tracer/tests/test_custom_eval_config.py::TestEvalTagIngestMappingValues::test_object_mapping_value_is_refused_before_a_config_is_created
FAILED tracer/tests/test_custom_eval_config.py::TestEvalTagIngestMappingValues::test_json_string_mapping_is_parsed_then_checked
11 failed, 81 passed

Frontend  Test Files  3 failed | 2 passed (5)
                Tests  8 failed | 66 passed (74)

# fix applied (GREEN)
93 passed in 8.26s

Frontend  Test Files  5 passed (5)
                Tests  74 passed (74)
```

Round 2, all four review fixes reverted at once:

```
# reverted (RED)
7 failed, 102 passed in 14.75s

# applied (GREEN)
109 passed
```

## Video

Before and after on the same task, same data, same browser. Left half is `origin/dev`, right half is this branch.

https://github.com/user-attachments/assets/9f1ffef3-4c4f-412e-bb2f-1c19673f0687

## Screenshot of test suite run

**Command** - the pytest and vitest runs above, each run twice: once with the fix reverted, once with it applied.

![Test suite run, red then green](https://github.com/user-attachments/assets/73c68a18-1e42-4202-bfa9-e31dfb9b246a)

## Screenshot of before and after

![Before and after on the same task](https://github.com/user-attachments/assets/74e48e84-c7e1-4930-8256-0434c1b24a0c)

## Backwards compatibility

Schema unchanged. No migration. Semantics change only for values that were already broken.

| Caller | Pre-PR | Post-PR |
|---|---|---|
| `resolvePath` with a string path | resolves | unchanged |
| `resolvePath` with `""` / `null` / `0` | `missing` | unchanged |
| `resolvePath` with a non-string, non-empty path | throws `TypeError` | `missing` |
| `resolveMappingFromRow` with a non-string value | throws, unmounts the page | the variable is omitted; valid ones still resolve |
| `sanitizeEvalMapping` with `""` / `null` / whitespace | dropped | unchanged |
| `sanitizeEvalMapping` with a non-string | forwarded | unchanged |
| Task detail page, healthy config | renders | unchanged |
| Task detail page, non-string mapping | whole dashboard replaced by the error page | renders, value reads `invalid mapping` |
| `POST`/`PATCH` custom-eval-config, string mapping | 200 | unchanged |
| `POST`/`PATCH` custom-eval-config, non-string mapping | 200, stored | 400 naming the keys |
| `POST`/`PATCH` custom-eval-config, any other validation failure | 400 with a stringified `ErrorDetail` repr | 400 with the field-keyed message |
| `apply-eval-group` with a non-string mapping | configs created | 400 naming the keys, no `ErrorDetail` in the body |
| OTEL eval-tag ingest (sync span endpoint), non-string mapping | config created, crashes the page later | 400, rejected before any config is created |
| OTEL eval-tag ingest (async OTLP export), non-string mapping | config created, crashes the page later | the tag is dropped and logged; **every span in the batch still lands** |
| `create_custom_eval_config` AI tool, truthy non-string mapping | rejected as "not a valid span attribute" | rejected as a non-path value, message names the key |
| `create_custom_eval_config` AI tool, falsy non-string mapping (`{}`, `[]`) | stored | rejected |
| Any gate with a **list** mapping (not a dict) | `AttributeError`, swallowed by the broad handler | `ValueError` naming the type |
| `_process_mapping` with `None` on a **required** key | `AttributeError: 'NoneType' ... 'split'`, swallowed | `EvalSkippedMissingAttribute`, recorded |
| `scan_eval_mapping_paths` over a list-valued row | aborts the whole sweep | reports `<mapping>=list` and continues |
| `RunCompareEvaluation` save with a non-string mapping | throws in the handler, save button silently dead | value forwarded, API rejects it with a message |
| `EvaluationStepExperimentCreation` chip, non-string mapping | renders `key: [object Object]` | renders `key: invalid mapping` |
| Eval run via `run_entry`, non-string mapping | `ERRORED`, message `'dict' object has no attribute 'split'` | `ERRORED`, message names the key and the type |
| Eval run via `evaluate_trace_observe`, non-string mapping | logged and dropped, no error row | `failed_spans` entry plus an error `EvalLogger` row |

No existing config with an all-string mapping changes behaviour in any way.

### Full frontend suite on this branch

`npx vitest run` -> **2560 passed, 7 failed** across 327 files. None of the seven is in this PR's diff, and each was traced rather than assumed:

| Failure | Verdict |
|---|---|
| `UsersGrid.test.jsx` | fails identically on a clean branch without this PR. Pre-existing |
| `annotate-components.test.jsx` | passes in isolation. Order-dependent |
| `render-performance.test.js` | `expected 105.97 to be less than 100`. Timing flake, passes in isolation |
| `buildAddEvalsDraft.test.js` (x4) | `TypeError: localStorage.clear is not a function` - the same jsdom environment issue behind the 32 collection failures present on the clean branch too. Not in this diff |

### Full backend suite on this branch

`pytest tracer/tests/ model_hub/tests/` → **9109 passed, 2 failed, 77 skipped** in 9m53s. Both failures (`test_eval_list.py::test_unknown_ui_value_is_silently_ignored`, `test_scores_api.py::test_upsert_existing_score`) **pass in isolation** on this same branch and neither file references `mapping`, `custom_eval_config`, `resolvePath` or anything else this PR touches. They are order-dependent flakes in the full run, not net-new.

## Manual verification (UI)

1. Point a local stack at a project that has traces and an eval task.
2. `update tracer_custom_eval_config set mapping = '{"input": {"type":"span_attribute","path":"input"}}'::jsonb where id = '<a config on that task>';`
3. Open `/dashboard/tasks/<task_id>` on `origin/dev`. The dashboard is replaced by the error page.
4. Open the same URL on this branch. The page renders, the healthy evals keep their real paths, the broken one reads `invalid mapping` in both the Evaluations card and the Live Preview panel.
5. `python manage.py scan_eval_mapping_paths` lists that config; re-query the row and confirm the mapping is byte-identical.
6. Re-map the variable in the UI and save. The row is repaired without any script.
7. BE check: `POST /tracer/custom-eval-config/` with an object mapping value returns 400 naming the offending keys.

## Why these decisions

- **The guard is at the mapping entry points, not inside the resolve loops.** A per-value check inside the loop is dead code on the ClickHouse path, because the heavy-id scan reads the raw values first. Tests 4 and 5 exist to keep it that way.
- **Three write gates, not one.** `apply-eval-group` and the OTEL eval-tag ingest both build configs without going near `CustomEvalConfigSerializer`. Gating only the serializer would have left the batch path and the SDK-facing path wide open, which is where these values most plausibly came from.
- **`ValueError` rather than a new exception type.** The eval callers already branch on `ValueError` to write `failed_spans` plus an error `EvalLogger` row. A new type would need every caller updated to get the same visibility.
- **The serializer, not the model.** Django only runs field validators inside `full_clean()`, which `CustomEvalConfig.save()` does not call, so a model validator would be decorative.
- **Rejecting rather than coercing.** Nothing in the codebase writes a non-string mapping value on purpose: the UI writes strings, the `create_custom_eval_config` AI tool validates against the project's string attribute list, and the resolvers all `split` on it. Coercing would invent a path the user never chose and quietly evaluate the wrong field.
- **`isMappingPath` does not trim.** An earlier draft used `value.trim() !== ""`, which would have silently changed behaviour for a whitespace-only path that used to descend. Dropping the trim keeps the falsy semantics of the original `!path` exactly and adds only the type check.
- **One test uses the customer's real shape; the rest assert on type.** The saved value is now confirmed as `{"source": "span_attribute", "column_id": "output.value"}`, quoted from the reporter's own analysis, and `test_customer_mapping_shape_fails_before_the_heavy_span_scan` pins it against the exact line that crashed. Every other test asserts "not a string", because the gate is the type, not any one shape.

## Out of scope

- **Where the value came from is now answered.** The reporter built the config over the API and invented the object shape by hand — `{"source": "span_attribute", "column_id": "output.value"}` — because `output.value` does not appear in `/api/traces/span-attribute-keys/` and `tracer/dashboard/filter_values/?metric_name=output.value` returns `{"values": []}`. They read that absence as "span content needs a different kind of mapping". It does not: a mapping value is always a plain path string. The absence is expected — the collector routes `input.value` / `output.value` into JSON overflow rather than the typed attribute maps, so they are invisible to the key index, filters and charts while staying fully resolvable by the eval runner.
- **The discoverability gap behind it is NOT fixed here and deserves its own ticket.** Their eval is trace-level, so the path that reaches span content is `spans.<first|last|n>.output.value` — `_is_heavy_span_tail` marks that tail heavy, `_heavy_span_ids_for_trace_mapping` loads exactly that span's heavy columns, and `_resolve_attr` finds the key. A bare `output.value` at trace level resolves `Trace.output["value"]` instead, because `output` is in `_TRACE_PUBLIC_FIELDS` — a different field entirely. Nothing in the product surfaces either of those paths: not the attribute-key index, not filter-values, not the mapping picker. A user has to type them blind, which is what sent this reporter to invent a schema.
- **The two out-of-diff findings from review are fixed in this PR, not deferred.** The fourth write path (`ai_tools`) and the two extra `develop-detail` render/split sites are the same defect class on the same legacy data, and each was a few lines through the predicate that already exists — cheaper to close than to carry as a ticket. Both are covered above.
- **No automatic repair of existing rows.** `scan_eval_mapping_paths` reports them and the UI now lets the owner fix them; see the rationale in the command's section above.
- **The `ErrorBoundary` in `app.jsx` still has no reset on navigation,** so any future render throw anywhere will still take the whole dashboard down rather than one route. That is a real robustness gap and it is a separate change with its own blast radius — this PR removes the throw, it does not rewrite the boundary.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [x] Follows the style guide of this project
- [x] Tests added, and they fail if the fix is reverted
- [x] No secrets, no ticket refs or AI cruft in source or test names
- [x] Rebased on latest `dev`

## Backout / rollback

Clean revert. No migration, no schema change, no data written. Reverting restores the prior behaviour exactly: the crash returns and non-string mappings become storable again.

## Linear

Closes TH-7710

