### PR TITLE
fix(harness): name environments by metadata, not their job id

### DIFF
--- a/frontend/src/components/harness/EnvironmentSwitcher.jsx
+++ b/frontend/src/components/harness/EnvironmentSwitcher.jsx
@@ -18,6 +18,7 @@ import {
   ICON_GUTTER,
   ICON_SIZE,
   agentTypeIcon,
+  environmentName,
   readable,
   stageStatus,
 } from "src/pages/dashboard/harness/harnessShared";
@@ -41,8 +42,7 @@ export default function EnvironmentSwitcher({
   const close = () => setAnchorEl(null);
 
   const current = jobs.find((item) => item.job?.job_id === currentJobId);
-  const label =
-    current?.job?.metadata?.agent_name || currentName || "RL environment";
+  const label = environmentName(current?.job, currentName || "RL environment");
 
   // A cold load of a detail URL can leave the list request unresolved or failed. Without
   // environments to switch between, a dropdown would open onto nothing but the create row,
@@ -126,7 +126,7 @@ export default function EnvironmentSwitcher({
                 />
                 <Stack sx={{ minWidth: 0, flex: 1 }}>
                   <Typography variant="body2" noWrap>
-                    {item.job.metadata?.agent_name || jobId}
+                    {environmentName(item.job)}
                   </Typography>
                   {updated && (
                     <Typography variant="caption" color="text.secondary" noWrap>

--- a/frontend/src/pages/dashboard/harness/HarnessDetail.jsx
+++ b/frontend/src/pages/dashboard/harness/HarnessDetail.jsx
@@ -54,6 +54,7 @@ import {
   stages,
   stageStatus,
   terminalStages,
+  environmentName,
 } from "./harnessShared";
 
 // A tab says where the run is: spinning while its stage is being worked, ticked once it has
@@ -392,7 +393,7 @@ export default function HarnessDetail() {
     <>
       <Helmet>
         <title>
-          {current.job?.metadata?.agent_name || "RL Environment"} | Future AGI
+          {environmentName(current.job, "RL Environment")} | Future AGI
         </title>
       </Helmet>
 
@@ -434,7 +435,7 @@ export default function HarnessDetail() {
               <EnvironmentSwitcher
                 jobs={jobs}
                 currentJobId={jobId}
-                currentName={current.job?.metadata?.agent_name}
+                currentName={environmentName(current.job, "")}
                 onSelect={(nextId) =>
                   navigate(paths.dashboard.simulate.harness.detail(nextId))
                 }
@@ -526,7 +527,7 @@ export default function HarnessDetail() {
             }}
           >
             <Typography variant="h6">
-              {current.job?.metadata?.agent_name}
+              {environmentName(current.job)}
             </Typography>
             <Stack direction="row" alignItems="center" spacing={0.5}>
               <Typography variant="caption" color="text.secondary" noWrap>

--- a/frontend/src/pages/dashboard/harness/HarnessList.jsx
+++ b/frontend/src/pages/dashboard/harness/HarnessList.jsx
@@ -23,6 +23,7 @@ import {
   errorMessage,
   readable,
   stageStatus,
+  environmentName,
 } from "./harnessShared";
 
 const updatedLabel = (status) => {
@@ -55,7 +56,7 @@ export default function HarnessList() {
     const term = debouncedSearchQuery.trim().toLowerCase();
     if (!term) return jobs;
     return jobs.filter((item) =>
-      [item.job?.metadata?.agent_name, item.job?.run_id]
+      [environmentName(item.job, ""), item.job?.run_id]
         .filter(Boolean)
         .some((value) => String(value).toLowerCase().includes(term)),
     );
@@ -75,7 +76,7 @@ export default function HarnessList() {
         enableSorting: false,
         cell: ({ row }) => (
           <Typography variant="body2" fontWeight={500} noWrap>
-            {row.original.job?.metadata?.agent_name || row.original.job?.job_id}
+            {environmentName(row.original.job)}
           </Typography>
         ),
       },

--- a/frontend/src/pages/dashboard/harness/harnessShared.js
+++ b/frontend/src/pages/dashboard/harness/harnessShared.js
@@ -177,6 +177,12 @@ export const shortRunId = (runId = "") => {
   return parts.length > 2 ? `${parts[0]}-${parts[1]}` : String(runId);
 };
 
+// Authoring writes `metadata.name`, older jobs `metadata.agent_name`. Never fall back to the
+// job id: it reads as a name and search cannot match it. Callers whose slot cannot be blank
+// pass their own fallback.
+export const environmentName = (job, fallback = "\u2014") =>
+  job?.metadata?.agent_name || job?.metadata?.name || fallback;
+
 // Four visual states for the run checklist.
 export const STAGE_STATE = {
   DONE: "done",

--- a/frontend/src/pages/dashboard/harness/harnessShared.test.js
+++ b/frontend/src/pages/dashboard/harness/harnessShared.test.js
@@ -8,6 +8,7 @@ import {
   readable,
   canceledProgress,
   completedStageCount,
+  environmentName,
   errorMessage,
   eventTime,
   runElapsed,
@@ -498,5 +499,39 @@ describe("tabState", () => {
     expect(tabState("environment", at("canceled"), [])).not.toBe(
       TAB_STATE.WORKING,
     );
+  });
+});
+
+describe("environmentName", () => {
+  it("prefers agent_name, which only older jobs carry", () => {
+    expect(
+      environmentName({ metadata: { agent_name: "ride-voice-agent", name: "repo" } }),
+    ).toBe("ride-voice-agent");
+  });
+
+  it("falls back to the name authoring writes", () => {
+    expect(environmentName({ metadata: { name: "harden-voice-harness-flows" } })).toBe(
+      "harden-voice-harness-flows",
+    );
+  });
+
+  // The job id is the value the list used to show, and the one search cannot match.
+  it("never shows the job id", () => {
+    const job = { job_id: "ee0f9fa4-e5a8-4c0e-a6d3-05522801abf5", metadata: {} };
+    expect(environmentName(job)).toBe("\u2014");
+  });
+
+  it("says nothing rather than a uuid when there is no name", () => {
+    expect(environmentName({ metadata: {} })).toBe("\u2014");
+    expect(environmentName({})).toBe("\u2014");
+    expect(environmentName(undefined)).toBe("\u2014");
+  });
+
+  it("treats a blank name as absent", () => {
+    expect(environmentName({ metadata: { agent_name: "", name: "" } })).toBe("\u2014");
+  });
+
+  it("lets a caller supply its own fallback for slots that cannot be blank", () => {
+    expect(environmentName({ metadata: {} }, "RL Environment")).toBe("RL Environment");
   });
 });


### PR DESCRIPTION
## Summary

The RL Environments list showed a raw uuid for every environment created on this branch, and its search box could not find any of them. Reported by @khushal-sonawat while testing `feat/hosted-bundle-v2-production` ("There are UUIDs for run names", "Search is not working").

Both symptoms have one cause, and the fix is a single shared helper.

## Linked issues

Closes #
Linear:

## Type of change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

---

## 1) What changes were done

**A. `environmentName` helper (`harnessShared.js`)**

Resolves `metadata.agent_name` → `metadata.name` → `—`. Callers whose slot cannot be blank (browser tab, collapsed switcher) pass their own fallback.

**B. All seven read sites now use it**

| site | before | after |
|---|---|---|
| `HarnessList:78` name column | `agent_name \|\| job_id` | `environmentName(job)` |
| `HarnessList:58` search | `[agent_name, run_id]` | `[environmentName(job, ""), run_id]` |
| `EnvironmentSwitcher:45` label | `agent_name \|\| currentName \|\| "RL environment"` | `environmentName(job, currentName \|\| "RL environment")` |
| `EnvironmentSwitcher:129` menu row | `agent_name \|\| jobId` | `environmentName(item.job)` |
| `HarnessDetail:395` page title | `agent_name \|\| "RL Environment"` | `environmentName(job, "RL Environment")` |
| `HarnessDetail:437` switcher prop | `agent_name` | `environmentName(job, "")` |
| `HarnessDetail:529` heading | `agent_name` — **rendered blank** | `environmentName(job)` |

No direct `metadata.agent_name` read remains in the harness UI.

## 2) Why

Two metadata keys are in play and nothing maps between them:

- **`metadata.name`** — written by `HarnessCreate.jsx:301` (the create page) *and* by the job-firing scripts. Everything created on this branch has it.
- **`metadata.agent_name`** — only older jobs carry it.

The UI read `agent_name` alone and fell back to `job_id`, so new environments rendered as a uuid that reads like a name. Search compounded it: it matched `agent_name` and `run_id` but **never `job_id`**, so the one value on screen was the one value it could not match. Typing what you saw returned nothing.

The job id is not a name, so it is no longer used as one. `—` says "unnamed" honestly; a uuid does not.

The backend already resolves these keys in this order (`hosted_harness_gateway.py:750`, `agent_name or name or "agent"`) — this brings the frontend in line rather than inventing a convention.

Confirmed against real data: in a 9-job dump from a tester's stack, `name` was present on 9/9 and `agent_name` on 0/9. `authoring_key` was byte-identical to `name` in all 9, so it adds nothing to the chain; `authoring_mode`, `authoring_object_key`, `source_kind`, `environment_value_names`, `submitted_by` are plumbing, not names.

cc @hadarishav — the create flow writing `name` while the backend prefers `agent_name` is worth a look separately; this PR only makes the UI tolerate both.

## 3) Tests

`harnessShared.test.js`, 6 new cases:

- prefers `agent_name` when both keys are present
- falls back to `metadata.name`
- never shows the job id (job with an id but empty metadata → `—`)
- returns `—` for empty metadata, `{}`, and `undefined`
- treats a blank-string name as absent
- honours a caller-supplied fallback

## 4) How to verify

Pre-fix: any environment created through the UI on this branch lists as a uuid, and searching that uuid returns nothing.

Post-fix, on a list containing all three shapes at once:

| rows | metadata | renders |
|---|---|---|
| 19 | `agent_name` | `ride-voice-agent`, `dummy-chat-agent`, … |
| 1 | `name` only | `harden-voice-harness-flows` |
| 1 | neither | `—` |

- name column contained **zero** uuids
- `search "harden"` → 1 row (was 0 before) — matches on `name`
- `search "ride"` → 4 rows — matches on `agent_name`
- `search "e7818f87"` → 1 row via `run_id`, unchanged
- unnamed job's detail page: heading `—`, switcher `RL environment`, tab title `RL Environment | Future AGI`

Resolution is per row, so a mixed list needs no migration — each row finds its own name.

## 5) Commands

```bash
cd frontend
npx vitest run src/pages/dashboard/harness src/components/harness   # 137 passed / 12 files
npx eslint src/pages/dashboard/harness src/components/harness       # clean
```

## 6) Videos & Screenshots

_To be added._
