### PR TITLE
fix(observe): scope graph metric picker to the current project [TH-6787]

### DIFF
--- a/e2e/FLOWS.md
+++ b/e2e/FLOWS.md
@@ -87,3 +87,23 @@
 - all four spans of both traces present in CH `spans` (FINAL)
 - project row auto-created in PG tracer_project, scoped to the actor org
 - UI row set equals the span-list API result for the equivalent filter (same CH dispatch)
+
+### OBS-E2E-003 — graph metric picker lists only the current project's evals
+
+**Goal:** A developer picking a metric to graph sees only the evals attached to the project they are viewing  
+**Spec:** `flows/observe/graph-metric-scoping.spec.ts:51`  
+**Tags:** —
+
+**User steps:**
+
+1. seed two projects in one org
+2. attach a distinctly-named eval to each
+3. open the first project's Observe graph view
+4. open the metric picker
+5. search the picker for the seeded eval names
+6. read the EVALS section
+
+**Backend state verified:**
+
+- the metrics catalog scoped to each project returns that project's eval template and not its sibling's
+- the frontend requests the catalog with project_ids set to the project being viewed

--- a/e2e/flows/observe/graph-metric-scoping.spec.ts
+++ b/e2e/flows/observe/graph-metric-scoping.spec.ts
@@ -1,0 +1,179 @@
+import { request, type APIRequestContext } from '@playwright/test';
+import { test, expect } from '../../lib/fixtures';
+import type { TestActor } from '../../lib/provisioning';
+import { sendTrace } from '../../lib/otlp';
+import { POLL, type StateProbe } from '../../lib/state-probe';
+import { E2E } from '../../lib/env';
+import { flowAnnotation } from '../../lib/flow-meta';
+
+// playwright.config.ts sets expect timeout to 10s, which this flow's UI step can
+// outrun: it waits on a cold metrics catalog, whose span-attribute discovery
+// carries a 15s server-side budget on its own. Both other observe flows use the
+// same constant for the same reason. The popover renders *empty* while the
+// catalog is in flight, so an under-budgeted wait looks identical to a broken fix.
+const UI_READY = 60_000;
+
+interface CreatedId { result: { id: string } }
+interface MetricsEnvelope {
+  result: { metrics: Array<{ category: string; display_name: string }> };
+}
+
+/** Seed a trace under a fresh project name and return the project id the collector created. */
+async function seedProject(
+  req: APIRequestContext,
+  actor: TestActor,
+  probe: StateProbe,
+  projectName: string,
+): Promise<string> {
+  const seeded = await sendTrace(req, {
+    collectorUrl: E2E.collectorUrl,
+    apiKey: actor.apiKey,
+    secretKey: actor.secretKey,
+    projectName,
+  });
+  await expect
+    .poll(async () => {
+      const rows = await probe.ch<{ n: string }>(
+        'SELECT count() AS n FROM spans FINAL WHERE trace_id = {t:String}',
+        { t: seeded.traceId },
+      );
+      return Number(rows[0].n);
+    }, POLL.SPAN_VISIBLE)
+    .toBe(seeded.spanIds.length);
+
+  const [{ project_id: projectId }] = await probe.ch<{ project_id: string }>(
+    'SELECT DISTINCT project_id FROM spans FINAL WHERE trace_id = {t:String}',
+    { t: seeded.traceId },
+  );
+  return projectId;
+}
+
+test('OBS-E2E-003: graph metric picker lists only the current project\'s evals', {
+  tag: ['@flow'],
+  annotation: flowAnnotation({
+    id: 'OBS-E2E-003',
+    area: 'observe',
+    userGoal:
+      'A developer picking a metric to graph sees only the evals attached to the project they are viewing',
+    steps: [
+      'seed two projects in one org',
+      'attach a distinctly-named eval to each',
+      "open the first project's Observe graph view",
+      'open the metric picker',
+      'search the picker for the seeded eval names',
+      'read the EVALS section',
+    ],
+    backendChecks: [
+      "the metrics catalog scoped to each project returns that project's eval template and not its sibling's",
+      'the frontend requests the catalog with project_ids set to the project being viewed',
+    ],
+  }),
+}, async ({ page, actor, probe }, testInfo) => {
+  // Two collector round-trips (SPAN_VISIBLE, 15s each), four API creates, two
+  // cold catalog builds, an SPA boot and three UI_READY-budgeted waits. The
+  // harness precedent is 240s for OBS-E2E-002 and 300s for OBS-E2E-001, both
+  // lighter than this. Under-budgeting means the outer timeout fires first and
+  // hides which assertion actually ran out.
+  test.setTimeout(240_000);
+  const req = await request.newContext();
+  const suffix = `${testInfo.workerIndex}-${Date.now().toString(36)}`;
+  const mineName = `e2e-scope-mine-${suffix}`;
+  const otherName = `e2e-scope-other-${suffix}`;
+
+  const mineProjectId = await seedProject(req, actor, probe, `e2e-scope-a-${suffix}`);
+  const otherProjectId = await seedProject(req, actor, probe, `e2e-scope-b-${suffix}`);
+  expect(mineProjectId).not.toBe(otherProjectId);
+
+  await test.step('attach one distinctly-named eval to each project', async () => {
+    for (const [name, projectId] of [
+      [mineName, mineProjectId],
+      [otherName, otherProjectId],
+    ] as const) {
+      // eval_type 'code' needs no model and never calls a provider: this flow
+      // only cares that the template is attached, never that it runs. The name
+      // must satisfy ^[a-z0-9_-]+$ with no leading/trailing/consecutive
+      // separators, so keep the suffix lowercase alphanumeric.
+      const template = await actor.api.post<CreatedId>('/model-hub/eval-templates/create-v2/', {
+        name,
+        eval_type: 'code',
+        // Required: the view rejects a non-draft code eval with no body
+        // ("Code is required for code-type evaluations."). `instructions` is
+        // ignored for code evals. Never executed — the e2e stack does not start
+        // code-executor.
+        code: 'def main(**kwargs):\n    return True',
+        code_language: 'python',
+        output_type: 'pass_fail',
+      });
+      await actor.api.post<CreatedId>('/tracer/custom-eval-config/', {
+        project: projectId,
+        eval_template: template.result.id,
+        name,
+        config: { mapping: {} },
+        mapping: {},
+        error_localizer: false,
+      });
+    }
+  });
+
+  await test.step('the scoped catalog separates them (API lane)', async () => {
+    const evalNames = async (projectId: string) => {
+      const body = await actor.api.get<MetricsEnvelope>('/tracer/dashboard/metrics/', {
+        project_ids: projectId,
+      });
+      return body.result.metrics
+        .filter((m) => m.category === 'eval_metric')
+        .map((m) => m.display_name);
+    };
+
+    // Asserted symmetrically rather than against the unscoped catalog: the
+    // unscoped cache key is shared with every other flow in this worker and
+    // lives 60s, so reading it here would flake. Each project seeing its own
+    // eval and not its sibling's proves the same thing without touching it.
+    const mine = await evalNames(mineProjectId);
+    expect(mine).toContain(mineName);
+    expect(mine).not.toContain(otherName);
+
+    const other = await evalNames(otherProjectId);
+    expect(other).toContain(otherName);
+    expect(other).not.toContain(mineName);
+  });
+
+  await test.step("the picker shows only this project's eval (UI lane)", async () => {
+    // Asserts the fix itself — that the FE sends project_ids — at the request
+    // level, so a regression is diagnosable without reading a trace dump.
+    // `!per_eval_config` is load-bearing, not noise: TraceFilterPanel calls the
+    // same endpoint with project_ids AND per_eval_config=true, and that call is
+    // unaffected by this fix — matching it would make this assertion pass on
+    // pre-fix code. The picker's own request is the template-level one.
+    const catalog = page.waitForResponse(
+      (r) =>
+        r.url().includes('/tracer/dashboard/metrics/') &&
+        r.url().includes(`project_ids=${mineProjectId}`) &&
+        !r.url().includes('per_eval_config') &&
+        r.ok(),
+      { timeout: UI_READY },
+    );
+
+    // `selectedTab` is the only real URL key here: viewMode lives in Zustand and
+    // already defaults to "graph", and `tab` is not a URL key.
+    await page.goto(`/dashboard/observe/${mineProjectId}/llm-tracing?selectedTab=trace`, {
+      waitUntil: 'domcontentloaded',
+    });
+    await catalog;
+
+    await page.getByTestId('graph-metric-picker-trigger').first().click({ timeout: UI_READY });
+    await expect(page.getByPlaceholder('Search metrics...')).toBeVisible({ timeout: UI_READY });
+
+    // Typing narrows to the minted names only, so neither assertion can be
+    // satisfied by an unrelated row and neither needs a scroll. The picker
+    // filters on the label, which is the EvalTemplate name verbatim.
+    await page.getByPlaceholder('Search metrics...').fill('e2e-scope-');
+
+    // The positive assertion gates the negative one: without it, toHaveCount(0)
+    // would pass vacuously against a picker that never finished loading.
+    await expect(page.getByRole('button', { name: mineName })).toBeVisible({ timeout: UI_READY });
+    await expect(page.getByRole('button', { name: otherName })).toHaveCount(0);
+  });
+
+  await req.dispose();
+});

--- a/frontend/src/sections/projects/LLMTracing/GraphSection/PrimaryGraph.jsx
+++ b/frontend/src/sections/projects/LLMTracing/GraphSection/PrimaryGraph.jsx
@@ -10,7 +10,13 @@
  * Metric dropdown shows ALL metrics from the dashboard metrics API:
  * system metrics, evals, annotations — same as what the dashboard module uses.
  */
-import React, { useCallback, useMemo, useRef, useState } from "react";
+import React, {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 import PropTypes from "prop-types";
 import {
   Badge,
@@ -101,11 +107,16 @@ const COMPARE_DATE_OPTIONS = [
 // ---------------------------------------------------------------------------
 // Hook: fetch all metrics from dashboard API (system + eval + annotation)
 // ---------------------------------------------------------------------------
-function useGraphMetrics() {
+function useGraphMetrics(projectId) {
   return useQuery({
-    queryKey: ["graph-metrics-all"],
+    // The catalog is project-scoped, so the project id belongs in the key: a
+    // shared key served one project's evals and annotation labels to the next
+    // project the user opened (TH-6787).
+    queryKey: ["graph-metrics-all", projectId || null],
     queryFn: async () => {
-      const { data } = await axios.get(endpoints.dashboard.metrics);
+      const { data } = await axios.get(endpoints.dashboard.metrics, {
+        params: projectId ? { project_ids: projectId } : undefined,
+      });
       return data?.result?.metrics || [];
     },
     select: (metrics) => {
@@ -267,8 +278,9 @@ const PrimaryGraph = ({
   };
 
   // Fetch all available metrics (system + eval + annotation)
-  const { data: dynamicMetricGroups } = useGraphMetrics();
-  // Use staticMetrics if provided (for sessions/users), otherwise dynamic
+  const { data: dynamicMetricGroups } = useGraphMetrics(effectiveObserveId);
+  // Use staticMetrics if provided, otherwise dynamic. No caller passes
+  // staticMetrics today — sessions and users use the dynamic catalog too.
   const metricGroups = staticMetrics || dynamicMetricGroups;
 
   // Flatten groups into a single options list for lookup
@@ -289,6 +301,15 @@ const PrimaryGraph = ({
       },
     [allMetrics, selectedMetric],
   );
+
+  // A metric selected in one project may not exist in the next one's catalog.
+  // Drop it once loaded so the trigger label and picker highlight agree.
+  useEffect(() => {
+    if (!metricGroups || !allMetrics.length) return;
+    if (!allMetrics.some((m) => m.id === selectedMetric)) {
+      setSelectedMetric(metricDef.id);
+    }
+  }, [metricGroups, allMetrics, selectedMetric, metricDef.id]);
 
   // Filter metrics by search term for the picker
   const filteredGroups = useMemo(() => {
@@ -319,6 +340,12 @@ const PrimaryGraph = ({
       "primary-graph",
       effectiveObserveId,
       selectedMetric,
+      // metricDef resolves asynchronously: while the project's scoped catalog
+      // loads it is the hardcoded latency fallback, so keying on selectedMetric
+      // alone pinned that first response for the real metric — the chart then
+      // showed latency data under the eval's name and unit (TH-6787).
+      metricDef.id,
+      metricDef.apiType,
       selectedInterval,
       combinedFilters,
       apiEndpoint,

--- a/frontend/src/sections/projects/LLMTracing/GraphSection/PrimaryGraph.jsx
+++ b/frontend/src/sections/projects/LLMTracing/GraphSection/PrimaryGraph.jsx
@@ -589,6 +589,7 @@ const PrimaryGraph = ({
 
           {/* Metric picker trigger */}
           <ButtonBase
+            data-testid="graph-metric-picker-trigger"
             onClick={(e) => setPickerAnchor(e.currentTarget)}
             sx={{
               height: 26,

--- a/frontend/src/sections/projects/LLMTracing/GraphSection/__tests__/PrimaryGraph.test.jsx
+++ b/frontend/src/sections/projects/LLMTracing/GraphSection/__tests__/PrimaryGraph.test.jsx
@@ -171,4 +171,77 @@ describe("PrimaryGraph", () => {
     const { id: _id, ...metricFilterWithoutId } = metricFilter;
     expect(postedFilters()).toEqual([metricFilterWithoutId]);
   });
+
+  it("requests the metric catalog scoped to the current project", async () => {
+    renderWithQueryClient(<PrimaryGraph observeIdOverride="project-alpha" />);
+
+    await waitFor(() => expect(axios.get).toHaveBeenCalled());
+
+    expect(axios.get).toHaveBeenCalledWith("/dashboard/metrics/", {
+      params: { project_ids: "project-alpha" },
+    });
+  });
+
+  it("does not serve one project's metric catalog to another", async () => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+    });
+
+    const { unmount } = render(
+      <QueryClientProvider client={queryClient}>
+        <PrimaryGraph observeIdOverride="project-alpha" />
+      </QueryClientProvider>,
+    );
+    await waitFor(() => expect(axios.get).toHaveBeenCalledTimes(1));
+    unmount();
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <PrimaryGraph observeIdOverride="project-beta" />
+      </QueryClientProvider>,
+    );
+
+    await waitFor(() => expect(axios.get).toHaveBeenCalledTimes(2));
+    expect(axios.get).toHaveBeenLastCalledWith("/dashboard/metrics/", {
+      params: { project_ids: "project-beta" },
+    });
+  });
+
+  it("refetches graph data once the catalog resolves the selected metric", async () => {
+    axios.get.mockResolvedValue({
+      data: {
+        result: {
+          metrics: [
+            {
+              category: "system_metric",
+              name: "latency",
+              displayName: "Latency",
+              type: "number",
+            },
+            {
+              category: "eval_metric",
+              name: "eval-uuid-1",
+              displayName: "My Eval",
+              type: "number",
+            },
+          ],
+        },
+      },
+    });
+
+    renderWithQueryClient(
+      <PrimaryGraph
+        observeIdOverride="project-alpha"
+        defaultMetric="eval-uuid-1"
+      />,
+    );
+
+    await waitFor(() => expect(axios.post).toHaveBeenCalled());
+
+    await waitFor(() =>
+      expect(axios.post.mock.calls.at(-1)[1].req_data_config).toMatchObject({
+        id: "eval-uuid-1",
+      }),
+    );
+  });
 });


### PR DESCRIPTION
## What

The Primary Graph metric picker listed **every eval template and annotation label in the organization** instead of the ones belonging to the project being viewed. Fixes [TH-6787](https://linear.app/future-agi/issue/TH-6787).

`useGraphMetrics` called `/tracer/dashboard/metrics/` with no params and cached the result under a project-independent React Query key. The endpoint has supported `project_ids` all along — `useDashboardMetrics` and `useTraceFilterProperties` already pass it. This caller just never did.

**No backend changes.** One hook fixes all five surfaces that share `PrimaryGraph`: the Traces and Spans tabs, the Compare graph, Sessions and Users.

## Before / after

Measured on the local stack. The ticket's own case is the Voice project:

| Project | Evals before | Evals after | Annotations before | after |
| --- | --- | --- | --- | --- |
| Voice Sim Demo | 20 | **3** | 7 | **2** |
| cookbook-observe-demo | 20 | **13** | 7 | **2** |

Voice Sim Demo now lists exactly `customer_agent_clarification_seeking`, `customer_agent_task_completion`, `tone` — the whole section fits without scrolling, versus the ticket video where the reporter scrolled through dozens of other people's test evals.

**Voice Sim Demo** — the ticket's own project. Before: other people's scratch evals (`dfgdfgdfg343434`, `draft-23004c29`, `xbvbjuiirtertcdfgdfg`, `jkljkljklasdasd`), mid-scroll through dozens. After: its own three, whole section visible at once.

| Before | After |
| --- | --- |
| <img width="480" src="https://github.com/user-attachments/assets/19f0d574-af1c-4f28-b4f5-11403ebe3958" /> | <img width="480" src="https://github.com/user-attachments/assets/a2eb00f2-5e30-445d-b685-32e228db2dfa" /> |

**cookbook-observe-demo** — shows the change runs in both directions. The junk disappears *and* the project's real evals (`customer_agent_clarification_seeking`, `eval_ranking`, `text_to_sql`, `tone`, `toxicity`, `word_info_preserved`) appear, having previously been absent.

| Before | After |
| --- | --- |
| <img width="480" src="https://github.com/user-attachments/assets/dcff3b16-9cb6-4ff7-a5e4-3494c4312ae9" /> | <img width="480" src="https://github.com/user-attachments/assets/52888f8d-d3de-4190-a18b-cbfaea98899f" /> |

Both captured on the same local stack, same projects, fix toggled — not from different environments.

## Reviewers: the list changes in BOTH directions

Scoping does not only remove foreign evals — it changes the source the backend reads from (ClickHouse used-templates + a `CustomEvalConfig` fallback, instead of every org `EvalTemplate`). So project evals **appear** that were previously missing: `toxicity`, `tone`, `text_to_sql`, `eval_ranking` show up on cookbook-observe-demo only after this change. Added rows are correct, not a regression.

## A second bug this had to fix

Per-project cache keys create a loading window that did not exist before — previously one shared entry meant the catalog was always warm on a project switch.

During that window `metricDef` falls back to a hardcoded `latency` (`PrimaryGraph.jsx`), while the graph-data query keyed only on `selectedMetric`. So: the request fired for latency under a key naming the *eval*, the catalog then arrived and `metricDef` became the eval, the key never changed, and React Query never refetched — **the chart rendered latency data under the eval's name and unit**.

`metricDef.id`/`apiType` now key that query. A selection missing from the newly loaded catalog is also reset, so the trigger label and the picker highlight agree instead of leaving an unhighlighted dropdown.

This is covered by a test that fails on the old code with `Expected "id": "eval-uuid-1" / Received "id": "latency"`.

## Testing

- **Unit** — 3 new tests in `PrimaryGraph.test.jsx`: the request carries `project_ids`; one project's catalog is not served to another (shared `QueryClient`, which is what reproduces the cache bleed); the graph refetches once the catalog resolves the selected metric. Full `src/sections/projects` suite: 320 passed / 41 files.
- **E2E** — new flow `OBS-E2E-003` in `e2e/flows/observe/graph-metric-scoping.spec.ts`. Seeds two projects in one org, attaches a distinctly-named eval to each, and asserts both the API lane (each project's scoped catalog contains its own eval and not its sibling's) and the UI lane (the picker lists one and not the other), plus a request-level assertion that the FE actually sends `project_ids`.
- **Manual** — all five surfaces driven in a real browser: 14 catalog requests, **0 without `project_ids`**. Cross-project navigation without reload re-scopes correctly and the carried-over eval is correctly absent.
- **Perf** — cold per-project catalog 106ms, warm 45ms. The key is one nothing else populates, so every project's first picker open pays it; on this dataset it is not noticeable.

## Known gap, tracked separately

The catalog's scoped annotation branch includes only labels that have a **score in the project**, while the canonical helper `get_annotation_labels_for_project` uses *owned by the project* **OR** *scored in it*. So a label created on a project but never yet applied will not appear in the graph picker, though it still appears in the trace filter panel — and `graph_dispatch.py` will happily *plot* a label this list refuses to show.

That is a backend fix (~3 lines, no existing test breaks) and is tracked separately as [TH-7717](https://linear.app/future-agi/issue/TH-7717) (sub-issue of TH-6787, assigned to Jayasurya) — deliberately not bundled here. It does not affect evals, which have a `CustomEvalConfig` fallback covering "attached but not yet run".

Also out of scope: `useDashboardMetricsPaginated` sends no `project_ids`, so the **dashboard widget** metric picker is still org-wide. Deliberately not touched here.
