### PR TITLE
fix(ui): correct invalid CSS width in Add Filter icon (20ox → 20px)

### DIFF
--- a/frontend/src/sections/develop-detail/DataTab/DevelopFilters/DevelopFilterRow.jsx
+++ b/frontend/src/sections/develop-detail/DataTab/DevelopFilters/DevelopFilterRow.jsx
@@ -108,7 +108,7 @@ const DevelopFilterRow = ({
               <SvgColor
                 src="/assets/icons/ic_add.svg"
                 sx={{
-                  width: "20ox !important",
+                  width: "20px !important",
                   height: "20px !important",
                   color: "primary.main",
                 }}

--- a/frontend/src/sections/evals/DevelopFilters/DevelopFilterRow.jsx
+++ b/frontend/src/sections/evals/DevelopFilters/DevelopFilterRow.jsx
@@ -76,7 +76,7 @@ const DevelopFilterRow = ({
               <SvgColor
                 src="/assets/icons/ic_add.svg"
                 sx={{
-                  width: "20ox !important",
+                  width: "20px !important",
                   height: "20px !important",
                   color: "primary.main",
                 }}


### PR DESCRIPTION
Closes #1967

## Summary

Fixes a CSS typo in the Add Filter button icon: `width: "20ox !important"` is not a valid CSS length, so browsers discard the declaration entirely and the icon falls back to its intrinsic width, breaking the alignment of the filter row. The sibling `height: "20px !important"` is valid and still applies, leaving a mismatched 20px height with an intrinsic width.

## Changes

Replaced `20ox` with `20px` in both files carrying the typo:

- `frontend/src/sections/develop-detail/DataTab/DevelopFilters/DevelopFilterRow.jsx` (line 111)
- `frontend/src/sections/evals/DevelopFilters/DevelopFilterRow.jsx` (line 79)

A repo-wide search for `20ox` now returns no results.

## Validation

- Only the CSS width value changed (1 line per file, no other code touched)
- No frontend lint/build run: `node_modules` is not installed in this environment (full `npm install` required); the change is a string-literal value fix with no syntax risk