### PR TITLE
ci(TH-7733): always build frontend from source in e2e runs

### DIFF
--- a/.github/workflows/e2e-ci.yml
+++ b/.github/workflows/e2e-ci.yml
@@ -72,7 +72,9 @@ jobs:
       packages: write # ghcr build-cache: read on PRs, written on pushes
     env:
       BUILD_BACKEND: ${{ needs.changes.outputs.backend }}
-      BUILD_FRONTEND: ${{ needs.changes.outputs.frontend }}
+      # Always from source: specs land with the frontend behavior they assert,
+      # so the released frontend image can be too old for them (TH-7733).
+      BUILD_FRONTEND: "true"
       BUILD_GATEWAY: ${{ needs.changes.outputs.gateway }}
     steps:
       - uses: actions/checkout@v4
@@ -116,10 +118,9 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      # An image whose filter did not fire is NOT built from this PR — the
-      # stack runs the released :latest for it. So an e2e/**-only PR exercises
-      # the released stack; a frontend PR tests its frontend against released
-      # backend/collector/gateway. Deliberate speed trade.
+      # A backend/gateway image whose filter did not fire is NOT built from
+      # this PR — the stack runs the released :latest for it. Deliberate speed
+      # trade. The frontend is exempt (see BUILD_FRONTEND above).
       - name: Build backend image from PR code
         if: env.BUILD_BACKEND == 'true'
         uses: docker/build-push-action@v5


### PR DESCRIPTION
Supersedes #2428, which was auto-closed by a branch rename (the repo's branch-name check doesn't allow a `ci/` prefix).

## Summary
- Backend-only PRs run e2e against the released `futureagi/frontend:latest`, but e2e specs merge together with the frontend behavior they assert — e.g. `OBS-E2E-003` asserts the `project_ids` eval scoping fix (TH-6787, merged to dev, not yet released), so every backend-only PR currently fails e2e (see [#2092's failure](https://github.com/future-agi/future-agi/pull/2092)).
- Fix: always build the frontend image from merge-ref source in e2e runs, same as dev push runs already do. Backend/collector/gateway keep their paths-filter behavior.
- Cost is small: the ghcr registry build cache is written on every dev push, so an unchanged-frontend build is mostly cache hits, and the `changes.any` gate still skips e2e entirely for docs-only PRs.

## Changes by file
- `.github/workflows/e2e-ci.yml`: `BUILD_FRONTEND` env changed from the `frontend` paths-filter output to `"true"`; the comment block on filtered builds updated to note the frontend exemption.

## Flows touched
- e2e CI on pull requests: the frontend image is now always built from the PR merge ref instead of falling back to Docker Hub `:latest` when `frontend/**` is untouched. Push/merge_group runs are unchanged (they already built everything).

## Test coverage
- CI workflow change — no unit-testable code. Verified with `actionlint` (clean) and by this PR's own e2e run, which exercises the new path exactly: workflow-only change → backend filter does not fire (released backend) → frontend builds from source → full spec suite including `OBS-E2E-003` must pass. Without this change, this PR's e2e run would fail on `OBS-E2E-003`.

## How tested
- `actionlint .github/workflows/e2e-ci.yml` — clean.
- This PR's e2e run is the live verification; will confirm green (and that the "Build frontend image from PR code" step actually ran) before marking ready for review. The e2e run from #2428 (same commit, [run 33375363770](https://github.com/future-agi/future-agi/actions/runs/33375363770)) already confirmed the frontend build step fires on a workflow-only PR.

## Media
_Screenshot / video:_ (placeholder — add manually if relevant)

## Test logs
<details>
<summary>actionlint output</summary>

```
$ actionlint .github/workflows/e2e-ci.yml
(no findings)
```

</details>

Linear: [TH-7733](https://linear.app/future-agi/issue/TH-7733/e2e-ci-pr-runs-use-stale-released-frontend-image-failing-specs-that)

Made with [Cursor](https://cursor.com)