### PR TITLE
Judge non-deterministic sub-goals on the platform, in the run's own tenant

### DIFF
--- a/futureagi/simulate/services/alk_simulate_ingestion.py
+++ b/futureagi/simulate/services/alk_simulate_ingestion.py
@@ -1616,3 +1616,32 @@ def _dispatch_evaluations_once(call_execution: CallExecution) -> bool:
         call_execution.call_metadata = call_metadata
         call_execution.save(update_fields=["call_metadata"])
         return False
+
+
+def _dispatch_sub_goal_judging_once(call_execution: CallExecution) -> None:
+    """Send this call's undecided judged sub-goals to be judged, at most once.
+
+    The pending list is the latch: the task clears the names it decides, so a crash between
+    here and the worker leaves them pending and a later delivery retries them. A flag written
+    before the enqueue would strand them instead.
+    """
+    metadata = dict(call_execution.call_metadata or {})
+    pending = [str(name) for name in (metadata.get("harness_judge_pending") or [])]
+    if not pending or metadata.get("harness_judge_status") == "running":
+        return
+    metadata["harness_judge_status"] = "running"
+    call_execution.call_metadata = metadata
+    call_execution.save(update_fields=["call_metadata"])
+    try:
+        from simulate.tasks.alk_sim import judge_harness_sub_goals
+
+        judge_harness_sub_goals.apply_async(args=(str(call_execution.id),))
+    except Exception as dispatch_error:
+        logger.exception(
+            "harness_judge_dispatch_failed",
+            call_execution_id=str(call_execution.id),
+        )
+        metadata["harness_judge_status"] = "failed"
+        metadata["harness_judge_error"] = str(dispatch_error)[:2000]
+        call_execution.call_metadata = metadata
+        call_execution.save(update_fields=["call_metadata"])

--- a/futureagi/simulate/services/harness_judging.py
+++ b/futureagi/simulate/services/harness_judging.py
@@ -1,0 +1,206 @@
+"""Deciding the harness sub-goals that no code could settle.
+
+The sandbox that ran the scenario holds no platform credentials by design, so it seals the
+evidence and stops there. This is the other half: the run's organization and workspace are known
+here, so the eval template is created in the right tenant rather than in whichever account the
+runner happened to be configured with.
+"""
+
+from __future__ import annotations
+
+import json
+import uuid
+from typing import Any
+
+import structlog
+from django.db.models import Q
+
+from model_hub.models.evals_metric import EvalTemplate
+from simulate.models import CallExecution, HostedHarnessArtifact
+from tfc.settings.settings import UPLOAD_BUCKET_NAME
+from tfc.utils.storage_client import get_storage_client
+
+logger = structlog.get_logger(__name__)
+
+_JUDGE_MODEL = "turing_large"
+_JUDGE_CHOICES = ["pass", "fail"]
+_HARNESS_EVAL_NAMESPACE = uuid.UUID("6b1f3a52-0e2a-4a0e-8a6f-6f5b6f6f5e21")
+
+
+def load_scenario_evidence(call: CallExecution) -> dict[str, Any] | None:
+    """The evidence bundle the guest sealed for this call's scenario."""
+    registration = getattr(call, "hosted_registration", None)
+    if registration is None:
+        return None
+    artifact = (
+        HostedHarnessArtifact.no_workspace_objects.filter(
+            job=registration.job,
+            scenario_key=registration.scenario_key,
+            kind="evidence",
+        )
+        .order_by("created_at")
+        .last()
+    )
+    if artifact is None:
+        return None
+    response = None
+    try:
+        response = get_storage_client().get_object(
+            UPLOAD_BUCKET_NAME, artifact.object_key
+        )
+        body = json.loads(response.read().decode("utf-8"))
+    except Exception:  # noqa: BLE001 - a missing or corrupt bundle is not a failed sub-goal
+        logger.exception("harness_evidence_unreadable", artifact_id=str(artifact.id))
+        return None
+    finally:
+        if response is not None:
+            response.close()
+            response.release_conn()
+    return body if isinstance(body, dict) else None
+
+
+def _instructions(claim: dict[str, Any], agent: str) -> str:
+    """What the judge decides, and from what.
+
+    The record carries the world as it finished, not only what was said: whether an answer was
+    correct is settled by what the tools returned and what the tables hold afterwards, and a
+    judge given the transcript alone can only report that it cannot tell.
+    """
+    question = str(claim.get("judged") or claim.get("what") or claim.get("name") or "")
+    return (
+        f"You are judging one run of {agent}.\n\n"
+        f"Decide strictly: {question}\n\n"
+        "You are given a JSON record of the run: every tool call the agent made with its "
+        "arguments and what came back, and the state of its world afterwards. Row counts are "
+        "reported alongside the rows actually shown, so treat a truncated table as evidence "
+        "about what is present, never as evidence about what is absent.\n\n"
+        "The tool calls are the truth about what happened. An agent that says it did something "
+        "no call performed has not done it, however convincing it sounds, and an answer is "
+        "correct when it matches what the calls returned. A refused call did not happen: judge "
+        "what the agent ended up doing, not what it tried on the way. Something merely not "
+        "contradicted does not hold. Where the claim is that something must not have happened, "
+        "it holds when the thing did not happen. Declining something holds only if the agent "
+        "both declined it and gave a true reason.\n\n"
+        "Answer 'pass' when the claim holds and 'fail' when it does not.\n\n"
+        "The run:\n<output>{{output}}</output>"
+    )
+
+
+def _agent_label(call: CallExecution) -> str:
+    run_test = call.test_execution.run_test
+    return getattr(getattr(run_test, "agent_definition", None), "name", "") or "agent"
+
+
+def _template_name(call: CallExecution, sub_goal: str) -> str:
+    """A name that cannot collide across the workspaces of one organization.
+
+    Template uniqueness is per organization while the lists that check for an existing one are
+    per workspace, so two workspaces testing agents that share a name would otherwise contend
+    for a single row and the loser would silently reuse the winner's instructions.
+    """
+    workspace_id = getattr(call.test_execution.run_test, "workspace_id", None)
+    scope = str(workspace_id)[:8] if workspace_id else "org"
+    return f"harness-{_agent_label(call)}-{scope}-{sub_goal}"[:255]
+
+
+def _ensure_template(
+    call: CallExecution, claim: dict[str, Any], instructions: str
+) -> EvalTemplate | None:
+    run_test = call.test_execution.run_test
+    name = _template_name(call, str(claim.get("name") or ""))
+    existing = (
+        EvalTemplate.no_workspace_objects.filter(
+            Q(organization=run_test.organization),
+            Q(workspace=run_test.workspace) | Q(workspace__isnull=True),
+            name=name,
+            deleted=False,
+        )
+        .order_by("-created_at")
+        .first()
+    )
+    if existing is not None:
+        if existing.criteria != instructions:
+            existing.criteria = instructions
+            existing.save(update_fields=["criteria"])
+        return existing
+    try:
+        return EvalTemplate.objects.create(
+            name=name,
+            description=str(claim.get("what") or "")[:1000],
+            organization=run_test.organization,
+            workspace=run_test.workspace,
+            criteria=instructions,
+            choices=list(_JUDGE_CHOICES),
+            model=_JUDGE_MODEL,
+            eval_tags=["harness", "sub-goal"],
+        )
+    except Exception:  # noqa: BLE001 - a template we cannot store still gets a verdict below
+        logger.exception("harness_judge_template_create_failed", template_name=name)
+        return None
+
+
+def _run_judge(instructions: str, record: str) -> tuple[bool, str] | None:
+    """The verdict, or None when the judge did not run.
+
+    None rather than a failure: an evaluator that could not answer says nothing about the agent,
+    and recording it as a failed sub-goal invents a finding.
+    """
+    try:
+        from ee.evals.llm.agent_evaluator.evaluator import AgentEvaluator
+
+        evaluator = AgentEvaluator(
+            rule_prompt=instructions,
+            model=_JUDGE_MODEL,
+            output_type="choices",
+            choices=list(_JUDGE_CHOICES),
+            agent_mode="agent",
+        )
+        batch_result = evaluator.run(output=record, required_keys=["output"])
+        data = batch_result.eval_results[0]["data"]
+    except Exception:  # noqa: BLE001
+        logger.exception("harness_judge_evaluator_failed")
+        return None
+    verdict = str(data.get("result") or "").strip().lower()
+    if verdict not in _JUDGE_CHOICES:
+        logger.warning("harness_judge_verdict_unrecognized", verdict=verdict[:120])
+        return None
+    return verdict == "pass", str(data.get("reason") or "")
+
+
+def judge_sub_goal(
+    call: CallExecution, claim: dict[str, Any], evidence: dict[str, Any]
+) -> tuple[str, dict[str, Any] | None]:
+    """One judged sub-goal, decided and shaped for ``CallExecution.eval_outputs``."""
+    name = str(claim.get("name") or "")
+    run_test = call.test_execution.run_test
+    # One instruction text, used both to judge and to store, so the template on the platform is
+    # always the question that actually produced the verdict.
+    instructions = _instructions(claim, _agent_label(call))
+    template = _ensure_template(call, claim, instructions)
+    output_id = (
+        str(template.id)
+        if template is not None
+        else str(uuid.uuid5(_HARNESS_EVAL_NAMESPACE, f"{run_test.id}:judge:{name}"))
+    )
+    record = json.dumps(
+        {
+            "calls": evidence.get("calls") or [],
+            "world_afterwards": evidence.get("world") or {},
+        },
+        ensure_ascii=False,
+        default=str,
+    )
+    decided = _run_judge(instructions, record)
+    if decided is None:
+        return output_id, None
+    held, reason = decided
+    return output_id, {
+        "name": name,
+        "output": "Passed" if held else "Failed",
+        "output_type": "Pass/Fail",
+        "reason": reason[:10000],
+        "status": "completed",
+        "source": "harness",
+        "kind": "judge",
+        "platform_template": template.name if template is not None else "",
+    }

--- a/futureagi/simulate/services/hosted_harness_ingestion.py
+++ b/futureagi/simulate/services/hosted_harness_ingestion.py
@@ -778,8 +778,19 @@ def _apply_receipt_to_call(
         _apply_conversation_metrics,
         _apply_harness_evaluation_outputs,
         _dispatch_csat_once,
+        _dispatch_sub_goal_judging_once,
     )
 
+    # A judged sub-goal arrives undecided: the sandbox holds no platform credentials, so the
+    # verdict is reached here instead. Recorded before the save so the dispatch below has it.
+    metadata["harness_judge_pending"] = [
+        str(goal["name"])
+        for goal in body.get("sub_goals") or []
+        if isinstance(goal, dict)
+        and goal.get("name")
+        and goal.get("judged")
+        and goal.get("held") is None
+    ]
     _apply_harness_evaluation_outputs(call)
     update_fields.append("eval_outputs")
     if body.get("failure"):
@@ -822,6 +833,13 @@ def _apply_receipt_to_call(
         call_id = call.id
         transaction.on_commit(
             lambda: _dispatch_csat_once(CallExecution.objects.get(id=call_id))
+        )
+        transaction.on_commit(
+            lambda: _dispatch_sub_goal_judging_once(
+                CallExecution.objects.select_related(
+                    "test_execution", "test_execution__run_test"
+                ).get(id=call_id)
+            )
         )
 
 

--- a/futureagi/simulate/tasks/alk_sim.py
+++ b/futureagi/simulate/tasks/alk_sim.py
@@ -186,3 +186,81 @@ def _set_csat_state(
         metadata.pop("csat_error", None)
     call.call_metadata = metadata
     call.save(update_fields=["call_metadata"])
+
+
+@temporal_activity(
+    time_limit=900,
+    max_retries=2,
+    queue="tasks_xl",
+)
+def judge_harness_sub_goals(call_execution_id: str) -> None:
+    """Decide the sub-goals no code could settle, from the evidence the guest sealed.
+
+    The sandbox holds no platform credentials, so judging happens here, where the run's
+    organization and workspace are already known.
+    """
+    close_old_connections()
+    try:
+        call = CallExecution.objects.select_related(
+            "test_execution", "test_execution__run_test"
+        ).get(id=call_execution_id)
+    except CallExecution.DoesNotExist:
+        logger.warning("harness_judge_call_missing", call_execution_id=call_execution_id)
+        return
+
+    metadata = dict(call.call_metadata or {})
+    pending = [str(name) for name in (metadata.get("harness_judge_pending") or [])]
+    if not pending:
+        return
+
+    from simulate.services.harness_judging import (
+        judge_sub_goal,
+        load_scenario_evidence,
+    )
+
+    evidence = load_scenario_evidence(call)
+    if evidence is None:
+        _set_judge_state(call, "failed", "no evidence artifact was sealed for this scenario")
+        return
+
+    claims = {
+        str(item.get("name")): item
+        for item in (evidence.get("judged_sub_goals") or [])
+        if isinstance(item, dict) and item.get("name")
+    }
+    outputs = dict(call.eval_outputs or {})
+    decided = 0
+    for name in pending:
+        claim = claims.get(name)
+        if claim is None:
+            logger.warning(
+                "harness_judge_claim_missing",
+                call_execution_id=call_execution_id,
+                sub_goal=name,
+            )
+            continue
+        output_id, result = judge_sub_goal(call, claim, evidence)
+        if result is None:
+            continue
+        outputs[output_id] = result
+        decided += 1
+
+    call.eval_outputs = outputs
+    metadata = dict(call.call_metadata or {})
+    metadata["harness_judge_pending"] = [
+        name for name in pending if name not in claims
+    ]
+    metadata["harness_judge_status"] = "completed" if decided else "failed"
+    call.call_metadata = metadata
+    call.save(update_fields=["eval_outputs", "call_metadata"])
+
+
+def _set_judge_state(call: CallExecution, status: str, error: str = "") -> None:
+    metadata = dict(call.call_metadata or {})
+    metadata["harness_judge_status"] = status
+    if error:
+        metadata["harness_judge_error"] = error[:2000]
+    else:
+        metadata.pop("harness_judge_error", None)
+    call.call_metadata = metadata
+    call.save(update_fields=["call_metadata"])


### PR DESCRIPTION
## Status: this one needs a decision before it merges

Stacked on #2445, which carries the `bool(held)` fix and the artifact kind and stands on its own. Nothing here is needed to make that fix correct. If the decision below goes the other way, close this and #2445 still lands.

## The decision

This PR judges non-deterministic sub-goals on the platform, after ingestion. That conflicts with the technical PRD, which is the governing document:

- G6, data-only platform integration: the platform receives and presents execution data, it does not contain harness execution logic.
- Section 29: ALK executes, the hosted execution plane isolates, the platform controls, stores and presents.
- Section 12.7 lists grading as an ALK responsibility.

Read strictly, judging belongs in ALK and this PR puts it in the wrong place.

**The engineering case for doing it here anyway.** Judging in the guest needs platform credentials inside the sandbox. There is no way to route them: `purpose` on a secret reference has two legal values, `target_provider` and `source_checkout`, and the sandbox also runs customer code. Adding a third would put a customer's platform credentials next to it. The tenant is only known on this side, so an eval template created in the guest is created wherever the runner's keys happen to point, which today is one static pair from the operator's environment for every job regardless of who submitted it.

There is also a throughput argument, made independently: judged evals need the world's database copy, that copy dissolves with the world, and that is why calls currently serialise behind the previous call's evals. Judging off the world removes that ordering constraint.

**What is not an argument for it.** Nobody loses live world access by this change, because judged sub-goals never had it. Even in the local lane `run/__init__.py:199` builds the world evidence a judge receives as `", ".join(f"{name}: {len(rows)} rows")`, table names and row counts and nothing else. The evidence bundle in agent-learning-kit#72 is a strict improvement on that in either architecture, which is why it is in a separate PR and worth having regardless of how this is decided.

The counter-shape, if the PRD reading wins, is to mint short-lived per-job platform credentials and route them into the sandbox under a new `purpose`. That is a larger change and moves credentials in the direction we have otherwise been moving them away from.

I have not assumed an answer. This is Karthik's call.

## What it does, if it lands

`receipt ingested -> transaction.on_commit -> celery task -> AgentEvaluator -> eval_outputs`, the same shape CSAT already uses.

`harness_judging.py` reads the sealed evidence artifact for the scenario, resolves or creates an eval template scoped to the run's own organization and workspace, and writes a real verdict with a reason into `eval_outputs`.

**Tenancy.** Template names are `harness-<agent>-<workspace>-<sub-goal>`. Uniqueness is per organization while the lookups that check for an existing template are per workspace, so without the workspace segment two workspaces in one organization testing agents with the same name contend for a single row and the loser silently reuses the winner's instructions. One instruction string is used both to judge and to store, so a stored template is always the question that actually produced the verdict.

**Idempotency.** The pending list is the latch: the task clears only the names it actually decided, so a crash between dispatch and the worker leaves them pending and a later delivery retries them. This deliberately does not copy `_dispatch_csat_once`, which writes its flag before enqueueing and permanently strands a call if it dies in between.

**A judge that could not run is not a sub-goal that failed.** An evaluator error, an unparseable verdict or a missing evidence bundle all return no result and leave the sub-goal undecided rather than recording it against the agent. That is the same distinction #2445 restores on the ingestion side, and undoing it here would put the bug straight back.

No `FI_API_KEY` or `FI_SECRET_KEY` reaches the sandbox, and no new `purpose` is introduced.

## Testing

Not yet exercised end to end. Verifying it needs a hosted job whose evidence the platform accepts, which needs both this and #2445 live in the local stack, and the backend picks up host edits only on a recreate. The unit-testable half is in #2445 and agent-learning-kit#72.
