### PR TITLE
Derive voice provider egress hosts from the job's own credentials

### DIFF
--- a/frontend/src/pages/dashboard/harness/HarnessCreate.jsx
+++ b/frontend/src/pages/dashboard/harness/HarnessCreate.jsx
@@ -284,6 +284,8 @@ export default function HarnessCreate() {
       read_only_source: true,
       allow_privileged: false,
       allow_host_runtime_control: false,
+      // Provider hosts are derived from the supplied credentials server-side. Only a host the
+      // credentials cannot imply, such as a self-hosted TURN server, needs adding here.
       allowed_egress_domains: [],
     },
     retry: {
@@ -327,6 +329,12 @@ export default function HarnessCreate() {
   };
 
   const run = async () => {
+    if (environmentText.trim()) {
+      setEnvironmentError(
+        "Apply the pasted values before starting the run, or clear the box.",
+      );
+      return;
+    }
     setSubmitting(true);
     setError("");
     try {
@@ -367,6 +375,7 @@ export default function HarnessCreate() {
       );
       setEnvironmentValues(merged.environmentValues);
       setConfigurationValues(merged.configurationValues);
+      setEnvironmentText("");
       setEnvironmentError("");
       setPreflightDirty(Boolean(preflight));
     } catch (parseError) {
@@ -1009,6 +1018,11 @@ export default function HarnessCreate() {
                       onChange={(event) =>
                         setEnvironmentText(event.target.value)
                       }
+                      onBlur={() => {
+                        if (environmentText.trim()) {
+                          loadEnvironment(environmentText);
+                        }
+                      }}
                     />
                     <Button
                       variant="text"

--- a/futureagi/simulate/services/hosted_harness_gateway.py
+++ b/futureagi/simulate/services/hosted_harness_gateway.py
@@ -392,6 +392,10 @@ _PRIVATE_HOST_PATTERNS = re.compile(
     r"^(10\.|172\.(1[6-9]|2\d|3[01])\.|192\.168\.|127\.|0\.|169\.254\.|localhost$)"
 )
 _GOOGLE_REGION = re.compile(r"^[a-z][a-z0-9-]{0,31}$")
+# A dotted hostname, so a value that is not an endpoint at all cannot become an egress rule.
+_HOSTNAME = re.compile(
+    r"^[a-z0-9]([a-z0-9-]*[a-z0-9])?(\.[a-z0-9]([a-z0-9-]*[a-z0-9])?)+$"
+)
 
 
 def _validate_egress_domains(domains: list[str]) -> None:
@@ -411,15 +415,51 @@ def _validate_egress_domains(domains: list[str]) -> None:
             )
 
 
-def _validate_resolved_egress_domains(domains: set[str]) -> None:
-    """Enforce Daytona's cap after platform, provider, and customer hosts are combined."""
+def _validate_resolved_egress_domains(
+    domains: set[str], requested: list[str] | None = None
+) -> None:
+    """Enforce Daytona's cap after platform, provider, and customer hosts are combined.
+
+    Provider hosts are derived rather than requested, so a job can sit under the request cap and
+    still overflow here. Name the split so the caller knows which half to trim; dropping a derived
+    host instead would take away the route the credential needs and fail the run much later.
+    """
     if len(domains) > _MAX_EGRESS_DOMAINS:
+        breakdown = (
+            f" ({len(requested)} requested, {len(domains) - len(requested)} required by the "
+            "credentials supplied)"
+            if requested is not None
+            else ""
+        )
         raise HostedHarnessError(
             "egress_domain_limit_exceeded",
             "resolved sandbox egress requires "
-            f"{len(domains)} domains; Daytona supports at most {_MAX_EGRESS_DOMAINS}",
+            f"{len(domains)} domains{breakdown}; Daytona supports at most "
+            f"{_MAX_EGRESS_DOMAINS}",
             status_code=400,
         )
+
+
+def _host_of(value: str) -> str:
+    """The bare host of a provider endpoint, given a URL or an already-bare host.
+
+    Returns "" for anything unusable rather than raising: an unparseable endpoint must not stop a
+    job being launched, it just contributes no rule. Private and loopback hosts are dropped too,
+    since they are unreachable from the sandbox and are rejected on the requested path anyway.
+    """
+    candidate = str(value or "").strip()
+    if not candidate:
+        return ""
+    if "//" not in candidate:
+        candidate = f"//{candidate}"
+    try:
+        host = urlparse(candidate).hostname or ""
+    except ValueError:
+        return ""
+    host = host.lower()
+    if _PRIVATE_HOST_PATTERNS.match(host) or not _HOSTNAME.fullmatch(host):
+        return ""
+    return host
 
 
 def _provider_egress_domains(secrets_map: dict[str, str]) -> set[str]:
@@ -427,10 +467,26 @@ def _provider_egress_domains(secrets_map: dict[str, str]) -> set[str]:
 
     These are platform-managed dependencies of the selected credential type, not customer
     requested egress. In particular, Vertex service-account credentials cannot work unless the
-    OAuth token endpoint and regional Vertex endpoint are reachable.
+    OAuth token endpoint and regional Vertex endpoint are reachable, and a voice run cannot place
+    a call unless its media server and speech providers are reachable.
+
+    A self-hosted LiveKit deployment that terminates TURN on a separate host is the one case this
+    cannot cover, because that host does not appear in ``LIVEKIT_URL``. Add it to the job's own
+    ``allowed_egress_domains`` or to ``ALK_HOSTED_BASE_EGRESS_DOMAINS``.
     """
     aliases = {name.upper() for name in secrets_map}
     domains: set[str] = set()
+    livekit_host = _host_of(secrets_map.get("LIVEKIT_URL", ""))
+    if livekit_host:
+        domains.add(livekit_host)
+    if aliases & {"DEEPGRAM_API_KEY"}:
+        domains.add("api.deepgram.com")
+    if aliases & {"CARTESIA_API_KEY"}:
+        domains.add("api.cartesia.ai")
+    if aliases & {"ELEVENLABS_API_KEY", "ELEVEN_API_KEY"}:
+        domains.add("api.elevenlabs.io")
+    if aliases & {"OPENAI_API_KEY"}:
+        domains.add("api.openai.com")
     if aliases & {
         "GOOGLE_APPLICATION_CREDENTIALS_JSON",
         "GOOGLE_APPLICATION_CREDENTIALS",
@@ -907,7 +963,9 @@ class DaytonaHostedGateway:
             allowed_domains.add(platform_host)
         # Egress union validation: cap at 20 user-supplied domains.
         _validate_egress_domains(payload["security"]["allowed_egress_domains"])
-        _validate_resolved_egress_domains(allowed_domains)
+        _validate_resolved_egress_domains(
+            allowed_domains, payload["security"]["allowed_egress_domains"]
+        )
         # Voice/WebRTC media (ICE) needs UDP to the media server's advertised IP, which a DNS
         # domain-allowlist cannot express when media and signaling resolve to different IPs. When
         # unrestricted egress is enabled the sandbox runs with open outbound so media can flow;

--- a/futureagi/simulate/tests/test_hosted_harness_gateway.py
+++ b/futureagi/simulate/tests/test_hosted_harness_gateway.py
@@ -44,6 +44,63 @@ def test_provider_egress_includes_vertex_auth_and_both_model_regions():
     }
 
 
+def test_provider_egress_derives_voice_hosts_from_credentials():
+    domains = _provider_egress_domains(
+        {
+            "LIVEKIT_URL": "wss://example-project.livekit.cloud",
+            "LIVEKIT_API_KEY": "<encrypted-at-rest>",
+            "DEEPGRAM_API_KEY": "<encrypted-at-rest>",
+        }
+    )
+
+    assert domains == {"example-project.livekit.cloud", "api.deepgram.com"}
+
+
+def test_provider_egress_covers_every_supported_speech_provider():
+    domains = _provider_egress_domains(
+        {
+            "CARTESIA_API_KEY": "<encrypted-at-rest>",
+            "ELEVENLABS_API_KEY": "<encrypted-at-rest>",
+            "OPENAI_API_KEY": "<encrypted-at-rest>",
+        }
+    )
+
+    assert domains == {
+        "api.cartesia.ai",
+        "api.elevenlabs.io",
+        "api.openai.com",
+    }
+
+
+def test_provider_egress_derives_nothing_without_credentials():
+    assert _provider_egress_domains({}) == set()
+
+
+@pytest.mark.parametrize(
+    "url",
+    ["", "   ", "not a url", "wss://", "ws://localhost:7880", "wss://127.0.0.1:7880"],
+)
+def test_provider_egress_ignores_unusable_livekit_urls(url):
+    """A malformed or private endpoint contributes no rule and never stops a launch."""
+    assert _provider_egress_domains({"LIVEKIT_URL": url}) == set()
+
+
+def test_provider_egress_accepts_a_bare_livekit_host():
+    assert _provider_egress_domains({"LIVEKIT_URL": "LiveKit.Example.COM"}) == {
+        "livekit.example.com"
+    }
+
+
+def test_resolved_egress_overflow_separates_requested_from_derived():
+    requested = [f"customer-{index}.example.com" for index in range(18)]
+    resolved = set(requested) | {"api.deepgram.com", "oauth2.googleapis.com", "x.io"}
+
+    with pytest.raises(HostedHarnessError) as raised:
+        _validate_resolved_egress_domains(resolved, requested)
+
+    assert "18 requested, 3 required by the credentials supplied" in str(raised.value)
+
+
 def test_resolved_egress_rejects_daytona_domain_overflow():
     with pytest.raises(HostedHarnessError, match="Daytona supports at most 20"):
         _validate_resolved_egress_domains(


### PR DESCRIPTION
## 1. Why

A hosted harness job created from the UI reaches the sandbox with no network route to LiveKit or Deepgram, so every voice call fails as a timeout. Jobs fired from a local script work, because those scripts pass the domains explicitly. That difference is the whole bug, and it is why this read as flaky infrastructure for three days across at least three people.

Two independent causes.

**The platform derives too few hosts.** `_provider_egress_domains` says it returns "the minimum provider hosts implied by run-scoped credentials", but it only ever derived Google and Vertex hosts. `LIVEKIT_URL`, `DEEPGRAM_API_KEY` and `CARTESIA_API_KEY` all sit in the same resolved secret map and each unambiguously implies a host, and none of them contributed a rule.

The union is assembled from `ALK_HOSTED_BASE_EGRESS_DOMAINS` (empty unless an operator sets it), the derived provider hosts, the job's own list, and the platform host. With Vertex credentials and an empty job list, a voice run got four Google hosts and the platform, and nothing it needed to place a call.

**The UI never sends a list.** `HarnessCreate.jsx` hardcodes `allowed_egress_domains: []` and offers no field for it.

Cartesia is worth calling out separately: it has never appeared on the hosted allowlist, so a run configured for Cartesia TTS had speech to text but no voice. That is a real historical failure, not a hypothetical one.

## 2. What changed

### Provider hosts are derived from the credentials

| Alias present | Host added |
|---|---|
| `LIVEKIT_URL` | its own host, parsed from the URL |
| `DEEPGRAM_API_KEY` | `api.deepgram.com` |
| `CARTESIA_API_KEY` | `api.cartesia.ai` |
| `ELEVENLABS_API_KEY` / `ELEVEN_API_KEY` | `api.elevenlabs.io` |
| `OPENAI_API_KEY` | `api.openai.com` |

The Google and Vertex derivation is unchanged.

LiveKit is parsed rather than pattern matched, so a self-hosted deployment and a LiveKit Cloud project both resolve. `_host_of` accepts a URL or a bare host, lowercases, and returns nothing for a value it cannot use: an unparseable endpoint contributes no rule rather than stopping a launch. It also drops private and loopback hosts, which are unreachable from the sandbox and already rejected on the requested path, and requires a dotted hostname so a value that is not an endpoint at all cannot become an egress rule. A unit test for the `"not a url"` case is what caught that last one.

### The fix is on the backend on purpose

The frontend could have sent a list instead. It should not be the fix: the API would still be wrong for every other caller, and the SDK and the scripts would each carry their own copy of the same table. `_provider_egress_domains` already had the right contract, so the change is to make it honour it.

### What derivation cannot cover

A self-hosted LiveKit deployment that terminates TURN on a separate host. That host does not appear in `LIVEKIT_URL` and there is no way to infer it, so this PR does not pretend to. It goes in `ALK_HOSTED_BASE_EGRESS_DOMAINS`, which is where our own EU coturn host already lives and what `test_daytona_livekit_launch_uses_coturn_domain_allowlist` already locks.

### Overflow now says which half to trim

Provider hosts are derived rather than requested, so a job can pass the 20-domain request cap and still overflow the resolved cap. The error now names the split, for example `23 domains (18 requested, 5 required by the credentials supplied)`. Derived hosts are never dropped to fit: dropping one removes the route a credential needs and fails the run twenty minutes later instead of at submission.

### A pasted env block is no longer silently discarded

Pasted values only reached the payload if the user clicked "Use values" first. People pasted a full env block, started the run, and only the separately uploaded credential file survived. Applying a paste now clears the box, leaving the field also applies it, and starting a run with text still sitting there stops and says so rather than submitting without it.

## 3. Behaviour callouts

- Voice jobs now reach their media server and speech providers without listing any domain by hand. Existing jobs that already listed them are unaffected: the union is additive.
- A job supplying many domains of its own may now hit the resolved cap where it previously did not. The error names the cause.
- `allowed_egress_domains: []` from the UI is now correct rather than broken, so no UI field is added here.

## 4. Tests

`futureagi/simulate/tests/test_hosted_harness_gateway.py`, six new cases: each alias maps to its host, every supported speech provider is covered, no credentials derive nothing, unusable and private LiveKit URLs derive nothing, a bare host is accepted and lowercased, and the overflow message separates requested from derived.

```
DJANGO_SETTINGS_MODULE=tfc.settings.test pytest simulate/tests/test_hosted_harness_gateway.py
19 passed, 12 errors
```

The 12 errors are every `@pytest.mark.django_db` case in the file failing to reach the test Postgres on this machine. They are unrelated to this change and fail identically on the base branch.

Frontend: `vitest run src/pages/dashboard/harness/HarnessCreate.test.js`, 5 passed. `eslint` on the changed file reports no errors.

## 5. Steps to test

1. Create a harness job from the UI against a voice agent, pasting an env block containing `LIVEKIT_URL`, `LIVEKIT_API_KEY`, `LIVEKIT_API_SECRET` and `DEEPGRAM_API_KEY`.
2. Start the run without clicking "Use values". Confirm it either applies on blur or stops and tells you, rather than starting with the values missing.
3. Confirm the launched sandbox's domain allowlist contains the LiveKit host and `api.deepgram.com`.
4. Confirm calls connect and produce turns.

## 6. Scope out

- **No egress field in the UI.** Sending an empty list is now correct, and the one case derivation cannot cover is operator-wide rather than per job, so it belongs in settings.
- **The authoring sandbox is untouched.** It has its own allowlist and reaches only the source host and the model provider; it never places a call.
