### PR TITLE
fix(harness): don't count unjudged checks as failures, and surface the scenario failure

### DIFF
--- a/frontend/src/pages/dashboard/harness/ScenarioOutcome.jsx
+++ b/frontend/src/pages/dashboard/harness/ScenarioOutcome.jsx
@@ -6,7 +6,7 @@ import Iconify from "src/components/iconify";
 import StatusChip from "src/components/custom-status-chip/CustomStatusChip";
 import { STATUS_TYPES } from "src/utils/statusUtils";
 
-import { callSummary } from "./harnessShared";
+import { callSummary, readable } from "./harnessShared";
 
 const chipStatus = (status) => {
   if (status === "passed") return STATUS_TYPES.PASS;
@@ -29,10 +29,13 @@ export default function ScenarioOutcome({ outcome }) {
   // A check that did not hold carries the sentence explaining why, which is the reason to
   // open this at all. The denominator matters too: one of one reads very differently from
   // five of six. A scenario that passed every check stays closed and quiet.
-  const failed = outcome.subGoals.filter((goal) => !goal.held);
+  // `held` is tri-state: true held, false did not, null never judged — which is what a
+  // scenario that errored before running reports. Counting null as failed claims the agent
+  // failed checks nobody ran.
+  const failed = outcome.subGoals.filter((goal) => goal.held === false);
   // An outcome can carry nothing worth drawing — a skipped scenario with no call and no
   // checks. Leave the row as it was rather than opening a gap under it.
-  if (!outcome.status && !summary && failed.length === 0) return null;
+  if (!outcome.status && !summary && failed.length === 0 && !outcome.failure) return null;
 
   return (
     <Stack spacing={0.75} sx={{ mt: 0.75 }}>
@@ -47,6 +50,16 @@ export default function ScenarioOutcome({ outcome }) {
         {summary && (
           <Typography variant="caption" color="text.secondary">
             {summary}
+          </Typography>
+        )}
+        {outcome.failure?.message && (
+          <Typography variant="caption" color="error.main" sx={{ minWidth: 0 }}>
+            {[outcome.failure.domain, outcome.failure.code]
+              .filter(Boolean)
+              .map(readable)
+              .join(" · ")}
+            {" — "}
+            {outcome.failure.message}
           </Typography>
         )}
         {failed.length > 0 && (
@@ -91,6 +104,11 @@ ScenarioOutcome.propTypes = {
     status: PropTypes.string,
     turns: PropTypes.number,
     durationMs: PropTypes.number,
+    failure: PropTypes.shape({
+      domain: PropTypes.string,
+      code: PropTypes.string,
+      message: PropTypes.string,
+    }),
     subGoals: PropTypes.arrayOf(
       PropTypes.shape({
         name: PropTypes.string,

--- a/frontend/src/pages/dashboard/harness/ScenarioOutcome.test.jsx
+++ b/frontend/src/pages/dashboard/harness/ScenarioOutcome.test.jsx
@@ -76,3 +76,50 @@ describe("ScenarioOutcome", () => {
     expect(container).toBeEmptyDOMElement();
   });
 });
+
+describe("ScenarioOutcome — unjudged checks and failures", () => {
+  const errored = {
+    status: "errored",
+    turns: null,
+    durationMs: null,
+    failure: {
+      domain: "environment",
+      code: "world_unavailable",
+      message: "target agent never joined the room: Target agent did not become ready",
+    },
+    // A scenario that errored before running reports every check as never judged.
+    subGoals: [
+      { name: "address_confirmed", held: null, reason: null },
+      { name: "otp_verified", held: null, reason: null },
+    ],
+  };
+
+  // Counting these as failures claimed the agent failed checks nobody ran.
+  it("does not count unjudged checks as failures", () => {
+    render(<ScenarioOutcome outcome={errored} />);
+    expect(screen.queryByRole("button", { name: /checks failed/ })).not.toBeInTheDocument();
+  });
+
+  it("shows the failure that actually explains the run", () => {
+    render(<ScenarioOutcome outcome={errored} />);
+    expect(screen.getByText(/never joined the room/)).toBeInTheDocument();
+    expect(screen.getByText(/Environment · World unavailable/)).toBeInTheDocument();
+  });
+
+  it("still counts a real failed check", () => {
+    render(
+      <ScenarioOutcome
+        outcome={{
+          status: "failed",
+          turns: 9,
+          durationMs: 88000,
+          subGoals: [
+            { name: "booking_status_checked", held: false, reason: "get_booking_status was never called" },
+            { name: "unjudged_one", held: null, reason: null },
+          ],
+        }}
+      />,
+    );
+    expect(screen.getByRole("button", { name: /1 of 2 checks failed/ })).toBeInTheDocument();
+  });
+});

--- a/frontend/src/pages/dashboard/harness/harnessShared.js
+++ b/frontend/src/pages/dashboard/harness/harnessShared.js
@@ -433,9 +433,12 @@ export const scenarioOutcome = (scenarioKey, scenarioAttempt, run) => {
     status: settled,
     turns: call.turns ?? null,
     durationMs: call.duration_ms ?? null,
-    // `held` is the verdict and carries a reason whenever it is false; `judged` only says
-    // whether a model was the one to decide, so it is not part of the outcome.
+    // A scenario that errored before it ran reports every check as `held: null` — never
+    // judged, which is not the same as failed. Only `false` is a verdict against the agent.
     subGoals: receipt?.sub_goals || [],
+    // An errored receipt carries the only account of what went wrong, and its checks are
+    // all unjudged, so without this the row has nothing true to say.
+    failure: receipt?.failure || null,
   };
 };
 

--- a/frontend/src/pages/dashboard/harness/harnessShared.test.js
+++ b/frontend/src/pages/dashboard/harness/harnessShared.test.js
@@ -756,3 +756,42 @@ describe("scenarioOutcome", () => {
     expect(outcome.subGoals).toEqual([]);
   });
 });
+
+// Shapes taken from a real hosted run: the scenario errored before it ran, so every check
+// is unjudged and the receipt's failure is the only account of what happened.
+describe("scenarioOutcome — an errored scenario", () => {
+  const run = {
+    scenarios: [{ scenario_key: "noor-books-uberx", status: "errored" }],
+    receipts: [
+      {
+        scenario_key: "noor-books-uberx",
+        scenario_attempt: 1,
+        status: "errored",
+        call: null,
+        failure: {
+          domain: "environment",
+          code: "world_unavailable",
+          stage: "running",
+          message: "target agent never joined the room: Target agent did not become ready",
+        },
+        sub_goals: [
+          { name: "address_confirmed", held: null, judged: false, reason: null },
+          { name: "otp_verified", held: null, judged: false, reason: null },
+        ],
+      },
+    ],
+  };
+
+  it("carries the failure that explains the run", () => {
+    const outcome = scenarioOutcome("noor-books-uberx", 1, run);
+    expect(outcome.status).toBe("errored");
+    expect(outcome.failure.code).toBe("world_unavailable");
+    expect(outcome.failure.message).toMatch(/never joined the room/);
+  });
+
+  it("survives a null call", () => {
+    const outcome = scenarioOutcome("noor-books-uberx", 1, run);
+    expect(outcome.turns).toBeNull();
+    expect(callSummary(outcome)).toBe("");
+  });
+});


### PR DESCRIPTION
## Summary

Two faults in the run timeline, both found by running a hosted job against Daytona rather than by reading the contract.

A scenario that **errors before it runs** reports every check as `held: null` — never judged. The row counted those as failures, so a run that never reached the agent claimed it had failed six checks and listed them with no reasons. Meanwhile the receipt's `failure` — the one sentence that explains the run — was dropped.

## Linked issues

Closes #
Linear:

## Type of change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

---

## 1) What changes were done

**A. `held` is tri-state, not a boolean** (`ScenarioOutcome.jsx`)

`true` held · `false` did not · `null` never judged. The filter was `!goal.held`, which swept `null` in with `false`. Now `goal.held === false`.

**B. The receipt's failure is shown** (`harnessShared.js`, `ScenarioOutcome.jsx`)

`scenarioOutcome` carries `failure`, and the row renders `domain · code — message`. An `errored` receipt is *required* to carry one (`HarnessResultReceiptSerializer.validate`) and its checks are empty by definition, so without this an errored scenario had nothing true to say.

## 2) Why

This is what a real errored run produced:

```
receipt.status  : errored
receipt.failure : { domain: "environment", code: "world_unavailable",
                    message: "target agent never joined the room:
                              Target agent did not become ready" }
sub_goals held  : [null, null, null, null, null, null]
```

Before: `6 of 6 checks failed`, six goals listed with no reasons, cause invisible.
After: no check count, and `Environment · World unavailable — target agent never joined the room`.

Worth being explicit that this corrects a wrong call in #2430: I concluded there that `held` was a clean boolean because every value in the sample data happened to be one. It isn't — `null` is real and reachable, and it produced exactly the misleading output the review had warned about.

## 3) Tests

171 pass (5 new), built from the two real payloads:

- an errored receipt carries its failure through the join
- a null `call` doesn't break the summary
- unjudged checks produce **no** "checks failed" toggle
- the failure line renders with domain and code
- a genuinely failed check is still counted alongside unjudged ones (`1 of 2`)

## 4) How to verify

Open a hosted run's **Runs** tab.

- A scenario that errored: chip, failure line, no check count.
- A scenario that ran: check count excludes any check that held or was never judged.

## 5) Commands

```bash
cd frontend
npx vitest run src/pages/dashboard/harness src/components/harness   # 171 passed / 13 files
npx eslint "src/pages/dashboard/harness/**/*.{js,jsx}"              # clean
```

## 6) Videos & Screenshots

![01-real-voice-run](https://github.com/user-attachments/assets/a59f624d-0a87-42d5-b3d7-0e1fd09462b7)

---

### Evidence

Unlike #2430, this is a **real hosted run on Daytona**, not a replayed payload — 22 turns, 3m 18s, 4 recordings, transcript, 8 graded sub-goals (3 held, 5 not).

The screenshot shows `5 of 8 checks failed`. Before this change it would have read `8 of 8`, because the three checks that *held* were counted as failures by the same `!held` bug.

Two follow-ups this surfaced, not addressed here:

- The **environment stage output** stores a degenerate early plan (`runtime: compose`, `services: []`, `readiness: []`) while the verified bundle is `kind: process` with four processes and three readiness checks. `_persist_stage_outputs` is guarded by `if "environment" not in existing`, so the authoritative bundle-derived projection is silently skipped. The Environment tab's summary ("4 runtime components described") contradicts its own empty body. cc @hadarishav
- A job whose launch activity throws (e.g. `resolved sandbox egress requires 21 domains`) sits at **`queued`** with nothing in the UI; the error exists only in worker logs.
