### PR TITLE
Stop recording an unjudged sub-goal as a failed eval

### DIFF
--- a/futureagi/simulate/services/hosted_harness_ingestion.py
+++ b/futureagi/simulate/services/hosted_harness_ingestion.py
@@ -53,6 +53,7 @@ _ARTIFACT_KINDS = {
     "recording_assistant",
     "transcript",
     "tool_trace",
+    "evidence",
     "result",
     "build",
     "trace",
@@ -61,7 +62,15 @@ _ARTIFACT_KINDS = {
 }
 _ALLOWED_ARTIFACTS = {
     "metadata-only": {"build", "result", "log"},
-    "traces": {"build", "result", "log", "trace", "tool_trace", "transcript"},
+    "traces": {
+        "build",
+        "result",
+        "log",
+        "trace",
+        "tool_trace",
+        "transcript",
+        "evidence",
+    },
     "traces-and-recordings": _ARTIFACT_KINDS - {"other"},
     "full": _ARTIFACT_KINDS,
 }
@@ -860,11 +869,16 @@ def _receipt_evaluations(body: dict[str, Any]) -> list[dict[str, Any]]:
     for goal in body.get("sub_goals") or []:
         if not isinstance(goal, dict) or not goal.get("name"):
             continue
+        # A null verdict means nothing decided this sub-goal, which is not the same as
+        # deciding against it. Coercing it would publish a failed, reasonless eval for
+        # every check a run never reached. Coverage carries the declared-but-unjudged count.
+        if goal.get("held") is None:
+            continue
         results.append(
             {
                 "name": str(goal["name"]),
                 "kind": "judge" if goal.get("judged") else "checkpoint",
-                "passed": bool(goal.get("held")),
+                "passed": bool(goal["held"]),
                 "reason": str(goal.get("reason") or ""),
             }
         )

--- a/futureagi/simulate/tests/test_hosted_harness_channels.py
+++ b/futureagi/simulate/tests/test_hosted_harness_channels.py
@@ -75,6 +75,25 @@ def test_receipt_evaluations_preserve_deterministic_and_judged_checks():
     ]
 
 
+def test_receipt_evaluations_omit_a_sub_goal_nothing_decided():
+    body = {
+        "sub_goals": [
+            {"name": "booking_created", "held": True, "judged": False, "reason": None},
+            {"name": "explained_refusal", "held": None, "judged": True, "reason": None},
+        ],
+        "evaluations": [],
+    }
+
+    assert _receipt_evaluations(body) == [
+        {
+            "name": "booking_created",
+            "kind": "checkpoint",
+            "passed": True,
+            "reason": "",
+        },
+    ]
+
+
 def test_receipt_coverage_distinguishes_missing_grading_from_agent_failure():
     assert _receipt_evaluation_coverage(
         {


### PR DESCRIPTION
## What this does

Stops the platform recording a sub-goal that nothing decided as a sub-goal that failed, and lets the hosted guest send the evidence a judge needs.

## The defect

`_receipt_evaluations` converted every receipt sub-goal with `"passed": bool(goal.get("held"))`. A judged sub-goal always arrives with `held: null`, because nothing in the hosted lane judges it. `bool(None)` is `False`, so `_apply_harness_evaluation_outputs` wrote it into `call.eval_outputs` as `{"output": "Failed", "output_type": "Pass/Fail", "status": "completed", "reason": ""}`.

The result was a completed, failed, reasonless eval on the call-details surface for every judged sub-goal in every hosted run. An agent was reported as failing checks that were never evaluated.

Two things kept this hidden. `_receipt_evaluation_coverage`, ten lines below in the same file, reads it correctly as `item.get("held") is not None`, so the coverage numbers looked healthy while the eval rows were wrong. And #2440 fixed exactly this reading, but only in the frontend: all four of its files are under `frontend/src/pages/dashboard/harness/`. The backend coercion that produces `eval_outputs` was untouched.

The fix skips `held is None` rather than coercing it. Coverage already carries the declared-but-unjudged count, so nothing is lost by omitting the row.

This is required by the PRD rather than merely compatible with it. G8 says missing actions must not be recorded as successful; recording an unevaluated check as a definite failure breaks the same guarantee in the other direction. G9 requires grading failure to stay distinct from agent failure, which is precisely the distinction the coercion destroyed.

## Also here

`evidence` is added to the accepted artifact kinds, allowed at `traces` and above. The hosted guest seals a per-scenario evidence bundle (agent-learning-kit#72) carrying the tool calls and a bounded snapshot of the world as it finished. The platform validates artifact `kind` against a fixed set and would reject it otherwise.

Accepting the kind is inert on its own: nothing here reads the bundle. It is in this PR because it is what makes the guest side mergeable, and because it is the half that has to land first.

## Merge order

This PR merges before agent-learning-kit#72. A guest sending `evidence` to a platform that does not accept the kind has its upload rejected, which is logged and non-fatal, so the run degrades to today's behaviour rather than failing. The reverse order is safe but pointless.

## Testing

`simulate/tests/test_hosted_harness_channels.py`, the pure-function tests: 6 passed, including a new one asserting a sub-goal with `held: null` produces no eval row at all. The 14 collection errors and 1 failure in that file are Postgres connection refusals on port 15432, present before this change and unrelated to it; the isolated test stack was not running on this machine.
