### PR TITLE
feat(dev): add parallel slot-based development stacks

### DIFF
--- a/.agents/skills/futureagi-slots/SKILL.md
+++ b/.agents/skills/futureagi-slots/SKILL.md
@@ -1,0 +1,11 @@
+---
+name: futureagi-slots
+description: Explain, select, and operate FutureAGI worktree development slots through the repository Make interface. Use for developer onboarding and feature overviews, or when starting, inspecting, testing, logging, entering, stopping, or purging a parallel local stack.
+---
+
+# Codex adapter
+
+Read `../../../.claude/skills/futureagi-slots/SKILL.md` completely and follow it
+as the canonical FutureAGI slot workflow. Resolve all paths relative to this
+repository. Do not duplicate or override its runtime-approval and destructive
+cleanup rules.

--- a/.agents/skills/futureagi-slots/agents/openai.yaml
+++ b/.agents/skills/futureagi-slots/agents/openai.yaml
@@ -1,0 +1,7 @@
+interface:
+  display_name: "FutureAGI Slots"
+  short_description: "Operate parallel worktree development stacks"
+  default_prompt: "Use $futureagi-slots to start or operate a safe parallel development slot for this worktree."
+
+policy:
+  allow_implicit_invocation: true

--- a/.claude/skills/futureagi-slots/SKILL.md
+++ b/.claude/skills/futureagi-slots/SKILL.md
@@ -1,0 +1,100 @@
+---
+name: futureagi-slots
+description: Explain, select, and operate FutureAGI worktree development slots through the repository Make interface. Use for developer onboarding and feature overviews, or when starting, inspecting, testing, logging, entering, stopping, or purging a parallel local stack.
+---
+
+# FutureAGI development slots
+
+Use the root `Makefile` as the only slot lifecycle interface. Never invoke the
+slot Compose files directly.
+
+## Explain and onboard
+
+When a developer asks what the slot system supports, how containers and shared
+state work, which command to use, or requests onboarding documentation, read
+[`references/feature-guide.md`](references/feature-guide.md). For a complete
+overview, present the guide in its existing order; for a focused question,
+include only the relevant sections.
+
+The guide describes capabilities, but it does not grant runtime approval. Use
+`make slot-status` and `make slot-urls` when current registered state is needed;
+do not contact Docker merely to explain the system.
+
+## Runtime approval gate
+
+Before running any target that contacts Docker, starts or stops containers,
+creates networks or volumes, binds ports, provisions live state, or runs a
+runtime smoke test, confirm that the user has explicitly approved local Docker
+testing in the current conversation. Planning approval or permission to edit
+code is not runtime approval.
+
+Without runtime approval, limit work to `make slot-help`, Python unit tests,
+static configuration inspection, and Compose rendering that does not contact
+the Docker daemon.
+
+## Choose a slot composition
+
+Every slot always gets a private frontend from the current worktree. Do not add
+`frontend` to `SERVICES`.
+
+Determine additional private provider groups by inspecting:
+
+1. The merge-base diff against `${BASE_REF:-origin/dev}`.
+2. Staged and unstaged changes.
+3. Relevant untracked files.
+
+Use the service map printed by `make slot-help`. Select every affected group;
+when uncertain, include the group rather than allowing incompatible code to use
+a shared default. `SERVICES=none` is valid for a frontend-only change.
+
+Supported provider groups are `backend`, `simulation`, `gateway`, `collector`,
+`serving`, `executor`, `peerdb`, and `observability`; `all` selects every group.
+Selecting a private backend also makes simulation, collector, and PeerDB
+private because those providers must consume the same state identity.
+
+When a topology must create a simulation provider, the worktree root must
+contain `agent_learning_kit-0.1.0-py3-none-any.whl`, the local input required by
+`Dockerfile.simulation-runner.dev`. `slot-up` validates this before mutating
+Docker. If it is absent, report the exact prerequisite; do not bypass the check
+or fabricate a package.
+
+## Start and verify
+
+After runtime approval:
+
+1. Show the chosen slot, groups, isolated engines, and reasoning.
+2. Prefer `SLOT=auto` unless the user chose a slot.
+3. For the approved live operation only, prefix Make with
+   `SLOTS_RUNTIME_APPROVED=1`; for example,
+   `SLOTS_RUNTIME_APPROVED=1 make slot-up SLOT=<slot> SERVICES=<groups>` with
+   optional `ISOLATE_INFRA=<engines>`.
+4. Run `make slot-status SLOT=<slot>` and `make slot-urls SLOT=<slot>`.
+5. Report provider reuse and health failures precisely.
+
+Do not add `FORCE=1`, environment-mismatch overrides, or destructive flags
+unless the user explicitly authorizes the corresponding risk.
+
+## Operate and clean up
+
+- Status: `make slot-status [SLOT=<slot>]`
+- URLs: `make slot-urls SLOT=<slot>`
+- Logs: `SLOTS_RUNTIME_APPROVED=1 make slot-logs SLOT=<slot> SERVICE=<service>`
+- Shell: `SLOTS_RUNTIME_APPROVED=1 make slot-shell SLOT=<slot> SERVICE=<service>`
+- Command: `SLOTS_RUNTIME_APPROVED=1 make slot-run SLOT=<slot> SERVICE=<service> COMMAND='<command>'`
+- Stop while preserving data: `SLOTS_RUNTIME_APPROVED=1 make slot-down SLOT=<slot>`
+- Diagnose: `SLOTS_RUNTIME_APPROVED=1 make slots-doctor`
+- Recover an interrupted lifecycle operation without deleting volumes:
+  `SLOTS_RUNTIME_APPROVED=1 make slots-recover`
+- For startup and same-slot replacement, recovery removes the partial runtime
+  while preserving volumes; rerun `slot-up` afterward. For interrupted down or
+  purge, inspect whether the result ends in `-retry` or `-complete`. A retry
+  requires the original Make command again; purge must cross its explicit
+  authorization and `CONFIRM=<slot>` gates again.
+- Remove stale runtime providers: `SLOTS_RUNTIME_APPROVED=1 make slots-prune`
+
+`SLOTS_RUNTIME_APPROVED=1 make slot-purge SLOT=<slot> CONFIRM=<slot>` deletes
+exact slot-owned volumes and private provider state; it preserves shared
+logical state. Treat it as destructive: restate the exact target and obtain
+explicit user authorization immediately before running it.
+
+Never stop, remove, or reconfigure unrelated local Docker resources.

--- a/.claude/skills/futureagi-slots/references/feature-guide.md
+++ b/.claude/skills/futureagi-slots/references/feature-guide.md
@@ -1,0 +1,357 @@
+# FutureAGI development slots: feature guide
+
+This guide is the developer-facing reference for running parallel FutureAGI
+worktrees. The root `Makefile` is the only supported entry and exit point; do
+not invoke files under `slots/compose/` directly.
+
+## What a slot is
+
+A slot is an isolated development identity numbered from 1 through 20. Each
+slot combines:
+
+- a frontend built from and bind-mounted to its worktree;
+- a complete provider map, with each provider either shared or private;
+- browser routes based on the slot number;
+- slot-specific generated configuration and lifecycle metadata;
+- logical state identity, and optionally physically isolated infrastructure.
+
+`SLOT=auto` selects the first unused slot. It is a selector only: `auto` never
+appears in a hostname or container name.
+
+The normal topology is intentionally asymmetric:
+
+```text
+shared control plane (one per machine)
+  PostgreSQL, ClickHouse, Redis, RabbitMQ, MinIO, Temporal, Temporal UI, Traefik
+             |
+shared default providers (one pool, reused by slots)
+  backend/worker, simulation, gateway, collector, serving, executor,
+  PeerDB group, Jaeger
+             |
+slot 01      +-- private frontend
+slot 02      +-- private frontend + selected private providers
+slot 03      +-- private frontend + private backend/state closure
+```
+
+The first slot starts the control plane and shared default provider pool, so it
+creates many containers even when `SERVICES=none`. Later frontend-only slots
+normally add just one frontend container and reuse that pool.
+
+## Feature summary
+
+| Capability | Behaviour |
+|---|---|
+| Parallel worktrees | Up to 20 registered slots can run at once. |
+| Always-fresh UI | Every slot always owns a frontend from its current worktree. |
+| Selective isolation | `SERVICES` makes only affected provider groups private. |
+| Safe sharing | Omitted providers use a validated shared default, never silently changed worktree code. |
+| Stateful isolation | Logical state is namespaced; selected engines can also receive private containers and volumes. |
+| Automatic routing | Traefik exposes predictable `*.N.localhost` browser URLs. |
+| Resource protection | Startup estimates memory and rejects unsafe topologies before creating them. |
+| Persistent cleanup | Normal down preserves named volumes and generated slot state. |
+| Recovery | Interrupted startup and replacement can be cleaned without deleting volumes. |
+| Agent support | Claude Code and Codex share this canonical workflow through repository skills. |
+
+## Choose the private services
+
+`SERVICES` controls additional private provider groups. The frontend is always
+private and must not be included in `SERVICES`.
+
+| Value | Use it when the worktree changes | Private estimate |
+|---|---|---:|
+| `none` | frontend only | 0 MiB beyond frontend |
+| `backend` | Django/API, backend dependencies, or shared state contract | 1,300 MiB |
+| `simulation` | simulation runner | 700 MiB |
+| `gateway` | agent control gateway | 350 MiB |
+| `collector` | telemetry collector | 350 MiB |
+| `serving` | model serving | 600 MiB |
+| `executor` | code executor | 600 MiB |
+| `peerdb` | PeerDB integration and UI | 700 MiB |
+| `observability` | tracing/Jaeger | 500 MiB |
+| `all` | cross-cutting or uncertain changes | every provider group |
+
+Multiple groups use commas, for example
+`SERVICES=gateway,serving`. Dependencies are expanded automatically.
+
+A private backend also makes `simulation`, `collector`, and `peerdb` private.
+Those groups are state-coupled and must consume the same state identity. This
+means `SERVICES=backend` is deliberately larger than a backend container plus
+worker.
+
+Before using a shared default, `slot-up` compares the provider's relevant paths
+against `${BASE_REF:-origin/dev}` and checks staged, unstaged, and relevant
+untracked files. Changed source cannot accidentally seed or replace a shared
+default. Select that provider privately or choose the correct `BASE_REF`.
+
+### Source update behaviour
+
+| Provider | Development update model |
+|---|---|
+| Frontend | Vite source is bind-mounted and reloads during development. |
+| Backend | Django source is bind-mounted and reloads during development. |
+| Simulation | Backend source is bind-mounted; restart the worker after dependency changes. |
+| Gateway, collector, serving, executor | Image-based; rerun `slot-up` to rebuild and recreate. |
+
+Source-backed images are built sequentially. BuildKit still reuses its cache,
+while sequential builds avoid a large transient memory spike.
+
+Creating a new simulation provider requires
+`agent_learning_kit-0.1.0-py3-none-any.whl` at the worktree root. Validation
+happens before Docker is mutated.
+
+## Worktree environment
+
+The root `.env` in each worktree is the single application-environment source
+for its slot. It may contain frontend and backend variables; for example:
+
+```dotenv
+VITE_EXPERIMENTAL_VIEW=true
+OPENAI_API_KEY=local-development-key
+NEW_BACKEND_SETTING=true
+```
+
+During `slot-up`, the runtime copies the worktree `.env` into the private,
+mode-`0600` generated `.slots/slots/NN/slot.env` and appends the generated slot
+topology. Generated container names, ports, database identities, and routing
+values therefore win when a key is duplicated. If the worktree has no `.env`,
+the Compose defaults and generated topology still work.
+
+Never edit the generated `slot.env`. Edit the root `.env` in the relevant
+worktree and rerun `make slot-up` for that slot. Worktree `.env` files are
+ignored by Git; update the committed `.env.example` when introducing a setting
+other developers need. Only variables prefixed with `VITE_` are exposed by Vite
+to browser code, so secrets must never use that prefix.
+
+The generated file contains the inherited application values and can therefore
+contain secrets. It is protected with mode `0600` and persists across
+`slot-down` together with the other generated slot state. The explicitly
+confirmed `slot-purge` operation removes it.
+
+The frontend is always private and automatically receives its worktree's
+environment. A shared provider has only one process environment and inherits
+the `.env` of its current owner worktree. If a worktree changes an environment
+setting that affects the backend or another provider, select that provider
+privately with `SERVICES`; for example, use `SERVICES=backend` for a backend
+setting. Shared-provider ownership handoff regenerates its environment from the
+new owner before recreating the provider.
+
+## Isolate stateful infrastructure
+
+By default, state engines share physical containers but use a logical state
+identity. A shared backend uses the reserved slot-0 identity; a private backend
+uses its slot's identity.
+
+| Engine | Logical separation |
+|---|---|
+| PostgreSQL | database |
+| ClickHouse | database |
+| Redis | three database numbers: application, cache, lock |
+| RabbitMQ | vhost |
+| MinIO | bucket |
+| Temporal | namespace |
+
+For physical isolation, pass one or more engines:
+
+```bash
+ISOLATE_INFRA=postgres,clickhouse,redis,rabbitmq,minio,temporal
+```
+
+Physical isolation requires `SERVICES=backend`, because infrastructure and the
+private provider state identity must move together. Each selected engine gets
+slot-private containers and named volumes.
+
+| Engine | Estimated memory |
+|---|---:|
+| PostgreSQL | 700 MiB |
+| ClickHouse | 1,000 MiB |
+| Redis | 200 MiB |
+| RabbitMQ | 500 MiB |
+| MinIO | 500 MiB |
+| Temporal | 900 MiB |
+
+Isolated engine ports are bound to loopback in the slot's numeric band. The
+base is `20000 + SLOT * 100`; offsets are PostgreSQL `+1`, ClickHouse HTTP
+`+2`, ClickHouse native `+3`, Redis `+4`, RabbitMQ `+5`, RabbitMQ management
+`+6`, MinIO API `+7`, MinIO console `+8`, and Temporal `+9`.
+
+## Command reference
+
+Inspect the interface without contacting Docker:
+
+```bash
+make slot-help
+```
+
+Live commands require the developer's explicit approval for local Docker work
+in the current conversation and the `SLOTS_RUNTIME_APPROVED=1` guard.
+
+| Task | Command |
+|---|---|
+| Start first free slot | `SLOTS_RUNTIME_APPROVED=1 make slot-up SLOT=auto SERVICES=none` |
+| Start a chosen composition | `SLOTS_RUNTIME_APPROVED=1 make slot-up SLOT=3 SERVICES=gateway,serving` |
+| Isolate physical state | `SLOTS_RUNTIME_APPROVED=1 make slot-up SLOT=3 SERVICES=backend ISOLATE_INFRA=postgres,redis` |
+| List all registered slots | `make slot-status` |
+| Inspect one slot | `make slot-status SLOT=3` |
+| Print browser routes | `make slot-urls SLOT=3` |
+| Follow service logs | `SLOTS_RUNTIME_APPROVED=1 make slot-logs SLOT=3 SERVICE=backend` |
+| Open a service shell | `SLOTS_RUNTIME_APPROVED=1 make slot-shell SLOT=3 SERVICE=backend` |
+| Run a command | `SLOTS_RUNTIME_APPROVED=1 make slot-run SLOT=3 SERVICE=backend COMMAND='python manage.py check'` |
+| Stop and preserve state | `SLOTS_RUNTIME_APPROVED=1 make slot-down SLOT=3` |
+| Inspect runtime health | `SLOTS_RUNTIME_APPROVED=1 make slots-doctor` |
+| Recover an interrupted lifecycle command | `SLOTS_RUNTIME_APPROVED=1 make slots-recover` |
+| Prune stale provider metadata | `SLOTS_RUNTIME_APPROVED=1 make slots-prune` |
+| Permanently purge slot-owned state | `SLOTS_RUNTIME_APPROVED=1 make slot-purge SLOT=3 CONFIRM=3` |
+
+`SERVICE` defaults to `frontend` for logs and shell commands. Supply it
+explicitly when inspecting another provider.
+
+### Common compositions
+
+Frontend-only worktree, reusing all default providers:
+
+```bash
+SLOTS_RUNTIME_APPROVED=1 make slot-up SLOT=auto SERVICES=none
+```
+
+API/state-contract work, with its required private closure:
+
+```bash
+SLOTS_RUNTIME_APPROVED=1 make slot-up SLOT=4 SERVICES=backend
+```
+
+Cross-cutting work with fully private providers but shared physical databases:
+
+```bash
+SLOTS_RUNTIME_APPROVED=1 make slot-up SLOT=5 SERVICES=all
+```
+
+Temporal schedule registration is disabled by default to prevent multiple
+workers registering the same namespace-wide schedules. For schedule
+development, opt in on startup with `SLOT_REGISTER_TEMPORAL_SCHEDULES=true`.
+
+## Browser routing
+
+No hosts-file maintenance is required for normal `*.localhost` resolution.
+Traefik uses the generated slot route to dispatch each hostname.
+
+| UI or service | Slot-N URL |
+|---|---|
+| Frontend | `http://N.localhost` |
+| Backend API | `http://api.N.localhost` |
+| Temporal UI | `http://temporal.N.localhost` |
+| PeerDB UI | `http://peerdb.N.localhost` |
+| MinIO API | `http://minio.N.localhost` |
+| MinIO console | `http://minio-console.N.localhost` |
+| RabbitMQ management | `http://rabbitmq.N.localhost` |
+| Gateway | `http://gateway.N.localhost` |
+| Model serving | `http://serving.N.localhost` |
+| Collector | `http://collector.N.localhost` |
+| Executor | `http://executor.N.localhost` |
+| Jaeger | `http://jaeger.N.localhost` |
+
+If port 80 is unavailable, set `SLOTS_HTTP_PORT`, for example
+`SLOTS_HTTP_PORT=8088`. All concurrently active slots must use the same public
+port, and URLs become `http://N.localhost:8088` and so on. Always use
+`make slot-urls SLOT=N` instead of reconstructing URLs manually.
+
+## What happens during `slot-up`
+
+1. Acquire the registry lock and resolve `SLOT=auto` or the requested number.
+2. Validate service selection, base-reference compatibility, prerequisites,
+   ports, and projected memory before starting the topology.
+3. Stage a mode-`0600` slot environment file (worktree `.env` followed by
+   generated topology), manifest, and Traefik route under `.slots/`.
+4. For same-slot replacement, stop the old private topology while retaining
+   its volumes and committed recovery information.
+5. Create the external `futureagi-slots` network and start the shared control
+   plane if needed.
+6. Provision logical databases, vhosts, buckets, and Temporal namespace.
+7. Create missing shared default providers, building source-backed providers
+   sequentially.
+8. Build selected private providers and the always-private frontend
+   sequentially.
+9. Restart only Traefik so it reloads the new route, then start the private slot
+   Compose project.
+10. Commit the registry entry and remove the recovery journal.
+
+The backend container runs migrations automatically during normal startup.
+The backend worker uses fast startup and does not repeat migrations.
+
+The PeerDB provider is a group rather than a single long-running container. It
+can include its catalog, Temporal and initialization job, MinIO and setup job,
+flow API and worker, server, UI, and final initialization job. One-shot helper
+containers may remain visible in Docker after successfully completing.
+
+## Resource admission
+
+Before startup, the slot system reads Docker's available memory and only lowers
+its configured cap; it never raises Docker Desktop's allocation. The default
+configured cap is 16 GiB, and startup admits at most 75% of the effective cap.
+
+The estimate includes:
+
+- 2,600 MiB when the first slot must start the shared control plane;
+- the missing shared provider pool on its first use;
+- 350 MiB for every private frontend;
+- selected private provider estimates;
+- selected isolated-infrastructure estimates.
+
+If the projected topology exceeds the limit, startup fails before committing
+the slot. `FORCE=1` bypasses this guard and must never be used without explicit
+authorization for that risk.
+
+## Stop, replace, recover, and purge
+
+`slot-down` is the normal exit. It stops the slot's private project and isolated
+engines, releases provider references, and stops shared providers that lose
+their final reference. When the last slot stops, the control plane and shared
+network also stop. It deliberately does not pass Compose `--volumes`.
+
+Generated state and named volumes persist across ordinary cleanup, allowing a
+slot to be started again without losing its data. Starting an already-used slot
+performs a controlled replacement of that slot.
+
+If startup is interrupted, `slots-recover` removes only the partial project
+recorded in the recovery journal and retains volumes. It covers both a failed
+first startup and a failed same-slot replacement; rerun `slot-up` afterward.
+Recovery also understands interrupted down and purge operations. A result
+ending in `-retry` means the registry did not commit, so rerun the original
+Make command. A result ending in `-complete` means only post-commit artifact
+cleanup remained. Purge is never resumed automatically: it requires renewed
+explicit authorization and the exact `CONFIRM=<slot>` value.
+
+`slots-prune` repairs stale, zero-reference shared-provider metadata left by an
+interrupted or older implementation. It is not required during normal down.
+
+`slot-purge` is destructive. `CONFIRM` must exactly equal `SLOT`; it removes
+exact slot-owned volumes and private-provider logical state, while preserving
+shared logical state and shared volumes. Restate the target and obtain explicit
+authorization immediately before invoking it.
+
+Never stop, delete, or reconfigure Docker resources outside the FutureAGI slot
+projects.
+
+## Generated files and sources of truth
+
+Slot metadata is kept under `.slots/` and is intentionally separate from
+worktree source. The main implementation references are:
+
+- `Makefile`: public command interface;
+- `slots/catalog.py`: service names, dependencies, memory estimates, and port
+  bands;
+- `slots/runtime.py`: lifecycle planning, routing, admission, and sharing;
+- `slots/config/compose-catalog.yaml`: topology and routing contract;
+- `slots/compose/`: internal Compose fragments, never a public entry point;
+- `slots/README.md`: repository-level overview;
+- `.claude/skills/futureagi-slots/SKILL.md`: canonical agent operating policy;
+- `.agents/skills/futureagi-slots/SKILL.md`: Codex adapter to the canonical
+  skill.
+
+## Current command-output limitation
+
+The lifecycle operations work, but the current Python adapter captures child
+process output. Consequently `slot-logs` may buffer followed logs,
+`slot-shell` is not a fully interactive terminal, and `slot-run` can hide the
+command's standard output behind its JSON result. Treat these as CLI-output
+limitations, not container-health failures; `slot-status`, `slot-urls`, and the
+browser routes remain reliable inspection paths.

--- a/.gitignore
+++ b/.gitignore
@@ -249,6 +249,9 @@ uninstall-*.log
 # Local compose override (developer testing, not shipped)
 docker-compose.override.yml
 
+# Slot orchestrator runtime state. Configuration and skills under slots/,
+# .claude/skills/, and .agents/skills/ remain tracked.
+/.slots/
 
 # (The private repo's own .gitignore now lives inside futureagi/ee/cloud/,
 # which is already ignored above — no separate rule needed.)

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,55 @@
+.PHONY: slot-help slot-up slot-down slot-status slot-urls slot-logs slot-shell slot-run slots-doctor slots-recover slots-prune slot-purge
+
+PYTHON ?= python3
+SLOT ?= auto
+SERVICES ?= none
+ISOLATE_INFRA ?=
+SERVICE ?= frontend
+COMMAND ?=
+CONFIRM ?=
+
+# `SLOT` is a Make/CLI selector, while generated Compose env files contain the
+# resolved numeric slot.  Command-line Make variables are exported by default;
+# keeping this one out of child processes prevents SLOT=auto from overriding
+# the generated SLOT=1..20 value used in browser URLs.
+unexport SLOT
+
+# Keep Make variables data-only when they cross into the recipe shell.  `value`
+# prevents a command-line value containing Make syntax from being re-expanded.
+shell_quote = '$(subst ','"'"',$(1))'
+
+slot-help:
+	@$(PYTHON) -c "print('FutureAGI slots are operated only through these Make targets.\n\nStart: make slot-up SLOT=auto|1..20 SERVICES=none|all|backend,simulation,gateway,collector,serving,executor,peerdb,observability [ISOLATE_INFRA=postgres,clickhouse,redis,rabbitmq,minio,temporal]\nFrontend is always slot-private; SERVICES selects additional private provider groups. A private backend also makes simulation, collector, and peerdb private so they share its state. Omitted groups use validated shared defaults. ISOLATE_INFRA requires SERVICES=backend.\nEach slot inherits application variables from its worktree-root .env; generated slot topology overrides matching reserved values. Rerun slot-up after editing .env.\nA newly built simulation provider requires agent_learning_kit-0.1.0-py3-none-any.whl at the worktree root; slot-up checks before Docker mutation.\nRuntime actions require SLOTS_RUNTIME_APPROVED=1: make slot-up, slot-down, slot-logs SLOT=1 SERVICE=backend, slot-shell SLOT=1 SERVICE=backend, slot-run SLOT=1 SERVICE=backend COMMAND=\"...\", slots-doctor, slots-recover, slots-prune, slot-purge SLOT=1 CONFIRM=1.\nInspect without runtime approval: make slot-status [SLOT=1] and make slot-urls SLOT=1.\nslot-down preserves generated files and provider state. slot-purge removes only exact slot Compose volumes; shared logical state is preserved, while private backend state requires CONFIRM to equal SLOT.\nslots-recover handles interrupted up, replacement, down, and purge operations while preserving volumes. Retry results require rerunning the original command; purge requires renewed approval and exact confirmation. slots-prune cleans stale zero-reference shared-provider metadata.')"
+
+slot-up:
+	$(PYTHON) -m slots.cli up --slot $(call shell_quote,$(value SLOT)) --services $(call shell_quote,$(value SERVICES)) --isolate-infra $(call shell_quote,$(value ISOLATE_INFRA))
+
+slot-down:
+	$(PYTHON) -m slots.cli down --slot $(call shell_quote,$(value SLOT))
+
+slot-status:
+	$(PYTHON) -m slots.cli status $(if $(filter-out auto,$(value SLOT)),--slot $(call shell_quote,$(value SLOT)))
+
+slot-urls:
+	$(PYTHON) -m slots.cli urls --slot $(call shell_quote,$(value SLOT))
+
+slot-logs:
+	$(PYTHON) -m slots.cli logs --slot $(call shell_quote,$(value SLOT)) --service $(call shell_quote,$(value SERVICE))
+
+slot-shell:
+	$(PYTHON) -m slots.cli shell --slot $(call shell_quote,$(value SLOT)) --service $(call shell_quote,$(value SERVICE))
+
+slot-run:
+	$(PYTHON) -m slots.cli run --slot $(call shell_quote,$(value SLOT)) --service $(call shell_quote,$(value SERVICE)) --command $(call shell_quote,$(value COMMAND))
+
+slots-doctor:
+	$(PYTHON) -m slots.cli doctor
+
+slots-recover:
+	$(PYTHON) -m slots.cli recover
+
+slots-prune:
+	$(PYTHON) -m slots.cli prune
+
+slot-purge:
+	$(PYTHON) -m slots.cli purge --slot $(call shell_quote,$(value SLOT)) --confirm $(call shell_quote,$(value CONFIRM))

--- a/fi-collector/cmd/fi-collector/main.go
+++ b/fi-collector/cmd/fi-collector/main.go
@@ -10,7 +10,8 @@
 // Config priority (later overrides earlier):
 //  1. Defaults coded into chwriter.New / server.New
 //  2. YAML file path from --config (or /etc/fi-collector/config.yaml)
-//  3. Environment overrides (FI_CH_URL, FI_GRPC_ADDR, FI_HTTP_ADDR,
+//  3. Environment overrides (FI_CH_URL, FI_AUTH_REDIS_ADDR,
+//     FI_AUTH_REDIS_DB, FI_GRPC_ADDR, FI_HTTP_ADDR,
 //     FI_GRPC_MAX_RECV_MIB, FI_DEAD_LETTER_FILE, ...)
 //
 // Health surfaces:
@@ -22,6 +23,7 @@ import (
 	"context"
 	"encoding/json"
 	"flag"
+	"fmt"
 	"log/slog"
 	"net/http"
 	"os"
@@ -46,8 +48,17 @@ type rootConfig struct {
 
 func main() {
 	var configPath string
+	var healthcheck bool
 	flag.StringVar(&configPath, "config", "/etc/fi-collector/config.yaml", "path to YAML config")
+	flag.BoolVar(&healthcheck, "healthcheck", false, "probe the local admin health endpoint and exit")
 	flag.Parse()
+	if healthcheck {
+		if err := probeHealth("http://127.0.0.1:9464/healthz"); err != nil {
+			_, _ = fmt.Fprintln(os.Stderr, err)
+			os.Exit(1)
+		}
+		return
+	}
 
 	log := slog.New(slog.NewJSONHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelInfo}))
 
@@ -68,7 +79,10 @@ func main() {
 
 	var rdb *redis.Client
 	if cfg.Auth.RedisAddr != "" {
-		rdb = redis.NewClient(&redis.Options{Addr: cfg.Auth.RedisAddr})
+		rdb = redis.NewClient(&redis.Options{
+			Addr: cfg.Auth.RedisAddr,
+			DB:   cfg.Auth.RedisDB,
+		})
 		defer rdb.Close()
 	} else {
 		log.Warn("FI_AUTH_REDIS_ADDR not set — quota enforcement, usage metering, key-revocation and project-delete cache invalidation are disabled; auth cache entries only expire via TTL")
@@ -122,6 +136,19 @@ func main() {
 		os.Exit(1)
 	}
 	log.Info("shutdown complete", "stats", writer.Snapshot())
+}
+
+func probeHealth(endpoint string) error {
+	client := &http.Client{Timeout: 3 * time.Second}
+	response, err := client.Get(endpoint)
+	if err != nil {
+		return fmt.Errorf("collector health probe failed: %w", err)
+	}
+	defer response.Body.Close()
+	if response.StatusCode != http.StatusOK {
+		return fmt.Errorf("collector health probe returned HTTP %d", response.StatusCode)
+	}
+	return nil
 }
 
 // loadPriceTable resolves the token-pricing table. FI_PRICING_JSON is
@@ -220,6 +247,13 @@ func applyEnvOverrides(log *slog.Logger, c *rootConfig) {
 	}
 	if v := os.Getenv("FI_AUTH_REDIS_ADDR"); v != "" {
 		c.Auth.RedisAddr = v
+	}
+	if v := os.Getenv("FI_AUTH_REDIS_DB"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n >= 0 && n < 64 {
+			c.Auth.RedisDB = n
+		} else {
+			log.Warn("ignoring invalid FI_AUTH_REDIS_DB", "value", v)
+		}
 	}
 }
 

--- a/fi-collector/cmd/fi-collector/main_test.go
+++ b/fi-collector/cmd/fi-collector/main_test.go
@@ -4,11 +4,35 @@ import (
 	"bytes"
 	"encoding/json"
 	"log/slog"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 )
+
+func TestProbeHealth(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, _ *http.Request) {
+		rw.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	if err := probeHealth(server.URL); err != nil {
+		t.Fatalf("healthy endpoint failed: %v", err)
+	}
+}
+
+func TestProbeHealthRejectsNonOK(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, _ *http.Request) {
+		rw.WriteHeader(http.StatusServiceUnavailable)
+	}))
+	defer server.Close()
+
+	if err := probeHealth(server.URL); err == nil {
+		t.Fatal("unhealthy endpoint unexpectedly passed")
+	}
+}
 
 // logLines parses newline-delimited slog JSON output into a slice of
 // decoded records for easy assertions.
@@ -106,5 +130,34 @@ func TestLoadPriceTable_SkippedEntriesWarns(t *testing.T) {
 	}
 	if !sawSkippedWarn {
 		t.Error("want a WARN log reporting the skipped-entry count")
+	}
+}
+
+func TestApplyEnvOverridesRedisDB(t *testing.T) {
+	t.Setenv("FI_AUTH_REDIS_DB", "17")
+	var buf bytes.Buffer
+	log := slog.New(slog.NewJSONHandler(&buf, nil))
+	cfg := rootConfig{}
+
+	applyEnvOverrides(log, &cfg)
+
+	if cfg.Auth.RedisDB != 17 {
+		t.Fatalf("want Redis DB 17, got %d", cfg.Auth.RedisDB)
+	}
+}
+
+func TestApplyEnvOverridesRejectsInvalidRedisDB(t *testing.T) {
+	t.Setenv("FI_AUTH_REDIS_DB", "64")
+	var buf bytes.Buffer
+	log := slog.New(slog.NewJSONHandler(&buf, nil))
+	cfg := rootConfig{}
+
+	applyEnvOverrides(log, &cfg)
+
+	if cfg.Auth.RedisDB != 0 {
+		t.Fatalf("invalid override changed Redis DB to %d", cfg.Auth.RedisDB)
+	}
+	if !strings.Contains(buf.String(), "ignoring invalid FI_AUTH_REDIS_DB") {
+		t.Fatal("want invalid FI_AUTH_REDIS_DB warning")
 	}
 }

--- a/fi-collector/docker-compose.standalone.yml
+++ b/fi-collector/docker-compose.standalone.yml
@@ -79,7 +79,7 @@ services:
           "/usr/local/bin/fi-collector",
           "-config",
           "/etc/fi-collector/config.yaml",
-          "--healthcheck-noop",
+          "--healthcheck",
         ]
       interval: 10s
       timeout: 2s

--- a/fi-collector/pkg/auth/config.go
+++ b/fi-collector/pkg/auth/config.go
@@ -8,6 +8,7 @@ type Config struct {
 	PGWrite     string        `yaml:"pg_write"`
 	PGRead      string        `yaml:"pg_read"`
 	RedisAddr   string        `yaml:"redis_addr"`
+	RedisDB     int           `yaml:"redis_db"`
 	CacheTTL    time.Duration `yaml:"cache_ttl"`
 	WarmTTL     time.Duration `yaml:"warm_ttl"`
 	PGPoolRead  int           `yaml:"pg_pool_read"`

--- a/slots/README.md
+++ b/slots/README.md
@@ -1,0 +1,112 @@
+# FutureAGI development slots
+
+The slot system runs multiple worktree development environments through one
+root Make interface. Every slot receives a private frontend; other providers
+can be shared or made private per slot.
+
+For the complete topology, feature, command, routing, persistence, and recovery
+reference used by both Claude Code and Codex, see the
+[development slots feature guide](../.claude/skills/futureagi-slots/references/feature-guide.md).
+
+Do not run the Compose assets in this directory directly. Inspect the interface
+without contacting Docker with:
+
+```bash
+make slot-help
+```
+
+Live targets are deliberately locked. After the developer explicitly approves
+local runtime testing, invoke them with `SLOTS_RUNTIME_APPROVED=1`.
+
+Common examples:
+
+```bash
+# Frontend-only worktree; reuse the default backend and infrastructure.
+SLOTS_RUNTIME_APPROVED=1 make slot-up SLOT=3 SERVICES=none
+
+# Backend change; create a private backend and consolidated worker.
+# Simulation, collector, and PeerDB also become private because they consume
+# the backend provider's state identity.
+SLOTS_RUNTIME_APPROVED=1 make slot-up SLOT=3 SERVICES=backend
+
+# Physically isolate selected state engines as well.
+SLOTS_RUNTIME_APPROVED=1 make slot-up SLOT=3 SERVICES=backend ISOLATE_INFRA=postgres,redis
+
+make slot-status SLOT=3
+make slot-urls SLOT=3
+SLOTS_RUNTIME_APPROVED=1 make slot-down SLOT=3
+```
+
+Ordinary cleanup preserves logical data and named volumes. Persistent state is
+deleted only by the explicitly confirmed `slot-purge` target.
+
+The first slot creates one shared default provider pool. Later slots reuse that
+pool and normally add only their private frontend. `SERVICES` replaces selected
+groups with worktree-private providers; changed worktree source never becomes a
+shared default implicitly.
+
+## Worktree environment
+
+Each slot inherits application configuration from the root `.env` of its own
+worktree. The slot runtime copies that file into its private generated
+`.slots/slots/NN/slot.env`, then appends generated container, routing, port, and
+state values. Generated values take precedence when the same key appears in
+both places. Do not edit `slot.env`; edit the worktree `.env` and rerun
+`make slot-up` for that slot.
+
+Because the generated file includes the worktree's application values, it may
+contain secrets. It is written with mode `0600`, remains after `slot-down`, and
+is removed with the rest of the generated slot metadata by `slot-purge`.
+
+The root `.env` can contain frontend and backend values. Only `VITE_`-prefixed
+values are exposed to browser code. Because a shared provider has one process
+environment, a worktree-specific backend or provider setting requires selecting
+that provider with `SERVICES`; the always-private frontend receives its
+worktree's values automatically. Shared providers inherit the `.env` belonging
+to their current owner worktree.
+
+Source-backed images are rebuilt sequentially before containers start. This
+keeps repeated builds incremental while avoiding the memory spike of a parallel
+Compose build. A topology that creates the simulation provider requires
+`agent_learning_kit-0.1.0-py3-none-any.whl` at the worktree root, as required by
+`Dockerfile.simulation-runner.dev`; `slot-up` checks this before changing Docker.
+
+Backend slots do not re-register namespace-wide Temporal schedules by default.
+For schedule-development work, opt in with
+`SLOT_REGISTER_TEMPORAL_SCHEDULES=true` on the Make invocation.
+
+`slot-down` stops slot-private containers, isolated engines, and providers that
+lost their last reference while retaining named volumes and generated state.
+The confirmed `slot-purge` target also works after `slot-down`: it removes exact
+slot-owned Compose volumes and, for a private backend, its provider-bound state.
+It never deletes shared logical state.
+
+If Docker or the invoking process stops during a lifecycle command,
+`make slots-recover` reconciles its journal without deleting named volumes. It
+removes partial first-start and same-slot replacement runtime; rerun `slot-up`
+afterward. For interrupted down or purge, a result ending in `-retry` means the
+original Make command must be run again. Purge always requires renewed explicit
+authorization and its exact `CONFIRM=<slot>` value.
+
+## Browser URLs
+
+For slot 3 the default routes are:
+
+- `http://3.localhost`
+- `http://api.3.localhost`
+- `http://temporal.3.localhost`
+- `http://peerdb.3.localhost`
+
+Set `SLOTS_HTTP_PORT` when port 80 is unavailable. All active slots must use the
+same public port. The status and URL targets print the resolved routes and any
+slot-banded isolated-engine ports.
+
+## Agent skills
+
+Claude Code discovers the canonical workflow at
+`.claude/skills/futureagi-slots/SKILL.md`. Codex discovers the adapter at
+`.agents/skills/futureagi-slots/SKILL.md`; the adapter points to the canonical
+instructions so behavior stays aligned.
+
+Both skills require explicit approval before they run live Docker slot tests or
+mutate local Docker runtime state.

--- a/slots/__init__.py
+++ b/slots/__init__.py
@@ -1,0 +1,35 @@
+"""Pure planning and state management for FutureAGI development slots."""
+
+from .catalog import SUPPORTED_SERVICES, expand_services, parse_services
+from .models import REGISTRY_VERSION, Registry, SlotRecord, StateIdentity
+from .provisioning import ProvisionPlan, PurgePlan, StateCommand
+from .registry import RegistryStore, discover_state_dir
+from .runtime import SlotRuntime
+from .state import (
+    INFRA_ENGINES,
+    StatePlan,
+    StateValidationError,
+    adapt_orchestrator_state,
+    build_state_plan,
+)
+
+__all__ = [
+    "INFRA_ENGINES",
+    "REGISTRY_VERSION",
+    "SUPPORTED_SERVICES",
+    "ProvisionPlan",
+    "PurgePlan",
+    "Registry",
+    "RegistryStore",
+    "SlotRecord",
+    "SlotRuntime",
+    "StateCommand",
+    "StateIdentity",
+    "StatePlan",
+    "StateValidationError",
+    "adapt_orchestrator_state",
+    "build_state_plan",
+    "discover_state_dir",
+    "expand_services",
+    "parse_services",
+]

--- a/slots/catalog.py
+++ b/slots/catalog.py
@@ -1,0 +1,132 @@
+"""The fixed provider catalog and selection validation rules."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class ServiceDefinition:
+    name: str
+    dependencies: tuple[str, ...] = ()
+    memory_mib: int = 0
+    port_offset: int = 0
+
+
+# `frontend` is intentionally absent: it is always slot-private and cannot be selected.
+CATALOG: dict[str, ServiceDefinition] = {
+    "backend": ServiceDefinition("backend", memory_mib=1300, port_offset=11),
+    "simulation": ServiceDefinition("simulation", ("backend",), 700, 20),
+    "gateway": ServiceDefinition("gateway", ("backend",), 350, 30),
+    "collector": ServiceDefinition("collector", ("backend",), 350, 40),
+    "serving": ServiceDefinition("serving", ("backend",), 600, 50),
+    "executor": ServiceDefinition("executor", ("backend",), 600, 60),
+    "peerdb": ServiceDefinition("peerdb", ("backend",), 700, 70),
+    "observability": ServiceDefinition("observability", (), 500, 80),
+}
+SUPPORTED_SERVICES = frozenset(("none", "all", *CATALOG))
+FRONTEND_MEMORY_MIB = 350
+FRONTEND_PORT_OFFSET = 10
+ISOLATABLE_INFRA = frozenset(
+    {"postgres", "clickhouse", "redis", "rabbitmq", "minio", "temporal"}
+)
+ISOLATED_PORT_OFFSETS = {
+    "postgres": 1,
+    "clickhouse_http": 2,
+    "clickhouse_native": 3,
+    "redis": 4,
+    "rabbitmq": 5,
+    "rabbitmq_management": 6,
+    "minio_api": 7,
+    "minio_console": 8,
+    "temporal": 9,
+}
+
+
+def parse_services(value: str | None) -> tuple[str, ...]:
+    """Parse the public SERVICES value without silently accepting typos."""
+    tokens = tuple(
+        token.strip().lower() for token in (value or "none").split(",") if token.strip()
+    )
+    if not tokens:
+        return ("none",)
+    unknown = set(tokens) - SUPPORTED_SERVICES
+    if unknown:
+        raise ValueError(f"unsupported SERVICES value(s): {', '.join(sorted(unknown))}")
+    if "none" in tokens and len(tokens) > 1:
+        raise ValueError("SERVICES=none cannot be combined with other services")
+    if "all" in tokens and len(tokens) > 1:
+        raise ValueError("SERVICES=all cannot be combined with other services")
+    if len(set(tokens)) != len(tokens):
+        raise ValueError("SERVICES cannot list the same service more than once")
+    return tuple(dict.fromkeys(tokens))
+
+
+def expand_services(selection: tuple[str, ...] | str | None) -> tuple[str, ...]:
+    requested = (
+        parse_services(selection)
+        if isinstance(selection, str) or selection is None
+        else selection
+    )
+    roots = (
+        tuple(CATALOG)
+        if requested == ("all",)
+        else (() if requested == ("none",) else requested)
+    )
+    expanded: set[str] = set()
+
+    def include(name: str) -> None:
+        if name in expanded:
+            return
+        expanded.add(name)
+        for dependency in CATALOG[name].dependencies:
+            include(dependency)
+
+    for service in roots:
+        include(service)
+    return tuple(name for name in CATALOG if name in expanded)
+
+
+def parse_isolated_infra(value: str | None) -> tuple[str, ...]:
+    tokens = tuple(
+        token.strip().lower() for token in (value or "").split(",") if token.strip()
+    )
+    unknown = set(tokens) - ISOLATABLE_INFRA
+    if unknown:
+        raise ValueError(
+            f"unsupported ISOLATE_INFRA value(s): {', '.join(sorted(unknown))}"
+        )
+    return tuple(dict.fromkeys(tokens))
+
+
+def private_ports(
+    slot: int, services: tuple[str, ...], isolated_infra: tuple[str, ...] = ()
+) -> dict[str, int]:
+    if not 1 <= slot <= 20:
+        raise ValueError("SLOT must be an integer from 1 through 20")
+    band = 20000 + slot * 100
+    ports = {"frontend": band + FRONTEND_PORT_OFFSET}
+    ports.update({service: band + CATALOG[service].port_offset for service in services})
+    for engine in isolated_infra:
+        if engine == "clickhouse":
+            ports["clickhouse_http"] = band + ISOLATED_PORT_OFFSETS["clickhouse_http"]
+            ports["clickhouse_native"] = (
+                band + ISOLATED_PORT_OFFSETS["clickhouse_native"]
+            )
+        elif engine == "rabbitmq":
+            ports["rabbitmq"] = band + ISOLATED_PORT_OFFSETS["rabbitmq"]
+            ports["rabbitmq_management"] = (
+                band + ISOLATED_PORT_OFFSETS["rabbitmq_management"]
+            )
+        elif engine == "minio":
+            ports["minio_api"] = band + ISOLATED_PORT_OFFSETS["minio_api"]
+            ports["minio_console"] = band + ISOLATED_PORT_OFFSETS["minio_console"]
+        else:
+            ports[engine] = band + ISOLATED_PORT_OFFSETS[engine]
+    return ports
+
+
+def estimate_resources(services: tuple[str, ...]) -> int:
+    return FRONTEND_MEMORY_MIB + sum(
+        CATALOG[service].memory_mib for service in services
+    )

--- a/slots/cli.py
+++ b/slots/cli.py
@@ -1,0 +1,187 @@
+"""The thin, daemon-free command surface used by root Make targets."""
+
+from __future__ import annotations
+
+import argparse
+from dataclasses import asdict, is_dataclass
+import json
+import os
+from pathlib import Path
+import subprocess
+import sys
+
+from .registry import (
+    CommandRunner,
+    RegistryStore,
+    _subprocess_runner,
+    discover_state_dir,
+)
+from .provisioning import execute_state_command
+from .runtime import CommandExecutor, SlotRuntime, StateCommandExecutor
+
+
+def _subprocess_executor(argv: list[str] | tuple[str, ...], cwd: Path) -> str:
+    return subprocess.run(
+        argv, cwd=cwd, check=True, text=True, capture_output=True
+    ).stdout
+
+
+def _apply_docker_memory_cap(
+    environment: dict[str, str], executor: CommandExecutor, cwd: Path
+) -> None:
+    """Safely lower (never raise) admission from approved Docker memory data."""
+    result = executor(("docker", "info", "--format", "{{.MemTotal}}"), cwd)
+    if not isinstance(result, (str, bytes)):
+        return
+    try:
+        bytes_total = int(
+            result.decode() if isinstance(result, bytes) else result.strip()
+        )
+    except ValueError:
+        return
+    if bytes_total <= 0:
+        return
+    docker_mib = bytes_total // (1024 * 1024)
+    configured = int(environment.get("SLOTS_MEMORY_CAP_MIB", 16 * 1024))
+    environment["SLOTS_MEMORY_CAP_MIB"] = str(min(configured, docker_mib))
+
+
+def _require_runtime_approval(environment: dict[str, str]) -> None:
+    if environment.get("SLOTS_RUNTIME_APPROVED") != "1":
+        raise ValueError("runtime execution requires SLOTS_RUNTIME_APPROVED=1")
+
+
+def _error_message(error: BaseException) -> str:
+    message = str(error)
+    details = getattr(error, "stderr", None) or getattr(error, "output", None)
+    if isinstance(details, bytes):
+        details = details.decode(errors="replace")
+    if isinstance(details, str) and details.strip():
+        cleaned = details.strip()
+        if len(cleaned) > 12_000:
+            cleaned = "...[earlier Docker output truncated]...\n" + cleaned[-12_000:]
+        return f"{message}: {cleaned}"
+    return message
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(prog="futureagi-slots")
+    commands = parser.add_subparsers(dest="action", required=True)
+    up = commands.add_parser("up")
+    up.add_argument("--slot", required=True)
+    up.add_argument("--services", default="none")
+    up.add_argument("--isolate-infra", default="")
+    up.add_argument("--revision", default="")
+    for action in ("down", "status", "urls", "purge"):
+        command = commands.add_parser(action)
+        command.add_argument("--slot", required=action != "status")
+        if action == "purge":
+            command.add_argument("--confirm", required=True)
+    for action in ("logs", "shell", "run"):
+        command = commands.add_parser(action)
+        command.add_argument("--slot", required=True)
+        command.add_argument("--service", required=True)
+        if action == "run":
+            command.add_argument("--command", required=True)
+    commands.add_parser("doctor")
+    commands.add_parser("recover")
+    commands.add_parser(
+        "prune", help="recovery cleanup for stale zero-reference shared providers"
+    )
+    return parser
+
+
+def _serialise(value: object) -> object:
+    if is_dataclass(value):
+        return _serialise(asdict(value))
+    if hasattr(value, "to_dict"):
+        return value.to_dict()  # type: ignore[no-any-return]
+    if hasattr(value, "argv") and hasattr(value, "cwd"):
+        return {"argv": list(value.argv), "cwd": str(value.cwd)}  # type: ignore[attr-defined]
+    if hasattr(value, "__dict__"):
+        return {key: _serialise(item) for key, item in value.__dict__.items()}
+    if isinstance(value, tuple):
+        return [_serialise(item) for item in value]
+    if isinstance(value, list):
+        return [_serialise(item) for item in value]
+    if isinstance(value, dict):
+        return {str(key): _serialise(item) for key, item in value.items()}
+    if isinstance(value, Path):
+        return str(value)
+    return value
+
+
+def main(
+    argv: list[str] | None = None,
+    cwd: Path | None = None,
+    runner: CommandRunner = _subprocess_runner,
+    executor: CommandExecutor | None = None,
+    state_executor: StateCommandExecutor | None = None,
+) -> int:
+    args = _parser().parse_args(argv)
+    state_dir = discover_state_dir(cwd, dict(os.environ), runner)
+    runtime = SlotRuntime(RegistryStore(state_dir), cwd or Path.cwd(), runner)
+    environment = dict(os.environ)
+    command_executor = _subprocess_executor if executor is None else executor
+    try:
+        if args.action == "up":
+            _require_runtime_approval(environment)
+            _apply_docker_memory_cap(environment, command_executor, cwd or Path.cwd())
+            result = runtime.apply_up(
+                args.slot,
+                args.services,
+                args.isolate_infra,
+                args.revision,
+                environment,
+                command_executor,
+                state_executor if state_executor is not None else execute_state_command,
+            )
+        elif args.action == "down":
+            _require_runtime_approval(environment)
+            result = runtime.apply_down(
+                args.slot,
+                command_executor,
+                state_executor if state_executor is not None else execute_state_command,
+            )
+        elif args.action == "purge":
+            _require_runtime_approval(environment)
+            result = runtime.apply_purge(
+                args.slot,
+                args.confirm,
+                command_executor,
+                state_executor if state_executor is not None else execute_state_command,
+            )
+        elif args.action in {"status", "urls"}:
+            records = runtime.status(args.slot if args.slot else None)
+            result = tuple(
+                record.routes if args.action == "urls" else record for record in records
+            )
+        elif args.action in {"logs", "shell", "run"}:
+            _require_runtime_approval(environment)
+            record = runtime.status(args.slot)[0]
+            result = runtime.service_command(
+                record, args.action, args.service, getattr(args, "command", None)
+            )
+            command_executor(result.argv, result.cwd)
+        elif args.action == "doctor":
+            _require_runtime_approval(environment)
+            _apply_docker_memory_cap(environment, command_executor, cwd or Path.cwd())
+            result = runtime.doctor(command_executor, environment)
+        elif args.action == "recover":
+            _require_runtime_approval(environment)
+            result = runtime.apply_recover(
+                command_executor,
+                state_executor if state_executor is not None else execute_state_command,
+            )
+        else:  # prune
+            _require_runtime_approval(environment)
+            result = runtime.apply_prune(command_executor)
+    except (ValueError, IndexError, RuntimeError, subprocess.SubprocessError) as error:
+        print(f"error: {_error_message(error)}", file=sys.stderr)
+        return 2
+    print(json.dumps(_serialise(result), sort_keys=True, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/slots/compose/backend.yaml
+++ b/slots/compose/backend.yaml
@@ -1,0 +1,101 @@
+# One private backend includes one all-queues development Temporal worker.
+name: ${SLOT_PROJECT:?SLOT_PROJECT is required}
+
+x-slot-runtime: &slot-runtime
+  build:
+    context: ${SLOT_WORKTREE:?SLOT_WORKTREE is required}
+    dockerfile: Dockerfile
+  image: ${SLOT_BACKEND_IMAGE:-futureagi/slot-backend}:${SLOT_ID:?SLOT_ID is required}
+  working_dir: /app/backend
+  env_file:
+    - ${SLOT_ENV_FILE:?SLOT_ENV_FILE is required}
+  volumes:
+    - ${SLOT_WORKTREE:?SLOT_WORKTREE is required}/futureagi:/app/backend
+    - slot-backend-media:/app/backend/media
+  networks: [slots]
+  restart: unless-stopped
+
+x-slot-state: &slot-state
+  ENV_TYPE: local
+  DJANGO_SETTINGS_MODULE: tfc.settings.settings
+  FAST_STARTUP: "true"
+  PG_HOST: ${SLOT_PG_HOST:-${SLOTS_POSTGRES_NAME:-futureagi-slots-postgres}}
+  PG_PORT: "5432"
+  PG_USER: ${SLOTS_PG_USER:-futureagi}
+  PG_PASSWORD: ${SLOTS_PG_PASSWORD:-futureagi}
+  PG_DB: ${SLOT_PG_DB:?SLOT_PG_DB is required}
+  PGBOUNCER_HOST: ${SLOT_PG_HOST:-${SLOTS_POSTGRES_NAME:-futureagi-slots-postgres}}
+  PGBOUNCER_PORT: "5432"
+  CH_HOST: ${SLOT_CH_HOST:-${SLOTS_CLICKHOUSE_NAME:-futureagi-slots-clickhouse}}
+  # Native client port and HTTP port are deliberately distinct.
+  CH_PORT: "9000"
+  CH_HTTP_PORT: "8123"
+  CH_DATABASE: ${SLOT_CH_DATABASE:?SLOT_CH_DATABASE is required}
+  CH25_DATABASE: ${SLOT_CH_DATABASE:?SLOT_CH_DATABASE is required}
+  REDIS_HOST: ${SLOT_REDIS_HOST:-${SLOTS_REDIS_NAME:-futureagi-slots-redis}}
+  REDIS_PORT: "6379"
+  REDIS_URL: redis://${SLOT_REDIS_HOST:-${SLOTS_REDIS_NAME:-futureagi-slots-redis}}:6379/${SLOT_REDIS_DB:?SLOT_REDIS_DB is required}
+  REDIS_CACHE_URL: redis://${SLOT_REDIS_HOST:-${SLOTS_REDIS_NAME:-futureagi-slots-redis}}:6379/${SLOT_REDIS_CACHE_DB:?SLOT_REDIS_CACHE_DB is required}
+  REDIS_LOCK_URL: redis://${SLOT_REDIS_HOST:-${SLOTS_REDIS_NAME:-futureagi-slots-redis}}:6379/${SLOT_REDIS_LOCK_DB:?SLOT_REDIS_LOCK_DB is required}
+  CELERY_BROKER_URL: amqp://${SLOTS_RABBITMQ_USER:-user}:${SLOTS_RABBITMQ_PASSWORD:-password}@${SLOT_RABBITMQ_HOST:-${SLOTS_RABBITMQ_NAME:-futureagi-slots-rabbitmq}}:5672/${SLOT_RABBITMQ_VHOST:?SLOT_RABBITMQ_VHOST is required}
+  STORAGE_BACKEND: minio
+  S3_ENDPOINT_URL: http://${SLOT_MINIO_HOST:-${SLOTS_MINIO_NAME:-futureagi-slots-minio}}:9000
+  # This is the public S3 API route, not the optional MinIO console route.
+  MINIO_URL: http://minio.${SLOT:?SLOT is required}.localhost:${SLOTS_HTTP_PORT:-80}
+  S3_ACCESS_KEY: ${SLOTS_MINIO_ROOT_USER:-futureagi}
+  S3_SECRET_KEY: ${SLOTS_MINIO_ROOT_PASSWORD:-futureagi}
+  S3_BUCKET: ${SLOT_MINIO_BUCKET:?SLOT_MINIO_BUCKET is required}
+  UPLOAD_BUCKET_NAME: ${SLOT_MINIO_BUCKET:?SLOT_MINIO_BUCKET is required}
+  TEMPORAL_HOST: ${SLOT_TEMPORAL_HOST:-${SLOTS_TEMPORAL_NAME:-futureagi-slots-temporal}}:7233
+  TEMPORAL_NAMESPACE: ${SLOT_TEMPORAL_NAMESPACE:?SLOT_TEMPORAL_NAMESPACE is required}
+
+services:
+  backend:
+    <<: *slot-runtime
+    container_name: ${SLOT_BACKEND_NAME:?SLOT_BACKEND_NAME is required}
+    environment:
+      <<: *slot-state
+      # The backend is the single schema owner for its provider state.  It must
+      # migrate a newly provisioned database before becoming healthy; workers
+      # retain FAST_STARTUP=true and wait for this health gate.
+      FAST_STARTUP: "false"
+      SERVICE_TYPE: backend
+      GRANIAN_WORKERS: "1"
+      GRANIAN_THREADS: "2"
+      ENABLE_HTTP: "true"
+      ENABLE_GRPC: "false"
+      # Periodic schedules are namespace-wide and need not be re-registered by
+      # every local slot. Opt in explicitly for schedule-development work.
+      REGISTER_TEMPORAL_SCHEDULES: ${SLOT_REGISTER_TEMPORAL_SCHEDULES:-false}
+      AGENTCC_INTERNAL_URL: http://${SLOT_GATEWAY_HOST:-${SLOT_GATEWAY_NAME:-agentcc-gateway}}:8080
+      SERVING_URL: http://${SLOT_SERVING_HOST:-${SLOT_SERVING_NAME:-serving}}:8080
+      CODE_EXECUTOR_URL: http://${SLOT_EXECUTOR_HOST:-${SLOT_EXECUTOR_NAME:-code-executor}}:8060
+    healthcheck:
+      test: ["CMD-SHELL", "python -c \"import socket; socket.create_connection(('127.0.0.1', 80), 2).close()\""]
+      interval: 15s
+      timeout: 5s
+      retries: 10
+      start_period: 300s
+
+  worker:
+    <<: *slot-runtime
+    container_name: ${SLOT_WORKER_NAME:?SLOT_WORKER_NAME is required}
+    environment:
+      <<: *slot-state
+      SERVICE_TYPE: temporal-worker
+      TEMPORAL_ALL_QUEUES: "true"
+      TEMPORAL_EXCLUDED_QUEUES: ${SLOT_TEMPORAL_EXCLUDED_QUEUES:-simulation_runner}
+      TEMPORAL_MAX_CONCURRENT_ACTIVITIES: ${SLOT_TEMPORAL_MAX_CONCURRENT_ACTIVITIES:-20}
+      TEMPORAL_MAX_CONCURRENT_WORKFLOW_TASKS: ${SLOT_TEMPORAL_MAX_CONCURRENT_WORKFLOW_TASKS:-20}
+    depends_on:
+      backend:
+        condition: service_healthy
+
+networks:
+  slots:
+    name: ${SLOTS_NETWORK:-futureagi-slots}
+    external: true
+
+volumes:
+  slot-backend-media:
+    name: ${SLOT_BACKEND_MEDIA_VOLUME:-futureagi-slot-${SLOT_ID:-00}-backend-media}

--- a/slots/compose/collector.yaml
+++ b/slots/compose/collector.yaml
@@ -1,0 +1,45 @@
+name: ${SLOT_PROJECT:?SLOT_PROJECT is required}
+
+services:
+  collector:
+    container_name: ${SLOT_COLLECTOR_NAME:?SLOT_COLLECTOR_NAME is required}
+    build:
+      context: ${SLOT_WORKTREE:?SLOT_WORKTREE is required}/fi-collector
+      dockerfile: Dockerfile
+    image: ${SLOT_COLLECTOR_IMAGE:-futureagi/slot-collector}:${SLOT_ID:?SLOT_ID is required}
+    env_file:
+      - ${SLOT_ENV_FILE:?SLOT_ENV_FILE is required}
+    environment:
+      FI_CH_URL: http://${SLOT_CH_HOST:-${SLOTS_CLICKHOUSE_NAME:-futureagi-slots-clickhouse}}:8123
+      FI_CH_DATABASE: ${SLOT_CH_DATABASE:?SLOT_CH_DATABASE is required}
+      FI_PG_WRITE: postgres://${SLOTS_PG_USER:-futureagi}:${SLOTS_PG_PASSWORD:-futureagi}@${SLOT_PG_HOST:-${SLOTS_POSTGRES_NAME:-futureagi-slots-postgres}}:5432/${SLOT_PG_DB:?SLOT_PG_DB is required}?sslmode=disable
+      FI_PG_READ: postgres://${SLOTS_PG_USER:-futureagi}:${SLOTS_PG_PASSWORD:-futureagi}@${SLOT_PG_HOST:-${SLOTS_POSTGRES_NAME:-futureagi-slots-postgres}}:5432/${SLOT_PG_DB:?SLOT_PG_DB is required}?sslmode=disable
+      FI_AUTH_REDIS_ADDR: ${SLOT_REDIS_HOST:-${SLOTS_REDIS_NAME:-futureagi-slots-redis}}:6379
+      FI_AUTH_REDIS_DB: ${SLOT_REDIS_DB:?SLOT_REDIS_DB is required}
+      # fi-collector validates this provider-bound database number (0..63).
+      FI_GRPC_ADDR: ":4317"
+      FI_HTTP_ADDR: ":4318"
+      FI_ADMIN_ADDR: ":9464"
+      FI_DEAD_LETTER_FILE: /var/lib/fi-collector/dead_letter.jsonl
+    volumes:
+      - slot-collector-data:/var/lib/fi-collector
+    networks: [slots]
+    healthcheck:
+      # The production image is distroless, so use its built-in probe rather
+      # than a shell/curl command that would always fail in that image.
+      test:
+        ["CMD", "/usr/local/bin/fi-collector", "--healthcheck"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+      start_period: 30s
+    restart: unless-stopped
+
+networks:
+  slots:
+    name: ${SLOTS_NETWORK:-futureagi-slots}
+    external: true
+
+volumes:
+  slot-collector-data:
+    name: ${SLOT_COLLECTOR_VOLUME:-futureagi-slot-${SLOT_ID:-00}-collector-data}

--- a/slots/compose/control-plane.yaml
+++ b/slots/compose/control-plane.yaml
@@ -1,0 +1,157 @@
+# Shared services are started once, using a project controlled by Make.
+# All mutable data lives in named volumes; generated routes live outside a worktree.
+name: ${SLOTS_CONTROL_PROJECT:-futureagi-slots}
+
+services:
+  traefik:
+    image: traefik:v3.3
+    container_name: ${SLOTS_TRAEFIK_NAME:-futureagi-slots-traefik}
+    command: ["--configFile=/etc/traefik/traefik.yaml"]
+    ports:
+      - "127.0.0.1:${SLOTS_HTTP_PORT:-80}:80"
+    volumes:
+      - ${SLOTS_TRAEFIK_STATIC_CONFIG:-./slots/traefik/traefik.yaml}:/etc/traefik/traefik.yaml:ro
+      - ${SLOTS_ROUTE_DIR:?SLOTS_ROUTE_DIR must point outside every worktree}:/etc/traefik/dynamic:ro
+    networks: [slots]
+    healthcheck:
+      test: ["CMD", "traefik", "healthcheck", "--ping"]
+      interval: 10s
+      timeout: 3s
+      retries: 5
+    restart: unless-stopped
+
+  postgres:
+    image: postgres:16
+    container_name: ${SLOTS_POSTGRES_NAME:-futureagi-slots-postgres}
+    command: ["postgres", "-c", "wal_level=logical", "-c", "max_wal_senders=25", "-c", "max_replication_slots=25"]
+    environment:
+      POSTGRES_USER: ${SLOTS_PG_USER:-futureagi}
+      POSTGRES_PASSWORD: ${SLOTS_PG_PASSWORD:-futureagi}
+      POSTGRES_DB: ${SLOTS_PG_CONTROL_DB:-futureagi}
+    volumes:
+      - slots-postgres-data:/var/lib/postgresql/data
+    networks: [slots]
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U $${POSTGRES_USER} -d $${POSTGRES_DB}"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+    restart: unless-stopped
+
+  clickhouse:
+    image: clickhouse/clickhouse-server:25.3-alpine
+    container_name: ${SLOTS_CLICKHOUSE_NAME:-futureagi-slots-clickhouse}
+    environment:
+      CLICKHOUSE_SKIP_USER_SETUP: "1"
+      CLICKHOUSE_DB: ${SLOTS_CH_CONTROL_DB:-default}
+    volumes:
+      - slots-clickhouse-data:/var/lib/clickhouse
+      - ${SLOTS_CLICKHOUSE_STORAGE_CONFIG:-./futureagi/.ci/clickhouse-storage-policy.xml}:/etc/clickhouse-server/config.d/storage-policy.xml:ro
+      - ${SLOTS_CLICKHOUSE_TEST_CONFIG:-./futureagi/.ci/clickhouse-test-config.xml}:/etc/clickhouse-server/config.d/test-overrides.xml:ro
+    ulimits:
+      nofile: {soft: 262144, hard: 262144}
+    networks: [slots]
+    healthcheck:
+      test: ["CMD", "clickhouse-client", "--query", "SELECT 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+    restart: unless-stopped
+
+  redis:
+    image: redis:7-alpine
+    container_name: ${SLOTS_REDIS_NAME:-futureagi-slots-redis}
+    command: ["redis-server", "--appendonly", "yes", "--databases", "64"]
+    volumes:
+      - slots-redis-data:/data
+    networks: [slots]
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+    restart: unless-stopped
+
+  rabbitmq:
+    image: rabbitmq:3-management
+    container_name: ${SLOTS_RABBITMQ_NAME:-futureagi-slots-rabbitmq}
+    environment:
+      RABBITMQ_DEFAULT_USER: ${SLOTS_RABBITMQ_USER:-user}
+      RABBITMQ_DEFAULT_PASS: ${SLOTS_RABBITMQ_PASSWORD:-password}
+    volumes:
+      - slots-rabbitmq-data:/var/lib/rabbitmq
+    networks: [slots]
+    healthcheck:
+      test: ["CMD", "rabbitmq-diagnostics", "check_running"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+    restart: unless-stopped
+
+  minio:
+    image: minio/minio:RELEASE.2025-02-07T23-21-09Z
+    container_name: ${SLOTS_MINIO_NAME:-futureagi-slots-minio}
+    command: ["server", "/data", "--console-address", ":9001"]
+    environment:
+      MINIO_ROOT_USER: ${SLOTS_MINIO_ROOT_USER:-futureagi}
+      MINIO_ROOT_PASSWORD: ${SLOTS_MINIO_ROOT_PASSWORD:-futureagi}
+    volumes:
+      - slots-minio-data:/data
+    networks: [slots]
+    healthcheck:
+      test: ["CMD", "mc", "ready", "local"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+    restart: unless-stopped
+
+  temporal:
+    image: temporalio/auto-setup:1.29.1
+    container_name: ${SLOTS_TEMPORAL_NAME:-futureagi-slots-temporal}
+    environment:
+      DB: postgres12
+      DB_PORT: "5432"
+      POSTGRES_USER: ${SLOTS_PG_USER:-futureagi}
+      POSTGRES_PWD: ${SLOTS_PG_PASSWORD:-futureagi}
+      POSTGRES_SEEDS: ${SLOTS_POSTGRES_NAME:-futureagi-slots-postgres}
+      DBNAME: ${SLOTS_PG_CONTROL_DB:-futureagi}
+      ENABLE_ES: "false"
+    networks: [slots]
+    healthcheck:
+      test: ["CMD-SHELL", "pgrep -x temporal-server"]
+      interval: 10s
+      timeout: 5s
+      retries: 15
+      start_period: 90s
+    restart: unless-stopped
+
+  temporal-ui:
+    image: temporalio/ui:2.43.3
+    container_name: ${SLOTS_TEMPORAL_UI_NAME:-futureagi-slots-temporal-ui}
+    environment:
+      TEMPORAL_ADDRESS: ${SLOTS_TEMPORAL_NAME:-futureagi-slots-temporal}:7233
+      TEMPORAL_CORS_ORIGINS: http://localhost,http://*.localhost
+    networks: [slots]
+    healthcheck:
+      test: ["CMD-SHELL", "wget -q --spider http://127.0.0.1:8080 || exit 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+    restart: unless-stopped
+
+networks:
+  slots:
+    name: ${SLOTS_NETWORK:-futureagi-slots}
+    external: true
+
+volumes:
+  slots-postgres-data:
+    name: ${SLOTS_POSTGRES_VOLUME:-futureagi-slots-postgres-data}
+  slots-clickhouse-data:
+    name: ${SLOTS_CLICKHOUSE_VOLUME:-futureagi-slots-clickhouse-data}
+  slots-redis-data:
+    name: ${SLOTS_REDIS_VOLUME:-futureagi-slots-redis-data}
+  slots-rabbitmq-data:
+    name: ${SLOTS_RABBITMQ_VOLUME:-futureagi-slots-rabbitmq-data}
+  slots-minio-data:
+    name: ${SLOTS_MINIO_VOLUME:-futureagi-slots-minio-data}

--- a/slots/compose/executor.yaml
+++ b/slots/compose/executor.yaml
@@ -1,0 +1,27 @@
+name: ${SLOT_PROJECT:?SLOT_PROJECT is required}
+
+services:
+  executor:
+    container_name: ${SLOT_EXECUTOR_NAME:?SLOT_EXECUTOR_NAME is required}
+    build:
+      context: ${SLOT_WORKTREE:?SLOT_WORKTREE is required}/futureagi/code-executor
+      dockerfile: Dockerfile
+    image: ${SLOT_EXECUTOR_IMAGE:-futureagi/slot-executor}:${SLOT_ID:?SLOT_ID is required}
+    env_file:
+      - ${SLOT_ENV_FILE:?SLOT_ENV_FILE is required}
+    privileged: true
+    deploy:
+      resources:
+        limits: {memory: 1G, cpus: "2"}
+    networks: [slots]
+    healthcheck:
+      test: ["CMD-SHELL", "curl -fsS http://127.0.0.1:8060/health >/dev/null"]
+      interval: 15s
+      timeout: 5s
+      retries: 10
+    restart: unless-stopped
+
+networks:
+  slots:
+    name: ${SLOTS_NETWORK:-futureagi-slots}
+    external: true

--- a/slots/compose/frontend.yaml
+++ b/slots/compose/frontend.yaml
@@ -1,0 +1,50 @@
+# Always include this template. The frontend remains private even when every
+# other provider is shared, and Traefik reaches it over the external network.
+name: ${SLOT_PROJECT:?SLOT_PROJECT is required}
+
+services:
+  frontend:
+    container_name: ${SLOT_FRONTEND_NAME:?SLOT_FRONTEND_NAME is required}
+    build:
+      context: ${SLOT_WORKTREE:?SLOT_WORKTREE is required}
+      dockerfile: frontend/Dockerfile
+      target: dev
+    image: ${SLOT_FRONTEND_IMAGE:-futureagi/slot-frontend}:${SLOT_ID:?SLOT_ID is required}
+    working_dir: /app
+    command:
+      - /bin/sh
+      - -ec
+      - |
+        lock_hash=$$(sha256sum yarn.lock | cut -d ' ' -f1)
+        installed_hash=$$(cat node_modules/.slot-lock-hash 2>/dev/null || true)
+        if [ ! -x node_modules/.bin/vite ] || [ "$$installed_hash" != "$$lock_hash" ]; then
+          yarn install --frozen-lockfile --network-timeout 600000
+          printf '%s\n' "$$lock_hash" > node_modules/.slot-lock-hash
+        fi
+        exec yarn dev --host 0.0.0.0 --port 3000
+    env_file:
+      - ${SLOT_ENV_FILE:?SLOT_ENV_FILE is required}
+    environment:
+      VITE_USE_POLLING: "true"
+      VITE_HOST_API: http://api.${SLOT:?SLOT is required}.localhost:${SLOTS_HTTP_PORT:-80}
+      VITE_ENVIRONMENT: development
+    volumes:
+      - ${SLOT_WORKTREE:?SLOT_WORKTREE is required}/frontend:/app
+      - slot-frontend-node-modules:/app/node_modules
+    networks: [slots]
+    healthcheck:
+      test: ["CMD-SHELL", "wget -q --spider http://127.0.0.1:3000 || exit 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+      start_period: 300s
+    restart: unless-stopped
+
+networks:
+  slots:
+    name: ${SLOTS_NETWORK:-futureagi-slots}
+    external: true
+
+volumes:
+  slot-frontend-node-modules:
+    name: ${SLOT_FRONTEND_NODE_MODULES_VOLUME:-futureagi-slot-${SLOT_ID:-00}-frontend-node-modules}

--- a/slots/compose/gateway.yaml
+++ b/slots/compose/gateway.yaml
@@ -1,0 +1,34 @@
+name: ${SLOT_PROJECT:?SLOT_PROJECT is required}
+
+services:
+  gateway:
+    container_name: ${SLOT_GATEWAY_NAME:?SLOT_GATEWAY_NAME is required}
+    build:
+      context: ${SLOT_WORKTREE:?SLOT_WORKTREE is required}/agentcc-gateway
+      dockerfile: Dockerfile
+    image: ${SLOT_GATEWAY_IMAGE:-futureagi/slot-gateway}:${SLOT_ID:?SLOT_ID is required}
+    env_file:
+      - ${SLOT_ENV_FILE:?SLOT_ENV_FILE is required}
+    environment:
+      AGENTCC_INTERNAL_API_KEY: ${AGENTCC_INTERNAL_API_KEY:-local-dev-only-shared-secret-replace-me}
+      AGENTCC_ADMIN_TOKEN: ${AGENTCC_ADMIN_TOKEN:-local-dev-only-admin-token-replace-me}
+      OPENAI_API_KEY: ${OPENAI_API_KEY:-}
+      ANTHROPIC_API_KEY: ${ANTHROPIC_API_KEY:-}
+      GEMINI_API_KEY: ${GOOGLE_API_KEY:-}
+      GOOGLE_APPLICATION_CREDENTIALS: /app/Vertex_AI_Creds.json
+      AGENTCC_REDIS_ADDRESS: ${SLOT_REDIS_HOST:-${SLOTS_REDIS_NAME:-futureagi-slots-redis}}:6379
+      AGENTCC_REDIS_DB: ${SLOT_REDIS_DB:?SLOT_REDIS_DB is required}
+    volumes:
+      - ${SLOT_WORKTREE:?SLOT_WORKTREE is required}/${AGENTCC_CONFIG_PATH:-agentcc-gateway/config.example.yaml}:/app/config.yaml:ro
+      - ${GOOGLE_APPLICATION_CREDENTIALS:-/dev/null}:/app/Vertex_AI_Creds.json:ro
+    networks: [slots]
+    # The production image is `FROM scratch`: it has neither a shell nor wget.
+    # Runtime health validation must probe the routed /healthz endpoint instead.
+    healthcheck:
+      disable: true
+    restart: unless-stopped
+
+networks:
+  slots:
+    name: ${SLOTS_NETWORK:-futureagi-slots}
+    external: true

--- a/slots/compose/isolated-infra.yaml
+++ b/slots/compose/isolated-infra.yaml
@@ -1,0 +1,227 @@
+# Run only the selected profile(s) for ISOLATE_INFRA.  The planner writes the
+# matching SLOT_*_HOST values into the env file and owns exact volume purges.
+name: ${SLOT_PROJECT:?SLOT_PROJECT is required}
+
+services:
+  isolated-postgres:
+    profiles: [isolated-postgres]
+    image: postgres:16
+    container_name: ${SLOT_ISOLATED_POSTGRES_NAME:-futureagi-slot-${SLOT_ID:?SLOT_ID is required}-postgres}
+    command: ["postgres", "-c", "wal_level=logical", "-c", "max_wal_senders=25", "-c", "max_replication_slots=25"]
+    environment:
+      POSTGRES_USER: ${SLOTS_PG_USER:-futureagi}
+      POSTGRES_PASSWORD: ${SLOTS_PG_PASSWORD:-futureagi}
+      POSTGRES_DB: ${SLOT_PG_DB:?SLOT_PG_DB is required}
+    ports: ["127.0.0.1:${SLOT_POSTGRES_PORT:?SLOT_POSTGRES_PORT is required}:5432"]
+    volumes: ["slot-postgres-data:/var/lib/postgresql/data"]
+    networks: [slots]
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U $${POSTGRES_USER} -d $${POSTGRES_DB}"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+    restart: unless-stopped
+
+  isolated-clickhouse:
+    profiles: [isolated-clickhouse]
+    image: clickhouse/clickhouse-server:25.3-alpine
+    container_name: ${SLOT_ISOLATED_CLICKHOUSE_NAME:-futureagi-slot-${SLOT_ID:?SLOT_ID is required}-clickhouse}
+    environment:
+      CLICKHOUSE_SKIP_USER_SETUP: "1"
+      CLICKHOUSE_DB: ${SLOT_CH_DATABASE:?SLOT_CH_DATABASE is required}
+    ports:
+      - "127.0.0.1:${SLOT_CLICKHOUSE_HTTP_PORT:?SLOT_CLICKHOUSE_HTTP_PORT is required}:8123"
+      - "127.0.0.1:${SLOT_CLICKHOUSE_NATIVE_PORT:?SLOT_CLICKHOUSE_NATIVE_PORT is required}:9000"
+    volumes:
+      - slot-clickhouse-data:/var/lib/clickhouse
+      - ${SLOT_CLICKHOUSE_STORAGE_CONFIG:-./futureagi/.ci/clickhouse-storage-policy.xml}:/etc/clickhouse-server/config.d/storage-policy.xml:ro
+      - ${SLOTS_CLICKHOUSE_TEST_CONFIG:-./futureagi/.ci/clickhouse-test-config.xml}:/etc/clickhouse-server/config.d/test-overrides.xml:ro
+    ulimits:
+      nofile: {soft: 262144, hard: 262144}
+    networks: [slots]
+    healthcheck:
+      test: ["CMD", "clickhouse-client", "--query", "SELECT 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+    restart: unless-stopped
+
+  isolated-redis:
+    profiles: [isolated-redis]
+    image: redis:7-alpine
+    container_name: ${SLOT_ISOLATED_REDIS_NAME:-futureagi-slot-${SLOT_ID:?SLOT_ID is required}-redis}
+    command: ["redis-server", "--appendonly", "yes", "--databases", "64"]
+    ports: ["127.0.0.1:${SLOT_REDIS_PORT:?SLOT_REDIS_PORT is required}:6379"]
+    volumes: ["slot-redis-data:/data"]
+    networks: [slots]
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+    restart: unless-stopped
+
+  isolated-rabbitmq:
+    profiles: [isolated-rabbitmq]
+    image: rabbitmq:3-management
+    container_name: ${SLOT_ISOLATED_RABBITMQ_NAME:-futureagi-slot-${SLOT_ID:?SLOT_ID is required}-rabbitmq}
+    environment:
+      RABBITMQ_DEFAULT_USER: ${SLOTS_RABBITMQ_USER:-user}
+      RABBITMQ_DEFAULT_PASS: ${SLOTS_RABBITMQ_PASSWORD:-password}
+      # RabbitMQ creates this vhost (and grants the default user access) on
+      # first boot.  It is the same vhost supplied to provider containers.
+      RABBITMQ_DEFAULT_VHOST: ${SLOT_RABBITMQ_VHOST:?SLOT_RABBITMQ_VHOST is required}
+    ports:
+      - "127.0.0.1:${SLOT_RABBITMQ_PORT:?SLOT_RABBITMQ_PORT is required}:5672"
+      - "127.0.0.1:${SLOT_RABBITMQ_MANAGEMENT_PORT:?SLOT_RABBITMQ_MANAGEMENT_PORT is required}:15672"
+    volumes: ["slot-rabbitmq-data:/var/lib/rabbitmq"]
+    networks: [slots]
+    healthcheck:
+      test: ["CMD", "rabbitmq-diagnostics", "check_running"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+    restart: unless-stopped
+
+  isolated-minio:
+    profiles: [isolated-minio]
+    image: minio/minio:RELEASE.2025-02-07T23-21-09Z
+    container_name: ${SLOT_ISOLATED_MINIO_NAME:-futureagi-slot-${SLOT_ID:?SLOT_ID is required}-minio}
+    command: ["server", "/data", "--console-address", ":9001"]
+    environment:
+      MINIO_ROOT_USER: ${SLOTS_MINIO_ROOT_USER:-futureagi}
+      MINIO_ROOT_PASSWORD: ${SLOTS_MINIO_ROOT_PASSWORD:-futureagi}
+    ports:
+      - "127.0.0.1:${SLOT_MINIO_API_PORT:?SLOT_MINIO_API_PORT is required}:9000"
+      - "127.0.0.1:${SLOT_MINIO_CONSOLE_PORT:?SLOT_MINIO_CONSOLE_PORT is required}:9001"
+    volumes: ["slot-minio-data:/data"]
+    networks: [slots]
+    healthcheck:
+      test: ["CMD", "mc", "ready", "http://127.0.0.1:9000"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+    restart: unless-stopped
+
+  # The planner runs this profile service explicitly with `run --rm` after
+  # isolated-minio is healthy.  It owns no volume and is idempotent, so a
+  # repeated start never recreates or deletes provider data.
+  isolated-minio-init:
+    profiles: [isolated-minio]
+    image: minio/minio:RELEASE.2025-02-07T23-21-09Z
+    entrypoint: ["/bin/sh", "-ec"]
+    command:
+      - |
+        until mc alias set local http://${SLOT_ISOLATED_MINIO_NAME:-futureagi-slot-${SLOT_ID:?SLOT_ID is required}-minio}:9000 "$${MINIO_ROOT_USER}" "$${MINIO_ROOT_PASSWORD}"; do sleep 1; done;
+        mc mb --ignore-existing "local/${SLOT_MINIO_BUCKET:?SLOT_MINIO_BUCKET is required}"
+    environment:
+      MINIO_ROOT_USER: ${SLOTS_MINIO_ROOT_USER:-futureagi}
+      MINIO_ROOT_PASSWORD: ${SLOTS_MINIO_ROOT_PASSWORD:-futureagi}
+    depends_on:
+      isolated-minio:
+        condition: service_healthy
+    networks: [slots]
+    restart: "no"
+
+  isolated-temporal:
+    profiles: [isolated-temporal]
+    image: temporalio/auto-setup:1.29.1
+    container_name: ${SLOT_ISOLATED_TEMPORAL_NAME:-futureagi-slot-${SLOT_ID:?SLOT_ID is required}-temporal}
+    environment:
+      DB: postgres12
+      DB_PORT: "5432"
+      POSTGRES_USER: ${SLOT_TEMPORAL_POSTGRES_USER:-temporal}
+      POSTGRES_PWD: ${SLOT_TEMPORAL_POSTGRES_PASSWORD:-temporal}
+      POSTGRES_SEEDS: ${SLOT_ISOLATED_TEMPORAL_POSTGRES_NAME:-futureagi-slot-${SLOT_ID:?SLOT_ID is required}-temporal-postgres}
+      DBNAME: ${SLOT_TEMPORAL_POSTGRES_DB:-temporal}
+      ENABLE_ES: "false"
+    ports: ["127.0.0.1:${SLOT_TEMPORAL_PORT:?SLOT_TEMPORAL_PORT is required}:7233"]
+    networks: [slots]
+    depends_on:
+      isolated-temporal-postgres:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD-SHELL", "pgrep -x temporal-server"]
+      interval: 10s
+      timeout: 5s
+      retries: 15
+      start_period: 90s
+    restart: unless-stopped
+
+  # The isolated Temporal server gets its own database.  It is profile-scoped
+  # and owns the exact `temporal` volume allocated by state.volume_name().
+  isolated-temporal-postgres:
+    profiles: [isolated-temporal]
+    image: postgres:16
+    container_name: ${SLOT_ISOLATED_TEMPORAL_POSTGRES_NAME:-futureagi-slot-${SLOT_ID:?SLOT_ID is required}-temporal-postgres}
+    environment:
+      POSTGRES_USER: ${SLOT_TEMPORAL_POSTGRES_USER:-temporal}
+      POSTGRES_PASSWORD: ${SLOT_TEMPORAL_POSTGRES_PASSWORD:-temporal}
+      POSTGRES_DB: ${SLOT_TEMPORAL_POSTGRES_DB:-temporal}
+    volumes: ["slot-temporal-data:/var/lib/postgresql/data"]
+    networks: [slots]
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U $${POSTGRES_USER} -d $${POSTGRES_DB}"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+    restart: unless-stopped
+
+  # Namespace creation is deliberately a separate one-shot service: the
+  # auto-setup server must first become reachable.  The planner must include
+  # this service whenever it starts the isolated-temporal profile.
+  isolated-temporal-init:
+    profiles: [isolated-temporal]
+    image: temporalio/admin-tools:1.29.6
+    container_name: ${SLOT_ISOLATED_TEMPORAL_INIT_NAME:-futureagi-slot-${SLOT_ID:?SLOT_ID is required}-temporal-init}
+    entrypoint: ["/bin/sh", "-ec"]
+    command:
+      - |
+        temporal operator namespace describe --address "$${TEMPORAL_CLI_ADDRESS}" --namespace "${SLOT_TEMPORAL_NAMESPACE:?SLOT_TEMPORAL_NAMESPACE is required}" >/dev/null 2>&1 ||
+        temporal operator namespace create --address "$${TEMPORAL_CLI_ADDRESS}" --namespace "${SLOT_TEMPORAL_NAMESPACE:?SLOT_TEMPORAL_NAMESPACE is required}"
+    environment:
+      TEMPORAL_CLI_ADDRESS: ${SLOT_ISOLATED_TEMPORAL_NAME:-futureagi-slot-${SLOT_ID:?SLOT_ID is required}-temporal}:7233
+    depends_on:
+      isolated-temporal:
+        condition: service_healthy
+    networks: [slots]
+    restart: "no"
+
+  isolated-temporal-ui:
+    profiles: [isolated-temporal]
+    image: temporalio/ui:2.43.3
+    # This fallback keeps the isolated profile usable with the generated env
+    # files from Wave 1; a runtime may emit SLOT_TEMPORAL_UI_NAME explicitly.
+    container_name: ${SLOT_TEMPORAL_UI_NAME:-futureagi-slot-${SLOT_ID:?SLOT_ID is required}-temporal-ui}
+    environment:
+      TEMPORAL_ADDRESS: ${SLOT_ISOLATED_TEMPORAL_NAME:-futureagi-slot-${SLOT_ID:?SLOT_ID is required}-temporal}:7233
+      TEMPORAL_CORS_ORIGINS: http://${SLOT:?SLOT is required}.localhost,http://${SLOT:?SLOT is required}.localhost:${SLOTS_HTTP_PORT:-80}
+    networks: [slots]
+    depends_on:
+      isolated-temporal:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "wget", "--spider", "-q", "http://127.0.0.1:8080"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+    restart: unless-stopped
+
+networks:
+  slots:
+    name: ${SLOTS_NETWORK:-futureagi-slots}
+    external: true
+
+volumes:
+  slot-postgres-data:
+    name: ${SLOT_POSTGRES_VOLUME:-futureagi_slot_${SLOT_ID:?SLOT_ID is required}_postgres_data}
+  slot-clickhouse-data:
+    name: ${SLOT_CLICKHOUSE_VOLUME:-futureagi_slot_${SLOT_ID:?SLOT_ID is required}_clickhouse_data}
+  slot-redis-data:
+    name: ${SLOT_REDIS_VOLUME:-futureagi_slot_${SLOT_ID:?SLOT_ID is required}_redis_data}
+  slot-rabbitmq-data:
+    name: ${SLOT_RABBITMQ_VOLUME:-futureagi_slot_${SLOT_ID:?SLOT_ID is required}_rabbitmq_data}
+  slot-minio-data:
+    name: ${SLOT_MINIO_VOLUME:-futureagi_slot_${SLOT_ID:?SLOT_ID is required}_minio_data}
+  slot-temporal-data:
+    name: ${SLOT_TEMPORAL_VOLUME:-futureagi_slot_${SLOT_ID:?SLOT_ID is required}_temporal_data}

--- a/slots/compose/observability.yaml
+++ b/slots/compose/observability.yaml
@@ -1,0 +1,22 @@
+name: ${SLOT_PROJECT:?SLOT_PROJECT is required}
+
+services:
+  observability:
+    image: jaegertracing/all-in-one:1.65.0
+    container_name: ${SLOT_OBSERVABILITY_NAME:-futureagi-slot-${SLOT_ID:?SLOT_ID is required}-jaeger}
+    environment:
+      COLLECTOR_OTLP_ENABLED: "true"
+      SPAN_STORAGE_TYPE: memory
+      MEMORY_MAX_TRACES: ${SLOT_JAEGER_MAX_TRACES:-50000}
+    networks: [slots]
+    healthcheck:
+      test: ["CMD-SHELL", "wget -q --spider http://127.0.0.1:16686 || exit 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+    restart: unless-stopped
+
+networks:
+  slots:
+    name: ${SLOTS_NETWORK:-futureagi-slots}
+    external: true

--- a/slots/compose/peerdb.yaml
+++ b/slots/compose/peerdb.yaml
@@ -1,0 +1,230 @@
+# Optional, slot-private CDC stack. Its one-shot initializers are idempotent
+# Compose services, and the `peerdb` target gives lifecycle commands one safe
+# service name that brings up the complete stack.
+name: ${SLOT_PROJECT:?SLOT_PROJECT is required}
+
+x-peerdb-catalog: &peerdb-catalog
+  PEERDB_CATALOG_HOST: ${SLOT_PEERDB_CATALOG_NAME:-futureagi-slot-${SLOT_ID:?SLOT_ID is required}-peerdb-catalog}
+  PEERDB_CATALOG_PORT: "5432"
+  PEERDB_CATALOG_USER: postgres
+  PEERDB_CATALOG_PASSWORD: ${SLOT_PEERDB_PASSWORD:-peerdb}
+  PEERDB_CATALOG_DATABASE: postgres
+
+x-peerdb-flow: &peerdb-flow
+  TEMPORAL_HOST_PORT: ${SLOT_PEERDB_TEMPORAL_NAME:-futureagi-slot-${SLOT_ID:?SLOT_ID is required}-peerdb-temporal}:7233
+  PEERDB_TEMPORAL_NAMESPACE: default
+
+x-peerdb-minio: &peerdb-minio
+  PEERDB_CLICKHOUSE_AWS_CREDENTIALS_AWS_ACCESS_KEY_ID: ${SLOT_PEERDB_MINIO_USER:-peerdb}
+  PEERDB_CLICKHOUSE_AWS_CREDENTIALS_AWS_SECRET_ACCESS_KEY: ${SLOT_PEERDB_MINIO_PASSWORD:-peerdb-local-only}
+  PEERDB_CLICKHOUSE_AWS_CREDENTIALS_AWS_REGION: us-east-1
+  PEERDB_CLICKHOUSE_AWS_CREDENTIALS_AWS_ENDPOINT_URL_S3: http://${SLOT_PEERDB_MINIO_NAME:-futureagi-slot-${SLOT_ID:?SLOT_ID is required}-peerdb-minio}:9000
+  PEERDB_CLICKHOUSE_AWS_S3_BUCKET_NAME: ${SLOT_PEERDB_MINIO_BUCKET:-peerdb}
+
+services:
+  peerdb-catalog:
+    image: postgres:16-alpine
+    container_name: ${SLOT_PEERDB_CATALOG_NAME:-futureagi-slot-${SLOT_ID:?SLOT_ID is required}-peerdb-catalog}
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: ${SLOT_PEERDB_PASSWORD:-peerdb}
+      POSTGRES_DB: postgres
+    volumes: ["slot-peerdb-catalog-data:/var/lib/postgresql/data"]
+    networks: [slots]
+    healthcheck:
+      test: ["CMD", "pg_isready", "-U", "postgres"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+    restart: unless-stopped
+
+  peerdb-temporal:
+    image: temporalio/auto-setup:1.29.1
+    container_name: ${SLOT_PEERDB_TEMPORAL_NAME:-futureagi-slot-${SLOT_ID:?SLOT_ID is required}-peerdb-temporal}
+    environment:
+      DB: postgres12
+      DB_PORT: "5432"
+      POSTGRES_USER: postgres
+      POSTGRES_PWD: ${SLOT_PEERDB_PASSWORD:-peerdb}
+      POSTGRES_SEEDS: ${SLOT_PEERDB_CATALOG_NAME:-futureagi-slot-${SLOT_ID:?SLOT_ID is required}-peerdb-catalog}
+      DYNAMIC_CONFIG_FILE_PATH: config/dynamicconfig/development-sql.yaml
+    volumes:
+      - ${SLOT_WORKTREE:?SLOT_WORKTREE is required}/futureagi/config/peerdb/temporal-dynamicconfig.yaml:/etc/temporal/config/dynamicconfig/development-sql.yaml:ro
+    networks: [slots]
+    depends_on:
+      peerdb-catalog: {condition: service_healthy}
+    healthcheck:
+      test: ["CMD-SHELL", "pgrep -x temporal-server"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+      start_period: 30s
+    restart: unless-stopped
+
+  # PeerDB requires this Temporal search attribute. Wait for the server, then
+  # accept only the known `already exists` response as an idempotent success.
+  peerdb-temporal-init:
+    image: temporalio/admin-tools:1.29.6
+    container_name: ${SLOT_PEERDB_TEMPORAL_INIT_NAME:-futureagi-slot-${SLOT_ID:?SLOT_ID is required}-peerdb-temporal-init}
+    entrypoint: ["/bin/sh", "-ec"]
+    command:
+      - |
+        attempt=0;
+        while :; do
+          if attributes=$$(temporal operator search-attribute list --namespace default --address "$${PEERDB_TEMPORAL_ADDRESS}" 2>&1); then
+            if printf '%s\n' "$$attributes" | grep -Eq '(^|[[:space:]])MirrorName([[:space:]]|$$)'; then exit 0; fi;
+            if output=$$(temporal operator search-attribute create --namespace default --name MirrorName --type Keyword --address "$${PEERDB_TEMPORAL_ADDRESS}" 2>&1); then exit 0; fi;
+            if printf '%s\n' "$$output" | grep -qi 'already exists'; then exit 0; fi;
+            printf '%s\n' "$$output" >&2; exit 1;
+          fi;
+          attempt=$$((attempt + 1));
+          if [ "$$attempt" -ge 30 ]; then printf '%s\n' "$$attributes" >&2; exit 1; fi;
+          sleep 2;
+        done
+    environment:
+      PEERDB_TEMPORAL_ADDRESS: ${SLOT_PEERDB_TEMPORAL_NAME:-futureagi-slot-${SLOT_ID:?SLOT_ID is required}-peerdb-temporal}:7233
+    networks: [slots]
+    depends_on:
+      peerdb-temporal: {condition: service_healthy}
+    restart: "no"
+
+  peerdb-minio:
+    image: minio/minio:RELEASE.2025-02-07T23-21-09Z
+    container_name: ${SLOT_PEERDB_MINIO_NAME:-futureagi-slot-${SLOT_ID:?SLOT_ID is required}-peerdb-minio}
+    command: ["server", "/data"]
+    environment:
+      MINIO_ROOT_USER: ${SLOT_PEERDB_MINIO_USER:-peerdb}
+      MINIO_ROOT_PASSWORD: ${SLOT_PEERDB_MINIO_PASSWORD:-peerdb-local-only}
+    volumes: ["slot-peerdb-minio-data:/data"]
+    networks: [slots]
+    healthcheck:
+      test: ["CMD", "mc", "ready", "local"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+    restart: unless-stopped
+
+  # PeerDB's ClickHouse staging bucket is separate from the application MinIO
+  # bucket. The runtime can safely rerun this one-shot initializer.
+  peerdb-minio-init:
+    image: minio/minio:RELEASE.2025-02-07T23-21-09Z
+    container_name: ${SLOT_PEERDB_MINIO_INIT_NAME:-futureagi-slot-${SLOT_ID:?SLOT_ID is required}-peerdb-minio-init}
+    entrypoint: ["/bin/sh", "-ec"]
+    command:
+      - |
+        until mc alias set local http://${SLOT_PEERDB_MINIO_NAME:-futureagi-slot-${SLOT_ID:?SLOT_ID is required}-peerdb-minio}:9000 "$${MINIO_ROOT_USER}" "$${MINIO_ROOT_PASSWORD}"; do sleep 1; done;
+        mc mb --ignore-existing "local/${SLOT_PEERDB_MINIO_BUCKET:-peerdb}"
+    environment:
+      MINIO_ROOT_USER: ${SLOT_PEERDB_MINIO_USER:-peerdb}
+      MINIO_ROOT_PASSWORD: ${SLOT_PEERDB_MINIO_PASSWORD:-peerdb-local-only}
+    networks: [slots]
+    depends_on:
+      peerdb-minio: {condition: service_healthy}
+    restart: "no"
+
+  peerdb-flow-api:
+    image: ghcr.io/peerdb-io/flow-api:stable-v0.36.9
+    container_name: ${SLOT_PEERDB_FLOW_API_NAME:-futureagi-slot-${SLOT_ID:?SLOT_ID is required}-peerdb-flow-api}
+    environment:
+      <<: [*peerdb-catalog, *peerdb-flow, *peerdb-minio]
+    networks: [slots]
+    depends_on:
+      peerdb-temporal: {condition: service_healthy}
+      peerdb-minio-init: {condition: service_completed_successfully}
+    restart: unless-stopped
+
+  peerdb-flow-worker:
+    image: ghcr.io/peerdb-io/flow-worker:stable-v0.36.9
+    container_name: ${SLOT_PEERDB_FLOW_WORKER_NAME:-futureagi-slot-${SLOT_ID:?SLOT_ID is required}-peerdb-flow-worker}
+    environment:
+      <<: [*peerdb-catalog, *peerdb-flow, *peerdb-minio]
+    networks: [slots]
+    depends_on:
+      peerdb-temporal: {condition: service_healthy}
+      peerdb-minio-init: {condition: service_completed_successfully}
+    restart: unless-stopped
+
+  peerdb-server:
+    image: ghcr.io/peerdb-io/peerdb-server:stable-v0.36.9
+    container_name: ${SLOT_PEERDB_SERVER_NAME:-futureagi-slot-${SLOT_ID:?SLOT_ID is required}-peerdb-server}
+    stop_signal: SIGINT
+    environment:
+      <<: *peerdb-catalog
+      PEERDB_PASSWORD: ${SLOT_PEERDB_PASSWORD:-peerdb}
+      PEERDB_FLOW_SERVER_ADDRESS: grpc://${SLOT_PEERDB_FLOW_API_NAME:-futureagi-slot-${SLOT_ID:?SLOT_ID is required}-peerdb-flow-api}:8112
+    networks: [slots]
+    depends_on:
+      peerdb-catalog: {condition: service_healthy}
+    restart: unless-stopped
+
+  peerdb-ui:
+    image: ghcr.io/peerdb-io/peerdb-ui:stable-v0.36.9
+    container_name: ${SLOT_PEERDB_UI_NAME:?SLOT_PEERDB_UI_NAME is required}
+    environment:
+      <<: *peerdb-catalog
+      PEERDB_FLOW_SERVER_HTTP: http://${SLOT_PEERDB_FLOW_API_NAME:-futureagi-slot-${SLOT_ID:?SLOT_ID is required}-peerdb-flow-api}:8113
+      NEXTAUTH_SECRET: ${SLOT_PEERDB_NEXTAUTH_SECRET:-peerdb-local-only}
+      NEXTAUTH_URL: http://peerdb.${SLOT:?SLOT is required}.localhost:${SLOTS_HTTP_PORT:-80}
+    networks: [slots]
+    depends_on:
+      peerdb-flow-api: {condition: service_started}
+    healthcheck:
+      test: ["CMD-SHELL", "wget -q --spider http://127.0.0.1:3000 || exit 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+    restart: unless-stopped
+
+  # Canonical peer/mirror setup, bound to the selected backend provider rather
+  # than root-compose service names. The script retries server readiness and is
+  # intentionally idempotent (`CREATE ... IF NOT EXISTS`).
+  peerdb-init:
+    image: postgres:16
+    container_name: ${SLOT_PEERDB_INIT_NAME:-futureagi-slot-${SLOT_ID:?SLOT_ID is required}-peerdb-init}
+    entrypoint: ["/bin/bash", "/scripts/peerdb-setup-mirrors.sh"]
+    environment:
+      PEERDB_HOST: ${SLOT_PEERDB_SERVER_NAME:-futureagi-slot-${SLOT_ID:?SLOT_ID is required}-peerdb-server}
+      PEERDB_PORT: "9900"
+      SRC_PG_HOST: ${SLOT_PG_HOST:-${SLOTS_POSTGRES_NAME:-futureagi-slots-postgres}}
+      SRC_PG_PORT: "5432"
+      SRC_PG_USER: ${SLOTS_PG_USER:-futureagi}
+      SRC_PG_PASSWORD: ${SLOTS_PG_PASSWORD:-futureagi}
+      SRC_PG_DB: ${SLOT_PG_DB:?SLOT_PG_DB is required}
+      DST_CH_HOST: ${SLOT_CH_HOST:-${SLOTS_CLICKHOUSE_NAME:-futureagi-slots-clickhouse}}
+      DST_CH_PORT: "9000"
+      DST_CH_USER: ${SLOTS_CH_USER:-default}
+      DST_CH_PASSWORD: ${SLOTS_CH_PASSWORD:-}
+      DST_CH_DB: ${SLOT_CH_DATABASE:?SLOT_CH_DATABASE is required}
+    volumes:
+      - ${SLOT_WORKTREE:?SLOT_WORKTREE is required}/futureagi/scripts/peerdb-setup-mirrors.sh:/scripts/peerdb-setup-mirrors.sh:ro
+    networks: [slots]
+    depends_on:
+      peerdb-server: {condition: service_started}
+      peerdb-temporal-init: {condition: service_completed_successfully}
+      peerdb-minio-init: {condition: service_completed_successfully}
+    restart: "no"
+
+  # The lifecycle provider target. Compose starts all dependencies, including
+  # the one-shot initialization services, before marking this target complete.
+  peerdb:
+    image: busybox:1.36
+    container_name: ${SLOT_PEERDB_AGGREGATE_NAME:-futureagi-slot-${SLOT_ID:?SLOT_ID is required}-peerdb-aggregate}
+    command: ["true"]
+    networks: [slots]
+    depends_on:
+      peerdb-flow-worker: {condition: service_started}
+      peerdb-ui: {condition: service_started}
+      peerdb-init: {condition: service_completed_successfully}
+      peerdb-minio-init: {condition: service_completed_successfully}
+    restart: "no"
+
+networks:
+  slots:
+    name: ${SLOTS_NETWORK:-futureagi-slots}
+    external: true
+
+volumes:
+  slot-peerdb-catalog-data:
+    name: ${SLOT_PEERDB_CATALOG_VOLUME:-futureagi-slot-${SLOT_ID:-00}-peerdb-catalog-data}
+  slot-peerdb-minio-data:
+    name: ${SLOT_PEERDB_MINIO_VOLUME:-futureagi-slot-${SLOT_ID:-00}-peerdb-minio-data}

--- a/slots/compose/serving.yaml
+++ b/slots/compose/serving.yaml
@@ -1,0 +1,27 @@
+name: ${SLOT_PROJECT:?SLOT_PROJECT is required}
+
+services:
+  serving:
+    container_name: ${SLOT_SERVING_NAME:?SLOT_SERVING_NAME is required}
+    build:
+      context: ${SLOT_WORKTREE:?SLOT_WORKTREE is required}/futureagi/model_serving
+      dockerfile: Dockerfile
+    image: ${SLOT_SERVING_IMAGE:-futureagi/slot-serving}:${SLOT_ID:?SLOT_ID is required}
+    env_file:
+      - ${SLOT_ENV_FILE:?SLOT_ENV_FILE is required}
+    working_dir: /app/embedding
+    volumes:
+      - ${SLOT_WORKTREE:?SLOT_WORKTREE is required}/futureagi/model_serving:/app/embedding
+    networks: [slots]
+    healthcheck:
+      test: ["CMD-SHELL", "curl -fsS http://127.0.0.1:8080/health >/dev/null"]
+      interval: 15s
+      timeout: 5s
+      retries: 20
+      start_period: 120s
+    restart: unless-stopped
+
+networks:
+  slots:
+    name: ${SLOTS_NETWORK:-futureagi-slots}
+    external: true

--- a/slots/compose/simulation.yaml
+++ b/slots/compose/simulation.yaml
@@ -1,0 +1,67 @@
+# Private hosted simulation runner. It uses the selected backend state tuple.
+name: ${SLOT_PROJECT:?SLOT_PROJECT is required}
+
+services:
+  simulation:
+    container_name: ${SLOT_SIMULATION_NAME:?SLOT_SIMULATION_NAME is required}
+    build:
+      context: ${SLOT_WORKTREE:?SLOT_WORKTREE is required}
+      dockerfile: Dockerfile.simulation-runner.dev
+      args:
+        BACKEND_IMAGE: ${SLOT_BACKEND_IMAGE_REF:?SLOT_BACKEND_IMAGE_REF is required}
+    image: ${SLOT_SIMULATION_IMAGE:-futureagi/slot-simulation}:${SLOT_ID:?SLOT_ID is required}
+    working_dir: /app/backend
+    env_file:
+      - ${SLOT_ENV_FILE:?SLOT_ENV_FILE is required}
+    environment:
+      ENV_TYPE: local
+      DJANGO_SETTINGS_MODULE: tfc.settings.settings
+      SERVICE_TYPE: temporal-worker
+      TEMPORAL_TASK_QUEUE: simulation_runner
+      TEMPORAL_ALL_QUEUES: "false"
+      TEMPORAL_HOST: ${SLOT_TEMPORAL_HOST:-${SLOTS_TEMPORAL_NAME:-futureagi-slots-temporal}}:7233
+      TEMPORAL_NAMESPACE: ${SLOT_TEMPORAL_NAMESPACE:?SLOT_TEMPORAL_NAMESPACE is required}
+      PG_HOST: ${SLOT_PG_HOST:-${SLOTS_POSTGRES_NAME:-futureagi-slots-postgres}}
+      PG_PORT: "5432"
+      PG_DB: ${SLOT_PG_DB:?SLOT_PG_DB is required}
+      PG_USER: ${SLOTS_PG_USER:-futureagi}
+      PG_PASSWORD: ${SLOTS_PG_PASSWORD:-futureagi}
+      PGBOUNCER_HOST: ${SLOT_PG_HOST:-${SLOTS_POSTGRES_NAME:-futureagi-slots-postgres}}
+      PGBOUNCER_PORT: "5432"
+      CH_HOST: ${SLOT_CH_HOST:-${SLOTS_CLICKHOUSE_NAME:-futureagi-slots-clickhouse}}
+      CH_PORT: "9000"
+      CH_HTTP_PORT: "8123"
+      CH_DATABASE: ${SLOT_CH_DATABASE:?SLOT_CH_DATABASE is required}
+      CH25_DATABASE: ${SLOT_CH_DATABASE:?SLOT_CH_DATABASE is required}
+      REDIS_HOST: ${SLOT_REDIS_HOST:-${SLOTS_REDIS_NAME:-futureagi-slots-redis}}
+      REDIS_PORT: "6379"
+      REDIS_URL: redis://${SLOT_REDIS_HOST:-${SLOTS_REDIS_NAME:-futureagi-slots-redis}}:6379/${SLOT_REDIS_DB:?SLOT_REDIS_DB is required}
+      REDIS_CACHE_URL: redis://${SLOT_REDIS_HOST:-${SLOTS_REDIS_NAME:-futureagi-slots-redis}}:6379/${SLOT_REDIS_CACHE_DB:?SLOT_REDIS_CACHE_DB is required}
+      REDIS_LOCK_URL: redis://${SLOT_REDIS_HOST:-${SLOTS_REDIS_NAME:-futureagi-slots-redis}}:6379/${SLOT_REDIS_LOCK_DB:?SLOT_REDIS_LOCK_DB is required}
+      CELERY_BROKER_URL: amqp://${SLOTS_RABBITMQ_USER:-user}:${SLOTS_RABBITMQ_PASSWORD:-password}@${SLOT_RABBITMQ_HOST:-${SLOTS_RABBITMQ_NAME:-futureagi-slots-rabbitmq}}:5672/${SLOT_RABBITMQ_VHOST:?SLOT_RABBITMQ_VHOST is required}
+      STORAGE_BACKEND: minio
+      S3_ENDPOINT_URL: http://${SLOT_MINIO_HOST:-${SLOTS_MINIO_NAME:-futureagi-slots-minio}}:9000
+      MINIO_URL: http://minio.${SLOT:?SLOT is required}.localhost:${SLOTS_HTTP_PORT:-80}
+      S3_ACCESS_KEY: ${SLOTS_MINIO_ROOT_USER:-futureagi}
+      S3_SECRET_KEY: ${SLOTS_MINIO_ROOT_PASSWORD:-futureagi}
+      S3_BUCKET: ${SLOT_MINIO_BUCKET:?SLOT_MINIO_BUCKET is required}
+      UPLOAD_BUCKET_NAME: ${SLOT_MINIO_BUCKET:?SLOT_MINIO_BUCKET is required}
+      ALK_RUNNER_API_URL: http://${SLOT_BACKEND_HOST:-${SLOT_BACKEND_NAME:-backend}}:80
+      FAST_STARTUP: "true"
+      HOSTED_RUNNER_ENABLED: "true"
+      ALK_RUNNER_MAX_CONCURRENCY: ${SLOT_SIMULATION_CONCURRENCY:-4}
+    volumes:
+      - ${SLOT_WORKTREE:?SLOT_WORKTREE is required}/futureagi:/app/backend
+      - ${GOOGLE_APPLICATION_CREDENTIALS:-/dev/null}:/app/backend/Vertex_AI_Creds.json:ro
+    networks: [slots]
+    healthcheck:
+      test: ["CMD-SHELL", "test -f /app/backend/manage.py"]
+      interval: 15s
+      timeout: 5s
+      retries: 10
+    restart: unless-stopped
+
+networks:
+  slots:
+    name: ${SLOTS_NETWORK:-futureagi-slots}
+    external: true

--- a/slots/config/compose-catalog.yaml
+++ b/slots/config/compose-catalog.yaml
@@ -1,0 +1,258 @@
+# Stable interface between the slot planner and Compose/routing templates.
+# Values marked required are emitted into the private, mode-0600 slot env file.
+# The worktree-root .env is copied first; generated topology is appended last so
+# application configuration is inherited without allowing it to replace slot
+# identity, routing, or state values with the same key.
+version: 1
+
+compose:
+  control_plane: slots/compose/control-plane.yaml
+  isolated_infra: slots/compose/isolated-infra.yaml
+  frontend: slots/compose/frontend.yaml
+  backend: slots/compose/backend.yaml
+  simulation: slots/compose/simulation.yaml
+  gateway: slots/compose/gateway.yaml
+  collector: slots/compose/collector.yaml
+  serving: slots/compose/serving.yaml
+  executor: slots/compose/executor.yaml
+  peerdb: slots/compose/peerdb.yaml
+  observability: slots/compose/observability.yaml
+  traefik_static: slots/traefik/traefik.yaml
+  traefik_routes_template: slots/traefik/routes.template.yaml
+
+environment:
+  control_plane:
+    SLOTS_CONTROL_PROJECT: futureagi-slots
+    SLOTS_NETWORK: futureagi-slots
+    SLOTS_HTTP_PORT: "80"
+    SLOTS_STATE_DIR: required
+    SLOTS_ROUTE_DIR: required
+    SLOTS_TRAEFIK_NAME: futureagi-slots-traefik
+    SLOTS_POSTGRES_NAME: futureagi-slots-postgres
+    SLOTS_CLICKHOUSE_NAME: futureagi-slots-clickhouse
+    SLOTS_REDIS_NAME: futureagi-slots-redis
+    SLOTS_RABBITMQ_NAME: futureagi-slots-rabbitmq
+    SLOTS_MINIO_NAME: futureagi-slots-minio
+    SLOTS_TEMPORAL_NAME: futureagi-slots-temporal
+    SLOTS_TEMPORAL_UI_NAME: futureagi-slots-temporal-ui
+  slot:
+    SLOT: required
+    SLOT_ID: required # zero-padded 01..20
+    SLOT_PROJECT: required
+    SLOT_WORKTREE: required
+    SLOT_ENV_FILE: required
+    SLOT_STATE_ID: required # e.g. futureagi-slot-03
+    SLOT_ROUTE_FILE: required
+    SLOT_FRONTEND_NAME: required
+    SLOT_BACKEND_NAME: required
+    SLOT_WORKER_NAME: required
+    SLOT_SIMULATION_NAME: required
+    SLOT_GATEWAY_NAME: required
+    SLOT_COLLECTOR_NAME: required
+    SLOT_SERVING_NAME: required
+    SLOT_EXECUTOR_NAME: required
+    SLOT_PEERDB_UI_NAME: required
+    SLOT_OBSERVABILITY_NAME: required
+    SLOT_PG_DB: required
+    SLOT_CH_DATABASE: required
+    SLOT_REDIS_DB: required
+    SLOT_REDIS_CACHE_DB: required
+    SLOT_REDIS_LOCK_DB: required
+    SLOT_RABBITMQ_VHOST: required
+    SLOT_MINIO_BUCKET: required
+    SLOT_TEMPORAL_NAMESPACE: required
+    # Optional explicit isolated resource names.  Compose defaults below are
+    # deterministic, but emitting them makes route selection inspectable.
+    SLOT_ISOLATED_POSTGRES_NAME: optional
+    SLOT_ISOLATED_CLICKHOUSE_NAME: optional
+    SLOT_ISOLATED_REDIS_NAME: optional
+    SLOT_ISOLATED_RABBITMQ_NAME: optional
+    SLOT_ISOLATED_MINIO_NAME: optional
+    SLOT_ISOLATED_TEMPORAL_NAME: optional
+    SLOT_ISOLATED_TEMPORAL_POSTGRES_NAME: optional
+    SLOT_TEMPORAL_UI_NAME: optional
+    SLOT_TEMPORAL_POSTGRES_USER: optional
+    SLOT_TEMPORAL_POSTGRES_PASSWORD: optional
+    SLOT_TEMPORAL_POSTGRES_DB: optional
+    # Provider identity overrides. The runtime must emit the shared values in
+    # shared_provider_overrides for a shared project; omitting them preserves
+    # the slot-private defaults embedded in each Compose template.
+    SLOT_BACKEND_MEDIA_VOLUME: optional
+    SLOT_COLLECTOR_VOLUME: optional
+    SLOT_PEERDB_CATALOG_NAME: optional
+    SLOT_PEERDB_TEMPORAL_NAME: optional
+    SLOT_PEERDB_TEMPORAL_INIT_NAME: optional
+    SLOT_PEERDB_MINIO_NAME: optional
+    SLOT_PEERDB_MINIO_INIT_NAME: optional
+    SLOT_PEERDB_FLOW_API_NAME: optional
+    SLOT_PEERDB_FLOW_WORKER_NAME: optional
+    SLOT_PEERDB_SERVER_NAME: optional
+    SLOT_PEERDB_INIT_NAME: optional
+    SLOT_PEERDB_AGGREGATE_NAME: optional
+    SLOT_PEERDB_CATALOG_VOLUME: optional
+    SLOT_PEERDB_MINIO_VOLUME: optional
+    SLOT_PORT_BASE: required # 20000 + SLOT * 100; host mappings are loopback-only
+    SLOT_POSTGRES_PORT: optional # SLOT_PORT_BASE + 1, for isolated postgres
+    SLOT_CLICKHOUSE_HTTP_PORT: optional # SLOT_PORT_BASE + 2
+    SLOT_CLICKHOUSE_NATIVE_PORT: optional # SLOT_PORT_BASE + 3
+    SLOT_REDIS_PORT: optional # SLOT_PORT_BASE + 4
+    SLOT_RABBITMQ_PORT: optional # SLOT_PORT_BASE + 5
+    SLOT_RABBITMQ_MANAGEMENT_PORT: optional # SLOT_PORT_BASE + 6
+    SLOT_MINIO_API_PORT: optional # SLOT_PORT_BASE + 7
+    SLOT_MINIO_CONSOLE_PORT: optional # SLOT_PORT_BASE + 8
+    SLOT_TEMPORAL_PORT: optional # SLOT_PORT_BASE + 9
+
+isolated_infra:
+  volumes:
+    postgres: futureagi_slot_${slot_id}_postgres_data
+    clickhouse: futureagi_slot_${slot_id}_clickhouse_data
+    redis: futureagi_slot_${slot_id}_redis_data
+    rabbitmq: futureagi_slot_${slot_id}_rabbitmq_data
+    minio: futureagi_slot_${slot_id}_minio_data
+    temporal: futureagi_slot_${slot_id}_temporal_data
+  startup_services:
+    minio: [isolated-minio, isolated-minio-init]
+    temporal: [isolated-temporal-postgres, isolated-temporal, isolated-temporal-init, isolated-temporal-ui]
+  initialization:
+    rabbitmq: SLOT_RABBITMQ_VHOST
+    minio: SLOT_MINIO_BUCKET
+    temporal: SLOT_TEMPORAL_NAMESPACE
+
+provider_groups:
+  none: []
+  backend: [backend, worker]
+  simulation: [simulation]
+  gateway: [gateway]
+  collector: [collector]
+  serving: [serving]
+  executor: [executor]
+  peerdb: [peerdb, peerdb-catalog, peerdb-temporal, peerdb-temporal-init, peerdb-minio, peerdb-minio-init, peerdb-flow-api, peerdb-flow-worker, peerdb-server, peerdb-ui, peerdb-init]
+  observability: [observability]
+  all: [backend, worker, simulation, gateway, collector, serving, executor, peerdb, observability]
+
+# Names supplied when an omitted provider is started once as a shared default.
+# Runtime must write these values into the owner slot's generated env file;
+# Compose uses its documented slot-name fallbacks only for private providers.
+shared_provider_overrides:
+  backend:
+    SLOT_BACKEND_NAME: shared-backend
+    SLOT_WORKER_NAME: shared-backend-worker
+    SLOT_BACKEND_MEDIA_VOLUME: futureagi-shared-backend-media
+  simulation:
+    SLOT_SIMULATION_NAME: shared-simulation
+  gateway:
+    SLOT_GATEWAY_NAME: shared-gateway
+  collector:
+    SLOT_COLLECTOR_NAME: shared-collector
+    SLOT_COLLECTOR_VOLUME: futureagi-shared-collector-data
+  serving:
+    SLOT_SERVING_NAME: shared-serving
+  executor:
+    SLOT_EXECUTOR_NAME: shared-executor
+  observability:
+    SLOT_OBSERVABILITY_NAME: shared-observability
+  peerdb:
+    SLOT_PEERDB_AGGREGATE_NAME: shared-peerdb-aggregate
+    SLOT_PEERDB_CATALOG_NAME: shared-peerdb-catalog
+    SLOT_PEERDB_TEMPORAL_NAME: shared-peerdb-temporal
+    SLOT_PEERDB_TEMPORAL_INIT_NAME: shared-peerdb-temporal-init
+    SLOT_PEERDB_MINIO_NAME: shared-peerdb-minio
+    SLOT_PEERDB_MINIO_INIT_NAME: shared-peerdb-minio-init
+    SLOT_PEERDB_FLOW_API_NAME: shared-peerdb-flow-api
+    SLOT_PEERDB_FLOW_WORKER_NAME: shared-peerdb-flow-worker
+    SLOT_PEERDB_SERVER_NAME: shared-peerdb-server
+    SLOT_PEERDB_UI_NAME: shared-peerdb-ui
+    SLOT_PEERDB_INIT_NAME: shared-peerdb-init
+    SLOT_PEERDB_CATALOG_VOLUME: futureagi-shared-peerdb-catalog-data
+    SLOT_PEERDB_MINIO_VOLUME: futureagi-shared-peerdb-minio-data
+
+private_provider_defaults:
+  containers: futureagi-slot-${slot_id}-${provider} (or the documented PeerDB component suffix)
+  backend_media_volume: futureagi-slot-${slot_id}-backend-media
+  collector_volume: futureagi-slot-${slot_id}-collector-data
+  peerdb_catalog_volume: futureagi-slot-${slot_id}-peerdb-catalog-data
+  peerdb_minio_volume: futureagi-slot-${slot_id}-peerdb-minio-data
+
+state_coupled_provider_closure:
+  backend: [backend, worker]
+  simulation:
+    requires: [backend]
+    state: uses the selected backend provider's PostgreSQL, ClickHouse, Redis, RabbitMQ, MinIO, and Temporal tuple
+  collector:
+    requires: [backend]
+    state: uses the selected backend provider's PostgreSQL, ClickHouse, and Redis tuple
+  peerdb:
+    requires: [backend]
+    state: mirrors the selected backend provider's PostgreSQL database into its selected ClickHouse database
+
+teardown_contract:
+  ordinary_down: docker compose down without --volumes; provider data is retained
+  volume_removal: only exact named volumes selected by the generated SLOT_*_VOLUME overrides may be removed
+  shared_refusal: shared provider volumes are never selected by slot-purge
+
+routes:
+  frontend: {host: "${slot}.localhost", target_env: SLOT_FRONTEND_NAME, port: 3000}
+  backend: {host: "api.${slot}.localhost", target_env: SLOT_BACKEND_NAME, port: 80}
+  temporal: {host: "temporal.${slot}.localhost", target_env: SLOTS_TEMPORAL_UI_NAME, port: 8080}
+  minio: {host: "minio.${slot}.localhost", target_env: SLOTS_MINIO_NAME, port: 9000}
+  minio_console: {host: "minio-console.${slot}.localhost", target_env: SLOTS_MINIO_NAME, port: 9001}
+  rabbitmq: {host: "rabbitmq.${slot}.localhost", target_env: SLOTS_RABBITMQ_NAME, port: 15672}
+  gateway: {host: "gateway.${slot}.localhost", target_env: SLOT_GATEWAY_NAME, port: 8080}
+  serving: {host: "serving.${slot}.localhost", target_env: SLOT_SERVING_NAME, port: 8080}
+  collector: {host: "collector.${slot}.localhost", target_env: SLOT_COLLECTOR_NAME, port: 9464}
+  executor: {host: "executor.${slot}.localhost", target_env: SLOT_EXECUTOR_NAME, port: 8060}
+  jaeger: {host: "jaeger.${slot}.localhost", target_env: SLOT_OBSERVABILITY_NAME, port: 16686}
+  peerdb: {host: "peerdb.${slot}.localhost", target_env: SLOT_PEERDB_UI_NAME, port: 3000}
+
+public_urls:
+  scheme: http
+  port_env: SLOTS_HTTP_PORT
+  default_port: "80"
+  rendering: omit the port when SLOTS_HTTP_PORT is 80; otherwise append :${SLOTS_HTTP_PORT}
+
+# The route file is per-slot, but its template tokens retain the historical
+# SLOTS_* names.  Before rendering an isolated slot, the runtime must choose
+# the matching isolated container names below instead of the control-plane
+# defaults.  It must also start temporal's init/UI services listed above.
+runtime_requirements:
+  completion_contracts:
+    peerdb:
+      aggregate_service: peerdb
+      initializers: [peerdb-temporal-init, peerdb-minio-init, peerdb-init]
+      success_condition: service_completed_successfully
+      startup_gate: compose_up_dependency_conditions
+  route_target_selection:
+    shared:
+      SLOTS_MINIO_NAME: futureagi-slots-minio
+      SLOTS_RABBITMQ_NAME: futureagi-slots-rabbitmq
+      SLOTS_TEMPORAL_UI_NAME: futureagi-slots-temporal-ui
+    isolated:
+      minio: SLOT_ISOLATED_MINIO_NAME
+      rabbitmq: SLOT_ISOLATED_RABBITMQ_NAME
+      temporal: SLOT_TEMPORAL_UI_NAME
+  isolated_compose:
+    - Emit the SLOT_ISOLATED_* names (or accept the documented Compose defaults).
+    - Start isolated-minio, then run isolated-minio-init with --rm to create SLOT_MINIO_BUCKET.
+    - Start isolated-temporal-init and isolated-temporal-ui with isolated-temporal.
+    - Route MinIO API to port 9000; expose the console only at minio-console.${slot}.localhost.
+  public_status:
+    - Build all returned browser URLs with public_urls.port_env.
+  health:
+    - Probe gateway through http://gateway.${slot}.localhost[:SLOTS_HTTP_PORT]/healthz because its scratch image has no in-container probe.
+  reload:
+    backend: bind-mounted Django source with the local development entrypoint reload.
+    frontend: bind-mounted Vite source with the dev server reload.
+    simulation: bind-mounted backend source; restart its worker after dependency changes.
+    collector: immutable distroless image; rebuild and recreate after source changes.
+    gateway: immutable scratch image; rebuild and recreate after source/config changes.
+    serving: image-based provider; rebuild and recreate after source changes.
+    executor: image-based provider; rebuild and recreate after source changes.
+
+invariants:
+  - The control plane and every provider join the pre-created external SLOTS_NETWORK.
+  - Traefik only reads generated file-provider routes; it never receives a Docker socket.
+  - The frontend template is always selected and no provider template publishes a host port by default.
+  - Generated route and env files live beneath SLOTS_STATE_DIR, outside slot worktrees.
+  - A generated provider env inherits its owner worktree's root .env, then appends generated topology values with higher precedence.
+  - Dedicated host mappings use 127.0.0.1:${SLOT_PORT_BASE}+offset only.
+  - "minio.${slot}.localhost is the S3 API; the optional console is minio-console.${slot}.localhost."

--- a/slots/models.py
+++ b/slots/models.py
@@ -1,0 +1,294 @@
+"""Typed, versioned data exchanged by the slot orchestration boundary."""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass, field
+from typing import Any
+
+from .catalog import CATALOG, ISOLATABLE_INFRA
+
+STATE_COUPLED_GROUPS = frozenset(("simulation", "collector", "peerdb"))
+
+REGISTRY_VERSION = 1
+
+
+@dataclass(frozen=True)
+class ResourceEstimate:
+    memory_mib: int
+    services: tuple[str, ...]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {"memory_mib": self.memory_mib, "services": list(self.services)}
+
+    @classmethod
+    def from_dict(cls, value: dict[str, Any]) -> ResourceEstimate:
+        return cls(int(value["memory_mib"]), tuple(value["services"]))
+
+
+@dataclass(frozen=True)
+class StateIdentity:
+    """A serialisable snapshot of the backend provider's state identity."""
+
+    slot: int
+    postgres_database: str
+    clickhouse_database: str
+    temporal_namespace: str
+    rabbitmq_vhost: str
+    minio_bucket: str
+    redis_databases: tuple[int, int, int]
+
+    @classmethod
+    def for_slot(cls, slot: int) -> StateIdentity:
+        if not 0 <= slot <= 20:
+            raise ValueError("state slot must be an integer from 0 through 20")
+        padded = f"{slot:02d}"
+        return cls(
+            slot=slot,
+            postgres_database=f"futureagi_slot_{padded}",
+            clickhouse_database=f"futureagi_slot_{padded}",
+            temporal_namespace=f"futureagi-slot-{padded}",
+            rabbitmq_vhost=f"futureagi-slot-{padded}",
+            minio_bucket=f"futureagi-slot-{padded}",
+            redis_databases=(slot * 3, slot * 3 + 1, slot * 3 + 2),
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        return {**asdict(self), "redis_databases": list(self.redis_databases)}
+
+    @classmethod
+    def from_dict(cls, value: dict[str, Any]) -> StateIdentity:
+        return cls(
+            slot=int(value["slot"]),
+            postgres_database=str(value["postgres_database"]),
+            clickhouse_database=str(value["clickhouse_database"]),
+            temporal_namespace=str(value["temporal_namespace"]),
+            rabbitmq_vhost=str(value["rabbitmq_vhost"]),
+            minio_bucket=str(value["minio_bucket"]),
+            redis_databases=tuple(int(item) for item in value["redis_databases"]),
+        )
+
+
+@dataclass(frozen=True)
+class ProviderRecord:
+    name: str
+    group: str
+    worktree: str
+    state: StateIdentity
+    references: tuple[int, ...] = ()
+    private: bool = False
+    base_ref: str = "origin/dev"
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            **asdict(self),
+            "state": self.state.to_dict(),
+            "references": list(self.references),
+        }
+
+    @classmethod
+    def from_dict(cls, value: dict[str, Any]) -> ProviderRecord:
+        return cls(
+            name=str(value["name"]),
+            group=str(value["group"]),
+            worktree=str(value["worktree"]),
+            state=StateIdentity.from_dict(value["state"]),
+            references=tuple(int(item) for item in value.get("references", [])),
+            private=bool(value.get("private", False)),
+            base_ref=str(value.get("base_ref", "origin/dev")),
+        )
+
+
+@dataclass(frozen=True)
+class SlotRecord:
+    slot: int
+    worktree: str
+    requested_services: tuple[str, ...]
+    services: tuple[str, ...]
+    providers: dict[str, str]
+    state: StateIdentity
+    routes: dict[str, str]
+    ports: dict[str, int]
+    resources: ResourceEstimate
+    environment_fingerprint: str = ""
+    revision: str = ""
+    isolated_infra: tuple[str, ...] = ()
+    http_port: str = "80"
+    retired_isolated_infra: tuple[str, ...] = ()
+    retained_private_backend_state: bool = False
+    shared_base_ref: str = "origin/dev"
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            **asdict(self),
+            "requested_services": list(self.requested_services),
+            "services": list(self.services),
+            "state": self.state.to_dict(),
+            "resources": self.resources.to_dict(),
+            "isolated_infra": list(self.isolated_infra),
+            "retired_isolated_infra": list(self.retired_isolated_infra),
+            "retained_private_backend_state": self.retained_private_backend_state,
+            "shared_base_ref": self.shared_base_ref,
+            "http_port": self.http_port,
+        }
+
+    @classmethod
+    def from_dict(cls, value: dict[str, Any]) -> SlotRecord:
+        return cls(
+            slot=int(value["slot"]),
+            worktree=str(value["worktree"]),
+            requested_services=tuple(value.get("requested_services", [])),
+            services=tuple(value["services"]),
+            providers={
+                str(key): str(item) for key, item in value.get("providers", {}).items()
+            },
+            state=StateIdentity.from_dict(value["state"]),
+            routes={str(key): str(item) for key, item in value["routes"].items()},
+            ports={str(key): int(item) for key, item in value["ports"].items()},
+            resources=ResourceEstimate.from_dict(value["resources"]),
+            environment_fingerprint=str(value.get("environment_fingerprint", "")),
+            revision=str(value.get("revision", "")),
+            isolated_infra=tuple(value.get("isolated_infra", [])),
+            http_port=str(value.get("http_port", "80")),
+            retired_isolated_infra=tuple(value.get("retired_isolated_infra", [])),
+            retained_private_backend_state=bool(
+                value.get("retained_private_backend_state", False)
+            ),
+            shared_base_ref=str(value.get("shared_base_ref", "origin/dev")),
+        )
+
+
+@dataclass(frozen=True)
+class Registry:
+    version: int = REGISTRY_VERSION
+    slots: dict[str, SlotRecord] = field(default_factory=dict)
+    providers: dict[str, ProviderRecord] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        self.validate()
+        return {
+            "version": self.version,
+            "slots": {key: value.to_dict() for key, value in self.slots.items()},
+            "providers": {
+                key: value.to_dict() for key, value in self.providers.items()
+            },
+        }
+
+    @classmethod
+    def from_dict(cls, value: dict[str, Any]) -> Registry:
+        if value.get("version") != REGISTRY_VERSION:
+            raise ValueError(
+                f"unsupported slots registry version: {value.get('version')!r}"
+            )
+        registry = cls(
+            version=REGISTRY_VERSION,
+            slots={
+                str(key): SlotRecord.from_dict(item)
+                for key, item in value.get("slots", {}).items()
+            },
+            providers={
+                str(key): ProviderRecord.from_dict(item)
+                for key, item in value.get("providers", {}).items()
+            },
+        )
+        registry.validate()
+        return registry
+
+    def validate(self) -> None:
+        """Reject corrupted registry relationships before they reach lifecycle code."""
+        for key, record in self.slots.items():
+            if key != str(record.slot) or not 1 <= record.slot <= 20:
+                raise ValueError(f"invalid slot registry key: {key!r}")
+            if "frontend" not in record.providers or "backend" not in record.providers:
+                raise ValueError(f"slot {record.slot} is missing mandatory providers")
+            if not record.worktree:
+                raise ValueError(f"slot {record.slot} has no worktree")
+            if set(record.services) - set(CATALOG):
+                raise ValueError(f"slot {record.slot} has unsupported services")
+            if set(record.providers) - {"frontend", *CATALOG}:
+                raise ValueError(f"slot {record.slot} has unsupported providers")
+            if set(record.isolated_infra) - ISOLATABLE_INFRA:
+                raise ValueError(
+                    f"slot {record.slot} has unsupported isolated infrastructure"
+                )
+            if len(set(record.isolated_infra)) != len(record.isolated_infra):
+                raise ValueError(f"slot {record.slot} repeats isolated infrastructure")
+            if set(record.retired_isolated_infra) & set(record.isolated_infra):
+                raise ValueError(
+                    f"slot {record.slot} retains active isolated infrastructure"
+                )
+            if set(record.retired_isolated_infra) - ISOLATABLE_INFRA:
+                raise ValueError(
+                    f"slot {record.slot} has invalid retired infrastructure"
+                )
+            try:
+                http_port = int(record.http_port)
+            except ValueError as error:
+                raise ValueError(f"slot {record.slot} has invalid HTTP port") from error
+            if not 1 <= http_port <= 65535:
+                raise ValueError(f"slot {record.slot} has invalid HTTP port")
+            band_start = 20000 + record.slot * 100
+            if any(
+                port < band_start or port >= band_start + 100
+                for port in record.ports.values()
+            ):
+                raise ValueError(f"slot {record.slot} has a port outside slot bands")
+            if record.state != StateIdentity.for_slot(record.state.slot):
+                raise ValueError(f"slot {record.slot} has an invalid state identity")
+            if not record.shared_base_ref:
+                raise ValueError(f"slot {record.slot} has an empty shared base ref")
+        expected_references: dict[str, set[int]] = {}
+        for record in self.slots.values():
+            for group, name in record.providers.items():
+                expected_references.setdefault(name, set()).add(record.slot)
+                provider = self.providers.get(name)
+                if provider is None:
+                    raise ValueError(
+                        f"slot {record.slot} references missing provider {name!r}"
+                    )
+                if provider.group != group:
+                    raise ValueError(f"provider {name!r} is mapped to the wrong group")
+                expected_name = (
+                    f"slot-{record.slot:02d}-{group}"
+                    if provider.private
+                    else f"shared-{group}"
+                )
+                if name != expected_name:
+                    raise ValueError(f"provider {name!r} has an invalid ownership name")
+            backend = self.providers[record.providers["backend"]]
+            if backend.state != record.state:
+                raise ValueError(
+                    f"slot {record.slot} backend state does not match provider"
+                )
+            for group in STATE_COUPLED_GROUPS:
+                provider = self.providers[record.providers[group]]
+                if provider.state != backend.state:
+                    raise ValueError(
+                        f"slot {record.slot} state-coupled {group} does not match backend"
+                    )
+                if backend.private and not provider.private:
+                    raise ValueError(
+                        f"slot {record.slot} private backend requires private {group}"
+                    )
+        for name, provider in self.providers.items():
+            if provider.name != name or not provider.worktree:
+                raise ValueError(f"provider {name!r} has invalid identity metadata")
+            if not provider.base_ref:
+                raise ValueError(f"provider {name!r} has an empty base ref")
+            if provider.group not in {"frontend", *CATALOG}:
+                raise ValueError(f"provider {name!r} has unsupported group")
+            if provider.state != StateIdentity.for_slot(provider.state.slot):
+                raise ValueError(f"provider {name!r} has invalid state identity")
+            if not provider.private and provider.state != StateIdentity.for_slot(0):
+                raise ValueError(f"shared provider {name!r} must use shared state")
+            if tuple(sorted(set(provider.references))) != provider.references:
+                raise ValueError(f"provider {name!r} has non-canonical references")
+            # A zero-reference shared provider is loadable solely for recovery
+            # cleanup by `slots-prune`; normal down removes it atomically.
+            if provider.references and set(
+                provider.references
+            ) != expected_references.get(name, set()):
+                raise ValueError(f"provider {name!r} has invalid references")
+            if not provider.references and name in expected_references:
+                raise ValueError(f"provider {name!r} lost active references")
+            if not provider.references and provider.private:
+                raise ValueError(f"private provider {name!r} cannot be orphaned")

--- a/slots/provisioning.py
+++ b/slots/provisioning.py
@@ -1,0 +1,873 @@
+"""Offline provisioning and exact-target purge command planners.
+
+The plans in this module are inert. They only run when an integration passes an
+executor, and every command names both its Compose project/file and cwd.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Iterable
+from dataclasses import dataclass
+from pathlib import Path
+import re
+import subprocess
+from typing import Final
+
+from .state import (
+    INFRA_ENGINES,
+    StatePlan,
+    StateValidationError,
+    build_state_plan,
+    project_name,
+    validate_isolated_infra,
+    validate_slot,
+    volume_name,
+)
+
+REPOSITORY_ROOT: Final = Path(__file__).resolve().parent.parent
+CONTROL_PLANE_PROJECT: Final = "futureagi-slots"
+CONTROL_PLANE_COMPOSE_FILE: Final = "slots/compose/control-plane.yaml"
+ISOLATED_COMPOSE_FILE: Final = "slots/compose/isolated-infra.yaml"
+_TARGET_IDENTIFIER: Final = re.compile(r"[a-z0-9][a-z0-9_-]{0,127}\Z")
+_PROJECT_TARGET: Final = re.compile(
+    r"futureagi-slot-(\d{2})-(postgres|clickhouse|redis|rabbitmq|minio|temporal)\Z"
+)
+_VOLUME_TARGET: Final = re.compile(
+    r"futureagi_slot_(\d{2})_(postgres|clickhouse|redis|rabbitmq|minio|temporal)_data\Z"
+)
+_REDIS_TARGET: Final = re.compile(r"redis-db-(\d{1,2})\Z")
+_DATABASE_TARGET: Final = re.compile(r"futureagi_slot_(?:0\d|1\d|20)\Z")
+_SERVICE_TARGET: Final = re.compile(r"futureagi-slot-(?:0\d|1\d|20)\Z")
+
+
+class PurgeConfirmationError(StateValidationError):
+    """Raised when a destructive plan is not confirmed for its exact owner."""
+
+
+class StateAlreadyExistsError(RuntimeError):
+    """Executor signal that an idempotent create found an existing resource."""
+
+
+class StateCommandExecutionError(RuntimeError):
+    """A production command failed without an approved idempotency translation."""
+
+
+def _shared_prefix(engine: str) -> tuple[str, ...]:
+    return (
+        "docker",
+        "compose",
+        "--project-name",
+        CONTROL_PLANE_PROJECT,
+        "-f",
+        CONTROL_PLANE_COMPOSE_FILE,
+        "exec",
+        "-T",
+        engine,
+    )
+
+
+def _minio_script(action: str) -> str:
+    alias = (
+        'mc alias set local http://127.0.0.1:9000 "$MINIO_ROOT_USER" '
+        '"$MINIO_ROOT_PASSWORD" >/dev/null\n'
+    )
+    if action == "ensure":
+        return alias + 'exec mc mb --ignore-existing "local/$1"\n'
+    if action == "delete":
+        return alias + 'exec mc rm --recursive --force "local/$1"\n'
+    raise StateValidationError("unsupported MinIO state action")
+
+
+def _postgres_exec(*args: str) -> tuple[str, ...]:
+    return (
+        *_shared_prefix("postgres"),
+        "sh",
+        "-ec",
+        'exec psql --username="$POSTGRES_USER" "$@"\n',
+        "slots-postgres-psql",
+        *args,
+    )
+
+
+def _isolated_prefix(project: str, engine: str) -> tuple[str, ...]:
+    service = f"isolated-{engine}"
+    return (
+        "docker",
+        "compose",
+        "--project-name",
+        project,
+        "-f",
+        ISOLATED_COMPOSE_FILE,
+        "--profile",
+        service,
+    )
+
+
+def _project_engine(target: str) -> str:
+    match = _PROJECT_TARGET.fullmatch(target)
+    if match is None:
+        raise StateValidationError("isolated project target is invalid")
+    return match.group(2)
+
+
+def _project_slot(target: str) -> int:
+    match = _PROJECT_TARGET.fullmatch(target)
+    if match is None:
+        raise StateValidationError("isolated project target is invalid")
+    return int(match.group(1))
+
+
+def _volume_engine(target: str) -> str:
+    match = _VOLUME_TARGET.fullmatch(target)
+    if match is None:
+        raise StateValidationError("isolated volume target is invalid")
+    return match.group(2)
+
+
+def _volume_slot(target: str) -> int:
+    match = _VOLUME_TARGET.fullmatch(target)
+    if match is None:
+        raise StateValidationError("isolated volume target is invalid")
+    return int(match.group(1))
+
+
+def generated_slot_env_file(state_dir: Path, slot: int) -> Path:
+    """Return the absolute generated environment file for an isolated provider."""
+    validate_slot(slot)
+    return state_dir.resolve() / "slots" / f"{slot:02d}" / "slot.env"
+
+
+def _isolated_env_file(operation: str, target: str, env_file: Path | None) -> Path:
+    if env_file is None:
+        raise StateValidationError(
+            "isolated state commands require a generated slot env file"
+        )
+    if not isinstance(env_file, Path):
+        raise StateValidationError("isolated state command env file must be a Path")
+    slot = (
+        _project_slot(target)
+        if operation
+        in {
+            "start_isolated_engine",
+            "stop_isolated_engine",
+            "suspend_isolated_engine",
+            "run_isolated_minio_init",
+            "run_isolated_temporal_init",
+        }
+        else _volume_slot(target)
+    )
+    if (
+        not env_file.is_absolute()
+        or env_file.name != "slot.env"
+        or env_file.parent.name != f"{slot:02d}"
+        or env_file.parent.parent.name != "slots"
+    ):
+        raise StateValidationError(
+            "isolated state command env file must be slots/<slot>/slot.env"
+        )
+    return env_file
+
+
+def _logical_target(target: str, *, database: bool) -> None:
+    pattern = _DATABASE_TARGET if database else _SERVICE_TARGET
+    if pattern.fullmatch(target) is None:
+        raise StateValidationError("logical state target is invalid")
+
+
+def _postgres_ensure_script(database: str) -> str:
+    return (
+        "SELECT format('CREATE DATABASE %I', :'slot_database')\n"
+        "WHERE NOT EXISTS (\n"
+        "  SELECT FROM pg_database WHERE datname = :'slot_database'\n"
+        ")\n"
+        "\\gexec\n"
+    )
+
+
+def _expected_argv(
+    operation: str, target: str, env_file: Path | None = None
+) -> tuple[str, ...]:
+    """Return the complete approved argv schema for one operation and target."""
+    if operation == "create_isolated_volume":
+        _volume_engine(target)
+        _isolated_env_file(operation, target, env_file)
+        return ("docker", "volume", "create", target)
+    if operation == "start_isolated_engine":
+        engine = _project_engine(target)
+        services = (
+            ("isolated-temporal", "isolated-temporal-ui")
+            if engine == "temporal"
+            else (f"isolated-{engine}",)
+        )
+        return (
+            *_isolated_prefix(target, engine),
+            "--env-file",
+            str(_isolated_env_file(operation, target, env_file)),
+            "up",
+            "--detach",
+            "--wait",
+            *services,
+        )
+    if operation == "run_isolated_minio_init":
+        if _project_engine(target) != "minio":
+            raise StateValidationError("MinIO initializer target is invalid")
+        return (
+            *_isolated_prefix(target, "minio"),
+            "--env-file",
+            str(_isolated_env_file(operation, target, env_file)),
+            "run",
+            "--rm",
+            "isolated-minio-init",
+        )
+    if operation == "run_isolated_temporal_init":
+        if _project_engine(target) != "temporal":
+            raise StateValidationError("Temporal initializer target is invalid")
+        return (
+            *_isolated_prefix(target, "temporal"),
+            "--env-file",
+            str(_isolated_env_file(operation, target, env_file)),
+            "run",
+            "--rm",
+            "isolated-temporal-init",
+        )
+    if operation in {"stop_isolated_engine", "suspend_isolated_engine"}:
+        engine = _project_engine(target)
+        return (
+            *_isolated_prefix(target, engine),
+            "--env-file",
+            str(_isolated_env_file(operation, target, env_file)),
+            "down",
+            "--remove-orphans",
+        )
+    if operation == "delete_isolated_volume":
+        _volume_engine(target)
+        _isolated_env_file(operation, target, env_file)
+        return ("docker", "volume", "rm", target)
+
+    if env_file is not None:
+        raise StateValidationError(
+            "logical state commands cannot receive an isolated env file"
+        )
+
+    if operation == "ensure_postgres_database":
+        _logical_target(target, database=True)
+        return _postgres_exec(
+            "--dbname=postgres",
+            "--set=ON_ERROR_STOP=1",
+            f"--set=slot_database={target}",
+            "--file=-",
+        )
+    if operation == "ensure_clickhouse_database":
+        _logical_target(target, database=True)
+        return (
+            *_shared_prefix("clickhouse"),
+            "clickhouse-client",
+            "--query",
+            f"CREATE DATABASE IF NOT EXISTS {target}",
+        )
+    if operation == "ensure_rabbitmq_vhost":
+        _logical_target(target, database=False)
+        return (*_shared_prefix("rabbitmq"), "rabbitmqctl", "add_vhost", target)
+    if operation == "ensure_minio_bucket":
+        _logical_target(target, database=False)
+        return (
+            *_shared_prefix("minio"),
+            "sh",
+            "-ec",
+            _minio_script("ensure"),
+            "slots-minio-bucket",
+            target,
+        )
+    if operation == "ensure_temporal_namespace":
+        _logical_target(target, database=False)
+        return (
+            *_shared_prefix("temporal"),
+            "temporal",
+            "operator",
+            "namespace",
+            "create",
+            "--namespace",
+            target,
+            "--address",
+            "temporal:7233",
+        )
+    if operation == "drop_postgres_database":
+        _logical_target(target, database=True)
+        return _postgres_exec(
+            "--dbname=postgres",
+            "--command",
+            f'DROP DATABASE IF EXISTS "{target}"',
+        )
+    if operation == "drop_clickhouse_database":
+        _logical_target(target, database=True)
+        return (
+            *_shared_prefix("clickhouse"),
+            "clickhouse-client",
+            "--query",
+            f"DROP DATABASE IF EXISTS {target}",
+        )
+    if operation == "flush_redis_database":
+        match = _REDIS_TARGET.fullmatch(target)
+        if match is None:
+            raise StateValidationError("Redis purge target is invalid")
+        return (
+            *_shared_prefix("redis"),
+            "redis-cli",
+            "-n",
+            match.group(1),
+            "FLUSHDB",
+        )
+    if operation == "delete_rabbitmq_vhost":
+        _logical_target(target, database=False)
+        return (*_shared_prefix("rabbitmq"), "rabbitmqctl", "delete_vhost", target)
+    if operation == "delete_minio_bucket":
+        _logical_target(target, database=False)
+        return (
+            *_shared_prefix("minio"),
+            "sh",
+            "-ec",
+            _minio_script("delete"),
+            "slots-minio-bucket",
+            target,
+        )
+    if operation == "delete_temporal_namespace":
+        _logical_target(target, database=False)
+        return (
+            *_shared_prefix("temporal"),
+            "temporal",
+            "operator",
+            "namespace",
+            "delete",
+            "--namespace",
+            target,
+            "--address",
+            "temporal:7233",
+        )
+    raise StateValidationError(f"unsupported state command operation: {operation!r}")
+
+
+def _expected_stdin(operation: str, target: str) -> str | None:
+    if operation == "ensure_postgres_database":
+        _logical_target(target, database=True)
+        return _postgres_ensure_script(target)
+    return None
+
+
+def _expected_already_exists_markers(operation: str) -> tuple[str, ...]:
+    if operation in {"ensure_rabbitmq_vhost", "ensure_temporal_namespace"}:
+        return ("already exists",)
+    if operation == "delete_isolated_volume":
+        return ("no such volume",)
+    if operation in {
+        "delete_rabbitmq_vhost",
+        "delete_minio_bucket",
+        "delete_temporal_namespace",
+    }:
+        return ("does not exist", "not found")
+    return ()
+
+
+def _matches_idempotency_signal(command: StateCommand, message: str) -> bool:
+    normalized = message.casefold()
+    if not any(marker in normalized for marker in command.already_exists_markers):
+        return False
+    # Missing-target failures are safe only when they name the exact reviewed
+    # destructive target. Never hide an unrelated missing service/container.
+    return not command.destructive or command.target.casefold() in normalized
+
+
+@dataclass(frozen=True, slots=True)
+class StateCommand:
+    """One exact, shell-free infrastructure command."""
+
+    operation: str
+    target: str
+    argv: tuple[str, ...]
+    destructive: bool = False
+    cwd: Path = REPOSITORY_ROOT
+    idempotent: bool = True
+    already_exists_markers: tuple[str, ...] = ()
+    stdin: str | None = None
+    env_file: Path | None = None
+
+    def __post_init__(self) -> None:
+        if _TARGET_IDENTIFIER.fullmatch(self.target) is None:
+            raise StateValidationError(
+                "state command target must be a strict identifier"
+            )
+        if self.cwd != REPOSITORY_ROOT:
+            raise StateValidationError(
+                "state commands must run from the repository root"
+            )
+        if self.argv != _expected_argv(self.operation, self.target, self.env_file):
+            raise StateValidationError(
+                "state command argv does not match its exact operation schema"
+            )
+        if self.stdin != _expected_stdin(self.operation, self.target):
+            raise StateValidationError(
+                "state command stdin does not match its exact operation schema"
+            )
+        if not self.idempotent:
+            raise StateValidationError("provisioning commands must be idempotent")
+        if self.already_exists_markers != _expected_already_exists_markers(
+            self.operation
+        ):
+            raise StateValidationError(
+                "state command already-existing markers do not match its operation"
+            )
+
+
+CommandExecutor = Callable[[StateCommand], object]
+SubprocessRunner = Callable[..., subprocess.CompletedProcess[str]]
+
+
+@dataclass(frozen=True, slots=True)
+class ProvisionPlan:
+    state: StatePlan
+    commands: tuple[StateCommand, ...]
+
+
+@dataclass(frozen=True, slots=True)
+class SuspendPlan:
+    """Non-destructive isolated-engine shutdown commands for slot-down/replacement."""
+
+    state: StatePlan
+    commands: tuple[StateCommand, ...]
+
+
+@dataclass(frozen=True, slots=True)
+class PurgePlan:
+    state: StatePlan
+    commands: tuple[StateCommand, ...]
+    confirmation: str
+
+    def __post_init__(self) -> None:
+        if not self.commands or not all(
+            command.destructive for command in self.commands
+        ):
+            raise StateValidationError(
+                "a purge plan must contain only destructive commands"
+            )
+        assert_exact_destructive_targets(self.commands)
+
+
+def _startup_command(
+    plan: StatePlan, engine: str, env_file: Path | None
+) -> tuple[StateCommand, ...]:
+    project = plan.project_for(engine)
+    volume = plan.volume_for(engine)
+    if project is None or volume is None:
+        return ()
+    commands = [
+        StateCommand(
+            "create_isolated_volume",
+            volume,
+            _expected_argv("create_isolated_volume", volume, env_file),
+            env_file=env_file,
+        ),
+        StateCommand(
+            "start_isolated_engine",
+            project,
+            _expected_argv("start_isolated_engine", project, env_file),
+            env_file=env_file,
+        ),
+    ]
+    initializer_by_engine = {
+        "minio": "run_isolated_minio_init",
+        "temporal": "run_isolated_temporal_init",
+    }
+    initializer = initializer_by_engine.get(engine)
+    if initializer is not None:
+        commands.append(
+            StateCommand(
+                initializer,
+                project,
+                _expected_argv(initializer, project, env_file),
+                env_file=env_file,
+            )
+        )
+    return tuple(commands)
+
+
+def _provision_command(plan: StatePlan, engine: str) -> StateCommand | None:
+    """Plan only shared logical state; isolated volumes are the state boundary."""
+    if plan.is_isolated(engine):
+        return None
+    identity = plan.identity
+    target_by_engine = {
+        "postgres": identity.postgres_database,
+        "clickhouse": identity.clickhouse_database,
+        "rabbitmq": identity.rabbitmq_vhost,
+        "minio": identity.minio_bucket,
+        "temporal": identity.temporal_namespace,
+    }
+    operation_by_engine = {
+        "postgres": "ensure_postgres_database",
+        "clickhouse": "ensure_clickhouse_database",
+        "rabbitmq": "ensure_rabbitmq_vhost",
+        "minio": "ensure_minio_bucket",
+        "temporal": "ensure_temporal_namespace",
+    }
+    if engine == "redis":
+        return None
+    target = target_by_engine[engine]
+    operation = operation_by_engine[engine]
+    markers = ("already exists",) if engine in {"rabbitmq", "temporal"} else ()
+    return StateCommand(
+        operation,
+        target,
+        _expected_argv(operation, target),
+        already_exists_markers=markers,
+        stdin=_expected_stdin(operation, target),
+    )
+
+
+def _plan_env_file(state: StatePlan, state_dir: Path | None) -> Path | None:
+    """Derive the only acceptable isolated Compose env file from state storage."""
+    if state.isolated_infra:
+        return _provider_env_file(state, state_dir)
+    return None
+
+
+def _provider_env_file(state: StatePlan, state_dir: Path | None) -> Path:
+    provider_slot = state.identity.provider_slot
+    if provider_slot is None:
+        raise StateValidationError("isolated state commands require a private provider")
+    if state_dir is None:
+        raise StateValidationError(
+            "isolated state plan requires an authoritative state directory"
+        )
+    if not isinstance(state_dir, Path) or not state_dir.is_absolute():
+        raise StateValidationError(
+            "isolated state plan state directory must be an absolute Path"
+        )
+    return generated_slot_env_file(state_dir, provider_slot)
+
+
+def build_provision_plan(
+    state: StatePlan, *, state_dir: Path | None = None
+) -> ProvisionPlan:
+    """Return idempotent commands needed to provision ``state``; do not run them."""
+    env_file = _plan_env_file(state, state_dir)
+    commands: list[StateCommand] = []
+    for engine in sorted(INFRA_ENGINES):
+        commands.extend(_startup_command(state, engine, env_file))
+        command = _provision_command(state, engine)
+        if command is not None:
+            commands.append(command)
+    return ProvisionPlan(state=state, commands=tuple(commands))
+
+
+def build_suspend_plan(
+    state: StatePlan, *, state_dir: Path | None = None
+) -> SuspendPlan:
+    """Stop isolated containers while preserving every logical and volume resource."""
+    env_file = _plan_env_file(state, state_dir)
+    commands: list[StateCommand] = []
+    for engine in sorted(state.isolated_infra):
+        project = state.project_for(engine)
+        assert project is not None
+        commands.append(
+            StateCommand(
+                "suspend_isolated_engine",
+                project,
+                _expected_argv("suspend_isolated_engine", project, env_file),
+                env_file=env_file,
+            )
+        )
+    return SuspendPlan(state=state, commands=tuple(commands))
+
+
+def provision_state(
+    slot: int,
+    *,
+    provider_slot: int | None = None,
+    isolate_infra: str | Iterable[str] | None = None,
+    state_dir: Path | None = None,
+    executor: CommandExecutor | None = None,
+) -> ProvisionPlan:
+    """Build an idempotent provision plan and optionally pass it to an executor."""
+    plan = build_provision_plan(
+        build_state_plan(
+            slot, provider_slot=provider_slot, isolate_infra=isolate_infra
+        ),
+        state_dir=state_dir,
+    )
+    if executor is not None:
+        apply_provision_plan(plan, executor)
+    return plan
+
+
+def suspend_state(
+    slot: int,
+    *,
+    provider_slot: int | None = None,
+    isolate_infra: str | Iterable[str] | None = None,
+    state_dir: Path | None = None,
+    executor: CommandExecutor | None = None,
+) -> SuspendPlan:
+    """Build a state-preserving isolated shutdown plan and optionally execute it."""
+    plan = build_suspend_plan(
+        build_state_plan(
+            slot, provider_slot=provider_slot, isolate_infra=isolate_infra
+        ),
+        state_dir=state_dir,
+    )
+    if executor is not None:
+        apply_suspend_plan(plan, executor)
+    return plan
+
+
+def apply_provision_plan(plan: ProvisionPlan, executor: CommandExecutor) -> None:
+    """Execute a previously reviewed plan through the caller's command boundary."""
+    for command in plan.commands:
+        try:
+            executor(command)
+        except StateAlreadyExistsError as error:
+            message = str(error).casefold()
+            if not any(marker in message for marker in command.already_exists_markers):
+                raise
+
+
+def apply_suspend_plan(plan: SuspendPlan, executor: CommandExecutor) -> None:
+    """Execute a state-preserving shutdown plan through an injected executor."""
+    for command in plan.commands:
+        if command.destructive:
+            raise StateValidationError(
+                "suspend plans cannot include destructive commands"
+            )
+        executor(command)
+
+
+def execute_state_command(
+    command: StateCommand, runner: SubprocessRunner = subprocess.run
+) -> subprocess.CompletedProcess[str]:
+    """Production adapter for a reviewed command; injectable for unit tests.
+
+    Only operations which declare an approved idempotency marker can convert a
+    non-zero subprocess result into ``StateAlreadyExistsError``. Every other
+    command failure remains a hard failure.
+    """
+    result = runner(
+        command.argv,
+        cwd=command.cwd,
+        input=command.stdin,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    if result.returncode == 0:
+        return result
+    stderr = result.stderr or ""
+    if _matches_idempotency_signal(command, stderr):
+        raise StateAlreadyExistsError(stderr)
+    raise StateCommandExecutionError(
+        f"{command.operation} failed for {command.target} (exit {result.returncode}): {stderr.strip()}"
+    )
+
+
+def _purge_command(plan: StatePlan, engine: str) -> StateCommand | None:
+    """Plan shared logical cleanup only; isolated volumes are purged physically."""
+    if plan.is_isolated(engine):
+        return None
+    identity = plan.identity
+    if engine == "postgres":
+        operation, target = "drop_postgres_database", identity.postgres_database
+    elif engine == "clickhouse":
+        operation, target = "drop_clickhouse_database", identity.clickhouse_database
+    elif engine == "redis":
+        return None
+    elif engine == "rabbitmq":
+        operation, target = "delete_rabbitmq_vhost", identity.rabbitmq_vhost
+    elif engine == "minio":
+        operation, target = "delete_minio_bucket", identity.minio_bucket
+    else:
+        operation, target = "delete_temporal_namespace", identity.temporal_namespace
+    return StateCommand(
+        operation,
+        target,
+        _expected_argv(operation, target),
+        destructive=True,
+        already_exists_markers=_expected_already_exists_markers(operation),
+    )
+
+
+def _redis_purge_commands(plan: StatePlan) -> tuple[StateCommand, ...]:
+    if plan.is_isolated("redis"):
+        return ()
+    commands: list[StateCommand] = []
+    for database in plan.identity.redis_databases:
+        target = f"redis-db-{database}"
+        commands.append(
+            StateCommand(
+                "flush_redis_database",
+                target,
+                _expected_argv("flush_redis_database", target),
+                destructive=True,
+            )
+        )
+    return tuple(commands)
+
+
+def _isolated_purge_commands(
+    plan: StatePlan, engine: str, env_file: Path | None
+) -> tuple[StateCommand, ...]:
+    project = plan.project_for(engine)
+    volume = plan.volume_for(engine)
+    if project is None or volume is None:
+        return ()
+    return (
+        StateCommand(
+            "stop_isolated_engine",
+            project,
+            _expected_argv("stop_isolated_engine", project, env_file),
+            destructive=True,
+            env_file=env_file,
+        ),
+        StateCommand(
+            "delete_isolated_volume",
+            volume,
+            _expected_argv("delete_isolated_volume", volume, env_file),
+            destructive=True,
+            already_exists_markers=_expected_already_exists_markers(
+                "delete_isolated_volume"
+            ),
+            env_file=env_file,
+        ),
+    )
+
+
+def build_purge_plan(
+    state: StatePlan, *, confirm: str | int, state_dir: Path | None = None
+) -> PurgePlan:
+    """Build an exact destructive plan only for the owning private provider slot."""
+    provider_slot = state.identity.provider_slot
+    if provider_slot is None or provider_slot != state.slot:
+        raise PurgeConfirmationError(
+            "only a private provider's owning slot can purge its state"
+        )
+    if str(confirm) != str(state.slot):
+        raise PurgeConfirmationError(
+            f"CONFIRM must equal the exact purge slot ({state.slot})"
+        )
+
+    env_file = _plan_env_file(state, state_dir)
+
+    commands: list[StateCommand] = []
+    for engine in sorted(INFRA_ENGINES):
+        commands.extend(_isolated_purge_commands(state, engine, env_file))
+        if engine == "redis":
+            commands.extend(_redis_purge_commands(state))
+        else:
+            command = _purge_command(state, engine)
+            if command is not None:
+                commands.append(command)
+    return PurgePlan(state=state, commands=tuple(commands), confirmation=str(confirm))
+
+
+def build_retired_isolated_purge_plan(
+    state: StatePlan,
+    *,
+    retired_infra: str | Iterable[str],
+    confirm: str | int,
+    state_dir: Path | None = None,
+) -> PurgePlan:
+    """Purge only physical state left by engines isolated in a retired topology.
+
+    Current isolated engines are owned by ``build_purge_plan``. Current shared
+    engines remain logical-purge targets there as well, so this planner cannot
+    accidentally suppress either part of the normal topology cleanup.
+    """
+    provider_slot = state.identity.provider_slot
+    if provider_slot is None or provider_slot != state.slot:
+        raise PurgeConfirmationError(
+            "only a private provider's owning slot can purge its state"
+        )
+    if str(confirm) != str(state.slot):
+        raise PurgeConfirmationError(
+            f"CONFIRM must equal the exact purge slot ({state.slot})"
+        )
+    retired = validate_isolated_infra(retired_infra)
+    if not retired:
+        raise StateValidationError(
+            "retired isolated purge requires at least one engine"
+        )
+    overlap = retired & state.isolated_infra
+    if overlap:
+        raise StateValidationError(
+            "retired isolated engines are still isolated in the current topology: "
+            + ", ".join(sorted(overlap))
+        )
+
+    env_file = _provider_env_file(state, state_dir)
+    commands: list[StateCommand] = []
+    for engine in sorted(retired):
+        project = project_name(provider_slot, engine)
+        volume = volume_name(provider_slot, engine)
+        commands.extend(
+            (
+                StateCommand(
+                    "stop_isolated_engine",
+                    project,
+                    _expected_argv("stop_isolated_engine", project, env_file),
+                    destructive=True,
+                    env_file=env_file,
+                ),
+                StateCommand(
+                    "delete_isolated_volume",
+                    volume,
+                    _expected_argv("delete_isolated_volume", volume, env_file),
+                    destructive=True,
+                    already_exists_markers=_expected_already_exists_markers(
+                        "delete_isolated_volume"
+                    ),
+                    env_file=env_file,
+                ),
+            )
+        )
+    return PurgePlan(state=state, commands=tuple(commands), confirmation=str(confirm))
+
+
+def purge_state(
+    slot: int,
+    *,
+    provider_slot: int | None = None,
+    isolate_infra: str | Iterable[str] | None = None,
+    state_dir: Path | None = None,
+    confirm: str | int | None = None,
+    executor: CommandExecutor | None = None,
+) -> PurgePlan:
+    """Build a purge plan and execute only through an injected executor."""
+    state = build_state_plan(
+        slot, provider_slot=provider_slot, isolate_infra=isolate_infra
+    )
+    plan = build_purge_plan(
+        state, confirm="" if confirm is None else confirm, state_dir=state_dir
+    )
+    if executor is not None:
+        apply_purge_plan(plan, executor)
+    return plan
+
+
+def apply_purge_plan(plan: PurgePlan, executor: CommandExecutor) -> None:
+    """Execute an exact-target purge plan through the caller's command boundary."""
+    assert_exact_destructive_targets(plan.commands)
+    for command in plan.commands:
+        try:
+            executor(command)
+        except StateAlreadyExistsError as error:
+            if not _matches_idempotency_signal(command, str(error)):
+                raise
+
+
+def assert_exact_destructive_targets(commands: Iterable[StateCommand]) -> None:
+    """Reject any destructive command that does not match its exact schema."""
+    for command in commands:
+        if not command.destructive:
+            raise StateValidationError(
+                "purge plans cannot include non-destructive commands"
+            )
+        if command.argv != _expected_argv(
+            command.operation, command.target, command.env_file
+        ):
+            raise StateValidationError("purge plan contains an inexact command")

--- a/slots/registry.py
+++ b/slots/registry.py
@@ -1,0 +1,87 @@
+"""Cross-worktree registry discovery, locking and atomic persistence."""
+
+from __future__ import annotations
+
+from contextlib import contextmanager
+import fcntl
+import json
+import os
+from pathlib import Path
+import subprocess
+from typing import Callable, Iterator, Sequence
+
+from .models import Registry
+
+CommandRunner = Callable[[Sequence[str], Path], str]
+
+
+def _subprocess_runner(command: Sequence[str], cwd: Path) -> str:
+    return subprocess.check_output(command, cwd=cwd, text=True).strip()
+
+
+def discover_primary_worktree(
+    cwd: Path, runner: CommandRunner = _subprocess_runner
+) -> Path:
+    """Return the primary worktree, falling back to cwd outside Git."""
+    try:
+        output = runner(("git", "worktree", "list", "--porcelain"), cwd)
+    except (OSError, subprocess.CalledProcessError):
+        return cwd.resolve()
+    for line in output.splitlines():
+        if line.startswith("worktree "):
+            return Path(line.removeprefix("worktree ")).resolve()
+    return cwd.resolve()
+
+
+def discover_state_dir(
+    cwd: Path | None = None,
+    environ: dict[str, str] | None = None,
+    runner: CommandRunner = _subprocess_runner,
+) -> Path:
+    environment = os.environ if environ is None else environ
+    if override := environment.get("SLOTS_STATE_DIR"):
+        return Path(override).expanduser().resolve()
+    return discover_primary_worktree((cwd or Path.cwd()).resolve(), runner) / ".slots"
+
+
+class RegistryStore:
+    """A locked JSON store. Callers mutate only while ``locked`` is active."""
+
+    def __init__(self, state_dir: Path) -> None:
+        self.state_dir = state_dir
+        self.registry_path = state_dir / "registry.json"
+        self.lock_path = state_dir / "registry.lock"
+
+    def load(self) -> Registry:
+        if not self.registry_path.exists():
+            return Registry()
+        with self.registry_path.open(encoding="utf-8") as handle:
+            return Registry.from_dict(json.load(handle))
+
+    def save(self, registry: Registry) -> None:
+        self.state_dir.mkdir(mode=0o700, parents=True, exist_ok=True)
+        temporary = self.registry_path.with_suffix(".json.tmp")
+        payload = json.dumps(registry.to_dict(), sort_keys=True, indent=2) + "\n"
+        descriptor = os.open(temporary, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+        try:
+            with os.fdopen(descriptor, "w", encoding="utf-8") as handle:
+                handle.write(payload)
+                handle.flush()
+                os.fsync(handle.fileno())
+            os.replace(temporary, self.registry_path)
+            os.chmod(self.registry_path, 0o600)
+        finally:
+            if temporary.exists():
+                temporary.unlink()
+
+    @contextmanager
+    def locked(self) -> Iterator[Registry]:
+        self.state_dir.mkdir(mode=0o700, parents=True, exist_ok=True)
+        with self.lock_path.open("a+", encoding="utf-8") as lock:
+            os.chmod(self.lock_path, 0o600)
+            fcntl.flock(lock.fileno(), fcntl.LOCK_EX)
+            registry = self.load()
+            try:
+                yield registry
+            finally:
+                fcntl.flock(lock.fileno(), fcntl.LOCK_UN)

--- a/slots/runtime.py
+++ b/slots/runtime.py
@@ -1,0 +1,1969 @@
+"""Daemon-free slot lifecycle planning and local generated-file management."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import hashlib
+import json
+import os
+from pathlib import Path
+from typing import Callable, Sequence
+
+from .catalog import (
+    CATALOG,
+    estimate_resources,
+    expand_services,
+    parse_isolated_infra,
+    parse_services,
+    private_ports,
+)
+from .models import (
+    ProviderRecord,
+    Registry,
+    ResourceEstimate,
+    SlotRecord,
+    StateIdentity,
+)
+from .provisioning import (
+    StateCommand,
+    ProvisionPlan,
+    PurgePlan,
+    SuspendPlan,
+    apply_provision_plan,
+    apply_purge_plan,
+    apply_suspend_plan,
+    build_provision_plan,
+    build_purge_plan,
+    build_suspend_plan,
+)
+from .registry import RegistryStore
+from .registry import CommandRunner, _subprocess_runner
+from .state import adapt_orchestrator_state, build_state_plan, volume_name
+
+DEFAULT_MEMORY_CAP_MIB = 16 * 1024
+ADMISSION_RATIO = 0.75
+CONTROL_PLANE_MEMORY_MIB = 2_600
+SIMULATION_WHEEL = "agent_learning_kit-0.1.0-py3-none-any.whl"
+STATE_COUPLED_GROUPS = frozenset(("simulation", "collector", "peerdb"))
+ISOLATED_MEMORY_MIB = {
+    "postgres": 700,
+    "clickhouse": 1_000,
+    "redis": 200,
+    "rabbitmq": 500,
+    "minio": 500,
+    "temporal": 900,
+}
+COMPOSE_GROUP_MEMBERS: dict[str, tuple[str, ...]] = {
+    "backend": ("backend", "worker"),
+    # The PeerDB template owns this aggregate target.  Its dependency graph
+    # starts catalog, Temporal/init, MinIO, flow, server, UI and setup jobs.
+    "peerdb": ("peerdb",),
+}
+COMPOSE_GROUP_PRIMARY: dict[str, str] = {"peerdb": "peerdb-ui"}
+BUILDABLE_GROUPS = frozenset(
+    ("frontend", "backend", "simulation", "gateway", "collector", "serving", "executor")
+)
+SHARED_PROVIDER_OVERRIDES: dict[str, dict[str, str]] = {
+    "backend": {
+        "SLOT_BACKEND_NAME": "shared-backend",
+        "SLOT_WORKER_NAME": "shared-backend-worker",
+        "SLOT_BACKEND_MEDIA_VOLUME": "futureagi-shared-backend-media",
+    },
+    "simulation": {"SLOT_SIMULATION_NAME": "shared-simulation"},
+    "gateway": {"SLOT_GATEWAY_NAME": "shared-gateway"},
+    "collector": {
+        "SLOT_COLLECTOR_NAME": "shared-collector",
+        "SLOT_COLLECTOR_VOLUME": "futureagi-shared-collector-data",
+    },
+    "serving": {"SLOT_SERVING_NAME": "shared-serving"},
+    "executor": {"SLOT_EXECUTOR_NAME": "shared-executor"},
+    "observability": {"SLOT_OBSERVABILITY_NAME": "shared-observability"},
+    "peerdb": {
+        "SLOT_PEERDB_AGGREGATE_NAME": "shared-peerdb-aggregate",
+        "SLOT_PEERDB_CATALOG_NAME": "shared-peerdb-catalog",
+        "SLOT_PEERDB_TEMPORAL_NAME": "shared-peerdb-temporal",
+        "SLOT_PEERDB_TEMPORAL_INIT_NAME": "shared-peerdb-temporal-init",
+        "SLOT_PEERDB_MINIO_NAME": "shared-peerdb-minio",
+        "SLOT_PEERDB_MINIO_INIT_NAME": "shared-peerdb-minio-init",
+        "SLOT_PEERDB_FLOW_API_NAME": "shared-peerdb-flow-api",
+        "SLOT_PEERDB_FLOW_WORKER_NAME": "shared-peerdb-flow-worker",
+        "SLOT_PEERDB_SERVER_NAME": "shared-peerdb-server",
+        "SLOT_PEERDB_UI_NAME": "shared-peerdb-ui",
+        "SLOT_PEERDB_INIT_NAME": "shared-peerdb-init",
+        "SLOT_PEERDB_CATALOG_VOLUME": "futureagi-shared-peerdb-catalog-data",
+        "SLOT_PEERDB_MINIO_VOLUME": "futureagi-shared-peerdb-minio-data",
+    },
+}
+
+
+class ResourceAdmissionError(ValueError):
+    pass
+
+
+@dataclass(frozen=True)
+class Command:
+    argv: tuple[str, ...]
+    cwd: Path
+    already_exists_markers: tuple[str, ...] = ()
+
+
+@dataclass(frozen=True)
+class LifecyclePlan:
+    action: str
+    slot: int
+    record: SlotRecord | None
+    commands: tuple[Command, ...]
+    state_commands: tuple[StateCommand, ...] = ()
+    stopped_providers: tuple[str, ...] = ()
+
+
+CommandExecutor = Callable[[Sequence[str], Path], None]
+StateCommandExecutor = Callable[[StateCommand], object]
+
+
+def allocate_slot(value: str | int, registry: Registry) -> int:
+    if isinstance(value, str) and value.strip().lower() == "auto":
+        occupied = {record.slot for record in registry.slots.values()}
+        for candidate in range(1, 21):
+            if candidate not in occupied:
+                return candidate
+        raise ValueError("no slots available (all slots 1 through 20 are in use)")
+    try:
+        slot = int(value)
+    except (TypeError, ValueError) as error:
+        raise ValueError("SLOT must be 1 through 20 or auto") from error
+    if not 1 <= slot <= 20:
+        raise ValueError("SLOT must be an integer from 1 through 20")
+    return slot
+
+
+def routes_for_slot(slot: int, http_port: str = "80") -> dict[str, str]:
+    suffix = "" if http_port == "80" else f":{http_port}"
+    routes = {
+        "frontend": f"http://{slot}.localhost{suffix}",
+        "backend": f"http://api.{slot}.localhost{suffix}",
+    }
+    for service in (
+        "temporal",
+        "peerdb",
+        "minio",
+        "minio-console",
+        "rabbitmq",
+        "gateway",
+        "serving",
+        "collector",
+        "executor",
+        "jaeger",
+    ):
+        routes[service] = f"http://{service}.{slot}.localhost{suffix}"
+    return routes
+
+
+def normalise_http_port(environment: dict[str, str]) -> str:
+    """Return a canonical public HTTP port without touching runtime state."""
+    raw = environment.get("SLOTS_HTTP_PORT", "80")
+    if not isinstance(raw, str) or not raw.isdecimal():
+        raise ValueError("SLOTS_HTTP_PORT must be an integer from 1 through 65535")
+    port = int(raw)
+    if not 1 <= port <= 65535:
+        raise ValueError("SLOTS_HTTP_PORT must be an integer from 1 through 65535")
+    return str(port)
+
+
+def effective_private_groups(requested_private: tuple[str, ...]) -> tuple[str, ...]:
+    """Close private backend selection over providers bound to its state tuple."""
+    selected = set(requested_private)
+    if "backend" in selected:
+        selected.update(STATE_COUPLED_GROUPS)
+    return tuple(group for group in CATALOG if group in selected)
+
+
+def provider_name(slot: int, group: str, private: bool) -> str:
+    return f"slot-{slot:02d}-{group}" if private else f"shared-{group}"
+
+
+def compose_members(group: str) -> tuple[str, ...]:
+    """Return exact Compose service members for one logical provider group."""
+    return COMPOSE_GROUP_MEMBERS.get(group, (group,))
+
+
+def compose_primary_member(group: str) -> str:
+    return COMPOSE_GROUP_PRIMARY.get(group, group)
+
+
+def command_for(
+    action: str,
+    record: SlotRecord,
+    state_dir: Path,
+    service: str | None = None,
+    command: str | None = None,
+) -> Command:
+    """Build a future Compose command without executing it."""
+    private_services = tuple(
+        service for service in record.resources.services if service != "frontend"
+    )
+    compose_files = (
+        "-f",
+        "slots/compose/frontend.yaml",
+        *(
+            argument
+            for service in private_services
+            for argument in ("-f", f"slots/compose/{service}.yaml")
+        ),
+    )
+    base = (
+        "docker",
+        "compose",
+        "--project-name",
+        f"futureagi-slot-{record.slot:02d}",
+        *compose_files,
+        "--env-file",
+        str(state_dir / "slots" / f"{record.slot:02d}" / "slot.env"),
+    )
+    if action == "up":
+        targets = [
+            member for group in private_services for member in compose_members(group)
+        ]
+        targets.append("frontend")
+        args = (*base, "up", "--detach", *targets)
+    elif action == "build":
+        if service not in BUILDABLE_GROUPS:
+            raise ValueError(f"service has no local build: {service}")
+        args = (*base, "build", compose_primary_member(service))
+    elif action == "down":
+        args = (*base, "down")
+    elif action == "logs":
+        args = (
+            *base,
+            "logs",
+            "--follow",
+            compose_primary_member(service or "frontend"),
+        )
+    elif action == "shell":
+        args = (*base, "exec", compose_primary_member(service or "frontend"), "sh")
+    elif action == "run":
+        if not command:
+            raise ValueError("COMMAND is required for slot-run")
+        args = (
+            *base,
+            "exec",
+            compose_primary_member(service or "frontend"),
+            "sh",
+            "-lc",
+            command,
+        )
+    else:
+        raise ValueError(f"unsupported lifecycle action: {action}")
+    return Command(args, Path(record.worktree))
+
+
+def _control_plane_command(record: SlotRecord, state_dir: Path) -> Command:
+    return Command(
+        (
+            "docker",
+            "compose",
+            "--project-name",
+            "futureagi-slots",
+            "-f",
+            "slots/compose/control-plane.yaml",
+            "--env-file",
+            str(state_dir / "slots" / f"{record.slot:02d}" / "slot.env"),
+            "up",
+            "--detach",
+            "--wait",
+        ),
+        Path(record.worktree),
+    )
+
+
+def _shared_backend_command(record: SlotRecord, state_dir: Path) -> Command:
+    return Command(
+        (
+            "docker",
+            "compose",
+            "--project-name",
+            "futureagi-slots-default-backend",
+            "-f",
+            "slots/compose/backend.yaml",
+            "--env-file",
+            str(state_dir / "slots" / f"{record.slot:02d}" / "slot.env"),
+            "up",
+            "--detach",
+            "backend",
+            "worker",
+        ),
+        Path(record.worktree),
+    )
+
+
+def _network_command(record: SlotRecord) -> Command:
+    # This is deliberately an exact, small idempotent operation.  It runs before
+    # the control plane so every subsequent Compose project can join the network.
+    return Command(
+        ("docker", "network", "create", "futureagi-slots"),
+        Path(record.worktree),
+        ("already exists",),
+    )
+
+
+def _shared_provider_command(
+    group: str,
+    record: SlotRecord | None,
+    state_dir: Path,
+    action: str,
+    owner_worktree: Path | None = None,
+    force_recreate: bool = False,
+) -> Command:
+    targets = compose_members(group)
+    suffix = (
+        (compose_primary_member(group),)
+        if action == "build"
+        else (
+            "--detach",
+            *(("--force-recreate",) if force_recreate else ()),
+            *targets,
+        )
+        if action == "up"
+        else ()
+    )
+    if owner_worktree is None:
+        if record is None:
+            raise ValueError("shared provider command requires an owner worktree")
+        owner_worktree = Path(record.worktree)
+    return Command(
+        (
+            "docker",
+            "compose",
+            "--project-name",
+            f"futureagi-slots-default-{group}",
+            "-f",
+            f"slots/compose/{group}.yaml",
+            "--env-file",
+            str(state_dir / "shared" / f"{group}.env"),
+            action,
+            *suffix,
+        ),
+        owner_worktree,
+    )
+
+
+def _control_plane_down_command(record: SlotRecord, state_dir: Path) -> Command:
+    return _control_plane_down_with_env(
+        Path(record.worktree), state_dir / "slots" / f"{record.slot:02d}" / "slot.env"
+    )
+
+
+def _traefik_restart_command(record: SlotRecord, state_dir: Path) -> Command:
+    """Reload bind-mounted routes reliably on Docker Desktop/Colima fileshares."""
+    return Command(
+        (
+            "docker",
+            "compose",
+            "--project-name",
+            "futureagi-slots",
+            "-f",
+            "slots/compose/control-plane.yaml",
+            "--env-file",
+            str(state_dir / "slots" / f"{record.slot:02d}" / "slot.env"),
+            "restart",
+            "traefik",
+        ),
+        Path(record.worktree),
+    )
+
+
+def _control_plane_down_with_env(worktree: Path, env_file: Path) -> Command:
+    return Command(
+        (
+            "docker",
+            "compose",
+            "--project-name",
+            "futureagi-slots",
+            "-f",
+            "slots/compose/control-plane.yaml",
+            "--env-file",
+            str(env_file),
+            "down",
+        ),
+        worktree,
+    )
+
+
+def _network_remove_command(record: SlotRecord) -> Command:
+    return Command(
+        ("docker", "network", "rm", "futureagi-slots"), Path(record.worktree)
+    )
+
+
+def _purge_project_command(record: SlotRecord, state_dir: Path) -> Command:
+    command = command_for("down", record, state_dir)
+    return Command((*command.argv, "--volumes"), command.cwd)
+
+
+def execute_commands(commands: Sequence[Command], executor: CommandExecutor) -> None:
+    """Execute plans only through an explicitly supplied adapter."""
+    for command in commands:
+        try:
+            executor(command.argv, command.cwd)
+        except Exception as error:
+            message = " ".join(
+                str(value)
+                for value in (
+                    error,
+                    getattr(error, "stderr", ""),
+                    getattr(error, "output", ""),
+                )
+                if value
+            ).casefold()
+            if command.already_exists_markers and any(
+                marker in message for marker in command.already_exists_markers
+            ):
+                continue
+            raise
+
+
+class SlotRuntime:
+    def __init__(
+        self,
+        store: RegistryStore,
+        worktree: Path,
+        git_runner: CommandRunner = _subprocess_runner,
+    ) -> None:
+        self.store = store
+        self.worktree = worktree.resolve()
+        self.git_runner = git_runner
+
+    def plan_up(
+        self,
+        slot_value: str | int,
+        services_value: str | None = None,
+        isolated_infra_value: str | None = None,
+        revision: str = "",
+        environment: dict[str, str] | None = None,
+    ) -> LifecyclePlan:
+        with self.store.locked() as registry:
+            return self._build_up(
+                registry,
+                slot_value,
+                services_value,
+                isolated_infra_value,
+                revision,
+                environment or {},
+            )
+
+    def apply_up(
+        self,
+        slot_value: str | int,
+        services_value: str | None,
+        isolated_infra_value: str | None,
+        revision: str,
+        environment: dict[str, str],
+        executor: CommandExecutor,
+        state_executor: StateCommandExecutor | None = None,
+    ) -> LifecyclePlan:
+        with self.store.locked() as registry:
+            self._require_clean_recovery()
+            plan = self._build_up(
+                registry,
+                slot_value,
+                services_value,
+                isolated_infra_value,
+                revision,
+                environment,
+            )
+            assert plan.record is not None
+            self._validate_local_build_inputs(plan.record, registry)
+            previous = registry.slots.get(str(plan.record.slot))
+            suspend_commands: tuple[StateCommand, ...] = ()
+            if previous is not None and previous.isolated_infra:
+                previous_state = self._state_plan_for(previous)
+                suspend_commands = build_suspend_plan(
+                    previous_state, state_dir=self.store.state_dir
+                ).commands
+            if (plan.state_commands or suspend_commands) and state_executor is None:
+                raise ValueError(
+                    "runtime state execution requires an injected StateCommand executor"
+                )
+            replacement_count = 1 if previous is not None else 0
+            snapshots: dict[Path, bytes | None] = {}
+            journal_written = False
+            external_attempted = False
+            try:
+                if replacement_count:
+                    self._write_recovery_journal(plan.record, "up")
+                    journal_written = True
+                    if suspend_commands:
+                        external_attempted = True
+                        apply_suspend_plan(
+                            SuspendPlan(previous_state, suspend_commands),
+                            state_executor,
+                        )
+                    external_attempted = True
+                    execute_commands(plan.commands[:replacement_count], executor)
+                snapshots = self._stage_artifacts(plan.record)
+                new_shared_groups = tuple(
+                    group
+                    for group, name in plan.record.providers.items()
+                    if group != "frontend"
+                    and name.startswith("shared-")
+                    and name not in registry.providers
+                )
+                for group in new_shared_groups:
+                    self._write_shared_environment(group, plan.record)
+                if not journal_written:
+                    self._write_recovery_journal(plan.record, "up")
+                    journal_written = True
+                external_attempted = True
+                execute_commands(
+                    plan.commands[replacement_count : replacement_count + 2], executor
+                )
+                if plan.state_commands:
+                    state = build_state_plan(
+                        plan.record.slot,
+                        provider_slot=plan.record.slot
+                        if plan.record.providers["backend"]
+                        == provider_name(plan.record.slot, "backend", True)
+                        else None,
+                        isolate_infra=plan.record.isolated_infra,
+                    )
+                    external_attempted = True
+                    apply_provision_plan(
+                        ProvisionPlan(state, plan.state_commands), state_executor
+                    )
+                external_attempted = True
+                execute_commands(plan.commands[replacement_count + 2 :], executor)
+                updated = self._attach(registry, plan.record)
+                updated, handoffs = self._handoff_shared_owners(
+                    updated,
+                    previous.worktree if previous is not None else "",
+                    executor,
+                )
+                stopped_shared = tuple(
+                    provider
+                    for name, provider in registry.providers.items()
+                    if name not in updated.providers and not provider.private
+                )
+                execute_commands(
+                    tuple(
+                        _shared_provider_command(
+                            provider.group,
+                            plan.record,
+                            self.store.state_dir,
+                            "down",
+                            Path(provider.worktree),
+                        )
+                        for provider in stopped_shared
+                    ),
+                    executor,
+                )
+                self.store.save(updated)
+            except Exception:
+                # Preserve the exact desired topology once a Docker mutation
+                # may have happened so `slots-recover` can reconcile it.
+                if snapshots and not external_attempted:
+                    self._restore_artifacts(snapshots)
+                if journal_written and not external_attempted:
+                    self._remove_recovery_journal()
+                raise
+            self._remove_recovery_journal()
+            return LifecyclePlan(
+                plan.action,
+                plan.slot,
+                plan.record,
+                (*plan.commands, *handoffs) if previous is not None else plan.commands,
+                plan.state_commands,
+                plan.stopped_providers,
+            )
+
+    def _validate_local_build_inputs(
+        self, record: SlotRecord, registry: Registry
+    ) -> None:
+        """Reject unavailable simulation inputs before any runtime mutation.
+
+        The repository's dev simulation Dockerfile deliberately consumes an
+        unreleased Agent Learning Kit wheel from the build-context root. A
+        missing wheel otherwise fails only after the large backend build and
+        after the shared control plane has already started.
+        """
+        dockerfile = self.worktree / "Dockerfile.simulation-runner.dev"
+        if not dockerfile.is_file():
+            # Synthetic/unit-test worktrees do not carry application sources.
+            return
+        simulation = record.providers["simulation"]
+        simulation_will_build = (
+            "simulation" in record.resources.services
+            or simulation not in registry.providers
+        )
+        if simulation_will_build and not (self.worktree / SIMULATION_WHEEL).is_file():
+            raise ValueError(
+                f"simulation build requires {SIMULATION_WHEEL} at the worktree "
+                "root (required by Dockerfile.simulation-runner.dev); copy or "
+                "build the Agent Learning Kit wheel before slot-up"
+            )
+
+    def plan_down(self, slot_value: str | int) -> LifecyclePlan:
+        with self.store.locked() as registry:
+            slot = allocate_slot(slot_value, registry)
+            record = registry.slots.get(str(slot))
+            if record is None:
+                raise ValueError(f"slot {slot} is not registered")
+            suspend_commands = (
+                build_suspend_plan(
+                    self._state_plan_for(record), state_dir=self.store.state_dir
+                ).commands
+                if record.isolated_infra
+                else ()
+            )
+            return LifecyclePlan(
+                "down",
+                slot,
+                record,
+                (command_for("down", record, self.store.state_dir),),
+                suspend_commands,
+            )
+
+    def apply_down(
+        self,
+        slot_value: str | int,
+        executor: CommandExecutor,
+        state_executor: StateCommandExecutor | None = None,
+    ) -> LifecyclePlan:
+        with self.store.locked() as registry:
+            self._require_clean_recovery()
+            slot = allocate_slot(slot_value, registry)
+            record = registry.slots.get(str(slot))
+            if record is None:
+                raise ValueError(f"slot {slot} is not registered")
+            suspend_commands = (
+                build_suspend_plan(
+                    self._state_plan_for(record), state_dir=self.store.state_dir
+                ).commands
+                if record.isolated_infra
+                else ()
+            )
+            if suspend_commands and state_executor is None:
+                raise ValueError(
+                    "runtime state execution requires an injected StateCommand executor"
+                )
+            plan = LifecyclePlan(
+                "down",
+                slot,
+                record,
+                (command_for("down", record, self.store.state_dir),),
+            )
+            self._write_recovery_journal(record, "down")
+            if suspend_commands:
+                apply_suspend_plan(
+                    SuspendPlan(self._state_plan_for(record), suspend_commands),
+                    state_executor,
+                )
+            execute_commands(plan.commands, executor)
+            updated, stopped = self._detach(registry, record)
+            updated, handoffs = self._handoff_shared_owners(
+                updated, record.worktree, executor
+            )
+            shared_stops = tuple(
+                _shared_provider_command(
+                    registry.providers[name].group,
+                    record,
+                    self.store.state_dir,
+                    "down",
+                    Path(registry.providers[name].worktree),
+                )
+                for name in stopped
+                if name in registry.providers and not registry.providers[name].private
+            )
+            execute_commands(shared_stops, executor)
+            tail: tuple[Command, ...] = ()
+            if not updated.slots:
+                tail = (
+                    _control_plane_down_command(record, self.store.state_dir),
+                    _network_remove_command(record),
+                )
+                execute_commands(tail, executor)
+            self.store.save(updated)
+            route_removed = self._remove_route(record)
+            route_reload = self._reload_routes_for_survivors(
+                updated, executor, route_removed
+            )
+            self._remove_recovery_journal()
+            return LifecyclePlan(
+                "down",
+                slot,
+                record,
+                (*plan.commands, *handoffs, *shared_stops, *tail, *route_reload),
+                suspend_commands,
+                stopped,
+            )
+
+    def plan_purge(
+        self, slot_value: str | int, confirmation: str | None
+    ) -> LifecyclePlan:
+        slot = allocate_slot(slot_value, self.store.load())
+        if confirmation != str(slot):
+            raise ValueError(f"slot-purge requires CONFIRM={slot}")
+        record = self.store.load().slots.get(str(slot)) or self._manifest_record(slot)
+        if record is None:
+            raise ValueError(f"slot {slot} is not registered")
+        state_commands: tuple[StateCommand, ...] = ()
+        if (
+            record.providers["backend"] == provider_name(slot, "backend", True)
+            or record.retained_private_backend_state
+        ):
+            state = self._purge_state_plan(record)
+            state_commands = build_purge_plan(
+                state,
+                state_dir=self.store.state_dir if state.isolated_infra else None,
+                confirm=confirmation,
+            ).commands
+        retired_volumes = self._retired_private_volume_commands(record)
+        return LifecyclePlan(
+            "purge",
+            slot,
+            record,
+            (_purge_project_command(record, self.store.state_dir), *retired_volumes),
+            state_commands,
+        )
+
+    def apply_purge(
+        self,
+        slot_value: str | int,
+        confirmation: str,
+        executor: CommandExecutor,
+        state_executor: StateCommandExecutor | None = None,
+    ) -> LifecyclePlan:
+        with self.store.locked() as registry:
+            self._require_clean_recovery()
+            slot = allocate_slot(slot_value, registry)
+            record = registry.slots.get(str(slot)) or self._manifest_record(slot)
+            if record is None:
+                raise ValueError(f"slot {slot} is not registered")
+            if confirmation != str(slot):
+                raise ValueError(f"slot-purge requires CONFIRM={slot}")
+            private_backend = (
+                record.providers["backend"] == provider_name(slot, "backend", True)
+                or record.retained_private_backend_state
+            )
+            purge_commands: tuple[StateCommand, ...] = ()
+            purge_state = None
+            if private_backend:
+                purge_state = self._purge_state_plan(record)
+                purge_commands = build_purge_plan(
+                    purge_state,
+                    state_dir=(
+                        self.store.state_dir if purge_state.isolated_infra else None
+                    ),
+                    confirm=confirmation,
+                ).commands
+            if purge_commands and state_executor is None:
+                raise ValueError(
+                    "runtime state execution requires an injected StateCommand executor"
+                )
+            runtime_down = _purge_project_command(record, self.store.state_dir)
+            retired_volumes = self._retired_private_volume_commands(record)
+            self._write_recovery_journal(record, "purge")
+            if record.isolated_infra:
+                suspend = build_suspend_plan(
+                    self._state_plan_for(record), state_dir=self.store.state_dir
+                )
+                apply_suspend_plan(suspend, state_executor)
+            execute_commands((runtime_down,), executor)
+            execute_commands(retired_volumes, executor)
+            if purge_commands:
+                assert purge_state is not None
+                apply_purge_plan(
+                    PurgePlan(
+                        purge_state,
+                        purge_commands,
+                        confirmation,
+                    ),
+                    state_executor,
+                )
+            updated, stopped = (
+                self._detach(registry, record)
+                if str(slot) in registry.slots
+                else (registry, ())
+            )
+            updated, handoffs = self._handoff_shared_owners(
+                updated, record.worktree, executor
+            )
+            shared_stops = tuple(
+                _shared_provider_command(
+                    registry.providers[name].group,
+                    record,
+                    self.store.state_dir,
+                    "down",
+                    Path(registry.providers[name].worktree),
+                )
+                for name in stopped
+                if name in registry.providers and not registry.providers[name].private
+            )
+            execute_commands(shared_stops, executor)
+            tail: tuple[Command, ...] = ()
+            if not updated.slots and str(slot) in registry.slots:
+                tail = (
+                    _control_plane_down_command(record, self.store.state_dir),
+                    _network_remove_command(record),
+                )
+                execute_commands(tail, executor)
+            self.store.save(updated)
+            route_removed = self._remove_route(record)
+            route_reload = self._reload_routes_for_survivors(
+                updated, executor, route_removed
+            )
+            directory = self.store.state_dir / "slots" / f"{slot:02d}"
+            for path in (directory / "slot.env", directory / "manifest.json"):
+                if path.exists():
+                    path.unlink()
+            self._remove_recovery_journal()
+            return LifecyclePlan(
+                "purge",
+                slot,
+                record,
+                (
+                    runtime_down,
+                    *retired_volumes,
+                    *handoffs,
+                    *shared_stops,
+                    *tail,
+                    *route_reload,
+                ),
+                purge_commands,
+                stopped,
+            )
+
+    def status(self, slot_value: str | int | None = None) -> tuple[SlotRecord, ...]:
+        registry = self.store.load()
+        if slot_value is None:
+            return tuple(registry.slots[key] for key in sorted(registry.slots, key=int))
+        slot = allocate_slot(slot_value, registry)
+        record = registry.slots.get(str(slot))
+        return () if record is None else (record,)
+
+    def doctor(
+        self, executor: CommandExecutor, environment: dict[str, str] | None = None
+    ) -> dict[str, object]:
+        """Run approved, read-only runtime inspection through the injected adapter."""
+        registry = self.store.load()
+        commands: list[Command] = [
+            Command(
+                ("docker", "network", "inspect", "futureagi-slots"),
+                self.worktree,
+                # A missing network is the healthy clean-state result before
+                # the first slot starts, not a doctor failure.
+                ("no such network", "network futureagi-slots not found"),
+            )
+        ]
+        if registry.slots:
+            owner = registry.slots[sorted(registry.slots, key=int)[0]]
+            commands.append(
+                Command(
+                    (
+                        "docker",
+                        "compose",
+                        "--project-name",
+                        "futureagi-slots",
+                        "-f",
+                        "slots/compose/control-plane.yaml",
+                        "--env-file",
+                        str(self._slot_env_path(owner)),
+                        "ps",
+                    ),
+                    Path(owner.worktree),
+                )
+            )
+        execute_commands(commands, executor)
+        cap = int(
+            (environment or os.environ).get(
+                "SLOTS_MEMORY_CAP_MIB", DEFAULT_MEMORY_CAP_MIB
+            )
+        )
+        journal = self._recovery_journal_path()
+        return {
+            "configured_memory_cap_mib": cap,
+            "admission_limit_mib": int(cap * ADMISSION_RATIO),
+            "recovery_journal": (
+                journal.read_text(encoding="utf-8").strip()
+                if journal.exists()
+                else None
+            ),
+            "slots": len(registry.slots),
+        }
+
+    def apply_prune(self, executor: CommandExecutor) -> LifecyclePlan:
+        """Recover legacy/corrupt zero-reference shared provider metadata.
+
+        Normal `down` removes the final provider reference and its metadata in
+        one transaction.  Consequently prune is deliberately *not* a normal
+        lifecycle operation or a way to preserve reusable defaults: it repairs
+        stale registry entries left by an interrupted older implementation.
+        """
+        with self.store.locked() as registry:
+            self._require_clean_recovery()
+            stale = tuple(
+                provider
+                for provider in registry.providers.values()
+                if not provider.references and not provider.private
+            )
+            commands = tuple(
+                Command(
+                    (
+                        "docker",
+                        "compose",
+                        "--project-name",
+                        f"futureagi-slots-default-{provider.group}",
+                        "-f",
+                        f"slots/compose/{provider.group}.yaml",
+                        "down",
+                    ),
+                    Path(provider.worktree),
+                )
+                for provider in stale
+            )
+            execute_commands(commands, executor)
+            if stale:
+                stale_names = {provider.name for provider in stale}
+                providers = {
+                    name: provider
+                    for name, provider in registry.providers.items()
+                    if name not in stale_names
+                }
+                self.store.save(
+                    Registry(registry.version, dict(registry.slots), providers)
+                )
+            return LifecyclePlan("prune", 0, None, commands)
+
+    def apply_recover(
+        self,
+        executor: CommandExecutor,
+        state_executor: StateCommandExecutor | None = None,
+    ) -> LifecyclePlan:
+        """Reconcile an interrupted lifecycle operation without deleting volumes."""
+        with self.store.locked() as registry:
+            journal_path = self._recovery_journal_path()
+            if not journal_path.exists():
+                raise ValueError("no slot recovery journal exists")
+            details = json.loads(journal_path.read_text(encoding="utf-8"))
+            action = details.get("action")
+            if action not in {"up", "down", "purge"}:
+                raise ValueError(f"unsupported recovery journal action: {action!r}")
+            slot = allocate_slot(details.get("slot"), registry)
+            raw_record = details.get("record")
+            record = (
+                SlotRecord.from_dict(raw_record)
+                if isinstance(raw_record, dict)
+                else self._manifest_record(slot)
+            )
+            previous = registry.slots.get(str(slot))
+            if action in {"down", "purge"}:
+                # Down and purge commit the registry only after their exact
+                # runtime/state operations succeed. If the old record remains,
+                # clearing the marker makes the original idempotent command
+                # explicitly retryable. Purge is never resumed automatically:
+                # it must cross the CONFIRM and approval gates again.
+                if previous is not None:
+                    self._remove_recovery_journal()
+                    return LifecyclePlan(f"recover-{action}-retry", slot, previous, ())
+
+                # A missing registry entry means the operation committed and
+                # only post-commit artifact cleanup may have been interrupted.
+                route_removed = (
+                    self._remove_route(record) if record is not None else False
+                )
+                commands = self._reload_routes_for_survivors(
+                    registry, executor, route_removed, force=True
+                )
+                if record is not None:
+                    if action == "purge":
+                        directory = self.store.state_dir / "slots" / f"{slot:02d}"
+                        for path in (
+                            directory / "slot.env",
+                            directory / "manifest.json",
+                        ):
+                            if path.exists():
+                                path.unlink()
+                self._remove_recovery_journal()
+                return LifecyclePlan(
+                    f"recover-{action}-complete", slot, record, commands
+                )
+
+            commands: list[Command] = []
+            if record is not None:
+                # The code may have been fixed after the failed attempt. Rebuild
+                # generated env/config from the typed journal record so recovery
+                # is not blocked by newly required interpolation variables.
+                self._stage_artifacts(record)
+                if previous is not None:
+                    # The committed registry still describes the pre-replace
+                    # topology. Remove only the partially recreated private
+                    # project; shared providers and the control plane may be
+                    # serving other slots. The next slot-up can then perform a
+                    # clean replacement while every named volume remains.
+                    suspend_commands: tuple[StateCommand, ...] = ()
+                    if record.isolated_infra:
+                        if state_executor is None:
+                            raise ValueError(
+                                "runtime state execution requires an injected "
+                                "StateCommand executor"
+                            )
+                        state = self._state_plan_for(record)
+                        suspend_commands = build_suspend_plan(
+                            state, state_dir=self.store.state_dir
+                        ).commands
+                        apply_suspend_plan(
+                            SuspendPlan(state, suspend_commands), state_executor
+                        )
+                    commands.append(command_for("down", record, self.store.state_dir))
+                    for group, name in record.providers.items():
+                        if (
+                            group != "frontend"
+                            and name.startswith("shared-")
+                            and name not in registry.providers
+                        ):
+                            commands.append(
+                                _shared_provider_command(
+                                    group,
+                                    record,
+                                    self.store.state_dir,
+                                    "down",
+                                    Path(record.worktree),
+                                )
+                            )
+                    execute_commands(commands, executor)
+                    self._remove_recovery_journal()
+                    return LifecyclePlan(
+                        "recover-replacement",
+                        slot,
+                        record,
+                        tuple(commands),
+                        suspend_commands,
+                    )
+                if record.isolated_infra:
+                    if state_executor is None:
+                        raise ValueError(
+                            "runtime state execution requires an injected StateCommand executor"
+                        )
+                    suspend = build_suspend_plan(
+                        self._state_plan_for(record), state_dir=self.store.state_dir
+                    )
+                    apply_suspend_plan(suspend, state_executor)
+                commands.append(command_for("down", record, self.store.state_dir))
+                for group, name in record.providers.items():
+                    if (
+                        group != "frontend"
+                        and name.startswith("shared-")
+                        and name not in registry.providers
+                    ):
+                        commands.append(
+                            _shared_provider_command(
+                                group,
+                                record,
+                                self.store.state_dir,
+                                "down",
+                                Path(record.worktree),
+                            )
+                        )
+                control_env = self._slot_env_path(record)
+                control_worktree = Path(record.worktree)
+            else:
+                # Older journals did not embed the desired record. Provider
+                # env files still identify safe, exact shared projects and can
+                # also tear down the control plane created before the failure.
+                shared_envs = tuple(
+                    sorted((self.store.state_dir / "shared").glob("*.env"))
+                )
+                if not shared_envs:
+                    raise ValueError(
+                        "legacy recovery journal has no manifest or shared environment"
+                    )
+                for env_path in shared_envs:
+                    group = env_path.stem
+                    if group in CATALOG and f"shared-{group}" not in registry.providers:
+                        commands.append(
+                            _shared_provider_command(
+                                group,
+                                None,
+                                self.store.state_dir,
+                                "down",
+                                self.worktree,
+                            )
+                        )
+                control_env = shared_envs[0]
+                control_worktree = self.worktree
+            if not registry.slots:
+                commands.extend(
+                    (
+                        _control_plane_down_with_env(control_worktree, control_env),
+                        Command(
+                            ("docker", "network", "rm", "futureagi-slots"),
+                            control_worktree,
+                            ("not found", "no such network"),
+                        ),
+                    )
+                )
+            execute_commands(commands, executor)
+            if record is not None:
+                self._remove_route(record)
+            self._remove_recovery_journal()
+            return LifecyclePlan("recover", slot, record, tuple(commands))
+
+    def service_command(
+        self, record: SlotRecord, action: str, service: str, command: str | None = None
+    ) -> Command:
+        if service != "frontend" and service not in CATALOG:
+            raise ValueError(f"unsupported service: {service}")
+        provider = self.store.load().providers.get(record.providers.get(service, ""))
+        if provider is None or provider.private or service == "frontend":
+            return command_for(action, record, self.store.state_dir, service, command)
+        base = (
+            "docker",
+            "compose",
+            "--project-name",
+            f"futureagi-slots-default-{provider.group}",
+            "-f",
+            f"slots/compose/{provider.group}.yaml",
+            "--env-file",
+            str(self._shared_env_path(provider.group)),
+        )
+        if action == "logs":
+            argv = (*base, "logs", "--follow", compose_primary_member(provider.group))
+        elif action == "shell":
+            argv = (*base, "exec", compose_primary_member(provider.group), "sh")
+        elif action == "run" and command:
+            argv = (
+                *base,
+                "exec",
+                compose_primary_member(provider.group),
+                "sh",
+                "-lc",
+                command,
+            )
+        else:
+            raise ValueError("COMMAND is required for slot-run")
+        return Command(argv, Path(provider.worktree))
+
+    def write_generated_files(self, record: SlotRecord) -> tuple[Path, Path]:
+        directory = self.store.state_dir / "slots" / f"{record.slot:02d}"
+        directory.mkdir(mode=0o700, parents=True, exist_ok=True)
+        env_path = directory / "slot.env"
+        manifest_path = directory / "manifest.json"
+        values = self.environment_for(record)
+        self._write_private(
+            env_path,
+            self._environment_contents(Path(record.worktree), values),
+        )
+        self._write_private(
+            manifest_path, json.dumps(record.to_dict(), sort_keys=True, indent=2) + "\n"
+        )
+        return env_path, manifest_path
+
+    def _shared_env_path(self, group: str) -> Path:
+        return self.store.state_dir / "shared" / f"{group}.env"
+
+    def _write_shared_environment(
+        self,
+        group: str,
+        record: SlotRecord,
+        owner_worktree: Path | None = None,
+    ) -> Path:
+        """Publish a provider-stable env file; never borrow a slot's env file."""
+        shared_state = StateIdentity.for_slot(0)
+        values = self.environment_for(record)
+        for key in tuple(values):
+            if (
+                key.startswith("SLOT_ISOLATED_")
+                or key.endswith("_HOST")
+                or key.endswith("_VOLUME")
+                or key == "SLOT_TEMPORAL_UI_NAME"
+            ):
+                values.pop(key)
+        owner = owner_worktree or Path(record.worktree)
+        values.update(
+            {
+                "SLOT": "0",
+                "SLOT_ID": "00",
+                "SLOT_PROJECT": f"futureagi-slots-default-{group}",
+                # Several provider templates bind-mount or build from the
+                # provider owner.  This must travel with owner handoff rather
+                # than accidentally retaining the first runtime instance.
+                "SLOT_WORKTREE": str(owner),
+                "SLOT_ENV_FILE": str(self._shared_env_path(group)),
+                "SLOT_STATE_ID": shared_state.temporal_namespace,
+                "SLOT_PG_DB": shared_state.postgres_database,
+                "SLOT_CH_DATABASE": shared_state.clickhouse_database,
+                "SLOT_REDIS_DB": str(shared_state.redis_databases[0]),
+                "SLOT_REDIS_DB_CACHE": str(shared_state.redis_databases[1]),
+                "SLOT_REDIS_DB_LOCK": str(shared_state.redis_databases[2]),
+                "SLOT_REDIS_CACHE_DB": str(shared_state.redis_databases[1]),
+                "SLOT_REDIS_LOCK_DB": str(shared_state.redis_databases[2]),
+                "SLOT_RABBITMQ_VHOST": shared_state.rabbitmq_vhost,
+                "SLOT_MINIO_BUCKET": shared_state.minio_bucket,
+                "SLOT_TEMPORAL_NAMESPACE": shared_state.temporal_namespace,
+            }
+        )
+        for service in CATALOG:
+            values[f"SLOT_{service.upper()}_NAME"] = f"shared-{service}"
+        values.update(SHARED_PROVIDER_OVERRIDES[group])
+        values["SLOT_TEMPORAL_UI_NAME"] = "futureagi-slots-temporal-ui"
+        path = self._shared_env_path(group)
+        self._write_private(path, self._environment_contents(owner, values))
+        return path
+
+    @staticmethod
+    def _environment_contents(worktree: Path, values: dict[str, str]) -> str:
+        """Layer generated topology over the worktree's application environment."""
+        source = worktree / ".env"
+        inherited = source.read_text(encoding="utf-8") if source.is_file() else ""
+        if inherited and not inherited.endswith("\n"):
+            inherited += "\n"
+        generated = "".join(f"{key}={value}\n" for key, value in sorted(values.items()))
+        return (
+            inherited
+            + "# Generated slot topology; values below override matching worktree entries.\n"
+            + generated
+        )
+
+    def environment_for(self, record: SlotRecord) -> dict[str, str]:
+        slot_id = f"{record.slot:02d}"
+        values = {
+            "SLOTS_STATE_DIR": str(self.store.state_dir),
+            "SLOTS_CONTROL_PROJECT": "futureagi-slots",
+            "SLOTS_NETWORK": "futureagi-slots",
+            "SLOTS_HTTP_PORT": record.http_port,
+            "SLOTS_TRAEFIK_NAME": "futureagi-slots-traefik",
+            "SLOTS_POSTGRES_NAME": "futureagi-slots-postgres",
+            "SLOTS_CLICKHOUSE_NAME": "futureagi-slots-clickhouse",
+            "SLOTS_REDIS_NAME": "futureagi-slots-redis",
+            "SLOTS_RABBITMQ_NAME": "futureagi-slots-rabbitmq",
+            "SLOTS_MINIO_NAME": "futureagi-slots-minio",
+            "SLOTS_TEMPORAL_NAME": "futureagi-slots-temporal",
+            "SLOT": str(record.slot),
+            "SLOT_ID": slot_id,
+            "SLOT_PROJECT": f"futureagi-slot-{slot_id}",
+            "SLOT_NETWORK": "futureagi-slots",
+            "SLOTS_ROUTE_DIR": str(self.store.state_dir / "routes"),
+            "SLOTS_TRAEFIK_STATIC_CONFIG": str(
+                self.store.state_dir / "control-plane" / "traefik.yaml"
+            ),
+            "SLOTS_CLICKHOUSE_STORAGE_CONFIG": str(
+                self.store.state_dir / "control-plane" / "clickhouse-storage-policy.xml"
+            ),
+            "SLOTS_CLICKHOUSE_TEST_CONFIG": str(
+                self.store.state_dir / "control-plane" / "clickhouse-test-config.xml"
+            ),
+            "SLOT_WORKTREE": record.worktree,
+            "SLOT_ENV_FILE": str(self.store.state_dir / "slots" / slot_id / "slot.env"),
+            "SLOT_ROUTE_FILE": str(
+                self.store.state_dir / "routes" / f"slot-{slot_id}.yaml"
+            ),
+            "SLOT_PORT_BASE": str(20000 + record.slot * 100),
+            "SLOT_STATE_ID": record.state.temporal_namespace,
+            "SLOT_PG_DB": record.state.postgres_database,
+            "SLOT_CH_DATABASE": record.state.clickhouse_database,
+            "SLOT_REDIS_DB": str(record.state.redis_databases[0]),
+            "SLOT_REDIS_DB_CACHE": str(record.state.redis_databases[1]),
+            "SLOT_REDIS_DB_LOCK": str(record.state.redis_databases[2]),
+            "SLOT_REDIS_CACHE_DB": str(record.state.redis_databases[1]),
+            "SLOT_REDIS_LOCK_DB": str(record.state.redis_databases[2]),
+            "SLOT_RABBITMQ_VHOST": record.state.rabbitmq_vhost,
+            "SLOT_MINIO_BUCKET": record.state.minio_bucket,
+            "SLOT_TEMPORAL_NAMESPACE": record.state.temporal_namespace,
+        }
+        ports = dict(record.ports)
+        ports.update(
+            {
+                key: value
+                for key, value in private_ports(
+                    record.slot,
+                    (),
+                    (
+                        "postgres",
+                        "clickhouse",
+                        "redis",
+                        "rabbitmq",
+                        "minio",
+                        "temporal",
+                    ),
+                ).items()
+                if key not in ports
+            }
+        )
+        for service, port in ports.items():
+            upper = service.upper()
+            values[f"SLOT_{upper}_NAME"] = record.providers.get(
+                service, f"slot-{slot_id}-{service}"
+            )
+            values[f"SLOT_{upper}_PORT"] = str(port)
+        for service in CATALOG:
+            values.setdefault(
+                f"SLOT_{service.upper()}_NAME",
+                record.providers.get(
+                    service, provider_name(record.slot, service, False)
+                ),
+            )
+        values["SLOT_WORKER_NAME"] = f"{record.providers['backend']}-worker"
+        values["SLOT_BACKEND_IMAGE_REF"] = (
+            f"futureagi/slot-backend:{slot_id}"
+            if record.providers["backend"].startswith(f"slot-{slot_id}-")
+            else "futureagi/slot-backend:00"
+        )
+        peerdb_prefix = f"futureagi-slot-{slot_id}-peerdb"
+        if record.providers["peerdb"].startswith(f"slot-{slot_id}-"):
+            values.update(
+                {
+                    "SLOT_PEERDB_AGGREGATE_NAME": f"{peerdb_prefix}-aggregate",
+                    "SLOT_PEERDB_CATALOG_NAME": f"{peerdb_prefix}-catalog",
+                    "SLOT_PEERDB_TEMPORAL_NAME": f"{peerdb_prefix}-temporal",
+                    "SLOT_PEERDB_TEMPORAL_INIT_NAME": f"{peerdb_prefix}-temporal-init",
+                    "SLOT_PEERDB_MINIO_NAME": f"{peerdb_prefix}-minio",
+                    "SLOT_PEERDB_MINIO_INIT_NAME": f"{peerdb_prefix}-minio-init",
+                    "SLOT_PEERDB_FLOW_API_NAME": f"{peerdb_prefix}-flow-api",
+                    "SLOT_PEERDB_FLOW_WORKER_NAME": f"{peerdb_prefix}-flow-worker",
+                    "SLOT_PEERDB_SERVER_NAME": f"{peerdb_prefix}-server",
+                    "SLOT_PEERDB_UI_NAME": f"{peerdb_prefix}-ui",
+                    "SLOT_PEERDB_INIT_NAME": f"{peerdb_prefix}-init",
+                    "SLOT_PEERDB_CATALOG_VOLUME": f"{peerdb_prefix}-catalog-data",
+                    "SLOT_PEERDB_MINIO_VOLUME": f"{peerdb_prefix}-minio-data",
+                }
+            )
+        else:
+            values["SLOT_PEERDB_UI_NAME"] = "shared-peerdb-ui"
+        values["SLOTS_TEMPORAL_UI_NAME"] = "futureagi-slots-temporal-ui"
+        isolated_names = {
+            "postgres": f"futureagi-slot-{slot_id}-postgres",
+            "clickhouse": f"futureagi-slot-{slot_id}-clickhouse",
+            "redis": f"futureagi-slot-{slot_id}-redis",
+            "rabbitmq": f"futureagi-slot-{slot_id}-rabbitmq",
+            "minio": f"futureagi-slot-{slot_id}-minio",
+            "temporal": f"futureagi-slot-{slot_id}-temporal",
+        }
+        for engine, name in isolated_names.items():
+            values[f"SLOT_ISOLATED_{engine.upper()}_NAME"] = name
+        values["SLOT_ISOLATED_TEMPORAL_POSTGRES_NAME"] = (
+            f"futureagi-slot-{slot_id}-temporal-postgres"
+        )
+        values["SLOT_TEMPORAL_UI_NAME"] = (
+            f"futureagi-slot-{slot_id}-temporal-ui"
+            if "temporal" in record.isolated_infra
+            else values["SLOTS_TEMPORAL_UI_NAME"]
+        )
+        if record.isolated_infra:
+            prefix = f"futureagi-slot-{slot_id}"
+            hosts = {
+                "postgres": ("SLOT_PG_HOST", f"{prefix}-postgres"),
+                "clickhouse": ("SLOT_CH_HOST", f"{prefix}-clickhouse"),
+                "redis": ("SLOT_REDIS_HOST", f"{prefix}-redis"),
+                "rabbitmq": ("SLOT_RABBITMQ_HOST", f"{prefix}-rabbitmq"),
+                "minio": ("SLOT_MINIO_HOST", f"{prefix}-minio"),
+                "temporal": ("SLOT_TEMPORAL_HOST", f"{prefix}-temporal"),
+            }
+            for engine in record.isolated_infra:
+                key, value = hosts[engine]
+                values[key] = value
+                values[f"SLOT_{engine.upper()}_VOLUME"] = volume_name(
+                    record.slot, engine
+                )
+            if "postgres" in record.isolated_infra:
+                values["SLOT_TEMPORAL_POSTGRES_HOST"] = values["SLOT_PG_HOST"]
+        return values
+
+    def _build_up(
+        self,
+        registry: Registry,
+        slot_value: str | int,
+        services_value: str | None,
+        isolated_infra_value: str | None,
+        revision: str,
+        environment: dict[str, str],
+    ) -> LifecyclePlan:
+        slot = allocate_slot(slot_value, registry)
+        environment = dict(environment)
+        environment["SLOTS_HTTP_PORT"] = normalise_http_port(environment)
+        active_ports = {item.http_port for item in registry.slots.values()}
+        if active_ports and environment["SLOTS_HTTP_PORT"] not in active_ports:
+            raise ValueError(
+                "SLOTS_HTTP_PORT must match the single public port used by active slots"
+            )
+        requested = parse_services(services_value)
+        requested_private = (
+            tuple(CATALOG)
+            if requested == ("all",)
+            else (() if requested == ("none",) else requested)
+        )
+        private = effective_private_groups(requested_private)
+        services = expand_services(requested)
+        isolated = parse_isolated_infra(isolated_infra_value)
+        if isolated and "backend" not in private:
+            raise ValueError("ISOLATE_INFRA requires SERVICES=backend")
+        prior = registry.slots.get(str(slot)) or self._manifest_record(slot)
+        record = self._record(
+            registry,
+            slot,
+            requested,
+            private,
+            services,
+            isolated,
+            revision,
+            environment,
+            tuple(
+                sorted(
+                    (set(prior.isolated_infra) | set(prior.retired_isolated_infra))
+                    - set(isolated)
+                )
+            )
+            if prior is not None
+            else (),
+            (
+                "backend" in private
+                or (
+                    prior.retained_private_backend_state if prior is not None else False
+                )
+                or (
+                    prior.providers["backend"] == provider_name(slot, "backend", True)
+                    if prior is not None
+                    else False
+                )
+            ),
+        )
+        default_groups = tuple(
+            service
+            for service, name in record.providers.items()
+            if service != "frontend"
+            and not name.startswith(f"slot-{slot:02d}-")
+            and name not in registry.providers
+        )
+        backend_needs_state = "backend" in default_groups or "backend" in private
+        overhead = (CONTROL_PLANE_MEMORY_MIB if not registry.slots else 0) + sum(
+            CATALOG[group].memory_mib for group in default_groups
+        )
+        self._admit(registry, record, environment, overhead)
+        commands: list[Command] = []
+        previous = registry.slots.get(str(slot))
+        if previous is not None:
+            commands.append(command_for("down", previous, self.store.state_dir))
+        commands.extend(
+            (
+                _network_command(record),
+                _control_plane_command(record, self.store.state_dir),
+            )
+        )
+        state_commands: tuple[StateCommand, ...] = ()
+        for group in default_groups:
+            self._validate_shared_candidate(
+                group, environment.get("BASE_REF", "origin/dev")
+            )
+        if backend_needs_state:
+            state = build_state_plan(
+                slot,
+                provider_slot=slot if "backend" in private else None,
+                isolate_infra=isolated,
+            )
+            adapt_orchestrator_state(record.state)
+            state_commands = build_provision_plan(
+                state,
+                state_dir=self.store.state_dir if isolated else None,
+            ).commands
+        for group in default_groups:
+            if group in BUILDABLE_GROUPS:
+                commands.append(
+                    _shared_provider_command(
+                        group, record, self.store.state_dir, "build"
+                    )
+                )
+            commands.append(
+                _shared_provider_command(group, record, self.store.state_dir, "up")
+            )
+        # Re-evaluate every source-backed private image sequentially. BuildKit
+        # keeps unchanged builds fast; sequencing avoids the large transient
+        # memory spike from Compose building all images while starting the graph.
+        # Backend precedes simulation because the latter inherits its exact tag.
+        for group in (*private, "frontend"):
+            if group in BUILDABLE_GROUPS:
+                commands.append(
+                    command_for("build", record, self.store.state_dir, service=group)
+                )
+        # Atomic route-file creation is not consistently reported through
+        # macOS VM bind mounts. Restart only the stateless proxy so every new
+        # slot route is loaded without recreating shared databases or queues.
+        commands.append(_traefik_restart_command(record, self.store.state_dir))
+        commands.append(command_for("up", record, self.store.state_dir))
+        return LifecyclePlan("up", slot, record, tuple(commands), state_commands)
+
+    def _validate_shared_candidate(
+        self, group: str, base_ref: str, worktree: Path | None = None
+    ) -> None:
+        paths = {
+            "backend": ("futureagi", "Dockerfile", "docker-compose.local.yml"),
+            "simulation": ("futureagi/simulate", "Dockerfile.simulation-runner.dev"),
+            "gateway": ("agentcc-gateway",),
+            "collector": ("fi-collector",),
+            "serving": ("futureagi/model_serving",),
+            "executor": ("futureagi/code-executor",),
+            "peerdb": (
+                "futureagi/config/peerdb",
+                "futureagi/docker-compose.peerdb.yml",
+                "futureagi/scripts/peerdb-setup-mirrors.sh",
+            ),
+            "observability": (
+                "futureagi/tracer",
+                "futureagi/docker-compose.observability.yml",
+            ),
+        }
+        candidate = worktree or self.worktree
+        changed = self.git_runner(
+            ("git", "diff", "--name-only", base_ref, "--", *paths[group]), candidate
+        )
+        untracked = self.git_runner(
+            ("git", "ls-files", "--others", "--exclude-standard", "--", *paths[group]),
+            candidate,
+        )
+        if changed.strip() or untracked.strip():
+            raise ValueError(
+                f"cannot create shared {group} default: source differs from {base_ref}"
+            )
+
+    def _route_path(self, record: SlotRecord) -> Path:
+        return self.store.state_dir / "routes" / f"slot-{record.slot:02d}.yaml"
+
+    def _slot_env_path(self, record: SlotRecord) -> Path:
+        return self.store.state_dir / "slots" / f"{record.slot:02d}" / "slot.env"
+
+    def _manifest_record(self, slot: int) -> SlotRecord | None:
+        path = self.store.state_dir / "slots" / f"{slot:02d}" / "manifest.json"
+        if not path.exists():
+            return None
+        with path.open(encoding="utf-8") as handle:
+            return SlotRecord.from_dict(json.load(handle))
+
+    def _recovery_journal_path(self) -> Path:
+        return self.store.state_dir / "recovery.json"
+
+    def _write_recovery_journal(self, record: SlotRecord, action: str) -> None:
+        """Leave an explicit marker if a process dies after runtime changes.
+
+        The registry cannot be atomically committed with Docker state.  The marker
+        is intentionally retained on a registry-save failure so `slots-doctor`
+        can tell an operator that reconciliation is required.
+        """
+        if self._recovery_journal_path().exists():
+            raise RuntimeError(
+                "slot recovery journal exists; run slots-doctor and reconcile before mutating"
+            )
+        self._write_private(
+            self._recovery_journal_path(),
+            json.dumps(
+                {"action": action, "slot": record.slot, "record": record.to_dict()},
+                sort_keys=True,
+            )
+            + "\n",
+        )
+
+    def _remove_recovery_journal(self) -> None:
+        path = self._recovery_journal_path()
+        if path.exists():
+            path.unlink()
+
+    def _require_clean_recovery(self) -> None:
+        path = self._recovery_journal_path()
+        if path.exists():
+            details = path.read_text(encoding="utf-8").strip()
+            raise RuntimeError(
+                "slot recovery journal blocks mutation; reconcile runtime state first"
+                + (f": {details}" if details else "")
+            )
+
+    def _route_contents(self, record: SlotRecord) -> str:
+        template = (
+            Path(__file__).parent / "traefik" / "routes.template.yaml"
+        ).read_text(encoding="utf-8")
+        values = self.environment_for(record)
+        replacements = {
+            "__SLOT_ID__": f"{record.slot:02d}",
+            "__SLOT__": str(record.slot),
+            "__FRONTEND_NAME__": values["SLOT_FRONTEND_NAME"],
+            "__BACKEND_NAME__": values["SLOT_BACKEND_NAME"],
+            "__TEMPORAL_UI_NAME__": values["SLOT_TEMPORAL_UI_NAME"],
+            "__MINIO_NAME__": (
+                values["SLOT_ISOLATED_MINIO_NAME"]
+                if "minio" in record.isolated_infra
+                else values["SLOTS_MINIO_NAME"]
+            ),
+            "__RABBITMQ_NAME__": (
+                values["SLOT_ISOLATED_RABBITMQ_NAME"]
+                if "rabbitmq" in record.isolated_infra
+                else values["SLOTS_RABBITMQ_NAME"]
+            ),
+            "__GATEWAY_NAME__": values["SLOT_GATEWAY_NAME"],
+            "__SERVING_NAME__": values["SLOT_SERVING_NAME"],
+            "__COLLECTOR_NAME__": values["SLOT_COLLECTOR_NAME"],
+            "__EXECUTOR_NAME__": values["SLOT_EXECUTOR_NAME"],
+            "__OBSERVABILITY_NAME__": values["SLOT_OBSERVABILITY_NAME"],
+            "__PEERDB_UI_NAME__": values["SLOT_PEERDB_UI_NAME"],
+        }
+        for token, value in replacements.items():
+            template = template.replace(token, value)
+        return template
+
+    def _stage_artifacts(self, record: SlotRecord) -> dict[Path, bytes | None]:
+        directory = self.store.state_dir / "slots" / f"{record.slot:02d}"
+        env_path, manifest_path = directory / "slot.env", directory / "manifest.json"
+        route_path = self._route_path(record)
+        control_dir = self.store.state_dir / "control-plane"
+        control_files = {
+            control_dir / "traefik.yaml": Path(__file__).parent
+            / "traefik"
+            / "traefik.yaml",
+            control_dir / "clickhouse-storage-policy.xml": Path(__file__).parent.parent
+            / "futureagi"
+            / ".ci"
+            / "clickhouse-storage-policy.xml",
+            control_dir / "clickhouse-test-config.xml": Path(__file__).parent.parent
+            / "futureagi"
+            / ".ci"
+            / "clickhouse-test-config.xml",
+        }
+        snapshots = {
+            path: path.read_bytes() if path.exists() else None
+            for path in (env_path, manifest_path, route_path, *control_files)
+        }
+        try:
+            for target, source in control_files.items():
+                self._write_private(target, source.read_text(encoding="utf-8"))
+            self.write_generated_files(record)
+            self._write_private(route_path, self._route_contents(record))
+        except Exception:
+            # A failure after publishing one generated file must not leave a
+            # mixed old/new environment behind, even before Compose is reached.
+            self._restore_artifacts(snapshots)
+            raise
+        return snapshots
+
+    def _restore_artifacts(self, snapshots: dict[Path, bytes | None]) -> None:
+        for path, contents in snapshots.items():
+            if contents is None:
+                if path.exists():
+                    path.unlink()
+            else:
+                self._write_private(path, contents.decode())
+
+    def _remove_route(self, record: SlotRecord) -> bool:
+        path = self._route_path(record)
+        if path.exists():
+            path.unlink()
+            return True
+        return False
+
+    def _reload_routes_for_survivors(
+        self,
+        registry: Registry,
+        executor: CommandExecutor,
+        route_removed: bool,
+        *,
+        force: bool = False,
+    ) -> tuple[Command, ...]:
+        """Force Traefik to observe a route deletion on VM-backed fileshares."""
+        if (not route_removed and not force) or not registry.slots:
+            return ()
+        owner = registry.slots[sorted(registry.slots, key=int)[0]]
+        command = _traefik_restart_command(owner, self.store.state_dir)
+        execute_commands((command,), executor)
+        return (command,)
+
+    def _record(
+        self,
+        registry: Registry,
+        slot: int,
+        requested: tuple[str, ...],
+        private: tuple[str, ...],
+        services: tuple[str, ...],
+        isolated: tuple[str, ...],
+        revision: str,
+        environment: dict[str, str],
+        retired_isolated: tuple[str, ...] = (),
+        retained_private_backend_state: bool = False,
+    ) -> SlotRecord:
+        providers: dict[str, str] = {"frontend": provider_name(slot, "frontend", True)}
+        backend_name = provider_name(slot, "backend", "backend" in private)
+        backend = registry.providers.get(backend_name)
+        state = (
+            backend.state
+            if backend
+            else StateIdentity.for_slot(slot if "backend" in private else 0)
+        )
+        providers["backend"] = backend_name
+        # Every slot gets a complete provider map.  Requested groups are private;
+        # omitted groups share one validated default stack, so advertised routes
+        # do not point at providers that were never started.
+        required = tuple(CATALOG)
+        for service in required:
+            providers[service] = provider_name(slot, service, service in private)
+        ports = private_ports(slot, private, isolated)
+        digest = hashlib.sha256(
+            json.dumps(environment, sort_keys=True).encode()
+        ).hexdigest()
+        effective_services = tuple(
+            group for group in CATALOG if group in set(services) | set(private)
+        )
+        estimated_services = ("frontend", *private)
+        return SlotRecord(
+            slot,
+            str(self.worktree),
+            requested,
+            effective_services,
+            providers,
+            state,
+            routes_for_slot(slot, environment.get("SLOTS_HTTP_PORT", "80")),
+            ports,
+            ResourceEstimate(
+                estimate_resources(private)
+                + sum(ISOLATED_MEMORY_MIB[engine] for engine in isolated),
+                estimated_services,
+            ),
+            digest,
+            revision,
+            isolated,
+            environment.get("SLOTS_HTTP_PORT", "80"),
+            retired_isolated,
+            retained_private_backend_state,
+            environment.get("BASE_REF", "origin/dev"),
+        )
+
+    def _admit(
+        self,
+        registry: Registry,
+        record: SlotRecord,
+        environment: dict[str, str],
+        overhead_mib: int = 0,
+    ) -> None:
+        if environment.get("FORCE") == "1":
+            return
+        cap = int(environment.get("SLOTS_MEMORY_CAP_MIB", DEFAULT_MEMORY_CAP_MIB))
+        existing = sum(
+            item.resources.memory_mib
+            for item in registry.slots.values()
+            if item.slot != record.slot
+        )
+        allowed = int(cap * ADMISSION_RATIO)
+        projected = existing + record.resources.memory_mib + overhead_mib
+        if projected > allowed:
+            raise ResourceAdmissionError(
+                f"slot {record.slot} needs {record.resources.memory_mib} MiB; projected {projected} MiB exceeds {allowed} MiB admission limit"
+            )
+
+    def _state_plan_for(self, record: SlotRecord):
+        return build_state_plan(
+            record.slot,
+            provider_slot=(
+                record.slot
+                if record.providers["backend"]
+                == provider_name(record.slot, "backend", True)
+                else None
+            ),
+            isolate_infra=record.isolated_infra,
+        )
+
+    def _purge_state_plan(self, record: SlotRecord):
+        """Preserve the physical ownership history of every state engine.
+
+        A backend may move an engine from isolated to shared during replacement.
+        Its old logical data still belongs only to the retired private volume,
+        so purge must not issue a same-named delete against the shared engine.
+        """
+        isolated = tuple(
+            sorted(set(record.isolated_infra) | set(record.retired_isolated_infra))
+        )
+        return build_state_plan(
+            record.slot,
+            provider_slot=record.slot,
+            isolate_infra=isolated,
+        )
+
+    def _handoff_shared_owners(
+        self, registry: Registry, departing_worktree: str, executor: CommandExecutor
+    ) -> tuple[Registry, tuple[Command, ...]]:
+        """Recreate a shared project from a surviving consumer before rebinding it.
+
+        Shared projects deliberately keep a provider-specific environment.  A
+        handoff therefore writes that environment for the successor before its
+        Compose project is recreated.  If either writing or execution fails,
+        restore every previous file and leave the registry unchanged; callers
+        retain their recovery journal for the interrupted external topology.
+        """
+        if not departing_worktree:
+            return registry, ()
+        providers = dict(registry.providers)
+        commands: list[Command] = []
+        snapshots: dict[Path, bytes | None] = {}
+        try:
+            for name, provider in tuple(providers.items()):
+                if provider.private or provider.worktree != departing_worktree:
+                    continue
+                active_consumers = tuple(
+                    registry.slots[str(slot)]
+                    for slot in provider.references
+                    if str(slot) in registry.slots
+                )
+                # A same-worktree replacement is not an owner departure. Keep
+                # the stable provider instead of needlessly recreating it.
+                if any(
+                    candidate.worktree == provider.worktree
+                    for candidate in active_consumers
+                ):
+                    continue
+                consumers = active_consumers
+                if not consumers:
+                    continue
+                owner = None
+                for candidate in sorted(consumers, key=lambda item: item.slot):
+                    try:
+                        self._validate_shared_candidate(
+                            provider.group,
+                            provider.base_ref,
+                            Path(candidate.worktree),
+                        )
+                    except ValueError:
+                        continue
+                    owner = candidate
+                    break
+                if owner is None:
+                    raise ValueError(
+                        f"cannot hand off shared {provider.group}: no surviving "
+                        f"consumer matches {provider.base_ref}; keep the owner "
+                        "worktree or make that provider private before retrying"
+                    )
+                env_path = self._shared_env_path(provider.group)
+                snapshots.setdefault(
+                    env_path, env_path.read_bytes() if env_path.exists() else None
+                )
+                self._write_shared_environment(
+                    provider.group, owner, Path(owner.worktree)
+                )
+                commands.append(
+                    _shared_provider_command(
+                        provider.group,
+                        owner,
+                        self.store.state_dir,
+                        "up",
+                        Path(owner.worktree),
+                        force_recreate=True,
+                    )
+                )
+                providers[name] = ProviderRecord(
+                    provider.name,
+                    provider.group,
+                    owner.worktree,
+                    provider.state,
+                    provider.references,
+                    False,
+                    provider.base_ref,
+                )
+            execute_commands(commands, executor)
+        except Exception:
+            self._restore_artifacts(snapshots)
+            raise
+        return Registry(registry.version, dict(registry.slots), providers), tuple(
+            commands
+        )
+
+    @staticmethod
+    def _retired_private_volume_commands(record: SlotRecord) -> tuple[Command, ...]:
+        """Remove the complete, allowlisted set of volumes owned by one slot.
+
+        Purge is explicitly confirmed for the slot, so trying every exact
+        slot-scoped name is safer than relying on the current topology to
+        remember providers that may have been retired several replacements
+        ago. Missing volumes are an idempotent success; shared names can never
+        be produced by this planner.
+        """
+        prefix = f"futureagi-slot-{record.slot:02d}"
+        names = (
+            f"{prefix}-frontend-node-modules",
+            f"{prefix}-backend-media",
+            f"{prefix}-collector-data",
+            f"{prefix}-peerdb-catalog-data",
+            f"{prefix}-peerdb-minio-data",
+        )
+        return tuple(
+            Command(
+                ("docker", "volume", "rm", name),
+                Path(record.worktree),
+                ("no such volume",),
+            )
+            for name in names
+        )
+
+    def _attach(self, registry: Registry, record: SlotRecord) -> Registry:
+        slots = dict(registry.slots)
+        providers = dict(registry.providers)
+        previous = slots.get(str(record.slot))
+        if previous:
+            detached, _ = self._detach(
+                Registry(registry.version, slots, providers), previous
+            )
+            slots, providers = dict(detached.slots), dict(detached.providers)
+        for service, name in record.providers.items():
+            existing = providers.get(name)
+            references = tuple(
+                sorted(set((existing.references if existing else ()) + (record.slot,)))
+            )
+            is_private = name.startswith(f"slot-{record.slot:02d}-")
+            state = record.state if is_private else StateIdentity.for_slot(0)
+            # Shared project/env are created by the first reference and remain
+            # rooted in that owner worktree until its final reference is gone.
+            owner_worktree = (
+                record.worktree if is_private or existing is None else existing.worktree
+            )
+            providers[name] = ProviderRecord(
+                name,
+                service,
+                owner_worktree,
+                state,
+                references,
+                is_private,
+                (existing.base_ref if existing is not None else record.shared_base_ref),
+            )
+        slots[str(record.slot)] = record
+        return Registry(registry.version, slots, providers)
+
+    def _detach(
+        self, registry: Registry, record: SlotRecord
+    ) -> tuple[Registry, tuple[str, ...]]:
+        slots = dict(registry.slots)
+        providers = dict(registry.providers)
+        stopped: list[str] = []
+        for name in set(record.providers.values()):
+            provider = providers.get(name)
+            if provider is None:
+                continue
+            references = tuple(
+                reference
+                for reference in provider.references
+                if reference != record.slot
+            )
+            if references:
+                providers[name] = ProviderRecord(
+                    provider.name,
+                    provider.group,
+                    provider.worktree,
+                    provider.state,
+                    references,
+                    provider.private,
+                    provider.base_ref,
+                )
+            else:
+                del providers[name]
+                stopped.append(name)
+        slots.pop(str(record.slot), None)
+        return Registry(registry.version, slots, providers), tuple(sorted(stopped))
+
+    @staticmethod
+    def _write_private(path: Path, contents: str) -> None:
+        path.parent.mkdir(mode=0o700, parents=True, exist_ok=True)
+        temporary = path.with_suffix(path.suffix + ".tmp")
+        descriptor = os.open(temporary, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+        with os.fdopen(descriptor, "w", encoding="utf-8") as handle:
+            handle.write(contents)
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(temporary, path)
+        os.chmod(path, 0o600)

--- a/slots/state.py
+++ b/slots/state.py
@@ -1,0 +1,233 @@
+"""Validated provider-bound state identities for development slots.
+
+All functions in this module are deterministic and have no I/O.  A provider is
+either the shared default (``None``) or the private backend belonging to a slot.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Final, Iterable, Protocol
+
+MIN_SLOT: Final = 1
+MAX_SLOT: Final = 20
+REDIS_DATABASES_PER_PROVIDER: Final = 3
+REDIS_DATABASE_COUNT: Final = 64
+INFRA_ENGINES: Final = frozenset(
+    {"postgres", "clickhouse", "redis", "rabbitmq", "minio", "temporal"}
+)
+
+
+class StateValidationError(ValueError):
+    """Raised before a state plan can name an infrastructure resource."""
+
+
+def validate_slot(slot: int) -> int:
+    """Return ``slot`` after enforcing the public 1--20 slot contract."""
+    if (
+        isinstance(slot, bool)
+        or not isinstance(slot, int)
+        or not MIN_SLOT <= slot <= MAX_SLOT
+    ):
+        raise StateValidationError(
+            f"SLOT must be an integer from {MIN_SLOT} to {MAX_SLOT}"
+        )
+    return slot
+
+
+def _provider_suffix(provider_slot: int | None) -> str:
+    return f"slot_{0 if provider_slot is None else provider_slot:02d}"
+
+
+def _provider_dash_suffix(provider_slot: int | None) -> str:
+    return f"slot-{0 if provider_slot is None else provider_slot:02d}"
+
+
+def validate_isolated_infra(value: str | Iterable[str] | None) -> frozenset[str]:
+    """Parse ``ISOLATE_INFRA`` without accepting aliases or unknown engines."""
+    if value is None:
+        return frozenset()
+    items = value.split(",") if isinstance(value, str) else list(value)
+    normalized: list[str] = []
+    for item in items:
+        if not isinstance(item, str):
+            raise StateValidationError("ISOLATE_INFRA entries must be strings")
+        engine = item.strip()
+        if not engine:
+            raise StateValidationError("ISOLATE_INFRA cannot contain an empty engine")
+        if engine not in INFRA_ENGINES:
+            supported = ", ".join(sorted(INFRA_ENGINES))
+            raise StateValidationError(
+                f"unsupported ISOLATE_INFRA engine {engine!r}; supported: {supported}"
+            )
+        if engine in normalized:
+            raise StateValidationError(f"ISOLATE_INFRA lists {engine!r} more than once")
+        normalized.append(engine)
+    return frozenset(normalized)
+
+
+@dataclass(frozen=True, slots=True)
+class ProvisioningStateIdentity:
+    """Logical state owned by one selected backend provider."""
+
+    provider_slot: int | None
+
+    def __post_init__(self) -> None:
+        if self.provider_slot is not None:
+            validate_slot(self.provider_slot)
+        if max(self.redis_databases, default=-1) >= REDIS_DATABASE_COUNT:
+            raise StateValidationError(
+                "Redis database allocation exceeds configured database count"
+            )
+
+    @property
+    def is_shared_default(self) -> bool:
+        return self.provider_slot is None
+
+    @property
+    def postgres_database(self) -> str:
+        return f"futureagi_{_provider_suffix(self.provider_slot)}"
+
+    @property
+    def clickhouse_database(self) -> str:
+        return f"futureagi_{_provider_suffix(self.provider_slot)}"
+
+    @property
+    def temporal_namespace(self) -> str:
+        return f"futureagi-{_provider_dash_suffix(self.provider_slot)}"
+
+    @property
+    def rabbitmq_vhost(self) -> str:
+        return f"futureagi-{_provider_dash_suffix(self.provider_slot)}"
+
+    @property
+    def minio_bucket(self) -> str:
+        return f"futureagi-{_provider_dash_suffix(self.provider_slot)}"
+
+    @property
+    def redis_databases(self) -> tuple[int, int, int]:
+        # The shared default owns 0--2; private slots 1--20 own 3--62.
+        start = (
+            0 if self.provider_slot is None else self.provider_slot
+        ) * REDIS_DATABASES_PER_PROVIDER
+        return (start, start + 1, start + 2)
+
+    @property
+    def label(self) -> str:
+        return (
+            "default"
+            if self.provider_slot is None
+            else f"slot-{self.provider_slot:02d}"
+        )
+
+
+class OrchestratorStateIdentity(Protocol):
+    """The subset of ``slots.models.StateIdentity`` provisioning requires."""
+
+    slot: int
+    postgres_database: str
+    clickhouse_database: str
+    temporal_namespace: str
+    rabbitmq_vhost: str
+    minio_bucket: str
+    redis_databases: tuple[int, int, int]
+
+
+def adapt_orchestrator_state(
+    identity: OrchestratorStateIdentity,
+) -> ProvisioningStateIdentity:
+    """Adapt and validate the orchestration state model without importing it."""
+    provider_slot = None if identity.slot == 0 else identity.slot
+    result = ProvisioningStateIdentity(provider_slot)
+    expected = (
+        result.postgres_database,
+        result.clickhouse_database,
+        result.temporal_namespace,
+        result.rabbitmq_vhost,
+        result.minio_bucket,
+        result.redis_databases,
+    )
+    actual = (
+        identity.postgres_database,
+        identity.clickhouse_database,
+        identity.temporal_namespace,
+        identity.rabbitmq_vhost,
+        identity.minio_bucket,
+        identity.redis_databases,
+    )
+    if actual != expected:
+        raise StateValidationError(
+            "orchestrator state identity does not match deterministic provisioning names"
+        )
+    return result
+
+
+def volume_name(provider_slot: int, engine: str) -> str:
+    """Return an isolated engine's one and only persistent Docker volume name."""
+    validate_slot(provider_slot)
+    if engine not in INFRA_ENGINES:
+        raise StateValidationError(f"unsupported infrastructure engine: {engine!r}")
+    return f"futureagi_slot_{provider_slot:02d}_{engine}_data"
+
+
+def project_name(provider_slot: int, engine: str) -> str:
+    """Return an isolated engine's dedicated Compose project name."""
+    validate_slot(provider_slot)
+    if engine not in INFRA_ENGINES:
+        raise StateValidationError(f"unsupported infrastructure engine: {engine!r}")
+    return f"futureagi-slot-{provider_slot:02d}-{engine}"
+
+
+@dataclass(frozen=True, slots=True)
+class StatePlan:
+    """The complete state topology selected for one slot before any mutation."""
+
+    slot: int
+    identity: ProvisioningStateIdentity
+    isolated_infra: frozenset[str]
+
+    def __post_init__(self) -> None:
+        validate_slot(self.slot)
+        if self.isolated_infra and self.identity.provider_slot is None:
+            raise StateValidationError(
+                "ISOLATE_INFRA requires a private backend provider"
+            )
+
+    def is_isolated(self, engine: str) -> bool:
+        if engine not in INFRA_ENGINES:
+            raise StateValidationError(f"unsupported infrastructure engine: {engine!r}")
+        return engine in self.isolated_infra
+
+    def volume_for(self, engine: str) -> str | None:
+        if not self.is_isolated(engine):
+            return None
+        assert self.identity.provider_slot is not None
+        return volume_name(self.identity.provider_slot, engine)
+
+    def project_for(self, engine: str) -> str | None:
+        if not self.is_isolated(engine):
+            return None
+        assert self.identity.provider_slot is not None
+        return project_name(self.identity.provider_slot, engine)
+
+
+def build_state_plan(
+    slot: int,
+    *,
+    provider_slot: int | None = None,
+    isolate_infra: str | Iterable[str] | None = None,
+) -> StatePlan:
+    """Build a state plan bound to the chosen backend provider.
+
+    ``provider_slot=None`` represents the shared default provider.  It cannot
+    receive a slot-private physical engine because a shared backend could not
+    safely use that isolated dependency.
+    """
+    validate_slot(slot)
+    if provider_slot is not None:
+        validate_slot(provider_slot)
+    return StatePlan(
+        slot=slot,
+        identity=ProvisioningStateIdentity(provider_slot),
+        isolated_infra=validate_isolated_infra(isolate_infra),
+    )

--- a/slots/traefik/routes.template.yaml
+++ b/slots/traefik/routes.template.yaml
@@ -1,0 +1,78 @@
+# Render one file per slot.  Tokens are intentionally not Compose variables:
+# Traefik's file provider does not interpolate environment variables.
+# The planner replaces every __TOKEN__ before atomically publishing the file.
+http:
+  routers:
+    slot-__SLOT_ID__-frontend:
+      rule: "Host(`__SLOT__.localhost`)"
+      entryPoints: [web]
+      service: slot-__SLOT_ID__-frontend
+    slot-__SLOT_ID__-backend:
+      rule: "Host(`api.__SLOT__.localhost`)"
+      entryPoints: [web]
+      service: slot-__SLOT_ID__-backend
+    slot-__SLOT_ID__-temporal:
+      rule: "Host(`temporal.__SLOT__.localhost`)"
+      entryPoints: [web]
+      service: slot-__SLOT_ID__-temporal-ui
+    slot-__SLOT_ID__-minio:
+      rule: "Host(`minio.__SLOT__.localhost`)"
+      entryPoints: [web]
+      service: slot-__SLOT_ID__-minio-api
+    slot-__SLOT_ID__-minio-console:
+      rule: "Host(`minio-console.__SLOT__.localhost`)"
+      entryPoints: [web]
+      service: slot-__SLOT_ID__-minio-console
+    slot-__SLOT_ID__-rabbitmq:
+      rule: "Host(`rabbitmq.__SLOT__.localhost`)"
+      entryPoints: [web]
+      service: slot-__SLOT_ID__-rabbitmq-management
+    slot-__SLOT_ID__-gateway:
+      rule: "Host(`gateway.__SLOT__.localhost`)"
+      entryPoints: [web]
+      service: slot-__SLOT_ID__-gateway
+    slot-__SLOT_ID__-serving:
+      rule: "Host(`serving.__SLOT__.localhost`)"
+      entryPoints: [web]
+      service: slot-__SLOT_ID__-serving
+    slot-__SLOT_ID__-collector:
+      rule: "Host(`collector.__SLOT__.localhost`)"
+      entryPoints: [web]
+      service: slot-__SLOT_ID__-collector
+    slot-__SLOT_ID__-executor:
+      rule: "Host(`executor.__SLOT__.localhost`)"
+      entryPoints: [web]
+      service: slot-__SLOT_ID__-executor
+    slot-__SLOT_ID__-jaeger:
+      rule: "Host(`jaeger.__SLOT__.localhost`)"
+      entryPoints: [web]
+      service: slot-__SLOT_ID__-jaeger
+    slot-__SLOT_ID__-peerdb:
+      rule: "Host(`peerdb.__SLOT__.localhost`)"
+      entryPoints: [web]
+      service: slot-__SLOT_ID__-peerdb
+  services:
+    slot-__SLOT_ID__-frontend:
+      loadBalancer: {servers: [{url: "http://__FRONTEND_NAME__:3000"}]}
+    slot-__SLOT_ID__-backend:
+      loadBalancer: {servers: [{url: "http://__BACKEND_NAME__:80"}]}
+    slot-__SLOT_ID__-temporal-ui:
+      loadBalancer: {servers: [{url: "http://__TEMPORAL_UI_NAME__:8080"}]}
+    slot-__SLOT_ID__-minio-api:
+      loadBalancer: {servers: [{url: "http://__MINIO_NAME__:9000"}]}
+    slot-__SLOT_ID__-minio-console:
+      loadBalancer: {servers: [{url: "http://__MINIO_NAME__:9001"}]}
+    slot-__SLOT_ID__-rabbitmq-management:
+      loadBalancer: {servers: [{url: "http://__RABBITMQ_NAME__:15672"}]}
+    slot-__SLOT_ID__-gateway:
+      loadBalancer: {servers: [{url: "http://__GATEWAY_NAME__:8080"}]}
+    slot-__SLOT_ID__-serving:
+      loadBalancer: {servers: [{url: "http://__SERVING_NAME__:8080"}]}
+    slot-__SLOT_ID__-collector:
+      loadBalancer: {servers: [{url: "http://__COLLECTOR_NAME__:9464"}]}
+    slot-__SLOT_ID__-executor:
+      loadBalancer: {servers: [{url: "http://__EXECUTOR_NAME__:8060"}]}
+    slot-__SLOT_ID__-jaeger:
+      loadBalancer: {servers: [{url: "http://__OBSERVABILITY_NAME__:16686"}]}
+    slot-__SLOT_ID__-peerdb:
+      loadBalancer: {servers: [{url: "http://__PEERDB_UI_NAME__:3000"}]}

--- a/slots/traefik/traefik.yaml
+++ b/slots/traefik/traefik.yaml
@@ -1,0 +1,20 @@
+# Static Traefik configuration for the shared slot control plane.
+# Dynamic routers are generated from routes.template.yaml into SLOTS_ROUTE_DIR.
+entryPoints:
+  web:
+    address: ":80"
+
+api:
+  dashboard: false
+
+ping: {}
+
+providers:
+  file:
+    directory: /etc/traefik/dynamic
+    watch: true
+
+log:
+  level: WARN
+
+accessLog: {}

--- a/tests/slots/test_catalog.py
+++ b/tests/slots/test_catalog.py
@@ -1,0 +1,40 @@
+import pytest
+
+from slots.catalog import (
+    expand_services,
+    parse_isolated_infra,
+    parse_services,
+    private_ports,
+)
+
+
+def test_services_are_validated_and_dependencies_are_expanded():
+    assert parse_services("collector") == ("collector",)
+    assert expand_services("collector") == ("backend", "collector")
+    assert expand_services("none") == ()
+    assert set(expand_services("all")) == {
+        "backend",
+        "simulation",
+        "gateway",
+        "collector",
+        "serving",
+        "executor",
+        "peerdb",
+        "observability",
+    }
+    with pytest.raises(ValueError, match="unsupported"):
+        parse_services("frontend")
+    with pytest.raises(ValueError, match="cannot be combined"):
+        parse_services("none,backend")
+
+
+def test_infra_and_ports_are_deterministic():
+    assert parse_isolated_infra("postgres,redis") == ("postgres", "redis")
+    assert private_ports(3, ("backend", "collector")) == {
+        "frontend": 20310,
+        "backend": 20311,
+        "collector": 20340,
+    }
+    assert private_ports(3, (), ("postgres",))["postgres"] == 20301
+    with pytest.raises(ValueError):
+        private_ports(21, ())

--- a/tests/slots/test_cli.py
+++ b/tests/slots/test_cli.py
@@ -1,0 +1,122 @@
+from pathlib import Path
+import subprocess
+
+from slots.cli import _error_message, main
+from slots.registry import RegistryStore
+
+
+def _primary(cwd: Path):
+    def runner(argv, _worktree):
+        if tuple(argv[:3]) == ("git", "worktree", "list"):
+            return f"worktree {cwd}\n"
+        return ""
+
+    return runner
+
+
+def test_cli_denies_before_any_registry_or_executor_mutation(
+    tmp_path: Path, monkeypatch
+):
+    monkeypatch.delenv("SLOTS_RUNTIME_APPROVED", raising=False)
+    compose_calls: list[tuple[str, ...]] = []
+    state_calls: list[object] = []
+
+    result = main(
+        ["up", "--slot", "1", "--services", "none"],
+        tmp_path,
+        _primary(tmp_path),
+        lambda argv, _cwd: compose_calls.append(tuple(argv)),
+        state_calls.append,
+    )
+
+    assert result == 2
+    assert compose_calls == []
+    assert state_calls == []
+    assert RegistryStore(tmp_path / ".slots").load().slots == {}
+
+
+def test_cli_error_message_includes_captured_subprocess_stderr():
+    error = subprocess.CalledProcessError(
+        1, ("docker", "compose", "up"), stderr="build failed\n"
+    )
+    assert _error_message(error).endswith(": build failed")
+
+
+def test_cli_error_message_truncates_large_build_output_from_the_front():
+    error = subprocess.CalledProcessError(
+        1,
+        ("docker", "compose", "up"),
+        stderr="old progress\n" * 2_000 + "decisive failure\n",
+    )
+    message = _error_message(error)
+    assert "earlier Docker output truncated" in message
+    assert message.endswith("decisive failure")
+    assert len(message) < 13_000
+
+
+def test_cli_routes_all_approved_execution_through_injected_adapters(
+    tmp_path: Path, monkeypatch
+):
+    monkeypatch.setenv("SLOTS_RUNTIME_APPROVED", "1")
+    monkeypatch.setenv("SLOTS_MEMORY_CAP_MIB", "12000")
+    compose_calls: list[tuple[str, ...]] = []
+    state_calls: list[object] = []
+
+    result = main(
+        ["up", "--slot", "1", "--services", "none"],
+        tmp_path,
+        _primary(tmp_path),
+        lambda argv, _cwd: compose_calls.append(tuple(argv)),
+        state_calls.append,
+    )
+
+    assert result == 0
+    assert compose_calls[0] == ("docker", "info", "--format", "{{.MemTotal}}")
+    assert ("docker", "network", "create", "futureagi-slots") in compose_calls
+    assert state_calls
+
+
+def test_cli_only_lowers_configured_memory_cap_from_injected_docker_info(
+    tmp_path: Path, monkeypatch
+):
+    monkeypatch.setenv("SLOTS_RUNTIME_APPROVED", "1")
+    monkeypatch.setenv("SLOTS_MEMORY_CAP_MIB", "20000")
+    commands: list[tuple[str, ...]] = []
+
+    def executor(argv, _cwd):
+        commands.append(tuple(argv))
+        return "17179869184\n" if argv[:2] == ("docker", "info") else None
+
+    result = main(
+        ["up", "--slot", "1", "--services", "none"],
+        tmp_path,
+        _primary(tmp_path),
+        executor,
+        lambda _command: None,
+    )
+
+    assert result == 0
+    # Sixteen GiB lowers the configured 20000 MiB cap without invoking Docker
+    # outside the injected executor.
+    assert commands[0] == ("docker", "info", "--format", "{{.MemTotal}}")
+
+
+def test_cli_doctor_lowers_cap_and_accepts_missing_clean_state_network(
+    tmp_path: Path, monkeypatch, capsys
+):
+    monkeypatch.setenv("SLOTS_RUNTIME_APPROVED", "1")
+    monkeypatch.setenv("SLOTS_MEMORY_CAP_MIB", "20000")
+
+    def executor(argv, _cwd):
+        if argv[:2] == ("docker", "info"):
+            return str(10 * 1024 * 1024 * 1024)
+        if argv[:3] == ("docker", "network", "inspect"):
+            raise subprocess.CalledProcessError(
+                1, argv, stderr="network futureagi-slots not found"
+            )
+        return None
+
+    assert main(["doctor"], tmp_path, _primary(tmp_path), executor) == 0
+    output = capsys.readouterr().out
+    assert '"configured_memory_cap_mib": 10240' in output
+    assert '"slots": 0' in output

--- a/tests/slots/test_compose_assets.py
+++ b/tests/slots/test_compose_assets.py
@@ -1,0 +1,429 @@
+"""Static contract tests for slot Compose and Traefik assets.
+
+These tests parse files only.  They deliberately never invoke Docker or a
+Compose binary, so the Wave 1 runtime approval gate remains intact.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+
+
+ROOT = Path(__file__).resolve().parents[2]
+SLOTS = ROOT / "slots"
+COMPOSE = SLOTS / "compose"
+
+
+def load(relative: str) -> dict:
+    with (SLOTS / relative).open(encoding="utf-8") as source:
+        return yaml.safe_load(source)
+
+
+def test_compose_and_traefik_assets_are_parseable() -> None:
+    paths = sorted(COMPOSE.glob("*.yaml"))
+    paths += sorted((SLOTS / "config").glob("*.yaml"))
+    paths += sorted((SLOTS / "traefik").glob("*.yaml"))
+
+    assert paths
+    for path in paths:
+        with path.open(encoding="utf-8") as source:
+            assert yaml.safe_load(source) is not None, path
+
+
+def test_control_plane_is_shared_external_and_safe_for_local_use() -> None:
+    control = load("compose/control-plane.yaml")
+    services = control["services"]
+
+    assert {
+        "traefik",
+        "postgres",
+        "clickhouse",
+        "redis",
+        "rabbitmq",
+        "minio",
+        "temporal",
+    } <= set(services)
+    assert services["redis"]["command"][-2:] == ["--databases", "64"]
+    assert control["networks"]["slots"]["external"] is True
+    assert control["networks"]["slots"]["name"] == "${SLOTS_NETWORK:-futureagi-slots}"
+    assert all(volume.get("name") for volume in control["volumes"].values())
+    assert services["traefik"]["ports"] == ["127.0.0.1:${SLOTS_HTTP_PORT:-80}:80"]
+    clickhouse_mounts = services["clickhouse"]["volumes"]
+    assert any("SLOTS_CLICKHOUSE_TEST_CONFIG" in mount for mount in clickhouse_mounts)
+
+    joined = "\n".join((COMPOSE / "control-plane.yaml").read_text().splitlines())
+    assert "/var/run/docker.sock" not in joined
+    assert "docker.sock" not in joined
+
+
+def test_private_frontend_backend_and_provider_templates_are_present() -> None:
+    expected = {
+        "frontend.yaml": "frontend",
+        "backend.yaml": "backend",
+        "simulation.yaml": "simulation",
+        "gateway.yaml": "gateway",
+        "collector.yaml": "collector",
+        "serving.yaml": "serving",
+        "executor.yaml": "executor",
+        "peerdb.yaml": "peerdb-ui",
+        "observability.yaml": "observability",
+    }
+    for filename, service in expected.items():
+        document = yaml.safe_load((COMPOSE / filename).read_text())
+        assert service in document["services"]
+        assert document["networks"]["slots"]["external"] is True
+
+    frontend = load("compose/frontend.yaml")["services"]["frontend"]
+    assert frontend["build"]["target"] == "dev"
+    assert "VITE_HOST_API" in frontend["environment"]
+    assert "SLOTS_HTTP_PORT" in frontend["environment"]["VITE_HOST_API"]
+    assert frontend["volumes"][-1].endswith(":/app/node_modules")
+    frontend_command = frontend["command"]
+    assert frontend_command[:2] == ["/bin/sh", "-ec"]
+    assert "yarn install --frozen-lockfile" in frontend_command[2]
+    assert ".slot-lock-hash" in frontend_command[2]
+
+    peerdb = load("compose/peerdb.yaml")["services"]
+    assert {
+        "peerdb",
+        "peerdb-temporal-init",
+        "peerdb-minio-init",
+        "peerdb-init",
+    } <= set(peerdb)
+    assert peerdb["peerdb-init"]["environment"]["SRC_PG_DB"] == (
+        "${SLOT_PG_DB:?SLOT_PG_DB is required}"
+    )
+    assert peerdb["peerdb-init"]["environment"]["DST_CH_DB"] == (
+        "${SLOT_CH_DATABASE:?SLOT_CH_DATABASE is required}"
+    )
+    assert load("compose/backend.yaml")["volumes"]["slot-backend-media"][
+        "name"
+    ].startswith("${SLOT_BACKEND_MEDIA_VOLUME:-")
+    assert load("compose/collector.yaml")["volumes"]["slot-collector-data"][
+        "name"
+    ].startswith("${SLOT_COLLECTOR_VOLUME:-")
+    assert peerdb["peerdb-catalog"]["volumes"] == [
+        "slot-peerdb-catalog-data:/var/lib/postgresql/data"
+    ]
+    assert peerdb["peerdb-minio"]["volumes"] == ["slot-peerdb-minio-data:/data"]
+    assert peerdb["peerdb"]["depends_on"]["peerdb-init"] == {
+        "condition": "service_completed_successfully"
+    }
+    assert peerdb["peerdb"]["depends_on"]["peerdb-minio-init"] == {
+        "condition": "service_completed_successfully"
+    }
+    assert peerdb["peerdb-flow-api"]["depends_on"]["peerdb-minio-init"] == {
+        "condition": "service_completed_successfully"
+    }
+    assert peerdb["peerdb-flow-worker"]["depends_on"]["peerdb-minio-init"] == {
+        "condition": "service_completed_successfully"
+    }
+    minio_init_command = peerdb["peerdb-minio-init"]["command"]
+    assert len(minio_init_command) == 1
+    assert "mc mb --ignore-existing" in minio_init_command[0]
+    temporal_init_command = peerdb["peerdb-temporal-init"]["command"]
+    assert len(temporal_init_command) == 1
+    temporal_init = temporal_init_command[0]
+    assert "|| true" not in temporal_init
+    assert "already exists" in temporal_init
+    assert "search-attribute list" in temporal_init
+    peerdb_identity_keys = {
+        "peerdb": "SLOT_PEERDB_AGGREGATE_NAME",
+        "peerdb-catalog": "SLOT_PEERDB_CATALOG_NAME",
+        "peerdb-temporal": "SLOT_PEERDB_TEMPORAL_NAME",
+        "peerdb-temporal-init": "SLOT_PEERDB_TEMPORAL_INIT_NAME",
+        "peerdb-minio": "SLOT_PEERDB_MINIO_NAME",
+        "peerdb-minio-init": "SLOT_PEERDB_MINIO_INIT_NAME",
+        "peerdb-flow-api": "SLOT_PEERDB_FLOW_API_NAME",
+        "peerdb-flow-worker": "SLOT_PEERDB_FLOW_WORKER_NAME",
+        "peerdb-server": "SLOT_PEERDB_SERVER_NAME",
+        "peerdb-ui": "SLOT_PEERDB_UI_NAME",
+        "peerdb-init": "SLOT_PEERDB_INIT_NAME",
+    }
+    for service, key in peerdb_identity_keys.items():
+        assert peerdb[service]["container_name"].startswith(f"${{{key}")
+
+    backend = load("compose/backend.yaml")["services"]
+    assert {"backend", "worker"} <= set(backend)
+    assert backend["backend"]["environment"]["FAST_STARTUP"] == "false"
+    assert backend["worker"]["environment"]["FAST_STARTUP"] == "true"
+    assert backend["worker"]["environment"]["TEMPORAL_ALL_QUEUES"] == "true"
+    state = backend["backend"]["environment"]
+    assert state["CH_PORT"] == "9000"
+    assert state["CH_HTTP_PORT"] == "8123"
+    assert (
+        state["UPLOAD_BUCKET_NAME"]
+        == "${SLOT_MINIO_BUCKET:?SLOT_MINIO_BUCKET is required}"
+    )
+    assert "SLOTS_HTTP_PORT" in state["MINIO_URL"]
+    assert state["REGISTER_TEMPORAL_SCHEDULES"] == (
+        "${SLOT_REGISTER_TEMPORAL_SCHEDULES:-false}"
+    )
+
+    simulation = load("compose/simulation.yaml")["services"]["simulation"][
+        "environment"
+    ]
+    for key in (
+        "PG_HOST",
+        "PG_DB",
+        "CH_HOST",
+        "CH_PORT",
+        "CH_HTTP_PORT",
+        "CH_DATABASE",
+        "REDIS_URL",
+        "REDIS_CACHE_URL",
+        "REDIS_LOCK_URL",
+        "CELERY_BROKER_URL",
+        "S3_ENDPOINT_URL",
+        "S3_BUCKET",
+        "UPLOAD_BUCKET_NAME",
+        "TEMPORAL_HOST",
+        "TEMPORAL_NAMESPACE",
+    ):
+        assert key in simulation
+    assert simulation["CH_PORT"] == "9000"
+
+    gateway = load("compose/gateway.yaml")["services"]["gateway"]
+    assert gateway["healthcheck"] == {"disable": True}
+    assert (
+        gateway["environment"]["AGENTCC_REDIS_DB"]
+        == "${SLOT_REDIS_DB:?SLOT_REDIS_DB is required}"
+    )
+    assert not any(volume.endswith("/app:ro") for volume in gateway["volumes"])
+
+    collector_text = (COMPOSE / "collector.yaml").read_text()
+    assert (
+        load("compose/collector.yaml")["services"]["collector"]["environment"][
+            "FI_AUTH_REDIS_DB"
+        ]
+        == "${SLOT_REDIS_DB:?SLOT_REDIS_DB is required}"
+    )
+    assert "provider-bound database number" in collector_text
+    assert (
+        "--healthcheck"
+        in load("compose/collector.yaml")["services"]["collector"]["healthcheck"][
+            "test"
+        ]
+    )
+    assert (
+        load("compose/observability.yaml")["services"]["observability"]["image"]
+        == "jaegertracing/all-in-one:1.65.0"
+    )
+    assert peerdb["peerdb-temporal-init"]["image"] == ("temporalio/admin-tools:1.29.6")
+
+
+def test_dynamic_routes_use_file_provider_tokens_and_cover_public_hosts() -> None:
+    static = load("traefik/traefik.yaml")
+    template = load("traefik/routes.template.yaml")
+    routes = template["http"]["routers"]
+
+    assert static["providers"]["file"] == {
+        "directory": "/etc/traefik/dynamic",
+        "watch": True,
+    }
+    assert static["ping"] == {}
+    assert {
+        "frontend",
+        "backend",
+        "temporal",
+        "minio",
+        "console",
+        "rabbitmq",
+        "gateway",
+        "serving",
+        "collector",
+        "executor",
+        "jaeger",
+        "peerdb",
+    } <= {name.rsplit("-", 1)[-1] for name in routes}
+    content = (SLOTS / "traefik" / "routes.template.yaml").read_text()
+    assert "__SLOT_ID__" in content and "__FRONTEND_NAME__" in content
+    assert "traefik.http." not in content
+    assert "flower" not in content
+    services = template["http"]["services"]
+    assert services["slot-__SLOT_ID__-minio-api"]["loadBalancer"]["servers"] == [
+        {"url": "http://__MINIO_NAME__:9000"}
+    ]
+    assert services["slot-__SLOT_ID__-minio-console"]["loadBalancer"]["servers"] == [
+        {"url": "http://__MINIO_NAME__:9001"}
+    ]
+    assert services["slot-__SLOT_ID__-jaeger"]["loadBalancer"]["servers"] == [
+        {"url": "http://__OBSERVABILITY_NAME__:16686"}
+    ]
+    assert all(name.startswith("slot-__SLOT_ID__-") for name in services)
+    assert all(
+        router["service"].startswith("slot-__SLOT_ID__-") for router in routes.values()
+    )
+
+    # Every rendered file owns its service namespace, so loading two slot route
+    # files through Traefik's file provider cannot overwrite another slot.
+    rendered = []
+    for slot_id, slot in (("01", "1"), ("02", "2")):
+        contents = content.replace("__SLOT_ID__", slot_id).replace("__SLOT__", slot)
+        rendered.append(set(yaml.safe_load(contents)["http"]["services"]))
+    assert rendered[0].isdisjoint(rendered[1])
+
+
+def test_isolated_infra_defaults_match_state_and_initialize_provider_assets() -> None:
+    isolated = load("compose/isolated-infra.yaml")
+    services = isolated["services"]
+    volumes = isolated["volumes"]
+    assert services["isolated-temporal-init"]["image"] == (
+        "temporalio/admin-tools:1.29.6"
+    )
+    assert any(
+        "SLOTS_CLICKHOUSE_TEST_CONFIG" in mount
+        for mount in services["isolated-clickhouse"]["volumes"]
+    )
+
+    for engine in ("postgres", "clickhouse", "redis", "rabbitmq", "minio", "temporal"):
+        assert volumes[f"slot-{engine}-data"]["name"] == (
+            f"${{SLOT_{engine.upper()}_VOLUME:-futureagi_slot_"
+            f"${{SLOT_ID:?SLOT_ID is required}}_{engine}_data}}"
+        )
+    assert services["isolated-rabbitmq"]["environment"]["RABBITMQ_DEFAULT_VHOST"] == (
+        "${SLOT_RABBITMQ_VHOST:?SLOT_RABBITMQ_VHOST is required}"
+    )
+    assert services["isolated-minio"]["command"] == [
+        "server",
+        "/data",
+        "--console-address",
+        ":9001",
+    ]
+    assert services["isolated-minio"]["healthcheck"]["test"] == [
+        "CMD",
+        "mc",
+        "ready",
+        "http://127.0.0.1:9000",
+    ]
+    minio_init = services["isolated-minio-init"]
+    assert minio_init["profiles"] == ["isolated-minio"]
+    assert len(minio_init["command"]) == 1
+    assert "mc mb --ignore-existing" in minio_init["command"][0]
+    assert "SLOT_MINIO_BUCKET" in minio_init["command"][0]
+    assert minio_init["depends_on"] == {
+        "isolated-minio": {"condition": "service_healthy"}
+    }
+    assert {
+        "isolated-temporal-postgres",
+        "isolated-temporal",
+        "isolated-temporal-init",
+        "isolated-temporal-ui",
+    } <= set(services)
+    assert services["isolated-temporal-init"]["profiles"] == ["isolated-temporal"]
+    assert len(services["isolated-temporal-init"]["command"]) == 1
+    assert "SLOT_TEMPORAL_NAMESPACE" in services["isolated-temporal-init"]["command"][0]
+    assert services["isolated-temporal-ui"]["profiles"] == ["isolated-temporal"]
+    assert services["isolated-temporal-postgres"]["volumes"] == [
+        "slot-temporal-data:/var/lib/postgresql/data"
+    ]
+    assert all(
+        port.startswith("127.0.0.1:")
+        for service in services.values()
+        for port in service.get("ports", [])
+    )
+
+
+def test_catalog_connects_template_names_to_provider_and_route_contracts() -> None:
+    catalog = load("config/compose-catalog.yaml")
+
+    assert catalog["provider_groups"]["backend"] == ["backend", "worker"]
+    assert catalog["provider_groups"]["peerdb"] == [
+        "peerdb",
+        "peerdb-catalog",
+        "peerdb-temporal",
+        "peerdb-temporal-init",
+        "peerdb-minio",
+        "peerdb-minio-init",
+        "peerdb-flow-api",
+        "peerdb-flow-worker",
+        "peerdb-server",
+        "peerdb-ui",
+        "peerdb-init",
+    ]
+    overrides = catalog["shared_provider_overrides"]
+    assert overrides["backend"]["SLOT_BACKEND_MEDIA_VOLUME"] == (
+        "futureagi-shared-backend-media"
+    )
+    assert overrides["collector"]["SLOT_COLLECTOR_VOLUME"] == (
+        "futureagi-shared-collector-data"
+    )
+    assert set(overrides["peerdb"]) == {
+        "SLOT_PEERDB_AGGREGATE_NAME",
+        "SLOT_PEERDB_CATALOG_NAME",
+        "SLOT_PEERDB_TEMPORAL_NAME",
+        "SLOT_PEERDB_TEMPORAL_INIT_NAME",
+        "SLOT_PEERDB_MINIO_NAME",
+        "SLOT_PEERDB_MINIO_INIT_NAME",
+        "SLOT_PEERDB_FLOW_API_NAME",
+        "SLOT_PEERDB_FLOW_WORKER_NAME",
+        "SLOT_PEERDB_SERVER_NAME",
+        "SLOT_PEERDB_UI_NAME",
+        "SLOT_PEERDB_INIT_NAME",
+        "SLOT_PEERDB_CATALOG_VOLUME",
+        "SLOT_PEERDB_MINIO_VOLUME",
+    }
+    assert catalog["state_coupled_provider_closure"]["backend"] == [
+        "backend",
+        "worker",
+    ]
+    for group in ("simulation", "collector", "peerdb"):
+        assert catalog["state_coupled_provider_closure"][group]["requires"] == [
+            "backend"
+        ]
+    assert catalog["teardown_contract"]["ordinary_down"] == (
+        "docker compose down without --volumes; provider data is retained"
+    )
+    assert "frontend" not in catalog["provider_groups"]["all"]
+    assert catalog["environment"]["slot"]["SLOT_PG_DB"] == "required"
+    assert catalog["environment"]["slot"]["SLOT_TEMPORAL_NAMESPACE"] == "required"
+    assert catalog["routes"]["backend"]["host"] == "api.${slot}.localhost"
+    assert catalog["routes"]["minio"]["port"] == 9000
+    assert catalog["routes"]["minio_console"]["port"] == 9001
+    assert catalog["routes"]["jaeger"] == {
+        "host": "jaeger.${slot}.localhost",
+        "target_env": "SLOT_OBSERVABILITY_NAME",
+        "port": 16686,
+    }
+    assert "flower" not in catalog["routes"]
+    assert catalog["public_urls"]["port_env"] == "SLOTS_HTTP_PORT"
+    assert (
+        catalog["isolated_infra"]["volumes"]["temporal"]
+        == "futureagi_slot_${slot_id}_temporal_data"
+    )
+    requirements = catalog["runtime_requirements"]
+    assert requirements["completion_contracts"]["peerdb"] == {
+        "aggregate_service": "peerdb",
+        "initializers": [
+            "peerdb-temporal-init",
+            "peerdb-minio-init",
+            "peerdb-init",
+        ],
+        "success_condition": "service_completed_successfully",
+        "startup_gate": "compose_up_dependency_conditions",
+    }
+    assert requirements["route_target_selection"]["isolated"] == {
+        "minio": "SLOT_ISOLATED_MINIO_NAME",
+        "rabbitmq": "SLOT_ISOLATED_RABBITMQ_NAME",
+        "temporal": "SLOT_TEMPORAL_UI_NAME",
+    }
+    assert any(
+        item.startswith("Start isolated-temporal-init")
+        for item in requirements["isolated_compose"]
+    )
+    assert catalog["isolated_infra"]["startup_services"]["temporal"] == [
+        "isolated-temporal-postgres",
+        "isolated-temporal",
+        "isolated-temporal-init",
+        "isolated-temporal-ui",
+    ]
+    assert catalog["isolated_infra"]["startup_services"]["minio"] == [
+        "isolated-minio",
+        "isolated-minio-init",
+    ]
+    assert any(
+        item.startswith("Traefik only reads generated file-provider routes")
+        for item in catalog["invariants"]
+    )

--- a/tests/slots/test_makefile.py
+++ b/tests/slots/test_makefile.py
@@ -1,0 +1,19 @@
+from pathlib import Path
+import subprocess
+
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def test_slot_selector_is_not_exported_to_child_processes(tmp_path: Path) -> None:
+    makefile = tmp_path / "Makefile"
+    makefile.write_text(
+        f'include {ROOT / "Makefile"}\ncheck-slot-environment:\n\t@test -z "$$SLOT"\n',
+        encoding="utf-8",
+    )
+
+    subprocess.run(
+        ["make", "-f", str(makefile), "check-slot-environment", "SLOT=auto"],
+        cwd=ROOT,
+        check=True,
+    )

--- a/tests/slots/test_provisioning.py
+++ b/tests/slots/test_provisioning.py
@@ -1,0 +1,579 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from slots.provisioning import (
+    CONTROL_PLANE_COMPOSE_FILE,
+    CONTROL_PLANE_PROJECT,
+    REPOSITORY_ROOT,
+    PurgeConfirmationError,
+    StateAlreadyExistsError,
+    StateCommand,
+    StateCommandExecutionError,
+    apply_purge_plan,
+    apply_suspend_plan,
+    apply_provision_plan,
+    build_provision_plan,
+    build_purge_plan,
+    build_retired_isolated_purge_plan,
+    build_suspend_plan,
+    execute_state_command,
+    generated_slot_env_file,
+    provision_state,
+    purge_state,
+    suspend_state,
+)
+from slots.state import INFRA_ENGINES, StateValidationError, build_state_plan
+
+
+def _generated_env(tmp_path: Path, slot: int = 3) -> Path:
+    return generated_slot_env_file(_state_dir(tmp_path), slot)
+
+
+def _state_dir(tmp_path: Path) -> Path:
+    return (tmp_path / ".slots").resolve()
+
+
+def test_provision_plan_is_inert_until_an_executor_is_injected() -> None:
+    plan = provision_state(3, provider_slot=3)
+
+    assert any(
+        command.operation == "ensure_postgres_database" for command in plan.commands
+    )
+    executed: list[StateCommand] = []
+    apply_provision_plan(plan, executed.append)
+    assert executed == list(plan.commands)
+
+
+def test_shared_commands_explicitly_name_control_plane_compose_project_and_cwd() -> (
+    None
+):
+    plan = provision_state(3, provider_slot=3)
+
+    assert all(command.cwd == REPOSITORY_ROOT for command in plan.commands)
+    assert all(
+        command.argv[:6]
+        == (
+            "docker",
+            "compose",
+            "--project-name",
+            CONTROL_PLANE_PROJECT,
+            "-f",
+            CONTROL_PLANE_COMPOSE_FILE,
+        )
+        for command in plan.commands
+    )
+
+
+def test_provision_plan_is_idempotent_for_repeated_preserved_state_starts(
+    tmp_path: Path,
+) -> None:
+    state = build_state_plan(3, provider_slot=3, isolate_infra="minio")
+    state_dir = _state_dir(tmp_path)
+
+    first = build_provision_plan(state, state_dir=state_dir)
+    second = build_provision_plan(state, state_dir=state_dir)
+
+    assert first == second
+    assert all(command.idempotent for command in first.commands)
+    volume = next(
+        command
+        for command in first.commands
+        if command.operation == "create_isolated_volume"
+    )
+    assert volume.argv == ("docker", "volume", "create", volume.target)
+    assert any(
+        command.stdin is not None and "\\gexec" in command.stdin
+        for command in first.commands
+        if command.operation == "ensure_postgres_database"
+    )
+
+
+def test_minio_state_commands_authenticate_alias_from_container_environment() -> None:
+    provision = next(
+        command
+        for command in provision_state(3, provider_slot=3).commands
+        if command.operation == "ensure_minio_bucket"
+    )
+    purge = next(
+        command
+        for command in purge_state(3, provider_slot=3, confirm="3").commands
+        if command.operation == "delete_minio_bucket"
+    )
+
+    for command in (provision, purge):
+        script = command.argv[-3]
+        assert "mc alias set local http://127.0.0.1:9000" in script
+        assert '"$MINIO_ROOT_USER"' in script
+        assert '"$MINIO_ROOT_PASSWORD"' in script
+        assert command.argv[-1] == "futureagi-slot-03"
+
+
+def test_temporal_state_commands_use_control_plane_service_address() -> None:
+    provision = next(
+        command
+        for command in provision_state(3, provider_slot=3).commands
+        if command.operation == "ensure_temporal_namespace"
+    )
+    purge = next(
+        command
+        for command in purge_state(3, provider_slot=3, confirm="3").commands
+        if command.operation == "delete_temporal_namespace"
+    )
+
+    for command in (provision, purge):
+        address = command.argv.index("--address")
+        assert command.argv[address + 1] == "temporal:7233"
+
+
+def test_provision_executor_accepts_only_expected_existing_state_signals() -> None:
+    plan = provision_state(3, provider_slot=3)
+    executed: list[StateCommand] = []
+
+    def executor(command: StateCommand) -> None:
+        executed.append(command)
+        if command.operation == "ensure_temporal_namespace":
+            raise StateAlreadyExistsError("namespace already exists")
+
+    apply_provision_plan(plan, executor)
+
+    assert executed == list(plan.commands)
+
+
+def test_production_executor_passes_safe_postgres_stdin_to_mocked_subprocess() -> None:
+    command = next(
+        command
+        for command in provision_state(3, provider_slot=3).commands
+        if command.operation == "ensure_postgres_database"
+    )
+    calls: list[tuple[tuple[str, ...], object, str | None]] = []
+
+    def runner(argv: tuple[str, ...], **kwargs: object) -> object:
+        calls.append((argv, kwargs["cwd"], kwargs["input"]))
+        return type("Result", (), {"returncode": 0, "stderr": ""})()
+
+    execute_state_command(command, runner)  # type: ignore[arg-type]
+
+    assert calls == [(command.argv, REPOSITORY_ROOT, command.stdin)]
+    assert "--command" not in command.argv
+    assert command.argv[-1] == "--file=-"
+    assert any(
+        'exec psql --username="$POSTGRES_USER" "$@"' in argument
+        for argument in command.argv
+    )
+    assert command.stdin is not None
+    assert "slot_database" in command.stdin
+
+
+def test_production_executor_translates_only_approved_existing_state_failures() -> None:
+    rabbitmq = next(
+        command
+        for command in provision_state(3, provider_slot=3).commands
+        if command.operation == "ensure_rabbitmq_vhost"
+    )
+    postgres = next(
+        command
+        for command in provision_state(3, provider_slot=3).commands
+        if command.operation == "ensure_postgres_database"
+    )
+
+    def exists_runner(*args: object, **kwargs: object) -> object:
+        return type("Result", (), {"returncode": 1, "stderr": "vhost already exists"})()
+
+    with pytest.raises(StateAlreadyExistsError):
+        execute_state_command(rabbitmq, exists_runner)  # type: ignore[arg-type]
+    with pytest.raises(StateCommandExecutionError):
+        execute_state_command(postgres, exists_runner)  # type: ignore[arg-type]
+
+
+def test_purge_retry_accepts_only_expected_missing_state_signals() -> None:
+    plan = purge_state(3, provider_slot=3, confirm="3")
+    executed: list[StateCommand] = []
+
+    def executor(command: StateCommand) -> None:
+        executed.append(command)
+        if command.operation in {
+            "delete_rabbitmq_vhost",
+            "delete_minio_bucket",
+            "delete_temporal_namespace",
+        }:
+            raise StateAlreadyExistsError(f"{command.target} does not exist")
+
+    apply_purge_plan(plan, executor)
+
+    assert executed == list(plan.commands)
+
+
+def test_production_executor_translates_approved_missing_volume_failure() -> None:
+    command = next(
+        command
+        for command in purge_state(
+            3,
+            provider_slot=3,
+            isolate_infra="postgres",
+            state_dir=Path("/tmp/.slots"),
+            confirm="3",
+        ).commands
+        if command.operation == "delete_isolated_volume"
+    )
+
+    def missing_runner(*args: object, **kwargs: object) -> object:
+        return type(
+            "Result",
+            (),
+            {"returncode": 1, "stderr": f"No such volume: {command.target}"},
+        )()
+
+    with pytest.raises(StateAlreadyExistsError):
+        execute_state_command(command, missing_runner)  # type: ignore[arg-type]
+
+
+def test_purge_retry_does_not_hide_unrelated_missing_runtime_errors() -> None:
+    plan = purge_state(3, provider_slot=3, confirm="3")
+
+    def executor(command: StateCommand) -> None:
+        if command.operation == "delete_rabbitmq_vhost":
+            raise StateAlreadyExistsError("control-plane container not found")
+
+    with pytest.raises(StateAlreadyExistsError, match="control-plane"):
+        apply_purge_plan(plan, executor)
+
+
+def test_isolated_engine_plan_uses_only_deterministic_project_and_volume(
+    tmp_path: Path,
+) -> None:
+    state = build_state_plan(3, provider_slot=3, isolate_infra="postgres,redis")
+    state_dir = _state_dir(tmp_path)
+    env_file = _generated_env(tmp_path)
+    commands = build_provision_plan(state, state_dir=state_dir).commands
+
+    assert ("docker", "volume", "create", "futureagi_slot_03_postgres_data") in [
+        c.argv for c in commands
+    ]
+    assert ("docker", "volume", "create", "futureagi_slot_03_redis_data") in [
+        c.argv for c in commands
+    ]
+    starts = [
+        command for command in commands if command.operation == "start_isolated_engine"
+    ]
+    assert {command.target for command in starts} == {
+        "futureagi-slot-03-postgres",
+        "futureagi-slot-03-redis",
+    }
+    assert all(
+        any(argument.startswith("isolated-") for argument in command.argv)
+        for command in starts
+    )
+    assert all(command.env_file == env_file for command in starts)
+    assert all("--env-file" in command.argv for command in starts)
+    assert all(str(env_file) in command.argv for command in starts)
+
+
+def test_every_isolated_engine_omits_logical_provisioning_and_cleanup(
+    tmp_path: Path,
+) -> None:
+    isolated = ",".join(sorted(INFRA_ENGINES))
+    state = build_state_plan(3, provider_slot=3, isolate_infra=isolated)
+
+    state_dir = _state_dir(tmp_path)
+    provision = build_provision_plan(state, state_dir=state_dir)
+    purge = build_purge_plan(state, confirm="3", state_dir=state_dir)
+
+    assert {command.operation for command in provision.commands} == {
+        "create_isolated_volume",
+        "start_isolated_engine",
+        "run_isolated_minio_init",
+        "run_isolated_temporal_init",
+    }
+    assert {command.operation for command in purge.commands} == {
+        "stop_isolated_engine",
+        "delete_isolated_volume",
+    }
+    assert len(provision.commands) == len(INFRA_ENGINES) * 2 + 2
+    assert len(purge.commands) == len(INFRA_ENGINES) * 2
+
+
+def test_suspend_plan_stops_every_isolated_engine_without_deleting_state(
+    tmp_path: Path,
+) -> None:
+    state = build_state_plan(
+        3,
+        provider_slot=3,
+        isolate_infra=",".join(sorted(INFRA_ENGINES)),
+    )
+
+    plan = build_suspend_plan(state, state_dir=_state_dir(tmp_path))
+
+    assert [command.operation for command in plan.commands] == [
+        "suspend_isolated_engine"
+    ] * len(INFRA_ENGINES)
+    assert all(not command.destructive for command in plan.commands)
+    assert all(
+        command.env_file == _generated_env(tmp_path) for command in plan.commands
+    )
+    assert all(
+        command.argv[-2:] == ("down", "--remove-orphans") for command in plan.commands
+    )
+    assert not any("volume" in command.operation for command in plan.commands)
+    assert not any("delete" in command.operation for command in plan.commands)
+
+
+def test_suspend_state_is_injected_and_preserves_the_purge_boundary(
+    tmp_path: Path,
+) -> None:
+    executed: list[StateCommand] = []
+
+    plan = suspend_state(
+        3,
+        provider_slot=3,
+        isolate_infra="postgres",
+        state_dir=_state_dir(tmp_path),
+        executor=executed.append,
+    )
+
+    assert executed == list(plan.commands)
+    assert all(not command.destructive for command in plan.commands)
+    assert all(
+        command.operation != "delete_isolated_volume" for command in plan.commands
+    )
+
+
+def test_suspend_executor_rejects_a_destructive_command(tmp_path: Path) -> None:
+    state = build_state_plan(3, provider_slot=3, isolate_infra="postgres")
+    purge = build_purge_plan(state, confirm="3", state_dir=_state_dir(tmp_path))
+
+    with pytest.raises(StateValidationError, match="cannot include destructive"):
+        apply_suspend_plan(purge, lambda command: None)  # type: ignore[arg-type]
+
+
+def test_retired_isolated_purge_targets_only_retired_engine_projects_and_volumes(
+    tmp_path: Path,
+) -> None:
+    state = build_state_plan(3, provider_slot=3, isolate_infra="postgres")
+
+    retired = build_retired_isolated_purge_plan(
+        state,
+        retired_infra="minio,redis",
+        confirm="3",
+        state_dir=_state_dir(tmp_path),
+    )
+    current = build_purge_plan(state, confirm="3", state_dir=_state_dir(tmp_path))
+
+    assert [command.operation for command in retired.commands] == [
+        "stop_isolated_engine",
+        "delete_isolated_volume",
+        "stop_isolated_engine",
+        "delete_isolated_volume",
+    ]
+    assert {command.target for command in retired.commands} == {
+        "futureagi-slot-03-minio",
+        "futureagi_slot_03_minio_data",
+        "futureagi-slot-03-redis",
+        "futureagi_slot_03_redis_data",
+    }
+    assert all(command.destructive for command in retired.commands)
+    assert not any("flush_redis" in command.operation for command in retired.commands)
+    assert not any(
+        "delete_minio_bucket" in command.operation for command in retired.commands
+    )
+    assert any(
+        command.operation == "flush_redis_database" for command in current.commands
+    )
+    assert any(
+        command.operation == "delete_minio_bucket" for command in current.commands
+    )
+
+
+def test_retired_isolated_purge_requires_exact_confirmation_and_valid_retired_subset(
+    tmp_path: Path,
+) -> None:
+    state = build_state_plan(3, provider_slot=3, isolate_infra="postgres")
+
+    with pytest.raises(PurgeConfirmationError):
+        build_retired_isolated_purge_plan(
+            state,
+            retired_infra="redis",
+            confirm="2",
+            state_dir=_state_dir(tmp_path),
+        )
+    with pytest.raises(StateValidationError, match="still isolated"):
+        build_retired_isolated_purge_plan(
+            state,
+            retired_infra="postgres",
+            confirm="3",
+            state_dir=_state_dir(tmp_path),
+        )
+    with pytest.raises(StateValidationError, match="at least one"):
+        build_retired_isolated_purge_plan(
+            state,
+            retired_infra=None,  # type: ignore[arg-type]
+            confirm="3",
+            state_dir=_state_dir(tmp_path),
+        )
+    with pytest.raises(StateValidationError, match="authoritative state directory"):
+        build_retired_isolated_purge_plan(state, retired_infra="redis", confirm="3")
+
+
+def test_purge_requires_confirmation_for_the_exact_private_provider_slot() -> None:
+    state = build_state_plan(3, provider_slot=3)
+
+    with pytest.raises(PurgeConfirmationError):
+        build_purge_plan(state, confirm="2")
+    with pytest.raises(PurgeConfirmationError):
+        build_purge_plan(build_state_plan(3), confirm="3")
+    with pytest.raises(PurgeConfirmationError):
+        build_purge_plan(build_state_plan(3, provider_slot=4), confirm="3")
+
+
+def test_purge_commands_are_precise_and_never_target_all_state(tmp_path: Path) -> None:
+    state_dir = _state_dir(tmp_path)
+    plan = purge_state(
+        20,
+        provider_slot=20,
+        isolate_infra="postgres",
+        confirm=20,
+        state_dir=state_dir,
+    )
+
+    assert all(command.destructive for command in plan.commands)
+    assert all(command.target not in {"", "*", "all", "/"} for command in plan.commands)
+    assert all(
+        "--all" not in command.argv and "--volumes" not in command.argv
+        for command in plan.commands
+    )
+    redis = [
+        command
+        for command in plan.commands
+        if command.operation == "flush_redis_database"
+    ]
+    assert [command.argv[-2:] for command in redis] == [
+        ("60", "FLUSHDB"),
+        ("61", "FLUSHDB"),
+        ("62", "FLUSHDB"),
+    ]
+    assert not any("FLUSHALL" in command.argv for command in plan.commands)
+
+
+def test_purge_execution_is_injected_and_mockable() -> None:
+    executed: list[StateCommand] = []
+
+    plan = purge_state(3, provider_slot=3, confirm="3", executor=executed.append)
+
+    assert executed == list(plan.commands)
+
+
+def test_isolated_plans_require_an_authoritative_absolute_state_directory(
+    tmp_path: Path,
+) -> None:
+    state = build_state_plan(3, provider_slot=3, isolate_infra="postgres")
+
+    with pytest.raises(StateValidationError, match="authoritative state directory"):
+        build_provision_plan(state)
+    with pytest.raises(StateValidationError, match="authoritative state directory"):
+        build_purge_plan(state, confirm="3")
+    with pytest.raises(StateValidationError, match="absolute Path"):
+        build_provision_plan(state, state_dir=Path(".slots"))
+    with pytest.raises(TypeError):
+        build_provision_plan(state, env_file=_generated_env(tmp_path, 4))  # type: ignore[call-arg]
+
+
+def test_shared_logical_commands_do_not_receive_a_generated_env_file(
+    tmp_path: Path,
+) -> None:
+    state = build_state_plan(3, provider_slot=3)
+
+    plan = build_provision_plan(state, state_dir=_state_dir(tmp_path))
+
+    assert all(command.env_file is None for command in plan.commands)
+
+
+def test_isolated_temporal_start_includes_init_and_ui_dependents(
+    tmp_path: Path,
+) -> None:
+    state = build_state_plan(3, provider_slot=3, isolate_infra="temporal")
+
+    commands = build_provision_plan(state, state_dir=_state_dir(tmp_path)).commands
+    command = next(
+        command for command in commands if command.operation == "start_isolated_engine"
+    )
+
+    assert command.argv[-2:] == (
+        "isolated-temporal",
+        "isolated-temporal-ui",
+    )
+    assert "--wait" in command.argv
+    initializer = commands[commands.index(command) + 1]
+    assert initializer.operation == "run_isolated_temporal_init"
+    assert initializer.argv[-3:] == (
+        "run",
+        "--rm",
+        "isolated-temporal-init",
+    )
+
+
+def test_isolated_minio_waits_then_runs_its_bucket_initializer(tmp_path: Path) -> None:
+    state = build_state_plan(3, provider_slot=3, isolate_infra="minio")
+    commands = build_provision_plan(state, state_dir=_state_dir(tmp_path)).commands
+
+    start = next(
+        command for command in commands if command.operation == "start_isolated_engine"
+    )
+    initializer = commands[commands.index(start) + 1]
+
+    assert start.argv[-4:] == ("up", "--detach", "--wait", "isolated-minio")
+    assert initializer.operation == "run_isolated_minio_init"
+    assert initializer.argv[-3:] == ("run", "--rm", "isolated-minio-init")
+
+
+def test_destructive_command_constructor_rejects_broad_targets_and_arguments() -> None:
+    with pytest.raises(StateValidationError):
+        StateCommand("bad", "futureagi;rm", ("echo", "no"))
+    with pytest.raises(StateValidationError):
+        StateCommand(
+            "delete_isolated_volume",
+            "futureagi_slot_03_postgres_data",
+            ("docker", "system", "prune"),
+            destructive=True,
+        )
+    with pytest.raises(StateValidationError):
+        StateCommand(
+            "drop_postgres_database",
+            "postgres",
+            (
+                "docker",
+                "compose",
+                "--project-name",
+                CONTROL_PLANE_PROJECT,
+                "-f",
+                CONTROL_PLANE_COMPOSE_FILE,
+                "exec",
+                "-T",
+                "postgres",
+                "psql",
+                "--dbname=postgres",
+                "--command",
+                'DROP DATABASE IF EXISTS "postgres"',
+            ),
+            destructive=True,
+        )
+    with pytest.raises(StateValidationError):
+        StateCommand(
+            "stop_isolated_engine",
+            "futureagi-slot-03-postgres",
+            (
+                "docker",
+                "compose",
+                "--project-name",
+                "futureagi-slot-03-postgres",
+                "-f",
+                "slots/compose/isolated-infra.yaml",
+                "--profile",
+                "isolated-postgres",
+                "down",
+                "--rmi",
+                "all",
+            ),
+            destructive=True,
+        )

--- a/tests/slots/test_registry.py
+++ b/tests/slots/test_registry.py
@@ -1,0 +1,26 @@
+from pathlib import Path
+
+from slots.registry import RegistryStore, discover_state_dir
+
+
+def test_state_dir_uses_primary_worktree_and_override(tmp_path: Path):
+    primary = tmp_path / "primary"
+    primary.mkdir()
+    output = f"worktree {primary}\nHEAD abc\n\nworktree {tmp_path / 'child'}\n"
+    assert (
+        discover_state_dir(tmp_path, {}, lambda _command, _cwd: output)
+        == primary / ".slots"
+    )
+    assert (
+        discover_state_dir(tmp_path, {"SLOTS_STATE_DIR": str(tmp_path / "custom")})
+        == tmp_path / "custom"
+    )
+
+
+def test_registry_is_versioned_atomic_and_private(tmp_path: Path):
+    store = RegistryStore(tmp_path / ".slots")
+    with store.locked() as registry:
+        store.save(registry)
+    assert store.load().version == 1
+    assert (tmp_path / ".slots" / "registry.json").stat().st_mode & 0o777 == 0o600
+    assert not (tmp_path / ".slots" / "registry.json.tmp").exists()

--- a/tests/slots/test_runtime.py
+++ b/tests/slots/test_runtime.py
@@ -1,0 +1,1135 @@
+from pathlib import Path
+import subprocess
+
+import pytest
+
+from slots.models import ProviderRecord, Registry, StateIdentity
+from slots.registry import RegistryStore
+from slots.runtime import (
+    ResourceAdmissionError,
+    SlotRuntime,
+    allocate_slot,
+    execute_commands,
+)
+
+
+def runtime(tmp_path: Path) -> SlotRuntime:
+    return SlotRuntime(
+        RegistryStore(tmp_path / ".slots"),
+        tmp_path / "worktree",
+        lambda _argv, _cwd: "",
+    )
+
+
+def apply(runtime: SlotRuntime, slot: str, services: str, isolate: str = ""):
+    return runtime.apply_up(
+        slot,
+        services,
+        isolate,
+        "",
+        {"SLOTS_MEMORY_CAP_MIB": "12000"},
+        lambda _argv, _cwd: None,
+        lambda _command: None,
+    )
+
+
+def test_auto_allocation_generated_files_and_frontend_private(tmp_path: Path):
+    current = runtime(tmp_path)
+    assert current.plan_up("auto", "collector").record is not None
+    assert current.status() == ()
+    result = apply(current, "auto", "collector")
+    record = result.record
+    assert record is not None
+    assert record.slot == 1
+    assert record.services == ("backend", "collector")
+    assert record.providers["frontend"] == "slot-01-frontend"
+    assert record.providers["backend"] == "shared-backend"
+    assert record.providers["collector"] == "slot-01-collector"
+    assert record.routes["backend"] == "http://api.1.localhost"
+    assert record.ports["frontend"] == 20110
+    env = tmp_path / ".slots" / "slots" / "01" / "slot.env"
+    assert "SLOT_FRONTEND_NAME=slot-01-frontend" in env.read_text()
+    assert "SLOT_PG_DB=futureagi_slot_00" in env.read_text()
+    assert env.stat().st_mode & 0o777 == 0o600
+    assert (
+        tmp_path / ".slots" / "slots" / "01" / "manifest.json"
+    ).stat().st_mode & 0o777 == 0o600
+
+
+def test_generated_environment_inherits_worktree_env_before_slot_topology(
+    tmp_path: Path,
+):
+    current = runtime(tmp_path)
+    current.worktree.mkdir(parents=True)
+    (current.worktree / ".env").write_text(
+        "CUSTOM_APPLICATION_SETTING=from-worktree\n"
+        "VITE_EXPERIMENTAL_VIEW=true\n"
+        "SLOT=99\n"
+        "SLOT_PG_DB=wrong_database\n",
+        encoding="utf-8",
+    )
+
+    apply(current, "1", "none")
+
+    contents = (tmp_path / ".slots" / "slots" / "01" / "slot.env").read_text(
+        encoding="utf-8"
+    )
+    assert "CUSTOM_APPLICATION_SETTING=from-worktree\n" in contents
+    assert "VITE_EXPERIMENTAL_VIEW=true\n" in contents
+    assert contents.index("SLOT=99\n") < contents.index("SLOT=1\n")
+    assert contents.index("SLOT_PG_DB=wrong_database\n") < contents.index(
+        "SLOT_PG_DB=futureagi_slot_00\n"
+    )
+
+
+def test_shared_environment_inherits_its_owner_worktree_env(tmp_path: Path):
+    current = runtime(tmp_path)
+    current.worktree.mkdir(parents=True)
+    (current.worktree / ".env").write_text(
+        "CUSTOM_SHARED_SETTING=owner-value\n", encoding="utf-8"
+    )
+
+    apply(current, "1", "none")
+
+    shared = (tmp_path / ".slots" / "shared" / "backend.env").read_text(
+        encoding="utf-8"
+    )
+    assert "CUSTOM_SHARED_SETTING=owner-value\n" in shared
+    assert "SLOT=0\n" in shared
+
+
+def test_doctor_accepts_missing_network_before_first_slot(tmp_path: Path):
+    current = runtime(tmp_path)
+
+    def executor(argv, _cwd):
+        if argv[:3] == ("docker", "network", "inspect"):
+            raise subprocess.CalledProcessError(
+                1, argv, stderr="network futureagi-slots not found"
+            )
+
+    report = current.doctor(executor, {"SLOTS_MEMORY_CAP_MIB": "10240"})
+    assert report["slots"] == 0
+    assert report["admission_limit_mib"] == 7680
+
+
+def test_replacement_and_down_update_reference_counts_without_deleting_data(
+    tmp_path: Path,
+):
+    current = runtime(tmp_path)
+    apply(current, "1", "backend")
+    apply(current, "2", "none")
+    replacement = apply(current, "1", "collector")
+    assert replacement.record.providers["backend"] == "shared-backend"
+    down = current.apply_down("1", lambda _argv, _cwd: None)
+    assert "slot-01-collector" in down.stopped_providers
+    assert (tmp_path / ".slots" / "slots" / "01" / "slot.env").exists()
+
+
+def test_down_reloads_traefik_after_removing_route_with_surviving_slots(
+    tmp_path: Path,
+):
+    current = runtime(tmp_path)
+    apply(current, "1", "none")
+    apply(current, "2", "none")
+    commands: list[tuple[str, ...]] = []
+
+    current.apply_down("1", lambda argv, _cwd: commands.append(tuple(argv)))
+
+    assert commands[-1][-2:] == ("restart", "traefik")
+    assert "futureagi-slots" in commands[-1]
+    assert not (tmp_path / ".slots" / "routes" / "slot-01.yaml").exists()
+
+
+def test_post_commit_down_recovery_retries_route_reload_after_route_is_gone(
+    tmp_path: Path,
+):
+    current = runtime(tmp_path)
+    apply(current, "1", "none")
+    apply(current, "2", "none")
+    record = current.status("1")[0]
+    current.apply_down("1", lambda _argv, _cwd: None)
+    current._write_recovery_journal(record, "down")
+    commands: list[tuple[str, ...]] = []
+
+    result = current.apply_recover(
+        lambda argv, _cwd: commands.append(tuple(argv)), lambda _command: None
+    )
+
+    assert result.action == "recover-down-complete"
+    assert commands[-1][-2:] == ("restart", "traefik")
+    assert current.status("1") == ()
+    assert len(current.status()) == 1
+
+
+def test_resource_admission_force_and_purge_confirmation(tmp_path: Path):
+    current = runtime(tmp_path)
+    with pytest.raises(ResourceAdmissionError):
+        current.plan_up("1", "backend", environment={"SLOTS_MEMORY_CAP_MIB": "1000"})
+    current.apply_up(
+        "1",
+        "backend",
+        "",
+        "",
+        {"SLOTS_MEMORY_CAP_MIB": "1000", "FORCE": "1"},
+        lambda _argv, _cwd: None,
+        lambda _command: None,
+    )
+    with pytest.raises(ValueError, match="CONFIRM=1"):
+        current.plan_purge("1", "2")
+    assert current.plan_purge("1", "1").action == "purge"
+
+
+def test_isolated_engines_require_private_backend_and_receive_a_port(tmp_path: Path):
+    current = runtime(tmp_path)
+    with pytest.raises(ValueError, match="SERVICES=backend"):
+        current.plan_up("1", "collector", "postgres")
+    plan = apply(current, "1", "backend", "postgres")
+    assert plan.record.ports["postgres"] == 20101
+    assert any(command.argv[-2:] == ("build", "backend") for command in plan.commands)
+    assert (
+        "SLOT_POSTGRES_PORT=20101"
+        in (tmp_path / ".slots" / "slots" / "01" / "slot.env").read_text()
+    )
+
+
+def test_isolated_environment_matches_volume_names_and_route_targets(tmp_path: Path):
+    current = runtime(tmp_path)
+    plan = current.plan_up(
+        "1",
+        "backend",
+        "minio,rabbitmq,temporal",
+        environment={"SLOTS_MEMORY_CAP_MIB": "16000", "SLOTS_HTTP_PORT": "8088"},
+    )
+    assert plan.record is not None
+    values = current.environment_for(plan.record)
+    route = current._route_contents(plan.record)
+
+    assert values["SLOT_MINIO_VOLUME"] == "futureagi_slot_01_minio_data"
+    assert values["SLOT_RABBITMQ_VOLUME"] == "futureagi_slot_01_rabbitmq_data"
+    assert values["SLOT_TEMPORAL_VOLUME"] == "futureagi_slot_01_temporal_data"
+    assert values["SLOT_ISOLATED_MINIO_NAME"] == "futureagi-slot-01-minio"
+    assert values["SLOT_ISOLATED_RABBITMQ_NAME"] == "futureagi-slot-01-rabbitmq"
+    assert values["SLOT_ISOLATED_TEMPORAL_NAME"] == "futureagi-slot-01-temporal"
+    assert (
+        values["SLOT_ISOLATED_TEMPORAL_POSTGRES_NAME"]
+        == "futureagi-slot-01-temporal-postgres"
+    )
+    assert values["SLOT_TEMPORAL_UI_NAME"] == "futureagi-slot-01-temporal-ui"
+    assert plan.record.routes["frontend"] == "http://1.localhost:8088"
+    assert (
+        plan.record.routes["minio-console"] == "http://minio-console.1.localhost:8088"
+    )
+    assert "futureagi-slot-01-minio:9000" in route
+    assert "futureagi-slot-01-rabbitmq:15672" in route
+    assert "futureagi-slot-01-temporal-ui:8080" in route
+    assert "shared-observability:16686" in route
+    assert plan.record.routes["jaeger"] == "http://jaeger.1.localhost:8088"
+
+
+def test_command_execution_is_explicitly_injected(tmp_path: Path):
+    current = runtime(tmp_path)
+    plan = current.plan_up("1", "none", environment={"SLOTS_MEMORY_CAP_MIB": "12000"})
+    executed = []
+    execute_commands(
+        plan.commands, lambda argv, cwd: executed.append((tuple(argv), cwd))
+    )
+    assert executed[0][0] == ("docker", "network", "create", "futureagi-slots")
+    current.apply_up(
+        "1",
+        "none",
+        "",
+        "",
+        {"SLOTS_MEMORY_CAP_MIB": "12000"},
+        lambda _argv, _cwd: None,
+        lambda _command: None,
+    )
+    assert allocate_slot("auto", current.store.load()) == 2
+
+
+def test_failed_external_execution_preserves_recovery_artifacts_without_commit(
+    tmp_path: Path,
+):
+    current = runtime(tmp_path)
+
+    with pytest.raises(RuntimeError, match="compose failed"):
+        current.apply_up(
+            "1",
+            "none",
+            "",
+            "",
+            {"SLOTS_MEMORY_CAP_MIB": "12000"},
+            lambda _argv, _cwd: (_ for _ in ()).throw(RuntimeError("compose failed")),
+            lambda _command: None,
+        )
+
+    assert current.status() == ()
+    assert (tmp_path / ".slots" / "slots" / "01" / "slot.env").exists()
+    assert (tmp_path / ".slots" / "routes" / "slot-01.yaml").exists()
+    journal = (tmp_path / ".slots" / "recovery.json").read_text()
+    assert '"record"' in journal
+
+
+def test_recover_cleans_failed_new_slot_without_deleting_volumes(tmp_path: Path):
+    current = runtime(tmp_path)
+    with pytest.raises(RuntimeError, match="compose failed"):
+        current.apply_up(
+            "1",
+            "none",
+            "",
+            "",
+            {"SLOTS_MEMORY_CAP_MIB": "12000"},
+            lambda _argv, _cwd: (_ for _ in ()).throw(RuntimeError("compose failed")),
+            lambda _command: None,
+        )
+
+    commands: list[tuple[str, ...]] = []
+    result = current.apply_recover(
+        lambda argv, _cwd: commands.append(tuple(argv)), lambda _command: None
+    )
+
+    assert result.action == "recover"
+    assert not (tmp_path / ".slots" / "recovery.json").exists()
+    assert current.status() == ()
+    assert any("futureagi-slots" in command for command in commands)
+    assert ("docker", "network", "rm", "futureagi-slots") in commands
+    assert not any("--volumes" in command for command in commands)
+
+
+def test_recover_supports_legacy_journal_with_provider_environment(tmp_path: Path):
+    current = runtime(tmp_path)
+    current._write_private(
+        tmp_path / ".slots" / "recovery.json", '{"action":"up","slot":1}\n'
+    )
+    current._write_private(
+        tmp_path / ".slots" / "shared" / "executor.env", "SLOT_ID=00\n"
+    )
+    commands: list[tuple[str, ...]] = []
+
+    current.apply_recover(lambda argv, _cwd: commands.append(tuple(argv)))
+
+    assert any("futureagi-slots-default-executor" in command for command in commands)
+    assert any("slots/compose/control-plane.yaml" in command for command in commands)
+    assert not (tmp_path / ".slots" / "recovery.json").exists()
+
+
+def test_recover_interrupted_replacement_cleans_only_private_project(tmp_path: Path):
+    current = runtime(tmp_path)
+    apply(current, "1", "backend")
+    record = current.status("1")[0]
+    current._write_recovery_journal(record, "up")
+    commands: list[tuple[str, ...]] = []
+
+    result = current.apply_recover(
+        lambda argv, _cwd: commands.append(tuple(argv)), lambda _command: None
+    )
+
+    assert result.action == "recover-replacement"
+    assert len(commands) == 1
+    assert "futureagi-slot-01" in commands[0]
+    assert commands[0][-1] == "down"
+    assert "slots/compose/control-plane.yaml" not in commands[0]
+    assert commands[0][:3] != ("docker", "network", "rm")
+    assert current.status("1") == (record,)
+    assert not (tmp_path / ".slots" / "recovery.json").exists()
+
+
+def test_recover_interrupted_replacement_suspends_new_isolated_infra(
+    tmp_path: Path,
+):
+    current = runtime(tmp_path)
+    apply(current, "1", "none")
+    previous = current.status("1")[0]
+    replacement = current.plan_up(
+        "1",
+        "backend",
+        "postgres",
+        environment={"SLOTS_MEMORY_CAP_MIB": "12000"},
+    ).record
+    assert replacement is not None
+    current._stage_artifacts(replacement)
+    current._write_recovery_journal(replacement, "up")
+    state_commands: list[object] = []
+
+    result = current.apply_recover(lambda _argv, _cwd: None, state_commands.append)
+
+    assert result.action == "recover-replacement"
+    assert current.status("1") == (previous,)
+    assert [command.operation for command in state_commands] == [
+        "suspend_isolated_engine"
+    ]
+    assert state_commands[0].target == "futureagi-slot-01-postgres"
+    assert not any(
+        command.operation == "delete_isolated_volume" for command in state_commands
+    )
+    assert not (tmp_path / ".slots" / "recovery.json").exists()
+
+
+@pytest.mark.parametrize("action", ["down", "purge"])
+def test_recover_unblocks_interrupted_cleanup_for_explicit_retry(
+    tmp_path: Path, action: str
+):
+    current = runtime(tmp_path)
+    apply(current, "1", "backend")
+    record = current.status("1")[0]
+    current._write_recovery_journal(record, action)
+
+    result = current.apply_recover(lambda _argv, _cwd: None, lambda _command: None)
+
+    assert result.action == f"recover-{action}-retry"
+    assert current.status("1") == (record,)
+    assert not (tmp_path / ".slots" / "recovery.json").exists()
+
+    if action == "down":
+        current.apply_down("1", lambda _argv, _cwd: None)
+    else:
+        current.apply_purge("1", "1", lambda _argv, _cwd: None, lambda _command: None)
+    assert current.status("1") == ()
+
+
+def test_staging_failure_rolls_back_partially_published_files(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    current = runtime(tmp_path)
+    monkeypatch.setattr(
+        current,
+        "_route_contents",
+        lambda _record: (_ for _ in ()).throw(RuntimeError("route render failed")),
+    )
+    calls: list[tuple[str, ...]] = []
+
+    with pytest.raises(RuntimeError, match="route render failed"):
+        current.apply_up(
+            "1",
+            "none",
+            "",
+            "",
+            {"SLOTS_MEMORY_CAP_MIB": "12000"},
+            lambda argv, _cwd: calls.append(tuple(argv)),
+            lambda _command: None,
+        )
+
+    assert calls == []
+    assert not (tmp_path / ".slots" / "slots" / "01" / "slot.env").exists()
+    assert not (tmp_path / ".slots" / "routes" / "slot-01.yaml").exists()
+
+
+def test_shared_default_is_refused_when_source_changed_from_base_ref(tmp_path: Path):
+    current = SlotRuntime(
+        RegistryStore(tmp_path / ".slots"),
+        tmp_path / "worktree",
+        lambda _argv, _cwd: "futureagi/tfc/settings.py\n",
+    )
+
+    with pytest.raises(ValueError, match="source differs"):
+        current.plan_up("1", "none")
+
+
+def test_private_backend_skips_shared_source_validation_and_starts_worker(
+    tmp_path: Path,
+):
+    def changed_backend_only(argv, _cwd):
+        return "futureagi/tfc/settings.py\n" if argv[-1] == "futureagi" else ""
+
+    current = SlotRuntime(
+        RegistryStore(tmp_path / ".slots"),
+        tmp_path / "worktree",
+        changed_backend_only,
+    )
+
+    plan = current.plan_up(
+        "1", "backend", environment={"SLOTS_MEMORY_CAP_MIB": "12000"}
+    )
+
+    assert plan.record is not None
+    assert plan.record.providers["backend"] == "slot-01-backend"
+    up = next(
+        command.argv
+        for command in plan.commands
+        if "futureagi-slot-01" in command.argv and "up" in command.argv
+    )
+    assert up[-6:] == (
+        "backend",
+        "worker",
+        "simulation",
+        "collector",
+        "peerdb",
+        "frontend",
+    )
+
+
+def test_network_then_control_then_state_then_compose_are_injected_in_order(
+    tmp_path: Path,
+):
+    current = runtime(tmp_path)
+    calls: list[tuple[str, str]] = []
+
+    current.apply_up(
+        "1",
+        "none",
+        "",
+        "",
+        {"SLOTS_MEMORY_CAP_MIB": "12000"},
+        lambda argv, _cwd: calls.append(("compose", " ".join(argv))),
+        lambda command: calls.append(("state", command.operation)),
+    )
+
+    assert calls[0] == ("compose", "docker network create futureagi-slots")
+    assert "control-plane.yaml" in calls[1][1]
+    first_state = next(index for index, call in enumerate(calls) if call[0] == "state")
+    assert first_state == 2
+    assert any(
+        "slots/compose/backend.yaml" in call[1] for call in calls[first_state + 1 :]
+    )
+    assert any("restart traefik" in call[1] for call in calls[first_state + 1 :])
+
+
+def test_runtime_never_falls_back_to_a_subprocess_state_executor(tmp_path: Path):
+    current = runtime(tmp_path)
+    compose_calls: list[tuple[str, ...]] = []
+
+    with pytest.raises(ValueError, match="StateCommand executor"):
+        current.apply_up(
+            "1",
+            "none",
+            "",
+            "",
+            {"SLOTS_MEMORY_CAP_MIB": "12000"},
+            lambda argv, _cwd: compose_calls.append(tuple(argv)),
+        )
+
+    assert compose_calls == []
+    assert current.status() == ()
+
+
+def test_replacement_stops_the_old_full_project_before_new_control_plane(
+    tmp_path: Path,
+):
+    current = runtime(tmp_path)
+    apply(current, "1", "collector")
+    calls: list[tuple[str, ...]] = []
+
+    apply_result = current.apply_up(
+        "1",
+        "backend",
+        "",
+        "",
+        {"SLOTS_MEMORY_CAP_MIB": "12000"},
+        lambda argv, _cwd: calls.append(tuple(argv)),
+        lambda _command: None,
+    )
+
+    assert apply_result.record is not None
+    assert calls[0][-1] == "down"
+    assert "slots/compose/collector.yaml" in calls[0]
+    assert calls[1] == ("docker", "network", "create", "futureagi-slots")
+
+
+def test_last_shared_reference_stops_all_implicit_shared_defaults(tmp_path: Path):
+    current = runtime(tmp_path)
+    apply(current, "1", "none")
+    apply(current, "2", "none")
+    first: list[tuple[str, ...]] = []
+    current.apply_down("1", lambda argv, _cwd: first.append(tuple(argv)))
+    assert not any("futureagi-slots-default-backend" in call for call in first)
+
+    second: list[tuple[str, ...]] = []
+    current.apply_down("2", lambda argv, _cwd: second.append(tuple(argv)))
+    projects = {
+        command[command.index("--project-name") + 1]
+        for command in second
+        if "--project-name" in command
+    }
+    assert {
+        "futureagi-slots-default-backend",
+        "futureagi-slots-default-simulation",
+        "futureagi-slots-default-gateway",
+        "futureagi-slots-default-collector",
+        "futureagi-slots-default-serving",
+        "futureagi-slots-default-executor",
+        "futureagi-slots-default-peerdb",
+        "futureagi-slots-default-observability",
+    } <= projects
+
+
+def test_purge_keeps_files_and_registry_when_private_state_cleanup_fails(
+    tmp_path: Path,
+):
+    current = runtime(tmp_path)
+    apply(current, "1", "backend", "postgres")
+    env = tmp_path / ".slots" / "slots" / "01" / "slot.env"
+
+    with pytest.raises(RuntimeError, match="purge failed"):
+        current.apply_purge(
+            "1",
+            "1",
+            lambda _argv, _cwd: None,
+            lambda _command: (_ for _ in ()).throw(RuntimeError("purge failed")),
+        )
+
+    assert current.status("1")
+    assert env.exists()
+
+
+def test_shared_service_commands_use_the_provider_owner_environment(tmp_path: Path):
+    current = runtime(tmp_path)
+    apply(current, "1", "none")
+    apply(current, "2", "none")
+    second = current.status("2")[0]
+
+    command = current.service_command(second, "logs", "backend")
+
+    assert "futureagi-slots-default-backend" in command.argv
+    assert str(tmp_path / ".slots" / "shared" / "backend.env") in command.argv
+
+
+@pytest.mark.parametrize("value", ["0", "65536", "abc", "80.5", " 80"])
+def test_invalid_http_port_fails_during_pure_planning(tmp_path: Path, value: str):
+    current = runtime(tmp_path)
+
+    with pytest.raises(ValueError, match="SLOTS_HTTP_PORT"):
+        current.plan_up("1", "none", environment={"SLOTS_HTTP_PORT": value})
+
+    assert current.status() == ()
+    assert not (tmp_path / ".slots" / "slots" / "01" / "slot.env").exists()
+
+
+def test_every_new_shared_default_is_clean_source_validated(tmp_path: Path):
+    calls: list[tuple[str, ...]] = []
+
+    def git_runner(argv, _cwd):
+        calls.append(tuple(argv))
+        return "" if "agentcc-gateway" not in argv else "agentcc-gateway/main.go\n"
+
+    current = SlotRuntime(
+        RegistryStore(tmp_path / ".slots"), tmp_path / "worktree", git_runner
+    )
+
+    with pytest.raises(ValueError, match="shared gateway"):
+        current.plan_up("1", "none")
+
+    checked = {argument for command in calls for argument in command}
+    assert "futureagi" in checked
+    assert "agentcc-gateway" in checked
+
+
+def test_prune_is_recovery_cleanup_for_a_stale_zero_reference_provider(tmp_path: Path):
+    current = runtime(tmp_path)
+    stale = ProviderRecord(
+        "shared-observability",
+        "observability",
+        str(tmp_path / "worktree"),
+        StateIdentity.for_slot(0),
+        (),
+        False,
+    )
+    with current.store.locked() as registry:
+        current.store.save(
+            Registry(registry.version, dict(registry.slots), {stale.name: stale})
+        )
+    commands: list[tuple[str, ...]] = []
+
+    result = current.apply_prune(lambda argv, _cwd: commands.append(tuple(argv)))
+
+    assert result.action == "prune"
+    assert commands[0][-1] == "down"
+    assert "futureagi-slots-default-observability" in commands[0]
+    assert current.store.load().providers == {}
+
+
+def test_peerdb_uses_its_exact_compose_members_and_ui_for_interactive_commands(
+    tmp_path: Path,
+):
+    current = runtime(tmp_path)
+    shared = current.plan_up("1", "none", environment={"SLOTS_MEMORY_CAP_MIB": "12000"})
+    shared_peerdb = next(
+        command.argv
+        for command in shared.commands
+        if "slots/compose/peerdb.yaml" in command.argv
+    )
+    assert shared_peerdb[-1:] == ("peerdb",)
+    assert not any(
+        command.argv[-2:] == ("wait", "peerdb") for command in shared.commands
+    )
+    plan = current.plan_up("1", "peerdb", environment={"SLOTS_MEMORY_CAP_MIB": "12000"})
+    private_up = plan.commands[-1].argv
+
+    assert private_up[-2:] == ("peerdb", "frontend")
+    assert "--build" not in private_up
+    private_builds = [
+        command.argv[-1]
+        for command in plan.commands
+        if command.argv[-2:-1] == ("build",) and "futureagi-slot-01" in command.argv
+    ]
+    assert private_builds == ["frontend"]
+    assert "slots/compose/frontend.yaml" in private_up
+    assert "slots/compose/backend.yaml" not in private_up
+    apply(current, "1", "peerdb")
+    command = current.service_command(current.status("1")[0], "shell", "peerdb")
+    assert command.argv[-2:] == ("peerdb-ui", "sh")
+
+
+def test_private_peerdb_relies_on_compose_dependency_gate_without_racy_wait(
+    tmp_path: Path,
+):
+    current = runtime(tmp_path)
+    plan = current.plan_up(
+        "1", "backend", environment={"SLOTS_MEMORY_CAP_MIB": "12000"}
+    )
+    private_up = plan.commands[-1].argv
+
+    assert private_up[-2:] == ("peerdb", "frontend")
+    assert not any(command.argv[-2:] == ("wait", "peerdb") for command in plan.commands)
+
+
+def test_private_source_images_build_sequentially_before_compose_up(tmp_path: Path):
+    current = runtime(tmp_path)
+    plan = current.plan_up(
+        "1", "backend", environment={"SLOTS_MEMORY_CAP_MIB": "12000"}
+    )
+    builds = [
+        command.argv[-1]
+        for command in plan.commands
+        if command.argv[-2:-1] == ("build",) and "futureagi-slot-01" in command.argv
+    ]
+
+    assert builds == ["backend", "simulation", "collector", "frontend"]
+    assert all("--build" not in command.argv for command in plan.commands)
+
+
+def test_private_backend_closes_state_coupled_provider_groups(tmp_path: Path):
+    current = runtime(tmp_path)
+    plan = apply(current, "1", "backend")
+    assert plan.record is not None
+    assert all(
+        plan.record.providers[group] == f"slot-01-{group}"
+        for group in ("backend", "simulation", "collector", "peerdb")
+    )
+    values = current.environment_for(plan.record)
+    assert values["SLOT_PEERDB_UI_NAME"] == "futureagi-slot-01-peerdb-ui"
+    assert (
+        values["SLOT_PEERDB_CATALOG_VOLUME"] == "futureagi-slot-01-peerdb-catalog-data"
+    )
+
+
+def test_missing_simulation_wheel_fails_before_runtime_mutation(tmp_path: Path):
+    current = runtime(tmp_path)
+    current.worktree.mkdir(parents=True)
+    (current.worktree / "Dockerfile.simulation-runner.dev").write_text("FROM scratch\n")
+    commands: list[tuple[str, ...]] = []
+
+    with pytest.raises(ValueError, match="simulation build requires"):
+        current.apply_up(
+            "1",
+            "backend",
+            "",
+            "",
+            {"SLOTS_MEMORY_CAP_MIB": "12000"},
+            lambda argv, _cwd: commands.append(tuple(argv)),
+            lambda _command: None,
+        )
+
+    assert commands == []
+    assert not (tmp_path / ".slots" / "recovery.json").exists()
+    assert not (tmp_path / ".slots" / "slots" / "01" / "slot.env").exists()
+
+
+def test_active_slots_require_one_global_public_port(tmp_path: Path):
+    current = runtime(tmp_path)
+    current.apply_up(
+        "1",
+        "none",
+        "",
+        "",
+        {"SLOTS_MEMORY_CAP_MIB": "12000", "SLOTS_HTTP_PORT": "8088"},
+        lambda _argv, _cwd: None,
+        lambda _command: None,
+    )
+    with pytest.raises(ValueError, match="single public port"):
+        current.plan_up(
+            "2",
+            "none",
+            environment={"SLOTS_MEMORY_CAP_MIB": "12000", "SLOTS_HTTP_PORT": "8089"},
+        )
+
+
+def test_recovery_journal_blocks_mutation_without_overwrite(tmp_path: Path):
+    current = runtime(tmp_path)
+    journal = tmp_path / ".slots" / "recovery.json"
+    journal.parent.mkdir()
+    journal.write_text('{"action":"up","slot":1}\n')
+    with pytest.raises(RuntimeError, match="recovery journal blocks"):
+        current.apply_up(
+            "1",
+            "none",
+            "",
+            "",
+            {"SLOTS_MEMORY_CAP_MIB": "12000"},
+            lambda _argv, _cwd: None,
+            lambda _command: None,
+        )
+    assert journal.read_text() == '{"action":"up","slot":1}\n'
+
+
+def test_last_down_passes_authoritative_env_to_control_plane(tmp_path: Path):
+    current = runtime(tmp_path)
+    apply(current, "1", "none")
+    commands: list[tuple[str, ...]] = []
+    current.apply_down("1", lambda argv, _cwd: commands.append(tuple(argv)))
+    control = next(
+        command for command in commands if "slots/compose/control-plane.yaml" in command
+    )
+    assert "--env-file" in control
+    assert str(tmp_path / ".slots" / "slots" / "01" / "slot.env") in control
+
+
+def test_active_purge_stops_last_shared_control_and_network_before_commit(
+    tmp_path: Path,
+):
+    current = runtime(tmp_path)
+    apply(current, "1", "none")
+    commands: list[tuple[str, ...]] = []
+    result = current.apply_purge(
+        "1", "1", lambda argv, _cwd: commands.append(tuple(argv))
+    )
+    assert result.stopped_providers
+    assert any("futureagi-slots-default-backend" in command for command in commands)
+    assert any("slots/compose/control-plane.yaml" in command for command in commands)
+    assert ("docker", "network", "rm", "futureagi-slots") in commands
+
+
+def test_shared_peerdb_up_uses_provider_stable_environment(tmp_path: Path):
+    current = runtime(tmp_path)
+    plan = current.plan_up("1", "none", environment={"SLOTS_MEMORY_CAP_MIB": "12000"})
+    peerdb_up = next(
+        command.argv
+        for command in plan.commands
+        if "futureagi-slots-default-peerdb" in command.argv
+    )
+    assert str(tmp_path / ".slots" / "shared" / "peerdb.env") in peerdb_up
+
+
+def test_shared_owner_worktree_is_preserved_while_referenced(tmp_path: Path):
+    store = RegistryStore(tmp_path / ".slots")
+    first = SlotRuntime(store, tmp_path / "first", lambda _argv, _cwd: "")
+    second = SlotRuntime(store, tmp_path / "second", lambda _argv, _cwd: "")
+    first.apply_up(
+        "1",
+        "none",
+        "",
+        "",
+        {"SLOTS_MEMORY_CAP_MIB": "12000"},
+        lambda _argv, _cwd: None,
+        lambda _command: None,
+    )
+    second.apply_up(
+        "2",
+        "none",
+        "",
+        "",
+        {"SLOTS_MEMORY_CAP_MIB": "12000"},
+        lambda _argv, _cwd: None,
+        lambda _command: None,
+    )
+    assert store.load().providers["shared-backend"].worktree == str(
+        (tmp_path / "first").resolve()
+    )
+
+
+def test_shared_owner_handoff_rebinds_environment_before_successor_up(
+    tmp_path: Path,
+):
+    store = RegistryStore(tmp_path / ".slots")
+    first_path = tmp_path / "first"
+    second_path = tmp_path / "second"
+    first = SlotRuntime(store, first_path, lambda _argv, _cwd: "")
+    second = SlotRuntime(store, second_path, lambda _argv, _cwd: "")
+    for current, slot in ((first, "1"), (second, "2")):
+        current.apply_up(
+            slot,
+            "none",
+            "",
+            "",
+            {"SLOTS_MEMORY_CAP_MIB": "12000"},
+            lambda _argv, _cwd: None,
+            lambda _command: None,
+        )
+
+    calls: list[tuple[tuple[str, ...], Path]] = []
+    second.apply_down("1", lambda argv, cwd: calls.append((tuple(argv), cwd)))
+
+    backend_calls = [
+        (argv, cwd) for argv, cwd in calls if "futureagi-slots-default-backend" in argv
+    ]
+    assert len(backend_calls) == 1
+    assert "--force-recreate" in backend_calls[0][0]
+    assert backend_calls[0][0][-2:] == ("backend", "worker")
+    assert backend_calls[0][1] == second_path.resolve()
+    assert store.load().providers["shared-backend"].worktree == str(
+        second_path.resolve()
+    )
+    shared_env = (tmp_path / ".slots" / "shared" / "backend.env").read_text()
+    assert f"SLOT_WORKTREE={second_path.resolve()}" in shared_env
+
+
+def test_shared_owner_handoff_failure_restores_environment_and_keeps_journal(
+    tmp_path: Path,
+):
+    store = RegistryStore(tmp_path / ".slots")
+    first_path = tmp_path / "first"
+    second_path = tmp_path / "second"
+    first = SlotRuntime(store, first_path, lambda _argv, _cwd: "")
+    second = SlotRuntime(store, second_path, lambda _argv, _cwd: "")
+    for current, slot in ((first, "1"), (second, "2")):
+        current.apply_up(
+            slot,
+            "none",
+            "",
+            "",
+            {"SLOTS_MEMORY_CAP_MIB": "12000"},
+            lambda _argv, _cwd: None,
+            lambda _command: None,
+        )
+    env_path = tmp_path / ".slots" / "shared" / "backend.env"
+    old_env = env_path.read_bytes()
+
+    def fail_successor_backend(argv, _cwd):
+        if "futureagi-slots-default-backend" in argv and argv[-2:] == (
+            "backend",
+            "worker",
+        ):
+            raise RuntimeError("successor compose failure")
+
+    with pytest.raises(RuntimeError, match="successor compose failure"):
+        second.apply_down("1", fail_successor_backend)
+
+    assert env_path.read_bytes() == old_env
+    assert store.load().providers["shared-backend"].worktree == str(
+        first_path.resolve()
+    )
+    assert (tmp_path / ".slots" / "recovery.json").exists()
+
+
+def test_shared_owner_handoff_refuses_changed_successor_source(tmp_path: Path):
+    store = RegistryStore(tmp_path / ".slots")
+    first_path = tmp_path / "first"
+    second_path = tmp_path / "second"
+    first = SlotRuntime(store, first_path, lambda _argv, _cwd: "")
+
+    def changed_backend(argv, cwd):
+        if cwd == second_path.resolve() and argv[:3] == (
+            "git",
+            "diff",
+            "--name-only",
+        ):
+            return "futureagi/changed.py\n"
+        return ""
+
+    second = SlotRuntime(store, second_path, changed_backend)
+    for current, slot in ((first, "1"), (second, "2")):
+        current.apply_up(
+            slot,
+            "none",
+            "",
+            "",
+            {"SLOTS_MEMORY_CAP_MIB": "12000"},
+            lambda _argv, _cwd: None,
+            lambda _command: None,
+        )
+    env_path = tmp_path / ".slots" / "shared" / "backend.env"
+    old_env = env_path.read_bytes()
+
+    with pytest.raises(ValueError, match="cannot hand off shared backend"):
+        second.apply_down("1", lambda _argv, _cwd: None)
+
+    assert env_path.read_bytes() == old_env
+    assert store.load().providers["shared-backend"].worktree == str(
+        first_path.resolve()
+    )
+    assert (tmp_path / ".slots" / "recovery.json").exists()
+
+
+def test_same_worktree_replacement_does_not_recreate_shared_owners(tmp_path: Path):
+    current = runtime(tmp_path)
+    apply(current, "1", "none")
+    calls: list[tuple[str, ...]] = []
+    current.apply_up(
+        "1",
+        "none",
+        "",
+        "",
+        {"SLOTS_MEMORY_CAP_MIB": "12000"},
+        lambda argv, _cwd: calls.append(tuple(argv)),
+        lambda _command: None,
+    )
+    assert not any("--force-recreate" in command for command in calls)
+
+
+def test_replacement_retains_retired_isolated_volume_for_confirmed_purge(
+    tmp_path: Path,
+):
+    current = runtime(tmp_path)
+    apply(current, "1", "backend", "postgres")
+    replacement = current.apply_up(
+        "1",
+        "none",
+        "",
+        "",
+        {"SLOTS_MEMORY_CAP_MIB": "12000"},
+        lambda _argv, _cwd: None,
+        lambda _command: None,
+    )
+    assert replacement.record is not None
+    assert replacement.record.retired_isolated_infra == ("postgres",)
+    state_commands: list[object] = []
+    current.apply_purge("1", "1", lambda _argv, _cwd: None, state_commands.append)
+    assert any(
+        command.operation == "delete_isolated_volume"
+        and command.target == "futureagi_slot_01_postgres_data"
+        for command in state_commands
+    )
+
+
+def test_retired_isolated_engine_is_not_purged_through_shared_control_plane(
+    tmp_path: Path,
+):
+    current = runtime(tmp_path)
+    apply(current, "1", "backend", "rabbitmq")
+    replacement = current.apply_up(
+        "1",
+        "none",
+        "",
+        "",
+        {"SLOTS_MEMORY_CAP_MIB": "12000"},
+        lambda _argv, _cwd: None,
+        lambda _command: None,
+    )
+    assert replacement.record is not None
+    assert replacement.record.retired_isolated_infra == ("rabbitmq",)
+
+    commands = current.plan_purge("1", "1").state_commands
+
+    assert any(
+        command.operation == "delete_isolated_volume"
+        and command.target == "futureagi_slot_01_rabbitmq_data"
+        for command in commands
+    )
+    assert any(
+        command.operation == "stop_isolated_engine"
+        and command.target == "futureagi-slot-01-rabbitmq"
+        for command in commands
+    )
+    assert not any(command.operation == "delete_rabbitmq_vhost" for command in commands)
+
+
+def test_shared_env_strips_private_isolation_host_and_volume_overrides(tmp_path: Path):
+    current = runtime(tmp_path)
+    apply(current, "1", "backend", "redis")
+    shared_gateway = (tmp_path / ".slots" / "shared" / "gateway.env").read_text()
+    assert "SLOT_REDIS_HOST=" not in shared_gateway
+    assert "SLOT_REDIS_VOLUME=" not in shared_gateway
+    assert "SLOT_REDIS_DB=0" in shared_gateway
+
+
+def test_simulation_receives_exact_private_or_shared_backend_image_reference(
+    tmp_path: Path,
+):
+    current = runtime(tmp_path)
+    private = current.plan_up(
+        "1", "backend", environment={"SLOTS_MEMORY_CAP_MIB": "12000"}
+    )
+    shared = current.plan_up(
+        "2", "simulation", environment={"SLOTS_MEMORY_CAP_MIB": "12000"}
+    )
+    assert current.environment_for(private.record)["SLOT_BACKEND_IMAGE_REF"] == (
+        "futureagi/slot-backend:01"
+    )
+    assert current.environment_for(shared.record)["SLOT_BACKEND_IMAGE_REF"] == (
+        "futureagi/slot-backend:00"
+    )
+
+
+def test_shared_replacement_retains_private_logical_state_for_confirmed_purge(
+    tmp_path: Path,
+):
+    current = runtime(tmp_path)
+    apply(current, "1", "backend", "postgres")
+    replacement = current.apply_up(
+        "1",
+        "none",
+        "",
+        "",
+        {"SLOTS_MEMORY_CAP_MIB": "12000"},
+        lambda _argv, _cwd: None,
+        lambda _command: None,
+    )
+    assert replacement.record is not None
+    assert replacement.record.retained_private_backend_state
+    commands: list[object] = []
+    current.apply_purge("1", "1", lambda _argv, _cwd: None, commands.append)
+    operations = {command.operation for command in commands}
+    assert {
+        "drop_clickhouse_database",
+        "flush_redis_database",
+        "delete_rabbitmq_vhost",
+        "delete_minio_bucket",
+        "delete_temporal_namespace",
+        "delete_isolated_volume",
+    } <= operations
+    assert "drop_postgres_database" not in operations
+    assert all("slot_00" not in command.target for command in commands)
+
+
+def test_shared_replacement_purge_removes_retired_private_provider_volumes(
+    tmp_path: Path,
+):
+    current = runtime(tmp_path)
+    apply(current, "1", "backend")
+    current.apply_up(
+        "1",
+        "none",
+        "",
+        "",
+        {"SLOTS_MEMORY_CAP_MIB": "12000"},
+        lambda _argv, _cwd: None,
+        lambda _command: None,
+    )
+    commands: list[tuple[str, ...]] = []
+    current.apply_purge(
+        "1", "1", lambda argv, _cwd: commands.append(tuple(argv)), lambda _command: None
+    )
+    assert {
+        ("docker", "volume", "rm", "futureagi-slot-01-frontend-node-modules"),
+        ("docker", "volume", "rm", "futureagi-slot-01-backend-media"),
+        ("docker", "volume", "rm", "futureagi-slot-01-collector-data"),
+        ("docker", "volume", "rm", "futureagi-slot-01-peerdb-catalog-data"),
+        ("docker", "volume", "rm", "futureagi-slot-01-peerdb-minio-data"),
+    } <= set(commands)
+    assert not any("futureagi-shared" in command[-1] for command in commands)
+
+
+def test_restarted_inactive_slot_preserves_manifest_purge_provenance(tmp_path: Path):
+    current = runtime(tmp_path)
+    apply(current, "1", "backend", "postgres")
+    current.apply_down("1", lambda _argv, _cwd: None, lambda _command: None)
+    restarted = current.apply_up(
+        "1",
+        "none",
+        "",
+        "",
+        {"SLOTS_MEMORY_CAP_MIB": "12000"},
+        lambda _argv, _cwd: None,
+        lambda _command: None,
+    )
+    assert restarted.record is not None
+    assert restarted.record.retained_private_backend_state
+    assert restarted.record.retired_isolated_infra == ("postgres",)
+    commands: list[object] = []
+    current.apply_purge("1", "1", lambda _argv, _cwd: None, commands.append)
+    assert not any(
+        command.operation == "drop_postgres_database" for command in commands
+    )
+    assert any(
+        command.operation == "delete_isolated_volume"
+        and command.target == "futureagi_slot_01_postgres_data"
+        for command in commands
+    )

--- a/tests/slots/test_skills.py
+++ b/tests/slots/test_skills.py
@@ -1,0 +1,49 @@
+from pathlib import Path
+
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[2]
+CANONICAL_SKILL = (
+    REPOSITORY_ROOT / ".claude" / "skills" / "futureagi-slots" / "SKILL.md"
+)
+CODEX_ADAPTER = REPOSITORY_ROOT / ".agents" / "skills" / "futureagi-slots" / "SKILL.md"
+FEATURE_GUIDE = CANONICAL_SKILL.parent / "references" / "feature-guide.md"
+
+
+def test_claude_skill_contains_shared_runtime_contract() -> None:
+    content = CANONICAL_SKILL.read_text()
+    normalized = " ".join(content.split())
+
+    assert "name: futureagi-slots" in content
+    assert "Every slot always gets a private frontend" in normalized
+    assert "explicitly approved local Docker" in normalized
+    assert "SLOTS_RUNTIME_APPROVED=1 make slot-up" in normalized
+    assert "Never invoke the slot Compose files directly" in normalized
+    assert "make slot-purge SLOT=<slot> CONFIRM=<slot>" in content
+    assert "references/feature-guide.md" in content
+    assert "developer onboarding and feature overviews" in content
+
+
+def test_codex_adapter_references_canonical_skill() -> None:
+    content = CODEX_ADAPTER.read_text()
+
+    assert "name: futureagi-slots" in content
+    assert "../../../.claude/skills/futureagi-slots/SKILL.md" in content
+    assert "Do not duplicate or override" in content
+    assert "developer onboarding and feature overviews" in content
+
+
+def test_feature_guide_covers_every_public_make_target() -> None:
+    guide = FEATURE_GUIDE.read_text()
+    makefile = (REPOSITORY_ROOT / "Makefile").read_text()
+    phony_line = next(
+        line for line in makefile.splitlines() if line.startswith(".PHONY:")
+    )
+    public_targets = set(phony_line.removeprefix(".PHONY:").split())
+
+    assert public_targets
+    assert all(target in guide for target in public_targets)
+    assert "The root `Makefile` is the only supported entry and exit point" in guide
+    assert "Every slot always owns a frontend" in guide
+    assert "CONFIRM` must exactly equal `SLOT" in guide
+    assert "root `.env` in each worktree" in guide
+    assert "rerun `make slot-up`" in guide

--- a/tests/slots/test_state.py
+++ b/tests/slots/test_state.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+import pytest
+
+from slots.models import StateIdentity as RegistryStateIdentity
+from slots.state import (
+    StateValidationError,
+    adapt_orchestrator_state,
+    build_state_plan,
+    project_name,
+    validate_isolated_infra,
+    volume_name,
+)
+
+
+def test_private_provider_has_deterministic_provider_bound_identities() -> None:
+    state = build_state_plan(3, provider_slot=3, isolate_infra="postgres,redis")
+
+    assert state.identity.postgres_database == "futureagi_slot_03"
+    assert state.identity.clickhouse_database == "futureagi_slot_03"
+    assert state.identity.temporal_namespace == "futureagi-slot-03"
+    assert state.identity.rabbitmq_vhost == "futureagi-slot-03"
+    assert state.identity.minio_bucket == "futureagi-slot-03"
+    assert state.identity.redis_databases == (9, 10, 11)
+    assert state.volume_for("postgres") == "futureagi_slot_03_postgres_data"
+    assert state.project_for("postgres") == "futureagi-slot-03-postgres"
+    assert state.volume_for("minio") is None
+
+
+def test_slot_twenty_uses_the_last_reserved_redis_triplet() -> None:
+    assert build_state_plan(20, provider_slot=20).identity.redis_databases == (
+        60,
+        61,
+        62,
+    )
+
+
+def test_shared_default_reserves_a_non_overlapping_redis_triplet() -> None:
+    state = build_state_plan(1)
+
+    assert state.identity.postgres_database == "futureagi_slot_00"
+    assert state.identity.redis_databases == (0, 1, 2)
+
+
+def test_orchestration_identity_can_be_adapted_without_importing_registry_models() -> (
+    None
+):
+    identity = adapt_orchestrator_state(RegistryStateIdentity.for_slot(3))
+
+    assert identity.provider_slot == 3
+    assert identity.redis_databases == (9, 10, 11)
+
+
+def test_orchestration_identity_adapter_rejects_non_deterministic_record() -> None:
+    class BadModelIdentity:
+        slot = 3
+        postgres_database = "postgres"
+        clickhouse_database = "futureagi_slot_03"
+        temporal_namespace = "futureagi-slot-03"
+        rabbitmq_vhost = "futureagi-slot-03"
+        minio_bucket = "futureagi-slot-03"
+        redis_databases = (9, 10, 11)
+
+    with pytest.raises(StateValidationError, match="does not match"):
+        adapt_orchestrator_state(BadModelIdentity())
+
+
+@pytest.mark.parametrize("slot", [0, 21, True, "3"])
+def test_slots_are_strictly_limited_to_public_range(slot: object) -> None:
+    with pytest.raises(StateValidationError):
+        build_state_plan(slot)  # type: ignore[arg-type]
+
+
+@pytest.mark.parametrize(
+    "value", ["postgres,unknown", "postgres,postgres", "postgres,", "all"]
+)
+def test_isolation_validation_rejects_ambiguous_or_unknown_values(value: str) -> None:
+    with pytest.raises(StateValidationError):
+        validate_isolated_infra(value)
+
+
+def test_isolation_cannot_be_attached_to_shared_backend_state() -> None:
+    with pytest.raises(StateValidationError, match="private backend"):
+        build_state_plan(3, isolate_infra="postgres")
+
+
+def test_deterministic_physical_names_validate_every_component() -> None:
+    assert volume_name(20, "temporal") == "futureagi_slot_20_temporal_data"
+    assert project_name(20, "temporal") == "futureagi-slot-20-temporal"
+    with pytest.raises(StateValidationError):
+        volume_name(1, "postgres; rm -rf /")


### PR DESCRIPTION
## Summary

- add a Make-only slot orchestrator for parallel worktree stacks across slots 1-20
- always run a private frontend while sharing validated default providers and stateful infrastructure
- support selectively private providers and optional per-engine infrastructure isolation
- add predictable `*.N.localhost` routing, resource admission, reference counting, persistence, recovery, and exact-target purge safeguards
- add canonical Claude Code and Codex skills plus a complete developer feature guide
- add collector health probing and provider-bound Redis database selection needed by slot health/state isolation

## Important behavior

- `make slot-up`, `slot-down`, and the other root Make targets are the only supported runtime interface
- ordinary cleanup preserves generated state and named volumes
- destructive purge requires `CONFIRM=<slot>` and only targets exact slot-owned state
- the Agent Learning Kit wheel is intentionally not committed; developers supply it locally when a simulation provider must be built

## Validation

- `117 passed` in `tests/slots`
- Ruff lint and format checks
- Python compilation checks
- collector Go tests for `cmd/fi-collector` and `pkg/auth`
- canonical Claude and Codex skill validation
- all slot Compose/config/Traefik YAML parsed successfully
- manual Docker smoke test with two frontend slots, browser/API routing, registration, and clean shutdown
- independent final audit and re-review with no remaining findings
