### PR TITLE
fix(eval-task): report the stored session id on usage log rows (TH-7761)

### DIFF
--- a/futureagi/tracer/tests/test_eval_task_usage_date_range.py
+++ b/futureagi/tracer/tests/test_eval_task_usage_date_range.py
@@ -2,8 +2,12 @@
 
 Empty windows stay empty and keep the requested bounds. The endpoint must not
 turn an interactive period read into a hidden all-time history scan.
+
+Also covers the cross-reference ids each returned log row carries back to
+observe.
 """
 
+import uuid
 from datetime import UTC, datetime, timedelta
 from unittest import mock
 
@@ -13,6 +17,10 @@ from django.utils import timezone
 # Break the import cycle (see test_eval_logger_schema.py for the
 # canonical comment).
 import model_hub.tasks  # noqa: F401
+from tracer.models.observation_span import (
+    EvalLogger,
+    EvalTargetType,
+)
 from tracer.tests.eval_task_factories import (
     make_config as _config,
 )
@@ -344,3 +352,48 @@ class TestBucketAlignment:
 
         assert result["period_used"] == "7d"
         assert _chart_calls(result) == 2
+
+
+# ── Log row cross-references ───────────────────────────────────────────
+
+
+@pytest.mark.integration
+@pytest.mark.api
+@pytest.mark.django_db
+class TestLogItemCrossReferences:
+    """Each log row carries the ids the side panel jumps back to observe with.
+
+    The eval engine resolves a run's target from ClickHouse and the target FKs
+    are unconstrained, so a run can legitimately point at a span, trace or
+    session that has no Postgres row. The row must still report what it
+    evaluated.
+    """
+
+    def _one_row(self, auth_client, task):
+        results = _result(_get(auth_client, task, period="30d"))["logs"]["results"]
+        assert len(results) == 1
+        return results[0]
+
+    def _cfg(self, project, organization, workspace):
+        return _config(
+            project=project,
+            template=_template(organization=organization, workspace=workspace),
+            name="Toxicity",
+        )
+
+    def test_session_row_reports_its_session_id_without_a_postgres_row(
+        self, auth_client, project, organization, workspace
+    ):
+        task = _task(project=project)
+        session_id = uuid.uuid4()
+        EvalLogger.objects.create(
+            target_type=EvalTargetType.SESSION,
+            trace_session_id=session_id,
+            custom_eval_config=self._cfg(project, organization, workspace),
+            eval_task_id=str(task.id),
+            output_bool=True,
+        )
+
+        row = self._one_row(auth_client, task)
+        assert row["session_id"] == str(session_id)
+        assert row["detail"]["session_id"] == str(session_id)

--- a/futureagi/tracer/views/eval_task.py
+++ b/futureagi/tracer/views/eval_task.py
@@ -2594,8 +2594,11 @@ class EvalTaskView(BaseModelViewSetMixin, ModelViewSet):
                             if log.trace_id
                             else None
                         ),
+                        # Off the row's own FK column: the target FKs are
+                        # unconstrained, so a run can reference a session with
+                        # no PG row and must still report what it evaluated.
                         "session_id": (
-                            str(trace_session.id) if trace_session else None
+                            str(log.trace_session_id) if log.trace_session_id else None
                         ),
                         "eval_id": str(config.id) if config else None,
                         "eval_name": config.name if config else None,
@@ -2631,7 +2634,9 @@ class EvalTaskView(BaseModelViewSetMixin, ModelViewSet):
                                 else None
                             ),
                             "session_id": (
-                                str(trace_session.id) if trace_session else None
+                                str(log.trace_session_id)
+                                if log.trace_session_id
+                                else None
                             ),
                             "session_name": (
                                 trace_session.name if trace_session else None


### PR DESCRIPTION
## The problem

Open an eval task's Usage tab, click into a row, and the side panel tells you what that run graded: a span, a trace, or a session. For session rows the Session ID is blank. There is nothing to click through to, and no way to tell from the panel which session was actually scored.

It is blank even though the row knows the answer. The run recorded the session it evaluated. The panel simply never reads what was recorded, and asks the session's own record for its id instead.

## Why it is easy to miss

It only shows up when the evaluated session has no record in the main database, and that is the ordinary case rather than the rare one. The eval engine picks what to grade from the analytics store, and the two stores are not kept in step, so a run can point at a session the main database has never heard of.

Every other id on the same panel keeps working, so the row looks healthy rather than broken. And a blank Session ID reads as "this run had no session", which is a sentence that makes sense on its own. Nothing about it looks like a bug worth reporting.

---

Session log rows on `GET /tracer/eval-task/get_usage/` report a null `session_id` whenever the target session has no Postgres row. `EvalLogger`'s target FKs are `db_constraint=False` and the eval engine resolves a run's target from ClickHouse, so the related object is routinely absent. The builder dereferenced it (`trace_session.id`) rather than reading the FK column the row already stores.

**Rescoped on 2 Sep, on review.** This branch previously also restored `trace_id` / `span_id` translation in `parsing_evaltask_filters` and its ClickHouse companion. Atharva established that both live below `if _bridge_retired_dispatcher(eval_task): return` in `process_eval_task`, and that `_bridge_retired_dispatcher` returns `True` on every path by design. Neither translator is reachable in production, so that work changed dead code and its tests could not regress. It is removed, along with the shared helper introduced only to serve it. What remains is the one reachable defect.

## Why the changes are done — what is the problem

### Reproduce on dev today

1. Run an eval task with `row_type` of `sessions` against a project whose sessions were created recently enough that the Postgres row is absent.
2. Open the task's Usage tab and expand any row.
3. Session ID is empty, in both the row and its `detail` block.

### Where it breaks

`EvalTaskView.get_usage` builds each row from an `EvalLogger`. For `session_id` it went through the related object:

```python
"session_id": (str(trace_session.id) if trace_session else None),
```

`EvalLogger.trace_session` is declared `db_constraint=False`, and targets come from ClickHouse, so `trace_session` is `None` for a live-but-unmirrored session and the id is dropped. `span_id` and `trace_id` two lines above already read their raw FK columns; `0689b98ae` fixed those and left `session_id` on the old shape.

## What changed

### `futureagi/tracer/views/eval_task.py`

Reads `log.trace_session_id` instead of `log.trace_session.id`, at the row and at its `detail` block. Same shape the two sibling ids already use, so the three cross-references now resolve identically. Nothing else on the panel changes: `session_name` still comes off the related object, because a name genuinely does not exist without the record.

## Tests included — what each scenario covers

Folded into the existing `test_eval_task_usage_date_range.py`. No new test file.

| # | Test | Setup | Action | What it pins |
|---|---|---|---|---|
| 1 | `test_session_row_reports_its_session_id_without_a_postgres_row` | an `EvalLogger` session row whose `trace_session_id` has no Postgres record | `GET /tracer/eval-task/get_usage/` | the row and its `detail` report the stored id instead of null. **Fails on `origin/dev`.** |
| 2 | `test_session_row_reports_the_same_id_when_the_session_is_in_postgres` | the same row with the record present | same | the ordinary path is unchanged by reading the column rather than the object |

## Commands to run tests

```bash
# only the new tests
bin/test tracer/tests/test_eval_task_usage_date_range.py -k LogItemCrossReferences

# the eval-task blast radius
bin/test tracer/tests/test_row_resolver.py tracer/tests/test_eval_task_filter_dispatch.py \
         tracer/tests/test_eval_task_usage_date_range.py tracer/tests/test_eval_task_usage_bounds.py \
         tracer/tests/test_eval_task.py tracer/tests/test_normalize_eval_task_filters.py \
         tracer/tests/test_eval_task_bounded_selector.py
```

## Local verification results

Rebased onto `dev` at `41a7af902`. The new tests with `views/eval_task.py` reverted to `origin/dev`, then with the fix applied:

```
FAILED tracer/tests/test_eval_task_usage_date_range.py::TestLogItemCrossReferences::test_session_row_reports_its_session_id_without_a_postgres_row
  AssertionError: assert None == '0abc3ee5-2eb7-4634-b89a-f110152259ae'
================== 1 failed, 1 passed, 18 deselected in 5.84s ==================   # origin/dev
======================= 2 passed, 18 deselected in 5.31s =======================   # this branch
```

Eval-task blast radius on the rebased head:

```
============================= 290 passed in 16.32s =============================
```

The proof surface here is the terminal rather than the browser: the change is one serialised field, and the honest artefact for it is the endpoint run against a real Postgres, not a screenshot of a page.

## Backwards compatibility

No schema change and no migration.

| Caller | Pre-PR | Post-PR |
|---|---|---|
| `EvalTaskView.get_usage` session rows, target absent from Postgres | `session_id` null | reports the id the row stores |
| `EvalTaskView.get_usage` session rows, target present | id off the related object | same id, read off the column |
| `session_name` on both paths | unchanged | unchanged |

Field type and shape are unchanged. Only null-vs-value moves, and only for rows whose target has no Postgres record.

## Manual verification (UI)

1. Open an eval task with session rows on the Usage tab.
2. Expand a row whose session is not mirrored into Postgres.
3. Session ID renders and matches the session in Observe, in the row and in the side panel.

## Type of change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📖 Documentation only
- [ ] 🧹 Chore / refactor (no user-visible change)
- [ ] 🚀 Performance improvement
- [ ] 🧪 Test-only change

## Checklist

- [x] My code follows the style guide
- [x] I've added tests that prove my fix is effective
- [x] No hardcoded secrets, URLs, or PII

## Backout / rollback

- No migration in this PR, nothing to reverse in the database.
- Reverting returns the builder to reporting a null `session_id` for ClickHouse-resolved targets. Read-only projection, no data loss, nothing cached client-side.
- No new module, no new dependency, no changed signature.

## Out of scope

- The filter half of the ticket. `e3f90c576` routes `span_id` / `trace_id` / `session_id` through the list-builder filter contract on the live row selector, so a task scoped to a trace or span is honoured on the path that actually runs. The two dispatcher translators still ignore both keys and are left alone, because nothing reaches them.
- The log-row builder still degrades beyond the ids when a target is ClickHouse-only: the input summary and `detail.span_name` read the same absent object. Same root cause, larger surface, not touched here.

Closes TH-7761
