### PR TITLE
fix: keep playground model config when clicking filter tabs (#2436)

### DIFF
--- a/frontend/src/components/custom-model-dropdown/ShowModelDropdown.test.jsx
+++ b/frontend/src/components/custom-model-dropdown/ShowModelDropdown.test.jsx
@@ -1,0 +1,50 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, userEvent } from "src/utils/test-utils";
+import ShowModelDropdown from "./ShowModelDropdown";
+
+describe("ShowModelDropdown filter tabs (#2436)", () => {
+  it("clicking a type tab filters via onModelTypeChange and does not select a model", async () => {
+    const onModelTypeChange = vi.fn();
+    const onChange = vi.fn();
+    const anchor = document.createElement("div");
+    document.body.appendChild(anchor);
+    Object.defineProperty(anchor, "offsetWidth", { value: 400 });
+    anchor.getBoundingClientRect = () => ({
+      bottom: 40,
+      top: 0,
+      left: 0,
+      right: 400,
+      width: 400,
+      height: 32,
+    });
+
+    render(
+      <ShowModelDropdown
+        ref={{ current: anchor }}
+        open
+        onClose={vi.fn()}
+        options={[
+          {
+            modelName: "gpt-4o",
+            providers: "openai",
+            isAvailable: true,
+            logoUrl: "",
+            type: "chat",
+          },
+        ]}
+        value="gpt-4o"
+        onChange={onChange}
+        onModelTypeChange={onModelTypeChange}
+        modelType="all"
+        setSearchQuery={vi.fn()}
+        fetchNextPage={vi.fn()}
+      />,
+    );
+
+    const user = userEvent.setup();
+    await user.click(screen.getByText("Image"));
+
+    expect(onModelTypeChange).toHaveBeenCalledWith("image");
+    expect(onChange).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/sections/workbench/createPrompt/Playground/ModelContainer.jsx
+++ b/frontend/src/sections/workbench/createPrompt/Playground/ModelContainer.jsx
@@ -132,13 +132,11 @@ const ModelContainer = ({
   };
 
   const handleOnModelTypeChange = (newModelType) => {
-    setModelConfig((pre) => {
-      // If changing to "all", keep the current model
-      if (newModelType === "all") {
-        return { ...pre, model_type: newModelType };
-      }
-      // For any other change (from "all" or between types), reset to default
-      return { ...modelConfigDefault, model_type: newModelType };
+    // Filter tabs only narrow the model list. Keep the current configuration
+    // (model, output format, tools, ...) and skip autosave so browsing tabs
+    // does not create a draft version.
+    setModelConfig((pre) => ({ ...pre, model_type: newModelType }), {
+      skipSave: true,
     });
   };
 

--- a/frontend/src/sections/workbench/createPrompt/Playground/ModelContainer.test.jsx
+++ b/frontend/src/sections/workbench/createPrompt/Playground/ModelContainer.test.jsx
@@ -1,0 +1,238 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, waitFor } from "src/utils/test-utils";
+import { modelConfigDefault } from "../WorkbenchContext";
+
+const { mockFetchQuery, dropdownProps } = vi.hoisted(() => ({
+  mockFetchQuery: vi.fn(),
+  dropdownProps: { current: null },
+}));
+
+vi.mock("react-router", async (importOriginal) => {
+  const actual = await importOriginal();
+  return {
+    ...actual,
+    useParams: () => ({ id: "prompt-1" }),
+  };
+});
+
+vi.mock("src/auth/hooks", () => ({
+  useAuthContext: () => ({ role: "Owner" }),
+}));
+
+vi.mock("../WorkbenchContext", async (importOriginal) => {
+  const actual = await importOriginal();
+  return {
+    ...actual,
+    usePromptWorkbenchContext: () => ({
+      selectedVersions: [{ version: "v1" }],
+      templateFormat: "mustache",
+      setTemplateFormat: vi.fn(),
+    }),
+  };
+});
+
+vi.mock("src/sections/workbench-v2/store/usePromptStore", () => ({
+  usePromptStoreShallow: () => ({
+    setSelectTemplateDrawerOpen: vi.fn(),
+    setSelectedPromptIndex: vi.fn(),
+  }),
+}));
+
+vi.mock("@tanstack/react-query", () => ({
+  useQueryClient: () => ({ fetchQuery: mockFetchQuery }),
+  useQuery: () => ({ data: undefined }),
+}));
+
+vi.mock("src/api/develop/prompt", () => ({
+  useModelParams: () => ({ data: undefined }),
+}));
+
+vi.mock("src/api/develop/develop-detail", () => ({
+  useVoiceOptions: () => ({ data: undefined }),
+}));
+
+vi.mock("src/utils/Mixpanel", () => ({
+  Events: {
+    promptSelectModelClicked: "promptSelectModelClicked",
+    promptUseTemplateClicked: "promptUseTemplateClicked",
+    promptSelectToolsClicked: "promptSelectToolsClicked",
+  },
+  PropertyName: {
+    click: "click",
+    promptId: "promptId",
+    type: "type",
+    version: "version",
+  },
+  trackEvent: vi.fn(),
+}));
+
+vi.mock("src/components/custom-model-dropdown/CustomModelDropdown", () => ({
+  default: (props) => {
+    dropdownProps.current = props;
+    return <div data-testid="model-dropdown" />;
+  },
+}));
+
+vi.mock("src/components/custom-model-tools", () => ({
+  default: () => <div data-testid="model-tools" />,
+}));
+
+vi.mock("./ModelParamsContainer", () => ({
+  default: () => <div data-testid="model-params" />,
+}));
+
+vi.mock("./ResponseFormatSelector", () => ({
+  default: () => <div data-testid="response-format" />,
+}));
+
+vi.mock("./TemplateFormatSelector", () => ({
+  default: () => <div data-testid="template-format" />,
+}));
+
+vi.mock("src/components/svg-color", () => ({
+  default: () => <span />,
+}));
+
+vi.mock("src/components/iconify", () => ({
+  default: () => <span />,
+}));
+
+vi.mock("src/components/tooltip", () => ({
+  default: ({ children }) => children,
+}));
+
+import ModelContainer from "./ModelContainer";
+
+const EXISTING_CONFIG = {
+  model: "gpt-4o",
+  model_detail: {
+    model_name: "gpt-4o",
+    providers: "openai",
+    type: "chat",
+    logoUrl: "https://example.com/gpt.png",
+    isAvailable: true,
+  },
+  output_format: "json_object",
+  responseFormat: "json_object",
+  tools: [{ id: "tool-1", name: "search" }],
+  tool_choice: "auto",
+  temperature: 0.4,
+  model_type: "all",
+};
+
+const applyLatestUpdater = (setModelConfig, previous = EXISTING_CONFIG) => {
+  const updater = setModelConfig.mock.calls.at(-1)[0];
+  return typeof updater === "function" ? updater(previous) : updater;
+};
+
+const renderContainer = (overrides = {}) => {
+  const setModelConfig = vi.fn();
+  render(
+    <ModelContainer
+      modelConfig={{ ...EXISTING_CONFIG, ...overrides }}
+      setModelConfig={setModelConfig}
+      open
+      setOpen={vi.fn()}
+      promptIndex={0}
+    />,
+  );
+  return setModelConfig;
+};
+
+describe("ModelContainer filter tabs (#2436)", () => {
+  beforeEach(() => {
+    mockFetchQuery.mockReset();
+    dropdownProps.current = null;
+  });
+
+  it("clicking a non-all filter tab keeps model, output format, and companion config and skips draft save", () => {
+    const setModelConfig = renderContainer();
+    setModelConfig.mockClear();
+
+    dropdownProps.current.onModelTypeChange("image");
+
+    expect(setModelConfig).toHaveBeenCalledTimes(1);
+    expect(setModelConfig.mock.calls[0][1]).toEqual({ skipSave: true });
+
+    const next = applyLatestUpdater(setModelConfig);
+    expect(next.model).toBe("gpt-4o");
+    expect(next.output_format).toBe("json_object");
+    expect(next.responseFormat).toBe("json_object");
+    expect(next.tools).toEqual([{ id: "tool-1", name: "search" }]);
+    expect(next.tool_choice).toBe("auto");
+    expect(next.temperature).toBe(0.4);
+    expect(next.model_detail.model_name).toBe("gpt-4o");
+    expect(next.model_type).toBe("image");
+    expect(next).not.toEqual(
+      expect.objectContaining({
+        model: modelConfigDefault.model,
+        output_format: modelConfigDefault.output_format,
+        tools: modelConfigDefault.tools,
+      }),
+    );
+  });
+
+  it("clicking the all tab also preserves configuration and skips draft save", () => {
+    const setModelConfig = renderContainer({ model_type: "llm" });
+    setModelConfig.mockClear();
+
+    dropdownProps.current.onModelTypeChange("all");
+
+    expect(setModelConfig.mock.calls[0][1]).toEqual({ skipSave: true });
+    const next = applyLatestUpdater(setModelConfig, {
+      ...EXISTING_CONFIG,
+      model_type: "llm",
+    });
+    expect(next.model).toBe("gpt-4o");
+    expect(next.output_format).toBe("json_object");
+    expect(next.tools).toHaveLength(1);
+    expect(next.model_type).toBe("all");
+  });
+
+  it("selecting a different model still updates config and does not skip save", async () => {
+    mockFetchQuery.mockResolvedValue({
+      data: {
+        result: {
+          sliders: [],
+          responseFormat: [{ value: "text" }, { value: "json_object" }],
+        },
+      },
+    });
+
+    const setModelConfig = renderContainer();
+    setModelConfig.mockClear();
+
+    dropdownProps.current.onChange({
+      target: {
+        value: {
+          modelName: "dall-e-3",
+          model_name: "dall-e-3",
+          providers: "openai",
+          type: "image_generation",
+          logoUrl: "https://example.com/dalle.png",
+          isAvailable: true,
+        },
+      },
+    });
+
+    await waitFor(() => {
+      expect(setModelConfig).toHaveBeenCalled();
+    });
+
+    const saveCall = setModelConfig.mock.calls.find(
+      ([, options]) => !options?.skipSave,
+    );
+    expect(saveCall).toBeTruthy();
+    expect(saveCall[1]).toBeUndefined();
+
+    const next =
+      typeof saveCall[0] === "function"
+        ? saveCall[0](EXISTING_CONFIG)
+        : saveCall[0];
+    expect(next.model).toBe("dall-e-3");
+    expect(next.model_detail.modelName ?? next.model_detail.model_name).toBe(
+      "dall-e-3",
+    );
+    expect(next.output_format).toBe("image");
+  });
+});


### PR DESCRIPTION
Filter tabs on the Prompt Playground model dropdown were replacing the whole model config with defaults whenever a tab other than All was clicked, which cleared the selected model, output format, and companion settings and created a draft. `handleOnModelTypeChange` now only updates `model_type` (the list filter) and passes `skipSave: true`, so browsing tabs does not dirty the prompt. Choosing a model still goes through the existing `handleModelOnChange` path.

Closes #2436.