### PR TITLE
fix: refuse bad document-cell links without deleting existing files (#2433)

### DIFF
--- a/frontend/src/sections/develop-detail/DataTab/DoubleClickEditCell/EditFile.jsx
+++ b/frontend/src/sections/develop-detail/DataTab/DoubleClickEditCell/EditFile.jsx
@@ -9,6 +9,10 @@ import DeleteMediaDialog from "./ConfirmDelete";
 import ReplaceMediaDialog from "./ReplaceMediaDialog";
 import _ from "lodash";
 import { getFileType } from "../../../common/DevelopCellRenderer/CellRenderers/common";
+import {
+  isDocumentWebAddress,
+  NOT_A_WEB_ADDRESS_MESSAGE,
+} from "./editHelper";
 
 const getTempFileData = (tempFile) => {
   if (tempFile instanceof File) {
@@ -77,16 +81,23 @@ export default function EditFile({ params, onClose, onCellValueChanged }) {
 
         reader.readAsDataURL(tempFile);
       } else if (typeof tempFile === "string") {
-        // Update cell with new link
+        if (!isDocumentWebAddress(tempFile)) {
+          enqueueSnackbar(NOT_A_WEB_ADDRESS_MESSAGE, { variant: "error" });
+          return;
+        }
         onCellValueChanged({
           ...params,
           newValue: tempFile,
           fileName: name,
+          onSuccess: () => {
+            setFileName(name);
+            setFileType(getFileType(type));
+            handleClose();
+          },
+          onError: () => {
+            setTempFile(null);
+          },
         });
-
-        setFileName(name);
-        setFileType(getFileType(type));
-        handleClose();
       }
       // Case 2: No new file selected, just closing/saving current state
       else {

--- a/frontend/src/sections/develop-detail/DataTab/DoubleClickEditCell/ReplaceMediaDialog.jsx
+++ b/frontend/src/sections/develop-detail/DataTab/DoubleClickEditCell/ReplaceMediaDialog.jsx
@@ -24,6 +24,10 @@ import Iconify from "src/components/iconify";
 import FormTextFieldV2 from "../../../../components/FormTextField/FormTextFieldV2";
 import { enqueueSnackbar } from "notistack";
 import { getFileIcon } from "../../../knowledge-base/sheet-view/icons";
+import {
+  isDocumentWebAddress,
+  NOT_A_WEB_ADDRESS_MESSAGE,
+} from "./editHelper";
 
 const tabItems = [
   { label: "Upload", value: "upload" },
@@ -98,9 +102,15 @@ export default function ReplaceMediaDialog({
   const onSubmit = (data) => {
     if (currentTab === "upload") {
       onUpload(data?.file?.[0]);
-    } else {
-      onUpload(data?.link);
+      handleClose();
+      return;
     }
+    const link = String(data?.link ?? "").trim();
+    if (!isDocumentWebAddress(link)) {
+      enqueueSnackbar(NOT_A_WEB_ADDRESS_MESSAGE, { variant: "error" });
+      return;
+    }
+    onUpload(link);
     handleClose();
   };
 

--- a/frontend/src/sections/develop-detail/DataTab/DoubleClickEditCell/__tests__/ReplaceMediaDialog.test.jsx
+++ b/frontend/src/sections/develop-detail/DataTab/DoubleClickEditCell/__tests__/ReplaceMediaDialog.test.jsx
@@ -1,0 +1,123 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen } from "src/utils/test-utils";
+import userEvent from "@testing-library/user-event";
+import { enqueueSnackbar } from "notistack";
+import ReplaceMediaDialog from "../ReplaceMediaDialog";
+import { NOT_A_WEB_ADDRESS_MESSAGE } from "../editHelper";
+
+vi.mock("notistack", () => ({
+  enqueueSnackbar: vi.fn(),
+}));
+
+vi.mock("src/components/svg-color", () => ({
+  default: () => <span data-testid="svg-color" />,
+}));
+
+vi.mock("src/components/iconify", () => ({
+  default: () => null,
+}));
+
+vi.mock("src/components/hook-form", () => ({
+  RHFUpload: ({ onDrop }) => (
+    <div data-testid="upload-dropzone">
+      <button
+        type="button"
+        onClick={() =>
+          onDrop([
+            new File(["hello"], "notes.exe", {
+              type: "application/x-msdownload",
+            }),
+          ])
+        }
+      >
+        drop-invalid
+      </button>
+      <button
+        type="button"
+        onClick={() =>
+          onDrop([
+            new File(["%PDF"], "report.pdf", { type: "application/pdf" }),
+          ])
+        }
+      >
+        drop-pdf
+      </button>
+    </div>
+  ),
+}));
+
+describe("ReplaceMediaDialog Link tab (#2433)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  const renderDialog = () => {
+    const onUpload = vi.fn();
+    const onClose = vi.fn();
+    render(
+      <ReplaceMediaDialog open onClose={onClose} onUpload={onUpload} />,
+    );
+    return { onUpload, onClose };
+  };
+
+  it("refuses a value that is not a web address and says so", async () => {
+    const user = userEvent.setup();
+    const { onUpload, onClose } = renderDialog();
+
+    await user.click(screen.getByRole("tab", { name: "Link" }));
+    await user.type(screen.getByLabelText("Link"), "sssss");
+    await user.click(screen.getByRole("button", { name: "Upload" }));
+
+    expect(enqueueSnackbar).toHaveBeenCalledWith(NOT_A_WEB_ADDRESS_MESSAGE, {
+      variant: "error",
+    });
+    expect(onUpload).not.toHaveBeenCalled();
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it("accepts a working document address with no new message", async () => {
+    const user = userEvent.setup();
+    const { onUpload } = renderDialog();
+    const url = "https://example.com/report.pdf";
+
+    await user.click(screen.getByRole("tab", { name: "Link" }));
+    await user.type(screen.getByLabelText("Link"), url);
+    await user.click(screen.getByRole("button", { name: "Upload" }));
+
+    expect(onUpload).toHaveBeenCalledWith(url);
+    expect(enqueueSnackbar).not.toHaveBeenCalled();
+  });
+});
+
+describe("ReplaceMediaDialog Upload tab", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("still refuses a file of the wrong type with a named reason", async () => {
+    const user = userEvent.setup();
+    const onUpload = vi.fn();
+    render(<ReplaceMediaDialog open onClose={vi.fn()} onUpload={onUpload} />);
+
+    await user.click(screen.getByRole("button", { name: "drop-invalid" }));
+
+    expect(enqueueSnackbar).toHaveBeenCalledWith("Invalid file type: notes.exe", {
+      variant: "error",
+    });
+    expect(onUpload).not.toHaveBeenCalled();
+  });
+
+  it("still accepts a pdf from disk", async () => {
+    const user = userEvent.setup();
+    const onUpload = vi.fn();
+    render(<ReplaceMediaDialog open onClose={vi.fn()} onUpload={onUpload} />);
+
+    await user.click(screen.getByRole("button", { name: "drop-pdf" }));
+    await user.click(screen.getByRole("button", { name: "Upload" }));
+
+    expect(onUpload).toHaveBeenCalledTimes(1);
+    expect(onUpload.mock.calls[0][0]).toBeInstanceOf(File);
+    expect(onUpload.mock.calls[0][0].name).toBe("report.pdf");
+    expect(enqueueSnackbar).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/sections/develop-detail/DataTab/DoubleClickEditCell/__tests__/editHelper.documentLink.test.js
+++ b/frontend/src/sections/develop-detail/DataTab/DoubleClickEditCell/__tests__/editHelper.documentLink.test.js
@@ -5,6 +5,7 @@ describe("isDocumentWebAddress", () => {
   it("accepts http(s) addresses", () => {
     expect(isDocumentWebAddress("https://example.com/report.pdf")).toBe(true);
     expect(isDocumentWebAddress("http://example.com/a.docx")).toBe(true);
+    expect(isDocumentWebAddress("HTTPS://EXAMPLE.COM/REPORT.PDF")).toBe(true);
   });
 
   it("refuses values that are not web addresses", () => {

--- a/frontend/src/sections/develop-detail/DataTab/DoubleClickEditCell/__tests__/editHelper.documentLink.test.js
+++ b/frontend/src/sections/develop-detail/DataTab/DoubleClickEditCell/__tests__/editHelper.documentLink.test.js
@@ -1,0 +1,19 @@
+import { describe, it, expect } from "vitest";
+import { isDocumentWebAddress } from "../editHelper";
+
+describe("isDocumentWebAddress", () => {
+  it("accepts http(s) addresses", () => {
+    expect(isDocumentWebAddress("https://example.com/report.pdf")).toBe(true);
+    expect(isDocumentWebAddress("http://example.com/a.docx")).toBe(true);
+  });
+
+  it("refuses values that are not web addresses", () => {
+    expect(isDocumentWebAddress("sssss")).toBe(false);
+    expect(isDocumentWebAddress("not a url")).toBe(false);
+    expect(isDocumentWebAddress("ftp://example.com/a.pdf")).toBe(false);
+    expect(isDocumentWebAddress("javascript:alert(1)")).toBe(false);
+    expect(isDocumentWebAddress("https://")).toBe(false);
+    expect(isDocumentWebAddress("")).toBe(false);
+    expect(isDocumentWebAddress(null)).toBe(false);
+  });
+});

--- a/frontend/src/sections/develop-detail/DataTab/DoubleClickEditCell/editHelper.js
+++ b/frontend/src/sections/develop-detail/DataTab/DoubleClickEditCell/editHelper.js
@@ -1,6 +1,20 @@
 import { AGENT_TYPES } from "src/sections/agents/constants";
 import { z } from "zod";
 
+export const NOT_A_WEB_ADDRESS_MESSAGE = "The value is not a web address.";
+
+export const isDocumentWebAddress = (value) => {
+  if (typeof value !== "string" || !value.trim()) {
+    return false;
+  }
+  try {
+    const parsed = new URL(value.trim());
+    return parsed.protocol === "http:" || parsed.protocol === "https:";
+  } catch {
+    return false;
+  }
+};
+
 export const getPopperDimensions = (dataType) => {
   const dimensions = {
     "date and time": { width: 700, height: 600 },

--- a/frontend/src/sections/develop-detail/DataTab/__tests__/onCellValueChanged.documentLink.test.js
+++ b/frontend/src/sections/develop-detail/DataTab/__tests__/onCellValueChanged.documentLink.test.js
@@ -1,0 +1,104 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import axios from "src/utils/axios";
+import { enqueueSnackbar } from "notistack";
+import { onCellValueChangedWrapper } from "../common";
+
+vi.mock("notistack", () => ({
+  enqueueSnackbar: vi.fn(),
+}));
+
+vi.mock("src/utils/logger", () => ({
+  default: { error: vi.fn(), warn: vi.fn(), info: vi.fn() },
+}));
+
+vi.mock("src/utils/axios", () => ({
+  default: { post: vi.fn() },
+  endpoints: {
+    develop: {
+      updateCellValue: (id) => `/model-hub/develops/${id}/update_cell_value/`,
+    },
+  },
+}));
+
+const existingUrl = "https://storage.example.com/kept.pdf";
+
+function makeParams({ newValue, apiError }) {
+  const setDataValue = vi.fn();
+  const refreshServerSide = vi.fn();
+  const onSuccess = vi.fn();
+  const onError = vi.fn();
+  const params = {
+    column: { colId: "col-1", colDef: { dataType: "document" } },
+    data: { row_id: "row-1" },
+    newValue,
+    oldValue: existingUrl,
+    fileName: "gone.pdf",
+    api: {
+      getRowNode: () => ({ setDataValue }),
+      refreshServerSide,
+    },
+    onSuccess,
+    onError,
+  };
+  return { params, setDataValue, refreshServerSide, onSuccess, onError, apiError };
+}
+
+describe("onCellValueChangedWrapper document link (#2433)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("does not report success or drop the existing value when the link is unreachable", async () => {
+    const { params, setDataValue, refreshServerSide, onSuccess, onError } =
+      makeParams({
+        newValue: "https://example.com/missing.pdf",
+      });
+    axios.post.mockRejectedValue({
+      response: { data: { message: "The address cannot be reached." } },
+    });
+
+    onCellValueChangedWrapper({ invalidateQueries: vi.fn() }, "ds-1")(params);
+    await vi.waitFor(() => expect(onError).toHaveBeenCalled());
+
+    expect(onSuccess).not.toHaveBeenCalled();
+    expect(refreshServerSide).not.toHaveBeenCalled();
+    expect(setDataValue).toHaveBeenCalledWith("col-1", existingUrl);
+    expect(enqueueSnackbar).toHaveBeenCalledWith(
+      "The address cannot be reached.",
+      { variant: "error" },
+    );
+  });
+
+  it("does not report success or drop the existing value when the link is not a document", async () => {
+    const { params, setDataValue, onSuccess, onError } = makeParams({
+      newValue: "https://example.com/index.html",
+    });
+    axios.post.mockRejectedValue({
+      response: { data: { message: "The address is not a document." } },
+    });
+
+    onCellValueChangedWrapper({ invalidateQueries: vi.fn() }, "ds-1")(params);
+    await vi.waitFor(() => expect(onError).toHaveBeenCalled());
+
+    expect(onSuccess).not.toHaveBeenCalled();
+    expect(setDataValue).toHaveBeenCalledWith("col-1", existingUrl);
+    expect(enqueueSnackbar).toHaveBeenCalledWith(
+      "The address is not a document.",
+      { variant: "error" },
+    );
+  });
+
+  it("stores a working document address without an error message", async () => {
+    const { params, refreshServerSide, onSuccess, onError } = makeParams({
+      newValue: "https://example.com/report.pdf",
+    });
+    axios.post.mockResolvedValue({ data: { status: true } });
+
+    onCellValueChangedWrapper({ invalidateQueries: vi.fn() }, "ds-1")(params);
+    await vi.waitFor(() => expect(onSuccess).toHaveBeenCalled());
+
+    expect(onError).not.toHaveBeenCalled();
+    expect(refreshServerSide).toHaveBeenCalled();
+    expect(enqueueSnackbar).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/sections/develop-detail/DataTab/__tests__/onCellValueChanged.documentLink.test.js
+++ b/frontend/src/sections/develop-detail/DataTab/__tests__/onCellValueChanged.documentLink.test.js
@@ -20,8 +20,6 @@ vi.mock("src/utils/axios", () => ({
   },
 }));
 
-const existingUrl = "https://storage.example.com/kept.pdf";
-
 function makeParams({ newValue, apiError }) {
   const setDataValue = vi.fn();
   const refreshServerSide = vi.fn();
@@ -31,7 +29,6 @@ function makeParams({ newValue, apiError }) {
     column: { colId: "col-1", colDef: { dataType: "document" } },
     data: { row_id: "row-1" },
     newValue,
-    oldValue: existingUrl,
     fileName: "gone.pdf",
     api: {
       getRowNode: () => ({ setDataValue }),
@@ -61,8 +58,8 @@ describe("onCellValueChangedWrapper document link (#2433)", () => {
     await vi.waitFor(() => expect(onError).toHaveBeenCalled());
 
     expect(onSuccess).not.toHaveBeenCalled();
-    expect(refreshServerSide).not.toHaveBeenCalled();
-    expect(setDataValue).toHaveBeenCalledWith("col-1", existingUrl);
+    expect(setDataValue).not.toHaveBeenCalled();
+    expect(refreshServerSide).toHaveBeenCalled();
     expect(enqueueSnackbar).toHaveBeenCalledWith(
       "The address cannot be reached.",
       { variant: "error" },
@@ -70,9 +67,10 @@ describe("onCellValueChangedWrapper document link (#2433)", () => {
   });
 
   it("does not report success or drop the existing value when the link is not a document", async () => {
-    const { params, setDataValue, onSuccess, onError } = makeParams({
-      newValue: "https://example.com/index.html",
-    });
+    const { params, setDataValue, refreshServerSide, onSuccess, onError } =
+      makeParams({
+        newValue: "https://example.com/index.html",
+      });
     axios.post.mockRejectedValue({
       response: { data: { message: "The address is not a document." } },
     });
@@ -81,7 +79,8 @@ describe("onCellValueChangedWrapper document link (#2433)", () => {
     await vi.waitFor(() => expect(onError).toHaveBeenCalled());
 
     expect(onSuccess).not.toHaveBeenCalled();
-    expect(setDataValue).toHaveBeenCalledWith("col-1", existingUrl);
+    expect(setDataValue).not.toHaveBeenCalled();
+    expect(refreshServerSide).toHaveBeenCalled();
     expect(enqueueSnackbar).toHaveBeenCalledWith(
       "The address is not a document.",
       { variant: "error" },

--- a/frontend/src/sections/develop-detail/DataTab/common.js
+++ b/frontend/src/sections/develop-detail/DataTab/common.js
@@ -598,8 +598,22 @@ export const onCellValueChangedWrapper = (queryClient, dataset) => (params) => {
     } catch (e) {
       logger.error("Failed to update cell:", e);
       onError?.();
+      if (typeof params?.onError === "function") {
+        params.onError(e);
+      }
+      const apiMessage =
+        e?.response?.data?.message ||
+        e?.response?.data?.detail ||
+        e?.response?.data?.error ||
+        (typeof e?.response?.data?.result === "string"
+          ? e.response.data.result
+          : null);
       enqueueSnackbar(
-        "Failed to update cell value. Reverting to previous value.",
+        dataType === "document" &&
+          typeof apiMessage === "string" &&
+          apiMessage.trim()
+          ? apiMessage
+          : "Failed to update cell value. Reverting to previous value.",
         {
           variant: "error",
         },

--- a/frontend/src/sections/develop-detail/DataTab/common.js
+++ b/frontend/src/sections/develop-detail/DataTab/common.js
@@ -669,12 +669,15 @@ export const onCellValueChangedWrapper = (queryClient, dataset) => (params) => {
           () => rowNode.setDataValue(columnId, oldValue),
         );
       } else if (dataType === "document") {
+        // Document edits come from FileCellRenderer (no oldValue). Reverting
+        // would setDataValue(undefined) and blank the cell. Reload server state.
+        const refreshDocumentGrid = () => {
+          gridApi?.refreshServerSide({});
+        };
         updateCellValue(
           { column_id: columnId, row_id: rowId, new_value: newValue },
-          () => {
-            gridApi?.refreshServerSide({});
-          },
-          () => rowNode.setDataValue(columnId, oldValue),
+          refreshDocumentGrid,
+          refreshDocumentGrid,
         );
       } else {
         const formattedValue =

--- a/futureagi/model_hub/tests/test_update_document_cell_link.py
+++ b/futureagi/model_hub/tests/test_update_document_cell_link.py
@@ -14,6 +14,7 @@ from model_hub.models.choices import CellStatus, DataTypeChoices, SourceChoices
 from model_hub.models.develop_dataset import Cell, Column, Dataset, Row
 from tfc.utils.document_link import (
     DOCUMENT_ADDRESS_NOT_A_DOCUMENT,
+    DOCUMENT_ADDRESS_TOO_LARGE,
     DOCUMENT_ADDRESS_UNREACHABLE,
     DOCUMENT_NOT_A_WEB_ADDRESS,
 )
@@ -142,3 +143,55 @@ def test_working_document_url_is_stored(auth_client, document_cell):
     if isinstance(infos, str):
         infos = json.loads(infos)
     assert infos.get("document_url") == stored_url
+
+
+def test_uppercase_scheme_url_is_stored(auth_client, document_cell):
+    dataset, row, column, cell = document_cell
+    new_url = "HTTPS://EXAMPLE.COM/REPORT.PDF"
+    stored_url = "https://storage.example.com/report.pdf"
+
+    with patch(
+        "model_hub.views.develop_dataset.upload_document_to_s3",
+        return_value=stored_url,
+    ) as mock_upload:
+        response = _post_link(auth_client, dataset, row, column, new_url)
+
+    assert response.status_code == status.HTTP_200_OK
+    mock_upload.assert_called_once()
+    assert mock_upload.call_args.args[0] == new_url
+    cell.refresh_from_db()
+    assert cell.value == stored_url
+
+
+def test_uppercase_scheme_unreachable_url_keeps_existing_document(
+    auth_client, document_cell
+):
+    dataset, row, column, cell = document_cell
+    new_url = "HTTPS://EXAMPLE.COM/MISSING.PDF"
+
+    with patch(
+        "model_hub.views.develop_dataset.upload_document_to_s3",
+        side_effect=ValueError("ERROR_DOWNLOADING_DOCUMENT: Max retries exceeded"),
+    ):
+        response = _post_link(auth_client, dataset, row, column, new_url)
+
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    assert DOCUMENT_ADDRESS_UNREACHABLE in (response.data.get("message") or "")
+    _assert_cell_unchanged(cell)
+
+
+def test_oversize_document_url_is_refused_and_keeps_existing_document(
+    auth_client, document_cell
+):
+    dataset, row, column, cell = document_cell
+    too_big = "https://example.com/huge.pdf"
+
+    with patch(
+        "model_hub.views.develop_dataset.upload_document_to_s3",
+        side_effect=ValueError("URL body exceeds 104857600 byte limit."),
+    ):
+        response = _post_link(auth_client, dataset, row, column, too_big)
+
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    assert DOCUMENT_ADDRESS_TOO_LARGE in (response.data.get("message") or "")
+    _assert_cell_unchanged(cell)

--- a/futureagi/model_hub/tests/test_update_document_cell_link.py
+++ b/futureagi/model_hub/tests/test_update_document_cell_link.py
@@ -1,0 +1,144 @@
+"""API tests for document-cell Link writes (#2433).
+
+A bad link must be refused with a reason, must not be reported as success,
+and must never delete the document already stored in the cell.
+"""
+
+import json
+from unittest.mock import patch
+
+import pytest
+from rest_framework import status
+
+from model_hub.models.choices import CellStatus, DataTypeChoices, SourceChoices
+from model_hub.models.develop_dataset import Cell, Column, Dataset, Row
+from tfc.utils.document_link import (
+    DOCUMENT_ADDRESS_NOT_A_DOCUMENT,
+    DOCUMENT_ADDRESS_UNREACHABLE,
+    DOCUMENT_NOT_A_WEB_ADDRESS,
+)
+
+
+EXISTING_URL = "https://storage.example.com/kept.pdf"
+EXISTING_INFOS = json.dumps(
+    {"document_url": EXISTING_URL, "document_name": "kept.pdf"}
+)
+
+
+@pytest.fixture
+def document_cell(organization, workspace):
+    dataset = Dataset.objects.create(
+        name="Document link dataset",
+        organization=organization,
+        workspace=workspace,
+    )
+    column = Column.objects.create(
+        name="doc",
+        data_type=DataTypeChoices.DOCUMENT.value,
+        dataset=dataset,
+        source=SourceChoices.OTHERS.value,
+    )
+    row = Row.objects.create(dataset=dataset, order=1)
+    cell = Cell.objects.create(
+        dataset=dataset,
+        row=row,
+        column=column,
+        value=EXISTING_URL,
+        value_infos=EXISTING_INFOS,
+        status=CellStatus.PASS.value,
+    )
+    return dataset, row, column, cell
+
+
+def _post_link(auth_client, dataset, row, column, new_value):
+    return auth_client.post(
+        f"/model-hub/develops/{dataset.id}/update_cell_value/",
+        {
+            "row_id": str(row.id),
+            "column_id": str(column.id),
+            "new_value": new_value,
+        },
+        format="json",
+    )
+
+
+def _value_infos(cell):
+    raw = cell.value_infos
+    if isinstance(raw, str):
+        return json.loads(raw)
+    return raw
+
+
+def _assert_cell_unchanged(cell):
+    cell.refresh_from_db()
+    assert cell.value == EXISTING_URL
+    assert _value_infos(cell).get("document_url") == EXISTING_URL
+    assert cell.status == CellStatus.PASS.value
+
+
+def test_invalid_non_url_is_refused_and_keeps_existing_document(
+    auth_client, document_cell
+):
+    dataset, row, column, cell = document_cell
+
+    response = _post_link(auth_client, dataset, row, column, "sssss")
+
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    assert DOCUMENT_NOT_A_WEB_ADDRESS in (response.data.get("message") or "")
+    _assert_cell_unchanged(cell)
+
+
+def test_unreachable_url_is_refused_and_keeps_existing_document(
+    auth_client, document_cell
+):
+    dataset, row, column, cell = document_cell
+    unreachable = "https://example.com/missing.pdf"
+
+    with patch(
+        "model_hub.views.develop_dataset.upload_document_to_s3",
+        side_effect=ValueError("ERROR_DOWNLOADING_DOCUMENT: Max retries exceeded"),
+    ):
+        response = _post_link(auth_client, dataset, row, column, unreachable)
+
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    assert DOCUMENT_ADDRESS_UNREACHABLE in (response.data.get("message") or "")
+    _assert_cell_unchanged(cell)
+
+
+def test_non_document_url_is_refused_and_keeps_existing_document(
+    auth_client, document_cell
+):
+    dataset, row, column, cell = document_cell
+    html_url = "https://example.com/index.html"
+
+    with patch(
+        "model_hub.views.develop_dataset.upload_document_to_s3",
+        side_effect=ValueError("Invalid document data (Content-Type: text/html)"),
+    ):
+        response = _post_link(auth_client, dataset, row, column, html_url)
+
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    assert DOCUMENT_ADDRESS_NOT_A_DOCUMENT in (response.data.get("message") or "")
+    _assert_cell_unchanged(cell)
+
+
+def test_working_document_url_is_stored(auth_client, document_cell):
+    dataset, row, column, cell = document_cell
+    new_url = "https://cdn.example.com/fresh.pdf"
+    stored_url = "https://storage.example.com/fresh.pdf"
+
+    with patch(
+        "model_hub.views.develop_dataset.upload_document_to_s3",
+        return_value=stored_url,
+    ) as mock_upload:
+        response = _post_link(auth_client, dataset, row, column, new_url)
+
+    assert response.status_code == status.HTTP_200_OK
+    mock_upload.assert_called_once()
+    cell.refresh_from_db()
+    assert cell.value == stored_url
+    assert cell.status == CellStatus.PASS.value
+    infos = cell.value_infos
+    if isinstance(infos, str):
+        infos = json.loads(infos)
+    assert infos.get("document_url") == stored_url

--- a/futureagi/model_hub/views/develop_dataset.py
+++ b/futureagi/model_hub/views/develop_dataset.py
@@ -279,6 +279,10 @@ from tfc.settings.settings import BASE_URL, HUGGINGFACE_API_TOKEN
 from tfc.telemetry import wrap_for_thread
 from tfc.temporal import temporal_activity
 from tfc.utils.api_contracts import validated_request
+from tfc.utils.document_link import (
+    document_link_failure_message,
+    resolve_document_cell_input,
+)
 from tfc.utils.error_codes import get_error_message
 from tfc.utils.functions import (
     calculate_column_average,
@@ -5512,23 +5516,28 @@ class UpdateCellValueView(APIView):
                     return self._gm.bad_request(str(e))
 
             elif column_data_type == DataTypeChoices.DOCUMENT.value:
+                converted = None
                 try:
                     logger.info("Got DOCUMENT FILE")
-                    name = new_value
-                    new_value = self._convert_file_to_base64(request)
+                    original_value = new_value
+                    converted = self._convert_file_to_base64(request)
                     logger.info("GOT DOCUMENT BASE64")
 
-                    # Handle empty document value
-                    if not new_value or (
-                        isinstance(new_value, str) and new_value.strip() == ""
-                    ):
+                    action, payload = resolve_document_cell_input(
+                        original_value, converted
+                    )
+                    if action == "reject":
+                        # Refuse without touching the existing document.
+                        return self._gm.bad_request(payload)
+
+                    if action == "clear":
                         cell.value = None
                         cell.value_infos = json.dumps({})
                         cell.status = CellStatus.PASS.value
                     else:
                         doc_key = f"documents/{dataset_id}/{uuid.uuid4()}"
                         doc_url = upload_document_to_s3(
-                            new_value,
+                            payload,
                             bucket_name="fi-customer-data-dev",
                             object_key=doc_key,
                         )
@@ -5538,13 +5547,22 @@ class UpdateCellValueView(APIView):
                         if not isinstance(value_infos, dict):
                             value_infos = {}
                         value_infos["document_url"] = doc_url
-                        value_infos["document_name"] = name[:400]
+                        name = original_value
+                        value_infos["document_name"] = (
+                            str(name)[:400] if name else ""
+                        )
                         cell.value_infos = json.dumps(value_infos)
                         cell.status = CellStatus.PASS.value
                         cell.value = doc_url
 
                 except Exception as e:
                     logger.error(f"ERROR: {e}")
+                    is_link = isinstance(converted, str) and converted.startswith(
+                        ("http://", "https://")
+                    )
+                    if is_link:
+                        # A failed link must not wipe the document already in the cell.
+                        return self._gm.bad_request(document_link_failure_message(e))
                     cell.value = None
                     cell.status = CellStatus.ERROR.value
                     cell.value_infos = json.dumps({"reason": str(e)})

--- a/futureagi/model_hub/views/develop_dataset.py
+++ b/futureagi/model_hub/views/develop_dataset.py
@@ -281,6 +281,7 @@ from tfc.temporal import temporal_activity
 from tfc.utils.api_contracts import validated_request
 from tfc.utils.document_link import (
     document_link_failure_message,
+    is_http_web_address,
     resolve_document_cell_input,
 )
 from tfc.utils.error_codes import get_error_message
@@ -5263,11 +5264,7 @@ class UpdateCellValueView(APIView):
             ):
                 # It's already a base64 string with mime type
                 return new_value
-            elif (
-                new_value
-                and isinstance(new_value, str)
-                and new_value.startswith("http")
-            ):
+            elif is_http_web_address(new_value):
                 return new_value
             elif (
                 new_value
@@ -5557,9 +5554,7 @@ class UpdateCellValueView(APIView):
 
                 except Exception as e:
                     logger.error(f"ERROR: {e}")
-                    is_link = isinstance(converted, str) and converted.startswith(
-                        ("http://", "https://")
-                    )
+                    is_link = is_http_web_address(converted)
                     if is_link:
                         # A failed link must not wipe the document already in the cell.
                         return self._gm.bad_request(document_link_failure_message(e))

--- a/futureagi/tfc/utils/document_link.py
+++ b/futureagi/tfc/utils/document_link.py
@@ -1,0 +1,66 @@
+"""Helpers for dataset document-cell Link writes.
+
+Kept independent of ``tfc.utils.storage`` so URL classification can be tested
+without pulling image/audio/MinIO dependencies.
+"""
+
+from urllib.parse import urlparse
+
+DOCUMENT_NOT_A_WEB_ADDRESS = "The value is not a web address."
+DOCUMENT_ADDRESS_UNREACHABLE = "The address cannot be reached."
+DOCUMENT_ADDRESS_NOT_A_DOCUMENT = "The address is not a document."
+
+
+def is_http_web_address(value) -> bool:
+    """True for http(s) URLs with a host. Data URIs are not web addresses."""
+    if not isinstance(value, str) or not value.strip():
+        return False
+    value = value.strip()
+    if value.startswith("data:"):
+        return False
+    try:
+        parsed = urlparse(value)
+    except Exception:
+        return False
+    return parsed.scheme in ("http", "https") and bool(parsed.netloc)
+
+
+def resolve_document_cell_input(original_value, converted_value):
+    """Classify a document-cell write before mutating storage.
+
+    Returns one of:
+        ("clear", None) — intentional empty write
+        ("reject", message) — refuse without changing the existing cell
+        ("store", converted_value) — proceed to upload
+    """
+    converted_empty = converted_value is None or (
+        isinstance(converted_value, str) and converted_value.strip() == ""
+    )
+    original_empty = original_value is None or (
+        isinstance(original_value, str) and str(original_value).strip() == ""
+    )
+
+    if converted_empty:
+        if original_empty:
+            return "clear", None
+        return "reject", DOCUMENT_NOT_A_WEB_ADDRESS
+
+    if isinstance(converted_value, str) and not converted_value.startswith("data:"):
+        if not is_http_web_address(converted_value):
+            return "reject", DOCUMENT_NOT_A_WEB_ADDRESS
+
+    return "store", converted_value
+
+
+def document_link_failure_message(exc: BaseException) -> str:
+    """Map a document-link fetch/upload failure to a user-facing reason."""
+    msg = str(exc).lower()
+    if (
+        "invalid document data" in msg
+        or "file type is not supported" in msg
+        or "downloaded file is empty" in msg
+    ):
+        return DOCUMENT_ADDRESS_NOT_A_DOCUMENT
+    if "url is not valid" in msg or "not a web address" in msg:
+        return DOCUMENT_NOT_A_WEB_ADDRESS
+    return DOCUMENT_ADDRESS_UNREACHABLE

--- a/futureagi/tfc/utils/document_link.py
+++ b/futureagi/tfc/utils/document_link.py
@@ -9,6 +9,7 @@ from urllib.parse import urlparse
 DOCUMENT_NOT_A_WEB_ADDRESS = "The value is not a web address."
 DOCUMENT_ADDRESS_UNREACHABLE = "The address cannot be reached."
 DOCUMENT_ADDRESS_NOT_A_DOCUMENT = "The address is not a document."
+DOCUMENT_ADDRESS_TOO_LARGE = "The document is too large."
 
 
 def is_http_web_address(value) -> bool:
@@ -22,7 +23,7 @@ def is_http_web_address(value) -> bool:
         parsed = urlparse(value)
     except Exception:
         return False
-    return parsed.scheme in ("http", "https") and bool(parsed.netloc)
+    return parsed.scheme.lower() in ("http", "https") and bool(parsed.netloc)
 
 
 def resolve_document_cell_input(original_value, converted_value):
@@ -63,4 +64,6 @@ def document_link_failure_message(exc: BaseException) -> str:
         return DOCUMENT_ADDRESS_NOT_A_DOCUMENT
     if "url is not valid" in msg or "not a web address" in msg:
         return DOCUMENT_NOT_A_WEB_ADDRESS
+    if "byte limit" in msg:
+        return DOCUMENT_ADDRESS_TOO_LARGE
     return DOCUMENT_ADDRESS_UNREACHABLE

--- a/futureagi/tfc/utils/storage.py
+++ b/futureagi/tfc/utils/storage.py
@@ -409,6 +409,9 @@ def download_document_from_url(doc_url, max_retries=5, timeout=20):
             logger.warning(f"SSRF-blocked URL, not retrying: {e}")
             raise ValueError(f"ERROR_DOWNLOADING_DOCUMENT: {e}") from e
         except RequestException as e:
+            # Size cap is permanent — retrying re-downloads the same oversize body.
+            if "byte limit" in str(e).lower():
+                raise ValueError(str(e)) from e
             logger.error(f"Attempt {attempt + 1} failed with error: {e}")
             if attempt < max_retries - 1:
                 time.sleep(2**attempt)

--- a/futureagi/tfc/utils/tests/test_document_link_validation.py
+++ b/futureagi/tfc/utils/tests/test_document_link_validation.py
@@ -4,6 +4,7 @@ import pytest
 
 from tfc.utils.document_link import (
     DOCUMENT_ADDRESS_NOT_A_DOCUMENT,
+    DOCUMENT_ADDRESS_TOO_LARGE,
     DOCUMENT_ADDRESS_UNREACHABLE,
     DOCUMENT_NOT_A_WEB_ADDRESS,
     document_link_failure_message,
@@ -17,6 +18,8 @@ from tfc.utils.document_link import (
     [
         ("https://example.com/report.pdf", True),
         ("http://example.com/a.docx", True),
+        ("HTTPS://EXAMPLE.COM/REPORT.PDF", True),
+        ("HTTP://EXAMPLE.COM/A.DOCX", True),
         ("sssss", False),
         ("not a url", False),
         ("ftp://example.com/a.pdf", False),
@@ -91,7 +94,17 @@ def test_resolve_stores_data_uri_upload():
             ValueError("ERROR_DOWNLOADING_DOCUMENT: blocked"),
             DOCUMENT_ADDRESS_UNREACHABLE,
         ),
+        (
+            ValueError("URL body exceeds 104857600 byte limit."),
+            DOCUMENT_ADDRESS_TOO_LARGE,
+        ),
     ],
 )
 def test_document_link_failure_message(exc, expected):
     assert document_link_failure_message(exc) == expected
+
+
+def test_resolve_stores_uppercase_scheme_url():
+    url = "HTTPS://EXAMPLE.COM/REPORT.PDF"
+    assert is_http_web_address(url) is True
+    assert resolve_document_cell_input(url, url) == ("store", url)

--- a/futureagi/tfc/utils/tests/test_document_link_validation.py
+++ b/futureagi/tfc/utils/tests/test_document_link_validation.py
@@ -1,0 +1,97 @@
+"""Unit tests for document-cell link validation helpers (#2433)."""
+
+import pytest
+
+from tfc.utils.document_link import (
+    DOCUMENT_ADDRESS_NOT_A_DOCUMENT,
+    DOCUMENT_ADDRESS_UNREACHABLE,
+    DOCUMENT_NOT_A_WEB_ADDRESS,
+    document_link_failure_message,
+    is_http_web_address,
+    resolve_document_cell_input,
+)
+
+
+@pytest.mark.parametrize(
+    "value,expected",
+    [
+        ("https://example.com/report.pdf", True),
+        ("http://example.com/a.docx", True),
+        ("sssss", False),
+        ("not a url", False),
+        ("ftp://example.com/a.pdf", False),
+        ("javascript:alert(1)", False),
+        ("data:application/pdf;base64,AAA", False),
+        ("https://", False),
+        ("", False),
+        (None, False),
+        (123, False),
+    ],
+)
+def test_is_http_web_address(value, expected):
+    assert is_http_web_address(value) is expected
+
+
+def test_resolve_clears_intentional_empty():
+    assert resolve_document_cell_input(None, None) == ("clear", None)
+    assert resolve_document_cell_input("", None) == ("clear", None)
+    assert resolve_document_cell_input("   ", None) == ("clear", None)
+
+
+def test_resolve_rejects_non_url_garbage():
+    action, message = resolve_document_cell_input("sssss", None)
+    assert action == "reject"
+    assert message == DOCUMENT_NOT_A_WEB_ADDRESS
+
+
+def test_resolve_rejects_non_http_converted_value():
+    action, message = resolve_document_cell_input("ftp://x/a.pdf", "ftp://x/a.pdf")
+    assert action == "reject"
+    assert message == DOCUMENT_NOT_A_WEB_ADDRESS
+
+
+def test_resolve_stores_http_url():
+    url = "https://cdn.example.com/paper.pdf"
+    assert resolve_document_cell_input(url, url) == ("store", url)
+
+
+def test_resolve_stores_data_uri_upload():
+    data_uri = "data:application/pdf;base64,AAAA"
+    assert resolve_document_cell_input(data_uri, data_uri) == ("store", data_uri)
+
+
+@pytest.mark.parametrize(
+    "exc,expected",
+    [
+        (
+            ValueError("Invalid document data (Content-Type: text/html)"),
+            DOCUMENT_ADDRESS_NOT_A_DOCUMENT,
+        ),
+        (
+            ValueError("The provided file type is not supported."),
+            DOCUMENT_ADDRESS_NOT_A_DOCUMENT,
+        ),
+        (
+            ValueError("Downloaded file is empty"),
+            DOCUMENT_ADDRESS_NOT_A_DOCUMENT,
+        ),
+        (
+            ValueError("The provided URL is not valid."),
+            DOCUMENT_NOT_A_WEB_ADDRESS,
+        ),
+        (
+            ValueError("ERROR_DOWNLOADING_DOCUMENT: Max retries exceeded"),
+            DOCUMENT_ADDRESS_UNREACHABLE,
+        ),
+        (
+            ValueError("Unable to process link. Status Code: 404"),
+            DOCUMENT_ADDRESS_UNREACHABLE,
+        ),
+        (
+            ValueError("ERROR_DOWNLOADING_DOCUMENT: blocked"),
+            DOCUMENT_ADDRESS_UNREACHABLE,
+        ),
+    ],
+)
+def test_document_link_failure_message(exc, expected):
+    assert document_link_failure_message(exc) == expected

--- a/futureagi/tfc/utils/tests/test_storage_ssrf.py
+++ b/futureagi/tfc/utils/tests/test_storage_ssrf.py
@@ -136,6 +136,16 @@ def test_download_document_from_url_fails_fast_on_ssrf_blocked():
     mock_sleep.assert_not_called()
 
 
+def test_download_document_from_url_fails_fast_on_body_limit():
+    with patch(
+        "tfc.utils.storage.safe_fetch",
+        side_effect=ValueError("URL body exceeds 104857600 byte limit."),
+    ), patch("tfc.utils.storage.time.sleep") as mock_sleep:
+        with pytest.raises(ValueError, match="byte limit"):
+            download_document_from_url("https://example.com/huge.pdf", max_retries=5)
+    mock_sleep.assert_not_called()
+
+
 def test_download_image_from_url_passes_explicit_max_bytes():
     """Regression: download_image_from_url must pass MAX_IMAGE_FILE_SIZE so it
     doesn't silently truncate at safe_fetch's 25 MiB default.


### PR DESCRIPTION
Garbage or unreachable Link values were treated as empty/success and wiped the document already in the cell. Validate web addresses on the Link tab, return a reason from the API, and leave the existing file untouched on failure.

Closes #2433.