### PR TITLE
fix(install): detect Windows netstat listeners

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -340,6 +340,12 @@ port_holder() {
   elif command -v ss >/dev/null 2>&1; then
     out=$(ss -ltn 2>/dev/null)
     [[ -n "$out" ]] && awk -v p=":$port\$" '$4 ~ p {print $0; exit}' <<<"$out"
+  elif command -v netstat >/dev/null 2>&1; then
+    # Windows netstat is available in MSYS2 and Git Bash, where lsof/ss are
+    # commonly absent. Keep only TCP listeners for the requested port.
+    out=$(netstat -ano 2>/dev/null | awk -v p=":$port$" \
+      '$1 ~ /^TCP/ && $2 ~ p && $4 == "LISTENING" {print; exit}')
+    [[ -n "$out" ]] && printf '%s\n' "$out"
   fi
   set -eE
   return 0

--- a/bin/test_install_port_holder.sh
+++ b/bin/test_install_port_holder.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+eval "$(sed -n '/^port_holder() {/,/^}/p' "$script_dir/install")"
+
+tmpdir="$(mktemp -d)"
+trap 'rm -rf "$tmpdir"' EXIT
+
+cat >"$tmpdir/netstat" <<'EOF'
+#!/usr/bin/env bash
+cat <<'OUTPUT'
+Active Connections
+  Proto  Local Address          Foreign Address        State           PID
+  TCP    0.0.0.0:3000           0.0.0.0:0              LISTENING       44576
+  TCP    0.0.0.0:3001           0.0.0.0:0              ESTABLISHED     44577
+OUTPUT
+EOF
+chmod +x "$tmpdir/netstat"
+
+PATH="$tmpdir:/usr/bin:/bin"
+export PATH
+
+result="$(port_holder 3000)"
+test "$result" = "TCP    0.0.0.0:3000           0.0.0.0:0              LISTENING       44576"
+test -z "$(port_holder 3001)"


### PR DESCRIPTION
## Summary

Closes #2274.

`bin/install` now detects TCP listeners with Windows `netstat` when `lsof` and `ss` are unavailable, which covers MSYS2 and Git Bash installations. The fallback preserves the existing Linux/macOS detection order and only reports matching TCP listeners in the `LISTENING` state.

## Testing

- `bin/test_install_port_holder.sh`
- `bash -n bin/install`
- `bash -n bin/test_install_port_holder.sh`
