### PR TITLE
fix(frontend): read the credit-exhaustion code from the field axios actually sets

### DIFF
--- a/frontend/src/hooks/__tests__/use-credit-exhaustion.test.js
+++ b/frontend/src/hooks/__tests__/use-credit-exhaustion.test.js
@@ -1,0 +1,84 @@
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("src/utils/PostHog/posthog", () => ({
+  trackPostHogEvent: vi.fn(),
+}));
+
+import { isCreditExhaustionError } from "src/hooks/use-credit-exhaustion";
+
+/**
+ * Errors rejected by the axios layer spread the response body onto the
+ * custom error (`{ ...errData, statusCode }`), so the code arrives as the
+ * envelope's top-level `code` — never as a top-level `errorCode`.
+ * isCreditExhaustionError must match on the shape that actually arrives.
+ */
+describe("isCreditExhaustionError", () => {
+  it("matches on HTTP 402 regardless of the body shape", () => {
+    expect(
+      isCreditExhaustionError({ statusCode: 402, detail: "upgrade" }),
+    ).toBe(true);
+    expect(
+      isCreditExhaustionError({ statusCode: 402, code: "SOMETHING_ELSE" }),
+    ).toBe(true);
+  });
+
+  it("matches billing codes from the envelope top-level code field", () => {
+    for (const code of [
+      "FREE_TIER_LIMIT",
+      "BUDGET_PAUSED",
+      "ENTITLEMENT_LIMIT",
+      "ENTITLEMENT_DENIED",
+      "PAYMENT_REQUIRED",
+    ]) {
+      expect(
+        isCreditExhaustionError({ statusCode: 403, code, message: "denied" }),
+      ).toBe(true);
+    }
+  });
+
+  it("matches billing codes nested under result (snake_case and camelCase)", () => {
+    expect(
+      isCreditExhaustionError({
+        statusCode: 403,
+        result: { error_code: "FREE_TIER_LIMIT" },
+      }),
+    ).toBe(true);
+    expect(
+      isCreditExhaustionError({
+        statusCode: 403,
+        result: { errorCode: "ENTITLEMENT_LIMIT" },
+      }),
+    ).toBe(true);
+  });
+
+  it("does not match non-credit error codes or missing codes", () => {
+    expect(
+      isCreditExhaustionError({ statusCode: 403, code: "AUTH_FAILED" }),
+    ).toBe(false);
+    expect(
+      isCreditExhaustionError({ statusCode: 500, code: "INTERNAL_ERROR" }),
+    ).toBe(false);
+    expect(isCreditExhaustionError({ statusCode: 400 })).toBe(false);
+  });
+
+  it("ignores the never-set top-level errorCode field", () => {
+    // The old implementation keyed off error.errorCode, a field the axios
+    // layer never sets — such a shape must not count as a credit error
+    // unless the status or a real code says so.
+    expect(isCreditExhaustionError({ errorCode: "FREE_TIER_LIMIT" })).toBe(
+      false,
+    );
+    expect(
+      isCreditExhaustionError({
+        statusCode: 403,
+        code: "AUTH_FAILED",
+        errorCode: "FREE_TIER_LIMIT",
+      }),
+    ).toBe(false);
+  });
+
+  it("returns false for falsy input", () => {
+    expect(isCreditExhaustionError(null)).toBe(false);
+    expect(isCreditExhaustionError(undefined)).toBe(false);
+  });
+});

--- a/frontend/src/hooks/use-credit-exhaustion.js
+++ b/frontend/src/hooks/use-credit-exhaustion.js
@@ -12,12 +12,32 @@ const CREDIT_ERROR_CODES = [
 ];
 
 /**
+ * Extract the billing/usage error code from an API error.
+ *
+ * The axios layer spreads the response body onto the rejected error, so the
+ * backend envelope's top-level `code` ("FREE_TIER_LIMIT", …) is what arrives
+ * here, with nested `result` shapes as fallbacks. There is deliberately no
+ * `error.errorCode` read: the axios layer never sets that field, so keying
+ * off it (the previous implementation) matched nothing for real responses.
+ */
+function extractCreditErrorCode(error) {
+  if (!error) return undefined;
+  return (
+    error.code ||
+    error.error_code ||
+    error.result?.error_code ||
+    error.result?.errorCode
+  );
+}
+
+/**
  * Check if an API error is a credit/usage exhaustion error.
  */
 export function isCreditExhaustionError(error) {
   if (!error) return false;
   return (
-    error.statusCode === 402 || CREDIT_ERROR_CODES.includes(error.errorCode)
+    error.statusCode === 402 ||
+    CREDIT_ERROR_CODES.includes(extractCreditErrorCode(error))
   );
 }
 
@@ -49,7 +69,7 @@ export function useCreditExhaustion({ feature = "unknown" } = {}) {
         setExhaustionError(error);
         trackPostHogEvent("credits_nudge_shown", {
           feature,
-          error_code: error.errorCode,
+          error_code: extractCreditErrorCode(error),
           dimension: error.dimension,
           current_usage: error.currentUsage,
           limit: error.limit,
@@ -67,7 +87,7 @@ export function useCreditExhaustion({ feature = "unknown" } = {}) {
     // if an attacker-controlled string ever landed in the payload.
     trackPostHogEvent("credits_upgrade_clicked", {
       feature,
-      error_code: exhaustionError?.errorCode,
+      error_code: extractCreditErrorCode(exhaustionError),
       target_plan: exhaustionError?.upgradeCta?.plan,
     });
     navigate(paths.dashboard.settings.pricing);
@@ -77,7 +97,7 @@ export function useCreditExhaustion({ feature = "unknown" } = {}) {
   const handleDismiss = useCallback(() => {
     trackPostHogEvent("credits_nudge_dismissed", {
       feature,
-      error_code: exhaustionError?.errorCode,
+      error_code: extractCreditErrorCode(exhaustionError),
     });
     setExhaustionError(null);
   }, [exhaustionError, feature]);


### PR DESCRIPTION
## What this fixes

`isCreditExhaustionError` (`frontend/src/hooks/use-credit-exhaustion.js`) keyed the credit/usage-error detection off `error.errorCode` — a field the axios error interceptor never sets. The interceptor spreads the response body onto the rejected error (`{ ...errData, statusCode }`), and the backend error envelope carries its code in the top-level `code` field (`tfc/utils/api_errors.py`, `build_error_envelope`).

Consequences while `error.errorCode` is always `undefined`:

- credit-exhaustion was only detected on HTTP **402**, but the billing/entitlement taxonomy (`tfc/utils/error_codes.py`) returns most codes on **403** — `FREE_TIER_LIMIT`, `BUDGET_PAUSED`, `ENTITLEMENT_LIMIT`, `ENTITLEMENT_DENIED` — so those never triggered the upgrade banner;
- the three analytics events (`credits_nudge_shown` / `credits_upgrade_clicked` / `credits_nudge_dismissed`) logged `error_code: undefined`.

Fixes #2338.

## Fix

Extract the code where the axios layer actually exposes it — `error.code`, `error.error_code`, and the nested `result` shapes (`result.error_code` / `result.errorCode`, matching the read style already used elsewhere in the codebase) — and use it in both the detection and the three PostHog events.

## Tests

New `frontend/src/hooks/__tests__/use-credit-exhaustion.test.js` (6 tests): 402 short-circuit; each billing code via the envelope top-level `code`; nested `result` shapes (snake and camel); non-credit codes and missing codes stay false; an error carrying *only* the never-set top-level `errorCode` stays false (locks in the old bug shape); falsy input.

Verified: `vitest run` on the new file (6 passed) and the neighbouring hook/axios suites (20 passed); prettier + eslint clean.
