### PR TITLE
fix(frontend): sanitize synthetic dataset requests

### DIFF
--- a/frontend/src/sections/develop/AddRowDrawer/CreateSyntheticData.jsx
+++ b/frontend/src/sections/develop/AddRowDrawer/CreateSyntheticData.jsx
@@ -27,6 +27,7 @@ import { FormSelectField } from "src/components/FormSelectField";
 import { useKnowledgeBaseList } from "src/api/knowledge-base/files";
 import FormTextFieldV2 from "src/components/FormTextField/FormTextFieldV2";
 import { getRequestErrorMessage } from "src/utils/errorUtils";
+import { buildSyntheticColumnPayload } from "./CreateSyntheticData/common";
 
 const createValidationSchema = (datasetId, openDescription) =>
   z.object({
@@ -177,9 +178,14 @@ const SyntheticDataDrawer = ({
     },
     onError: (error) => {
       enqueueSnackbar(
-        getRequestErrorMessage(error, "Failed to create synthetic dataset", {
-          retryAction: "creating this synthetic dataset",
-        }),
+        getRequestErrorMessage(
+          error,
+          "We couldn't create the synthetic dataset. Please review the form and try again.",
+          {
+            retryAction: "creating this synthetic dataset",
+            sanitizeTechnicalFieldErrors: true,
+          },
+        ),
         { variant: "error" },
       );
     },
@@ -233,17 +239,14 @@ const SyntheticDataDrawer = ({
       num_rows: Number(formData.rowNumber),
       kb_id: formData?.kb_id,
       columns: formData.columns.map((item, index) => {
-        const property = {};
-        item.property.forEach((dummy) => {
-          property[dummy.type] = dummy.value;
-        });
         if (index === 0) {
           cols[item.name] = item.description;
         }
         const newItem = {
-          ...item,
-          description: replaceColumn(item.description, item.name),
-          property,
+          ...buildSyntheticColumnPayload(
+            item,
+            replaceColumn(item.description, item.name),
+          ),
           ...(datasetId && { is_new: true, skip: true }),
         };
         return newItem;

--- a/frontend/src/sections/develop/AddRowDrawer/CreateSyntheticData/common.js
+++ b/frontend/src/sections/develop/AddRowDrawer/CreateSyntheticData/common.js
@@ -53,3 +53,10 @@ export const buildSyntheticColumnPayload = (column, description) => ({
   description: description ?? column?.description ?? "",
   property: normalizeSyntheticColumnProperty(column?.property),
 });
+
+export const buildSyntheticDatasetPayload = (data = {}) => ({
+  ...data,
+  ...(Array.isArray(data.columns) && {
+    columns: data.columns.map((column) => buildSyntheticColumnPayload(column)),
+  }),
+});

--- a/frontend/src/sections/develop/AddRowDrawer/CreateSyntheticData/common.js
+++ b/frontend/src/sections/develop/AddRowDrawer/CreateSyntheticData/common.js
@@ -33,3 +33,23 @@ export const transformColumnPayload = (columns = []) => {
       : [],
   }));
 };
+
+const normalizeSyntheticColumnProperty = (property) => {
+  if (Array.isArray(property)) {
+    return property.reduce((normalized, entry) => {
+      if (entry?.type) {
+        normalized[entry.type] = entry.value;
+      }
+      return normalized;
+    }, {});
+  }
+
+  return property && typeof property === "object" ? property : {};
+};
+
+export const buildSyntheticColumnPayload = (column, description) => ({
+  name: column?.name,
+  data_type: column?.data_type ?? column?.dataType,
+  description: description ?? column?.description ?? "",
+  property: normalizeSyntheticColumnProperty(column?.property),
+});

--- a/frontend/src/sections/develop/AddRowDrawer/CreateSyntheticData/common.test.js
+++ b/frontend/src/sections/develop/AddRowDrawer/CreateSyntheticData/common.test.js
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
   buildSyntheticColumnPayload,
+  buildSyntheticDatasetPayload,
   getSyntheticDefaultValues,
 } from "./common";
 
@@ -87,6 +88,34 @@ describe("buildSyntheticColumnPayload", () => {
       data_type: "Text",
       description: "Rendered description",
       property: { min_length: 4, required: true },
+    });
+  });
+
+  it("sanitizes columns in an existing dataset payload", () => {
+    expect(
+      buildSyntheticDatasetPayload({
+        dataset: { name: "existing dataset" },
+        columns: [
+          {
+            id: "server-column-id",
+            name: "answer",
+            data_type: "Text",
+            description: "Answer",
+            property: { required: true },
+            status: "running",
+          },
+        ],
+      }),
+    ).toEqual({
+      dataset: { name: "existing dataset" },
+      columns: [
+        {
+          name: "answer",
+          data_type: "Text",
+          description: "Answer",
+          property: { required: true },
+        },
+      ],
     });
   });
 });

--- a/frontend/src/sections/develop/AddRowDrawer/CreateSyntheticData/common.test.js
+++ b/frontend/src/sections/develop/AddRowDrawer/CreateSyntheticData/common.test.js
@@ -1,5 +1,8 @@
 import { describe, expect, it } from "vitest";
-import { getSyntheticDefaultValues } from "./common";
+import {
+  buildSyntheticColumnPayload,
+  getSyntheticDefaultValues,
+} from "./common";
 
 describe("getSyntheticDefaultValues", () => {
   it("normalizes canonical snake_case synthetic config responses", () => {
@@ -58,6 +61,32 @@ describe("getSyntheticDefaultValues", () => {
       kb_id: "kb-camel",
       rowNumber: 10,
       columns: [{ name: "legacy", data_type: "Text", property: [] }],
+    });
+  });
+});
+
+describe("buildSyntheticColumnPayload", () => {
+  it("omits server metadata while preserving the API column shape", () => {
+    expect(
+      buildSyntheticColumnPayload(
+        {
+          id: "server-column-id",
+          name: "answer",
+          dataType: "Text",
+          description: "Original description",
+          property: [
+            { type: "min_length", value: 4 },
+            { type: "required", value: true },
+          ],
+          status: "running",
+        },
+        "Rendered description",
+      ),
+    ).toEqual({
+      name: "answer",
+      data_type: "Text",
+      description: "Rendered description",
+      property: { min_length: 4, required: true },
     });
   });
 });

--- a/frontend/src/sections/develop/AddRowDrawer/CreateSyntheticDataView.jsx
+++ b/frontend/src/sections/develop/AddRowDrawer/CreateSyntheticDataView.jsx
@@ -27,7 +27,10 @@ import { LoadingButton } from "@mui/lab";
 import { useKnowledgeBaseList } from "src/api/knowledge-base/files";
 import PropTypes from "prop-types";
 
-import { getSyntheticDefaultValues } from "./CreateSyntheticData/common";
+import {
+  buildSyntheticColumnPayload,
+  getSyntheticDefaultValues,
+} from "./CreateSyntheticData/common";
 import CreateSyntheticDatasetOptionModal from "./EditSyntheticData/CreateSyntheticDatasetOptionModal";
 import { useEditSyntheticDataStore } from "./EditSyntheticData/state";
 import { useDatasetOriginStore } from "../../develop-detail/states";
@@ -215,9 +218,14 @@ const CreateSyntheticDataView = ({
     },
     onError: (error) => {
       enqueueSnackbar(
-        getRequestErrorMessage(error, "Failed to create synthetic dataset", {
-          retryAction: "creating this synthetic dataset",
-        }),
+        getRequestErrorMessage(
+          error,
+          "We couldn't create the synthetic dataset. Please review the form and try again.",
+          {
+            retryAction: "creating this synthetic dataset",
+            sanitizeTechnicalFieldErrors: true,
+          },
+        ),
         { variant: "error" },
       );
     },
@@ -251,9 +259,14 @@ const CreateSyntheticDataView = ({
     },
     onError: (error) => {
       enqueueSnackbar(
-        getRequestErrorMessage(error, "Failed to update synthetic dataset", {
-          retryAction: "updating this synthetic dataset",
-        }),
+        getRequestErrorMessage(
+          error,
+          "We couldn't update the synthetic dataset. Please review the form and try again.",
+          {
+            retryAction: "updating this synthetic dataset",
+            sanitizeTechnicalFieldErrors: true,
+          },
+        ),
         { variant: "error" },
       );
     },
@@ -285,20 +298,13 @@ const CreateSyntheticDataView = ({
       num_rows: Number(formData.rowNumber),
       kb_id: kb_id,
       columns: formData.columns.map((item, index) => {
-        const property = {};
-        item.property.forEach((dummy) => {
-          property[dummy.type] = dummy.value;
-        });
         if (index === 0) {
           cols[item.name] = item.description;
         }
-        const newItem = {
-          ...item,
-          description: replaceColumn(item.description, item.name),
-          property,
-          // ...(datasetId && { is_new: true, skip: true }),  // It need for the perticular dataset
-        };
-        return newItem;
+        return buildSyntheticColumnPayload(
+          item,
+          replaceColumn(item.description, item.name),
+        );
       }),
     };
 

--- a/frontend/src/sections/develop/AddRowDrawer/EditSyntheticData/SyntheticSummaryDrawer.jsx
+++ b/frontend/src/sections/develop/AddRowDrawer/EditSyntheticData/SyntheticSummaryDrawer.jsx
@@ -15,7 +15,10 @@ import { useEditSyntheticDataStore } from "./state";
 import SvgColor from "../../../../components/svg-color";
 import PropTypes from "prop-types";
 import EachColumnSummary from "../CreateSyntheticData/Summary/EachColumnSummary";
-import { transformColumnPayload } from "../CreateSyntheticData/common";
+import {
+  buildSyntheticDatasetPayload,
+  transformColumnPayload,
+} from "../CreateSyntheticData/common";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import axios, { endpoints } from "src/utils/axios";
 import { useNavigate, useParams } from "react-router";
@@ -290,7 +293,10 @@ export default function SyntheticSummaryDrawer() {
 
   const handleRegenerate = useCallback(() => {
     if (!dataset) return;
-    updateSyntheticData({ ...data, regenerate: true });
+    updateSyntheticData({
+      ...buildSyntheticDatasetPayload(data),
+      regenerate: true,
+    });
   }, [data, dataset, updateSyntheticData]);
 
   const _onEditSuccessCallback = useCallback(() => {

--- a/frontend/src/utils/errorUtils.js
+++ b/frontend/src/utils/errorUtils.js
@@ -2,6 +2,7 @@ import { RESPONSE_CODES } from "./constants";
 
 const DEFAULT_RATE_LIMIT_MESSAGE = "Rate limit reached.";
 const DEFAULT_RETRY_GUIDANCE = "Please try again in a few minutes.";
+const TECHNICAL_FIELD_ERROR_PATTERN = /(?:^|\s)[\w.-]+\s*:\s*unknown field\b/i;
 
 const hasTerminalPunctuation = (message) => /[.!?]$/.test(message);
 
@@ -59,7 +60,7 @@ export function getRequestErrorMessage(
   fallback = "Something went wrong",
   options = {},
 ) {
-  const { retryAction } = options;
+  const { retryAction, sanitizeTechnicalFieldErrors = false } = options;
   const responseData = error?.response?.data || {};
   const statusCode =
     error?.response?.status ||
@@ -76,9 +77,15 @@ export function getRequestErrorMessage(
     error?.message,
   );
 
+  const message =
+    sanitizeTechnicalFieldErrors &&
+    TECHNICAL_FIELD_ERROR_PATTERN.test(extractedMessage)
+      ? fallback
+      : extractedMessage || fallback;
+
   if (statusCode === RESPONSE_CODES.LIMIT_REACHED) {
-    return withRetryGuidance(extractedMessage || fallback, retryAction);
+    return withRetryGuidance(message, retryAction);
   }
 
-  return extractedMessage || fallback;
+  return message;
 }

--- a/frontend/src/utils/errorUtils.test.js
+++ b/frontend/src/utils/errorUtils.test.js
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest";
+import { getRequestErrorMessage } from "./errorUtils";
+
+describe("getRequestErrorMessage", () => {
+  it("hides backend unknown-field wording when requested", () => {
+    expect(
+      getRequestErrorMessage(
+        { response: { data: { error: "status: Unknown field." } } },
+        "We couldn't save the synthetic dataset. Please review the form and try again.",
+        { sanitizeTechnicalFieldErrors: true },
+      ),
+    ).toBe(
+      "We couldn't save the synthetic dataset. Please review the form and try again.",
+    );
+  });
+
+  it("keeps user-facing server messages unchanged", () => {
+    expect(
+      getRequestErrorMessage(
+        {
+          response: {
+            data: { error: "A dataset with this name already exists." },
+          },
+        },
+        "Fallback",
+        { sanitizeTechnicalFieldErrors: true },
+      ),
+    ).toBe("A dataset with this name already exists.");
+  });
+});


### PR DESCRIPTION
Closes #2313

Original issue: https://github.com/future-agi/future-agi/issues/2313

This PR predates and supersedes #2494, which is a narrower duplicate implementation.

## Summary

The synthetic dataset form reused API response column objects when building create, edit, and regenerate requests. Server metadata such as `status` can be rejected as an unknown field, and the regenerate path could surface that internal validation wording directly to users.

This change:

- Builds synthetic dataset requests from only the fields accepted by the API, while preserving existing `dataType` compatibility and drawer-specific flags.
- Applies the same payload shaping across create, edit, and regenerate flows.
- Uses shared request error formatting for regeneration failures, replacing backend unknown-field wording with a plain-language fallback while preserving user-facing server messages and rate-limit retry guidance.

## Validation

- Focused Vitest: 3 tests passed.
- Full Vitest: 328 test files and 2,841 tests passed; remaining failures are isolated to existing Windows/Docker preflight assumptions and a Pricing import timeout, with no failures in the changed paths.
- ESLint: 0 errors; existing warnings remain.
- Prettier, `git diff --check`, and the production Vite build passed.
