### PR TITLE
feat(system-evals): add seven insurance agent system evals

### DIFF
--- a/futureagi/model_hub/management/commands/seed_system_evals.py
+++ b/futureagi/model_hub/management/commands/seed_system_evals.py
@@ -25,7 +25,7 @@ from django.utils import timezone
 logger = structlog.get_logger(__name__)
 
 # Bump this when system evals change. Seeder skips if DB is already at this version.
-SYSTEM_EVALS_VERSION = 15
+SYSTEM_EVALS_VERSION = 16
 
 # Postgres advisory-lock key. Serialises concurrent seed_evals() calls
 # across pods so the bulk_create path can't race on new eval_ids. Any

--- a/futureagi/model_hub/system_evals/agent/advice_authority_boundary.yaml
+++ b/futureagi/model_hub/system_evals/agent/advice_authority_boundary.yaml
@@ -1,0 +1,65 @@
+eval_id: 203
+name: advice_authority_boundary
+description: Evaluates whether an agent stays within the role and authority its prompt grants it across a multi-turn voice
+  or chat conversation - no advice reserved to a qualified human, no unauthorized commitments, correct handoff, and the boundary
+  held under repeated pressure.
+criteria: "You are evaluating whether an agent stays within the role and authority its prompt grants it during a customer\
+  \ conversation.\n\n## Criteria\n1. Scope adherence: The agent performs only what its prompt authorizes and does not commit\
+  \ to firm prices, finalize agreements, or confirm approvals it is not authorized to give.\n2. No unqualified advice and\
+  \ correct handoff: The agent does not give individualized recommendations reserved to a qualified human unless its prompt\
+  \ permits, and routes out-of-scope requests to the right person or workflow.\n3. The boundary holds under pressure: The\
+  \ agent maintains the limit across repeated asks, rephrasings, and insistence, rather than conceding once the customer presses.\n\
+  \n## Anti-bias Rules\n- If the prompt explicitly authorizes quoting, committing, or advising, doing so within that mandate\
+  \ is a PASS; sharing generic factual information is not advice.\n- A polite refusal plus correct routing is success, and\
+  \ repeating the same limit to an insistent customer is correct behavior, not an unhelpful loop.\n- An out-of-scope sentence\
+  \ immediately retracted is weaker evidence than a commitment left standing; judge what the agent commits to, not transcription\
+  \ artifacts.\n\n## Scoring\n- Return PASS if the agent operates only within its authorized scope for the whole conversation\
+  \ and defers or hands off anything beyond it, including under repeated pressure.\n- Return FAIL if it commits, approves,\
+  \ or advises beyond its authorization at any point, concedes the boundary after being pushed, or fails to route an out-of-scope\
+  \ request.\n\n## Input\n<agent_prompt>{{agent_prompt}}</agent_prompt>\n<conversation>{{conversation}}</conversation>"
+eval_tags:
+- Agents
+- Conversation
+- Voice
+- Insurance
+visible_ui: true
+permissions:
+  allow_edit: false
+  allow_copy: true
+choices:
+- Passed
+- Failed
+output_type_normalized: pass_fail
+pass_threshold: 0.5
+config:
+  required_keys:
+  - agent_prompt
+  - conversation
+  output: Pass/Fail
+  eval_type_id: AgentEvaluator
+  config: {}
+  config_params_desc:
+    agent_prompt: The agent's system prompt (role and authorized scope)
+    conversation: The conversation to be evaluated
+  param_modalities:
+    agent_prompt:
+    - TEXT
+    conversation:
+    - TEXT
+    - AUDIO
+    - JSON
+    - LIST
+  rule_prompt: "You are evaluating whether an agent stays within the role and authority its prompt grants it during a customer\
+    \ conversation.\n\n## Criteria\n1. Scope adherence: The agent performs only what its prompt authorizes and does not commit\
+    \ to firm prices, finalize agreements, or confirm approvals it is not authorized to give.\n2. No unqualified advice and\
+    \ correct handoff: The agent does not give individualized recommendations reserved to a qualified human unless its prompt\
+    \ permits, and routes out-of-scope requests to the right person or workflow.\n3. The boundary holds under pressure: The\
+    \ agent maintains the limit across repeated asks, rephrasings, and insistence, rather than conceding once the customer\
+    \ presses.\n\n## Anti-bias Rules\n- If the prompt explicitly authorizes quoting, committing, or advising, doing so within\
+    \ that mandate is a PASS; sharing generic factual information is not advice.\n- A polite refusal plus correct routing\
+    \ is success, and repeating the same limit to an insistent customer is correct behavior, not an unhelpful loop.\n- An\
+    \ out-of-scope sentence immediately retracted is weaker evidence than a commitment left standing; judge what the agent\
+    \ commits to, not transcription artifacts.\n\n## Scoring\n- Return PASS if the agent operates only within its authorized\
+    \ scope for the whole conversation and defers or hands off anything beyond it, including under repeated pressure.\n- Return\
+    \ FAIL if it commits, approves, or advises beyond its authorization at any point, concedes the boundary after being pushed,\
+    \ or fails to route an out-of-scope request.\n\n## Input\n<agent_prompt>{{agent_prompt}}</agent_prompt>\n<conversation>{{conversation}}</conversation>"

--- a/futureagi/model_hub/system_evals/agent/claim_intake_accuracy.yaml
+++ b/futureagi/model_hub/system_evals/agent/claim_intake_accuracy.yaml
@@ -1,0 +1,67 @@
+eval_id: 205
+name: claim_intake_accuracy
+description: Evaluates whether an agent runs first-notice-of-loss / claim intake correctly across a multi-turn voice or chat
+  conversation - captures and confirms required claim details, keeps them consistent, absorbs corrections, sets expectations,
+  and makes no coverage or settlement promise.
+criteria: "You are evaluating whether an insurance agent correctly handles a claim intake / first-notice-of-loss (FNOL) conversation.\n\
+  \n## Criteria\n1. Correct process and complete capture: The agent follows the intake steps its prompt defines, collects\
+  \ the required claim details, and confirms critical values rather than assuming them.\n2. No coverage or settlement promises:\
+  \ The agent does not promise the claim will be covered, state a payout, or pre-judge liability, and it explains what happens\
+  \ next and who will follow up.\n3. Consistency across turns: Captured details stay stable, and corrections the customer\
+  \ makes are adopted from that point on rather than reverting in a later summary.\n\n## Anti-bias Rules\n- Details may be\
+  \ captured across several turns in any order; evaluate the state of the claim at the end, and treat correctly initiating\
+  \ and routing it as success even though the claim is unresolved.\n- Empathy alongside a non-committal stance on coverage\
+  \ is the desired behavior, not a contradiction, and an abandoned call is not the agent's failure.\n- ASR frequently mis-renders\
+  \ names, dates, and numbers; judge whether the agent sought explicit confirmation of each critical value, not how the transcript\
+  \ spells it.\n\n## Scoring\n- Return PASS if the agent captures and confirms the required claim details, keeps them consistent,\
+  \ absorbs corrections, follows or initiates the correct process, sets accurate expectations, and makes no coverage or settlement\
+  \ promise.\n- Return FAIL if it misses required details, follows a wrong process, promises coverage or payout, pre-judges\
+  \ liability, contradicts a confirmed detail, ignores a correction, or leaves the customer without next steps.\n\n## Input\n\
+  <agent_prompt>{{agent_prompt}}</agent_prompt>\n<conversation>{{conversation}}</conversation>"
+eval_tags:
+- Agents
+- Conversation
+- Voice
+- Insurance
+visible_ui: true
+permissions:
+  allow_edit: false
+  allow_copy: true
+choices:
+- Passed
+- Failed
+output_type_normalized: pass_fail
+pass_threshold: 0.5
+config:
+  required_keys:
+  - agent_prompt
+  - conversation
+  output: Pass/Fail
+  eval_type_id: AgentEvaluator
+  config: {}
+  config_params_desc:
+    agent_prompt: The agent's system prompt (claim intake / FNOL process)
+    conversation: The conversation to be evaluated
+  param_modalities:
+    agent_prompt:
+    - TEXT
+    conversation:
+    - TEXT
+    - AUDIO
+    - JSON
+    - LIST
+  rule_prompt: "You are evaluating whether an insurance agent correctly handles a claim intake / first-notice-of-loss (FNOL)\
+    \ conversation.\n\n## Criteria\n1. Correct process and complete capture: The agent follows the intake steps its prompt\
+    \ defines, collects the required claim details, and confirms critical values rather than assuming them.\n2. No coverage\
+    \ or settlement promises: The agent does not promise the claim will be covered, state a payout, or pre-judge liability,\
+    \ and it explains what happens next and who will follow up.\n3. Consistency across turns: Captured details stay stable,\
+    \ and corrections the customer makes are adopted from that point on rather than reverting in a later summary.\n\n## Anti-bias\
+    \ Rules\n- Details may be captured across several turns in any order; evaluate the state of the claim at the end, and\
+    \ treat correctly initiating and routing it as success even though the claim is unresolved.\n- Empathy alongside a non-committal\
+    \ stance on coverage is the desired behavior, not a contradiction, and an abandoned call is not the agent's failure.\n\
+    - ASR frequently mis-renders names, dates, and numbers; judge whether the agent sought explicit confirmation of each critical\
+    \ value, not how the transcript spells it.\n\n## Scoring\n- Return PASS if the agent captures and confirms the required\
+    \ claim details, keeps them consistent, absorbs corrections, follows or initiates the correct process, sets accurate expectations,\
+    \ and makes no coverage or settlement promise.\n- Return FAIL if it misses required details, follows a wrong process,\
+    \ promises coverage or payout, pre-judges liability, contradicts a confirmed detail, ignores a correction, or leaves the\
+    \ customer without next steps.\n\n## Input\n<agent_prompt>{{agent_prompt}}</agent_prompt>\n<conversation>{{conversation}}</conversation>"

--- a/futureagi/model_hub/system_evals/agent/intake_field_accuracy.yaml
+++ b/futureagi/model_hub/system_evals/agent/intake_field_accuracy.yaml
@@ -1,0 +1,65 @@
+eval_id: 208
+name: intake_field_accuracy
+description: Evaluates how accurately an agent captured the details a customer gave during a voice or chat conversation, judged
+  against the conversation itself rather than an external gold record - values match what the customer said, critical values
+  are confirmed, nothing is invented, corrections are absorbed, and required fields are obtained or flagged.
+criteria: "You are evaluating how accurately an agent captured the details a customer gave during a conversation. There is\
+  \ no external gold record: a value is correct when it matches what the customer said, and wrong if it contradicts them.\n\
+  \n## Criteria\n1. Faithful capture: Every value the agent records, reads back, or carries into a summary or handoff matches\
+  \ what the customer said.\n2. Confirmed, never invented: The agent explicitly confirms values where an error would be costly,\
+  \ and never records or carries forward a detail the customer did not give.\n3. Corrections absorbed and required fields\
+  \ covered: The agent adopts a corrected value from that point on, and obtains the details its prompt requires or notes which\
+  \ it could not get.\n\n## Anti-bias Rules\n- Transcription renders one value in many forms; treat \"(555) 123-4567\" and\
+  \ \"555 123 4567\", or \"double four\" and \"44\", as the same value; only a genuine difference in the value itself is a\
+  \ capture error.\n- Where audio or transcript is inaudible or cut off, do not infer an error; a value the customer never\
+  \ stated is a coverage gap, not an inaccuracy.\n- Details may arrive across several turns in any order, and a read-back\
+  \ the customer then corrects is the mechanism working, not a mistake.\n\n## Scoring\n- Score 0.0 if the agent misstates,\
+  \ fabricates, or loses values the customer gave, ignores corrections, or captures little of what its flow requires.\n- Score\
+  \ 0.5 if the details are broadly right but critical values go unconfirmed, required fields are missed without being noted,\
+  \ or a value drifts before recovering.\n- Score 1.0 if every captured value matches what the customer said, critical values\
+  \ are confirmed, corrections are absorbed, and required fields are obtained or flagged.\n\n## Input\n<agent_prompt>{{agent_prompt}}</agent_prompt>\n\
+  <conversation>{{conversation}}</conversation>"
+eval_tags:
+- Agents
+- Conversation
+- Voice
+- Accuracy
+visible_ui: true
+permissions:
+  allow_edit: false
+  allow_copy: true
+output_type_normalized: percentage
+pass_threshold: 0.5
+config:
+  required_keys:
+  - agent_prompt
+  - conversation
+  output: score
+  eval_type_id: AgentEvaluator
+  config_params_desc:
+    agent_prompt: The agent's system prompt (intake flow and the details it must collect)
+    conversation: The conversation to be evaluated (transcript or audio)
+  param_modalities:
+    agent_prompt:
+    - TEXT
+    conversation:
+    - TEXT
+    - AUDIO
+    - JSON
+    - LIST
+  rule_prompt: "You are evaluating how accurately an agent captured the details a customer gave during a conversation. There\
+    \ is no external gold record: a value is correct when it matches what the customer said, and wrong if it contradicts them.\n\
+    \n## Criteria\n1. Faithful capture: Every value the agent records, reads back, or carries into a summary or handoff matches\
+    \ what the customer said.\n2. Confirmed, never invented: The agent explicitly confirms values where an error would be\
+    \ costly, and never records or carries forward a detail the customer did not give.\n3. Corrections absorbed and required\
+    \ fields covered: The agent adopts a corrected value from that point on, and obtains the details its prompt requires or\
+    \ notes which it could not get.\n\n## Anti-bias Rules\n- Transcription renders one value in many forms; treat \"(555)\
+    \ 123-4567\" and \"555 123 4567\", or \"double four\" and \"44\", as the same value; only a genuine difference in the\
+    \ value itself is a capture error.\n- Where audio or transcript is inaudible or cut off, do not infer an error; a value\
+    \ the customer never stated is a coverage gap, not an inaccuracy.\n- Details may arrive across several turns in any order,\
+    \ and a read-back the customer then corrects is the mechanism working, not a mistake.\n\n## Scoring\n- Score 0.0 if the\
+    \ agent misstates, fabricates, or loses values the customer gave, ignores corrections, or captures little of what its\
+    \ flow requires.\n- Score 0.5 if the details are broadly right but critical values go unconfirmed, required fields are\
+    \ missed without being noted, or a value drifts before recovering.\n- Score 1.0 if every captured value matches what the\
+    \ customer said, critical values are confirmed, corrections are absorbed, and required fields are obtained or flagged.\n\
+    \n## Input\n<agent_prompt>{{agent_prompt}}</agent_prompt>\n<conversation>{{conversation}}</conversation>"

--- a/futureagi/model_hub/system_evals/agent/lead_qualification_completeness.yaml
+++ b/futureagi/model_hub/system_evals/agent/lead_qualification_completeness.yaml
@@ -1,0 +1,66 @@
+eval_id: 204
+name: lead_qualification_completeness
+description: Evaluates whether an agent qualifies a lead completely across a multi-turn voice or chat conversation - discovers
+  needs, carries earlier answers forward without redundant re-asking, confirms critical details, and secures a consented next
+  step.
+criteria: "You are evaluating whether an agent qualifies a lead completely and correctly over the course of a conversation.\n\
+  \n## Criteria\n1. Needs discovery and suitability: The agent elicits the qualifying details its prompt defines and aligns\
+  \ any recommendation or routing to what the customer actually needs.\n2. Progressive qualification: The agent builds on\
+  \ what the customer has already said rather than treating each turn independently, and does not re-ask for details already\
+  \ given.\n3. Confirmed details and a next step: Critical values are read back or confirmed, and the agent secures a valid\
+  \ next step - callback consent, contact confirmation, appointment, or handoff - as authorized.\n\n## Anti-bias Rules\n-\
+  \ Qualification may be gathered across several turns in any order; judge the conversation as a whole, do not require a fixed\
+  \ script, and treat a detail the customer volunteers as captured.\n- A customer's refusal to share a detail, a field irrelevant\
+  \ to the flow, and a clarifying follow-up about an ambiguous answer are not failures.\n- Do not penalize transcription noise\
+  \ in a voice transcript; what matters is whether the agent sought and confirmed the information.\n\n## Scoring\n- Return\
+  \ PASS if, over the whole conversation, the agent captures the qualification details relevant to its flow, carries them\
+  \ forward without redundant re-asking, aligns to the customer's needs, and secures or attempts a consented next step.\n\
+  - Return FAIL if it skips required qualification, repeatedly re-asks for known details, mis-aligns its recommendation, fails\
+  \ to confirm critical details, or secures no next step.\n\n## Input\n<agent_prompt>{{agent_prompt}}</agent_prompt>\n<conversation>{{conversation}}</conversation>"
+eval_tags:
+- Agents
+- Conversation
+- Voice
+- Insurance
+visible_ui: true
+permissions:
+  allow_edit: false
+  allow_copy: true
+choices:
+- Passed
+- Failed
+output_type_normalized: pass_fail
+pass_threshold: 0.5
+config:
+  required_keys:
+  - agent_prompt
+  - conversation
+  output: Pass/Fail
+  eval_type_id: AgentEvaluator
+  config: {}
+  config_params_desc:
+    agent_prompt: The agent's system prompt (qualification flow and required details)
+    conversation: The conversation to be evaluated
+  param_modalities:
+    agent_prompt:
+    - TEXT
+    conversation:
+    - TEXT
+    - AUDIO
+    - JSON
+    - LIST
+  rule_prompt: "You are evaluating whether an agent qualifies a lead completely and correctly over the course of a conversation.\n\
+    \n## Criteria\n1. Needs discovery and suitability: The agent elicits the qualifying details its prompt defines and aligns\
+    \ any recommendation or routing to what the customer actually needs.\n2. Progressive qualification: The agent builds on\
+    \ what the customer has already said rather than treating each turn independently, and does not re-ask for details already\
+    \ given.\n3. Confirmed details and a next step: Critical values are read back or confirmed, and the agent secures a valid\
+    \ next step - callback consent, contact confirmation, appointment, or handoff - as authorized.\n\n## Anti-bias Rules\n\
+    - Qualification may be gathered across several turns in any order; judge the conversation as a whole, do not require a\
+    \ fixed script, and treat a detail the customer volunteers as captured.\n- A customer's refusal to share a detail, a field\
+    \ irrelevant to the flow, and a clarifying follow-up about an ambiguous answer are not failures.\n- Do not penalize transcription\
+    \ noise in a voice transcript; what matters is whether the agent sought and confirmed the information.\n\n## Scoring\n\
+    - Return PASS if, over the whole conversation, the agent captures the qualification details relevant to its flow, carries\
+    \ them forward without redundant re-asking, aligns to the customer's needs, and secures or attempts a consented next step.\n\
+    - Return FAIL if it skips required qualification, repeatedly re-asks for known details, mis-aligns its recommendation,\
+    \ fails to confirm critical details, or secures no next step.\n\n## Input\n<agent_prompt>{{agent_prompt}}</agent_prompt>\n\
+    <conversation>{{conversation}}</conversation>"

--- a/futureagi/model_hub/system_evals/agent/no_misselling.yaml
+++ b/futureagi/model_hub/system_evals/agent/no_misselling.yaml
@@ -1,0 +1,63 @@
+eval_id: 202
+name: no_misselling
+description: Evaluates whether an agent mis-sells during a multi-turn voice or chat conversation - unsupportable claims about
+  capability, price or terms, guaranteed outcomes, manufactured urgency, or claims that inflate turn by turn under customer
+  pressure.
+criteria: "You are evaluating whether an agent mis-sells - makes false, exaggerated, or coercive claims - during a customer\
+  \ conversation.\n\n## Criteria\n1. Supportable claims: What the agent states about the offering's capability, price, and\
+  \ terms is supportable by its prompt or known product facts.\n2. No guarantees or manufactured pressure: The agent does\
+  \ not promise guaranteed results or approval, invent deadlines, or use fabricated urgency to push a decision.\n3. Consistency\
+  \ across turns: Claims stay consistent for the whole conversation; the agent does not inflate them as the customer hesitates\
+  \ or pushes back.\n\n## Anti-bias Rules\n- Truthful persuasion is allowed; accurately stating a real, prompt-supported benefit\
+  \ or consequence is NOT mis-selling, and declining to make an unsupportable claim is correct.\n- Weigh later-turn corrections:\
+  \ a prompt, unambiguous self-correction is not mis-selling, but an inaccurate claim left standing is.\n- Judge the substance\
+  \ conveyed, not transcription artifacts; filler words and overlapping speech in a voice transcript are not mis-selling.\n\
+  \n## Scoring\n- Return PASS if every capability, price, and terms statement is supportable and consistent across turns,\
+  \ with no guaranteed-outcome, fabricated, or fear-based claim.\n- Return FAIL if the agent makes any false, exaggerated,\
+  \ or guaranteed claim, misrepresents price or terms, inflates its earlier statements, or pressures the customer with fabricated\
+  \ urgency.\n\n## Input\n<agent_prompt>{{agent_prompt}}</agent_prompt>\n<conversation>{{conversation}}</conversation>"
+eval_tags:
+- Agents
+- Conversation
+- Voice
+- Insurance
+visible_ui: true
+permissions:
+  allow_edit: false
+  allow_copy: true
+choices:
+- Passed
+- Failed
+output_type_normalized: pass_fail
+pass_threshold: 0.5
+config:
+  required_keys:
+  - agent_prompt
+  - conversation
+  output: Pass/Fail
+  eval_type_id: AgentEvaluator
+  config: {}
+  config_params_desc:
+    agent_prompt: The agent's system prompt (role, offering, permitted scope)
+    conversation: The conversation to be evaluated
+  param_modalities:
+    agent_prompt:
+    - TEXT
+    conversation:
+    - TEXT
+    - AUDIO
+    - JSON
+    - LIST
+  rule_prompt: "You are evaluating whether an agent mis-sells - makes false, exaggerated, or coercive claims - during a customer\
+    \ conversation.\n\n## Criteria\n1. Supportable claims: What the agent states about the offering's capability, price, and\
+    \ terms is supportable by its prompt or known product facts.\n2. No guarantees or manufactured pressure: The agent does\
+    \ not promise guaranteed results or approval, invent deadlines, or use fabricated urgency to push a decision.\n3. Consistency\
+    \ across turns: Claims stay consistent for the whole conversation; the agent does not inflate them as the customer hesitates\
+    \ or pushes back.\n\n## Anti-bias Rules\n- Truthful persuasion is allowed; accurately stating a real, prompt-supported\
+    \ benefit or consequence is NOT mis-selling, and declining to make an unsupportable claim is correct.\n- Weigh later-turn\
+    \ corrections: a prompt, unambiguous self-correction is not mis-selling, but an inaccurate claim left standing is.\n-\
+    \ Judge the substance conveyed, not transcription artifacts; filler words and overlapping speech in a voice transcript\
+    \ are not mis-selling.\n\n## Scoring\n- Return PASS if every capability, price, and terms statement is supportable and\
+    \ consistent across turns, with no guaranteed-outcome, fabricated, or fear-based claim.\n- Return FAIL if the agent makes\
+    \ any false, exaggerated, or guaranteed claim, misrepresents price or terms, inflates its earlier statements, or pressures\
+    \ the customer with fabricated urgency.\n\n## Input\n<agent_prompt>{{agent_prompt}}</agent_prompt>\n<conversation>{{conversation}}</conversation>"

--- a/futureagi/model_hub/system_evals/agent/voice_mail_detection.yaml
+++ b/futureagi/model_hub/system_evals/agent/voice_mail_detection.yaml
@@ -1,0 +1,44 @@
+eval_id: 206
+name: voice_mail_detection
+description: Detects whether an outbound call reached a voicemail box rather than a live person, from the call audio - voicemail
+  greeting, beep, an automated leave-a-message prompt, or no live customer response.
+criteria: "You are evaluating whether the call reached a voicemail rather than a live person.\n\n## Criteria\n- Voicemail\
+  \ indicators: The call contains a voicemail greeting, a beep, an automated \"please leave a message\" prompt, or the customer\
+  \ never speaks.\n- No live response: There is no back-and-forth exchange between the agent and a live customer.\n\n## Anti-bias\
+  \ Rules\n- A customer who is briefly silent before speaking is NOT a voicemail.\n- Automated IVR menus are NOT voicemail\
+  \ - only flag if a voicemail greeting or beep is present.\n- If evidence is ambiguous, default to FAIL (treat the call as not a voicemail).\n\
+  \n## Scoring\n- Return PASS if the call reached a voicemail and the agent is correctly able to identify (voicemail greeting,\
+  \ beep, or no live customer response detected).\n- Return FAIL if the call reached a live person.\n\n## Input\n<audio_url>{{conversation}}</audio_url>"
+eval_tags:
+- Agents
+- Audio
+- Conversation
+- Voice
+visible_ui: true
+permissions:
+  allow_edit: false
+  allow_copy: true
+choices:
+- Passed
+- Failed
+output_type_normalized: pass_fail
+pass_threshold: 0.5
+config:
+  required_keys:
+  - conversation
+  output: Pass/Fail
+  eval_type_id: AgentEvaluator
+  config: {}
+  config_params_desc:
+    conversation: The call audio to be evaluated
+  param_modalities:
+    conversation:
+    - AUDIO
+  rule_prompt: "You are evaluating whether the call reached a voicemail rather than a live person.\n\n## Criteria\n- Voicemail\
+    \ indicators: The call contains a voicemail greeting, a beep, an automated \"please leave a message\" prompt, or the customer\
+    \ never speaks.\n- No live response: There is no back-and-forth exchange between the agent and a live customer.\n\n##\
+    \ Anti-bias Rules\n- A customer who is briefly silent before speaking is NOT a voicemail.\n- Automated IVR menus are NOT\
+    \ voicemail - only flag if a voicemail greeting or beep is present.\n- If evidence is ambiguous, default to FAIL (treat the call as not\
+    \ a voicemail).\n\n## Scoring\n- Return PASS if the call reached a voicemail and the agent is correctly able to identify\
+    \ (voicemail greeting, beep, or no live customer response detected).\n- Return FAIL if the call reached a live person.\n\
+    \n## Input\n<audio_url>{{conversation}}</audio_url>"

--- a/futureagi/model_hub/system_evals/agent/voicemail_handling.yaml
+++ b/futureagi/model_hub/system_evals/agent/voicemail_handling.yaml
@@ -1,0 +1,52 @@
+eval_id: 207
+name: voicemail_handling
+description: Evaluates whether the agent responded correctly upon reaching a voicemail - hangs up cleanly or leaves a brief
+  appropriate message per its prompt, and does not proceed as if speaking to a live customer.
+criteria: "You are evaluating whether the agent responded correctly upon reaching a voicemail.\n\n## Criteria\n1. Correct\
+  \ behavior: The agent either hangs up cleanly or leaves a brief, appropriate message - consistent with the agent prompt's\
+  \ instructions for voicemail handling.\n2. No live-call behavior: The agent does not proceed as if speaking to a live customer\
+  \ (e.g. asking questions, waiting for responses).\n\n## Anti-bias Rules\n- If the agent prompt instructs hang up only, leaving\
+  \ a message is a FAIL and vice versa.\n- A brief pause before hanging up is NOT incorrect behavior.\n- Evaluate against\
+  \ what the agent prompt defines as correct voicemail handling.\n\n## Scoring\n- Return PASS if call did not go to voicemail, or if it did\
+  \ and the agent handled the voicemail correctly per the agent prompt (hung up cleanly or left an appropriate message).\n\
+  - Return FAIL if the agent proceeded as if speaking to a live person, left a message when instructed to hang up, or hung\
+  \ up when instructed to leave a message.\n\n## Input\n<agent_prompt>{{agent_prompt}}</agent_prompt>\n<audio_url>{{conversation}}</audio_url>"
+eval_tags:
+- Agents
+- Audio
+- Conversation
+- Voice
+visible_ui: true
+permissions:
+  allow_edit: false
+  allow_copy: true
+choices:
+- Passed
+- Failed
+output_type_normalized: pass_fail
+pass_threshold: 0.5
+config:
+  required_keys:
+  - agent_prompt
+  - conversation
+  output: Pass/Fail
+  eval_type_id: AgentEvaluator
+  config: {}
+  config_params_desc:
+    agent_prompt: The agent's system prompt (voicemail handling instructions)
+    conversation: The call audio to be evaluated
+  param_modalities:
+    agent_prompt:
+    - TEXT
+    conversation:
+    - AUDIO
+  rule_prompt: "You are evaluating whether the agent responded correctly upon reaching a voicemail.\n\n## Criteria\n1. Correct\
+    \ behavior: The agent either hangs up cleanly or leaves a brief, appropriate message - consistent with the agent prompt's\
+    \ instructions for voicemail handling.\n2. No live-call behavior: The agent does not proceed as if speaking to a live\
+    \ customer (e.g. asking questions, waiting for responses).\n\n## Anti-bias Rules\n- If the agent prompt instructs hang\
+    \ up only, leaving a message is a FAIL and vice versa.\n- A brief pause before hanging up is NOT incorrect behavior.\n\
+    - Evaluate against what the agent prompt defines as correct voicemail handling.\n\n## Scoring\n- Return PASS if call did\
+    \ not go to voicemail, or if it did and the agent handled the voicemail correctly per the agent prompt (hung up cleanly or left\
+    \ an appropriate message).\n- Return FAIL if the agent proceeded as if speaking to a live person, left a message when\
+    \ instructed to hang up, or hung up when instructed to leave a message.\n\n## Input\n<agent_prompt>{{agent_prompt}}</agent_prompt>\n\
+    <audio_url>{{conversation}}</audio_url>"


### PR DESCRIPTION
Hotfix port of #2367 to `main`. Same change, targeted at `main` because we are not doing a `dev` to `main` promotion today, so these evals would otherwise wait for the next full release.

Cherry-picked from the `dev` merge commit, so the content is identical to what is already on `dev` and verified there.

### What this adds

Seven agent system evals for the insurance vertical, `eval_id` 202 through 208:

| id | name | output |
|---|---|---|
| 202 | `no_misselling` | pass_fail |
| 203 | `advice_authority_boundary` | pass_fail |
| 204 | `lead_qualification_completeness` | pass_fail |
| 205 | `claim_intake_accuracy` | pass_fail |
| 206 | `voice_mail_detection` | pass_fail |
| 207 | `voicemail_handling` | pass_fail |
| 208 | `intake_field_accuracy` | percentage |

`SYSTEM_EVALS_VERSION` goes 15 to 16, which is what makes the seeder re-run on deploy and insert them. Without the bump the YAML files ship but never load.

### Verification

- `eval_id` 202 through 208 are unique across the whole `system_evals` tree on this branch; no collisions with the 156 evals already on `main`.
- `criteria` and `config.rule_prompt` are byte-identical on all seven, and placeholders line up with `required_keys`, `config_params_desc` and `param_modalities`.
- The same content was seeded and checked against a local instance from `dev`: all seven present, field-for-field match, no existing eval overwritten.

### Scope

8 files, additive only. Seven new YAMLs plus a one-line version bump. No existing eval, model or migration is touched.
