### PR TITLE
fix(tracer): composite external eval raises TypeError from a wrong keyword name

### DIFF
--- a/futureagi/tracer/utils/external_eval.py
+++ b/futureagi/tracer/utils/external_eval.py
@@ -136,7 +136,7 @@ def _execute_composite_on_external_platform(config: ExternalEvalConfig):
             f"Composite {parent.id} has no children — cannot run externally."
         )
 
-    _log_and_deduct_cost_for_external_eval(config, futureagi_eval=False)
+    _log_and_deduct_cost_for_external_eval(config, is_futureagi_eval=False)
 
     outcome = execute_composite_children_sync(
         parent=parent,


### PR DESCRIPTION
## Problem

`_execute_composite_on_external_platform` calls the cost-logging helper with a
keyword the helper does not have, so running a composite eval on an external
platform always raises `TypeError`.

`futureagi/tracer/utils/external_eval.py:49`:

```python
def _log_and_deduct_cost_for_external_eval(
    config: ExternalEvalConfig, is_futureagi_eval: bool
):
```

`futureagi/tracer/utils/external_eval.py:139`:

```python
_log_and_deduct_cost_for_external_eval(config, futureagi_eval=False)
```

The parameter is `is_futureagi_eval`, not `futureagi_eval`, and the function
takes no `**kwargs`, so the second argument never binds:

```
TypeError: _log_and_deduct_cost_for_external_eval() got an unexpected keyword
argument 'futureagi_eval' / missing a required argument: 'is_futureagi_eval'
```

## Sibling baseline

The other call site — the non-composite path in
`_execute_evaluation_on_external_platform` — passes the same value positionally
and is fine (`external_eval.py:192`):

```python
_log_and_deduct_cost_for_external_eval(config, futureagi_eval)
```

So exactly one of the two call sites is broken, and the working one shows the
intended value.

## Reachability

The broken call sits directly in the body of
`_execute_composite_on_external_platform` (lines 117–168), before
`execute_composite_children_sync`, with no guard in front of it. Every composite
eval routed to an external platform hits it.

## Fix

```diff
-    _log_and_deduct_cost_for_external_eval(config, futureagi_eval=False)
+    _log_and_deduct_cost_for_external_eval(config, is_futureagi_eval=False)
```

The `False` value is unchanged — only the keyword is corrected.

## Verification

Both call sites were extracted from the file at HEAD with `ast` and replayed
against the declared signature with `inspect.Signature.bind`:

```
def  _log_and_deduct_cost_for_external_eval(config, is_futureagi_eval)  # line 49
  line 139: (config, futureagi_eval=False)  ->  TypeError: missing a required argument: 'is_futureagi_eval'
  line 192: (config, futureagi_eval)        ->  OK

patched line 139:
  (config, is_futureagi_eval=False) -> OK
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
