### PR TITLE
fix(observe): stop session grid icons shrinking with the value [TH-7711]

### DIFF
--- a/frontend/src/sections/projects/SessionsView/SessionCellRenderer.jsx
+++ b/frontend/src/sections/projects/SessionsView/SessionCellRenderer.jsx
@@ -67,7 +67,12 @@ const SessionCellRenderer = (params) => {
     if (colId === "duration") {
       return (
         <Box display="flex" alignItems="center" justifyContent={"flex-end"}>
-          <Iconify icon="radix-icons:clock" width={14} marginRight="7px" />
+          <Iconify
+            icon="radix-icons:clock"
+            width={14}
+            marginRight="7px"
+            sx={{ flexShrink: 0 }}
+          />
           {value}s
         </Box>
       );
@@ -95,6 +100,7 @@ const SessionCellRenderer = (params) => {
             color="text.primary"
             height={16}
             width={16}
+            sx={{ flexShrink: 0 }}
           />
           {value}
         </Box>
@@ -111,7 +117,7 @@ const SessionCellRenderer = (params) => {
           <SvgColor
             src="/assets/icons/ic_tokens.svg"
             color="text.primary"
-            sx={{ width: 16, height: 16 }}
+            sx={{ width: 16, height: 16, flexShrink: 0 }}
           />
           {value}
         </Box>


### PR DESCRIPTION
## What

Icons in the session grid rendered at a different size on every row. Fixes [TH-7711](https://linear.app/future-agi/issue/TH-7711).

Reported against **Group by → Sessions**, which routes to `SessionsView`, not the flat trace grid.

<img width="330" src="https://github.com/user-attachments/assets/679fdad4-2fab-4e16-b9e5-55133f738fe8" />

## Cause

The cell is a flex row of `[icon] [value]`, and `clean-data-table.css` pins that row to `width: 100%` with `white-space: nowrap`. The text therefore cannot shrink, leaving the icon as the only flexible item — so it absorbed the entire overflow.

Longer value → smaller icon, which is why the **shortest** value in the report (`0.5054983`) is the one with a full-size icon.

## Reproduction

Rendering the reporter's own six values and measuring the SVG:

| Value | Icon width |
| --- | --- |
| `0.44403279999999984` | **0px** — invisible, matching the missing icon in the report |
| `0.45625119999999997` | 5.3px |
| `0.4828163000000001` | 10.7px |
| `0.5054983` | **16px** — shortest text, full size |
| `0.4442280999999998` | 5.5px |
| `0.4223441999999999` | 8.7px |

Six distinct widths between 0 and 16.

| Before | After |
| --- | --- |
| <img width="330" src="https://github.com/user-attachments/assets/86b10a6a-3376-4f81-b326-4db45f3c41ee" /> | <img width="330" src="https://github.com/user-attachments/assets/a9865b62-a46c-4521-8b65-5e8f1a0caee0" /> |

The same effect with values that lengthen a character at a time — the icon shrinks in step:

| Before | After |
| --- | --- |
| <img width="330" src="https://github.com/user-attachments/assets/0fab6ecb-32b4-4e76-875b-3d9fed33af8f" /> | <img width="330" src="https://github.com/user-attachments/assets/53f0270d-70d9-460d-aaaa-6db2e9db401f" /> |

## Fix

`flex-shrink: 0` on the icons in `SessionCellRenderer.jsx`. Three columns share the pattern and all three had the defect:

| Column | Icon | Before (18-char value) | After |
| --- | --- | --- | --- |
| `total_cost` | `Iconify mage:dollar` | 9.5px | **16px** |
| `duration` | `Iconify radix-icons:clock` | 3.6px | **14px** |
| `total_tokens` | `SvgColor ic_tokens.svg` | — | **16px** |

## Trade-off: the icon can now clip instead of shrinking

Holding its size means a long value overflows the 200px default column and the icon edge is clipped rather than silently resized. Measured on the reporter's values: **1 of 6 rows**, clipped by **4.1px**.

Autosizing the column (double-click the column border) widens it to 238px and clears it completely — **0 of 6 clipped**.

| Default 200px | After autosize, 238px |
| --- | --- |
| <img width="330" src="https://github.com/user-attachments/assets/6d073a78-6878-4813-ba3a-8903df168d39" /> | <img width="330" src="https://github.com/user-attachments/assets/3a20b1ce-a069-44a2-86ce-abe42ca7574f" /> |

## Testing

`src/sections/projects` suite: 317 passing, 41 files. Lint clean. All measurements above are read from the rendered SVG in a real browser rather than judged by eye.
