### PR TITLE
fix: sync VITE_HOST_API when BACKEND_PORT auto-switches (#2340)

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -383,6 +383,32 @@ set_env_var() {
   fi
 }
 
+# Keep VITE_HOST_API in sync when BACKEND_PORT auto-switches (#2340).
+# Empty/unset (the .env.example default) and existing localhost URLs all
+# fall through to the SPA's http://localhost:8000 fallback; after a port
+# switch that would miss the backend. Custom/split-domain URLs are left
+# alone. Prints the new URL when a write happens (empty stdout = skipped).
+# The frontend entrypoint regenerates /config.js from this env var at
+# container start, so no image rebuild is needed.
+sync_vite_host_api() {
+  local new_port="$1"
+  local current=""
+  if grep -Eq '^VITE_HOST_API=' .env; then
+    current=$(grep -E '^VITE_HOST_API=' .env | tail -1 | cut -d= -f2- || true)
+  fi
+  current="${current%$'\r'}"
+  local unquoted="$current"
+  case "$unquoted" in
+    \"*\") unquoted="${unquoted#\"}"; unquoted="${unquoted%\"}" ;;
+    \'*\') unquoted="${unquoted#\'}"; unquoted="${unquoted%\'}" ;;
+  esac
+  if [[ -z "$unquoted" || "$unquoted" =~ ^https?://localhost:[0-9]+/?$ ]]; then
+    set_env_var "VITE_HOST_API" "http://localhost:${new_port}"
+    printf '%s\n' "http://localhost:${new_port}"
+  fi
+  return 0
+}
+
 # All host-bound ports. Data-store ports bind 127.0.0.1 in compose, but
 # they still collide with anything else on that interface (other docker
 # stacks, SSH tunnels, host services). PeerDB ports only matter in --full.
@@ -458,14 +484,17 @@ for entry in "${PORTS_TO_CHECK[@]}"; do
   if (( apply == 1 )); then
     set_env_var "$var" "$suggestion"
     ok "  $var=$suggestion  written to .env"
-    # Keep VITE_HOST_API in sync when BACKEND_PORT moves. The frontend
-    # bundle bakes the URL at build time; if .env still has the old
-    # localhost:8000 default after we switch BACKEND_PORT, the bundle
-    # would call a port that's no longer ours.
-    if [[ "$var" == "BACKEND_PORT" ]] && \
-       grep -Eq '^VITE_HOST_API=https?://localhost:[0-9]+/?$' .env; then
-      sed_inplace -E "s|^VITE_HOST_API=.*|VITE_HOST_API=http://localhost:${suggestion}|" .env
-      ok "  VITE_HOST_API=http://localhost:${suggestion}  (kept in sync)"
+    # Keep VITE_HOST_API in sync when BACKEND_PORT moves. Empty
+    # (the .env.example default) and existing localhost URLs would
+    # otherwise keep calling http://localhost:8000 after the switch.
+    # Custom/split-domain URLs are left alone. The frontend entrypoint
+    # regenerates /config.js from this env var at container start, so
+    # no image rebuild is needed.
+    if [[ "$var" == "BACKEND_PORT" ]]; then
+      synced="$(sync_vite_host_api "$suggestion" || true)"
+      if [[ -n "$synced" ]]; then
+        ok "  VITE_HOST_API=${synced}  (kept in sync)"
+      fi
     fi
   else
     UNRESOLVED+=("$var=$port  ←  $holder")

--- a/scripts/test-install-vite-host-api.sh
+++ b/scripts/test-install-vite-host-api.sh
@@ -1,0 +1,152 @@
+#!/usr/bin/env bash
+# Regression for github.com/future-agi/future-agi/issues/2340
+#
+# When bin/install auto-switches BACKEND_PORT, VITE_HOST_API must follow
+# if it is empty/unset (the .env.example default) or already a localhost
+# URL. Custom/split-domain URLs must be left alone.
+#
+# No Docker. Extracts sed_inplace / set_env_var / sync_vite_host_api from
+# bin/install so this tests the production functions.
+set -euo pipefail
+
+ROOT="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)"
+INSTALL="$ROOT/bin/install"
+
+fail() { printf 'FAIL: %s\n' "$*" >&2; exit 1; }
+pass() { printf '  ok  %s\n' "$*"; }
+
+[[ -f "$INSTALL" ]] || fail "missing $INSTALL"
+
+grep -q 'sync_vite_host_api' "$INSTALL" \
+  || fail "bin/install does not call sync_vite_host_api"
+
+# The apply-block must call sync_vite_host_api only when var is BACKEND_PORT.
+python3 -c '
+import sys
+from pathlib import Path
+text = Path(sys.argv[1]).read_text()
+needle = "if [[ \"$var\" == \"BACKEND_PORT\" ]]; then"
+if needle not in text:
+    raise SystemExit("missing BACKEND_PORT guard around sync_vite_host_api")
+idx = text.index(needle)
+window = text[idx:idx + 400]
+if "sync_vite_host_api" not in window:
+    raise SystemExit("sync_vite_host_api not called under BACKEND_PORT guard")
+' "$INSTALL" || fail "BACKEND_PORT call site is missing or too broad"
+
+extract_fn() {
+  local name="$1"
+  python3 -c '
+import sys
+from pathlib import Path
+text = Path(sys.argv[1]).read_text()
+name = sys.argv[2]
+sig = f"{name}() {{"
+start = text.find(sig)
+if start == -1:
+    raise SystemExit(f"function {name}() not found")
+i = start + len(sig) - 1
+depth = 0
+for j in range(i, len(text)):
+    ch = text[j]
+    if ch == "{":
+        depth += 1
+    elif ch == "}":
+        depth -= 1
+        if depth == 0:
+            sys.stdout.write(text[start : j + 1] + "\n")
+            break
+else:
+    raise SystemExit(f"unterminated function {name}")
+' "$INSTALL" "$name"
+}
+
+eval "$(extract_fn sed_inplace)"
+eval "$(extract_fn set_env_var)"
+eval "$(extract_fn sync_vite_host_api)"
+
+WORKDIR="$(mktemp -d "${TMPDIR:-/tmp}/fagi-2340.XXXXXX")"
+cleanup() { rm -rf "$WORKDIR"; }
+trap cleanup EXIT
+cd "$WORKDIR"
+
+read_vite() {
+  if grep -Eq '^VITE_HOST_API=' .env; then
+    grep -E '^VITE_HOST_API=' .env | tail -1 | cut -d= -f2-
+  else
+    printf '<unset>'
+  fi
+}
+
+run_case() {
+  local name="$1" env_body="$2" expect="$3" expect_stdout="$4"
+  printf '%s\n' "$env_body" > .env
+  local out
+  out="$(sync_vite_host_api 8001 || true)"
+  local got
+  got="$(read_vite)"
+  [[ "$got" == "$expect" ]] || fail "$name: VITE_HOST_API='$got' want '$expect'"
+  [[ "$out" == "$expect_stdout" ]] || fail "$name: stdout='$out' want '$expect_stdout'"
+  pass "$name"
+}
+
+echo "==> sync_vite_host_api (#2340)"
+
+run_case "empty value (env.example default)" \
+  $'BACKEND_PORT=8000\nVITE_HOST_API=\nFRONTEND_URL=' \
+  "http://localhost:8001" "http://localhost:8001"
+
+run_case "unset key" \
+  $'BACKEND_PORT=8000\nFRONTEND_URL=' \
+  "http://localhost:8001" "http://localhost:8001"
+
+run_case "quoted empty double" \
+  $'VITE_HOST_API=""' \
+  "http://localhost:8001" "http://localhost:8001"
+
+run_case "quoted empty single" \
+  "VITE_HOST_API=''" \
+  "http://localhost:8001" "http://localhost:8001"
+
+run_case "http localhost" \
+  "VITE_HOST_API=http://localhost:8000" \
+  "http://localhost:8001" "http://localhost:8001"
+
+run_case "https localhost" \
+  "VITE_HOST_API=https://localhost:8000" \
+  "http://localhost:8001" "http://localhost:8001"
+
+run_case "trailing slash" \
+  "VITE_HOST_API=http://localhost:8000/" \
+  "http://localhost:8001" "http://localhost:8001"
+
+run_case "quoted http localhost" \
+  'VITE_HOST_API="http://localhost:8000"' \
+  "http://localhost:8001" "http://localhost:8001"
+
+run_case "quoted https localhost trailing slash" \
+  'VITE_HOST_API="https://localhost:8000/"' \
+  "http://localhost:8001" "http://localhost:8001"
+
+run_case "CRLF empty value" \
+  $'VITE_HOST_API=\r' \
+  "http://localhost:8001" "http://localhost:8001"
+
+run_case "custom https API left alone" \
+  "VITE_HOST_API=https://api.example.com" \
+  "https://api.example.com" ""
+
+run_case "quoted custom API left alone" \
+  'VITE_HOST_API="https://api.example.com"' \
+  '"https://api.example.com"' ""
+
+run_case "localhost with path left alone" \
+  "VITE_HOST_API=http://localhost:8000/api" \
+  "http://localhost:8000/api" ""
+
+run_case "127.0.0.1 left alone (not in installer defaults)" \
+  "VITE_HOST_API=http://127.0.0.1:8000" \
+  "http://127.0.0.1:8000" ""
+
+echo
+echo "PASS"


### PR DESCRIPTION
## Summary
- When `bin/install` auto-switches `BACKEND_PORT` because 8000 is taken, also set `VITE_HOST_API=http://localhost:<new-port>` if it is empty/unset (the `.env.example` default) or already a localhost URL.
- Custom/split-domain `VITE_HOST_API` values are left alone.
- No frontend rebuild: compose `up` after the port check injects the env, and the frontend entrypoint regenerates `/config.js`.

Closes #2340

## Test plan
- [x] `bash scripts/test-install-vite-host-api.sh` (no Docker)
- [ ] On a host where 8000 is taken: `./bin/install --no-up -y` and confirm `.env` has matching `BACKEND_PORT` and `VITE_HOST_API=http://localhost:<port>`