### PR TITLE
fix: remove span status filter for voice projects

### DIFF
--- a/frontend/src/sections/projects/LLMTracing/TraceFilterPanel.jsx
+++ b/frontend/src/sections/projects/LLMTracing/TraceFilterPanel.jsx
@@ -95,12 +95,16 @@ const SPAN_ID_FIELD = {
 //   `tab` === "spans"  → Trace ID + Span ID
 //   otherwise          → no id fields (preserves behavior for non-LLMTracing
 //                        consumers such as sessions/users).
+// Voice (simulator) projects drop the span Status field — span status doesn't
+// reflect call state and conflicts with the call status attribute.
 // Exported for direct unit testing.
-export const getTraceFilterFields = (tab) => {
-  if (tab === "trace") return [TRACE_ID_FIELD, ...BASE_TRACE_FILTER_FIELDS];
-  if (tab === "spans")
-    return [TRACE_ID_FIELD, SPAN_ID_FIELD, ...BASE_TRACE_FILTER_FIELDS];
-  return BASE_TRACE_FILTER_FIELDS;
+export const getTraceFilterFields = (tab, { isSimulator = false } = {}) => {
+  const baseFields = isSimulator
+    ? BASE_TRACE_FILTER_FIELDS.filter((f) => f.value !== "status")
+    : BASE_TRACE_FILTER_FIELDS;
+  if (tab === "trace") return [TRACE_ID_FIELD, ...baseFields];
+  if (tab === "spans") return [TRACE_ID_FIELD, SPAN_ID_FIELD, ...baseFields];
+  return baseFields;
 };
 
 // Map a static trace field to a picker property. In spans view the root
@@ -607,6 +611,18 @@ export function buildTraceFilterProperties(
 
       // Exclude simulation metrics for non-simulator projects
       if (src === "simulation" && !isSimulator) return false;
+
+      // Voice projects: drop the trace span status (OK/ERROR/UNSET). Scoped to
+      // the system metric so a custom span attribute named "status" is kept.
+      // The simulation call status stays. Mirrors the backend catalog gating.
+      if (
+        isSimulator &&
+        name === "status" &&
+        src === "traces" &&
+        (cat === "system_metric" || cat === "systemMetric")
+      ) {
+        return false;
+      }
 
       // Exclude custom_column (dataset columns)
       if (cat === "custom_column" || cat === "customColumn") return false;
@@ -1938,7 +1954,7 @@ const TraceFilterPanel = ({
     // Start with static trace fields (trace_name, status, model, etc.) —
     // prepend trace_id / span_id when rendered inside the LLM Tracing
     // trace or span tab. In spans view, relabel "Trace Name" to "Span Name".
-    const staticProps = getTraceFilterFields(tab).map((f) =>
+    const staticProps = getTraceFilterFields(tab, { isSimulator }).map((f) =>
       toStaticFilterProperty(f, isSpansView),
     );
     const knownIds = new Set(staticProps.map((p) => p.id));
@@ -1963,6 +1979,7 @@ const TraceFilterPanel = ({
     propertyFilter,
     tab,
     isSpansView,
+    isSimulator,
   ]);
   const propertyById = useMemo(
     () => Object.fromEntries(properties.map((p) => [p.id, p])),

--- a/frontend/src/sections/projects/LLMTracing/__tests__/TraceFilterPanel.test.jsx
+++ b/frontend/src/sections/projects/LLMTracing/__tests__/TraceFilterPanel.test.jsx
@@ -295,6 +295,20 @@ describe("getTraceFilterFields (TH-4571)", () => {
     expect(fromNull).toEqual(fromUndefined);
     expect(fromNull).toEqual(fromUnknown);
   });
+
+  it("drops the status field for voice (simulator) projects", () => {
+    ["trace", "spans", null].forEach((tab) => {
+      const fields = getTraceFilterFields(tab, { isSimulator: true });
+      expect(fields.some((f) => f.value === "status")).toBe(false);
+    });
+  });
+
+  it("keeps the status field for non-simulator projects", () => {
+    ["trace", "spans", null].forEach((tab) => {
+      const fields = getTraceFilterFields(tab, { isSimulator: false });
+      expect(fields.some((f) => f.value === "status")).toBe(true);
+    });
+  });
 });
 
 describe("toStaticFilterProperty (spans Span Name)", () => {
@@ -474,6 +488,68 @@ describe("annotator annotation filter (TH-4710)", () => {
         }),
       ]),
     );
+  });
+
+  it("drops trace status but keeps simulation status for voice projects", () => {
+    const metrics = [
+      {
+        name: "status",
+        display_name: "Status",
+        category: "system_metric",
+        source: "traces",
+        type: "string",
+      },
+      {
+        name: "status",
+        display_name: "Status",
+        category: "system_metric",
+        source: "simulation",
+        type: "string",
+      },
+    ];
+
+    const voice = buildTraceFilterProperties(metrics, {
+      isSimulator: true,
+      sourceScope: "traces",
+    });
+    // Trace span status gone; the simulation call status remains.
+    expect(voice.some((p) => p.id === "status")).toBe(true);
+    expect(voice.filter((p) => p.id === "status")).toHaveLength(1);
+
+    const observe = buildTraceFilterProperties(metrics, {
+      isSimulator: false,
+      sourceScope: "traces",
+    });
+    // Non-voice keeps the trace status (simulation metric excluded elsewhere).
+    expect(observe.some((p) => p.id === "status")).toBe(true);
+  });
+
+  it("keeps a custom span attribute named status for voice projects", () => {
+    const metrics = [
+      {
+        name: "status",
+        display_name: "Status",
+        category: "system_metric",
+        source: "traces",
+        type: "string",
+      },
+      {
+        name: "status",
+        display_name: "Status",
+        category: "custom_attribute",
+        source: "traces",
+        type: "string",
+      },
+    ];
+
+    const voice = buildTraceFilterProperties(metrics, {
+      isSimulator: true,
+      sourceScope: "traces",
+    });
+    // Only the system span status is dropped; the custom attribute survives.
+    const statuses = voice.filter((p) => p.id === "status");
+    expect(statuses).toHaveLength(1);
+    expect(statuses[0].category).toBe("attribute");
   });
 
   it("adds a global Annotator property inside annotation filters", () => {

--- a/futureagi/tracer/services/dashboard_metrics_catalog.py
+++ b/futureagi/tracer/services/dashboard_metrics_catalog.py
@@ -528,7 +528,8 @@ def build_metrics_catalog(
 
     filter_by_project = bool(req_project_ids and project_ids)
 
-    if (
+    # Scope is voice-only when every filtered project is a simulator project.
+    simulator_only_scope = (
         filter_by_project
         and not Project.objects.filter(
             id__in=project_ids,
@@ -537,7 +538,14 @@ def build_metrics_catalog(
             source=ProjectSourceChoices.SIMULATOR.value,
         )
         .exists()
-    ):
+    )
+
+    if simulator_only_scope:
+        metrics = [
+            m
+            for m in metrics
+            if not (m.get("name") == "status" and m.get("source") == "traces")
+        ]
         metrics.append(
             {
                 "name": "agent_talk_percentage",

--- a/futureagi/tracer/tests/test_dashboard.py
+++ b/futureagi/tracer/tests/test_dashboard.py
@@ -748,6 +748,64 @@ class TestMetricsEndpoint:
         metric_names = [m["name"] for m in response.json()["result"]["metrics"]]
         assert "agent_talk_percentage" not in metric_names
 
+    @pytest.mark.django_db
+    @patch("tracer.views.dashboard.is_clickhouse_enabled", return_value=False)
+    @patch("tracer.views.dashboard.SQL_query_handler.get_span_attributes_for_project")
+    def test_metrics_drops_trace_status_for_simulator_project(
+        self,
+        mock_get_span_attrs,
+        _mock_clickhouse_enabled,
+        auth_client,
+        organization,
+        workspace,
+    ):
+        from model_hub.models.ai_model import AIModel
+        from tracer.models.project import Project, ProjectSourceChoices
+
+        simulator_project = Project.objects.create(
+            name="Voice Project",
+            organization=organization,
+            workspace=workspace,
+            model_type=AIModel.ModelTypes.GENERATIVE_LLM,
+            trace_type="observe",
+            source=ProjectSourceChoices.SIMULATOR.value,
+        )
+        mock_get_span_attrs.return_value = []
+
+        response = auth_client.get(
+            f"/tracer/dashboard/metrics/?project_ids={simulator_project.id}"
+        )
+
+        assert response.status_code == 200
+        metrics = response.json()["result"]["metrics"]
+        # Span status (OK/ERROR/UNSET) is confusing for voice — must be gone.
+        assert not any(
+            m["name"] == "status" and m["source"] == "traces" for m in metrics
+        )
+
+    @pytest.mark.django_db
+    @patch("tracer.views.dashboard.is_clickhouse_enabled", return_value=False)
+    @patch("tracer.views.dashboard.SQL_query_handler.get_span_attributes_for_project")
+    def test_metrics_keeps_trace_status_for_non_simulator_project(
+        self,
+        mock_get_span_attrs,
+        _mock_clickhouse_enabled,
+        auth_client,
+        observe_project,
+    ):
+        # observe_project defaults to ProjectSourceChoices.PROTOTYPE.
+        mock_get_span_attrs.return_value = []
+
+        response = auth_client.get(
+            f"/tracer/dashboard/metrics/?project_ids={observe_project.id}"
+        )
+
+        assert response.status_code == 200
+        metrics = response.json()["result"]["metrics"]
+        assert any(
+            m["name"] == "status" and m["source"] == "traces" for m in metrics
+        )
+
     @pytest.fixture
     def _annotation_label_factory(self, db, organization, workspace):
         from model_hub.models.choices import AnnotationTypeChoices


### PR DESCRIPTION
## Summary

In voice projects the trace/span list filter exposed a **span status** field (`OK` / `ERROR` / `UNSET`) alongside the call status, showing two conflicting "status" variables that didn't match the UI. Span status is a technical execution status and doesn't reflect call state, so this removes it from the filter for voice (simulator-source) projects only. The meaningful call status stays; non-voice projects are untouched.

## Linked issues

Closes #
Linear: Fixed TH-5097

## Type of change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

---

## 1) What changes were done

**A. Backend — metrics catalog gating (`dashboard_metrics_catalog.py`)**

- When the request scope is voice-only (every filtered project is simulator-source), the trace `status` (`source: "traces"`) system metric is dropped from the catalog before it's returned. This removes it from every consumer of the catalog for voice — the filter picker as well as breakdown/widget pickers.
- Extracted the existing all-simulator condition into a named `simulator_only_scope` boolean and reused it for both the new removal and the existing `agent_talk_percentage` gate (behavior of the latter unchanged).

**B. Frontend — filter panel (`TraceFilterPanel.jsx`)**

- `getTraceFilterFields(tab, { isSimulator })` drops the hardcoded static `status` field for voice (the backend can't remove a frontend-defined field).
- `buildTraceFilterProperties` drops the dynamic `status` **only** when it is the system metric on the `traces` source — a defensive net for the 60s-cached catalog. The `simulation` call status and any custom span attribute named `status` are preserved.
- Threaded `isSimulator` into the `properties` memo and its dependency array so the filter set recomputes correctly when switching projects.

**C. Layering**

- Backend is the authoritative source; the frontend guards handle the frontend-only static field and act as a cache safety net. The two layers discriminate on `source: "traces"` so the `simulation` call status is never affected.

---

## 2) Why the changes were done

- **Product/UX:** Two "status" fields that don't match the displayed data are confusing (TH-5097). Voice users care about call state, not OTel span status.
- **Technical:** `status` is emitted from two places (a hardcoded frontend field and the backend catalog, which also dedupe-merge on the frontend). Removing only the static field lets the backend one leak back through the merge, so it must be gated at every entry point.
- **Architecture:** Gating on `source: "traces"` + system-metric category keeps the change surgical — the `simulation` call status and user-defined `status` attributes are untouched.

---

## 3) Tests written + scenarios each covers

**`futureagi/tracer/tests/test_dashboard.py`** — metrics catalog gating

- `test_metrics_drops_trace_status_for_simulator_project` — voice-only scope: no `status`/`source=traces` in the catalog.
- `test_metrics_keeps_trace_status_for_non_simulator_project` — non-voice: trace `status` remains.

**`frontend/.../__tests__/TraceFilterPanel.test.jsx`** — filter field + property assembly

- `drops the status field for voice (simulator) projects` — static field removed across trace/spans/null tabs.
- `keeps the status field for non-simulator projects` — static field retained.
- `drops trace status but keeps simulation status for voice projects` — dynamic path drops trace status, keeps the simulation call status (id collision handled).
- `keeps a custom span attribute named status for voice projects` — only the system status is dropped; a custom attribute named `status` survives.

> Run result: backend **6 passed** (`trace_status` + `agent_talk_percentage`), frontend **26 passed** in the filter panel suite. ESLint clean (0 errors).

---

## 4) How to run / test

### Backend tests

```bash
cd futureagi
bin/test tracer/tests/test_dashboard.py -k "trace_status or agent_talk_percentage" -v
```

### Frontend tests

```bash
cd frontend
yarn test:run src/sections/projects/LLMTracing/__tests__/TraceFilterPanel.test.jsx
```

### UI steps (manual)

1. Start the stack and open a **voice (simulator) project** at http://localhost:3031.
2. Open the trace/span list filter panel.
3. Verify the span **Status** (`OK`/`ERROR`/`UNSET`) option is gone; the call status remains.
4. Open a normal observe project and verify **Status** is still present.

---

## 6) Edge cases & considerations

- **Custom span attribute named `status`:** kept — the frontend guard is scoped to the system-metric category; the backend removal runs before custom attributes are appended to the catalog (verified empirically).
- **Mixed project selection (voice + observe):** the gate requires *every* selected project to be simulator, so a mixed scope keeps `status`.
- **Workspace-wide catalog call (no project_ids):** keeps `status`.
- **`simulation` call status:** preserved — both layers discriminate on `source: "traces"`.

---

## 7) Pre-existing issues (NOT introduced by this PR)

- The voice call-status **value mismatch** (list displays a normalized `completed`/`in-progress`, while the stored `call.status` attribute is the provider-raw `ended`/`error`, so filtering on the displayed value matches nothing) is a separate, pre-existing issue and is **not** addressed here.
- Four annotation-label / cache-outage tests in `TestMetricsEndpoint` fail locally due to unseeded ClickHouse fixtures; confirmed failing identically on the clean tree.

---

## 8) Architectural / important decisions

- **Backend as source of truth + frontend guards:** the catalog is authoritative for voice, but the frontend still needs to drop its own hardcoded static field and guard the cached merge. Chosen over a frontend-only fix (which leaked via the dynamic merge) and over a backend-only fix (can't touch the frontend static field).
- **Category-scoped frontend guard:** the dynamic guard checks system-metric category so it can't over-remove a user-defined `status` attribute; the backend is safe by ordering (removal precedes custom-attribute discovery).
