### PR TITLE
fix: handle null execution filters and dataset processing state

### DIFF
--- a/frontend/src/components/traceDetailDrawer/addToDataset/AddExistingDataset.jsx
+++ b/frontend/src/components/traceDetailDrawer/addToDataset/AddExistingDataset.jsx
@@ -22,6 +22,7 @@ import { useNavigate, useParams } from "react-router";
 import FormSearchSelectFieldState from "src/components/FromSearchSelectField/FormSearchSelectFieldState";
 import { LLM_TABS } from "../../../sections/projects/LLMTracing/common";
 import { coreSpanFields } from "../common";
+import { getAddToDatasetStatus } from "./status";
 
 const AddExistingDataset = ({
   handleclose,
@@ -260,10 +261,13 @@ const AddExistingDataset = ({
       axios.post(endpoints.project.addExistingDataset, payload),
     onSuccess: (res) => {
       if (res.data?.status) {
+        const { message, variant } = getAddToDatasetStatus(
+          res.data?.result,
+          "Data added successfully",
+        );
         enqueueSnackbar(
           <>
-            <span>Data added successfully</span>
-            {/* {res.data.result.message} */}
+            <span>{message}</span>
             <span
               onClick={() =>
                 navigate(`/dashboard/develop/${selectedDataset}?tab=data`, {
@@ -281,7 +285,7 @@ const AddExistingDataset = ({
               View Dataset
             </span>
           </>,
-          { variant: "success" },
+          { variant },
         );
         handleclose();
         if (onSuccess) {

--- a/frontend/src/components/traceDetailDrawer/addToDataset/AddNewDataset.jsx
+++ b/frontend/src/components/traceDetailDrawer/addToDataset/AddNewDataset.jsx
@@ -17,6 +17,7 @@ import { LoadingButton } from "@mui/lab";
 import { useNavigate, useParams } from "react-router";
 import { LLM_TABS } from "../../../sections/projects/LLMTracing/common";
 import { coreSpanFields } from "../common";
+import { getAddToDatasetStatus } from "./status";
 
 const AddNewDataset = ({
   handleclose,
@@ -111,13 +112,18 @@ const AddNewDataset = ({
         axios.post(endpoints.project.addNewDataset, payload),
 
       onSuccess: (res) => {
+        const result = res?.data?.result;
+        const { message, variant } = getAddToDatasetStatus(
+          result,
+          "Datapoints added to newly created dataset",
+        );
         enqueueSnackbar(
           <>
-            Datapoints added to newly created dataset
+            {message}
             <span
               onClick={() =>
                 navigate(
-                  `/dashboard/develop/${res?.data?.result?.dataset_id ?? res?.data?.result?.datasetId}?tab=data`,
+                  `/dashboard/develop/${result?.dataset_id ?? result?.datasetId}?tab=data`,
                   { state: { from: location.pathname } },
                 )
               }
@@ -132,7 +138,7 @@ const AddNewDataset = ({
               View Dataset
             </span>
           </>,
-          { variant: "success" },
+          { variant },
         );
         handleclose();
         if (onSuccess) {

--- a/frontend/src/components/traceDetailDrawer/addToDataset/status.js
+++ b/frontend/src/components/traceDetailDrawer/addToDataset/status.js
@@ -1,0 +1,11 @@
+const PROCESSING_MESSAGE =
+  "Rows are still being added in the background. This can take a while for large selections.";
+
+export function getAddToDatasetStatus(result, completedMessage) {
+  const isProcessing = result?.status !== "completed";
+
+  return {
+    message: isProcessing ? PROCESSING_MESSAGE : completedMessage,
+    variant: isProcessing ? "info" : "success",
+  };
+}

--- a/frontend/src/components/traceDetailDrawer/addToDataset/status.test.js
+++ b/frontend/src/components/traceDetailDrawer/addToDataset/status.test.js
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+import { getAddToDatasetStatus } from "./status";
+
+describe("getAddToDatasetStatus", () => {
+  it("uses an in-progress message unless the API confirms completion", () => {
+    expect(
+      getAddToDatasetStatus(
+        { status: "processing" },
+        "Datapoints added to newly created dataset",
+      ),
+    ).toEqual({
+      message:
+        "Rows are still being added in the background. This can take a while for large selections.",
+      variant: "info",
+    });
+
+    expect(
+      getAddToDatasetStatus(
+        undefined,
+        "Datapoints added to newly created dataset",
+      ),
+    ).toEqual({
+      message:
+        "Rows are still being added in the background. This can take a while for large selections.",
+      variant: "info",
+    });
+  });
+
+  it("uses a success message only for a completed response", () => {
+    expect(
+      getAddToDatasetStatus({ status: "completed" }, "Data added successfully"),
+    ).toEqual({
+      message: "Data added successfully",
+      variant: "success",
+    });
+  });
+});

--- a/futureagi/simulate/tests/test_scenario_column_reconciliation.py
+++ b/futureagi/simulate/tests/test_scenario_column_reconciliation.py
@@ -230,6 +230,109 @@ class TestScenarioDatasetColumnFilter:
         assert {str(ce.id) for ce in result} == {str(ce1.id)}
 
 
+class TestExecutionNumberNullFilters:
+    @staticmethod
+    def _apply_filter(test_execution, column_id, filter_op):
+        return TestExecutionUtils()._apply_filters(
+            CallExecution.objects.filter(test_execution=test_execution),
+            [
+                {
+                    "column_id": column_id,
+                    "filter_config": {
+                        "filter_type": "number",
+                        "filter_op": filter_op,
+                        "filter_value": None,
+                    },
+                }
+            ],
+            [],
+            {},
+        )
+
+    def test_number_null_filters_distinguish_null_from_zero(self, test_execution):
+        missing = CallExecution.objects.create(
+            test_execution=test_execution,
+            avg_agent_latency_ms=None,
+        )
+        zero = CallExecution.objects.create(
+            test_execution=test_execution,
+            avg_agent_latency_ms=0,
+        )
+
+        null_ids = set(
+            self._apply_filter(
+                test_execution, "avg_agent_latency_ms", "is_null"
+            ).values_list("id", flat=True)
+        )
+        present_ids = set(
+            self._apply_filter(
+                test_execution, "avg_agent_latency_ms", "is_not_null"
+            ).values_list("id", flat=True)
+        )
+
+        assert null_ids == {missing.id}
+        assert present_ids == {zero.id}
+
+    def test_cost_null_filters_require_both_cost_fields_to_be_missing(
+        self, test_execution
+    ):
+        missing = CallExecution.objects.create(
+            test_execution=test_execution,
+            cost_cents=None,
+            customer_cost_cents=None,
+        )
+        zero_cost = CallExecution.objects.create(
+            test_execution=test_execution,
+            cost_cents=0,
+            customer_cost_cents=None,
+        )
+        customer_cost = CallExecution.objects.create(
+            test_execution=test_execution,
+            cost_cents=None,
+            customer_cost_cents=12,
+        )
+
+        null_ids = set(
+            self._apply_filter(test_execution, "cost", "is_null").values_list(
+                "id", flat=True
+            )
+        )
+        present_ids = set(
+            self._apply_filter(test_execution, "cost", "is_not_null").values_list(
+                "id", flat=True
+            )
+        )
+
+        assert null_ids == {missing.id}
+        assert present_ids == {zero_cost.id, customer_cost.id}
+
+    def test_response_time_null_filters_do_not_require_a_filter_value(
+        self, test_execution
+    ):
+        missing = CallExecution.objects.create(
+            test_execution=test_execution,
+            response_time_ms=None,
+        )
+        zero = CallExecution.objects.create(
+            test_execution=test_execution,
+            response_time_ms=0,
+        )
+
+        null_ids = set(
+            self._apply_filter(test_execution, "responseTime", "is_null").values_list(
+                "id", flat=True
+            )
+        )
+        present_ids = set(
+            self._apply_filter(
+                test_execution, "responseTime", "is_not_null"
+            ).values_list("id", flat=True)
+        )
+
+        assert null_ids == {missing.id}
+        assert present_ids == {zero.id}
+
+
 class TestScenarioDatasetGrouping:
     def test_groups_across_datasets(
         self, organization, workspace, user, test_execution

--- a/futureagi/simulate/utils/test_execution_utils.py
+++ b/futureagi/simulate/utils/test_execution_utils.py
@@ -79,6 +79,10 @@ class TestExecutionUtils:
 
         def apply_number_filter(queryset, field, op, value, transform=lambda v: v):
             values = as_list(value)
+            if op == "is_null":
+                return queryset.filter(**{f"{field}__isnull": True})
+            if op == "is_not_null":
+                return queryset.filter(**{f"{field}__isnull": False})
             if op == "equals":
                 return queryset.filter(**{field: transform(values[0])})
             if op == "not_equals":
@@ -121,6 +125,16 @@ class TestExecutionUtils:
                     condition |= q_for(field, lookup, val)
                 return condition
 
+            def all_fields_q(lookup, val):
+                condition = models.Q()
+                for field in fields:
+                    condition &= q_for(field, lookup, val)
+                return condition
+
+            if op == "is_null":
+                return queryset.filter(all_fields_q("isnull", True))
+            if op == "is_not_null":
+                return queryset.filter(any_field_q("isnull", False))
             if op == "equals":
                 return queryset.filter(any_field_q(None, transform(values[0])))
             if op == "not_equals":
@@ -411,29 +425,38 @@ class TestExecutionUtils:
                 elif column_id in ["responseTime", "response_time"]:
                     # Filter by response time (convert to milliseconds for database comparison)
                     if filter_type == "number":
-                        filter_value = float(filter_value)
-                        # Convert seconds to milliseconds for database comparison
-                        filter_value_ms = filter_value * 1000
-                        if filter_op == "greater_than":
+                        if filter_op == "is_null":
                             call_executions = call_executions.filter(
-                                response_time_ms__gt=filter_value_ms
+                                response_time_ms__isnull=True
                             )
-                        elif filter_op == "less_than":
+                        elif filter_op == "is_not_null":
                             call_executions = call_executions.filter(
-                                response_time_ms__lt=filter_value_ms
+                                response_time_ms__isnull=False
                             )
-                        elif filter_op == "equals":
-                            call_executions = call_executions.filter(
-                                response_time_ms=filter_value_ms
-                            )
-                        elif filter_op == "greater_than_or_equal":
-                            call_executions = call_executions.filter(
-                                response_time_ms__gte=filter_value_ms
-                            )
-                        elif filter_op == "less_than_or_equal":
-                            call_executions = call_executions.filter(
-                                response_time_ms__lte=filter_value_ms
-                            )
+                        else:
+                            filter_value = float(filter_value)
+                            # Convert seconds to milliseconds for database comparison
+                            filter_value_ms = filter_value * 1000
+                            if filter_op == "greater_than":
+                                call_executions = call_executions.filter(
+                                    response_time_ms__gt=filter_value_ms
+                                )
+                            elif filter_op == "less_than":
+                                call_executions = call_executions.filter(
+                                    response_time_ms__lt=filter_value_ms
+                                )
+                            elif filter_op == "equals":
+                                call_executions = call_executions.filter(
+                                    response_time_ms=filter_value_ms
+                                )
+                            elif filter_op == "greater_than_or_equal":
+                                call_executions = call_executions.filter(
+                                    response_time_ms__gte=filter_value_ms
+                                )
+                            elif filter_op == "less_than_or_equal":
+                                call_executions = call_executions.filter(
+                                    response_time_ms__lte=filter_value_ms
+                                )
 
                 elif column_id == "status":
                     # Filter by status


### PR DESCRIPTION
## Summary
Fixes two independent correctness issues in simulation filters and asynchronous dataset imports.

## Linked issues
Closes #2165
Closes #1770

## Changes

### #2165 — simulation number null filters
- Add `is_null` and `is_not_null` handling for regular numeric fields.
- Treat cost as absent only when both `cost_cents` and `customer_cost_cents` are null.
- Support null filters for `responseTime` without coercing an absent filter value.
- Preserve zero as a valid non-null value.

### #1770 — async dataset import status
- Show success only when the backend explicitly returns `completed`.
- Show an informational in-progress message for `processing`, missing, or unknown statuses.
- Share status resolution between new-dataset and existing-dataset flows.

## Tests
- Added simulation regression coverage for numeric, cost, and response-time null filters.
- Added Vitest coverage for dataset import status resolution.
- Passed: Ruff check/format, Python compile, ESLint (0 errors; 4 pre-existing warnings in the touched components), Prettier, Vitest (2/2).
- Not run: Django integration tests require Docker-backed PostgreSQL/ClickHouse, unavailable on this machine.

## Notes
- No API contract changes.
- No documentation change is required.
