### PR TITLE
fix(tracer): record an errored eval row on non-ValueError failures

### DIFF
--- a/futureagi/tracer/tests/test_evaluate_observation_span_error_handling.py
+++ b/futureagi/tracer/tests/test_evaluate_observation_span_error_handling.py
@@ -1,0 +1,57 @@
+"""Regression for #2334: a non-ValueError failure during evaluation must
+still leave a visible, errored EvalLogger row — not silently drop the span
+with no eval record and no retry.
+"""
+
+import pytest
+
+from tracer.models.observation_span import EvalLogger
+from tracer.utils.eval import evaluate_observation_span, evaluate_observation_span_observe
+
+
+@pytest.mark.integration
+class TestEvaluateObservationSpanErrorHandling:
+    def test_non_value_error_still_creates_error_eval_logger(
+        self, mocker, observation_span, custom_eval_config
+    ):
+        mocker.patch(
+            "tracer.services.clickhouse.v2.eval_loader.get_observation_span",
+            return_value=observation_span,
+        )
+        mocker.patch("tracer.utils.eval._process_mapping", return_value={})
+        mocker.patch(
+            "tracer.utils.eval._execute_evaluation",
+            side_effect=RuntimeError("boom"),
+        )
+
+        result = evaluate_observation_span(observation_span.id, custom_eval_config.id)
+
+        assert result is False
+        row = EvalLogger.objects.get(
+            observation_span=observation_span, custom_eval_config=custom_eval_config
+        )
+        assert row.error is True
+        assert "boom" in row.error_message
+
+    def test_observe_variant_also_creates_error_eval_logger(
+        self, mocker, observation_span, custom_eval_config
+    ):
+        mocker.patch(
+            "tracer.services.clickhouse.v2.eval_loader.get_observation_span",
+            return_value=observation_span,
+        )
+        mocker.patch("tracer.utils.eval._process_mapping", return_value={})
+        mocker.patch(
+            "tracer.utils.eval._execute_evaluation",
+            side_effect=RuntimeError("boom"),
+        )
+
+        result = evaluate_observation_span_observe(
+            observation_span.id, custom_eval_config.id
+        )
+
+        assert result is False
+        row = EvalLogger.objects.get(
+            observation_span=observation_span, custom_eval_config=custom_eval_config
+        )
+        assert row.error is True

--- a/futureagi/tracer/utils/eval.py
+++ b/futureagi/tracer/utils/eval.py
@@ -2000,9 +2000,13 @@ def evaluate_observation_span(
         return False
 
     except Exception as e:
+        # Same handling as the ValueError branch above: an unevaluated span
+        # with no eval row at all is invisible to retry/reconcile, unlike a
+        # recorded failure (see #2334).
         logger.exception(
             f"Exception during evaluation in evaluate_observation_span: {e}"
         )
+        _create_error_eval_logger(observation_span, custom_eval_config, None, str(e))
         return False
 
 
@@ -2165,9 +2169,12 @@ def evaluate_observation_span_observe(
 
         return False
     except Exception as e:
+        # Same gap as evaluate_observation_span (#2334): the sibling
+        # ValueError branch above records a failed-eval row, this one didn't.
         logger.exception(
             f"Exception during evaluation in evaluate_observation_span_observe: {e}"
         )
+        _create_error_eval_logger(observation_span, custom_eval_config, eval_task_id, e)
         return False
 
 


### PR DESCRIPTION
## Problem

`evaluate_observation_span` records a failed-eval row on `ValueError`, but on any other exception it logs and returns without creating any eval row — the span is left with no eval record at all and nothing to retry.

```python
except ValueError as e:
    logger.warning(...)
    _create_error_eval_logger(observation_span, custom_eval_config, None, str(e))
    return False
except Exception as e:
    logger.exception(...)
    return False   # no _create_error_eval_logger, no visible result
```

When an eval fails for any non-`ValueError` reason (a transient provider error, a bug, etc.), the span shows no eval result at all, not even a failed/errored one.

## Fix

Mirror the `ValueError` branch's `_create_error_eval_logger` call in the generic `except Exception` branch, so the failure is visible and eligible for the existing requeue/reconcile path.

The sibling function `evaluate_observation_span_observe` has the exact same gap in its own `except Exception` branch (same file, same pattern) — fixed that one too rather than leaving an identical bug next to the one being fixed.

## Test plan

- [x] `python3 -m py_compile tracer/utils/eval.py tracer/tests/test_evaluate_observation_span_error_handling.py`
- [x] Added `tracer/tests/test_evaluate_observation_span_error_handling.py`: for both `evaluate_observation_span` and `evaluate_observation_span_observe`, forces a non-`ValueError` exception from `_execute_evaluation` and asserts an `EvalLogger` row with `error=True` is created.

Fixes #2334