### PR TITLE
fix(evals): auto-select newly added evals and restore saved model on edit hydration

### DIFF
--- a/frontend/src/sections/common/EvalPicker/EvalPickerConfigFull.jsx
+++ b/frontend/src/sections/common/EvalPicker/EvalPickerConfigFull.jsx
@@ -520,6 +520,9 @@ const EvalPickerConfigFull = ({ evalData, onBack, onSave, isSaving }) => {
 
       const normalizedRunConfig = {
         ...rawRunConfig,
+        model:
+          rawRunConfig.model ??
+          evalData?.model,
         agent_mode:
           rawRunConfig.agent_mode ??
           rawRunConfig.agentMode ??
@@ -597,12 +600,6 @@ const EvalPickerConfigFull = ({ evalData, onBack, onSave, isSaving }) => {
         setCode("");
       }
       setCodeLanguage(getEvalCodeLanguage(normalizedFullEval));
-      // Priority: user's saved run-config override → canonical detail
-      // (`fullEval.model`, full form e.g. "turing_small") → list-level
-      // `evalData.model`. The list endpoint returns a stripped form
-      // ("small") for built-in templates while detail returns the full
-      // canonical value, so we intentionally prefer `fullEval.model`
-      // over `evalData.model` to avoid the chip rendering "small".
       setModel(
         config?.model || fullEval?.model || evalData?.model || "turing_large",
       );

--- a/frontend/src/sections/common/EvaluationDrawer/EvaluationDrawer.jsx
+++ b/frontend/src/sections/common/EvaluationDrawer/EvaluationDrawer.jsx
@@ -75,6 +75,7 @@ const EvaluationDrawerChild = ({
   const [confirmRunEvaluationsOpen, setConfirmRunEvaluationsOpen] =
     useState(false);
   const [evalPickerOpen, setEvalPickerOpen] = useState(false);
+  const [addedEvalNames, setAddedEvalNames] = useState(new Set());
   // When editing an existing eval, pre-select it so the picker opens at config step
   const [editingEval, setEditingEval] = useState(null);
 
@@ -364,6 +365,7 @@ const EvaluationDrawerChild = ({
                     evals={SavedEvals}
                     allColumns={allColumns}
                     onClose={onClose}
+                    autoSelectedNames={addedEvalNames}
                     disableDelete={
                       module === "experiment" &&
                       Array.isArray(SavedEvals) &&
@@ -752,6 +754,9 @@ const EvaluationDrawerChild = ({
                 });
               }
               refreshGrid?.(null, true);
+              if (evalConfig.name) {
+                setAddedEvalNames((prev) => new Set([...prev, evalConfig.name]));
+              }
               setEvalPickerOpen(false);
               setVisibleSection("list");
             } catch (err) {
@@ -769,7 +774,11 @@ const EvaluationDrawerChild = ({
           }
           // await so errors propagate to EvalPickerDrawer's handleSaveEval
           // catch block — keeps the drawer open on failure.
+          const addedName = payload.name;
           await handleRun(payload, () => {
+            if (addedName) {
+              setAddedEvalNames((prev) => new Set([...prev, addedName]));
+            }
             setEvalPickerOpen(false);
             setVisibleSection("list");
           });

--- a/frontend/src/sections/common/EvaluationDrawer/SavedEvalsList.jsx
+++ b/frontend/src/sections/common/EvaluationDrawer/SavedEvalsList.jsx
@@ -1,5 +1,5 @@
 /* eslint-disable react/prop-types */
-import React, { useState } from "react";
+import React, { useEffect, useRef, useState } from "react";
 import {
   Box,
   Button,
@@ -744,6 +744,7 @@ const SavedEvalsList = ({
   onClose,
   disableDelete = false,
   disableDeleteReason,
+  autoSelectedNames,
 }) => {
   const { setVisibleSection, setCurrentTab } = useEvaluationContext();
   const handleAddClick = () => {
@@ -755,6 +756,21 @@ const SavedEvalsList = ({
     setVisibleSection("config");
   };
   const [sel, setSel] = useState(new Set());
+  const processedRef = useRef(new Set());
+
+  useEffect(() => {
+    if (!autoSelectedNames?.size) return;
+    const newIds = evals
+      .filter((e) => autoSelectedNames.has(e.name) && !processedRef.current.has(e.id))
+      .map((e) => e.id);
+    if (newIds.length === 0) return;
+    newIds.forEach((id) => processedRef.current.add(id));
+    setSel((prev) => {
+      const next = new Set(prev);
+      newIds.forEach((id) => next.add(id));
+      return next;
+    });
+  }, [evals, autoSelectedNames]);
   const [confirmBulkDelete, setConfirmBulkDelete] = useState(false);
   const toggle = (item) =>
     setSel((p) => {
@@ -965,6 +981,7 @@ SavedEvalsList.propTypes = {
   onClose: PropTypes.func,
   disableDelete: PropTypes.bool,
   disableDeleteReason: PropTypes.string,
+  autoSelectedNames: PropTypes.instanceOf(Set),
 };
 
 export default SavedEvalsList;

--- a/futureagi/model_hub/tests/test_workbench_eval_model_propagation.py
+++ b/futureagi/model_hub/tests/test_workbench_eval_model_propagation.py
@@ -216,7 +216,7 @@ def test_evaluation_configs_endpoint_surfaces_run_config(
     row = response.json()["result"]["evaluation_configs"][0]
     assert row["run_config"]["agent_mode"] == "agent"
     assert row["run_config"]["pass_threshold"] == 0.5
-    assert set(row["run_config"].keys()) == set(_RUN_CONFIG_DEFAULTS)
+    assert set(row["run_config"].keys()) == set(_RUN_CONFIG_DEFAULTS) | {"model"}
 
 
 @pytest.mark.django_db

--- a/futureagi/model_hub/utils/eval_list.py
+++ b/futureagi/model_hub/utils/eval_list.py
@@ -31,6 +31,9 @@ def build_run_config_view(eval_config) -> dict:
     binding_json = getattr(eval_config, "config", None) or {}
     run_config = binding_json.get("run_config") or {}
     view = {k: run_config.get(k, deepcopy(v)) for k, v in _RUN_CONFIG_DEFAULTS.items()}
+    for key in ("model", "choice_scores", "multi_choice"):
+        if key in run_config:
+            view[key] = run_config[key]
     summary = view["summary"]
     if isinstance(summary, dict):
         view["summary"] = summary.get("type", _RUN_CONFIG_DEFAULTS["summary"])


### PR DESCRIPTION
When users add or edit evals in the dataset side drawer, those evals are now automatically selected in the SavedEvalsList so users don't have to manually check each one. Deselecting a previously auto-selected eval is respected — re-adding another eval won't re-check it. Additionally, editing a system eval (e.g. changing the model from turing_large to turing_small) now correctly renders the saved settings when reopening the edit form. The root cause was that `model` was the only runtime setting not explicitly mapped in the hydration effect's `normalizedRunConfig`, so it fell through to the template default instead of using the user's saved value. The backend `build_run_config_view` was also missing `model`, `choice_scores`, and `multi_choice` from its output.

## Test plan
- [ ] Add a system eval to a dataset — verify it appears checked in SavedEvalsList
- [ ] Add a second eval — verify both are checked
- [ ] Uncheck the first eval, add a third — verify only the first stays unchecked
- [ ] Edit a system eval, change the model to turing_small, save, reopen edit — verify turing_small is selected
- [ ] Edit a system eval, change agent_mode, save, reopen — verify the saved mode renders
- [ ] Add a new eval in create flow (not edit) — verify model defaults to turing_large as before

### Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

### Checklist
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings