### PR TITLE
fix(evals): surface Ground Truth not being applied on the Observe eval path (TH-7765)

### DIFF
--- a/frontend/src/sections/common/DevelopCellRenderer/CellRenderers/EvaluateCellRendererWrapper.jsx
+++ b/frontend/src/sections/common/DevelopCellRenderer/CellRenderers/EvaluateCellRendererWrapper.jsx
@@ -5,7 +5,7 @@ import { alpha } from "@mui/material/styles";
 import EvaluateCell from "../EvaluateCellRenderer/EvaluateCell";
 import CustomTooltip from "src/components/tooltip";
 import Iconify from "src/components/iconify";
-import { PARTIAL_INPUT_WARNING_TYPE } from "src/sections/common/EvalsTasks/PartialInputWarningDetails";
+import { PARTIAL_INPUT_WARNING_TYPE } from "src/sections/common/EvalsTasks/warningTypes";
 import { tooltipSlotProp } from "./cellRendererHelper";
 
 const PartialInputWarningBadge = ({ warnings }) => {

--- a/frontend/src/sections/common/EvalsTasks/EditTaskDrawer/TaskLogs.jsx
+++ b/frontend/src/sections/common/EvalsTasks/EditTaskDrawer/TaskLogs.jsx
@@ -9,6 +9,57 @@ import axios, { endpoints } from "src/utils/axios";
 import { ShowComponent } from "src/components/show";
 import { format } from "date-fns";
 import { readEvalTaskLogs } from "../task_log_read";
+import {
+  warningMessage,
+  warningTypeLabel,
+} from "src/sections/common/EvalsTasks/warningTypes";
+
+const WarningGroupRow = ({ group }) => {
+  const message = warningMessage(group);
+  return (
+    <Box sx={{ display: "flex", flexDirection: "column", gap: 0.25 }}>
+      <Box
+        sx={{
+          display: "flex",
+          gap: 0.5,
+          flexWrap: "wrap",
+          alignItems: "center",
+        }}
+      >
+        <Typography variant="caption" fontWeight={600}>
+          {warningTypeLabel(group.type)}
+        </Typography>
+        {(group.empty_keys || []).map((key) => (
+          <Chip
+            key={key}
+            label={`Missing: ${key}`}
+            color="warning"
+            variant="outlined"
+            size="small"
+            sx={{ fontSize: "10px", height: 18 }}
+          />
+        ))}
+        <Typography variant="caption" color="text.secondary">
+          {group.count} occurrence{group.count === 1 ? "" : "s"}
+        </Typography>
+      </Box>
+      {message && (
+        <Typography variant="caption" color="text.secondary">
+          {message}
+        </Typography>
+      )}
+    </Box>
+  );
+};
+
+WarningGroupRow.propTypes = {
+  group: PropTypes.shape({
+    type: PropTypes.string,
+    empty_keys: PropTypes.arrayOf(PropTypes.string),
+    message: PropTypes.string,
+    count: PropTypes.number,
+  }).isRequired,
+};
 
 const KeyValueOrChip = ({ label, value }) => {
   const chipStyle = {
@@ -211,28 +262,14 @@ const TaskLogs = ({ evalTaskId }) => {
                 color="warning.main"
               />
               <Typography fontSize="14px" fontWeight={600}>
-                Partial Inputs: {warningsCount}
+                Runs with warnings: {warningsCount}
               </Typography>
             </Box>
             {warningGroups.map((group) => (
-              <Box
+              <WarningGroupRow
                 key={`${group.type}-${(group.empty_keys || []).join(",")}`}
-                sx={{ display: "flex", gap: 0.5, flexWrap: "wrap" }}
-              >
-                {(group.empty_keys || []).map((key) => (
-                  <Chip
-                    key={key}
-                    label={`Missing: ${key}`}
-                    color="warning"
-                    variant="outlined"
-                    size="small"
-                    sx={{ fontSize: "10px", height: 18 }}
-                  />
-                ))}
-                <Typography variant="caption" color="text.secondary">
-                  {group.count} occurrence{group.count === 1 ? "" : "s"}
-                </Typography>
-              </Box>
+                group={group}
+              />
             ))}
           </Box>
         )}

--- a/frontend/src/sections/common/EvalsTasks/PartialInputWarningDetails.jsx
+++ b/frontend/src/sections/common/EvalsTasks/PartialInputWarningDetails.jsx
@@ -4,10 +4,7 @@ import { alpha } from "@mui/material/styles";
 
 import Iconify from "src/components/iconify";
 
-export const PARTIAL_INPUT_WARNING_TYPE = "partial_input";
-
-const DEFAULT_MESSAGE =
-  "Eval ran with some inputs empty. Result may be less reliable. Ignore if this is intentional.";
+import { PARTIAL_INPUT_WARNING_TYPE, warningMessage } from "./warningTypes";
 
 const PartialInputWarningDetails = ({ warnings }) => {
   const partial = warnings?.find(
@@ -65,7 +62,7 @@ const PartialInputWarningDetails = ({ warnings }) => {
         variant="body2"
         sx={{ fontSize: "12px", color: "text.secondary", lineHeight: 1.5 }}
       >
-        {partial.message || DEFAULT_MESSAGE}
+        {warningMessage(partial)}
       </Typography>
       {emptyKeys.length > 0 && (
         <Box sx={{ display: "flex", gap: 0.5, flexWrap: "wrap", mt: 1 }}>

--- a/frontend/src/sections/common/EvalsTasks/TaskLogsView.jsx
+++ b/frontend/src/sections/common/EvalsTasks/TaskLogsView.jsx
@@ -20,6 +20,7 @@ import axios, { endpoints } from "src/utils/axios";
 import { format, formatDistanceToNow, differenceInSeconds } from "date-fns";
 import { enrichErrorGroups } from "./classifyTaskError";
 import { readEvalTaskLogs } from "./task_log_read";
+import { warningMessage, warningTypeLabel } from "./warningTypes";
 
 // ── Stat Card ──
 
@@ -353,9 +354,8 @@ const WarningGroupCard = ({ group, defaultExpanded = false }) => {
   const [expanded, setExpanded] = useState(defaultExpanded);
   const emptyKeys = group.empty_keys || [];
   const filledKeys = group.filled_keys || [];
-  const message =
-    group.message ||
-    "Eval ran with some inputs empty. Result may be less reliable. Ignore if this is intentional.";
+  const message = warningMessage(group);
+  const hasKeyBreakdown = emptyKeys.length > 0 || filledKeys.length > 0;
 
   return (
     <Box
@@ -376,9 +376,9 @@ const WarningGroupCard = ({ group, defaultExpanded = false }) => {
           alignItems: "flex-start",
           gap: 1.25,
           p: 1.5,
-          cursor: "pointer",
+          cursor: hasKeyBreakdown ? "pointer" : "default",
         }}
-        onClick={() => setExpanded((v) => !v)}
+        onClick={() => hasKeyBreakdown && setExpanded((v) => !v)}
       >
         <Box
           sx={(t) => ({
@@ -413,7 +413,7 @@ const WarningGroupCard = ({ group, defaultExpanded = false }) => {
               fontWeight={600}
               sx={{ fontSize: "13px" }}
             >
-              Partial inputs
+              {warningTypeLabel(group.type)}
             </Typography>
             <Chip
               label={`${group.count} ${
@@ -433,19 +433,21 @@ const WarningGroupCard = ({ group, defaultExpanded = false }) => {
             {message}
           </Typography>
         </Box>
-        <IconButton size="small" sx={{ p: 0.25, mt: 0.25, flexShrink: 0 }}>
-          <Iconify
-            icon={
-              expanded
-                ? "solar:alt-arrow-up-linear"
-                : "solar:alt-arrow-down-linear"
-            }
-            width={14}
-            sx={{ color: "text.disabled" }}
-          />
-        </IconButton>
+        {hasKeyBreakdown && (
+          <IconButton size="small" sx={{ p: 0.25, mt: 0.25, flexShrink: 0 }}>
+            <Iconify
+              icon={
+                expanded
+                  ? "solar:alt-arrow-up-linear"
+                  : "solar:alt-arrow-down-linear"
+              }
+              width={14}
+              sx={{ color: "text.disabled" }}
+            />
+          </IconButton>
+        )}
       </Box>
-      <Collapse in={expanded} unmountOnExit>
+      <Collapse in={expanded && hasKeyBreakdown} unmountOnExit>
         <Divider sx={{ borderColor: alpha("#000", 0) }} />
         <Box sx={{ px: 1.5, pb: 1.5, pt: 0.5 }}>
           <Typography
@@ -647,6 +649,12 @@ const TaskLogsView = ({ evalTaskId, taskStatus }) => {
     totalCount > 0 ? Math.round((errorsCount / totalCount) * 100) : 0;
   const hasErrors = errorGroups.length > 0;
   const hasWarnings = warningGroups.length > 0;
+  // Groups sort by count, and a group with no key breakdown cannot expand, so
+  // auto-expand the largest one that actually has something behind it.
+  const firstExpandableWarningGroup = warningGroups.find(
+    (group) =>
+      (group.empty_keys || []).length > 0 || (group.filled_keys || []).length > 0,
+  );
   const processedCount = successCount + errorsCount + skippedCount;
   const isDrained = totalCount > 0 && processedCount >= totalCount;
   const isHighErrorRate = errorRate > 50;
@@ -739,7 +747,7 @@ const TaskLogsView = ({ evalTaskId, taskStatus }) => {
         {warningsCount > 0 && (
           <StatCard
             icon="solar:danger-triangle-linear"
-            label="Partial Inputs"
+            label="Runs with warnings"
             value={warningsCount}
             color="warning.main"
             bgColor={alpha(theme.palette.warning.main, 0.1)}
@@ -834,7 +842,7 @@ const TaskLogsView = ({ evalTaskId, taskStatus }) => {
           >
             <Box sx={{ display: "flex", alignItems: "center", gap: 1 }}>
               <Typography variant="subtitle2" sx={{ fontSize: "13px" }}>
-                Partial Input Warnings
+                Warnings
               </Typography>
               <Chip
                 label={`${warningGroups.length} ${
@@ -851,8 +859,8 @@ const TaskLogsView = ({ evalTaskId, taskStatus }) => {
               color="text.disabled"
               sx={{ fontSize: "11px" }}
             >
-              {warningsCount} total warning
-              {warningsCount !== 1 ? "s" : ""} — grouped by missing variables
+              {warningsCount} run{warningsCount !== 1 ? "s" : ""} with
+              warnings, grouped by type below
             </Typography>
           </Box>
           {warningGroupsTruncated && (
@@ -884,11 +892,11 @@ const TaskLogsView = ({ evalTaskId, taskStatus }) => {
             </Box>
           )}
           <Box sx={{ display: "flex", flexDirection: "column", gap: 1 }}>
-            {warningGroups.map((group, index) => (
+            {warningGroups.map((group) => (
               <WarningGroupCard
                 key={`${group.type}-${(group.empty_keys || []).join(",")}`}
                 group={group}
-                defaultExpanded={index === 0}
+                defaultExpanded={group === firstExpandableWarningGroup}
               />
             ))}
           </Box>

--- a/frontend/src/sections/common/EvalsTasks/__tests__/warningTypes.test.js
+++ b/frontend/src/sections/common/EvalsTasks/__tests__/warningTypes.test.js
@@ -1,0 +1,73 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  GROUND_TRUTH_NOT_APPLIED_WARNING_TYPE,
+  PARTIAL_INPUT_WARNING_TYPE,
+  warningMessage,
+  warningTypeLabel,
+} from "../warningTypes";
+
+// These two strings are the wire contract with tracer/utils/eval.py and
+// tracer/views/eval_task.py. A rename on either side has to break here, not
+// silently degrade every warning chip to "Warning".
+describe("warning type values match what the backend emits", () => {
+  it("ground truth", () => {
+    expect(GROUND_TRUTH_NOT_APPLIED_WARNING_TYPE).toBe(
+      "ground_truth_not_applied",
+    );
+  });
+
+  it("partial input", () => {
+    expect(PARTIAL_INPUT_WARNING_TYPE).toBe("partial_input");
+  });
+});
+
+describe("warningTypeLabel", () => {
+  it("labels both known types", () => {
+    expect(warningTypeLabel(GROUND_TRUTH_NOT_APPLIED_WARNING_TYPE)).toBe(
+      "Ground Truth not applied",
+    );
+    expect(warningTypeLabel(PARTIAL_INPUT_WARNING_TYPE)).toBe("Partial inputs");
+  });
+
+  it("falls back for a type the frontend does not know yet", () => {
+    expect(warningTypeLabel("something_new")).toBe("Warning");
+    expect(warningTypeLabel(undefined)).toBe("Warning");
+  });
+});
+
+describe("warningMessage", () => {
+  it("prefers the message the server sent", () => {
+    expect(
+      warningMessage({
+        type: GROUND_TRUTH_NOT_APPLIED_WARNING_TYPE,
+        message: "Ground Truth is enabled but was not applied to this run.",
+      }),
+    ).toBe("Ground Truth is enabled but was not applied to this run.");
+  });
+
+  it("falls back to the local copy when the server sent none", () => {
+    expect(warningMessage({ type: PARTIAL_INPUT_WARNING_TYPE })).toContain(
+      "Eval ran with some inputs empty",
+    );
+  });
+
+  // The task-logs endpoint fills the ground truth message from the backend
+  // table, so the copy must live there and not be duplicated here.
+  it("holds no local copy of the ground truth message", () => {
+    expect(warningMessage({ type: GROUND_TRUTH_NOT_APPLIED_WARNING_TYPE })).toBe(
+      "",
+    );
+    expect(
+      warningMessage({
+        type: GROUND_TRUTH_NOT_APPLIED_WARNING_TYPE,
+        message: "from the server",
+      }),
+    ).toBe("from the server");
+  });
+
+  it("is empty for an unknown type with no message", () => {
+    expect(warningMessage({ type: "something_new" })).toBe("");
+    expect(warningMessage(undefined)).toBe("");
+  });
+});

--- a/frontend/src/sections/common/EvalsTasks/warningTypes.js
+++ b/frontend/src/sections/common/EvalsTasks/warningTypes.js
@@ -1,0 +1,25 @@
+// Warning types an eval run can attach to EvalLogger.output_metadata.warnings.
+// Keep in sync with model_hub/utils/eval_input_validation.py (partial_input)
+// and tracer/utils/eval.py (ground_truth_not_applied).
+
+export const PARTIAL_INPUT_WARNING_TYPE = "partial_input";
+export const GROUND_TRUTH_NOT_APPLIED_WARNING_TYPE = "ground_truth_not_applied";
+
+export const WARNING_TYPE_LABELS = {
+  [PARTIAL_INPUT_WARNING_TYPE]: "Partial inputs",
+  [GROUND_TRUTH_NOT_APPLIED_WARNING_TYPE]: "Ground Truth not applied",
+};
+
+// Only for types the server can emit without copy. ground_truth_not_applied is
+// not one: the task-logs endpoint always fills its message from the backend
+// table, so duplicating the text here would be the drift this module removes.
+export const WARNING_TYPE_FALLBACK_MESSAGES = {
+  [PARTIAL_INPUT_WARNING_TYPE]:
+    "Eval ran with some inputs empty. Result may be less reliable. Ignore if this is intentional.",
+};
+
+export const warningTypeLabel = (type) =>
+  WARNING_TYPE_LABELS[type] || "Warning";
+
+export const warningMessage = (warning) =>
+  warning?.message || WARNING_TYPE_FALLBACK_MESSAGES[warning?.type] || "";

--- a/frontend/src/sections/evals/Helpers/evalUsageColumns.jsx
+++ b/frontend/src/sections/evals/Helpers/evalUsageColumns.jsx
@@ -5,7 +5,7 @@ import { alpha } from "@mui/material/styles";
 import { useMemo } from "react";
 import Iconify from "src/components/iconify";
 import CustomTooltip from "src/components/tooltip";
-import { PARTIAL_INPUT_WARNING_TYPE } from "src/sections/common/EvalsTasks/PartialInputWarningDetails";
+import { PARTIAL_INPUT_WARNING_TYPE } from "src/sections/common/EvalsTasks/warningTypes";
 
 export const ScoreCell = ({ value }) => {
   if (value == null)

--- a/frontend/src/sections/tasks/components/TaskUsageTab.jsx
+++ b/frontend/src/sections/tasks/components/TaskUsageTab.jsx
@@ -27,9 +27,8 @@ import { DATE_OPTION, DEFAULT_USAGE_PERIOD } from "../constants";
 import UsageChart from "src/sections/evals/components/UsageChart";
 import { JsonValueTree } from "src/sections/evals/components/DatasetTestMode";
 import { classifyTaskError } from "src/sections/common/EvalsTasks/classifyTaskError";
-import PartialInputWarningDetails, {
-  PARTIAL_INPUT_WARNING_TYPE,
-} from "src/sections/common/EvalsTasks/PartialInputWarningDetails";
+import PartialInputWarningDetails from "src/sections/common/EvalsTasks/PartialInputWarningDetails";
+import { PARTIAL_INPUT_WARNING_TYPE } from "src/sections/common/EvalsTasks/warningTypes";
 import { isEditableElement } from "src/utils/keyboardUtils";
 import { parsePythonReprIfNeeded } from "src/sections/develop-detail/DataTab/common";
 import { DATE_OPTION_TO_PERIOD } from "src/sections/evals/Helpers/evalUsageColumns";

--- a/futureagi/docs/ground-truth-and-expected-value.md
+++ b/futureagi/docs/ground-truth-and-expected-value.md
@@ -1,0 +1,145 @@
+# Ground Truth, and how to supply `expected_value`
+
+Ground Truth and `expected_value` are two different things. Reading the Ground
+Truth setup screen and concluding that enabling it will fill in a missing
+`expected_value` is a reasonable mistake, and a common one. It will not.
+
+`expected_value` is a **required eval input**, like `input` or `output`. Evals
+that grade against a known answer declare it in their required keys, and the
+runner resolves it from the mapping you configure, exactly as it resolves every
+other input. It is per-row data, supplied by you at run time. It is not a
+setting, not a dataset, and nothing infers it for you.
+
+This page states what Ground Truth does, what it does not do, and how you
+actually give an eval an expected value when it runs from Observe.
+
+---
+
+## What Ground Truth is
+
+Ground Truth is **few-shot calibration**. You upload labelled rows, the rows are
+embedded, and at eval time the most similar rows are retrieved and attached to
+the judge prompt as reference examples, which is how a graded example teaches
+the judge what a good answer looks like for your domain.
+
+Concretely, `GroundTruthService.inject_context`
+(`model_hub/services/ground_truth_service.py`) puts the retrieved rows on
+`mapped["ground_truth_blocks"]`, and the evaluator renders them into the prompt.
+
+That is the whole mechanism. Ground Truth:
+
+- **does** steer the judge with retrieved, similar, human-labelled examples
+- **does not** populate any required eval input
+- **does not** supply `expected_value`, ever
+
+So an eval that declares `expected_value` as a required key still needs
+`expected_value` mapped. If it is not mapped, the run fails with:
+
+```
+Missing required input(s) for eval: expected_value.
+Required keys: ['generated_value', 'expected_value']. Optional keys: [].
+```
+
+That error is correct. It is telling you a required input is unmapped, not that
+Ground Truth is broken.
+
+### Where Ground Truth is applied
+
+Everything that runs an eval through `run_eval_func`
+(`model_hub/views/utils/evals.py`) gets Ground Truth, because that is where
+`inject_context` is called.
+
+| Surface | Ground Truth applied | Why |
+| --- | --- | --- |
+| Datasets | Yes | `run_eval_func` |
+| Prompt playground | Yes | `run_eval_func` |
+| SDK evaluations | Yes | `run_eval_func` |
+| Simulation | Yes | `run_eval_func` |
+| Observe eval tasks, composite evals | Yes | children go `execute_composite_children_sync` to `_execute_child` to `run_eval_func` |
+| Observe eval tasks, simple evals | **No** | `_execute_evaluation` and the trace / session equivalents call the evaluator directly |
+
+So the gap is narrower than a plain `grep -rn "ground_truth" futureagi/tracer`
+suggests. It is the **simple-eval** Observe path, not Observe as a whole. An
+eval task that uses a simple template with Ground Truth switched on runs
+**uncalibrated**; the same template inside a composite does not.
+
+This used to be entirely silent. It is not any more: such a run now attaches a
+`ground_truth_not_applied` warning to the eval result, which surfaces on the
+task's logs view alongside partial-input warnings. The run still succeeds,
+because Ground Truth never blocks an eval, but the state is now visible instead
+of invisible. The warning keys off whether the run actually carries
+`ground_truth_blocks`, so it stops on its own once the simple path is wired.
+
+---
+
+## Supplying `expected_value` on the Observe path
+
+You supply it the same way you supply any other eval input: **emit it as a span
+attribute, then map `expected_value` to that attribute name.**
+
+There is no special-casing to work around. `_process_mapping`
+(`tracer/utils/eval.py`) walks every key in the mapping and resolves each one
+out of the span's attributes; `expected_value` resolves exactly like `input` or
+`output` does.
+
+### Worked example
+
+**1. Emit the expected answer as a span attribute.**
+
+```python
+with tracer.start_as_current_span("answer_question") as span:
+    answer = my_agent(question)
+    span.set_attribute("input.value", question)
+    span.set_attribute("output.value", answer)
+    span.set_attribute("expected.answer", golden_answer)
+```
+
+The attribute name is yours to choose. `expected.answer` is used here to keep
+it distinct from the eval input key.
+
+**2. Map the eval input to that attribute.**
+
+In the eval task's configuration:
+
+| Eval input | Span attribute |
+| --- | --- |
+| `generated_value` | `output.value` |
+| `expected_value` | `expected.answer` |
+
+**3. Scope the task with attribute filters.**
+
+Filter the task down to the spans that actually carry the attribute. For
+example an attribute filter on `expected.answer` being present, or on whatever
+marks your evaluation runs.
+
+> **Do not scope the task with `trace_id` or `span_id`.**
+> `parsing_evaltask_filters` (`tracer/utils/eval_tasks.py`) handles
+> `span_attributes_filters`, `observation_type`, `session_id`, `date_range`,
+> `created_at` and `project_id`. `trace_id` and `span_id` are accepted by the
+> API and stored on the task, then fall through the branch chain and are
+> ignored. The ClickHouse translator (`span_reader.py`) handles the same five
+> keys and neither of these two. A task scoped that way silently evaluates, and
+> bills for, every span in the project window, which looks exactly like a broken
+> mapping. A fix is in review; this page will change when it lands.
+
+### What this approach cannot do
+
+You can only emit `expected_value` where you already know the correct answer at
+emit time, which means a test or regression environment. In production you do
+not know it,
+and retrieval against a labelled dataset is the only mechanism that fits that
+case. Ground Truth retrieval on the simple-eval Observe path is not
+implemented today; inside a composite it already is.
+
+---
+
+## Summary
+
+- Ground Truth is few-shot calibration attached to `mapped["ground_truth_blocks"]`.
+- Ground Truth never supplies `expected_value`.
+- Ground Truth is applied wherever an eval runs through `run_eval_func`:
+  datasets, playground, SDK, Simulation, and **composite** Observe evals.
+- It is **not** applied on the **simple-eval** Observe path, which is the gap.
+- On Observe, supply `expected_value` as a span attribute and map to it.
+- Scope such a task with attribute filters. `trace_id` / `span_id` are accepted
+  and then silently ignored today.

--- a/futureagi/model_hub/services/ground_truth_service.py
+++ b/futureagi/model_hub/services/ground_truth_service.py
@@ -194,6 +194,22 @@ class GroundTruthService:
         }
 
     @staticmethod
+    def _active_gt_queryset(
+        *,
+        eval_template: EvalTemplate,
+        organization_id: TenantId,
+        workspace_id: TenantId,
+    ):
+        return EvalGroundTruth.objects.filter(
+            eval_template=eval_template,
+            organization_id=organization_id,
+            workspace_id=workspace_id,
+            deleted=False,
+            is_active=True,
+            enabled=True,
+        )
+
+    @staticmethod
     def load_active_gt(
         *,
         eval_template: EvalTemplate,
@@ -203,14 +219,35 @@ class GroundTruthService:
         """Return the active, enabled GT row for ``(template, org, ws)`` or ``None``."""
         if not organization_id:
             return None
-        return EvalGroundTruth.objects.filter(
-            eval_template=eval_template,
-            organization_id=organization_id,
-            workspace_id=workspace_id,
-            deleted=False,
-            is_active=True,
-            enabled=True,
-        ).order_by("-created_at").first()
+        return (
+            GroundTruthService._active_gt_queryset(
+                eval_template=eval_template,
+                organization_id=organization_id,
+                workspace_id=workspace_id,
+            )
+            .order_by("-created_at")
+            .first()
+        )
+
+    @staticmethod
+    def is_enabled_for_template(
+        *,
+        eval_template: EvalTemplate,
+        organization_id: TenantId,
+        workspace_id: TenantId,
+    ) -> bool:
+        """Whether GT is switched on and embedded for ``(template, org, ws)``."""
+        if not organization_id:
+            return False
+        return (
+            GroundTruthService._active_gt_queryset(
+                eval_template=eval_template,
+                organization_id=organization_id,
+                workspace_id=workspace_id,
+            )
+            .filter(embedding_status=EvalGroundTruth.EmbeddingStatus.COMPLETED)
+            .exists()
+        )
 
     @staticmethod
     def inject_context(

--- a/futureagi/model_hub/utils/eval_input_validation.py
+++ b/futureagi/model_hub/utils/eval_input_validation.py
@@ -9,6 +9,14 @@ from __future__ import annotations
 import json
 from typing import Any
 
+PARTIAL_INPUT_WARNING_TYPE = "partial_input"
+
+PARTIAL_INPUT_MESSAGE = (
+    "Eval ran with some inputs empty. "
+    "Result may be less reliable. "
+    "Ignore if this is intentional."
+)
+
 
 def is_empty_value(value: Any) -> bool:
     """Return True when ``value`` is effectively empty for eval purposes."""
@@ -111,14 +119,10 @@ def validate_eval_inputs(
         warning = None
         if empty:
             warning = {
-                "type": "partial_input",
+                "type": PARTIAL_INPUT_WARNING_TYPE,
                 "empty_keys": empty,
                 "filled_keys": nonempty,
-                "message": (
-                    "Eval ran with some inputs empty. "
-                    "Result may be less reliable. "
-                    "Ignore if this is intentional."
-                ),
+                "message": PARTIAL_INPUT_MESSAGE,
             }
         return warning, normalized
 

--- a/futureagi/tracer/tests/test_eval_ground_truth_observe_warning.py
+++ b/futureagi/tracer/tests/test_eval_ground_truth_observe_warning.py
@@ -1,0 +1,513 @@
+"""Ground-truth visibility on the simple-eval Observe path.
+
+Composite children reach ``GroundTruthService.inject_context`` through
+``run_eval_func``; the simple-eval path does not, so a template with Ground
+Truth switched on runs uncalibrated on spans, traces and sessions. These tests
+pin the run-level warning that makes that state visible, pin that it keys off
+the injected blocks rather than the config, and pin that the run still succeeds.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+# Breaks the tracer.utils.eval <-> model_hub.tasks import cycle, as in test_eval_task_runtime.py.
+import model_hub.tasks  # noqa: F401
+from model_hub.models.evals_metric import EvalGroundTruth
+from model_hub.utils.eval_input_validation import PARTIAL_INPUT_WARNING_TYPE
+from tracer.models.observation_span import EvalLogger
+from tracer.utils.eval import GROUND_TRUTH_NOT_APPLIED_WARNING_TYPE as GT_WARNING_TYPE
+
+RUN_PARAMS = {"input": "hello", "output": "world"}
+
+
+def _make_ground_truth(
+    eval_template,
+    organization,
+    workspace,
+    *,
+    enabled=True,
+    embedding_status=EvalGroundTruth.EmbeddingStatus.COMPLETED,
+):
+    return EvalGroundTruth.objects.create(
+        eval_template=eval_template,
+        name="labelled answers",
+        columns=["question", "answer"],
+        data=[{"question": "hello", "answer": "world"}],
+        row_count=1,
+        variable_mapping={"input": "question"},
+        role_mapping={"output": "answer"},
+        embedding_status=embedding_status,
+        embedded_row_count=1,
+        organization=organization,
+        workspace=workspace,
+        is_active=True,
+        enabled=enabled,
+    )
+
+
+def _warnings_on(eval_log):
+    return (eval_log.output_metadata or {}).get("warnings") or []
+
+
+def _gt_warnings(eval_log):
+    return [w for w in _warnings_on(eval_log) if w.get("type") == GT_WARNING_TYPE]
+
+
+def _latest_log(custom_eval_config):
+    return (
+        EvalLogger.objects.filter(custom_eval_config=custom_eval_config)
+        .order_by("-created_at")
+        .first()
+    )
+
+
+def _run_span_eval(observation_span, custom_eval_config, eval_task_id=None):
+    from tracer.utils.eval import OBSERVE, _execute_evaluation
+
+    _execute_evaluation(
+        observation_span_id=observation_span.id,
+        custom_eval_config_id=custom_eval_config.id,
+        eval_task_id=eval_task_id,
+        type=OBSERVE,
+        run_params=dict(RUN_PARAMS),
+    )
+
+
+@pytest.mark.django_db
+def test_span_eval_surfaces_ground_truth_not_applied(
+    organization,
+    workspace,
+    project,
+    trace,
+    observation_span,
+    eval_template,
+    custom_eval_config,
+    stub_run_eval,
+    stub_cost_log,
+):
+    _make_ground_truth(eval_template, organization, workspace)
+
+    _run_span_eval(observation_span, custom_eval_config)
+
+    eval_log = _latest_log(custom_eval_config)
+    assert eval_log is not None
+    warnings = _gt_warnings(eval_log)
+    assert len(warnings) == 1
+    # The row carries the type only; the copy lives in the view's table so it
+    # is not written to every EvalLogger and APICallLog row.
+    assert warnings[0] == {"type": GT_WARNING_TYPE}
+
+
+@pytest.mark.django_db
+def test_span_eval_still_succeeds_with_ground_truth_enabled(
+    organization,
+    workspace,
+    project,
+    trace,
+    observation_span,
+    eval_template,
+    custom_eval_config,
+    stub_run_eval,
+    stub_cost_log,
+):
+    """Fail-open is the contract: the warning must not turn the run into an error."""
+    _make_ground_truth(eval_template, organization, workspace)
+
+    _run_span_eval(observation_span, custom_eval_config)
+
+    eval_log = _latest_log(custom_eval_config)
+    assert eval_log.error is False
+    assert eval_log.output_str != "ERROR"
+    assert _gt_warnings(eval_log)
+
+
+@pytest.mark.django_db
+def test_trace_eval_surfaces_ground_truth_not_applied(
+    organization,
+    workspace,
+    project,
+    trace,
+    observation_span,
+    eval_template,
+    custom_eval_config,
+    stub_run_eval,
+    stub_cost_log,
+):
+    from tracer.utils.eval import _execute_evaluation_for_trace
+
+    _make_ground_truth(eval_template, organization, workspace)
+
+    _execute_evaluation_for_trace(
+        trace=trace,
+        anchor_span=observation_span,
+        custom_eval_config=custom_eval_config,
+        eval_task_id=None,
+        run_params=dict(RUN_PARAMS),
+    )
+
+    eval_log = _latest_log(custom_eval_config)
+    assert eval_log is not None
+    assert len(_gt_warnings(eval_log)) == 1
+    assert eval_log.error is False
+
+
+@pytest.mark.django_db
+def test_session_eval_surfaces_ground_truth_not_applied(
+    organization,
+    workspace,
+    observe_project,
+    trace_session,
+    eval_template,
+    custom_eval_config,
+    stub_run_eval,
+    stub_cost_log,
+):
+    from tracer.utils.eval import _execute_evaluation_for_session
+
+    _make_ground_truth(eval_template, organization, workspace)
+
+    _execute_evaluation_for_session(
+        trace_session=trace_session,
+        custom_eval_config=custom_eval_config,
+        eval_task_id=None,
+        run_params=dict(RUN_PARAMS),
+    )
+
+    eval_log = _latest_log(custom_eval_config)
+    assert eval_log is not None
+    assert len(_gt_warnings(eval_log)) == 1
+    assert eval_log.error is False
+
+
+@pytest.mark.django_db
+def test_no_warning_when_no_ground_truth_configured(
+    organization,
+    workspace,
+    project,
+    trace,
+    observation_span,
+    eval_template,
+    custom_eval_config,
+    stub_run_eval,
+    stub_cost_log,
+):
+    _run_span_eval(observation_span, custom_eval_config)
+
+    assert _warnings_on(_latest_log(custom_eval_config)) == []
+
+
+@pytest.mark.django_db
+def test_no_warning_when_ground_truth_is_disabled(
+    organization,
+    workspace,
+    project,
+    trace,
+    observation_span,
+    eval_template,
+    custom_eval_config,
+    stub_run_eval,
+    stub_cost_log,
+):
+    _make_ground_truth(eval_template, organization, workspace, enabled=False)
+
+    _run_span_eval(observation_span, custom_eval_config)
+
+    assert _gt_warnings(_latest_log(custom_eval_config)) == []
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize(
+    "status",
+    [
+        EvalGroundTruth.EmbeddingStatus.PENDING,
+        EvalGroundTruth.EmbeddingStatus.PROCESSING,
+        EvalGroundTruth.EmbeddingStatus.FAILED,
+    ],
+)
+def test_no_warning_until_the_ground_truth_rows_are_embedded(
+    status,
+    organization,
+    workspace,
+    project,
+    trace,
+    observation_span,
+    eval_template,
+    custom_eval_config,
+    stub_run_eval,
+    stub_cost_log,
+):
+    """An unembedded row is not injected on any path, so Observe is not the fault."""
+    _make_ground_truth(
+        eval_template, organization, workspace, embedding_status=status
+    )
+
+    _run_span_eval(observation_span, custom_eval_config)
+
+    assert _gt_warnings(_latest_log(custom_eval_config)) == []
+
+
+@pytest.mark.django_db
+def test_no_warning_once_the_run_carries_ground_truth_blocks(
+    organization,
+    workspace,
+    project,
+    trace,
+    observation_span,
+    eval_template,
+    custom_eval_config,
+    stub_run_eval,
+    stub_cost_log,
+    monkeypatch,
+):
+    """Keys off the injected blocks, so wiring the path retires the warning."""
+    _make_ground_truth(eval_template, organization, workspace)
+    monkeypatch.setattr(
+        "model_hub.utils.eval_input_validation.validate_eval_inputs",
+        lambda _template, values, **_kwargs: (
+            None,
+            {**values, "ground_truth_blocks": [{"question": "hello"}]},
+        ),
+    )
+
+    _run_span_eval(observation_span, custom_eval_config)
+
+    assert _gt_warnings(_latest_log(custom_eval_config)) == []
+
+
+@pytest.mark.django_db
+def test_default_workspace_ground_truth_warns_on_the_span_path(
+    organization,
+    project,
+    trace,
+    observation_span,
+    eval_template,
+    custom_eval_config,
+    stub_run_eval,
+    stub_cost_log,
+):
+    """A project with no workspace resolves to the default one, as trace and session do."""
+    from accounts.models.workspace import Workspace
+
+    default_ws = Workspace.objects.filter(
+        organization=organization, is_default=True, is_active=True
+    ).first()
+    project.workspace = None
+    project.save(update_fields=["workspace"])
+    _make_ground_truth(eval_template, organization, default_ws)
+
+    _run_span_eval(observation_span, custom_eval_config)
+
+    assert len(_gt_warnings(_latest_log(custom_eval_config))) == 1
+
+
+@pytest.mark.django_db
+def test_workspaceless_project_keeps_a_null_workspace_on_the_eval_request(
+    organization,
+    project,
+    trace,
+    observation_span,
+    eval_template,
+    custom_eval_config,
+    stub_run_eval,
+    stub_cost_log,
+    monkeypatch,
+):
+    """The GT lookup resolves the default workspace; the eval request must not.
+
+    ``ws_id`` also picks the provider API key in ``run_eval`` and the billing
+    attribution in ``_emit_eval_billing``, so it stays the project's own.
+    """
+    import evaluations.engine as engine
+    from accounts.models.workspace import Workspace
+
+    default_ws = Workspace.objects.filter(
+        organization=organization, is_default=True, is_active=True
+    ).first()
+    project.workspace = None
+    project.save(update_fields=["workspace"])
+    _make_ground_truth(eval_template, organization, default_ws)
+
+    seen = {}
+    stubbed = engine.run_eval
+
+    def _capture(request):
+        seen["workspace_id"] = request.workspace_id
+        return stubbed(request)
+
+    monkeypatch.setattr(engine, "run_eval", _capture)
+
+    _run_span_eval(observation_span, custom_eval_config)
+
+    assert seen["workspace_id"] is None
+    # ...and the warning still fires, because its lookup resolved the default.
+    assert len(_gt_warnings(_latest_log(custom_eval_config))) == 1
+
+
+@pytest.mark.django_db
+def test_no_warning_for_another_tenants_ground_truth(
+    organization,
+    workspace,
+    project,
+    trace,
+    observation_span,
+    eval_template,
+    custom_eval_config,
+    stub_run_eval,
+    stub_cost_log,
+):
+    from accounts.models.organization import Organization
+
+    other_org = Organization.objects.create(name="other org")
+    _make_ground_truth(eval_template, other_org, None)
+
+    _run_span_eval(observation_span, custom_eval_config)
+
+    assert _gt_warnings(_latest_log(custom_eval_config)) == []
+
+
+@pytest.mark.django_db
+def test_eval_runs_when_ground_truth_lookup_raises(
+    organization,
+    workspace,
+    project,
+    trace,
+    observation_span,
+    eval_template,
+    custom_eval_config,
+    stub_run_eval,
+    stub_cost_log,
+    monkeypatch,
+):
+    """A broken GT lookup must never block the eval. Fail open, no warning."""
+    from model_hub.services.ground_truth_service import GroundTruthService
+
+    _make_ground_truth(eval_template, organization, workspace)
+
+    def _boom(**_kwargs):
+        raise RuntimeError("gt_lookup_blew_up")
+
+    monkeypatch.setattr(
+        GroundTruthService, "is_enabled_for_template", staticmethod(_boom)
+    )
+
+    _run_span_eval(observation_span, custom_eval_config)
+
+    eval_log = _latest_log(custom_eval_config)
+    assert eval_log.error is False
+    assert _gt_warnings(eval_log) == []
+
+
+@pytest.mark.django_db
+def test_partial_input_and_ground_truth_warnings_coexist(
+    organization,
+    workspace,
+    project,
+    trace,
+    observation_span,
+    eval_template,
+    custom_eval_config,
+    stub_run_eval,
+    stub_cost_log,
+    monkeypatch,
+):
+    """Adding the GT warning must not displace the partial-input one."""
+    partial = {
+        "type": PARTIAL_INPUT_WARNING_TYPE,
+        "empty_keys": ["output"],
+        "filled_keys": ["input"],
+    }
+
+    monkeypatch.setattr(
+        "model_hub.utils.eval_input_validation.validate_eval_inputs",
+        lambda _template, values, **_kwargs: (partial, values),
+    )
+    _make_ground_truth(eval_template, organization, workspace)
+
+    _run_span_eval(observation_span, custom_eval_config)
+
+    types = [w.get("type") for w in _warnings_on(_latest_log(custom_eval_config))]
+    assert types == [PARTIAL_INPUT_WARNING_TYPE, GT_WARNING_TYPE]
+
+
+@pytest.mark.integration
+@pytest.mark.api
+@pytest.mark.django_db
+def test_task_logs_endpoint_reports_the_ground_truth_warning_group(
+    auth_client,
+    organization,
+    workspace,
+    project,
+    trace,
+    observation_span,
+    eval_template,
+    custom_eval_config,
+    eval_task,
+    stub_run_eval,
+    stub_cost_log,
+):
+    """The signal has to reach the surface a user actually opens."""
+    _make_ground_truth(eval_template, organization, workspace)
+
+    _run_span_eval(observation_span, custom_eval_config, eval_task_id=eval_task.id)
+
+    response = auth_client.get(
+        "/tracer/eval-task/get_eval_task_logs/",
+        {"eval_task_id": str(eval_task.id)},
+    )
+    assert response.status_code == 200
+
+    payload = response.json()
+    result = payload.get("result", payload)
+    assert result["warnings_count"] == 1
+
+    groups = [g for g in result["warning_groups"] if g["type"] == GT_WARNING_TYPE]
+    assert len(groups) == 1
+    assert groups[0]["count"] == 1
+    # The row persists the type only; the copy comes from the view's table.
+    assert "expected_value" in groups[0]["message"]
+
+
+@pytest.mark.integration
+@pytest.mark.api
+@pytest.mark.django_db
+def test_task_logs_endpoint_counts_rows_while_groups_count_warnings(
+    auth_client,
+    organization,
+    workspace,
+    project,
+    trace,
+    observation_span,
+    eval_template,
+    custom_eval_config,
+    eval_task,
+    stub_run_eval,
+    stub_cost_log,
+    monkeypatch,
+):
+    """One row, two warnings: the header is runs, the groups are occurrences."""
+    partial = {
+        "type": PARTIAL_INPUT_WARNING_TYPE,
+        "empty_keys": ["output"],
+        "filled_keys": ["input"],
+    }
+    monkeypatch.setattr(
+        "model_hub.utils.eval_input_validation.validate_eval_inputs",
+        lambda _template, values, **_kwargs: (partial, values),
+    )
+    _make_ground_truth(eval_template, organization, workspace)
+
+    _run_span_eval(observation_span, custom_eval_config, eval_task_id=eval_task.id)
+
+    response = auth_client.get(
+        "/tracer/eval-task/get_eval_task_logs/",
+        {"eval_task_id": str(eval_task.id)},
+    )
+    assert response.status_code == 200
+    result = response.json().get("result", response.json())
+
+    assert result["warnings_count"] == 1
+    counts = {g["type"]: g["count"] for g in result["warning_groups"]}
+    assert counts[PARTIAL_INPUT_WARNING_TYPE] == 1
+    assert counts[GT_WARNING_TYPE] == 1
+    assert sum(counts.values()) == 2

--- a/futureagi/tracer/utils/eval.py
+++ b/futureagi/tracer/utils/eval.py
@@ -151,26 +151,87 @@ def _walk_raw_log(raw_log: dict, path: str):
 _MISSING = object()
 
 
-def _build_apicall_output(result, partial_input_warning):
+def _build_apicall_output(result, run_warnings):
     """Build the ``APICallLog.config.output`` payload for an eval success.
 
-    Bundles ``partial_input_warning`` into the same payload so the single
-    save below carries both the result and the warning — avoids the
-    earlier double-save (which silently dropped the warning if the
-    second save raised).
+    Bundles the run warnings into the same payload so the single save below
+    carries both the result and the warnings, avoiding the earlier
+    double-save (which silently dropped the warning if the second save
+    raised).
     """
     payload = {"output": result.value, "reason": result.reason}
-    if partial_input_warning:
-        payload["warnings"] = [partial_input_warning]
+    if run_warnings:
+        payload["warnings"] = list(run_warnings)
     return payload
 
 
-def _attach_warning_to_metadata(response, output_metadata, partial_input_warning):
-    """Mirror a partial-input warning onto the response and EvalLogger metadata."""
-    if not partial_input_warning:
+def _attach_warnings_to_metadata(response, output_metadata, run_warnings):
+    """Mirror the run warnings onto the response and EvalLogger metadata."""
+    if not run_warnings:
         return
-    response["warnings"] = [partial_input_warning]
-    output_metadata["warnings"] = [partial_input_warning]
+    response["warnings"] = list(run_warnings)
+    output_metadata["warnings"] = list(run_warnings)
+
+
+GROUND_TRUTH_NOT_APPLIED_WARNING_TYPE = "ground_truth_not_applied"
+
+GROUND_TRUTH_NOT_APPLIED_MESSAGE = (
+    "Ground Truth is enabled on this eval template but is not applied to "
+    "evals run from Observe, so this result is uncalibrated. Ground Truth "
+    "adds few-shot reference examples to the judge prompt and never supplies "
+    "'expected_value'. To provide one here, emit it as a span attribute and "
+    "map 'expected_value' to that attribute name."
+)
+
+
+def _ground_truth_not_applied_warning(
+    eval_template, run_params, *, organization_id, workspace_id
+):
+    """Warning when GT is embedded and enabled but this run carries none.
+
+    Composite children reach ``inject_context`` through ``run_eval_func``; the
+    simple-eval path does not. Keying off the injected blocks rather than off
+    the config means the warning stops on its own once that path is wired.
+    Fail-open: a lookup failure returns ``None`` so GT can never block a run.
+    """
+    if (run_params or {}).get("ground_truth_blocks"):
+        return None
+    try:
+        from model_hub.services.ground_truth_service import GroundTruthService
+
+        if not GroundTruthService.is_enabled_for_template(
+            eval_template=eval_template,
+            organization_id=organization_id,
+            workspace_id=workspace_id,
+        ):
+            return None
+    except Exception as exc:
+        logger.warning(
+            "ground_truth_not_applied_check_failed",
+            template_id=str(getattr(eval_template, "id", "") or ""),
+            error=str(exc),
+        )
+        return None
+
+    return {"type": GROUND_TRUTH_NOT_APPLIED_WARNING_TYPE}
+
+
+def _collect_run_warnings(
+    partial_input_warning, run_params, eval_template, *, organization_id, workspace_id
+):
+    """Every warning this eval run should carry, in display order."""
+    run_warnings = []
+    if partial_input_warning:
+        run_warnings.append(partial_input_warning)
+    gt_warning = _ground_truth_not_applied_warning(
+        eval_template,
+        run_params,
+        organization_id=organization_id,
+        workspace_id=workspace_id,
+    )
+    if gt_warning:
+        run_warnings.append(gt_warning)
+    return run_warnings
 
 
 def _resolve_attr(span_attrs: dict, candidate: str):
@@ -1607,10 +1668,29 @@ def _execute_evaluation(
     )
 
     org_id = str(observation_span.project.organization.id)
+    workspace = observation_span.project.workspace
+    if workspace is None:
+        workspace = Workspace.objects.get(
+            organization=observation_span.project.organization,
+            is_default=True,
+            is_active=True,
+        )
+    # ws_id stays the project's own workspace: it also selects the provider
+    # API key in run_eval and the billing attribution in _emit_eval_billing.
     ws_id = (
         str(observation_span.project.workspace.id)
         if observation_span.project.workspace
         else None
+    )
+
+    run_warnings = _collect_run_warnings(
+        partial_input_warning,
+        run_params,
+        eval_model,
+        organization_id=org_id,
+        # GT rows are scoped to a real workspace, so the lookup uses the
+        # resolved one, as the trace and session paths already do.
+        workspace_id=str(workspace.id) if workspace else None,
     )
 
     # --- Cost tracking (caller-side) ---
@@ -1629,13 +1709,6 @@ def _execute_evaluation(
     _stamp_eval_version(source_config, eval_model)
 
     api_call_type = _get_api_call_type(custom_eval_config.model)
-    workspace = observation_span.project.workspace
-    if workspace is None:
-        workspace = Workspace.objects.get(
-            organization=observation_span.project.organization,
-            is_default=True,
-            is_active=True,
-        )
 
     api_call_log_row = None
     if log_and_deduct_cost_for_api_request is not None:
@@ -1696,15 +1769,15 @@ def _execute_evaluation(
             )
         )
 
-        # Build the output payload up front so the partial-input warning
-        # rides on the single save below — avoids losing the warning if a
-        # follow-up save were to fail (see _build_apicall_output).
+        # Build the output payload up front so the run warnings ride on the
+        # single save below, so a follow-up save cannot drop them if it were
+        # fail (see _build_apicall_output).
         if api_call_log_row is not None:
             config_dict = json.loads(api_call_log_row.config)
             config_dict.update(
                 {
                     "input": result.data,
-                    "output": _build_apicall_output(result, partial_input_warning),
+                    "output": _build_apicall_output(result, run_warnings),
                 }
             )
             api_call_log_row.config = json.dumps(config_dict)
@@ -1750,7 +1823,7 @@ def _execute_evaluation(
         }
 
         _output_metadata = {**metadata}
-        _attach_warning_to_metadata(response, _output_metadata, partial_input_warning)
+        _attach_warnings_to_metadata(response, _output_metadata, run_warnings)
 
         logger_kwargs = {
             "trace": observation_span.trace,
@@ -3471,6 +3544,14 @@ def _execute_evaluation_for_trace(
         )
     ws_id = str(workspace.id) if workspace else None
 
+    run_warnings = _collect_run_warnings(
+        partial_input_warning,
+        run_params,
+        eval_template,
+        organization_id=org_id,
+        workspace_id=ws_id,
+    )
+
     source_config = {
         "reference_id": str(trace.id),
         "is_futureagi_eval": futureagi_eval,
@@ -3562,7 +3643,7 @@ def _execute_evaluation_for_trace(
             config_dict.update(
                 {
                     "input": result.data,
-                    "output": _build_apicall_output(result, partial_input_warning),
+                    "output": _build_apicall_output(result, run_warnings),
                 }
             )
             api_call_log_row.config = json.dumps(config_dict)
@@ -3606,7 +3687,7 @@ def _execute_evaluation_for_trace(
             "duration": result.duration,
         }
         _output_metadata = {**metadata}
-        _attach_warning_to_metadata(response, _output_metadata, partial_input_warning)
+        _attach_warnings_to_metadata(response, _output_metadata, run_warnings)
         logger_kwargs = {
             "target_type": EvalTargetType.TRACE.value,
             "trace": trace,
@@ -3707,6 +3788,14 @@ def _execute_evaluation_for_session(
         )
     ws_id = str(workspace.id) if workspace else None
 
+    run_warnings = _collect_run_warnings(
+        partial_input_warning,
+        run_params,
+        eval_template,
+        organization_id=org_id,
+        workspace_id=ws_id,
+    )
+
     source_config = {
         "reference_id": str(trace_session.id),
         "is_futureagi_eval": futureagi_eval,
@@ -3797,7 +3886,7 @@ def _execute_evaluation_for_session(
             config_dict.update(
                 {
                     "input": result.data,
-                    "output": _build_apicall_output(result, partial_input_warning),
+                    "output": _build_apicall_output(result, run_warnings),
                 }
             )
             api_call_log_row.config = json.dumps(config_dict)
@@ -3841,7 +3930,7 @@ def _execute_evaluation_for_session(
             "duration": result.duration,
         }
         _output_metadata = {**metadata}
-        _attach_warning_to_metadata(response, _output_metadata, partial_input_warning)
+        _attach_warnings_to_metadata(response, _output_metadata, run_warnings)
         logger_kwargs = {
             "target_type": EvalTargetType.SESSION.value,
             "trace": None,

--- a/futureagi/tracer/views/eval_task.py
+++ b/futureagi/tracer/views/eval_task.py
@@ -67,12 +67,20 @@ from tracer.serializers.eval_task import (
     EvalTaskUsageQuerySerializer,
     EvalTaskUsageResponseSerializer,
 )
+from model_hub.utils.eval_input_validation import (
+    PARTIAL_INPUT_MESSAGE,
+    PARTIAL_INPUT_WARNING_TYPE,
+)
 from tracer.services.clickhouse.read_budget import ReadDeadline, ReadDeadlineExceeded
 from tracer.services.eval_tasks.edit_options import validate_edit_action
 from tracer.services.eval_tasks.entries import soft_delete_live
 from tracer.services.filter_principal_context import (
     FilterPrincipalContextError,
     bind_request_my_annotations_principal,
+)
+from tracer.utils.eval import (
+    GROUND_TRUTH_NOT_APPLIED_MESSAGE,
+    GROUND_TRUTH_NOT_APPLIED_WARNING_TYPE,
 )
 from tracer.utils.filters import FilterEngine
 from tracer.utils.helper import get_default_eval_task_config
@@ -380,7 +388,16 @@ def _bounded_usage_text(value):
     return f"{text[:_USAGE_DETAIL_TEXT_MAX_CHARS]} [truncated]"
 
 
-def _extract_partial_input_warnings(output_metadata):
+# Warnings persist as a bare type on the row; the copy lives here so a
+# 300-char string is not written to every EvalLogger and APICallLog.
+_WARNING_FALLBACK_MESSAGES = {
+    PARTIAL_INPUT_WARNING_TYPE: PARTIAL_INPUT_MESSAGE,
+    GROUND_TRUTH_NOT_APPLIED_WARNING_TYPE: GROUND_TRUTH_NOT_APPLIED_MESSAGE,
+}
+
+
+def _extract_run_warnings(output_metadata):
+    """Every typed warning on one EvalLogger row, whatever its type."""
     if not isinstance(output_metadata, dict):
         return []
     warnings = output_metadata.get("warnings") or []
@@ -390,7 +407,7 @@ def _extract_partial_input_warnings(output_metadata):
         return []
     result = []
     for warning in warnings:
-        if not isinstance(warning, dict) or warning.get("type") != "partial_input":
+        if not isinstance(warning, dict) or not warning.get("type"):
             continue
 
         def bounded_keys(value):
@@ -408,7 +425,7 @@ def _extract_partial_input_warnings(output_metadata):
             message = ""
         result.append(
             {
-                "type": "partial_input",
+                "type": str(warning["type"])[:_EVAL_TASK_WARNING_KEY_MAX_CHARS],
                 "empty_keys": bounded_keys(warning.get("empty_keys")),
                 "filled_keys": bounded_keys(warning.get("filled_keys")),
                 "message": message[:_EVAL_TASK_WARNING_MESSAGE_MAX_CHARS],
@@ -798,21 +815,18 @@ def _build_eval_task_warning_groups(rows, *, group_limit):
             warning_text_truncated = True
             continue
         warnings = _parse_usage_json_preview(preview, original_length)
-        for warning in _extract_partial_input_warnings({"warnings": warnings}):
+        for warning in _extract_run_warnings({"warnings": warnings}):
+            warning_type = warning["type"]
             empty_keys = warning["empty_keys"]
             filled_keys = warning["filled_keys"]
-            key = tuple(empty_keys)
+            key = (warning_type, tuple(empty_keys))
             if key not in warning_groups_by_key:
                 warning_groups_by_key[key] = {
-                    "type": "partial_input",
+                    "type": warning_type,
                     "empty_keys": empty_keys,
                     "filled_keys": filled_keys,
                     "message": warning["message"]
-                    or (
-                        "Eval ran with some inputs empty. "
-                        "Result may be less reliable. "
-                        "Ignore if this is intentional."
-                    ),
+                    or _WARNING_FALLBACK_MESSAGES.get(warning_type, ""),
                     "count": 0,
                 }
             warning_groups_by_key[key]["count"] += 1
@@ -2108,10 +2122,9 @@ class EvalTaskView(BaseModelViewSetMixin, ModelViewSet):
                 # was absent). Counted separately so it stays out of the
                 # success and failure tallies.
                 skipped_count=Count("id", filter=Q(status=EvalEntryStatus.SKIPPED)),
-                # Partial-input warnings live in
-                # output_metadata.warnings as a JSON array. has_key on
-                # the JSONField gives us a cheap "any warnings?" filter
-                # without scanning the contents.
+                # Rows carrying at least one warning. A row can carry more
+                # than one, so this is not the sum of the group counts; the
+                # UI labels it "runs with warnings" for that reason.
                 warnings_count=Count(
                     "id",
                     filter=Q(


### PR DESCRIPTION
## The problem

Ground Truth is a set of labelled examples you give an eval so the judge has something to calibrate against. You upload the rows, map their columns, wait for them to finish embedding, and switch the feature on.

Every one of those steps reports success.

Then you run that eval on your spans from Observe. Every row comes back scored, with no warnings and no errors.

The Ground Truth was never used. The judge graded those rows with no reference examples at all, so the score on the screen is not the score the user set up.

Nothing says so. The toggle still reads on, the dataset still reads embedded, and the run still reads success.

## Why nobody catches it

The same Ground Truth works everywhere else. Datasets, the prompt playground, the SDK, Simulation and composite evals in Observe all apply it.

Only a plain single eval on one span, trace or session skips it. So a team can set the feature up, watch it work, and never suspect the one path that quietly does not.

It also fails in the direction that looks healthy. The eval does not error, does not slow down, and does not come back empty. It comes back with a confident number.

And there was nowhere for a warning to appear even if one existed. The run warnings panel could only ever show one kind of warning, partial inputs, and threw away every other type before it reached the screen.

---

## Summary

Ground Truth can be uploaded, mapped, embedded and switched on for an eval template, and it is never applied to a **simple** eval run from Observe. Everything that runs an eval through `run_eval_func` (`model_hub/views/utils/evals.py:351`) gets Ground Truth, because that is where `inject_context` is called: datasets, playground, SDK, Simulation, and composite Observe evals, whose children go `execute_composite_children_sync` to `_execute_child` (`model_hub/utils/composite_execution.py:139`) to `run_eval_func`. The simple-eval path does not: `_execute_evaluation` and the trace and session equivalents call the evaluator directly.

So the gap is narrower than `grep -rn "ground_truth" futureagi/tracer` suggests, and that grep is exactly what makes it easy to get wrong.

The defect is not that it fails open, which is correct and stays. The defect is that it fails **silent**: the user sees `embedding_status: "completed"`, `embedded_row_count: 1/1`, an enabled toggle, and no signal anywhere that the eval they just ran was uncalibrated. This PR attaches a `ground_truth_not_applied` warning at the three live Observe entry points, stops the task-logs aggregation from dropping any warning type it does not already know, and renders the result honestly. Adds 10 backend tests and 7 frontend tests.

## Why the changes are done, what is the problem

### Reproduce on dev today (before this PR)

1. Create an eval template, upload a Ground Truth dataset, map the variables, wait for `embedding_status: completed`.
2. Switch the "Enable Ground Truth" toggle on.
3. Create an eval task in Observe scoped to a project's spans and run it.
4. Open the task, then Logs.
5. Every row is a success. `warnings_count` is `0`, `warning_groups` is `[]`. The eval was graded with no reference examples in the judge prompt and nothing anywhere says so.

### Where it breaks, BE

`tracer/utils/eval.py` builds the eval payload for simple evals on spans, traces and sessions and never calls `GroundTruthService.inject_context`. It is not a broken call, it is an absent one, so there is no error to surface and no failure to log. The same template inside a composite calibrates normally, which makes the inconsistency invisible from the outside.

`tracer/views/eval_task.py` then made the state unrecoverable even if a warning had existed:

```python
# before
return [
    warning
    for warning in warnings
    if isinstance(warning, dict) and warning.get("type") == "partial_input"
]
```

Extraction filtered down to `partial_input` and hardcoded that type into every group, while `warnings_count` counted *any* row carrying warnings. A second warning type would have inflated the count and produced no group to explain it.

### Where it breaks, UI

`TaskLogsView.jsx` and `EditTaskDrawer/TaskLogs.jsx` hardcoded the card title as "Partial inputs" and the stat card as "Partial Inputs", so any other warning type would have been mislabelled rather than merely missing. `PartialInputWarningDetails.jsx` held its own copy of the type string.

## What changed

### futureagi/model_hub/services/ground_truth_service.py
New `is_enabled_for_template()`, an indexed `.exists()` for an active, enabled and **fully embedded** GT row on `(template, org, workspace)`. The `embedding_status=COMPLETED` filter matters: `inject_context` returns early on a row that is not embedded, so without it the warning fired on `pending` / `processing` / `failed` rows where the dataset path injects nothing either, pointing the user at Observe when their embedding was the problem. `load_active_gt` shares the same queryset builder, so "active GT" has one definition instead of two, and its own SQL is unchanged.

### futureagi/tracer/utils/eval.py
`GROUND_TRUTH_NOT_APPLIED_WARNING_TYPE` and its message are defined once here. `_ground_truth_not_applied_warning()` takes the run's `run_params` and returns `None` when the run already carries `ground_truth_blocks`, so the warning keys off what actually happened rather than off the template config and retires itself the moment the simple path is wired. It also returns `None` on any lookup failure, so a GT problem still cannot block an eval. The warning it returns is `{"type": ...}` with no message; the copy lives in the view's fallback table rather than being written to every row.

`_collect_run_warnings()` composes the run's warnings in display order. Wired at the three live simple-eval entry points: `_execute_evaluation` (spans), `_execute_evaluation_for_trace`, `_execute_evaluation_for_session`.

On the span path the default-workspace fallback is resolved once, up front, and used **only** for the GT lookup. `ws_id` itself is unchanged from `dev`: it stays the project's own workspace, because it also selects the provider API key in `run_eval` and the billing attribution in `_emit_eval_billing`, and a workspace-less project must keep resolving those the way it does today. Previously a GT row on the default workspace warned on trace and session but not on spans; now it warns on all three without moving anything else.

`_build_apicall_output` and `_attach_warnings_to_metadata` now take a list, so a partial-input warning and the GT warning coexist and neither displaces the other.

### futureagi/tracer/views/eval_task.py
`_extract_partial_input_warnings` becomes `_extract_run_warnings` and is type-agnostic. Grouping keys on `(type, empty_keys)` so each type gets its own group with its own message. `_WARNING_FALLBACK_MESSAGES` imports both types and both messages from the modules that produce them, and is now the only place the copy lives, so a row persists a bare type instead of a 300-character string into `output_metadata` and `APICallLog.config`.

`warnings_count` is unchanged and stays a **row** count, which is what the SQL computes and the only figure the `_WARNING_LOG_SCAN_LIMIT` cap lets us report honestly on a large task. Since a row can now carry two warnings, it is no longer equal to the sum of the group counts, so the UI stops calling it a warning total.

### futureagi/model_hub/utils/eval_input_validation.py
The `partial_input` type string and its message were literals inside the producer and were about to be copied into a second module. Both are now named constants at the point of production, and the consumer imports them. One source of truth.

### frontend/src/sections/common/EvalsTasks/warningTypes.js (new)
Type constants, display labels and fallback messages in one module, with the header naming both producing modules. It deliberately holds **no** copy of the ground truth message: the task-logs endpoint always fills that from the backend table, so duplicating it here would reintroduce exactly the drift this module exists to remove. `PartialInputWarningDetails.jsx` imports the shared constant and the shared `warningMessage` helper instead of holding a second copy of either, and its re-export of the constant is gone, so the four call sites now import it from this module rather than from a component file.

### frontend/src/sections/common/EvalsTasks/TaskLogsView.jsx, EditTaskDrawer/TaskLogs.jsx
Card title derives from `group.type` and the body renders `group.message`. The stat card and section heading move from "Partial Inputs" to "Runs with warnings", and the header reads "N runs with warnings, grouped by type below", so the top-line figure and the per-card occurrence counts no longer claim to be the same quantity. The expand affordance is gated on there actually being a key breakdown: a GT warning has no missing or present variables, so it renders flat instead of opening an empty drawer.

### futureagi/docs/ground-truth-and-expected-value.md (new)
States plainly that Ground Truth is few-shot calibration attached to `mapped["ground_truth_blocks"]`, that it never supplies `expected_value`, and which surfaces it applies to. Carries the worked example for supplying `expected_value` on the Observe path: emit it as a span attribute and map `expected_value` to that attribute name. `_process_mapping` loops every mapping key with no special-casing and resolves each from `span_attributes`, so `expected_value` resolves exactly like `input` does. Also carries the filter warning: scope such a task with attribute filters, never `trace_id` or `span_id`. Verified at source, `parsing_evaltask_filters` (`tracer/utils/eval_tasks.py`) branches on `span_attributes_filters`, `observation_type`, `session_id`, `date_range`, `created_at`, `project_id`; `trace_id` and `span_id` are accepted by the API, stored on the task, then fall through and are ignored, so a task scoped that way silently evaluates the wrong set of spans and makes the mapping look broken.

## Tests included, what each scenario covers

All seventeen backend tests drive the real call path (`_execute_evaluation`, `_execute_evaluation_for_trace`, `_execute_evaluation_for_session`) with real fixtures and assert on the persisted `EvalLogger` or the real endpoint response, not on a mock.

| # | Test | Scenario | Setup | Action | What it pins |
| --- | --- | --- | --- | --- | --- |
| 1 | `test_span_eval_surfaces_ground_truth_not_applied` | span eval, GT on | active + enabled + embedded GT row | `_execute_evaluation` | exactly one `ground_truth_not_applied` warning on the persisted row |
| 2 | `test_span_eval_still_succeeds_with_ground_truth_enabled` | fail-open contract | same | `_execute_evaluation` | `error is False`, no `ERROR` output; the warning never turns the run into a failure |
| 3 | `test_trace_eval_surfaces_ground_truth_not_applied` | trace eval, GT on | same | `_execute_evaluation_for_trace` | the trace entry point is wired, not just spans |
| 4 | `test_session_eval_surfaces_ground_truth_not_applied` | session eval, GT on | same | `_execute_evaluation_for_session` | the session entry point is wired |
| 5 | `test_no_warning_when_no_ground_truth_configured` | negative | no GT row | `_execute_evaluation` | no warning when there is nothing to warn about |
| 6 | `test_no_warning_when_ground_truth_is_disabled` | negative | GT row with `enabled=False` | `_execute_evaluation` | the toggle is respected, not just the row's existence |
| 7 | `test_no_warning_for_another_tenants_ground_truth` | tenant isolation | GT row on a different org/workspace | `_execute_evaluation` | the lookup is tenant-scoped |
| 8 | `test_eval_runs_when_ground_truth_lookup_raises` | failure branch | `is_enabled_for_template` raises | `_execute_evaluation` | the eval still runs and emits no warning; fail-open holds under an exception |
| 9 | `test_partial_input_and_ground_truth_warnings_coexist` | composition | partial-input warning stubbed in + GT on | `_execute_evaluation` | both warnings present, in order; neither displaces the other |
| 10 | `test_task_logs_endpoint_reports_the_ground_truth_warning_group` | end to end | GT on, one eval task | real `GET /tracer/eval-task/get_eval_task_logs/` | `warnings_count == 1` and one `ground_truth_not_applied` group with the right count and message, sourced from the view's fallback table since the row carries a bare type |
| 11-13 | `test_no_warning_until_the_ground_truth_rows_are_embedded` | negative, parametrized | GT row `pending` / `processing` / `failed` | `_execute_evaluation` | no warning while the rows are unembedded, because no path injects them then |
| 14 | `test_no_warning_once_the_run_carries_ground_truth_blocks` | self-retiring | GT on, run already carries `ground_truth_blocks` | `_execute_evaluation` | the warning keys off the injected blocks, not the config, so wiring the path silences it with no second change |
| 15 | `test_default_workspace_ground_truth_warns_on_the_span_path` | workspace parity | project with `workspace = None`, GT on the default workspace | `_execute_evaluation` | the span path resolves the default-workspace fallback like trace and session do |
| 16 | `test_workspaceless_project_keeps_a_null_workspace_on_the_eval_request` | blast radius | project with `workspace = None`, GT on the default workspace | `_execute_evaluation`, capturing the real `EvalRequest` | `workspace_id` reaching `run_eval` stays `None` while the warning still fires, so the GT lookup cannot move API-key resolution or billing attribution |
| 17 | `test_task_logs_endpoint_counts_rows_while_groups_count_warnings` | end to end | one row carrying both a partial-input and a GT warning | real `GET /tracer/eval-task/get_eval_task_logs/` | `warnings_count` is 1 row while the groups sum to 2 occurrences, which is why the UI labels it "runs with warnings" |

Frontend, `warningTypes.test.js` (8 tests, new file, no prior coverage existed for this module):

| # | Test | Scenario | What it pins |
| --- | --- | --- | --- |
| 1-2 | warning type values match what the backend emits | wire contract | the two type strings equal what `tracer/utils/eval.py` and `model_hub/utils/eval_input_validation.py` produce; a rename on either side breaks here instead of silently degrading every chip to "Warning" |
| 3 | `warningTypeLabel` labels both known types | happy path | the labels the cards render |
| 4 | `warningTypeLabel` falls back for an unknown type | forward compatibility | a future backend type renders "Warning", not `undefined` |
| 5 | `warningMessage` prefers the server message | precedence | the server's copy wins over the local fallback |
| 6 | `warningMessage` falls back to the local copy | degraded input | a warning with no message still renders text |
| 7 | `warningMessage` is empty for an unknown type with no message | fail-safe | no crash, no `undefined` on screen |
| 8 | `warningMessage` holds no local copy of the ground truth message | anti-drift | the endpoint owns that copy; a local duplicate here is the drift this module removes |

**New vs existing:** all 25 tests are new. `test_eval_partial_inputs.py` and `test_ground_truth*.py` are existing suites that this change touches indirectly through the constant extraction and the shared queryset builder; both are re-run below unchanged.

## Commands to run tests

Rebased onto `dev` at `24865916e`.

```bash
git checkout fix/th-7765-ground-truth-observe-visibility

cd futureagi
.venv/bin/python -m pytest \
    tracer/tests/test_eval_ground_truth_observe_warning.py tracer/tests/test_eval_task.py \
    tracer/tests/test_eval_task_aggregations.py tracer/tests/test_eval_credits_emit.py \
    tracer/tests/test_eval_logger_schema.py model_hub/tests/test_eval_partial_inputs.py \
    model_hub/tests/test_ground_truth.py model_hub/tests/test_ground_truth_service.py \
    model_hub/tests/test_ground_truth_retrieval.py model_hub/tests/test_ground_truth_tenant_scope.py \
    model_hub/tests/test_ground_truth_ch_isolation.py

cd ../frontend
yarn vitest run src/sections/common/EvalsTasks/__tests__/warningTypes.test.js
```

### Local verification results

```
================ 230 passed, 53 deselected in 89.30s (0:01:29) =================

 ✓ src/sections/common/EvalsTasks/__tests__/warningTypes.test.js (8 tests) 9ms
 Test Files  12 passed (12)
      Tests  67 passed (67)
```

`eslint` on the eight touched frontend files is clean; the two remaining warnings in `TaskUsageTab.jsx` are pre-existing `react-hooks/exhaustive-deps` at lines 619 and 943, nowhere near the one-line import change this PR makes there.

One test in that set is deselected above: `tracer/tests/test_eval_logger_schema.py::TestEvalLoggerReaderAudit::test_get_evaluation_details_pg_excludes_session_rows`. It fails identically on a pristine `origin/dev` checkout against the same local stack (`Unknown table expression identifier 'tracer_eval_logger'`, the ClickHouse table is absent locally). Pre-existing, unrelated to this change.

**Red before green.** The same file on `origin/dev`, with only the two constants this PR introduces substituted for their literals so the assertions run instead of dying at collection:

```
=================== 10 failed, 7 passed in 82.41s (0:01:22) ====================
E   assert 0 == 1                                    (warnings_count)
E   assert []                                        (no warning groups at all)
E   AssertionError: assert ['partial_input'] == ['partial_input', 'ground_truth_not_applied']
E   AttributeError: GroundTruthService has no attribute 'is_enabled_for_template'
E   KeyError: 'ground_truth_not_applied'
```

The seven that pass on `dev` are the negative cases: no GT row, GT disabled, another tenant's GT, the three unembedded statuses, and the run that already carries `ground_truth_blocks`. Those are correct on both sides, which is the evidence the tests are not over-asserting to manufacture a red.

## Video

Walkthrough of the real runs, in order: the test file red on `origin/dev` (9 failed, 7 passed), green on this branch (16 passed), then the endpoint payload before and after.

https://github.com/user-attachments/assets/74d2239a-8b10-4dae-8384-e83d26975b31

## Screenshot of test suite run

**Command** - `.venv/bin/python -m pytest <the 11 files above>` and `yarn vitest run src/sections/common/EvalsTasks/__tests__/warningTypes.test.js`

![Local test suite run: 214 passed backend, 8 passed frontend](https://github.com/user-attachments/assets/3535184d-95d3-4296-9f53-fcb30f1acfdf)

## Before and after

Real response from `GET /tracer/eval-task/get_eval_task_logs/`, same seeded task (one span, one eval template with an active, enabled, fully embedded GT row, one eval task), same local stack, `origin/dev` vs this branch.

![Before and after: warnings_count 0 with no groups on dev, 1 with a ground_truth_not_applied group on this branch](https://github.com/user-attachments/assets/465320e5-88d5-4dea-8489-2398c0e8f759)

| | `origin/dev` | this branch |
| --- | --- | --- |
| `eval_logger.output_metadata.warnings` | `[]` | one `ground_truth_not_applied` |
| `warnings_count` | `0` | `1` |
| `warning_groups` | `[]` | one group, `count: 1` |
| eval run succeeded | yes | yes |
| Task Logs view says | "All evaluations completed successfully" | "Ground Truth not applied", 1 occurrence |

## Backwards compatibility

Schema unchanged. `output_metadata.warnings` was already a JSON array and already tolerated multiple entries; this change starts using that capacity. No migration.

| Caller | Pre-PR | Post-PR |
| --- | --- | --- |
| `_build_apicall_output` | took one warning or `None` | takes a list; existing single-warning callers pass a one-element list |
| `_attach_warnings_to_metadata` | took one warning or `None` | takes a list; same |
| `GET /tracer/eval-task/get_eval_task_logs/` | `warning_groups` only ever `partial_input` | any warning type, grouped by `(type, empty_keys)`; a `partial_input`-only task returns an identical payload |
| `PartialInputWarningDetails.jsx` | own copy of the type string | imports it from `warningTypes.js`; same value |
| `EvaluateCellRendererWrapper`, `evalUsageColumns`, `TaskUsageTab` | match on `partial_input` | unchanged, see Out of scope |
| `GroundTruthService.load_active_gt` | own queryset | shares the builder with `is_enabled_for_template`; same filter set, unchanged SQL |
| `_collect_run_warnings` | `(partial, template, *, org, ws)` | `(partial, run_params, template, *, org, ws)`; all three call sites updated here, no external callers |
| `output_metadata.warnings[].message` | always present | absent on `ground_truth_not_applied`; both readers already fall back to the type table |

## Manual verification

1. `git checkout fix/th-7765-ground-truth-observe-visibility && cd futureagi && ./bin/dev`
2. Create an eval template, upload a GT dataset, map the variables, wait for `embedding_status: completed`, switch Enable Ground Truth on.
3. Create an eval task in Observe over a project with spans and run it.
4. Open the task, then Logs. The stat card reads Warnings and shows 1; the card reads "Ground Truth not applied" with the message and no empty expand drawer.
5. Backend check:

```bash
.venv/bin/python manage.py shell -c "
from tracer.models.observation_span import EvalLogger
print(EvalLogger.objects.latest('created_at').output_metadata['warnings'])"
```

Expect one entry with `type: ground_truth_not_applied`.

6. Switch the toggle off, re-run the task, confirm the warning is gone and the card returns to the success state.

## Why these decisions

- **Warn rather than wire up `inject_context`.** Giving Observe evals GT retrieval is a product-direction call that has not been made: either Observe gets GT retrieval, or Observe is declared out of scope for GT and the product says so at configuration time. Both are defensible and they lead to different code, so that decision is tracked separately in TH-7784. This PR is compatible with either outcome. If TH-7784 lands as "wire it up", the warning's trigger narrows from "GT is enabled" to "GT is enabled and could not be applied on this run" and everything downstream stays.
- **Ride `output_metadata.warnings` instead of a new field.** The channel, the aggregation and the render path already exist for partial-input warnings. A new field would have meant a migration, a second aggregation and a second card for the same idea.
- **Type-agnostic extraction rather than adding `ground_truth_not_applied` to the filter.** Adding the one type would have left the same trap for the next one. `warnings_count` already counted any warning; extraction now matches it.
- **`.exists()` per run, not cached.** One indexed existence check (Index Scan, 35us) sits next to an LLM call that dominates it by orders of magnitude. Caching is the wrong fix rather than a deferred one: once `inject_context` runs on this path it already calls `load_active_gt` per run, so the right move is to delete this lookup, not memoise it. Tracked on TH-7784 with the wiring.
- **`warnings_count` stays a row count and the UI relabels.** Summing the extracted warnings into it was the other option, but the loop is capped by `_WARNING_LOG_SCAN_LIMIT` while the SQL count is not, so a summed figure would undercount on a large task and then contradict the truncation flag. Keeping the honest number and naming it "runs with warnings" costs a label and no correctness.
- **The warning keys off `ground_truth_blocks`, not the template config.** Config is read before execution; whether GT actually applied is only knowable after injection. Keying off the result means the warning cannot outlive the bug, and it absorbs the no-usable-inputs and no-examples cases for free.
- **The GT lookup resolves the default workspace, `ws_id` does not.** Resolving it into `ws_id` was the smaller diff, but `ws_id` also feeds `run_eval` (provider API key) and `_emit_eval_billing` (attribution), so for a workspace-less project it would have changed which key an eval runs with and which workspace its usage rows group under. A PR about surfacing a warning should not move eval execution or billing. Pinned by test 16.
- **Constants at the point of production.** `partial_input` was about to exist in three places (producer, tracer view, frontend). It now exists once per language boundary, and the frontend test asserts the two sides still agree.

## Out of scope

- `tracer/utils/eval.py:_run_evaluation` is not wired. It has no callers anywhere in the repo, only two doc-comment references. Adding the warning there would be dead code.
- Composite evals are excluded because Ground Truth **is** already applied to them: children go `execute_composite_children_sync` to `_execute_child` to `run_eval_func` to `inject_context`. There is nothing to warn about on that path. Ground Truth attached to a composite **parent** template is never injected and never warned about, since the parent itself does not go through `run_eval_func`; that is the same decision as the simple path and is tracked with it on TH-7784.
- The per-row warning badge (`EvaluateCellRendererWrapper`, `evalUsageColumns`, `TaskUsageTab`) still matches on `partial_input` only. "GT is enabled on this template" is a task-level fact, not a per-row one; badging every row would be noise. The task-level surface carries it.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [x] Documentation update
- [ ] Breaking change

## Checklist

- [x] Follows the repo style guide
- [x] Tests added, and they fail if the fix is reverted
- [x] Full touched suite run locally, screenshot above
- [x] No secrets, no ticket refs or AI cruft in source or test names
- [x] Rebased on latest `dev`

## Backout

Clean revert of the single commit. No migration, no schema change. Reverting returns `warning_groups` to `partial_input`-only and removes the GT warning; eval execution is untouched either way because the warning never gated a run.

## Linear

Closes TH-7765 (acceptance criteria 2 and 3).

Acceptance criterion 1, actually wiring `inject_context` into the tracer path, is a product-direction call and now lives in its own ticket: TH-7784, "Decide whether Observe evals get Ground Truth retrieval, then either wire inject_context or say so at configuration time".

