### PR TITLE
feat: add HTTP Request node with SSRF-protected runner and config persistence

### DIFF
--- a/api_contracts/openapi/swagger.json
+++ b/api_contracts/openapi/swagger.json
@@ -79000,6 +79000,11 @@
                 "prompt_template": {
                     "$ref": "#/definitions/PromptTemplateData"
                 },
+                "config": {
+                    "title": "Config",
+                    "type": "object",
+                    "default": {}
+                },
                 "ports": {
                     "type": "array",
                     "items": {
@@ -79124,6 +79129,13 @@
                     "readOnly": true,
                     "x-nullable": true
                 },
+                "node_template_name": {
+                    "title": "Node template name",
+                    "type": "string",
+                    "readOnly": true,
+                    "minLength": 1,
+                    "x-nullable": true
+                },
                 "ref_graph_version_id": {
                     "title": "Ref graph version id",
                     "type": "string",
@@ -79184,6 +79196,10 @@
                 },
                 "prompt_template": {
                     "$ref": "#/definitions/PromptTemplateData"
+                },
+                "config": {
+                    "title": "Config",
+                    "type": "object"
                 },
                 "ref_graph_version_id": {
                     "title": "Ref graph version id",

--- a/frontend/src/api/agent-playground/node-templates.js
+++ b/frontend/src/api/agent-playground/node-templates.js
@@ -1,6 +1,9 @@
 import { useQuery } from "@tanstack/react-query";
 import axios, { endpoints } from "src/utils/axios";
-import { NODE_TYPES } from "../../sections/agent-playground/utils/constants";
+import {
+  NODE_TYPES,
+  NODE_TYPE_CONFIG,
+} from "../../sections/agent-playground/utils/constants";
 
 /**
  * Hook for fetching graphs that can be referenced as agent nodes.
@@ -19,25 +22,36 @@ export const useGetReferenceableGraphs = (graphId, options = {}) =>
   });
 
 /**
- * Hook for fetching node templates. Filters to llm_prompt only for now.
+ * Hook for fetching node templates.
  * Maps API shape to NodeCard shape: { id, node_template_id, title, description, iconSrc, color }
  * @param {object} options - Additional react-query options
  */
+const PALETTE_TEMPLATE_NAMES = [
+  NODE_TYPES.LLM_PROMPT,
+  NODE_TYPES.HTTP_REQUEST,
+];
+
 export const useGetNodeTemplates = (options = {}) =>
   useQuery({
     queryKey: ["agent-playground", "node-templates"],
     queryFn: () => axios.get(endpoints.agentPlayground.nodeTemplates),
     select: (res) =>
       (res.data?.result?.node_templates ?? [])
-        .filter((t) => t.name === NODE_TYPES.LLM_PROMPT)
-        .map((t) => ({
-          id: t.name,
-          node_template_id: t.id,
-          title: t.display_name,
-          description: t.description,
-          iconSrc: "/assets/icons/ic_chat_single.svg",
-          color: "orange.500",
-        })),
+        .filter((t) => PALETTE_TEMPLATE_NAMES.includes(t.name))
+        .map((t) => {
+          const typeConfig = NODE_TYPE_CONFIG[t.name] || {
+            iconSrc: "/assets/icons/ic_chat_single.svg",
+            color: "orange.500",
+          };
+          return {
+            id: t.name,
+            node_template_id: t.id,
+            title: t.display_name,
+            description: t.description,
+            iconSrc: typeConfig.iconSrc,
+            color: typeConfig.color,
+          };
+        }),
     staleTime: 5 * 60 * 1000,
     ...options,
   });

--- a/frontend/src/api/contracts/openapi-contract.generated.js
+++ b/frontend/src/api/contracts/openapi-contract.generated.js
@@ -50619,6 +50619,11 @@ export const OPENAPI_CONTRACT = Object.freeze({
         "prompt_template": {
           "$ref": "#/definitions/PromptTemplateData"
         },
+        "config": {
+          "title": "Config",
+          "type": "object",
+          "default": {}
+        },
         "ports": {
           "type": "array",
           "items": {
@@ -61695,6 +61700,13 @@ export const OPENAPI_CONTRACT = Object.freeze({
           "type": "string",
           "format": "uuid",
           "readOnly": true,
+          "x-nullable": true
+        },
+        "node_template_name": {
+          "title": "Node template name",
+          "type": "string",
+          "readOnly": true,
+          "minLength": 1,
           "x-nullable": true
         },
         "ref_graph_version_id": {
@@ -72966,6 +72978,10 @@ export const OPENAPI_CONTRACT = Object.freeze({
         },
         "prompt_template": {
           "$ref": "#/definitions/PromptTemplateData"
+        },
+        "config": {
+          "title": "Config",
+          "type": "object"
         },
         "ref_graph_version_id": {
           "title": "Ref graph version id",

--- a/frontend/src/generated/api-contracts/api.schemas.ts
+++ b/frontend/src/generated/api-contracts/api.schemas.ts
@@ -1965,6 +1965,8 @@ export const CreateNodeApiType = {
 
 export type CreateNodeApiPosition = { [key: string]: unknown };
 
+export type CreateNodeApiConfig = { [key: string]: unknown };
+
 /**
  * Type of content item
  */
@@ -2126,6 +2128,7 @@ export interface CreateNodeApi {
   position?: CreateNodeApiPosition;
   source_node_id?: string;
   prompt_template?: PromptTemplateDataApi;
+  config?: CreateNodeApiConfig;
   ports?: PortCreateApi[];
   /** List of input mappings from port display_name to source reference */
   input_mappings?: InputMappingApi[];
@@ -2204,6 +2207,8 @@ export interface NodeReadApi {
   /** UI coordinates {"x": 0, "y": 0} */
   readonly position?: NodeReadApiPosition;
   readonly node_template_id?: string;
+  /** @minLength 1 */
+  readonly node_template_name?: string;
   readonly ref_graph_version_id?: string;
   /** @minLength 1 */
   readonly ref_graph_name?: string;
@@ -2216,6 +2221,8 @@ export interface NodeReadApi {
 
 export type UpdateNodeApiPosition = { [key: string]: unknown };
 
+export type UpdateNodeApiConfig = { [key: string]: unknown };
+
 export interface UpdateNodeApi {
   /**
      * @minLength 1
@@ -2224,6 +2231,7 @@ export interface UpdateNodeApi {
   name?: string;
   position?: UpdateNodeApiPosition;
   prompt_template?: PromptTemplateDataApi;
+  config?: UpdateNodeApiConfig;
   ref_graph_version_id?: string;
   /** List of input mappings from port display_name to source reference */
   input_mappings?: InputMappingApi[];

--- a/frontend/src/generated/api-contracts/api.zod.ts
+++ b/frontend/src/generated/api-contracts/api.zod.ts
@@ -3182,6 +3182,7 @@ export const agentPlaygroundGraphsVersionsNodesCreateBodyPositionDefault = {  };
 
 export const agentPlaygroundGraphsVersionsNodesCreateBodyPromptTemplateResponseFormatDefault = `text`;
 export const agentPlaygroundGraphsVersionsNodesCreateBodyPromptTemplateSavePromptVersionDefault = false;
+export const agentPlaygroundGraphsVersionsNodesCreateBodyConfigDefault = {  };
 export const agentPlaygroundGraphsVersionsNodesCreateBodyPortsItemKeyMax = 100;
 
 export const agentPlaygroundGraphsVersionsNodesCreateBodyPortsItemDisplayNameMax = 100;
@@ -3237,6 +3238,9 @@ export const AgentPlaygroundGraphsVersionsNodesCreateBody = zod.object({
   "template_format": zod.string().optional().describe('Template format: \'mustache\' or \'jinja\''),
   "save_prompt_version": zod.boolean().default(agentPlaygroundGraphsVersionsNodesCreateBodyPromptTemplateSavePromptVersionDefault)
 }).optional(),
+  "config": zod.object({
+
+}).passthrough().default(agentPlaygroundGraphsVersionsNodesCreateBodyConfigDefault),
   "ports": zod.array(zod.object({
   "id": zod.string().uuid().describe('FE-generated UUID'),
   "key": zod.string().min(1).max(agentPlaygroundGraphsVersionsNodesCreateBodyPortsItemKeyMax),
@@ -3269,6 +3273,7 @@ export const AgentPlaygroundGraphsVersionsNodesReadParams = zod.object({
 
 
 
+
 export const AgentPlaygroundGraphsVersionsNodesReadResponse = zod.object({
   "id": zod.string().uuid().optional(),
   "type": zod.enum(['subgraph', 'atomic']).optional().describe('\'subgraph\' for subgraph nodes, \'atomic\' for nodes using a NodeTemplate'),
@@ -3280,6 +3285,7 @@ export const AgentPlaygroundGraphsVersionsNodesReadResponse = zod.object({
 
 }).passthrough().optional().describe('UI coordinates {\"x\": 0, \"y\": 0}'),
   "node_template_id": zod.string().uuid().optional(),
+  "node_template_name": zod.string().min(1).optional(),
   "ref_graph_version_id": zod.string().uuid().optional(),
   "ref_graph_name": zod.string().min(1).optional(),
   "ref_graph_id": zod.string().uuid().optional(),
@@ -3372,6 +3378,9 @@ export const AgentPlaygroundGraphsVersionsNodesPartialUpdateBody = zod.object({
   "template_format": zod.string().optional().describe('Template format: \'mustache\' or \'jinja\''),
   "save_prompt_version": zod.boolean().default(agentPlaygroundGraphsVersionsNodesPartialUpdateBodyPromptTemplateSavePromptVersionDefault)
 }).optional(),
+  "config": zod.object({
+
+}).passthrough().optional(),
   "ref_graph_version_id": zod.string().uuid().optional(),
   "input_mappings": zod.array(zod.object({
   "key": zod.string().min(1).describe('Input port display_name'),
@@ -3446,6 +3455,9 @@ export const AgentPlaygroundGraphsVersionsNodesPartialUpdateResponse = zod.objec
   "template_format": zod.string().optional().describe('Template format: \'mustache\' or \'jinja\''),
   "save_prompt_version": zod.boolean().default(agentPlaygroundGraphsVersionsNodesPartialUpdateResponsePromptTemplateSavePromptVersionDefault)
 }).optional(),
+  "config": zod.object({
+
+}).passthrough().optional(),
   "ref_graph_version_id": zod.string().uuid().optional(),
   "input_mappings": zod.array(zod.object({
   "key": zod.string().min(1).describe('Input port display_name'),
@@ -3497,6 +3509,7 @@ export const AgentPlaygroundGraphsVersionsNodesPossibleEdgeMappingsQueryParams =
 
 
 
+
 export const AgentPlaygroundGraphsVersionsNodesPossibleEdgeMappingsResponse = zod.object({
   "count": zod.number(),
   "next": zod.string().url().optional(),
@@ -3512,6 +3525,7 @@ export const AgentPlaygroundGraphsVersionsNodesPossibleEdgeMappingsResponse = zo
 
 }).passthrough().optional().describe('UI coordinates {\"x\": 0, \"y\": 0}'),
   "node_template_id": zod.string().uuid().optional(),
+  "node_template_name": zod.string().min(1).optional(),
   "ref_graph_version_id": zod.string().uuid().optional(),
   "ref_graph_name": zod.string().min(1).optional(),
   "ref_graph_id": zod.string().uuid().optional(),

--- a/frontend/src/sections/agent-playground/AgentBuilder/GraphView.jsx
+++ b/frontend/src/sections/agent-playground/AgentBuilder/GraphView.jsx
@@ -12,7 +12,7 @@ import {
   useReactFlow,
 } from "@xyflow/react";
 import "@xyflow/react/dist/style.css";
-import { PromptNode, AgentNode, EvalNode } from "./nodes";
+import { PromptNode, AgentNode, EvalNode, HttpRequestNode } from "./nodes";
 import { AnimatedEdge } from "./edges";
 import { enqueueSnackbar } from "notistack";
 import {
@@ -38,6 +38,7 @@ const nodeTypes = {
   [NODE_TYPES.LLM_PROMPT]: PromptNode,
   agent: AgentNode,
   eval: EvalNode,
+  [NODE_TYPES.HTTP_REQUEST]: HttpRequestNode,
 };
 
 const edgeTypes = {

--- a/frontend/src/sections/agent-playground/AgentBuilder/NodeDrawer/NodeConfigurationForm.jsx
+++ b/frontend/src/sections/agent-playground/AgentBuilder/NodeDrawer/NodeConfigurationForm.jsx
@@ -1,12 +1,18 @@
 import React from "react";
 import PropTypes from "prop-types";
-import { PromptNodeForm, EvalsNodeForm, AgentNodeForm } from "./forms";
+import {
+  PromptNodeForm,
+  EvalsNodeForm,
+  AgentNodeForm,
+  HttpRequestNodeForm,
+} from "./forms";
 import { NODE_TYPES } from "../../utils/constants";
 
 const FORM_COMPONENTS = {
   [NODE_TYPES.LLM_PROMPT]: PromptNodeForm,
   eval: EvalsNodeForm,
   [NODE_TYPES.AGENT]: AgentNodeForm,
+  [NODE_TYPES.HTTP_REQUEST]: HttpRequestNodeForm,
 };
 
 export default function NodeConfigurationForm({ nodeType, nodeId }) {
@@ -20,7 +26,11 @@ export default function NodeConfigurationForm({ nodeType, nodeId }) {
 }
 
 NodeConfigurationForm.propTypes = {
-  nodeType: PropTypes.oneOf([NODE_TYPES.LLM_PROMPT, "eval", NODE_TYPES.AGENT])
-    .isRequired,
+  nodeType: PropTypes.oneOf([
+    NODE_TYPES.LLM_PROMPT,
+    "eval",
+    NODE_TYPES.AGENT,
+    NODE_TYPES.HTTP_REQUEST,
+  ]).isRequired,
   nodeId: PropTypes.string.isRequired,
 };

--- a/frontend/src/sections/agent-playground/AgentBuilder/NodeDrawer/__tests__/httpRequestForm.test.js
+++ b/frontend/src/sections/agent-playground/AgentBuilder/NodeDrawer/__tests__/httpRequestForm.test.js
@@ -1,0 +1,153 @@
+import { describe, it, expect } from "vitest";
+import {
+  httpRequestNodeFormSchema,
+  getNodeFormSchema,
+} from "../forms/nodeFormSchemas";
+import { getDefaultValues } from "../nodeFormUtils";
+import { NODE_TYPES } from "../../../utils/constants";
+
+const validForm = {
+  name: "fetch_users",
+  method: "GET",
+  url: "https://api.example.com/users",
+  headers: {},
+  body: "",
+  authType: "none",
+  authToken: "",
+  authUsername: "",
+  authPassword: "",
+  timeout: 30,
+  retries: 0,
+};
+
+describe("httpRequestNodeFormSchema", () => {
+  it("accepts a valid GET request form", () => {
+    const result = httpRequestNodeFormSchema.safeParse(validForm);
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects an empty url", () => {
+    const result = httpRequestNodeFormSchema.safeParse({
+      ...validForm,
+      url: "",
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects a url without http(s) scheme", () => {
+    const result = httpRequestNodeFormSchema.safeParse({
+      ...validForm,
+      url: "ftp://example.com",
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects an invalid method", () => {
+    const result = httpRequestNodeFormSchema.safeParse({
+      ...validForm,
+      method: "OPTIONS",
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects timeout above 300", () => {
+    const result = httpRequestNodeFormSchema.safeParse({
+      ...validForm,
+      timeout: 301,
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects retries above 5", () => {
+    const result = httpRequestNodeFormSchema.safeParse({
+      ...validForm,
+      retries: 6,
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects an invalid node name", () => {
+    const result = httpRequestNodeFormSchema.safeParse({
+      ...validForm,
+      name: "Fetch Users!",
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("applies defaults for optional fields", () => {
+    const result = httpRequestNodeFormSchema.safeParse({
+      name: "fetch_users",
+      method: "GET",
+      url: "https://api.example.com",
+    });
+    expect(result.success).toBe(true);
+    expect(result.data.headers).toEqual({});
+    expect(result.data.authType).toBe("none");
+    expect(result.data.timeout).toBe(30);
+    expect(result.data.retries).toBe(0);
+  });
+});
+
+describe("getNodeFormSchema dispatch", () => {
+  it("returns the http request schema for HTTP_REQUEST nodes", () => {
+    expect(getNodeFormSchema(NODE_TYPES.HTTP_REQUEST)).toBe(
+      httpRequestNodeFormSchema,
+    );
+  });
+});
+
+describe("getDefaultValues — http_request", () => {
+  it("returns defaults for a fresh http_request node", () => {
+    const values = getDefaultValues({
+      type: NODE_TYPES.HTTP_REQUEST,
+      data: { label: "http_1" },
+    });
+    expect(values.method).toBe("GET");
+    expect(values.url).toBe("");
+    expect(values.headers).toEqual({});
+    expect(values.authType).toBe("none");
+    expect(values.timeout).toBe(30);
+    expect(values.retries).toBe(0);
+  });
+
+  it("hydrates form fields from stored config", () => {
+    const values = getDefaultValues({
+      type: NODE_TYPES.HTTP_REQUEST,
+      data: {
+        label: "fetch_users",
+        config: {
+          method: "POST",
+          url: "https://api.example.com/users/{{user_id}}",
+          headers: { "X-Api-Key": "{{api_key}}" },
+          body: '{"name": "test"}',
+          auth: { type: "bearer", token: "secret" },
+          timeout: 15,
+          retries: 2,
+        },
+      },
+    });
+    expect(values.method).toBe("POST");
+    expect(values.url).toBe("https://api.example.com/users/{{user_id}}");
+    expect(values.headers).toEqual({ "X-Api-Key": "{{api_key}}" });
+    expect(values.body).toBe('{"name": "test"}');
+    expect(values.authType).toBe("bearer");
+    expect(values.authToken).toBe("secret");
+    expect(values.timeout).toBe(15);
+    expect(values.retries).toBe(2);
+  });
+
+  it("hydrates basic auth credentials", () => {
+    const values = getDefaultValues({
+      type: NODE_TYPES.HTTP_REQUEST,
+      data: {
+        label: "fetch_users",
+        config: {
+          auth: { type: "basic", username: "admin", password: "pw" },
+        },
+      },
+    });
+    expect(values.authType).toBe("basic");
+    expect(values.authUsername).toBe("admin");
+    expect(values.authPassword).toBe("pw");
+  });
+});

--- a/frontend/src/sections/agent-playground/AgentBuilder/NodeDrawer/forms/HttpRequestNodeForm.jsx
+++ b/frontend/src/sections/agent-playground/AgentBuilder/NodeDrawer/forms/HttpRequestNodeForm.jsx
@@ -1,0 +1,363 @@
+import React, { useMemo, useState } from "react";
+import PropTypes from "prop-types";
+import {
+  Box,
+  Divider,
+  IconButton,
+  MenuItem,
+  Select,
+  Stack,
+  TextField,
+  Typography,
+} from "@mui/material";
+import LoadingButton from "@mui/lab/LoadingButton";
+import { useFormContext, useWatch } from "react-hook-form";
+import { enqueueSnackbar } from "notistack";
+import FormTextFieldV2 from "src/components/FormTextField/FormTextFieldV2";
+import Iconify from "src/components/iconify";
+import {
+  useAgentPlaygroundStore,
+  useAgentPlaygroundStoreShallow,
+} from "../../../store";
+import usePartialNodeUpdate from "../../hooks/usePartialNodeUpdate";
+import { useSaveDraftContext } from "../../saveDraftContext";
+import VariableAccessInfo from "../../../components/VariableAccessInfo";
+
+const HTTP_METHODS = ["GET", "POST", "PUT", "PATCH", "DELETE"];
+const AUTH_TYPES = [
+  { value: "none", label: "None" },
+  { value: "bearer", label: "Bearer Token" },
+  { value: "basic", label: "Basic Auth" },
+];
+
+function headersToRows(headers) {
+  return Object.entries(headers || {}).map(([key, value], index) => ({
+    id: `${key}-${index}`,
+    key,
+    value,
+  }));
+}
+
+function rowsToHeaders(rows) {
+  const headers = {};
+  rows.forEach((row) => {
+    if (row.key.trim()) {
+      headers[row.key.trim()] = row.value;
+    }
+  });
+  return headers;
+}
+
+function buildHttpConfig(data) {
+  let body = data.body;
+  if (typeof body === "string" && body.trim()) {
+    try {
+      body = JSON.parse(body);
+    } catch {
+      body = data.body;
+    }
+  } else if (!body || (typeof body === "string" && !body.trim())) {
+    body = null;
+  }
+
+  const auth = { type: data.authType || "none" };
+  if (data.authType === "bearer") {
+    auth.token = data.authToken || "";
+  } else if (data.authType === "basic") {
+    auth.username = data.authUsername || "";
+    auth.password = data.authPassword || "";
+  }
+
+  return {
+    method: data.method,
+    url: data.url,
+    headers: data.headers || {},
+    body,
+    auth,
+    timeout: data.timeout ?? 30,
+    retries: data.retries ?? 0,
+  };
+}
+
+export default function HttpRequestNodeForm({ nodeId }) {
+  const { handleSubmit, control, setValue } = useFormContext();
+  const authType = useWatch({ name: "authType" });
+  const method = useWatch({ name: "method" });
+
+  const [headerRows, setHeaderRows] = useState(() => {
+    const node = useAgentPlaygroundStore.getState().getNodeById(nodeId);
+    return headersToRows(node?.data?.config?.headers);
+  });
+
+  const { updateNodeData, clearSelectedNode, clearValidationErrorNode } =
+    useAgentPlaygroundStoreShallow((state) => ({
+      updateNodeData: state.updateNodeData,
+      clearSelectedNode: state.clearSelectedNode,
+      clearValidationErrorNode: state.clearValidationErrorNode,
+    }));
+  const { partialUpdate, isPending } = usePartialNodeUpdate();
+  const { ensureDraft } = useSaveDraftContext();
+
+  const showBody = useMemo(() => method && method !== "GET", [method]);
+
+  const handleHeaderRowChange = (id, field, value) => {
+    setHeaderRows((rows) =>
+      rows.map((row) => (row.id === id ? { ...row, [field]: value } : row)),
+    );
+  };
+
+  const handleAddHeaderRow = () => {
+    setHeaderRows((rows) => [
+      ...rows,
+      { id: `header-${Date.now()}`, key: "", value: "" },
+    ]);
+  };
+
+  const handleRemoveHeaderRow = (id) => {
+    setHeaderRows((rows) => rows.filter((row) => row.id !== id));
+  };
+
+  const onSave = async (data) => {
+    const storeState = useAgentPlaygroundStore.getState();
+    const otherNodes = storeState.nodes.filter((n) => n.id !== nodeId);
+    if (otherNodes.some((n) => n.data?.label === data.name)) {
+      enqueueSnackbar("A node with this name already exists", {
+        variant: "error",
+      });
+      return;
+    }
+
+    const config = buildHttpConfig({
+      ...data,
+      headers: rowsToHeaders(headerRows),
+    });
+
+    const draftResult = await ensureDraft();
+    if (draftResult === false) return;
+
+    clearValidationErrorNode(nodeId);
+    updateNodeData(nodeId, { label: data.name, config });
+
+    try {
+      await partialUpdate(nodeId, {
+        label: data.name,
+        config,
+      });
+      enqueueSnackbar("HTTP request node saved", { variant: "success" });
+      clearSelectedNode();
+    } catch (error) {
+      enqueueSnackbar(error?.message || "Failed to save node", {
+        variant: "error",
+      });
+    }
+  };
+
+  return (
+    <Box
+      sx={{
+        display: "flex",
+        flexDirection: "column",
+        gap: 1.25,
+        height: "100%",
+      }}
+    >
+      <FormTextFieldV2
+        fullWidth
+        size="small"
+        control={control}
+        fieldName="name"
+        label="Node Name"
+        required
+      />
+
+      <Stack direction="row" spacing={1}>
+        <Select
+          size="small"
+          value={method || "GET"}
+          onChange={(e) =>
+            setValue("method", e.target.value, { shouldDirty: true })
+          }
+          sx={{ width: 130 }}
+        >
+          {HTTP_METHODS.map((m) => (
+            <MenuItem key={m} value={m}>
+              {m}
+            </MenuItem>
+          ))}
+        </Select>
+        <FormTextFieldV2
+          fullWidth
+          size="small"
+          control={control}
+          fieldName="url"
+          label="URL"
+          placeholder="https://api.example.com/users/{{user_id}}"
+          required
+        />
+      </Stack>
+
+      <Divider />
+
+      <Box sx={{ flex: 1, overflowY: "auto", minHeight: 0 }}>
+        <Stack spacing={1.5}>
+          <VariableAccessInfo />
+
+          <Stack
+            direction="row"
+            alignItems="center"
+            justifyContent="space-between"
+          >
+            <Typography typography="s1_2" fontWeight="fontWeightMedium">
+              Headers
+            </Typography>
+            <IconButton size="small" onClick={handleAddHeaderRow}>
+              <Iconify icon="solar:add-circle-outline" width={20} />
+            </IconButton>
+          </Stack>
+
+          {headerRows.map((row) => (
+            <Stack
+              key={row.id}
+              direction="row"
+              spacing={1}
+              alignItems="center"
+            >
+              <TextField
+                size="small"
+                placeholder="Key"
+                value={row.key}
+                onChange={(e) =>
+                  handleHeaderRowChange(row.id, "key", e.target.value)
+                }
+                sx={{ flex: 1 }}
+              />
+              <TextField
+                size="small"
+                placeholder="Value or {{variable}}"
+                value={row.value}
+                onChange={(e) =>
+                  handleHeaderRowChange(row.id, "value", e.target.value)
+                }
+                sx={{ flex: 2 }}
+              />
+              <IconButton
+                size="small"
+                onClick={() => handleRemoveHeaderRow(row.id)}
+              >
+                <Iconify icon="solar:trash-bin-trash-outline" width={18} />
+              </IconButton>
+            </Stack>
+          ))}
+
+          {showBody && (
+            <FormTextFieldV2
+              fullWidth
+              size="small"
+              control={control}
+              fieldName="body"
+              label="Body (JSON or text)"
+              placeholder='{"name": "{{name}}"}'
+              multiline
+              minRows={4}
+            />
+          )}
+
+          <Divider />
+
+          <Typography typography="s1_2" fontWeight="fontWeightMedium">
+            Authentication
+          </Typography>
+          <Select
+            size="small"
+            value={authType || "none"}
+            onChange={(e) =>
+              setValue("authType", e.target.value, { shouldDirty: true })
+            }
+          >
+            {AUTH_TYPES.map((option) => (
+              <MenuItem key={option.value} value={option.value}>
+                {option.label}
+              </MenuItem>
+            ))}
+          </Select>
+
+          {authType === "bearer" && (
+            <FormTextFieldV2
+              fullWidth
+              size="small"
+              control={control}
+              fieldName="authToken"
+              label="Bearer Token"
+              placeholder="Token or {{variable}}"
+            />
+          )}
+
+          {authType === "basic" && (
+            <>
+              <FormTextFieldV2
+                fullWidth
+                size="small"
+                control={control}
+                fieldName="authUsername"
+                label="Username"
+              />
+              <FormTextFieldV2
+                fullWidth
+                size="small"
+                control={control}
+                fieldName="authPassword"
+                label="Password"
+                fieldType="password"
+              />
+            </>
+          )}
+
+          <Divider />
+
+          <Stack direction="row" spacing={1}>
+            <FormTextFieldV2
+              fullWidth
+              size="small"
+              control={control}
+              fieldName="timeout"
+              label="Timeout (seconds)"
+              fieldType="number"
+            />
+            <FormTextFieldV2
+              fullWidth
+              size="small"
+              control={control}
+              fieldName="retries"
+              label="Retries"
+              fieldType="number"
+            />
+          </Stack>
+        </Stack>
+      </Box>
+
+      <Box
+        sx={{
+          display: "flex",
+          justifyContent: "flex-end",
+          pt: 1.5,
+          borderTop: 1,
+          borderColor: "divider",
+        }}
+      >
+        <LoadingButton
+          type="submit"
+          variant="outlined"
+          size="small"
+          loading={isPending}
+          onClick={handleSubmit(onSave)}
+        >
+          Save
+        </LoadingButton>
+      </Box>
+    </Box>
+  );
+}
+
+HttpRequestNodeForm.propTypes = {
+  nodeId: PropTypes.string.isRequired,
+};

--- a/frontend/src/sections/agent-playground/AgentBuilder/NodeDrawer/forms/index.js
+++ b/frontend/src/sections/agent-playground/AgentBuilder/NodeDrawer/forms/index.js
@@ -1,3 +1,4 @@
 export { default as PromptNodeForm } from "./PromptNodeForm";
 export { default as EvalsNodeForm } from "./EvalsNodeForm";
 export { default as AgentNodeForm } from "./AgentNodeForm";
+export { default as HttpRequestNodeForm } from "./HttpRequestNodeForm";

--- a/frontend/src/sections/agent-playground/AgentBuilder/NodeDrawer/forms/nodeFormSchemas.js
+++ b/frontend/src/sections/agent-playground/AgentBuilder/NodeDrawer/forms/nodeFormSchemas.js
@@ -148,6 +148,35 @@ export const evalNodeFormSchema = z.object({
 });
 
 /**
+ * Schema for HTTP Request Node Form
+ */
+export const httpRequestNodeFormSchema = z.object({
+  nodeType: z.literal(NODE_TYPES.HTTP_REQUEST).optional(),
+  nodeId: z.string().optional(),
+  name: z
+    .string()
+    .min(1, "Node name is required")
+    .regex(
+      /^[a-z][a-z0-9_]*$/,
+      "Name must be lowercase letters, numbers, and underscores only",
+    )
+    .trim(),
+  method: z.enum(["GET", "POST", "PUT", "PATCH", "DELETE"]),
+  url: z
+    .string()
+    .min(1, "URL is required")
+    .regex(/^https?:\/\//, "URL must start with http:// or https://"),
+  headers: z.record(z.string()).optional().default({}),
+  body: z.union([z.string(), z.object({}).passthrough()]).optional(),
+  authType: z.enum(["none", "bearer", "basic"]).optional().default("none"),
+  authToken: z.string().optional().default(""),
+  authUsername: z.string().optional().default(""),
+  authPassword: z.string().optional().default(""),
+  timeout: z.number().min(1).max(300).optional().default(30),
+  retries: z.number().min(0).max(5).optional().default(0),
+});
+
+/**
  * Get the appropriate schema based on node type
  * @param {string} nodeType - The type of node ('prompt', 'agent', 'eval')
  * @returns {z.ZodSchema} The Zod schema for the node type
@@ -158,6 +187,8 @@ export function getNodeFormSchema(nodeType) {
       return getPromptNodeFormSchema();
     case NODE_TYPES.AGENT:
       return agentNodeFormSchema;
+    case NODE_TYPES.HTTP_REQUEST:
+      return httpRequestNodeFormSchema;
     case "eval":
       return evalNodeFormSchema;
     default:

--- a/frontend/src/sections/agent-playground/AgentBuilder/NodeDrawer/nodeFormUtils.js
+++ b/frontend/src/sections/agent-playground/AgentBuilder/NodeDrawer/nodeFormUtils.js
@@ -167,6 +167,22 @@ export function getDefaultValues(nodeData) {
     };
   }
 
+  if (nodeData?.type === NODE_TYPES.HTTP_REQUEST) {
+    return {
+      ...baseValues,
+      method: mergedConfig?.method || "GET",
+      url: mergedConfig?.url || "",
+      headers: mergedConfig?.headers || {},
+      body: mergedConfig?.body ?? "",
+      authType: mergedConfig?.auth?.type || "none",
+      authToken: mergedConfig?.auth?.token || "",
+      authUsername: mergedConfig?.auth?.username || "",
+      authPassword: mergedConfig?.auth?.password || "",
+      timeout: mergedConfig?.timeout ?? 30,
+      retries: mergedConfig?.retries ?? 0,
+    };
+  }
+
   return baseValues;
 }
 

--- a/frontend/src/sections/agent-playground/AgentBuilder/hooks/useAddNodeOptimistic.js
+++ b/frontend/src/sections/agent-playground/AgentBuilder/hooks/useAddNodeOptimistic.js
@@ -108,6 +108,9 @@ export default function useAddNodeOptimistic() {
                   ],
             },
           }),
+          ...(payload.type === NODE_TYPES.HTTP_REQUEST && {
+            config: config || {},
+          }),
         },
       })
         .then((apiResult) => {

--- a/frontend/src/sections/agent-playground/AgentBuilder/hooks/usePartialNodeUpdate.js
+++ b/frontend/src/sections/agent-playground/AgentBuilder/hooks/usePartialNodeUpdate.js
@@ -31,6 +31,17 @@ function buildAgentPatchPayload(updateData) {
 }
 
 /**
+ * Build PATCH payload for http_request nodes.
+ * Sends name and the raw node config (method, url, headers, body, auth, ...).
+ */
+function buildHttpRequestPatchPayload(updateData) {
+  const patch = {};
+  if (updateData.label) patch.name = updateData.label;
+  if (updateData.config) patch.config = updateData.config;
+  return patch;
+}
+
+/**
  * Wraps the partial update API.
  * Transforms store-shaped nodeUpdate into contract-shaped PATCH payload
  * using prompt_template_id/prompt_version_id from the store.
@@ -45,10 +56,14 @@ export default function usePartialNodeUpdate() {
       const config = node?.data?.config;
       const graphId = state.currentAgent?.id;
       const versionId = state.currentAgent?.version_id;
-      const apiPayload =
-        node?.type === NODE_TYPES.LLM_PROMPT
-          ? buildPatchPayload(updateData, config)
-          : buildAgentPatchPayload(updateData);
+      let apiPayload;
+      if (node?.type === NODE_TYPES.LLM_PROMPT) {
+        apiPayload = buildPatchPayload(updateData, config);
+      } else if (node?.type === NODE_TYPES.HTTP_REQUEST) {
+        apiPayload = buildHttpRequestPatchPayload(updateData);
+      } else {
+        apiPayload = buildAgentPatchPayload(updateData);
+      }
 
       return mutateAsync({ graphId, versionId, nodeId, data: apiPayload });
     },

--- a/frontend/src/sections/agent-playground/AgentBuilder/nodes/BaseNode.jsx
+++ b/frontend/src/sections/agent-playground/AgentBuilder/nodes/BaseNode.jsx
@@ -28,6 +28,7 @@ const BaseNode = ({
   data,
   isConnectable,
   selected: _UI_SELECTED_NODE,
+  content,
 }) => {
   const { label, preview, ports } = data;
   const outputPort = ports?.find((p) => p.direction === PORT_DIRECTION.OUTPUT);
@@ -192,6 +193,10 @@ const BaseNode = ({
           )}
         </Stack>
 
+        {content && (
+          <Box sx={{ width: 200, maxWidth: 200, mt: 0.75 }}>{content}</Box>
+        )}
+
         {/* Single output handle (right side) */}
         <Handle
           type="source"
@@ -288,6 +293,7 @@ BaseNode.propTypes = {
   }).isRequired,
   isConnectable: PropTypes.bool,
   selected: PropTypes.bool,
+  content: PropTypes.node,
 };
 
 const MemoizedBaseNode = memo(BaseNode);

--- a/frontend/src/sections/agent-playground/AgentBuilder/nodes/HttpRequestNode.jsx
+++ b/frontend/src/sections/agent-playground/AgentBuilder/nodes/HttpRequestNode.jsx
@@ -1,0 +1,77 @@
+import React, { memo } from "react";
+import PropTypes from "prop-types";
+import { Box, Chip, Typography } from "@mui/material";
+import BaseNode from "./BaseNode";
+import { NODE_TYPES } from "../../utils/constants";
+
+const METHOD_COLORS = {
+  GET: "green.600",
+  POST: "blue.600",
+  PUT: "orange.600",
+  PATCH: "purple.600",
+  DELETE: "red.600",
+};
+
+function truncateUrl(url, maxLength = 32) {
+  if (!url) return "";
+  return url.length > maxLength ? `${url.slice(0, maxLength)}...` : url;
+}
+
+const HttpRequestNode = ({ id, data, isConnectable, selected }) => {
+  const config = data?.config || {};
+  const method = config.method || "GET";
+  const url = config.url || "";
+
+  const content = url ? (
+    <Box
+      sx={{
+        display: "flex",
+        alignItems: "center",
+        gap: 0.75,
+        minWidth: 0,
+      }}
+    >
+      <Chip
+        label={method}
+        size="small"
+        sx={{
+          height: 18,
+          fontSize: 10,
+          fontWeight: "fontWeightBold",
+          bgcolor: (theme) => theme.palette[METHOD_COLORS[method]] || "grey.600",
+          color: "common.white",
+          "& .MuiChip-label": { px: 0.75 },
+        }}
+      />
+      <Typography
+        typography="s2_1"
+        color="text.secondary"
+        noWrap
+        title={url}
+        sx={{ minWidth: 0, flex: 1 }}
+      >
+        {truncateUrl(url)}
+      </Typography>
+    </Box>
+  ) : null;
+
+  return (
+    <BaseNode
+      id={id}
+      data={data}
+      isConnectable={isConnectable}
+      selected={selected}
+      type={NODE_TYPES.HTTP_REQUEST}
+      content={content}
+    />
+  );
+};
+
+HttpRequestNode.propTypes = {
+  id: PropTypes.string.isRequired,
+  data: PropTypes.object.isRequired,
+  isConnectable: PropTypes.bool,
+  selected: PropTypes.bool,
+};
+
+export default memo(HttpRequestNode);

--- a/frontend/src/sections/agent-playground/AgentBuilder/nodes/index.js
+++ b/frontend/src/sections/agent-playground/AgentBuilder/nodes/index.js
@@ -1,4 +1,5 @@
 export { default as PromptNode } from "./PromptNode";
 export { default as AgentNode } from "./AgentNode";
 export { default as EvalNode } from "./EvalNode";
+export { default as HttpRequestNode } from "./HttpRequestNode";
 export { default as BaseNode } from "./BaseNode";

--- a/frontend/src/sections/agent-playground/store/agent-playground-store.js
+++ b/frontend/src/sections/agent-playground/store/agent-playground-store.js
@@ -341,7 +341,17 @@ export const useAgentPlaygroundStore = create(
                 prompt_template_id: config?.prompt_template_id ?? null,
                 prompt_version_id: null,
               }
-            : {};
+            : type === NODE_TYPES.HTTP_REQUEST
+              ? {
+                  method: config?.method ?? "GET",
+                  url: config?.url ?? "",
+                  headers: config?.headers ?? {},
+                  body: config?.body ?? null,
+                  auth: config?.auth ?? { type: "none" },
+                  timeout: config?.timeout ?? 30,
+                  retries: config?.retries ?? 0,
+                }
+              : {};
 
         // Caller-provided config is transient — only for form population, not persisted
         const initialConfig =

--- a/frontend/src/sections/agent-playground/utils/__tests__/versionPayloadUtils-httpRequest.test.js
+++ b/frontend/src/sections/agent-playground/utils/__tests__/versionPayloadUtils-httpRequest.test.js
@@ -1,0 +1,106 @@
+import { describe, it, expect } from "vitest";
+import { parseVersionResponse } from "../versionPayloadUtils";
+import { API_NODE_TYPES, NODE_TYPES } from "../constants";
+
+function createApiHttpNode(overrides = {}) {
+  return {
+    id: "http-1",
+    type: API_NODE_TYPES.ATOMIC,
+    name: "Fetch users",
+    node_template_id: "tpl-http",
+    node_template_name: "http_request",
+    position: { x: 10, y: 20 },
+    config: {
+      method: "POST",
+      url: "https://api.example.com/users/{{user_id}}",
+      headers: { "X-Api-Key": "{{api_key}}" },
+      body: '{"name": "{{name}}"}',
+      auth: { type: "bearer", token: "{{token}}" },
+      timeout: 15,
+      retries: 2,
+    },
+    ports: [
+      {
+        id: "port-in-1",
+        key: "user_id",
+        display_name: "user_id",
+        direction: "input",
+        data_schema: { type: "string" },
+        required: true,
+      },
+      {
+        id: "port-out-1",
+        key: "response",
+        display_name: "response",
+        direction: "output",
+        data_schema: { type: "object" },
+        required: true,
+      },
+    ],
+    ...overrides,
+  };
+}
+
+describe("parseVersionResponse — http_request nodes", () => {
+  it("maps atomic nodes with node_template_name http_request to HTTP_REQUEST type", () => {
+    const { nodes } = parseVersionResponse({ nodes: [createApiHttpNode()] });
+    expect(nodes[0].type).toBe(NODE_TYPES.HTTP_REQUEST);
+  });
+
+  it("keeps atomic nodes without template name as LLM_PROMPT", () => {
+    const apiNode = createApiHttpNode();
+    delete apiNode.node_template_name;
+    const { nodes } = parseVersionResponse({ nodes: [apiNode] });
+    expect(nodes[0].type).toBe(NODE_TYPES.LLM_PROMPT);
+  });
+
+  it("carries raw config onto the node data", () => {
+    const { nodes } = parseVersionResponse({ nodes: [createApiHttpNode()] });
+    expect(nodes[0].data.config).toEqual({
+      method: "POST",
+      url: "https://api.example.com/users/{{user_id}}",
+      headers: { "X-Api-Key": "{{api_key}}" },
+      body: '{"name": "{{name}}"}',
+      auth: { type: "bearer", token: "{{token}}" },
+      timeout: 15,
+      retries: 2,
+    });
+  });
+
+  it("carries node_template_id and node_template_name", () => {
+    const { nodes } = parseVersionResponse({ nodes: [createApiHttpNode()] });
+    expect(nodes[0].data.node_template_id).toBe("tpl-http");
+    expect(nodes[0].data.node_template_name).toBe("http_request");
+  });
+
+  it("defaults config to empty object when missing", () => {
+    const apiNode = createApiHttpNode();
+    delete apiNode.config;
+    const { nodes } = parseVersionResponse({ nodes: [apiNode] });
+    expect(nodes[0].data.config).toEqual({});
+  });
+
+  it("maps ports with direction and schema", () => {
+    const { nodes } = parseVersionResponse({ nodes: [createApiHttpNode()] });
+    const ports = nodes[0].data.ports;
+    expect(ports).toHaveLength(2);
+    expect(ports[0]).toMatchObject({
+      id: "port-in-1",
+      key: "user_id",
+      direction: "input",
+    });
+    expect(ports[1]).toMatchObject({
+      id: "port-out-1",
+      key: "response",
+      direction: "output",
+    });
+  });
+
+  it("accepts camelCase API shape (nodeTemplateName)", () => {
+    const apiNode = createApiHttpNode();
+    apiNode.nodeTemplateName = "http_request";
+    delete apiNode.node_template_name;
+    const { nodes } = parseVersionResponse({ nodes: [apiNode] });
+    expect(nodes[0].type).toBe(NODE_TYPES.HTTP_REQUEST);
+  });
+});

--- a/frontend/src/sections/agent-playground/utils/constants.js
+++ b/frontend/src/sections/agent-playground/utils/constants.js
@@ -4,6 +4,7 @@ export const NODE_X_OFFSET = 450;
 export const NODE_TYPES = {
   LLM_PROMPT: "llm_prompt",
   AGENT: "agent",
+  HTTP_REQUEST: "http_request",
 };
 
 export const AGENT_NODE = {
@@ -21,6 +22,13 @@ export const NODE_TYPE_CONFIG = {
     description: "Run a prompt against an LLM",
     iconSrc: "/assets/icons/ic_chat_single.svg",
     color: "orange.500",
+  },
+  [NODE_TYPES.HTTP_REQUEST]: {
+    id: NODE_TYPES.HTTP_REQUEST,
+    title: "HTTP Request",
+    description: "Make an HTTP request to an external API",
+    iconSrc: "/assets/icons/integrations/cloud-storage.svg",
+    color: "blue.600",
   },
   [NODE_TYPES.AGENT]: AGENT_NODE,
 };

--- a/frontend/src/sections/agent-playground/utils/versionPayloadUtils.js
+++ b/frontend/src/sections/agent-playground/utils/versionPayloadUtils.js
@@ -292,19 +292,17 @@ export function parseVersionResponse(apiData) {
               },
               ref_graph_version_id: refGraphVersionId,
             }
-          : {
-              node_template_id:
-                node.nodeTemplateId ?? node.node_template_id ?? null,
-              prompt_template_id:
-                promptTemplate?.promptTemplateId ??
-                promptTemplate?.prompt_template_id ??
-                null,
-              prompt_version_id:
-                promptTemplate?.promptVersionId ??
-                promptTemplate?.prompt_version_id ??
-                null,
-              config: {
-                ...formConfig,
+          : nodeType === NODE_TYPES.HTTP_REQUEST
+            ? {
+                node_template_id:
+                  node.nodeTemplateId ?? node.node_template_id ?? null,
+                node_template_name:
+                  node.nodeTemplateName ?? node.node_template_name ?? null,
+                config: node.config || {},
+              }
+            : {
+                node_template_id:
+                  node.nodeTemplateId ?? node.node_template_id ?? null,
                 prompt_template_id:
                   promptTemplate?.promptTemplateId ??
                   promptTemplate?.prompt_template_id ??
@@ -313,19 +311,29 @@ export function parseVersionResponse(apiData) {
                   promptTemplate?.promptVersionId ??
                   promptTemplate?.prompt_version_id ??
                   null,
-                payload: {
-                  ...formConfig?.payload,
-                  promptConfig: [
-                    {
-                      configuration: {
-                        ...(promptTemplate || {}),
-                        responseFormat: promptTemplate?.response_format,
+                config: {
+                  ...formConfig,
+                  prompt_template_id:
+                    promptTemplate?.promptTemplateId ??
+                    promptTemplate?.prompt_template_id ??
+                    null,
+                  prompt_version_id:
+                    promptTemplate?.promptVersionId ??
+                    promptTemplate?.prompt_version_id ??
+                    null,
+                  payload: {
+                    ...formConfig?.payload,
+                    promptConfig: [
+                      {
+                        configuration: {
+                          ...(promptTemplate || {}),
+                          responseFormat: promptTemplate?.response_format,
+                        },
                       },
-                    },
-                  ],
+                    ],
+                  },
                 },
-              },
-            }),
+              }),
       },
     };
   });
@@ -353,11 +361,16 @@ export function parseVersionResponse(apiData) {
  * Map API node type to XYFlow node type.
  */
 function mapApiTypeToNodeType(apiNode) {
-  if (apiNode.type === API_NODE_TYPES.ATOMIC) {
-    return NODE_TYPES.LLM_PROMPT;
-  }
   if (apiNode.type === API_NODE_TYPES.SUBGRAPH) {
     return NODE_TYPES.AGENT;
+  }
+  const templateName =
+    apiNode.nodeTemplateName ?? apiNode.node_template_name ?? null;
+  if (templateName === NODE_TYPES.HTTP_REQUEST) {
+    return NODE_TYPES.HTTP_REQUEST;
+  }
+  if (apiNode.type === API_NODE_TYPES.ATOMIC) {
+    return NODE_TYPES.LLM_PROMPT;
   }
   return apiNode.type || NODE_TYPES.LLM_PROMPT;
 }

--- a/futureagi/agent_playground/serializers/node.py
+++ b/futureagi/agent_playground/serializers/node.py
@@ -22,6 +22,9 @@ class NodeReadSerializer(serializers.ModelSerializer):
     node_template_id = serializers.UUIDField(
         source="node_template.id", read_only=True, allow_null=True
     )
+    node_template_name = serializers.CharField(
+        source="node_template.name", read_only=True, allow_null=True, default=None
+    )
     ref_graph_version_id = serializers.UUIDField(
         source="ref_graph_version.id", read_only=True, allow_null=True
     )
@@ -50,6 +53,7 @@ class NodeReadSerializer(serializers.ModelSerializer):
             "config",
             "position",
             "node_template_id",
+            "node_template_name",
             "ref_graph_version_id",
             "ref_graph_name",
             "ref_graph_id",
@@ -501,6 +505,7 @@ class CreateNodeSerializer(serializers.Serializer):
     prompt_template = PromptTemplateDataSerializer(
         required=False, allow_null=True, default=None
     )
+    config = serializers.JSONField(required=False, default=dict)
     ports = PortCreateSerializer(many=True, required=False, default=list)
     input_mappings = InputMappingSerializer(
         many=True,
@@ -550,6 +555,7 @@ class UpdateNodeSerializer(serializers.Serializer):
     name = serializers.CharField(required=False, max_length=255)
     position = serializers.JSONField(required=False)
     prompt_template = PromptTemplateDataSerializer(required=False, allow_null=True)
+    config = serializers.JSONField(required=False)
     ref_graph_version_id = serializers.UUIDField(required=False, allow_null=True)
     input_mappings = InputMappingSerializer(
         many=True,

--- a/futureagi/agent_playground/services/engine/runners/__init__.py
+++ b/futureagi/agent_playground/services/engine/runners/__init__.py
@@ -6,6 +6,7 @@ Runners self-register on module import.
 
 Current runners:
     - llm_prompt: LLM completion using LiteLLM
+    - http_request: HTTP calls to external APIs with SSRF protection
 
 Adding a new runner:
     1. Create a new file (e.g., http_request.py)
@@ -16,4 +17,5 @@ Adding a new runner:
 
 # Import runner modules to trigger self-registration.
 # Add new runners here as they are created.
+import agent_playground.services.engine.runners.http_request  # noqa: F401
 import agent_playground.services.engine.runners.llm_prompt  # noqa: F401

--- a/futureagi/agent_playground/services/engine/runners/http_request.py
+++ b/futureagi/agent_playground/services/engine/runners/http_request.py
@@ -1,0 +1,244 @@
+"""
+HTTP Request Runner for Graph Execution Engine.
+
+This runner executes http_request nodes by making an HTTP call to an external
+API using the node's config (method, url, headers, body, auth, timeout,
+retries). Template variables in the URL, headers, and body are resolved from
+input ports using the same {{variable}} / dot-notation resolution as the
+llm_prompt runner.
+
+Security:
+    - SSRF protection: requests to private, loopback, link-local, and
+      reserved IP ranges are rejected. DNS resolution is checked before
+      the request is made.
+
+Output:
+    - response: dict with keys:
+        - status_code: int
+        - headers: dict
+        - body: parsed JSON (dict/list) when the response is JSON,
+                otherwise the raw text string
+"""
+
+import ipaddress
+import json
+import re
+import socket
+from typing import Any
+from urllib.parse import urlparse
+
+import requests
+
+from agent_playground.services.engine.node_runner import BaseNodeRunner, register_runner
+from agent_playground.services.engine.utils.json_path import resolve_variable
+
+_PLACEHOLDER_PATTERN = re.compile(r"\{\{\s*(?P<placeholder>.*?)\s*\}\}")
+
+_MAX_RESPONSE_BYTES = 5 * 1024 * 1024
+
+_ALLOWED_METHODS = {"GET", "POST", "PUT", "PATCH", "DELETE"}
+
+
+class SSRFError(ValueError):
+    """Raised when a request targets a blocked network address."""
+
+
+def _is_blocked_ip(ip_str: str) -> bool:
+    try:
+        ip = ipaddress.ip_address(ip_str)
+    except ValueError:
+        return True
+    return (
+        ip.is_private
+        or ip.is_loopback
+        or ip.is_link_local
+        or ip.is_reserved
+        or ip.is_multicast
+        or ip.is_unspecified
+    )
+
+
+def validate_url(url: str) -> None:
+    """
+    Validate that a URL is safe to request.
+
+    Raises:
+        SSRFError: If the URL scheme is not http/https or the host resolves
+                   to a blocked IP address.
+    """
+    parsed = urlparse(url)
+    if parsed.scheme not in ("http", "https"):
+        raise SSRFError(f"Blocked URL scheme '{parsed.scheme}': only http/https allowed")
+
+    hostname = parsed.hostname
+    if not hostname:
+        raise SSRFError("URL has no hostname")
+
+    try:
+        addr_info = socket.getaddrinfo(hostname, parsed.port or (443 if parsed.scheme == "https" else 80))
+    except socket.gaierror as e:
+        raise SSRFError(f"Cannot resolve hostname '{hostname}': {e}") from e
+
+    for _family, _, _, _, sockaddr in addr_info:
+        ip_str = str(sockaddr[0])
+        if _is_blocked_ip(ip_str):
+            raise SSRFError(
+                f"Blocked request to '{hostname}': resolves to private/reserved address {ip_str}"
+            )
+
+
+def interpolate_template(text: str, inputs: dict[str, Any]) -> str:
+    """
+    Replace {{variable}} placeholders in a string with resolved input values.
+
+    Uses the same resolution logic as the llm_prompt runner (dot notation,
+    global variable fallback).
+
+    Raises:
+        ValueError: If a placeholder cannot be resolved.
+    """
+
+    def _replace(match: re.Match) -> str:
+        variable_name = match.group("placeholder")
+        value = resolve_variable(variable_name, inputs)
+        if isinstance(value, (dict, list)):
+            return json.dumps(value)
+        return str(value)
+
+    return _PLACEHOLDER_PATTERN.sub(_replace, text)
+
+
+def interpolate_structure(value: Any, inputs: dict[str, Any]) -> Any:
+    """
+    Recursively interpolate {{variable}} placeholders in strings nested
+    inside dicts and lists.
+    """
+    if isinstance(value, str):
+        return interpolate_template(value, inputs)
+    if isinstance(value, dict):
+        return {k: interpolate_structure(v, inputs) for k, v in value.items()}
+    if isinstance(value, list):
+        return [interpolate_structure(item, inputs) for item in value]
+    return value
+
+
+class HttpRequestRunner(BaseNodeRunner):
+    """
+    Runner for http_request template nodes.
+
+    Reads method/url/headers/body/auth/timeout/retries from node config,
+    interpolates input variables, performs the request with SSRF protection,
+    and returns the parsed response.
+    """
+
+    def run(
+        self,
+        config: dict[str, Any],
+        inputs: dict[str, Any],
+        execution_context: dict[str, Any],
+    ) -> dict[str, Any]:
+        """
+        Execute an HTTP request.
+
+        Args:
+            config: Node config with method, url, headers, body, auth,
+                    timeout, retries.
+            inputs: Input port values used to fill {{variable}} placeholders.
+            execution_context: Execution-level context (unused).
+
+        Returns:
+            Dict with "response" key containing status_code, headers, body.
+
+        Raises:
+            ValueError: If config is invalid or a variable cannot be resolved.
+            SSRFError: If the URL targets a blocked address.
+            requests.RequestException: If the request fails after retries.
+        """
+        method = (config.get("method") or "GET").upper()
+        if method not in _ALLOWED_METHODS:
+            raise ValueError(f"Unsupported HTTP method '{method}'")
+
+        url = config.get("url")
+        if not url:
+            raise ValueError("HTTP request config missing 'url'")
+
+        url = interpolate_template(url, inputs)
+
+        headers = {}
+        raw_headers = config.get("headers") or {}
+        for key, value in raw_headers.items():
+            headers[key] = interpolate_template(str(value), inputs)
+
+        auth = config.get("auth") or {}
+        auth_type = auth.get("type", "none")
+        request_auth = None
+        if auth_type == "bearer":
+            token = interpolate_template(auth.get("token", ""), inputs)
+            if token:
+                headers["Authorization"] = f"Bearer {token}"
+        elif auth_type == "basic":
+            username = interpolate_template(auth.get("username", ""), inputs)
+            password = interpolate_template(auth.get("password", ""), inputs)
+            request_auth = (username, password)
+
+        body = config.get("body")
+        request_body = None
+        if body is not None:
+            request_body = interpolate_structure(body, inputs)
+
+        timeout = config.get("timeout") or 30
+        retries = config.get("retries") or 0
+
+        validate_url(url)
+
+        last_error: Exception | None = None
+        for attempt in range(retries + 1):
+            try:
+                response = requests.request(
+                    method=method,
+                    url=url,
+                    headers=headers,
+                    json=request_body if isinstance(request_body, (dict, list)) else None,
+                    data=request_body if isinstance(request_body, str) else None,
+                    auth=request_auth,
+                    timeout=timeout,
+                    allow_redirects=False,
+                )
+                return self._build_response(response)
+            except SSRFError:
+                raise
+            except requests.RequestException as e:
+                last_error = e
+                if attempt < retries:
+                    continue
+                raise
+
+        raise RuntimeError("HTTP request failed") from last_error
+
+    def _build_response(self, response: requests.Response) -> dict[str, Any]:
+        content = response.content[:_MAX_RESPONSE_BYTES]
+        content_type = response.headers.get("Content-Type", "")
+
+        body: Any
+        if "json" in content_type.lower():
+            try:
+                body = json.loads(content)
+            except (json.JSONDecodeError, UnicodeDecodeError):
+                body = content.decode("utf-8", errors="replace")
+        else:
+            text = content.decode("utf-8", errors="replace")
+            try:
+                body = json.loads(text)
+            except (json.JSONDecodeError, ValueError):
+                body = text
+
+        return {
+            "response": {
+                "status_code": response.status_code,
+                "headers": dict(response.headers),
+                "body": body,
+            }
+        }
+
+
+register_runner("http_request", HttpRequestRunner())

--- a/futureagi/agent_playground/services/node_crud.py
+++ b/futureagi/agent_playground/services/node_crud.py
@@ -181,6 +181,7 @@ def create_node(
     source_node_id = data.get("source_node_id")
     prompt_data = data.get("prompt_template")
     ports_data = data.get("ports", [])
+    node_config = data.get("config") or {}
 
     node_template = None
     ref_graph_version = None
@@ -202,13 +203,21 @@ def create_node(
         ref_graph_version=ref_graph_version,
         type=node_type,
         name=name,
-        config={},
+        config=node_config,
         position=position,
     )
     node.save(skip_validation=True)
 
+    # Handle HTTP request nodes (config-driven, dynamic input ports)
+    if node_template and node_template.name == "http_request":
+        _create_input_ports_from_http_config(node, node_config)
+        if ports_data:
+            _create_ports_from_fe_array(node, ports_data)
+        else:
+            _create_http_output_port(node)
+
     # Handle LLM prompt nodes (DYNAMIC input_mode)
-    if node_template and node_template.input_mode == PortMode.DYNAMIC:
+    elif node_template and node_template.input_mode == PortMode.DYNAMIC:
         # LLM-type node — always create PT/PTV/PTN
         effective_prompt = prompt_data or _default_prompt_data()
         pt, pv = _resolve_or_create_pt_ptv(
@@ -298,6 +307,8 @@ def update_node(
         node.name = data["name"]
     if "position" in data:
         node.position = data["position"]
+    if "config" in data:
+        node.config = data["config"] or {}
 
     # Handle ref_graph_version_id update (subgraph nodes)
     if "ref_graph_version_id" in data:
@@ -310,6 +321,10 @@ def update_node(
             node.ref_graph_version = None
 
     node.save(skip_validation=True)
+
+    # Reconcile http_request input ports when config changes
+    if "config" in data and node.node_template and node.node_template.name == "http_request":
+        _reconcile_http_ports(node, node.config)
 
     # Handle input_mappings update (subgraph nodes only)
     if "input_mappings" in data and node.type == NodeType.SUBGRAPH:
@@ -842,6 +857,119 @@ def _create_input_ports_from_prompt(node: Node, prompt_data: dict[str, Any]) -> 
             direction=PortDirection.INPUT,
             data_schema={"type": "string"},
         ).save(skip_validation=True)
+
+
+_HTTP_VARIABLE_PATTERN = re.compile(r"\{\{\s*(?P<placeholder>.*?)\s*\}\}")
+
+
+def _extract_http_variables(config: dict[str, Any]) -> list[str]:
+    """Extract unique {{variable}} names from http_request config (url, headers, body)."""
+    text_parts: list[str] = []
+
+    url = config.get("url")
+    if isinstance(url, str):
+        text_parts.append(url)
+
+    headers = config.get("headers") or {}
+    if isinstance(headers, dict):
+        for value in headers.values():
+            if isinstance(value, str):
+                text_parts.append(value)
+
+    auth = config.get("auth") or {}
+    if isinstance(auth, dict):
+        for key in ("token", "username", "password"):
+            value = auth.get(key)
+            if isinstance(value, str):
+                text_parts.append(value)
+
+    def _collect_body(value: Any) -> None:
+        if isinstance(value, str):
+            text_parts.append(value)
+        elif isinstance(value, dict):
+            for v in value.values():
+                _collect_body(v)
+        elif isinstance(value, list):
+            for item in value:
+                _collect_body(item)
+
+    _collect_body(config.get("body"))
+
+    seen: set[str] = set()
+    variables: list[str] = []
+    for text in text_parts:
+        for match in _HTTP_VARIABLE_PATTERN.finditer(text):
+            name = match.group("placeholder").strip()
+            if name and name not in seen:
+                seen.add(name)
+                variables.append(name)
+    return variables
+
+
+def _create_input_ports_from_http_config(node: Node, config: dict[str, Any]) -> None:
+    """Create input ports for an http_request node from {{variable}} placeholders."""
+    for var in _extract_http_variables(config):
+        Port(
+            node=node,
+            key="custom",
+            display_name=var,
+            direction=PortDirection.INPUT,
+            data_schema={"type": "string"},
+        ).save(skip_validation=True)
+
+
+def _create_http_output_port(node: Node) -> None:
+    """Create the default 'response' output port for an http_request node."""
+    Port(
+        node=node,
+        key="response",
+        display_name="response",
+        direction=PortDirection.OUTPUT,
+        data_schema={},
+    ).save(skip_validation=True)
+
+
+def _reconcile_http_ports(node: Node, config: dict[str, Any]) -> None:
+    """
+    Reconcile input ports against {{variables}} in http_request config.
+
+    Adds ports for new variables, soft-deletes ports (and their edges)
+    for removed variables.
+    """
+    now = timezone.now()
+    new_vars = _extract_http_variables(config)
+
+    existing_input_ports = list(
+        Port.no_workspace_objects.filter(node=node, direction=PortDirection.INPUT)
+    )
+    existing_names = {p.display_name: p for p in existing_input_ports}
+
+    new_vars_set = set(new_vars)
+    existing_vars_set = set(existing_names.keys())
+
+    to_add = new_vars_set - existing_vars_set
+    to_remove = existing_vars_set - new_vars_set
+
+    for var in to_add:
+        Port(
+            node=node,
+            key="custom",
+            display_name=var,
+            direction=PortDirection.INPUT,
+            data_schema={"type": "string"},
+        ).save(skip_validation=True)
+
+    for name in to_remove:
+        port = existing_names[name]
+        Edge.no_workspace_objects.filter(source_port=port).update(
+            deleted=True, deleted_at=now
+        )
+        Edge.no_workspace_objects.filter(target_port=port).update(
+            deleted=True, deleted_at=now
+        )
+        port.deleted = True
+        port.deleted_at = now
+        port.save(skip_validation=True)
 
 
 def _create_default_output_port_from_prompt(

--- a/futureagi/agent_playground/templates/_registry.py
+++ b/futureagi/agent_playground/templates/_registry.py
@@ -28,6 +28,7 @@ def register_template(definition: TemplateDefinition) -> None:
 def get_all_templates() -> dict[str, TemplateDefinition]:
     """Import all template modules and return a copy of the registry."""
     # Import template modules to trigger registration
+    import agent_playground.templates.http_request  # noqa: F401
     import agent_playground.templates.llm_prompt  # noqa: F401
 
     return dict(_TEMPLATE_REGISTRY)

--- a/futureagi/agent_playground/templates/http_request.py
+++ b/futureagi/agent_playground/templates/http_request.py
@@ -1,0 +1,66 @@
+from agent_playground.templates._registry import TemplateDefinition, register_template
+
+HTTP_REQUEST_TEMPLATE: TemplateDefinition = {
+    "name": "http_request",
+    "display_name": "HTTP Request",
+    "description": (
+        "Make an HTTP request to an external API. Supports GET, POST, PUT, PATCH, "
+        "and DELETE methods with configurable headers, body, authentication, timeout, "
+        "and retries. Input ports are dynamic — auto-generated from {{variable}} "
+        "placeholders in the URL, headers, and body."
+    ),
+    "icon": None,
+    "categories": ["http", "api", "integration"],
+    "input_definition": [],
+    "output_definition": [
+        {
+            "key": "response",
+            "data_schema": {},
+        }
+    ],
+    "input_mode": "dynamic",
+    "output_mode": "strict",
+    "config_schema": {
+        "type": "object",
+        "properties": {
+            "method": {
+                "type": "string",
+                "enum": ["GET", "POST", "PUT", "PATCH", "DELETE"],
+            },
+            "url": {"type": "string", "minLength": 1},
+            "headers": {
+                "type": "object",
+                "additionalProperties": {"type": "string"},
+            },
+            "body": {"type": ["string", "object", "null"]},
+            "auth": {
+                "type": ["object", "null"],
+                "properties": {
+                    "type": {
+                        "type": "string",
+                        "enum": ["none", "bearer", "basic"],
+                    },
+                    "token": {"type": "string"},
+                    "username": {"type": "string"},
+                    "password": {"type": "string"},
+                },
+            },
+            "timeout": {
+                "type": "integer",
+                "minimum": 1,
+                "maximum": 300,
+                "default": 30,
+            },
+            "retries": {
+                "type": "integer",
+                "minimum": 0,
+                "maximum": 5,
+                "default": 0,
+            },
+        },
+        "required": ["method", "url"],
+        "additionalProperties": False,
+    },
+}
+
+register_template(HTTP_REQUEST_TEMPLATE)

--- a/futureagi/agent_playground/tests/services/test_http_request_node_crud.py
+++ b/futureagi/agent_playground/tests/services/test_http_request_node_crud.py
@@ -1,0 +1,226 @@
+"""Tests for http_request node creation and config updates in node_crud."""
+
+import uuid
+
+import pytest
+
+from agent_playground.models.choices import NodeType, PortDirection
+from agent_playground.models.node_template import NodeTemplate
+from agent_playground.models.port import Port
+from agent_playground.services.node_crud import (
+    _extract_http_variables,
+    create_node,
+    update_node,
+)
+from agent_playground.templates.http_request import HTTP_REQUEST_TEMPLATE
+
+
+@pytest.fixture
+def http_template(db):
+    return NodeTemplate.no_workspace_objects.create(
+        name=HTTP_REQUEST_TEMPLATE["name"],
+        display_name=HTTP_REQUEST_TEMPLATE["display_name"],
+        description=HTTP_REQUEST_TEMPLATE["description"],
+        icon=HTTP_REQUEST_TEMPLATE["icon"],
+        categories=HTTP_REQUEST_TEMPLATE["categories"],
+        input_definition=HTTP_REQUEST_TEMPLATE["input_definition"],
+        output_definition=HTTP_REQUEST_TEMPLATE["output_definition"],
+        input_mode=HTTP_REQUEST_TEMPLATE["input_mode"],
+        output_mode=HTTP_REQUEST_TEMPLATE["output_mode"],
+        config_schema=HTTP_REQUEST_TEMPLATE["config_schema"],
+    )
+
+
+def _http_data(**overrides):
+    data = {
+        "id": uuid.uuid4(),
+        "type": NodeType.ATOMIC,
+        "name": "Fetch User",
+        "config": {
+            "method": "GET",
+            "url": "https://api.example.com/users/{{user_id}}",
+            "headers": {"X-Token": "{{token}}"},
+        },
+    }
+    data.update(overrides)
+    return data
+
+
+@pytest.mark.unit
+class TestExtractHttpVariables:
+    def test_extracts_from_url_and_headers(self):
+        config = {
+            "url": "https://x.example.com/{{a}}",
+            "headers": {"H": "{{b}}"},
+        }
+        assert _extract_http_variables(config) == ["a", "b"]
+
+    def test_dedupes_and_preserves_order(self):
+        config = {"url": "{{a}}/{{b}}/{{a}}"}
+        assert _extract_http_variables(config) == ["a", "b"]
+
+    def test_extracts_from_nested_body(self):
+        config = {"body": {"outer": {"inner": "{{deep}}", "list": ["{{item}}"]}}}
+        assert _extract_http_variables(config) == ["deep", "item"]
+
+    def test_extracts_from_auth_fields(self):
+        config = {"auth": {"type": "bearer", "token": "{{secret}}"}}
+        assert _extract_http_variables(config) == ["secret"]
+
+    def test_empty_config_no_variables(self):
+        assert _extract_http_variables({}) == []
+
+
+@pytest.mark.integration
+class TestCreateHttpNode:
+    def test_create_stores_config(
+        self, db, graph_version, http_template, user, organization, workspace
+    ):
+        data = _http_data(node_template_id=http_template.id)
+        node, nc = create_node(graph_version, data, user, organization, workspace)
+
+        assert node.config["method"] == "GET"
+        assert node.config["url"] == "https://api.example.com/users/{{user_id}}"
+        assert nc is None
+
+    def test_create_builds_input_ports_from_variables(
+        self, db, graph_version, http_template, user, organization, workspace
+    ):
+        data = _http_data(node_template_id=http_template.id)
+        node, _ = create_node(graph_version, data, user, organization, workspace)
+
+        input_ports = Port.no_workspace_objects.filter(
+            node=node, direction=PortDirection.INPUT, deleted=False
+        )
+        names = sorted(p.display_name for p in input_ports)
+        assert names == ["token", "user_id"]
+        assert all(p.key == "custom" for p in input_ports)
+
+    def test_create_builds_response_output_port(
+        self, db, graph_version, http_template, user, organization, workspace
+    ):
+        data = _http_data(node_template_id=http_template.id)
+        node, _ = create_node(graph_version, data, user, organization, workspace)
+
+        output_ports = Port.no_workspace_objects.filter(
+            node=node, direction=PortDirection.OUTPUT, deleted=False
+        )
+        assert [p.key for p in output_ports] == ["response"]
+
+    def test_create_does_not_create_prompt_template_node(
+        self, db, graph_version, http_template, user, organization, workspace
+    ):
+        from agent_playground.models.prompt_template_node import PromptTemplateNode
+
+        data = _http_data(node_template_id=http_template.id)
+        node, _ = create_node(graph_version, data, user, organization, workspace)
+
+        assert not PromptTemplateNode.no_workspace_objects.filter(node=node).exists()
+
+    def test_create_with_body_variables(
+        self, db, graph_version, http_template, user, organization, workspace
+    ):
+        data = _http_data(
+            node_template_id=http_template.id,
+            config={
+                "method": "POST",
+                "url": "https://api.example.com/items",
+                "body": {"name": "{{item_name}}", "qty": "{{qty}}"},
+            },
+        )
+        node, _ = create_node(graph_version, data, user, organization, workspace)
+
+        input_ports = Port.no_workspace_objects.filter(
+            node=node, direction=PortDirection.INPUT, deleted=False
+        )
+        assert sorted(p.display_name for p in input_ports) == ["item_name", "qty"]
+
+
+@pytest.mark.integration
+class TestUpdateHttpNodeConfig:
+    def _create(self, graph_version, http_template, user, organization, workspace):
+        data = _http_data(node_template_id=http_template.id)
+        node, _ = create_node(graph_version, data, user, organization, workspace)
+        return node
+
+    def test_update_config_persists(
+        self, db, graph_version, http_template, user, organization, workspace
+    ):
+        node = self._create(graph_version, http_template, user, organization, workspace)
+        new_config = {"method": "POST", "url": "https://api.example.com/v2"}
+
+        updated = update_node(
+            node=node,
+            data={"config": new_config},
+            user=user,
+            organization=organization,
+            workspace=workspace,
+        )
+
+        assert updated.config == new_config
+
+    def test_update_config_reconciles_ports_add(
+        self, db, graph_version, http_template, user, organization, workspace
+    ):
+        node = self._create(graph_version, http_template, user, organization, workspace)
+
+        update_node(
+            node=node,
+            data={
+                "config": {
+                    "method": "GET",
+                    "url": "https://api.example.com/{{user_id}}/{{region}}",
+                }
+            },
+            user=user,
+            organization=organization,
+            workspace=workspace,
+        )
+
+        input_ports = Port.no_workspace_objects.filter(
+            node=node, direction=PortDirection.INPUT, deleted=False
+        )
+        assert sorted(p.display_name for p in input_ports) == ["region", "user_id"]
+
+    def test_update_config_reconciles_ports_remove_and_cascades_edges(
+        self, db, graph_version, http_template, user, organization, workspace
+    ):
+        node = self._create(graph_version, http_template, user, organization, workspace)
+
+        token_port = Port.no_workspace_objects.get(
+            node=node, display_name="token", direction=PortDirection.INPUT
+        )
+
+        update_node(
+            node=node,
+            data={"config": {"method": "GET", "url": "https://api.example.com/static"}},
+            user=user,
+            organization=organization,
+            workspace=workspace,
+        )
+
+        token_port.refresh_from_db()
+        assert token_port.deleted is True
+
+        remaining = Port.no_workspace_objects.filter(
+            node=node, direction=PortDirection.INPUT, deleted=False
+        )
+        assert list(remaining) == []
+
+    def test_update_without_config_leaves_ports_untouched(
+        self, db, graph_version, http_template, user, organization, workspace
+    ):
+        node = self._create(graph_version, http_template, user, organization, workspace)
+
+        update_node(
+            node=node,
+            data={"name": "Renamed"},
+            user=user,
+            organization=organization,
+            workspace=workspace,
+        )
+
+        input_ports = Port.no_workspace_objects.filter(
+            node=node, direction=PortDirection.INPUT, deleted=False
+        )
+        assert sorted(p.display_name for p in input_ports) == ["token", "user_id"]

--- a/futureagi/agent_playground/tests/services/test_http_request_runner.py
+++ b/futureagi/agent_playground/tests/services/test_http_request_runner.py
@@ -1,0 +1,288 @@
+"""Tests for the HTTP Request runner: SSRF guard, interpolation, retries."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+import requests
+
+from agent_playground.services.engine.node_runner import get_runner, has_runner
+from agent_playground.services.engine.runners.http_request import (
+    HttpRequestRunner,
+    SSRFError,
+    interpolate_structure,
+    interpolate_template,
+    validate_url,
+)
+
+
+@pytest.mark.unit
+class TestRunnerRegistration:
+    def test_runner_registered(self):
+        assert has_runner("http_request")
+
+    def test_get_runner_returns_instance(self):
+        runner = get_runner("http_request")
+        assert isinstance(runner, HttpRequestRunner)
+
+
+@pytest.mark.unit
+class TestValidateUrl:
+    def test_blocks_file_scheme(self):
+        with pytest.raises(SSRFError, match="scheme"):
+            validate_url("file:///etc/passwd")
+
+    def test_blocks_ftp_scheme(self):
+        with pytest.raises(SSRFError, match="scheme"):
+            validate_url("ftp://example.com/data")
+
+    def test_blocks_gopher_scheme(self):
+        with pytest.raises(SSRFError, match="scheme"):
+            validate_url("gopher://example.com/")
+
+    def test_blocks_missing_hostname(self):
+        with pytest.raises(SSRFError, match="no hostname"):
+            validate_url("http://")
+
+    def test_blocks_loopback(self):
+        with pytest.raises(SSRFError, match="private/reserved"):
+            validate_url("http://127.0.0.1/admin")
+
+    def test_blocks_private_range(self):
+        with pytest.raises(SSRFError, match="private/reserved"):
+            validate_url("http://10.0.0.5/internal")
+
+    def test_blocks_192_168(self):
+        with pytest.raises(SSRFError, match="private/reserved"):
+            validate_url("http://192.168.1.1/router")
+
+    def test_blocks_169_254_link_local(self):
+        with pytest.raises(SSRFError, match="private/reserved"):
+            validate_url("http://169.254.169.254/latest/meta-data/")
+
+    def test_blocks_ipv6_loopback(self):
+        with pytest.raises(SSRFError, match="private/reserved"):
+            validate_url("http://[::1]/admin")
+
+    def test_blocks_unresolvable_hostname(self):
+        with pytest.raises(SSRFError, match="Cannot resolve"):
+            validate_url("http://this-host-does-not-exist-xyz123.invalid/")
+
+    def test_allows_public_hostname(self):
+        with patch(
+            "agent_playground.services.engine.runners.http_request.socket.getaddrinfo",
+            return_value=[(2, 1, 6, "", ("93.184.216.34", 443))],
+        ):
+            validate_url("https://example.com/api")
+
+
+@pytest.mark.unit
+class TestInterpolation:
+    def test_simple_variable(self):
+        result = interpolate_template(
+            "https://api.example.com/users/{{user_id}}", {"user_id": "42"}
+        )
+        assert result == "https://api.example.com/users/42"
+
+    def test_whitespace_in_placeholder(self):
+        result = interpolate_template("Hello {{ name }}", {"name": "Ada"})
+        assert result == "Hello Ada"
+
+    def test_multiple_variables(self):
+        result = interpolate_template(
+            "{{a}}-{{b}}-{{a}}", {"a": "1", "b": "2"}
+        )
+        assert result == "1-2-1"
+
+    def test_dict_value_serialized_as_json(self):
+        result = interpolate_template("{{payload}}", {"payload": {"k": "v"}})
+        assert result == '{"k": "v"}'
+
+    def test_unresolved_variable_raises(self):
+        with pytest.raises(ValueError):
+            interpolate_template("{{missing}}", {})
+
+    def test_interpolate_structure_nested(self):
+        body = {
+            "name": "{{name}}",
+            "tags": ["{{tag}}", "static"],
+            "nested": {"id": "{{id}}"},
+        }
+        result = interpolate_structure(
+            body, {"name": "Ada", "tag": "x", "id": "7"}
+        )
+        assert result == {
+            "name": "Ada",
+            "tags": ["x", "static"],
+            "nested": {"id": "7"},
+        }
+
+    def test_interpolate_structure_non_string_passthrough(self):
+        assert interpolate_structure(42, {}) == 42
+        assert interpolate_structure(None, {}) is None
+
+
+def _mock_response(status_code=200, json_body=None, text_body=None, content_type="application/json"):
+    resp = MagicMock(spec=requests.Response)
+    resp.status_code = status_code
+    resp.headers = {"Content-Type": content_type}
+    if json_body is not None:
+        import json as _json
+
+        resp.content = _json.dumps(json_body).encode()
+    else:
+        resp.content = (text_body or "").encode()
+    return resp
+
+
+@pytest.mark.unit
+class TestRunnerExecution:
+    def _run(self, config, inputs=None):
+        runner = HttpRequestRunner()
+        return runner.run(config, inputs or {}, {"node_id": "n1"})
+
+    @patch("agent_playground.services.engine.runners.http_request.validate_url")
+    @patch("agent_playground.services.engine.runners.http_request.requests.request")
+    def test_get_request_returns_parsed_json(self, mock_request, mock_validate):
+        mock_request.return_value = _mock_response(
+            status_code=200, json_body={"ok": True}
+        )
+        result = self._run({"method": "GET", "url": "https://api.example.com/x"})
+        assert result["response"]["status_code"] == 200
+        assert result["response"]["body"] == {"ok": True}
+        mock_validate.assert_called_once_with("https://api.example.com/x")
+
+    @patch("agent_playground.services.engine.runners.http_request.validate_url")
+    @patch("agent_playground.services.engine.runners.http_request.requests.request")
+    def test_url_interpolation_before_request(self, mock_request, mock_validate):
+        mock_request.return_value = _mock_response(json_body={})
+        self._run(
+            {"method": "GET", "url": "https://api.example.com/users/{{uid}}"},
+            {"uid": "99"},
+        )
+        mock_validate.assert_called_once_with("https://api.example.com/users/99")
+        _, kwargs = mock_request.call_args
+        assert kwargs["url"] == "https://api.example.com/users/99"
+
+    @patch("agent_playground.services.engine.runners.http_request.validate_url")
+    @patch("agent_playground.services.engine.runners.http_request.requests.request")
+    def test_bearer_auth_sets_header(self, mock_request, mock_validate):
+        mock_request.return_value = _mock_response(json_body={})
+        self._run(
+            {
+                "method": "GET",
+                "url": "https://api.example.com/x",
+                "auth": {"type": "bearer", "token": "secret-token"},
+            }
+        )
+        _, kwargs = mock_request.call_args
+        assert kwargs["headers"]["Authorization"] == "Bearer secret-token"
+
+    @patch("agent_playground.services.engine.runners.http_request.validate_url")
+    @patch("agent_playground.services.engine.runners.http_request.requests.request")
+    def test_basic_auth_tuple(self, mock_request, mock_validate):
+        mock_request.return_value = _mock_response(json_body={})
+        self._run(
+            {
+                "method": "GET",
+                "url": "https://api.example.com/x",
+                "auth": {"type": "basic", "username": "u", "password": "p"},
+            }
+        )
+        _, kwargs = mock_request.call_args
+        assert kwargs["auth"] == ("u", "p")
+
+    @patch("agent_playground.services.engine.runners.http_request.validate_url")
+    @patch("agent_playground.services.engine.runners.http_request.requests.request")
+    def test_dict_body_sent_as_json(self, mock_request, mock_validate):
+        mock_request.return_value = _mock_response(json_body={})
+        self._run(
+            {
+                "method": "POST",
+                "url": "https://api.example.com/x",
+                "body": {"name": "{{name}}"},
+            },
+            {"name": "Ada"},
+        )
+        _, kwargs = mock_request.call_args
+        assert kwargs["json"] == {"name": "Ada"}
+        assert kwargs["data"] is None
+
+    @patch("agent_playground.services.engine.runners.http_request.validate_url")
+    @patch("agent_playground.services.engine.runners.http_request.requests.request")
+    def test_string_body_sent_as_data(self, mock_request, mock_validate):
+        mock_request.return_value = _mock_response(json_body={})
+        self._run(
+            {
+                "method": "POST",
+                "url": "https://api.example.com/x",
+                "body": "raw={{val}}",
+            },
+            {"val": "1"},
+        )
+        _, kwargs = mock_request.call_args
+        assert kwargs["data"] == "raw=1"
+        assert kwargs["json"] is None
+
+    @patch("agent_playground.services.engine.runners.http_request.validate_url")
+    @patch("agent_playground.services.engine.runners.http_request.requests.request")
+    def test_retries_on_failure_then_succeeds(self, mock_request, mock_validate):
+        mock_request.side_effect = [
+            requests.ConnectionError("boom"),
+            _mock_response(json_body={"ok": True}),
+        ]
+        result = self._run(
+            {"method": "GET", "url": "https://api.example.com/x", "retries": 1}
+        )
+        assert result["response"]["body"] == {"ok": True}
+        assert mock_request.call_count == 2
+
+    @patch("agent_playground.services.engine.runners.http_request.validate_url")
+    @patch("agent_playground.services.engine.runners.http_request.requests.request")
+    def test_retries_exhausted_raises(self, mock_request, mock_validate):
+        mock_request.side_effect = requests.ConnectionError("boom")
+        with pytest.raises(requests.ConnectionError):
+            self._run(
+                {"method": "GET", "url": "https://api.example.com/x", "retries": 2}
+            )
+        assert mock_request.call_count == 3
+
+    def test_missing_url_raises(self):
+        with pytest.raises(ValueError, match="url"):
+            self._run({"method": "GET"})
+
+    def test_unsupported_method_raises(self):
+        with pytest.raises(ValueError, match="method"):
+            self._run({"method": "OPTIONS", "url": "https://api.example.com/x"})
+
+    @patch("agent_playground.services.engine.runners.http_request.requests.request")
+    def test_ssrf_check_runs_before_request(self, mock_request):
+        with pytest.raises(SSRFError):
+            self._run({"method": "GET", "url": "http://127.0.0.1/admin"})
+        mock_request.assert_not_called()
+
+    @patch("agent_playground.services.engine.runners.http_request.validate_url")
+    @patch("agent_playground.services.engine.runners.http_request.requests.request")
+    def test_redirects_not_followed(self, mock_request, mock_validate):
+        mock_request.return_value = _mock_response(status_code=302, json_body={})
+        self._run({"method": "GET", "url": "https://api.example.com/x"})
+        _, kwargs = mock_request.call_args
+        assert kwargs["allow_redirects"] is False
+
+    @patch("agent_playground.services.engine.runners.http_request.validate_url")
+    @patch("agent_playground.services.engine.runners.http_request.requests.request")
+    def test_non_json_response_returns_text(self, mock_request, mock_validate):
+        mock_request.return_value = _mock_response(
+            text_body="hello world", content_type="text/plain"
+        )
+        result = self._run({"method": "GET", "url": "https://api.example.com/x"})
+        assert result["response"]["body"] == "hello world"
+
+    @patch("agent_playground.services.engine.runners.http_request.validate_url")
+    @patch("agent_playground.services.engine.runners.http_request.requests.request")
+    def test_timeout_passed_through(self, mock_request, mock_validate):
+        mock_request.return_value = _mock_response(json_body={})
+        self._run(
+            {"method": "GET", "url": "https://api.example.com/x", "timeout": 5}
+        )
+        _, kwargs = mock_request.call_args
+        assert kwargs["timeout"] == 5

--- a/futureagi/agent_playground/tests/templates/test_http_request_template.py
+++ b/futureagi/agent_playground/tests/templates/test_http_request_template.py
@@ -1,0 +1,115 @@
+"""Tests for the HTTP Request template definition."""
+
+import jsonschema
+import pytest
+
+from agent_playground.templates import get_all_templates
+from agent_playground.templates.http_request import HTTP_REQUEST_TEMPLATE
+
+REQUIRED_FIELDS = {
+    "name",
+    "display_name",
+    "description",
+    "icon",
+    "categories",
+    "input_definition",
+    "output_definition",
+    "input_mode",
+    "output_mode",
+    "config_schema",
+}
+
+
+@pytest.mark.unit
+class TestHttpRequestDefinitionStructure:
+    def test_has_all_required_fields(self):
+        assert set(HTTP_REQUEST_TEMPLATE.keys()) == REQUIRED_FIELDS
+
+    def test_registered_in_registry(self):
+        templates = get_all_templates()
+        assert "http_request" in templates
+        assert templates["http_request"] is HTTP_REQUEST_TEMPLATE
+
+    def test_input_mode_is_dynamic(self):
+        assert HTTP_REQUEST_TEMPLATE["input_mode"] == "dynamic"
+
+    def test_output_mode_is_strict(self):
+        assert HTTP_REQUEST_TEMPLATE["output_mode"] == "strict"
+
+    def test_input_definition_empty_for_dynamic(self):
+        assert HTTP_REQUEST_TEMPLATE["input_definition"] == []
+
+    def test_output_definition_has_response_port(self):
+        keys = [p["key"] for p in HTTP_REQUEST_TEMPLATE["output_definition"]]
+        assert "response" in keys
+
+    def test_config_schema_is_valid_json_schema(self):
+        jsonschema.Draft7Validator.check_schema(
+            HTTP_REQUEST_TEMPLATE["config_schema"]
+        )
+
+
+@pytest.mark.unit
+class TestHttpRequestConfigSchema:
+    def _validate(self, config):
+        jsonschema.validate(
+            instance=config, schema=HTTP_REQUEST_TEMPLATE["config_schema"]
+        )
+
+    def test_minimal_valid_config(self):
+        self._validate({"method": "GET", "url": "https://api.example.com"})
+
+    def test_full_valid_config(self):
+        self._validate(
+            {
+                "method": "POST",
+                "url": "https://api.example.com/users",
+                "headers": {"X-Api-Key": "abc"},
+                "body": {"name": "Ada"},
+                "auth": {"type": "bearer", "token": "t"},
+                "timeout": 10,
+                "retries": 2,
+            }
+        )
+
+    def test_all_methods_allowed(self):
+        for method in ("GET", "POST", "PUT", "PATCH", "DELETE"):
+            self._validate({"method": method, "url": "https://x.example.com"})
+
+    def test_missing_method_rejected(self):
+        with pytest.raises(jsonschema.ValidationError):
+            self._validate({"url": "https://api.example.com"})
+
+    def test_missing_url_rejected(self):
+        with pytest.raises(jsonschema.ValidationError):
+            self._validate({"method": "GET"})
+
+    def test_invalid_method_rejected(self):
+        with pytest.raises(jsonschema.ValidationError):
+            self._validate({"method": "OPTIONS", "url": "https://x.example.com"})
+
+    def test_empty_url_rejected(self):
+        with pytest.raises(jsonschema.ValidationError):
+            self._validate({"method": "GET", "url": ""})
+
+    def test_timeout_bounds_enforced(self):
+        with pytest.raises(jsonschema.ValidationError):
+            self._validate(
+                {"method": "GET", "url": "https://x.example.com", "timeout": 0}
+            )
+        with pytest.raises(jsonschema.ValidationError):
+            self._validate(
+                {"method": "GET", "url": "https://x.example.com", "timeout": 301}
+            )
+
+    def test_retries_bounds_enforced(self):
+        with pytest.raises(jsonschema.ValidationError):
+            self._validate(
+                {"method": "GET", "url": "https://x.example.com", "retries": 6}
+            )
+
+    def test_unknown_config_key_rejected(self):
+        with pytest.raises(jsonschema.ValidationError):
+            self._validate(
+                {"method": "GET", "url": "https://x.example.com", "evil": 1}
+            )


### PR DESCRIPTION
## Summary

Adds a new **HTTP Request** node to the Agent Playground builder, following the existing `llm_prompt` template architecture. Users can now call external APIs from a graph: pick a method, set a URL, headers, body, auth, timeout and retries, and wire upstream node outputs into the request via `{{variable}}` placeholders. The runner executes the call with SSRF protection, and the node exposes a structured `response` output port.

## Linked issues

Closes #29
Linear: n/a

## Type of change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📖 Documentation only
- [ ] 🧹 Chore / refactor (no user-visible change)
- [ ] 🚀 Performance improvement
- [ ] 🧪 Test-only change

---

## 1) What changes were done

**A. Backend — node template and runner**

- New seeded `NodeTemplate` `http_request` with a JSON-schema `config_schema` (method, url, headers, body, auth, timeout, retries) registered in the template registry, so it ships with `seed_node_templates` and appears in the node palette.
- New runner `runners/http_request.py`: resolves `{{variable}}` placeholders from input port values, validates the target against an SSRF guard (blocks non-http(s) schemes, loopback, private, and link-local addresses after DNS resolution, does not follow redirects), applies timeout and bounded retries, supports bearer/basic auth, and returns a structured output (`status_code`, `headers`, `body` parsed as JSON when possible).

**B. Backend — config persistence and ports**

- `CreateNodeSerializer` / `UpdateNodeSerializer` now accept `config`; `NodeReadSerializer` exposes `config` and a read-only `node_template_name` so clients can tell node templates apart.
- `node_crud.create_node` / `update_node` persist config for `http_request` nodes, extract `{{var}}` placeholders from url/headers/body/auth, create one input port per variable (same pattern as prompt variable extraction), create the `response` output port, and reconcile ports when config changes on update (removing stale ports cascades their edges).

**C. Frontend — form, node, palette**

- New `HttpRequestNodeForm` (method select, URL, dynamic header rows, JSON body, none/bearer/basic auth, timeout, retries) with a Zod schema, `getDefaultValues` hydration, and a PATCH payload that sends `{ name, config }`.
- New `HttpRequestNode` canvas component rendering a method color badge and truncated URL via a new optional `content` slot on `BaseNode`.
- Node palette and add-node flow now include `http_request` (template list hook, optimistic node defaults, React Flow `nodeTypes` registration); `versionPayloadUtils` maps API nodes by `node_template_name` instead of assuming every atomic node is a prompt.

**D. API contracts**

- Regenerated `swagger.json` (only the `CreateNode` / `NodeRead` / `UpdateNode` definitions changed) plus the OpenAPI contract and orval client.

---

## 2) Why the changes were done

- **Product/UX:** graphs could only call LLMs; hitting an external API (fetch data, trigger webhooks, integrate tools) is a core workflow users need.
- **Technical:** reuses the existing `TemplateDefinition` registry, runner dispatch, and port model instead of a one-off node type, so execution flows through the same generic engine path (`get_runner(template_name)` + `node.config`) with no engine changes.
- **Architecture:** SSRF guard lives in the runner (defense at execution time), schema validation lives in the template `config_schema` (single source of truth), and port derivation from `{{var}}` placeholders mirrors the prompt node behavior so the graph wiring UX stays consistent.

---

## 3) Tests written + scenarios each covers

**`test_http_request_template.py`** — template registration and config schema validation

- `test_has_all_required_fields`, `test_registered_in_registry` — template is registered with the expected metadata
- `test_input_mode_is_dynamic`, `test_output_definition_has_response_port` — dynamic inputs, strict `response` output
- `test_config_schema_is_valid_json_schema`, `test_minimal_valid_config`, `test_full_valid_config` — schema shape and valid configs
- `test_all_methods_allowed`, `test_missing_method_rejected`, `test_missing_url_rejected`, `test_invalid_method_rejected`, `test_empty_url_rejected` — method/url validation
- `test_timeout_bounds_enforced`, `test_retries_bounds_enforced`, `test_unknown_config_key_rejected` — bounds and strict keys

**`test_http_request_runner.py`** — runner behavior with mocked HTTP

- `test_runner_registered`, `test_get_runner_returns_instance` — runner dispatch
- `test_blocks_file_scheme` … `test_blocks_unresolvable_hostname`, `test_allows_public_hostname` — SSRF guard across schemes, loopback, private ranges, link-local, IPv6, DNS failure
- `test_simple_variable` … `test_interpolate_structure_non_string_passthrough` — `{{var}}` interpolation incl. whitespace, dedupe, nested structures, JSON-serialized dict values, unresolved variable error
- `test_get_request_returns_parsed_json`, `test_url_interpolation_before_request`, `test_bearer_auth_sets_header`, `test_basic_auth_tuple`, `test_dict_body_sent_as_json`, `test_string_body_sent_as_data` — request construction
- `test_retries_on_failure_then_succeeds`, `test_retries_exhausted_raises`, `test_timeout_passed_through`, `test_redirects_not_followed`, `test_non_json_response_returns_text` — resilience and response handling
- `test_missing_url_raises`, `test_unsupported_method_raises`, `test_ssrf_check_runs_before_request` — error paths

**`test_http_request_node_crud.py`** — DB-backed node create/update flows

- `test_create_stores_config`, `test_create_builds_input_ports_from_variables`, `test_create_builds_response_output_port`, `test_create_with_body_variables`, `test_create_does_not_create_prompt_template_node` — creation path
- `test_update_config_persists`, `test_update_config_reconciles_ports_add`, `test_update_config_reconciles_ports_remove_and_cascades_edges`, `test_update_without_config_leaves_ports_untouched` — update path and port reconciliation

**`versionPayloadUtils-httpRequest.test.js`** — API payload → canvas mapping

- maps `node_template_name: http_request` to the HTTP node type, keeps unnamed atomic nodes as prompt, carries raw config/template ids, defaults missing config, maps ports, accepts camelCase shape

**`httpRequestForm.test.js`** — Zod schema + form defaults

- accepts a valid GET form, rejects empty/non-http url, invalid method, out-of-bounds timeout/retries, invalid name; applies defaults; schema dispatch; hydrates stored config incl. basic auth

> Run result: backend **1209 passed** (full `agent_playground` suite, incl. 65 new HTTP tests); frontend **615 passed** (agent-playground suites, incl. 19 new). Ruff and ESLint clean, `yarn contracts:check` passing.

---

## 4) How to run / test

### Backend tests

```bash
cd futureagi
bin/test agent_playground
bin/test agent_playground/tests/services/test_http_request_runner.py -v
bin/test agent_playground/tests/services/test_http_request_node_crud.py -v
bin/test agent_playground/tests/templates/test_http_request_template.py -v
```

### Frontend tests

```bash
cd frontend
eval "$(fnm env)" && fnm use 22
yarn test:run
```

### Contract verification

```bash
./scripts/generate-openapi-schema.sh
cd frontend && yarn contracts:generate && yarn contracts:check
```

### UI steps (manual)

1. Start the stack, log in at **http://localhost:3031**, run `seed_node_templates` so the new template exists.
2. Open Agent Playground → a graph → add node: the HTTP Request card appears in the palette.
3. Add it, open the drawer, configure method/URL/headers/body/auth, save — the canvas node shows the method badge and URL.
4. Reference an upstream output as `{{var}}` in the URL/body: an input port appears for it after save.

---

## 5) Screenshots / recordings

### Test output

Backend: `1209 passed in 82.67s` (agent_playground suite). Frontend: `615 passed` (agent-playground vitest run).

### UI testing

Will add a short recording of the drawer + canvas node in a follow-up comment.

---

## 6) Edge cases & considerations

- SSRF: hostname is resolved and every resolved address is checked before the request; redirects are not followed; non-http(s) schemes are rejected.
- `{{var}}` with no matching input port value raises a clear execution error instead of sending a literal placeholder.
- Updating config removes ports that no longer have variables and cascades connected edges, matching prompt node behavior.
- Timeout is capped at 300s and retries at 5 by the config schema.
- Non-JSON response bodies fall back to raw text in the structured output.

---

## 8) Architectural / important decisions

- **Template + runner over a bespoke node type:** keeps execution on the generic engine path and makes future node types cheap to add.
- **`node_template_name` on the read serializer:** the frontend previously mapped every atomic node to the prompt form; the explicit template name is the reliable discriminator.
- **SSRF validation at execution time in the runner:** config-time checks can be bypassed by interpolation, so the guard runs on the final URL right before the request.

---

## Checklist

- [x] My code follows the [style guide](../CONTRIBUTING.md#code-style)
- [x] I've added tests that prove my fix is effective or that my feature works
- [x] `bin/test` passes locally (backend)
- [x] `yarn test:run` passes locally (frontend)
- [x] `yarn contracts:check` passes if API surface changed
- [ ] I've updated the documentation where relevant
- [x] No hardcoded secrets, URLs, or PII
- [x] I've signed the [CLA](../CONTRIBUTING.md#contributor-license-agreement-cla)
- [x] PR title follows Conventional Commits
- [ ] Linear issue is linked and updated with status
