### PR TITLE
fix(system-evals): resolve voicemail scoring contradictions and accept JSON/LIST transcripts

### DIFF
--- a/futureagi/model_hub/system_evals/agent/advice_authority_boundary.yaml
+++ b/futureagi/model_hub/system_evals/agent/advice_authority_boundary.yaml
@@ -47,6 +47,8 @@ config:
     conversation:
     - TEXT
     - AUDIO
+    - JSON
+    - LIST
   rule_prompt: "You are evaluating whether an agent stays within the role and authority its prompt grants it during a customer\
     \ conversation.\n\n## Criteria\n1. Scope adherence: The agent performs only what its prompt authorizes and does not commit\
     \ to firm prices, finalize agreements, or confirm approvals it is not authorized to give.\n2. No unqualified advice and\

--- a/futureagi/model_hub/system_evals/agent/claim_intake_accuracy.yaml
+++ b/futureagi/model_hub/system_evals/agent/claim_intake_accuracy.yaml
@@ -48,6 +48,8 @@ config:
     conversation:
     - TEXT
     - AUDIO
+    - JSON
+    - LIST
   rule_prompt: "You are evaluating whether an insurance agent correctly handles a claim intake / first-notice-of-loss (FNOL)\
     \ conversation.\n\n## Criteria\n1. Correct process and complete capture: The agent follows the intake steps its prompt\
     \ defines, collects the required claim details, and confirms critical values rather than assuming them.\n2. No coverage\

--- a/futureagi/model_hub/system_evals/agent/intake_field_accuracy.yaml
+++ b/futureagi/model_hub/system_evals/agent/intake_field_accuracy.yaml
@@ -45,6 +45,8 @@ config:
     conversation:
     - TEXT
     - AUDIO
+    - JSON
+    - LIST
   rule_prompt: "You are evaluating how accurately an agent captured the details a customer gave during a conversation. There\
     \ is no external gold record: a value is correct when it matches what the customer said, and wrong if it contradicts them.\n\
     \n## Criteria\n1. Faithful capture: Every value the agent records, reads back, or carries into a summary or handoff matches\

--- a/futureagi/model_hub/system_evals/agent/lead_qualification_completeness.yaml
+++ b/futureagi/model_hub/system_evals/agent/lead_qualification_completeness.yaml
@@ -47,6 +47,8 @@ config:
     conversation:
     - TEXT
     - AUDIO
+    - JSON
+    - LIST
   rule_prompt: "You are evaluating whether an agent qualifies a lead completely and correctly over the course of a conversation.\n\
     \n## Criteria\n1. Needs discovery and suitability: The agent elicits the qualifying details its prompt defines and aligns\
     \ any recommendation or routing to what the customer actually needs.\n2. Progressive qualification: The agent builds on\

--- a/futureagi/model_hub/system_evals/agent/no_misselling.yaml
+++ b/futureagi/model_hub/system_evals/agent/no_misselling.yaml
@@ -46,6 +46,8 @@ config:
     conversation:
     - TEXT
     - AUDIO
+    - JSON
+    - LIST
   rule_prompt: "You are evaluating whether an agent mis-sells - makes false, exaggerated, or coercive claims - during a customer\
     \ conversation.\n\n## Criteria\n1. Supportable claims: What the agent states about the offering's capability, price, and\
     \ terms is supportable by its prompt or known product facts.\n2. No guarantees or manufactured pressure: The agent does\

--- a/futureagi/model_hub/system_evals/agent/voice_mail_detection.yaml
+++ b/futureagi/model_hub/system_evals/agent/voice_mail_detection.yaml
@@ -6,7 +6,7 @@ criteria: "You are evaluating whether the call reached a voicemail rather than a
   \ indicators: The call contains a voicemail greeting, a beep, an automated \"please leave a message\" prompt, or the customer\
   \ never speaks.\n- No live response: There is no back-and-forth exchange between the agent and a live customer.\n\n## Anti-bias\
   \ Rules\n- A customer who is briefly silent before speaking is NOT a voicemail.\n- Automated IVR menus are NOT voicemail\
-  \ - only flag if a voicemail greeting or beep is present.\n- If evidence is ambiguous, default to PASS (not a voicemail).\n\
+  \ - only flag if a voicemail greeting or beep is present.\n- If evidence is ambiguous, default to FAIL (treat the call as not a voicemail).\n\
   \n## Scoring\n- Return PASS if the call reached a voicemail and the agent is correctly able to identify (voicemail greeting,\
   \ beep, or no live customer response detected).\n- Return FAIL if the call reached a live person.\n\n## Input\n<audio_url>{{conversation}}</audio_url>"
 eval_tags:
@@ -38,7 +38,7 @@ config:
     \ indicators: The call contains a voicemail greeting, a beep, an automated \"please leave a message\" prompt, or the customer\
     \ never speaks.\n- No live response: There is no back-and-forth exchange between the agent and a live customer.\n\n##\
     \ Anti-bias Rules\n- A customer who is briefly silent before speaking is NOT a voicemail.\n- Automated IVR menus are NOT\
-    \ voicemail - only flag if a voicemail greeting or beep is present.\n- If evidence is ambiguous, default to PASS (not\
+    \ voicemail - only flag if a voicemail greeting or beep is present.\n- If evidence is ambiguous, default to FAIL (treat the call as not\
     \ a voicemail).\n\n## Scoring\n- Return PASS if the call reached a voicemail and the agent is correctly able to identify\
     \ (voicemail greeting, beep, or no live customer response detected).\n- Return FAIL if the call reached a live person.\n\
     \n## Input\n<audio_url>{{conversation}}</audio_url>"

--- a/futureagi/model_hub/system_evals/agent/voicemail_handling.yaml
+++ b/futureagi/model_hub/system_evals/agent/voicemail_handling.yaml
@@ -7,7 +7,7 @@ criteria: "You are evaluating whether the agent responded correctly upon reachin
   \ instructions for voicemail handling.\n2. No live-call behavior: The agent does not proceed as if speaking to a live customer\
   \ (e.g. asking questions, waiting for responses).\n\n## Anti-bias Rules\n- If the agent prompt instructs hang up only, leaving\
   \ a message is a FAIL and vice versa.\n- A brief pause before hanging up is NOT incorrect behavior.\n- Evaluate against\
-  \ what the agent prompt defines as correct voicemail handling.\n\n## Scoring\n- Return PASS if call did not go to the VOICEMAIL\
+  \ what the agent prompt defines as correct voicemail handling.\n\n## Scoring\n- Return PASS if call did not go to voicemail, or if it did\
   \ and the agent handled the voicemail correctly per the agent prompt (hung up cleanly or left an appropriate message).\n\
   - Return FAIL if the agent proceeded as if speaking to a live person, left a message when instructed to hang up, or hung\
   \ up when instructed to leave a message.\n\n## Input\n<agent_prompt>{{agent_prompt}}</agent_prompt>\n<audio_url>{{conversation}}</audio_url>"
@@ -46,7 +46,7 @@ config:
     \ customer (e.g. asking questions, waiting for responses).\n\n## Anti-bias Rules\n- If the agent prompt instructs hang\
     \ up only, leaving a message is a FAIL and vice versa.\n- A brief pause before hanging up is NOT incorrect behavior.\n\
     - Evaluate against what the agent prompt defines as correct voicemail handling.\n\n## Scoring\n- Return PASS if call did\
-    \ not go to the VOICEMAIL and the agent handled the voicemail correctly per the agent prompt (hung up cleanly or left\
+    \ not go to voicemail, or if it did and the agent handled the voicemail correctly per the agent prompt (hung up cleanly or left\
     \ an appropriate message).\n- Return FAIL if the agent proceeded as if speaking to a live person, left a message when\
     \ instructed to hang up, or hung up when instructed to leave a message.\n\n## Input\n<agent_prompt>{{agent_prompt}}</agent_prompt>\n\
     <audio_url>{{conversation}}</audio_url>"


### PR DESCRIPTION
Three fixes to the seven new evals on `feat/insurance-agent-system-evals`. Targets that branch so it lands inside #2367. 7 files, +14 / -4.

Prose edits are applied to both `criteria` and `config.rule_prompt`, which are byte-identical mirrors here; both updated and verified.

### 1. `voicemail_handling` could never return PASS

Was: PASS if the call did not go to voicemail **and** the agent handled the voicemail correctly.

Those are mutually exclusive, so nothing satisfied both. Changed to **or**, which is what was intended: there is no skipped verdict on the platform, so a call that never reached voicemail has to fold into PASS.

### 2. `voice_mail_detection` defined PASS both ways

The Anti-bias Rules said "if evidence is ambiguous, default to PASS (**not** a voicemail)" while the scoring said "PASS if the call **reached** a voicemail". A judge cannot resolve that and results would vary per call.

PASS means voicemail detected, so the anti-bias line is the one that was off. An ambiguous call now defaults to FAIL, that is, treated as not a voicemail. The criteria, the PASS line and the FAIL line are unchanged: this PR touches that one line only.

### 3. `param_modalities` rejected transcripts

`conversation` accepted only `TEXT` and `AUDIO` on the five text evals; a transcript also arrives as `JSON` or `LIST`, so both are added. The numerics and `DATETIME` that other evals carry are left out on purpose, they are not meaningful for a conversation. The two voicemail evals stay `AUDIO`-only, since voicemail cannot occur in a chat transcript.

### Not in this PR

Raised on #2367 instead: the `claim_intake_accuracy` / `intake_field_accuracy` overlap on the corrections criterion, the second new `Accuracy` tag, and the absence of any test covering the seven evals.

Also left for #2367: the Scoring branches on `voice_mail_detection` are not exhaustive. PASS requires the call to reach a voicemail and the agent to identify it, FAIL covers only reaching a live person, so a voicemail the agent failed to identify matches neither and `pass_fail` has no third state for it.
