### PR TITLE
fix(accounts): reset invite expiry on every resend path, not just one

### DIFF
--- a/futureagi/accounts/tests/test_e2e_resend_reactivate.py
+++ b/futureagi/accounts/tests/test_e2e_resend_reactivate.py
@@ -29,6 +29,8 @@ from tfc.middleware.workspace_context import (
 # URL constants
 INVITE_URL = "/accounts/organization/invite/"
 INVITE_RESEND_URL = "/accounts/organization/invite/resend/"
+LEGACY_USER_RESEND_URL = "/accounts/user/resend-invite/"
+BULK_RESEND_URL = "/accounts/resend-invitation-emails/"
 MEMBER_LIST_URL = "/accounts/organization/members/"
 MEMBER_REMOVE_URL = "/accounts/organization/members/remove/"
 MEMBER_REACTIVATE_URL = "/accounts/organization/members/reactivate/"
@@ -426,6 +428,108 @@ class TestResendInviteFromWorkspaceTab:
         # Resend should refresh expiration (resets created_at to now)
         resp = owner_client.post(
             INVITE_RESEND_URL, {"invite_id": str(invite.id)}, format="json"
+        )
+        assert resp.status_code == status.HTTP_200_OK
+
+        invite.refresh_from_db()
+        assert invite.effective_status == "Pending"
+
+    def test_resend_expired_invite_from_legacy_user_endpoint(
+        self, owner_client, org, default_ws, second_ws
+    ):
+        """The members-screen legacy resend (#2437) must refresh the same
+        OrganizationInvite expiry InviteResendAPIView does, not just re-send
+        the email — otherwise the invite still reads as expired everywhere
+        that checks OrganizationInvite.is_expired."""
+        _invite_user(
+            owner_client,
+            ["legacy_resend@ws.com"],
+            Level.MEMBER,
+            workspace_access=[
+                {"workspace_id": str(second_ws.id), "level": Level.WORKSPACE_MEMBER}
+            ],
+        )
+
+        invite = OrganizationInvite.objects.get(
+            organization=org, target_email="legacy_resend@ws.com"
+        )
+        invite.created_at = timezone.now() - timedelta(days=30)
+        invite.save(update_fields=["created_at"])
+        assert invite.effective_status == "Expired"
+
+        invited_user = User.objects.get(email="legacy_resend@ws.com")
+
+        resp = owner_client.post(
+            LEGACY_USER_RESEND_URL,
+            {"user_id": str(invited_user.id)},
+            format="json",
+        )
+        assert resp.status_code == status.HTTP_200_OK
+
+        invite.refresh_from_db()
+        assert invite.effective_status == "Pending"
+
+    def test_resend_from_legacy_endpoint_does_not_reopen_accepted_invite(
+        self, owner_client, org, default_ws, second_ws
+    ):
+        """An already-accepted invite must not be silently reopened by a
+        resend from the legacy endpoint."""
+        _invite_user(
+            owner_client,
+            ["already_accepted@ws.com"],
+            Level.MEMBER,
+            workspace_access=[
+                {"workspace_id": str(second_ws.id), "level": Level.WORKSPACE_MEMBER}
+            ],
+        )
+
+        invite = OrganizationInvite.objects.get(
+            organization=org, target_email="already_accepted@ws.com"
+        )
+        invite.status = InviteStatus.ACCEPTED
+        invite.created_at = timezone.now() - timedelta(days=30)
+        invite.save(update_fields=["status", "created_at"])
+
+        invited_user = User.objects.get(email="already_accepted@ws.com")
+
+        resp = owner_client.post(
+            LEGACY_USER_RESEND_URL,
+            {"user_id": str(invited_user.id)},
+            format="json",
+        )
+        assert resp.status_code == status.HTTP_200_OK
+
+        invite.refresh_from_db()
+        assert invite.status == InviteStatus.ACCEPTED
+        assert invite.effective_status == "Accepted"
+
+    def test_resend_expired_invite_from_bulk_endpoint(
+        self, owner_client, org, default_ws, second_ws
+    ):
+        """The bulk resend-invitation-emails endpoint (#2437) has the exact
+        same gap as the legacy per-user one and must be fixed the same way."""
+        _invite_user(
+            owner_client,
+            ["bulk_resend@ws.com"],
+            Level.MEMBER,
+            workspace_access=[
+                {"workspace_id": str(second_ws.id), "level": Level.WORKSPACE_MEMBER}
+            ],
+        )
+
+        invite = OrganizationInvite.objects.get(
+            organization=org, target_email="bulk_resend@ws.com"
+        )
+        invite.created_at = timezone.now() - timedelta(days=30)
+        invite.save(update_fields=["created_at"])
+        assert invite.effective_status == "Expired"
+
+        invited_user = User.objects.get(email="bulk_resend@ws.com")
+
+        resp = owner_client.post(
+            BULK_RESEND_URL,
+            {"user_ids": [str(invited_user.id)]},
+            format="json",
         )
         assert resp.status_code == status.HTTP_200_OK
 

--- a/futureagi/accounts/utils.py
+++ b/futureagi/accounts/utils.py
@@ -377,6 +377,25 @@ def persist_pending_org_invite(
     )
 
 
+def refresh_pending_invite_expiration(organization, email):
+    """Reset the expiry of the matching PENDING OrganizationInvite for this
+    email, if one exists (#2437).
+
+    Every place that resends an invitation email must call this, or the
+    invite still reads as expired anywhere OrganizationInvite.is_expired is
+    checked (e.g. the members list), even though a fresh email went out.
+    A no-op when there's no matching invite row — not every legacy invitee
+    has one, and that's fine; resending still just re-sends their email.
+    """
+    invite = OrganizationInvite.objects.filter(
+        organization=organization,
+        target_email__iexact=email,
+        status=InviteStatus.PENDING,
+    ).first()
+    if invite:
+        invite.refresh_expiration()
+
+
 def build_invite_accept_link(user):
     """Build the accept-invite link for an inactive invited user.
 

--- a/futureagi/accounts/views/signup.py
+++ b/futureagi/accounts/views/signup.py
@@ -862,6 +862,14 @@ def resend_invitation_emails(request):
 
             if user:
                 logger.info(f"Resending invitation email to {user.email}")
+
+                # Refresh the matching OrganizationInvite's expiry too, so
+                # this bulk path behaves the same as the other resend
+                # endpoints (#2437).
+                from accounts.utils import refresh_pending_invite_expiration
+
+                refresh_pending_invite_expiration(organization, user.email)
+
                 # Generate a token
                 token = default_token_generator.make_token(user)
 

--- a/futureagi/accounts/views/workspace_management.py
+++ b/futureagi/accounts/views/workspace_management.py
@@ -1344,7 +1344,14 @@ class ResendInviteAPIView(APIView):
                 current_workspace = None
 
             # Generate new password and send email
-            from accounts.utils import generate_password
+            from accounts.utils import (
+                generate_password,
+                refresh_pending_invite_expiration,
+            )
+
+            # Refresh the matching OrganizationInvite's expiry too, so this
+            # path behaves the same as InviteResendAPIView (#2437).
+            refresh_pending_invite_expiration(organization, target_user.email)
 
             new_password = generate_password()
             target_user.set_password(new_password)


### PR DESCRIPTION
## Summary
- Three different places can resend an invitation email: `InviteResendAPIView` (RBAC endpoint), `ResendInviteAPIView` (workspace members screen's legacy per-user resend), and `resend_invitation_emails` (bulk resend). Only the first one actually reset the invite's expiry, via `invite.refresh_expiration()`.
- The other two just re-sent the email without touching the `OrganizationInvite` record at all, so `OrganizationInvite.is_expired` (what the members list and the rest of the product read as the source of truth) kept the invite looking expired even after a fresh email went out.
- Added a shared `refresh_pending_invite_expiration(organization, email)` helper in `accounts/utils.py` and call it from both previously-broken paths. No-op when there's no matching pending invite (some legacy invitees have none), and an already-accepted invite is never reopened by a resend since the lookup filters on `status=PENDING`.

Related to #2437.

## Test plan
- [x] `python3 -m py_compile` on all four touched files (no Django/Postgres available in the environment this was written in — issue #2393 tracks that gap in the repo itself)
- [x] Added three tests to `test_e2e_resend_reactivate.py`, mirroring the existing `InviteResendAPIView` coverage: resending an expired invite via the legacy per-user endpoint flips it back to `Pending`, resending never reopens an already-accepted invite, and the bulk endpoint gets the same coverage since it had the identical gap