### PR TITLE
fix(harness): surface hosted voice call metrics + agent type in simulations UI

### DIFF
--- a/futureagi/simulate/services/harness_provider.py
+++ b/futureagi/simulate/services/harness_provider.py
@@ -178,6 +178,13 @@ def serialize_job(job: HostedHarnessJob) -> dict[str, Any]:
             else None
         ),
     }
+    # Surface the resolved transport connector so the environments list can show
+    # the agent Type (voice/chat). ``resolve_authored_connector`` pins a concrete
+    # connector (e.g. "livekit") on the payload during authoring; before that it
+    # is "auto" and the type genuinely is not known yet.
+    _agent_cfg = job.payload.get("agent") or {}
+    _connector = str(_agent_cfg.get("connector") or "").strip().lower()
+    detected_connectors = [_connector] if _connector and _connector != "auto" else []
     return {
         "job": {
             "job_id": str(job.id),
@@ -208,6 +215,7 @@ def serialize_job(job: HostedHarnessJob) -> dict[str, Any]:
             (job.payload.get("metadata") or {}).get("adjustments") or []
         ),
         "platform": platform,
+        "credentials": {"detected_connectors": detected_connectors},
     }
 
 

--- a/futureagi/simulate/services/hosted_harness_ingestion.py
+++ b/futureagi/simulate/services/hosted_harness_ingestion.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import hashlib
 import json
+import logging
 import tempfile
 from datetime import timedelta
 from typing import Any, BinaryIO
@@ -10,6 +11,7 @@ from django.db import IntegrityError, transaction
 from django.utils import timezone
 
 from simulate.models import (
+    AgentDefinition,
     CallExecution,
     CallTranscript,
     HostedHarnessArtifact,
@@ -29,6 +31,8 @@ from simulate.services.hosted_harness import (
 )
 from tfc.settings.settings import UPLOAD_BUCKET_NAME
 from tfc.utils.storage_client import get_object_url, get_storage_client
+
+logger = logging.getLogger(__name__)
 
 _EVENT_TYPES = {
     "stage_changed",
@@ -742,6 +746,7 @@ def _apply_receipt_to_call(
             update_fields.append("provider_call_data")
     call.call_metadata = metadata
     from simulate.services.alk_simulate_ingestion import (
+        _apply_conversation_metrics,
         _apply_harness_evaluation_outputs,
         _dispatch_csat_once,
     )
@@ -750,12 +755,64 @@ def _apply_receipt_to_call(
     update_fields.append("eval_outputs")
     if body.get("failure"):
         call.error_message = body["failure"]["message"]
+    # A sealed voice call stores its transcript, but the hosted path never
+    # derived the conversation analytics the non-hosted voice flow computes
+    # (turn/message counts, talk ratio, WPM, interruptions, agent latency,
+    # token usage), leaving call-details empty.  Compute them from the stored
+    # transcript; keep it best-effort so a metrics error never fails ingestion.
+    if call.simulation_call_type == CallExecution.SimulationCallType.VOICE:
+        try:
+            _apply_conversation_metrics(call)
+        except Exception:  # noqa: BLE001 - metrics are best-effort, never fatal
+            logger.warning(
+                "hosted conversation metrics failed for call %s",
+                call.id,
+                exc_info=True,
+            )
+        else:
+            update_fields.extend(
+                [
+                    "avg_agent_latency_ms",
+                    "user_interruption_count",
+                    "user_interruption_rate",
+                    "ai_interruption_count",
+                    "ai_interruption_rate",
+                    "user_wpm",
+                    "bot_wpm",
+                    "talk_ratio",
+                    "avg_stop_time_after_interruption_ms",
+                    "message_count",
+                    "conversation_metrics_data",
+                    "duration_seconds",
+                ]
+            )
     call.save(update_fields=list(dict.fromkeys(update_fields)))
+    if resolved_modality == CallExecution.SimulationCallType.VOICE:
+        _ensure_run_agent_is_voice(registration.job)
     if call.status == CallExecution.CallStatus.COMPLETED:
         call_id = call.id
         transaction.on_commit(
             lambda: _dispatch_csat_once(CallExecution.objects.get(id=call_id))
         )
+
+
+def _ensure_run_agent_is_voice(job: HostedHarnessJob) -> None:
+    """Promote the run's agent definition to voice from definitive evidence.
+
+    ``_resolve_scenario_modality`` runs at scenario-provision time, before the
+    authoring contract is guaranteed persisted on the job, so a voice run can
+    register a ``text`` agent definition and then render through the chat
+    schema -- effectively disappearing from call-details.  A sealed recording
+    is ground truth and arrives with the receipt, so correct the definition
+    here (idempotent; text runs never reach this path).
+    """
+    run_test = getattr(job, "run_test", None)
+    if run_test is None:
+        return
+    agent = run_test.agent_definition
+    if agent is not None and agent.agent_type != AgentDefinition.AgentTypeChoices.VOICE:
+        agent.agent_type = AgentDefinition.AgentTypeChoices.VOICE
+        agent.save(update_fields=["agent_type", "updated_at"])
 
 
 def _call_lifecycle_status(body: dict[str, Any]) -> str:
@@ -861,6 +918,22 @@ def _ingest_hosted_transcript(
         messages = payload.get("messages") if isinstance(payload, dict) else []
         rows: list[CallTranscript] = []
         if isinstance(messages, list):
+            # The v2 transcript carries absolute speech timing
+            # (``started_speaking_at`` / ``stopped_speaking_at`` in epoch
+            # seconds).  Anchor to the earliest turn so CallTranscript stores
+            # real per-turn offsets in ms: conversation metrics (talk ratio,
+            # WPM, agent latency, interruptions) are all derived from these and
+            # collapse to zero when every turn shares the row index.
+            speech_starts = [
+                message["started_speaking_at"]
+                for message in messages
+                if isinstance(message, dict)
+                and isinstance(message.get("started_speaking_at"), (int, float))
+            ]
+            base_time = min(speech_starts) if speech_starts else None
+            valid_roles = {
+                choice for choice, _label in CallTranscript.SpeakerRole.choices
+            }
             for index, message in enumerate(messages):
                 if not isinstance(message, dict):
                     continue
@@ -868,16 +941,26 @@ def _ingest_hosted_transcript(
                 if content is None:
                     continue
                 role = str(message.get("role") or "unknown")
-                valid_roles = {
-                    choice for choice, _label in CallTranscript.SpeakerRole.choices
-                }
+                started = message.get("started_speaking_at")
+                stopped = message.get("stopped_speaking_at")
+                if base_time is not None and isinstance(started, (int, float)):
+                    start_ms = int(round((started - base_time) * 1000))
+                    end_ms = (
+                        int(round((stopped - base_time) * 1000))
+                        if isinstance(stopped, (int, float))
+                        else start_ms
+                    )
+                else:
+                    # Older guests emit no timing; preserve turn order only.
+                    start_ms = index
+                    end_ms = index
                 rows.append(
                     CallTranscript(
                         call_execution=call,
                         speaker_role=role if role in valid_roles else "unknown",
                         content=str(content),
-                        start_time_ms=index,
-                        end_time_ms=index,
+                        start_time_ms=start_ms,
+                        end_time_ms=end_ms,
                     )
                 )
         if not rows and isinstance(payload, dict) and payload.get("transcript"):


### PR DESCRIPTION
## Problem
Hosted voice runs executed real calls (transcripts + recordings landed), but the simulations tab showed **empty analytics** and the environments list showed **Type: "Not detected"**. Root causes were in the platform ingestion/serialization, not the harness/guest.

## Changes (backend-only, `simulate/services/`)
- **Conversation metrics**: `hosted_harness_ingestion._apply_receipt_to_call` now runs the existing `_apply_conversation_metrics` on the sealed transcript, populating `turn_count`/`message_count`, `talk_ratio`, agent/customer talk %, `user_wpm`/`bot_wpm`, `avg_agent_latency`, interruptions, and token usage. The hosted path stored the transcript but never computed these.
- **Real per-turn timing**: `_ingest_hosted_transcript` now parses `started_speaking_at`/`stopped_speaking_at` (epoch seconds, anchored to the first turn) into `CallTranscript.start_time_ms`/`end_time_ms` instead of the loop index — the prerequisite that makes every timing-derived metric non-zero. Falls back to index for older guests with no timing.
- **Agent type**: promote the run's `AgentDefinition` to `voice` from the definitive recording signal on receipt. `_resolve_scenario_modality` runs at scenario-provision time (before the authoring contract is guaranteed persisted), so a voice run could register a `text` agent and render through the chat schema. This also fixes `duration`/`start_time`, which branch on `_is_chat_simulation`.
- **Environments list Type**: `serialize_job` emits `credentials.detected_connectors` from the resolved `agent.connector`, so the list renders **Voice agent** instead of "Not detected".

## Verification
Fresh live run end-to-end (ride-voice-agent, in-sandbox authoring → execution → terminal), metrics populated via the **live** ingestion path (no backfill):
- KPIs: `agent_type=voice`, `avg_turn_count=5.0`, `avg_talk_ratio=1.97`, `agent_talk%=66.3`, `avg_agent_latency=2532ms`, `avg_user_wpm=212.5`, `avg_bot_wpm=206.3`.
- Per-call: `duration`, `turn_count`, `talk_ratio`, `user_wpm`/`bot_wpm` all populated.
- Re-ingestion is idempotent (transcript rows replaced via delete+create; metrics recompute, not accumulate) — verified with a double-apply test (rows 2→2→2).

## Notes
- Rebased onto latest `feat/hosted-bundle-v2-production` (`782b47cfb`); no conflicts with `hosted_harness_ingestion.py`, and the `serialize_job` addition is disjoint from the incoming rerun changes.
- **csat** is correctly wired (matches vapi) but needs a Celery worker + a reachable eval model (bedrock/`agentcc-gateway` not up locally) — out of scope here; populates where those exist.
- The local NLTK import-guard in `ee/agenthub/trace_scanner/compress.py` is intentionally **not** included (local-only workaround).