### PR TITLE
fix(harness): make the run timeline readable and say how each scenario went

### DIFF
--- a/frontend/src/pages/dashboard/harness/HarnessDetail.jsx
+++ b/frontend/src/pages/dashboard/harness/HarnessDetail.jsx
@@ -21,6 +21,7 @@ import { useNavigate, useParams } from "react-router-dom";
 
 import Iconify from "src/components/iconify";
 import StatusChip from "src/components/custom-status-chip/CustomStatusChip";
+import ScenarioOutcome from "./ScenarioOutcome";
 import CustomTooltip from "src/components/tooltip";
 
 import StageOutput from "./StageOutput";
@@ -51,6 +52,8 @@ import {
   eventMessage,
   jobProgress,
   readable,
+  scenarioOutcome,
+  scenarioTally,
   stages,
   stageStatus,
   terminalStages,
@@ -563,9 +566,7 @@ export default function HarnessDetail() {
             />
             <Stack direction="row" justifyContent="space-between" mt={0.5}>
               <Typography variant="caption" color="text.secondary">
-                {status?.completed_scenarios || 0} /{" "}
-                {status?.total_scenarios || current.job?.scenario_count || 0}{" "}
-                scenarios
+                {scenarioTally(status, current.job)}
               </Typography>
               {elapsedLabel && (
                 <Typography variant="caption" color="text.secondary">
@@ -926,6 +927,13 @@ export default function HarnessDetail() {
                         <Typography variant="body2">
                           {eventMessage(entry.event)}
                         </Typography>
+                        <ScenarioOutcome
+                          outcome={scenarioOutcome(
+                            entry.event.payload?.scenario_key,
+                            entry.event.payload?.scenario_attempt,
+                            current,
+                          )}
+                        />
                       </Paper>
                     ),
                   )}

--- a/frontend/src/pages/dashboard/harness/HarnessDetail.jsx
+++ b/frontend/src/pages/dashboard/harness/HarnessDetail.jsx
@@ -906,8 +906,13 @@ export default function HarnessDetail() {
                       >
                         <Stack direction="row" justifyContent="space-between">
                           <Typography variant="caption" color="accent.brand">
+                            {/* Hosted events name their stage at the top level, the
+                              sandbox nests it in the payload. Without both, a hosted
+                              card falls back to its type and repeats the body. */}
                             {readable(
-                              entry.event.payload?.stage || entry.event.type,
+                              entry.event.payload?.stage ||
+                                entry.event.stage ||
+                                entry.event.type,
                             )}
                           </Typography>
                           <Typography

--- a/frontend/src/pages/dashboard/harness/ScenarioOutcome.jsx
+++ b/frontend/src/pages/dashboard/harness/ScenarioOutcome.jsx
@@ -1,0 +1,102 @@
+import { useState } from "react";
+import PropTypes from "prop-types";
+import { Box, Collapse, Link, Stack, Typography } from "@mui/material";
+
+import Iconify from "src/components/iconify";
+import StatusChip from "src/components/custom-status-chip/CustomStatusChip";
+import { STATUS_TYPES } from "src/utils/statusUtils";
+
+import { callSummary } from "./harnessShared";
+
+const chipStatus = (status) => {
+  if (status === "passed") return STATUS_TYPES.PASS;
+  if (status === "failed" || status === "errored") return STATUS_TYPES.ERROR;
+  if (status === "skipped") return STATUS_TYPES.CANCELED;
+  return STATUS_TYPES.RUNNING;
+};
+
+/**
+ * What became of the scenario a timeline row started. The run reports the verdict, the call
+ * and the sub-goals apart from the event, so this hangs off the joined outcome rather than
+ * the event itself, and renders nothing at all when there is none — a scenario still running,
+ * or a sandbox run, which reports neither.
+ */
+export default function ScenarioOutcome({ outcome }) {
+  const [open, setOpen] = useState(false);
+  if (!outcome) return null;
+
+  const summary = callSummary(outcome);
+  // A check that did not hold carries the sentence explaining why, which is the reason to
+  // open this at all. The denominator matters too: one of one reads very differently from
+  // five of six. A scenario that passed every check stays closed and quiet.
+  const failed = outcome.subGoals.filter((goal) => !goal.held);
+  // An outcome can carry nothing worth drawing — a skipped scenario with no call and no
+  // checks. Leave the row as it was rather than opening a gap under it.
+  if (!outcome.status && !summary && failed.length === 0) return null;
+
+  return (
+    <Stack spacing={0.75} sx={{ mt: 0.75 }}>
+      <Stack direction="row" alignItems="center" spacing={1}>
+        {outcome.status && (
+          <StatusChip
+            label={outcome.status}
+            status={chipStatus(outcome.status)}
+            showIcon={false}
+          />
+        )}
+        {summary && (
+          <Typography variant="caption" color="text.secondary">
+            {summary}
+          </Typography>
+        )}
+        {failed.length > 0 && (
+          <Link
+            component="button"
+            type="button"
+            variant="caption"
+            underline="hover"
+            color="text.secondary"
+            onClick={() => setOpen((wasOpen) => !wasOpen)}
+            sx={{ display: "inline-flex", alignItems: "center", gap: 0.25 }}
+          >
+            {failed.length} of {outcome.subGoals.length} checks failed
+            <Iconify
+              icon={open ? "eva:chevron-up-fill" : "eva:chevron-down-fill"}
+              width={14}
+            />
+          </Link>
+        )}
+      </Stack>
+
+      <Collapse in={open} unmountOnExit>
+        <Stack component="ul" spacing={0.25} sx={{ m: 0, pl: 2 }}>
+          {failed.map((goal) => (
+            <Box component="li" key={goal.name}>
+              <Typography variant="caption" color="text.secondary">
+                <Box component="span" sx={{ color: "text.primary" }}>
+                  {goal.name}
+                </Box>
+                {goal.reason ? ` — ${goal.reason}` : ""}
+              </Typography>
+            </Box>
+          ))}
+        </Stack>
+      </Collapse>
+    </Stack>
+  );
+}
+
+ScenarioOutcome.propTypes = {
+  outcome: PropTypes.shape({
+    status: PropTypes.string,
+    turns: PropTypes.number,
+    durationMs: PropTypes.number,
+    subGoals: PropTypes.arrayOf(
+      PropTypes.shape({
+        name: PropTypes.string,
+        held: PropTypes.bool,
+        reason: PropTypes.string,
+      }),
+    ),
+  }),
+};

--- a/frontend/src/pages/dashboard/harness/ScenarioOutcome.test.jsx
+++ b/frontend/src/pages/dashboard/harness/ScenarioOutcome.test.jsx
@@ -1,0 +1,78 @@
+import { screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it } from "vitest";
+
+import { render } from "src/utils/test-utils";
+
+import ScenarioOutcome from "./ScenarioOutcome";
+
+const failing = {
+  status: "failed",
+  turns: 13,
+  durationMs: 97560,
+  subGoals: [
+    { name: "ride_booked", held: false, reason: "book_ride never succeeded" },
+    { name: "address_confirmed", held: true, reason: null },
+  ],
+};
+
+describe("ScenarioOutcome", () => {
+  it("says how the scenario went and how long its call ran", () => {
+    render(<ScenarioOutcome outcome={failing} />);
+    expect(screen.getByText("failed")).toBeInTheDocument();
+    expect(screen.getByText("13 turns · 1m 37s")).toBeInTheDocument();
+  });
+
+  // The reason a scenario failed is the point of the row, but it is a paragraph per goal —
+  // kept behind a toggle so ten scenarios still read as a list.
+  it("keeps the failed-check reasons behind a toggle", async () => {
+    const user = userEvent.setup();
+    render(<ScenarioOutcome outcome={failing} />);
+
+    expect(screen.queryByText(/book_ride never succeeded/)).not.toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: /1 of 2 checks failed/ }));
+    expect(screen.getByText(/book_ride never succeeded/)).toBeInTheDocument();
+  });
+
+  it("lists only the goals that did not hold", async () => {
+    const user = userEvent.setup();
+    render(<ScenarioOutcome outcome={failing} />);
+    await user.click(screen.getByRole("button", { name: /1 of 2 checks failed/ }));
+    expect(screen.getByText("ride_booked")).toBeInTheDocument();
+    expect(screen.queryByText("address_confirmed")).not.toBeInTheDocument();
+  });
+
+  it("offers nothing to open when every goal held", () => {
+    render(
+      <ScenarioOutcome
+        outcome={{
+          status: "passed",
+          turns: 11,
+          durationMs: 106000,
+          subGoals: [{ name: "suspension_refused_with_handoff", held: true, reason: null }],
+        }}
+      />,
+    );
+    expect(screen.getByText("passed")).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /checks failed/ })).not.toBeInTheDocument();
+  });
+
+  // A scenario still running, or any sandbox run, reports no outcome at all.
+  it("renders nothing without an outcome", () => {
+    const { container } = render(<ScenarioOutcome outcome={null} />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("survives a scenario whose call was never measured", () => {
+    render(<ScenarioOutcome outcome={{ status: "failed", turns: null, durationMs: null, subGoals: [] }} />);
+    expect(screen.getByText("failed")).toBeInTheDocument();
+    expect(screen.queryByText(/turns/)).not.toBeInTheDocument();
+  });
+
+  it("renders nothing when the outcome carries nothing to show", () => {
+    const { container } = render(
+      <ScenarioOutcome outcome={{ status: null, turns: null, durationMs: null, subGoals: [] }} />,
+    );
+    expect(container).toBeEmptyDOMElement();
+  });
+});

--- a/frontend/src/pages/dashboard/harness/harnessShared.js
+++ b/frontend/src/pages/dashboard/harness/harnessShared.js
@@ -391,6 +391,63 @@ export function eventMessage(event) {
   return readable(event.type || "Progress updated");
 }
 
+// "1 / 10" reads as nine still to come when in fact nine failed. Hosted runs count failures
+// separately, so say so; the sandbox has no such count and keeps the plain ratio.
+export const scenarioTally = (status, job) => {
+  const total = status?.total_scenarios || job?.scenario_count || 0;
+  const passed = status?.completed_scenarios || 0;
+  const failed = status?.failed_scenarios;
+  if (typeof failed !== "number" || failed === 0)
+    return `${passed} / ${total} scenarios`;
+  return `${passed} passed · ${failed} failed / ${total} scenarios`;
+};
+
+// Every verdict a receipt can carry. A scenario is registered before it runs, so anything
+// outside this set — "registered" — means it has not finished, not that it went badly.
+const SETTLED = new Set(["passed", "failed", "errored", "skipped"]);
+
+// A scenario's outcome and its call are reported apart from the event that started it: the
+// stream has no "scenario finished". Join them so a started row can say how it went. A retry
+// emits a second row under the same key, so the attempt has to match too, or the first row
+// would claim the retry's verdict. Absent until the attempt reports, and on sandbox runs,
+// which send neither scenarios nor receipts.
+export const scenarioOutcome = (scenarioKey, scenarioAttempt, run) => {
+  if (!scenarioKey) return null;
+  const attempt = Number(scenarioAttempt) || 1;
+  const attempts = (run?.receipts || []).filter(
+    (item) => item.scenario_key === scenarioKey,
+  );
+  const receipt = attempts.find(
+    (item) => (Number(item.scenario_attempt) || 1) === attempt,
+  );
+  // The registration holds one verdict for the scenario, which belongs to whichever attempt
+  // ran last. Read it only when no attempt has reported one of its own.
+  const registration = attempts.length
+    ? null
+    : (run?.scenarios || []).find((item) => item.scenario_key === scenarioKey);
+  const status = receipt?.status || registration?.status || null;
+  const settled = SETTLED.has(status) ? status : null;
+  if (!settled && !receipt) return null;
+  const call = receipt?.call || {};
+  return {
+    status: settled,
+    turns: call.turns ?? null,
+    durationMs: call.duration_ms ?? null,
+    // `held` is the verdict and carries a reason whenever it is false; `judged` only says
+    // whether a model was the one to decide, so it is not part of the outcome.
+    subGoals: receipt?.sub_goals || [],
+  };
+};
+
+// Turns and duration read as one line under the scenario name, and only when measured.
+export const callSummary = (outcome) =>
+  [
+    outcome?.turns != null ? `${outcome.turns} turns` : "",
+    outcome?.durationMs != null ? shortDuration(outcome.durationMs) : "",
+  ]
+    .filter(Boolean)
+    .join(" · ");
+
 // A completed run is 100% regardless of where its stage landed in the list; anything else
 // sits half a stage into its slot, with a floor so a queued run still shows a sliver.
 export const jobProgress = (status) => {

--- a/frontend/src/pages/dashboard/harness/harnessShared.js
+++ b/frontend/src/pages/dashboard/harness/harnessShared.js
@@ -316,11 +316,69 @@ export const agentTypeIcon = (item) => {
   return { src: "/assets/icons/ic_bot.svg", label: "Not detected" };
 };
 
+// Hosted runs speak a different event vocabulary to the local sandbox: flat types that keep
+// their detail in named payload fields rather than a `detail` string. Read those fields, or
+// every card in the feed renders as its own type name — ten scenarios in a row reading
+// "Scenario started" with the key that tells them apart sitting unused in the payload.
+const hostedMessage = (type, payload) => {
+  switch (type) {
+    case "stage_changed":
+      // The first stage has no predecessor to arrow from.
+      return payload.from
+        ? `${readable(payload.from)} → ${readable(payload.to)}`
+        : `Started ${readable(payload.to).toLowerCase()}`;
+    case "baseline_frozen":
+      return payload.baseline_ref
+        ? `Baseline frozen · ${payload.baseline_ref}`
+        : "Baseline frozen";
+    case "baseline_inputs_changed":
+      return "Baseline inputs changed";
+    case "world_unhealthy":
+      return "World unhealthy";
+    case "parallelism_degraded":
+      return `Parallelism reduced ${payload.requested} → ${payload.effective} · ${readable(payload.reason)}`;
+    case "scenario_started":
+    case "scenario_retried": {
+      const verb = type === "scenario_retried" ? "retried" : "started";
+      const attempt = Number(payload.scenario_attempt) || 1;
+      // A first attempt is the norm and saying so on every line is noise.
+      const again = attempt > 1 ? ` · attempt ${attempt}` : "";
+      return `Scenario ${payload.scenario_key} ${verb}${again}`;
+    }
+    case "terminal": {
+      const counts = payload.scenario_counts || {};
+      // How the run actually went is the most useful line in the feed; it was being dropped.
+      const tally = ["passed", "failed", "errored", "skipped"]
+        .filter((outcome) => counts[outcome])
+        .map((outcome) => `${counts[outcome]} ${outcome}`)
+        .join(", ");
+      return [
+        readable(payload.stage || ""),
+        tally,
+        payload.reason ? readable(payload.reason) : "",
+      ]
+        .filter(Boolean)
+        .join(" · ");
+    }
+    default:
+      return null;
+  }
+};
+
 export function eventMessage(event) {
   const payload = event.payload || {};
   if (payload.detail) return String(payload.detail);
+  // Hosted `log` events land here, carrying the line they want shown.
   if (payload.message) return String(payload.message);
+
+  const hosted = hostedMessage(event.type, payload);
+  if (hosted) return hosted;
+
   if (payload.stage) {
+    // A run-level event names the run, not the stage: "Run completed", never the
+    // "Completed completed" that reading its terminal stage back produced.
+    if (event.type?.startsWith("harness.run."))
+      return `Run ${event.type.slice("harness.run.".length)}`;
     // "Calls completed" reads better than "Calls Harness.stage.completed".
     if (event.type?.endsWith(".started"))
       return `${readable(payload.stage)} started`;

--- a/frontend/src/pages/dashboard/harness/harnessShared.test.js
+++ b/frontend/src/pages/dashboard/harness/harnessShared.test.js
@@ -10,6 +10,7 @@ import {
   completedStageCount,
   environmentName,
   errorMessage,
+  eventMessage,
   eventTime,
   runElapsed,
   shortDuration,
@@ -533,5 +534,113 @@ describe("environmentName", () => {
 
   it("lets a caller supply its own fallback for slots that cannot be blank", () => {
     expect(environmentName({ metadata: {} }, "RL Environment")).toBe("RL Environment");
+  });
+});
+
+describe("eventMessage — hosted vocabulary", () => {
+  const hosted = (type, payload, stage) => ({ type, stage, payload });
+
+  it("arrows a stage change, and says 'started' when there is no predecessor", () => {
+    expect(
+      eventMessage(hosted("stage_changed", { from: null, to: "validating_environment" })),
+    ).toBe("Started validating environment");
+    expect(
+      eventMessage(
+        hosted("stage_changed", { from: "validating_environment", to: "running" }),
+      ),
+    ).toBe("Validating environment → Running scenarios");
+  });
+
+  it("names the frozen baseline", () => {
+    expect(
+      eventMessage(hosted("baseline_frozen", { baseline_ref: "alk_baseline_world_db" })),
+    ).toBe("Baseline frozen · alk_baseline_world_db");
+    expect(eventMessage(hosted("baseline_frozen", {}))).toBe("Baseline frozen");
+  });
+
+  // Ten of these in a row are indistinguishable without the key.
+  it("names the scenario, and only mentions a repeat attempt", () => {
+    expect(
+      eventMessage(
+        hosted("scenario_started", { scenario_key: "book-with-card-and-otp", scenario_attempt: 1 }),
+      ),
+    ).toBe("Scenario book-with-card-and-otp started");
+    expect(
+      eventMessage(
+        hosted("scenario_retried", { scenario_key: "cancel-booked-ride", scenario_attempt: 2 }),
+      ),
+    ).toBe("Scenario cancel-booked-ride retried · attempt 2");
+  });
+
+  it("reports how the run actually went", () => {
+    expect(
+      eventMessage(
+        hosted("terminal", {
+          stage: "completed",
+          reason: null,
+          scenario_counts: { passed: 1, failed: 9, errored: 0, skipped: 0 },
+        }),
+      ),
+    ).toBe("Completed · 1 passed, 9 failed");
+  });
+
+  it("gives the reason a run was cut short", () => {
+    expect(
+      eventMessage(
+        hosted("terminal", { stage: "canceled", reason: "ttl_exceeded", scenario_counts: {} }),
+      ),
+    ).toBe("Canceled · Ttl exceeded");
+  });
+
+  it("spells out degraded parallelism", () => {
+    expect(
+      eventMessage(
+        hosted("parallelism_degraded", { requested: 4, effective: 1, reason: "fixed_port" }),
+      ),
+    ).toBe("Parallelism reduced 4 → 1 · Fixed port");
+  });
+
+  it("covers the remaining contract types", () => {
+    expect(eventMessage(hosted("world_unhealthy", {}))).toBe("World unhealthy");
+    expect(eventMessage(hosted("baseline_inputs_changed", {}))).toBe(
+      "Baseline inputs changed",
+    );
+  });
+
+  it("shows a log line as written", () => {
+    expect(
+      eventMessage(hosted("log", { level: "warning", message: "retrying upload" })),
+    ).toBe("retrying upload");
+  });
+
+  // An event type ALK adds later still reads as its name rather than breaking.
+  it("falls back to the type for an unknown event", () => {
+    expect(eventMessage(hosted("something_new", {}))).toBe("Something new");
+  });
+});
+
+describe("eventMessage — sandbox vocabulary is unchanged", () => {
+  it("still reads stage events off the payload", () => {
+    expect(
+      eventMessage({ type: "harness.stage.started", payload: { stage: "environment" } }),
+    ).toBe("Environment started");
+    expect(
+      eventMessage({ type: "harness.stage.completed", payload: { stage: "calls" } }),
+    ).toBe("Calls completed");
+    expect(
+      eventMessage({ type: "harness.stage.failed", payload: { stage: "scenarios" } }),
+    ).toBe("Scenarios failed");
+  });
+
+  it("names the run rather than repeating its terminal stage", () => {
+    expect(
+      eventMessage({ type: "harness.run.completed", payload: { stage: "completed" } }),
+    ).toBe("Run completed");
+  });
+
+  it("still prefers an explicit detail or message", () => {
+    expect(
+      eventMessage({ type: "stage_changed", payload: { detail: "hand written", to: "running" } }),
+    ).toBe("hand written");
   });
 });

--- a/frontend/src/pages/dashboard/harness/harnessShared.test.js
+++ b/frontend/src/pages/dashboard/harness/harnessShared.test.js
@@ -9,9 +9,12 @@ import {
   canceledProgress,
   completedStageCount,
   environmentName,
+  callSummary,
   errorMessage,
   eventMessage,
   eventTime,
+  scenarioOutcome,
+  scenarioTally,
   runElapsed,
   shortDuration,
   shortRunId,
@@ -642,5 +645,114 @@ describe("eventMessage — sandbox vocabulary is unchanged", () => {
     expect(
       eventMessage({ type: "stage_changed", payload: { detail: "hand written", to: "running" } }),
     ).toBe("hand written");
+  });
+});
+
+describe("scenarioTally", () => {
+  it("names the failures a hosted run reports", () => {
+    expect(
+      scenarioTally({ completed_scenarios: 1, failed_scenarios: 9, total_scenarios: 10 }),
+    ).toBe("1 passed · 9 failed / 10 scenarios");
+  });
+
+  // The sandbox sends no failure count; inventing one would be worse than the ratio.
+  it("keeps the plain ratio when nothing failed or nothing is counted", () => {
+    expect(scenarioTally({ completed_scenarios: 1, total_scenarios: 1 })).toBe(
+      "1 / 1 scenarios",
+    );
+    expect(
+      scenarioTally({ completed_scenarios: 3, failed_scenarios: 0, total_scenarios: 3 }),
+    ).toBe("3 / 3 scenarios");
+  });
+
+  it("falls back to the requested count before the run reports one", () => {
+    expect(scenarioTally({}, { scenario_count: 10 })).toBe("0 / 10 scenarios");
+    expect(scenarioTally(undefined, undefined)).toBe("0 / 0 scenarios");
+  });
+});
+
+describe("scenarioOutcome", () => {
+  const run = {
+    scenarios: [{ scenario_key: "book-with-card-and-otp", status: "failed" }],
+    receipts: [
+      {
+        scenario_key: "book-with-card-and-otp",
+        scenario_attempt: 1,
+        status: "failed",
+        call: { turns: 13, duration_ms: 97560 },
+        sub_goals: [
+          { name: "ride_booked", held: false, judged: false, reason: "book_ride never succeeded" },
+        ],
+      },
+    ],
+  };
+
+  it("joins a scenario to its call and sub-goals on the key", () => {
+    const outcome = scenarioOutcome("book-with-card-and-otp", 1, run);
+    expect(outcome.status).toBe("failed");
+    expect(outcome.turns).toBe(13);
+    expect(outcome.subGoals).toHaveLength(1);
+    expect(callSummary(outcome)).toBe("13 turns · 1m 37s");
+  });
+
+  // Scenarios are registered before they run, so `scenarios[]` answers for one that has not
+  // started. "registered" is not a verdict and must not reach the row as a chip.
+  it("says nothing for a scenario that has only been registered", () => {
+    expect(
+      scenarioOutcome("pending-one", 1, {
+        scenarios: [{ scenario_key: "pending-one", status: "registered" }],
+        receipts: [],
+      }),
+    ).toBeNull();
+  });
+
+  // A retry emits a second row under the same key. Attempt 1 must not claim attempt 2's verdict.
+  it("keeps each attempt to its own receipt", () => {
+    const retried = {
+      scenarios: [{ scenario_key: "flaky", status: "passed" }],
+      receipts: [
+        { scenario_key: "flaky", scenario_attempt: 1, status: "failed", call: { turns: 4 }, sub_goals: [] },
+        { scenario_key: "flaky", scenario_attempt: 2, status: "passed", call: { turns: 9 }, sub_goals: [] },
+      ],
+    };
+    expect(scenarioOutcome("flaky", 1, retried).status).toBe("failed");
+    expect(scenarioOutcome("flaky", 1, retried).turns).toBe(4);
+    expect(scenarioOutcome("flaky", 2, retried).status).toBe("passed");
+    expect(scenarioOutcome("flaky", 2, retried).turns).toBe(9);
+  });
+
+  // The registration's verdict belongs to the attempt that ran last, so a row whose own
+  // attempt has not reported shows nothing rather than borrowing it.
+  it("does not lend the registration verdict to an unreported attempt", () => {
+    expect(
+      scenarioOutcome("flaky", 1, {
+        scenarios: [{ scenario_key: "flaky", status: "passed" }],
+        receipts: [
+          { scenario_key: "flaky", scenario_attempt: 2, status: "passed", call: {}, sub_goals: [] },
+        ],
+      }),
+    ).toBeNull();
+  });
+
+  it("treats a missing attempt as the first", () => {
+    const outcome = scenarioOutcome("book-with-card-and-otp", undefined, run);
+    expect(outcome.status).toBe("failed");
+  });
+
+  it("returns nothing when the scenario has not reported", () => {
+    expect(scenarioOutcome("not-run-yet", 1, run)).toBeNull();
+    expect(scenarioOutcome("book-with-card-and-otp", 1, { scenarios: [], receipts: [] })).toBeNull();
+    expect(scenarioOutcome(undefined, 1, run)).toBeNull();
+    expect(scenarioOutcome("book-with-card-and-otp", 1, undefined)).toBeNull();
+  });
+
+  it("reports a scenario whose call was never measured", () => {
+    const outcome = scenarioOutcome("k", 1, {
+      scenarios: [{ scenario_key: "k", status: "passed" }],
+      receipts: [],
+    });
+    expect(outcome.status).toBe("passed");
+    expect(callSummary(outcome)).toBe("");
+    expect(outcome.subGoals).toEqual([]);
   });
 });


### PR DESCRIPTION
## Summary

A hosted run's activity feed was unreadable and its results were thrown away.

Every card read as its own type name, twice — `Stage changed / Stage changed`, and ten consecutive `Scenario started / Scenario started` that nobody could tell apart. The header said `1 / 10 scenarios`, which reads as nine still to come when in fact **nine had failed**. Raised by @khushal-sonawat while testing this branch ("I don't know what to make of these").

Nothing was missing from the wire. The scenario key, the pass/fail tally, the per-scenario verdict, call length and the named checks all arrive in the response and were dropped at render.

## Linked issues

Closes #
Linear:

## Type of change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)

---

## 1) What changes were done

**A. The timeline learned the hosted event vocabulary** (`0b392115e`)

Two vocabularies exist. The local sandbox emits dotted types (`harness.stage.started`) with `payload.stage`. Hosted/Daytona emits a validated contract of nine flat types (`stage_changed`, `baseline_frozen`, `scenario_started`, `scenario_retried`, `parallelism_degraded`, `world_unhealthy`, `baseline_inputs_changed`, `log`, `terminal`) that name their stage at the **top level** and keep detail in named payload fields. `eventMessage` only knew the sandbox shape, so both title and body fell through to `readable(event.type)`.

All nine are handled; the card title now also reads `event.stage`. An event type ALK adds later still degrades to its own name — today's behaviour, no longer the common case.

Also drops `Completed completed`, which a run-level event produced by reading its terminal stage back as a verb. Now `Run completed`.

**B. Scenario outcomes joined onto the feed** (`075a19559`)

- `scenarioTally` — the header counts failures when the run reports them.
- `scenarioOutcome` — joins the event to `scenarios[]`/`receipts[]` on **key + attempt** for verdict, turns, duration and sub-goals.
- `ScenarioOutcome.jsx` — status chip, `13 turns · 1m 37s`, and a `N of M checks failed` toggle listing each unmet check with its reason.

## 2) Why

The checks are the point. `ride_booked — book_ride never succeeded` is the sentence an operator would otherwise reconstruct by reading a 13-turn transcript.

Two behaviours worth calling out, both from review:

- **Scenarios are registered before they run.** `_scenario_status` returns the literal `"registered"` until a call exists, so a row shows nothing until its own attempt reports. A live run fills in per row rather than all at once.
- **A retry reports separately under the same key.** The join matches `scenario_attempt` too, or attempt 1 would render attempt 2's verdict.

Degradation is deliberate: sandbox runs send no `scenarios`, no `receipts` and no `failed_scenarios` — their response model has no such fields — so they render exactly as before. Verified by stripping those fields and diffing the output.

## 3) Tests

166 pass across 13 files (23 new).

- all nine hosted event types, incl. first stage change with no predecessor, attempt suffix only when >1, a cancelled run's reason, and an unknown future type degrading to its name
- the three sandbox forms unchanged, and `harness.run.completed` → `Run completed`
- tally: hosted failures named; plain ratio when nothing failed or nothing is counted
- join: registered-only scenario yields nothing; per-attempt retry; registration verdict not lent to an unreported attempt
- component: toggle hides reasons until clicked, only unmet checks listed, passed scenario offers no toggle, null and unmeasured-call cases render nothing

## 4) How to verify

Open a hosted run's **Runs** tab. Before: ten identical rows and `1 / 10 scenarios`. After: each scenario named, with its verdict, call length and failed checks.

## 5) Commands

```bash
cd frontend
npx vitest run src/pages/dashboard/harness src/components/harness   # 166 passed / 13 files
npx eslint "src/pages/dashboard/harness/**/*.{js,jsx}"              # clean
```

## 6) Videos & Screenshots

**Voice run — finished.** Each scenario named, with its verdict, call length and failed checks. The first row is expanded to show why it failed.

![01-voice-run](https://github.com/user-attachments/assets/d878630e-fd67-4e9b-be19-621eb616dd56)

**Chat agent.** Same feature, chat run. Note `turns` is always `2` — see the note below.

![02-chat-run](https://github.com/user-attachments/assets/8f2e62ac-a818-47b4-bd63-81d907e50942)

**Run in progress.** Three scenarios have reported and carry their verdict; two are still running and show a plain row — no chip, because `registered` is not a verdict. The feed fills in per row.

![03-run-in-progress](https://github.com/user-attachments/assets/a6c2ef2e-d69e-4545-a252-51d6745ad1c1)

### A note on the evidence

The screenshots are rendered by this branch against **real captured payloads, replayed** — not live runs. The voice one is @khushal-sonawat's actual run (the list response he posted in the thread). The chat one is that payload reshaped to what `chat_call_runner.py` emits (connector `http`, `turns: 2`, no recordings). The in-progress one is the same run truncated to three reported scenarios and seven still registered.

I could not run this end to end locally: the sandbox provider doesn't emit `scenarios`/`receipts` at all, and the hosted path needs a Daytona key. **A real hosted run is still the outstanding verification.**

Two things deliberately left alone:

- For chat agents `turns` is always `2` — `chat_call_runner.py` hardcodes it, since a chat scenario is a single exchange. Harmless but uninformative; worth deciding whether the harness's chat mode should be multi-turn (@hadarishav).
- `receipts[].failure` is unused. An `errored` receipt is *required* to carry it and its sub-goals are empty, so an errored scenario currently shows a chip and no reason. Small follow-up.

