### PR TITLE
fix(tracer): fill sparse trace cursor pages

### DIFF
--- a/fi-collector/pkg/propertycatalog/revision_fence.go
+++ b/fi-collector/pkg/propertycatalog/revision_fence.go
@@ -18,7 +18,11 @@ const (
 	maxRevisionFenceBytes   = 1 << 20
 	maxRevisionFenceEntries = 256
 	maxRevisionProjects     = 256
-	maxRevisionLease        = 30 * time.Minute
+	// Keep this hard safety bound aligned with
+	// PROPERTY_CATALOG_MAX_REVISION_LEASE_SECONDS. Extended initial backfills
+	// may use up to the setting's supported 60-minute maximum while preserving
+	// lease headroom for the drain handshake.
+	maxRevisionLease = 60 * time.Minute
 )
 
 // RevisionFence is an activation-control-plane-owned build assignment. The

--- a/fi-collector/pkg/propertycatalog/revision_fence_test.go
+++ b/fi-collector/pkg/propertycatalog/revision_fence_test.go
@@ -143,7 +143,7 @@ func TestFileRevisionProviderValidatesDrainingBoundaryAndDeadline(t *testing.T) 
 func TestFileRevisionProviderAcceptsExtendedInitialBuildLease(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "fence.json")
 	draining := testRevisionFence(17, "draining")
-	draining.IssuedAt = "2026-08-14 11:30:00.000000"
+	draining.IssuedAt = "2026-08-14 11:00:00.000000"
 	draining.ExpiresAt = "2026-08-14 12:00:00.000000"
 	draining.DrainDeadline = draining.ExpiresAt
 	draining.FencedSequence = 3
@@ -160,7 +160,7 @@ func TestFileRevisionProviderAcceptsExtendedInitialBuildLease(t *testing.T) {
 		return value
 	}
 	if _, err := provider.CurrentRevision(context.Background(), testOrganization, testWorkspace); err != nil {
-		t.Fatalf("30-minute Python lease was rejected: %v", err)
+		t.Fatalf("60-minute Python lease was rejected: %v", err)
 	}
 
 	draining.ExpiresAt = "2026-08-14 12:00:00.000001"

--- a/frontend/src/components/BoundedCursorPaginationControl.jsx
+++ b/frontend/src/components/BoundedCursorPaginationControl.jsx
@@ -21,15 +21,19 @@ import { PROPERTY_PICKER_PREFETCH_MARGIN_PX } from "src/config/runtime_limits";
  *
  * A channel is either a catalog page or a retained-attribute page. Multiple
  * channels may advance together. A newly published continuation may load while
- * the sentinel remains visible, but a continuation already attempted by this
- * mounted picker can never be replayed automatically. Failed channels are
- * retried only by the explicit retry control. Changing resetKey starts a new
- * logical cursor chain and makes its continuations eligible again.
+ * the sentinel remains visible when autoAdvanceWhileVisible is enabled, but a
+ * continuation already attempted by this mounted picker can never be replayed
+ * automatically. Search surfaces disable that follow-on behavior so an empty
+ * exact lookup cannot drain a retained window without another viewport-entry
+ * gesture. Failed channels are retried only by the explicit retry control.
+ * Changing resetKey starts a new logical cursor chain and makes its
+ * continuations eligible again.
  */
 const BoundedCursorPaginationControl = ({
   channels,
   rootRef,
   resetKey,
+  autoAdvanceWhileVisible = true,
   loadingLabel = "Loading more…",
   retryLabel = "Retry loading properties",
   errorMessage,
@@ -40,6 +44,7 @@ const BoundedCursorPaginationControl = ({
   const channelsRef = useRef(channels);
   const activeRequestRef = useRef(null);
   const isIntersectingRef = useRef(false);
+  const visibleEntryConsumedRef = useRef(false);
   const attemptedContinuationsRef = useRef(new Set());
   const [isRequestPending, setIsRequestPending] = useState(false);
 
@@ -133,6 +138,7 @@ const BoundedCursorPaginationControl = ({
 
   useLayoutEffect(() => {
     attemptedContinuationsRef.current.clear();
+    visibleEntryConsumedRef.current = false;
     activeRequestRef.current = null;
     setIsRequestPending(false);
   }, [resetKey]);
@@ -158,7 +164,15 @@ const BoundedCursorPaginationControl = ({
       ([entry]) => {
         const isIntersecting = Boolean(entry?.isIntersecting);
         isIntersectingRef.current = isIntersecting;
-        if (isIntersecting) loadAtVisibleEnd();
+        if (!isIntersecting) {
+          visibleEntryConsumedRef.current = false;
+          return;
+        }
+        if (!autoAdvanceWhileVisible && visibleEntryConsumedRef.current) {
+          return;
+        }
+        visibleEntryConsumedRef.current = true;
+        loadAtVisibleEnd();
       },
       {
         root,
@@ -168,14 +182,20 @@ const BoundedCursorPaginationControl = ({
     );
     observer.observe(sentinel);
     return () => observer.disconnect();
-  }, [loadAtVisibleEnd, rootRef, shouldRender]);
+  }, [autoAdvanceWhileVisible, loadAtVisibleEnd, rootRef, shouldRender]);
 
   useEffect(() => {
-    if (!loading && isIntersectingRef.current && !hasRetryableError) {
+    if (
+      autoAdvanceWhileVisible &&
+      !loading &&
+      isIntersectingRef.current &&
+      !hasRetryableError
+    ) {
       loadAtVisibleEnd();
     }
   }, [
     continuationSignature,
+    autoAdvanceWhileVisible,
     hasRetryableError,
     loadAtVisibleEnd,
     loading,
@@ -242,6 +262,7 @@ BoundedCursorPaginationControl.propTypes = {
   ).isRequired,
   rootRef: PropTypes.shape({ current: PropTypes.any }),
   resetKey: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+  autoAdvanceWhileVisible: PropTypes.bool,
   loadingLabel: PropTypes.string,
   retryLabel: PropTypes.string,
   errorMessage: PropTypes.string,

--- a/frontend/src/components/__tests__/BoundedCursorPaginationControl.test.jsx
+++ b/frontend/src/components/__tests__/BoundedCursorPaginationControl.test.jsx
@@ -93,6 +93,60 @@ describe("BoundedCursorPaginationControl", () => {
     expect(loadNextPage).toHaveBeenCalledTimes(2);
   });
 
+  it("requires a new viewport entry before advancing a searched continuation", async () => {
+    const intersect = installObserver();
+    const firstPage = deferred();
+    const secondPage = deferred();
+    const loadNextPage = vi
+      .fn()
+      .mockImplementationOnce(() => firstPage.promise)
+      .mockImplementationOnce(() => secondPage.promise);
+    const { rerender } = render(
+      <BoundedCursorPaginationControl
+        autoAdvanceWhileVisible={false}
+        channels={[
+          {
+            channelKey: "attributes",
+            hasNextPage: true,
+            continuationKey: "cursor-1",
+            loadNextPage,
+          },
+        ]}
+      />,
+    );
+
+    intersect(true);
+    expect(loadNextPage).toHaveBeenCalledOnce();
+    await act(async () => {
+      firstPage.resolve();
+      await firstPage.promise;
+    });
+    rerender(
+      <BoundedCursorPaginationControl
+        autoAdvanceWhileVisible={false}
+        channels={[
+          {
+            channelKey: "attributes",
+            hasNextPage: true,
+            continuationKey: "cursor-2",
+            loadNextPage,
+          },
+        ]}
+      />,
+    );
+
+    await act(async () => undefined);
+    expect(loadNextPage).toHaveBeenCalledOnce();
+
+    intersect(false);
+    intersect(true);
+    expect(loadNextPage).toHaveBeenCalledTimes(2);
+    await act(async () => {
+      secondPage.resolve();
+      await secondPage.promise;
+    });
+  });
+
   it("advances independent catalog and attribute channels together", async () => {
     const intersect = installObserver();
     const loadCatalog = vi.fn().mockResolvedValue(undefined);

--- a/frontend/src/sections/projects/LLMTracing/TraceFilterPanel.jsx
+++ b/frontend/src/sections/projects/LLMTracing/TraceFilterPanel.jsx
@@ -1554,6 +1554,7 @@ export function shouldUseRetainedAttributePages({
 export function PropertyPickerPaginationControl({
   scrollRootRef,
   resetKey,
+  autoAdvanceWhileVisible,
   attributePageAvailable,
   attributeContinuationKey,
   isFetchingAttributePage,
@@ -1569,6 +1570,7 @@ export function PropertyPickerPaginationControl({
     <BoundedCursorPaginationControl
       rootRef={scrollRootRef}
       resetKey={resetKey}
+      autoAdvanceWhileVisible={autoAdvanceWhileVisible}
       channels={[
         {
           channelKey: "attributes",
@@ -2477,6 +2479,11 @@ function PropertyPicker({
                     category,
                     debouncedSearch,
                   ])}
+                  // A missing exact key may publish many bounded checkpoints.
+                  // Advance only once per real viewport-entry gesture while
+                  // searching instead of draining the retained window merely
+                  // because an empty sentinel remains visible.
+                  autoAdvanceWhileVisible={!search.trim()}
                   scrollRootRef={propertyOptionsListRef}
                   attributePageAvailable={attributePageAvailable}
                   attributeContinuationKey={exactAttributeContinuationKey}

--- a/frontend/src/sections/projects/LLMTracing/TraceGrid.jsx
+++ b/frontend/src/sections/projects/LLMTracing/TraceGrid.jsx
@@ -473,7 +473,10 @@ const TraceGrid = React.forwardRef(
 
               // Prefetch next page so scroll feels instant
               if (exactPage.canPrefetch) {
-                loadTraceObservePage(buildParams(pageNumber + 1))
+                loadTraceObservePage(
+                  buildParams(pageNumber + 1),
+                  cursorPagination.current.cancellationSignal(),
+                )
                   .then((res) => {
                     if (cursorPagination.current.isCurrent(requestGeneration)) {
                       prefetchCache.current.set(pageNumber + 1, res);

--- a/frontend/src/sections/projects/LLMTracing/__tests__/listCursorPagination.test.js
+++ b/frontend/src/sections/projects/LLMTracing/__tests__/listCursorPagination.test.js
@@ -968,6 +968,44 @@ describe("list cursor pagination", () => {
     expect(requestSignal.aborted).toBe(true);
   });
 
+  it("aborts an in-flight exact-page request when its grid generation resets", async () => {
+    const pagination = createListCursorPagination();
+    let requestSignal;
+    let markStarted;
+    const started = new Promise((resolve) => {
+      markStarted = resolve;
+    });
+    const page = loadExactListPage({
+      pagination,
+      pageNumber: 0,
+      targetRowCount: 1,
+      loadResponse: (signal) => {
+        requestSignal = signal;
+        markStarted();
+        return new Promise((_resolve, reject) => {
+          signal.addEventListener(
+            "abort",
+            () =>
+              reject(
+                Object.assign(new Error("canceled"), { code: "ERR_CANCELED" }),
+              ),
+            { once: true },
+          );
+        });
+      },
+      nextResponse: vi.fn(),
+      rowsFromResponse: (response) => response.rows,
+      metadataFromResponse: (response) => response.metadata,
+      rowIdentity: (row) => row.id,
+    });
+
+    await started;
+    pagination.reset();
+
+    expect(requestSignal.aborted).toBe(true);
+    await expect(page).rejects.toMatchObject({ code: "ERR_CANCELED" });
+  });
+
   it("fails closed when a non-empty continuation repeats its cursor", async () => {
     const pagination = createListCursorPagination();
     await expect(

--- a/frontend/src/sections/projects/LLMTracing/listCursorPagination.js
+++ b/frontend/src/sections/projects/LLMTracing/listCursorPagination.js
@@ -206,6 +206,7 @@ export const createListCursorPagination = ({
 
   let mode = UNKNOWN_MODE;
   let generation = 0;
+  let generationController = new AbortController();
   const cursorByPage = new Map([[0, null]]);
   const transportCursorByPage = new Map();
   const bufferedVisiblePageByPage = new Map();
@@ -225,8 +226,14 @@ export const createListCursorPagination = ({
     seenCursors.add(cursor);
   };
 
-  const reset = () => {
+  const advanceGeneration = () => {
     generation += 1;
+    generationController.abort();
+    generationController = new AbortController();
+  };
+
+  const reset = () => {
+    advanceGeneration();
     mode = UNKNOWN_MODE;
     cursorByPage.clear();
     cursorByPage.set(0, null);
@@ -248,7 +255,7 @@ export const createListCursorPagination = ({
   };
 
   const disableCursor = () => {
-    generation += 1;
+    advanceGeneration();
     fallbackToNumbered();
   };
 
@@ -453,6 +460,7 @@ export const createListCursorPagination = ({
     mode: () => mode,
     generation: () => generation,
     isCurrent: (requestGeneration) => requestGeneration === generation,
+    cancellationSignal: () => generationController.signal,
     canRecoverFromContinuationError: (pageNumber, error) =>
       mode === CURSOR_MODE &&
       pageNumber > 0 &&
@@ -522,6 +530,11 @@ export const loadExactListPage = async ({
   if (!Number.isFinite(maxElapsedMs) || maxElapsedMs < 1) {
     throw new Error("Invalid list continuation deadline");
   }
+  const activeCancellationSignal =
+    cancellationSignal ||
+    (typeof pagination.cancellationSignal === "function"
+      ? pagination.cancellationSignal()
+      : undefined);
 
   let buffered = pagination.bufferedVisiblePage(pageNumber);
   const accumulatedRows = [];
@@ -578,7 +591,7 @@ export const loadExactListPage = async ({
           continuationCount === 0 && !resumeBufferedCheckpoint
             ? (signal) => loadResponse(signal)
             : (signal) => nextResponse(metadata.next_cursor, signal),
-        cancellationSignal,
+        cancellationSignal: activeCancellationSignal,
         remainingMs,
       });
       if (!transport.completed) {

--- a/futureagi/tracer/services/clickhouse/query_builders/trace_list.py
+++ b/futureagi/tracer/services/clickhouse/query_builders/trace_list.py
@@ -1546,6 +1546,25 @@ class TraceListQueryBuilder(BaseQueryBuilder):
 
         return not self._bounded_identity_only
 
+    def fill_bounded_cursor_page_across_slices(self) -> bool:
+        """Fill one public trace page before publishing a slice checkpoint.
+
+        Sparse filters can produce only a handful of matches in each finite
+        time slice.  Those matches are already exact and can safely accumulate
+        across adjacent slices inside the selector's existing request wall,
+        query-count, memory, and byte limits.  Internal, bulk, population-proof,
+        and sampled readers retain their smaller checkpoint contract.
+        """
+
+        return bool(
+            not self._bounded_internal_scan
+            and not self._bounded_identity_only
+            and not self._bounded_bulk_scan
+            and not self._bounded_population_proof
+            and self._bounded_sampling_rate is None
+            and 1 <= self.page_size <= 500
+        )
+
     @staticmethod
     def recommended_filter_page_hydration_reserve_ms() -> int:
         """Reserve one bounded statement for exact-root page hydration."""

--- a/futureagi/tracer/services/clickhouse/v2/property_catalog/reader.py
+++ b/futureagi/tracer/services/clickhouse/v2/property_catalog/reader.py
@@ -1191,15 +1191,13 @@ def require_property_catalog_activation_coverage(
         raise unavailable_type("activation_scope_invalid")
     requested_projects = frozenset(scope["project_ids"])
     covered_projects = frozenset(source_scope.project_ids)
-    workspace_scope = scope.get("workspace_scope") is True
-    if workspace_scope:
-        # The API materializes the full currently-eligible Observe-project set
-        # for a workspace request. Equality prevents both stale extra projects
-        # and newly-created uncovered projects from producing a partial exact
-        # response.
-        if requested_projects != covered_projects:
-            raise unavailable_type("activation_scope_incomplete")
-    elif not requested_projects or not requested_projects.issubset(covered_projects):
+    # The API materializes the complete *live* authorized project set. A full
+    # repair deliberately freezes soft-deleted projects too so it can publish
+    # their tombstones, therefore its immutable source scope may be a strict
+    # superset. The query predicate still contains only requested_projects, so
+    # accepting that proven superset never widens visibility. A newly-created
+    # live project remains fail-closed because it is absent from covered_projects.
+    if not requested_projects or not requested_projects.issubset(covered_projects):
         raise unavailable_type("activation_scope_incomplete")
 
     if (requested_span_since_us is None) != (requested_span_until_us is None):

--- a/futureagi/tracer/services/dashboard_metrics_catalog.py
+++ b/futureagi/tracer/services/dashboard_metrics_catalog.py
@@ -502,7 +502,13 @@ def _resolve_metrics_catalog_project_scope(
     requested_project_ids = [
         value.strip() for value in project_ids_param.split(",") if value.strip()
     ]
-    project_filters: dict[str, object] = {"workspace": workspace}
+    # A workspace foreign key is not sufficient tenant authority on legacy or
+    # inconsistent rows.  Every catalog scope must prove the denormalized
+    # project organization matches the already-authorized workspace too.
+    project_filters: dict[str, object] = {
+        "workspace": workspace,
+        "organization_id": workspace.organization_id,
+    }
     if eligible_trace_type:
         project_filters["trace_type"] = eligible_trace_type
     if requested_project_ids:

--- a/futureagi/tracer/tests/test_bounded_trace_filter_reads.py
+++ b/futureagi/tracer/tests/test_bounded_trace_filter_reads.py
@@ -1785,10 +1785,37 @@ def test_long_window_scalar_trace_uses_exact_classifier_without_witness() -> Non
         == 10
     )
     assert builder.recommended_filter_page_hydration_reserve_ms() == 750
+    assert builder.fill_bounded_cursor_page_across_slices() is True
     assert builder.recommended_filter_classify_read_settings() == {
         "max_block_size": 2_048,
         "preferred_max_column_in_block_size_bytes": 1_048_576,
     }
+
+
+@pytest.mark.parametrize(
+    "builder_kwargs",
+    [
+        {"bounded_internal_scan": True, "bounded_identity_only": True},
+        {
+            "bounded_internal_scan": True,
+            "bounded_identity_only": True,
+            "bounded_bulk_scan": True,
+        },
+        {"bounded_sampling_salt": "sample", "bounded_sampling_rate": 10.0},
+        {"page_size": 501},
+    ],
+    ids=["internal", "bulk", "sampled", "oversized"],
+)
+def test_non_public_trace_readers_do_not_fill_cursor_pages_across_slices(
+    builder_kwargs: dict[str, object],
+) -> None:
+    builder = TraceListQueryBuilder(
+        project_id=PROJECT_ID,
+        filters=[_time_filter(END - timedelta(days=14), END)],
+        **builder_kwargs,
+    )
+
+    assert builder.fill_bounded_cursor_page_across_slices() is False
 
 
 def test_long_window_attribute_plus_search_keeps_bounded_root_batch() -> None:

--- a/futureagi/tracer/tests/test_property_catalog_scope_isolation.py
+++ b/futureagi/tracer/tests/test_property_catalog_scope_isolation.py
@@ -13,12 +13,17 @@ from tracer.services.dashboard_metrics_catalog import (
     resolve_property_catalog_project_scope,
 )
 
+ORGANIZATION_ID = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa"
+
 
 def test_property_catalog_project_scope_uses_explicit_workspace_manager():
     """Authorization cannot inherit an unrelated ambient workspace scope."""
 
     project_id = "11111111-1111-4111-8111-111111111111"
-    workspace = SimpleNamespace(id="22222222-2222-4222-8222-222222222222")
+    workspace = SimpleNamespace(
+        id="22222222-2222-4222-8222-222222222222",
+        organization_id=ORGANIZATION_ID,
+    )
     explicit_manager = MagicMock()
     explicit_manager.filter.return_value.order_by.return_value.values_list.return_value = [
         project_id
@@ -41,6 +46,7 @@ def test_property_catalog_project_scope_uses_explicit_workspace_manager():
     assert resolved == [project_id]
     explicit_manager.filter.assert_called_once_with(
         workspace=workspace,
+        organization_id=ORGANIZATION_ID,
         trace_type="observe",
         id__in=[project_id],
     )
@@ -52,7 +58,10 @@ def test_property_catalog_workspace_scope_materializes_every_eligible_observe_pr
         "11111111-1111-4111-8111-111111111111",
         "33333333-3333-4333-8333-333333333333",
     ]
-    workspace = SimpleNamespace(id="22222222-2222-4222-8222-222222222222")
+    workspace = SimpleNamespace(
+        id="22222222-2222-4222-8222-222222222222",
+        organization_id=ORGANIZATION_ID,
+    )
     explicit_manager = MagicMock()
     explicit_manager.filter.return_value.order_by.return_value.values_list.return_value = project_ids
 
@@ -73,13 +82,17 @@ def test_property_catalog_workspace_scope_materializes_every_eligible_observe_pr
     assert resolved == project_ids
     explicit_manager.filter.assert_called_once_with(
         workspace=workspace,
+        organization_id=ORGANIZATION_ID,
         trace_type="observe",
     )
 
 
 def test_legacy_metrics_scope_does_not_inherit_observe_only_eligibility():
     project_ids = ["11111111-1111-4111-8111-111111111111"]
-    workspace = SimpleNamespace(id="22222222-2222-4222-8222-222222222222")
+    workspace = SimpleNamespace(
+        id="22222222-2222-4222-8222-222222222222",
+        organization_id=ORGANIZATION_ID,
+    )
     explicit_manager = MagicMock()
     explicit_manager.filter.return_value.order_by.return_value.values_list.return_value = project_ids
 
@@ -99,7 +112,10 @@ def test_legacy_metrics_scope_does_not_inherit_observe_only_eligibility():
 
     assert resolved == project_ids
     assert explicit is False
-    explicit_manager.filter.assert_called_once_with(workspace=workspace)
+    explicit_manager.filter.assert_called_once_with(
+        workspace=workspace,
+        organization_id=ORGANIZATION_ID,
+    )
 
 
 @pytest.mark.parametrize(
@@ -112,7 +128,10 @@ def test_legacy_metrics_scope_does_not_inherit_observe_only_eligibility():
 def test_property_catalog_project_scope_rejects_malformed_or_oversized_input(
     project_ids,
 ):
-    workspace = SimpleNamespace(id="22222222-2222-4222-8222-222222222222")
+    workspace = SimpleNamespace(
+        id="22222222-2222-4222-8222-222222222222",
+        organization_id=ORGANIZATION_ID,
+    )
 
     with (
         patch.object(Project, "no_workspace_objects") as manager,
@@ -130,7 +149,10 @@ def test_property_catalog_project_scope_rejects_malformed_or_oversized_input(
 def test_property_catalog_project_scope_rejects_mixed_foreign_ids():
     authorized = "11111111-1111-4111-8111-111111111111"
     foreign = "33333333-3333-4333-8333-333333333333"
-    workspace = SimpleNamespace(id="22222222-2222-4222-8222-222222222222")
+    workspace = SimpleNamespace(
+        id="22222222-2222-4222-8222-222222222222",
+        organization_id=ORGANIZATION_ID,
+    )
     explicit_manager = MagicMock()
     explicit_manager.filter.return_value.order_by.return_value.values_list.return_value = [
         authorized

--- a/futureagi/tracer/tests/test_unified_property_catalog_reader.py
+++ b/futureagi/tracer/tests/test_unified_property_catalog_reader.py
@@ -1046,6 +1046,33 @@ def test_catalog_reader_rejects_partial_workspace_activation_coverage(settings):
     assert len(executor.calls) == 1
 
 
+def test_catalog_reader_accepts_workspace_scope_with_deleted_project_tombstones(
+    settings,
+):
+    settings.SECRET_KEY = "property-reader-secret"
+    executor = FakeExecutor(
+        [
+            [
+                _activation_row(
+                    covered_project_ids=(PROJECT_ID, OTHER_PROJECT_ID),
+                )
+            ],
+            [_conflict_row(catalog_count_all=0, catalog_count_custom_attribute=0)],
+            [],
+        ]
+    )
+
+    PropertyCatalogReader(
+        executor, catalog_database="property_catalog_dev_test"
+    ).read_page(
+        scope=_scope(project_ids=(PROJECT_ID,), workspace_scope=True),
+        query=QUERY,
+        page_size=50,
+    )
+
+    assert executor.calls[1]["params"]["catalog_project_ids"] == (PROJECT_ID,)
+
+
 def test_catalog_reader_rejects_unproven_empty_project_scope(settings):
     settings.SECRET_KEY = "property-reader-secret"
     executor = FakeExecutor([[_activation_row()]])

--- a/futureagi/tracer/tests/test_unified_property_catalog_value_reader.py
+++ b/futureagi/tracer/tests/test_unified_property_catalog_value_reader.py
@@ -985,6 +985,31 @@ def test_value_reader_rejects_partial_workspace_activation_coverage(settings):
     assert len(executor.calls) == 1
 
 
+def test_value_reader_accepts_workspace_scope_with_deleted_project_tombstones(
+    settings,
+):
+    settings.SECRET_KEY = "property-value-reader-secret"
+    executor = FakeExecutor(
+        [
+            [
+                _activation_row(
+                    covered_project_ids=(PROJECT_ID, OTHER_PROJECT_ID),
+                )
+            ],
+            [_definition_row()],
+            [{"value_conflicts": 0}],
+            [],
+        ]
+    )
+
+    _read(
+        _reader(executor),
+        scope=_scope(project_ids=(PROJECT_ID,), workspace_scope=True),
+    )
+
+    assert executor.calls[1]["params"]["catalog_project_ids"] == (PROJECT_ID,)
+
+
 def test_value_reader_workspace_scope_uses_authorized_project_ids(settings):
     settings.SECRET_KEY = "property-value-reader-secret"
     executor = FakeExecutor(


### PR DESCRIPTION
## Summary
- keep scanning adjacent bounded time slices until a public trace cursor page is full
- retain existing request wall, query-count, memory, byte, and hydration guardrails
- preserve the smaller checkpoint behavior for internal, bulk, sampled, population-proof, and oversized reads

## Why
Sparse filtered trace windows currently publish 1-5 exact rows per slice with has_more=true. That forces the frontend to chain many requests and can collide with auto-refresh before one visible page settles. The generic bounded selector already supports accumulating classified rows across slices, and the voice-call list uses the same hook for this exact sparse-page behavior.

## Validation
- 6 focused bounded-selector regression tests
- 93 trace-list builder, pagination, and API-contract tests
- Ruff lint and formatting checks