### PR TITLE
fix(accounts): refresh expired invitations on legacy resend

### DIFF
--- a/futureagi/accounts/tests/test_signup.py
+++ b/futureagi/accounts/tests/test_signup.py
@@ -739,6 +739,19 @@ class TestPasswordResetValidation:
 class TestResendInvitationEmails:
     """Tests for /accounts/resend-invitation-emails/ endpoint."""
 
+    @staticmethod
+    def _create_invite(organization, invited_by, invitee, invite_status):
+        from accounts.models.organization_invite import OrganizationInvite
+        from tfc.constants.levels import Level
+
+        return OrganizationInvite.objects.create(
+            organization=organization,
+            target_email=invitee.email,
+            level=Level.MEMBER,
+            invited_by=invited_by,
+            status=invite_status,
+        )
+
     def test_resend_invitation_rejects_unknown_request_fields(self, auth_client):
         response = auth_client.post(
             "/accounts/resend-invitation-emails/",
@@ -774,6 +787,97 @@ class TestResendInvitationEmails:
         result = response.json()
         # Should have error in response
         assert any("error" in r for r in result if isinstance(r, dict))
+
+    def test_resend_refreshes_expired_pending_invitation(
+        self, auth_client, organization, user, second_user
+    ):
+        from datetime import timedelta
+
+        from django.utils import timezone
+
+        from accounts.models.organization_invite import InviteStatus
+        from tfc.constants.levels import INVITE_VALIDITY_DAYS
+
+        invite = self._create_invite(
+            organization, user, second_user, InviteStatus.PENDING
+        )
+        invite.created_at = timezone.now() - timedelta(days=INVITE_VALIDITY_DAYS + 1)
+        invite.save(update_fields=["created_at"])
+        assert invite.effective_status == InviteStatus.EXPIRED
+
+        started_at = timezone.now()
+        with patch("accounts.views.signup.email_helper") as mocked_email:
+            response = auth_client.post(
+                "/accounts/resend-invitation-emails/",
+                {"user_ids": [str(second_user.id)]},
+                format="json",
+            )
+        finished_at = timezone.now()
+
+        assert response.status_code == status.HTTP_200_OK
+        assert response.json() == [
+            {
+                "user_id": str(second_user.id),
+                "message": "Invitation email has been resent.",
+            }
+        ]
+        invite.refresh_from_db()
+        assert started_at <= invite.created_at <= finished_at
+        assert invite.effective_status == InviteStatus.PENDING
+        mocked_email.assert_called_once()
+
+    def test_resend_keeps_unexpired_pending_invitation_working(
+        self, auth_client, organization, user, second_user
+    ):
+        from accounts.models.organization_invite import InviteStatus
+
+        invite = self._create_invite(
+            organization, user, second_user, InviteStatus.PENDING
+        )
+        original_created_at = invite.created_at
+
+        with patch("accounts.views.signup.email_helper") as mocked_email:
+            response = auth_client.post(
+                "/accounts/resend-invitation-emails/",
+                {"user_ids": [str(second_user.id)]},
+                format="json",
+            )
+
+        assert response.status_code == status.HTTP_200_OK
+        assert "message" in response.json()[0]
+        invite.refresh_from_db()
+        assert invite.created_at >= original_created_at
+        assert invite.effective_status == InviteStatus.PENDING
+        mocked_email.assert_called_once()
+
+    @pytest.mark.parametrize("invite_status", ["Accepted", "Cancelled"])
+    def test_resend_rejects_non_pending_invitation(
+        self,
+        auth_client,
+        organization,
+        user,
+        second_user,
+        invite_status,
+    ):
+        invite = self._create_invite(organization, user, second_user, invite_status)
+
+        with patch("accounts.views.signup.email_helper") as mocked_email:
+            response = auth_client.post(
+                "/accounts/resend-invitation-emails/",
+                {"user_ids": [str(second_user.id)]},
+                format="json",
+            )
+
+        assert response.status_code == status.HTTP_200_OK
+        assert response.json() == [
+            {
+                "user_id": str(second_user.id),
+                "error": "Pending invitation does not exist.",
+            }
+        ]
+        invite.refresh_from_db()
+        assert invite.status == invite_status
+        mocked_email.assert_not_called()
 
 
 @pytest.mark.integration

--- a/futureagi/accounts/views/signup.py
+++ b/futureagi/accounts/views/signup.py
@@ -847,6 +847,8 @@ def accept_invitation_mail(request, uidb64, token):
     reject_unknown_fields=True,
 )
 def resend_invitation_emails(request):
+    from accounts.models.organization_invite import InviteStatus, OrganizationInvite
+
     user_ids = [str(user_id) for user_id in request.validated_data.get("user_ids", [])]
     responses = []
 
@@ -861,7 +863,23 @@ def resend_invitation_emails(request):
             )
 
             if user:
+                invite = OrganizationInvite.objects.filter(
+                    target_email__iexact=user.email,
+                    organization=organization,
+                    status=InviteStatus.PENDING,
+                ).first()
+                if invite is None:
+                    responses.append(
+                        {
+                            "user_id": user_id,
+                            "error": "Pending invitation does not exist.",
+                        }
+                    )
+                    continue
+
                 logger.info(f"Resending invitation email to {user.email}")
+                invite.refresh_expiration()
+
                 # Generate a token
                 token = default_token_generator.make_token(user)
 


### PR DESCRIPTION
## Summary

The workspace members table uses the legacy `/accounts/resend-invitation-emails/` endpoint. That path generated and emailed a new user token without refreshing the matching `OrganizationInvite`, so a derived-expired invite stayed expired.

This change resolves the matching pending invite before sending, refreshes its expiration using the existing model helper, and returns a per-user error when no pending invite exists. Accepted and cancelled invitations therefore are not silently reopened or emailed.

## Linked issues

Closes #2437

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## What changed

- Refresh the matching pending `OrganizationInvite` before the legacy resend path builds the email.
- Refuse to send when the user has no pending invitation, while preserving the endpoint's existing per-user result format.
- Add regression coverage for expired, unexpired, accepted, and cancelled invitations.

## Why

The newer RBAC resend endpoint already refreshes the invite before emailing it. Applying the same lifecycle rule to the workspace-members path prevents admins from sending a fresh-looking link backed by stale invitation state.

## Tests and verification

`accounts/tests/test_signup.py::TestResendInvitationEmails` now covers:

- an expired pending invite becoming pending again before email delivery;
- an unexpired pending invite continuing to resend successfully;
- accepted and cancelled invites returning an error without sending email.

Local checks completed:

- `python -m py_compile accounts/views/signup.py accounts/tests/test_signup.py`
- `node scripts/check-staged-safety.mjs`
- `git diff --check`
- Ruff comparison against upstream: both touched files retain the same single pre-existing `I001` finding; this patch introduces no additional Ruff finding.

The repository's Docker-based backend test stack is not available on this Windows host, so I have not claimed a local pytest pass. This is a draft so the repository's backend CI can run the complete test shards before review.

## How to test

```bash
cd futureagi
bin/test accounts/tests/test_signup.py -k TestResendInvitationEmails
```

## Edge cases

- Matching is organization-scoped and email case-insensitive.
- Only `Pending` records are refreshed; terminal invitation states remain unchanged.
- If email delivery fails after refresh, the existing per-user failure response is retained, matching the refresh-before-send order of the newer endpoint.

## Checklist

- [x] Focused two-file change
- [x] Regression tests added
- [x] No API schema change
- [x] No hardcoded secrets, URLs, or PII
- [ ] Full backend test suite (pending GitHub Actions)
- [ ] CLA check (pending bot)

AI assistance was used during implementation and review. I manually reviewed the final diff and verified every check reported above.