### PR TITLE
fix(annotations): make annotation queue items table columns resizable

### DIFF
--- a/frontend/src/sections/annotations/queues/items/queue-items-table.jsx
+++ b/frontend/src/sections/annotations/queues/items/queue-items-table.jsx
@@ -634,7 +634,7 @@ export default function QueueItemsTable({
       lockVisible: true,
       filter: false,
       sortable: false,
-      resizable: false,
+      resizable: true,
       suppressHeaderMenuButton: true,
       suppressHeaderContextMenu: true,
     }),


### PR DESCRIPTION
## What does this PR do?

Makes the annotation queue items table columns resizable by changing `resizable: false` to `resizable: true` in the `defaultColDef`.

## Why is this needed?

In the annotation queue items table, no column could be resized by dragging its header border. The shared `defaultColDef` set `resizable: false`, which disabled resizing for every column in the grid, while comparable data grids elsewhere in the platform (e.g. the LLM Tracing traces table) support it.

## Changes

- Changed `resizable: false` to `resizable: true` in `defaultColDef`

## Testing

Verified that the change matches the traces table behavior.

Fixes #1966