### PR TITLE
fix(accounts): resolve demo fixtures relative to base_data.py, not CWD

### DIFF
--- a/futureagi/accounts/base_data.py
+++ b/futureagi/accounts/base_data.py
@@ -1,9 +1,17 @@
 import json
+from pathlib import Path
 
-with open("accounts/demo_dataset/table_data.json") as f:
+# Resolve the demo fixtures relative to this file, not the process CWD.
+# These loads run at import time, and this module is reached from
+# accounts/migrations/0020_reseed_broken_demo_data.py, so a CWD-relative
+# path makes any `migrate` (and any test that triggers it) fail with
+# FileNotFoundError unless it happens to be run from `futureagi/`.
+_DEMO_DATASET_DIR = Path(__file__).resolve().parent / "demo_dataset"
+
+with open(_DEMO_DATASET_DIR / "table_data.json") as f:
     dataset_data = json.load(f)
 
-with open("accounts/demo_dataset/run_prompt_config.json") as f:
+with open(_DEMO_DATASET_DIR / "run_prompt_config.json") as f:
     run_prompt_config = json.load(f)
 
 prompt_config = [
@@ -32,8 +40,8 @@ prompt_config = [
     }
 ]
 
-with open("accounts/demo_dataset/experiment.json") as f:
+with open(_DEMO_DATASET_DIR / "experiment.json") as f:
     experiment_data = json.load(f)
 
-with open("accounts/demo_dataset/img_dataset_data.json") as f:
+with open(_DEMO_DATASET_DIR / "img_dataset_data.json") as f:
     image_dataset_data = json.load(f)


### PR DESCRIPTION
## Summary

`accounts/base_data.py` opens its four demo-dataset fixtures with CWD-relative paths, at module import time. The module is reached from migration `accounts/migrations/0020_reseed_broken_demo_data.py`, so `migrate` — and any test that triggers migrations — raises `FileNotFoundError` unless the process happens to be running from `futureagi/`.

It works today only because every documented entry point (`bin/test`, `manage.py`, the container `WORKDIR`) cds there first. Resolving the paths from `Path(__file__).parent` removes that hidden coupling.

Independent of #2408 / #2409, though it is what unblocks the `django_db` tests those two make collectible.

## Linked issues

Closes #
Linear:

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation only
- [ ] Chore / refactor
- [ ] Performance improvement
- [ ] Test-only change

---

## 1) What changes were done

**A. `futureagi/accounts/base_data.py` — resolve fixtures from `__file__`**

```python
# before
with open("accounts/demo_dataset/table_data.json") as f:

# after
_DEMO_DATASET_DIR = Path(__file__).resolve().parent / "demo_dataset"
with open(_DEMO_DATASET_DIR / "table_data.json") as f:
```

Applied to all four loads (`table_data`, `run_prompt_config`, `experiment`, `img_dataset_data`) — lines 3, 6, 35, 38 before the change. A short comment records why, so the CWD-relative form does not come back.

No other file in the repo has this pattern (`grep -rn 'open("accounts/\|open("model_hub/\|open("tracer/\|open("simulate/'` returns only these four).

---

## 2) Why the changes were done

- **Technical:** the loads run at import time, so the failure is not confined to whatever code path wanted the fixture — importing the module at all from the wrong directory raises. That makes it a latent trap for any new entry point (a management command run from the repo root, a script, a test runner invoked from a subdirectory).
- **Concretely:** it is what makes `django_db` tests unrunnable from `futureagi/agentic_eval/`. That surfaced while fixing the `agentic_eval` suite (#2408, #2409), but the bug is in `accounts/` and is not specific to those tests, so it is sent on its own.
- **Why `Path(__file__)` over `settings.BASE_DIR`:** the fixtures are packaged next to the module that reads them, so anchoring to the module keeps them together if the app ever moves. It also avoids importing Django settings into a module that currently needs none.

---

## 3) Tests written + scenarios each covers

No new tests — this is a path-resolution fix with no new branch to cover. Verified by controlled comparison instead, loading the module directly (it needs only `json` and `pathlib`, so Django is not involved):

| module | cwd | result |
|---|---|---|
| patched | `/tmp` | all 4 fixtures load |
| patched | `futureagi/` | all 4 fixtures load (unchanged) |
| original (`origin/dev`) | `/tmp` | `FileNotFoundError: 'accounts/demo_dataset/table_data.json'` |
| original (`origin/dev`) | `futureagi/` | loads (which is why nobody has hit it) |

**Regression check:** `pytest accounts/` from `futureagi/` is **1367 passed** both before and after — the fix is a no-op from the directory everything currently runs in.

---

## 4) How to run / test

```bash
cd futureagi
bin/test up
uv run pytest accounts/ -q      # 1367 passed
```

Reproduce the original bug against `origin/dev`:

```bash
cd /tmp
PYTHONPATH=/path/to/futureagi python -c "from accounts.base_data import dataset_data"
# origin/dev -> FileNotFoundError
# this branch -> loads fine
```

---

## 5) Screenshots / recordings

No UI surface.

---

## 6) Edge cases & considerations

- **Symlinked checkouts:** `.resolve()` follows symlinks before joining, so the fixtures are found via the real path rather than the symlink's parent. That matches how the files are actually laid out on disk.
- **Packaging:** `demo_dataset/*.json` sits next to `base_data.py`, so anchoring to `__file__` keeps the two together under any install layout, whereas a CWD- or `BASE_DIR`-relative path assumes the repo tree.
- **No behavior change in the container:** the image's `WORKDIR` is already the backend root, so runtime behavior is byte-identical; this only removes the requirement.

---

## 7) Pre-existing issues (NOT introduced by this PR)

None introduced. For context on what this unblocks: with this fix plus #2408 and #2409, the `agentic_eval` tree runs clean under the same marker filter the root `pytest.ini` uses —

```
1 failed, 447 passed, 16 skipped, 629 deselected
```

The single remaining failure, `core_evals/run_prompt/tests/test_image_generation.py::TestLiteLLMImageModelManager::test_get_provider_for_dalle`, is a pre-existing assertion against an unconfigured `MagicMock` and is unrelated to any of these three PRs. Filing separately.
