### PR TITLE
fix: load pdf.js worker from local pdfjs-dist (#2339)

### DIFF
--- a/frontend/src/components/PdfPreviewDrawer.jsx
+++ b/frontend/src/components/PdfPreviewDrawer.jsx
@@ -10,6 +10,7 @@ import { LoadingScreen } from "src/components/loading-screen";
 import React, { useState, useEffect, useRef } from "react";
 import { Viewer, Worker } from "@react-pdf-viewer/core";
 import { defaultLayoutPlugin } from "@react-pdf-viewer/default-layout";
+import pdfjsWorkerUrl from "pdfjs-dist/build/pdf.worker.min.js?url";
 import { usePdfPreviewStoreShallow } from "src/utils/CommonStores/pdfPreviewStore";
 import Iconify from "./iconify";
 import SvgColor from "./svg-color";
@@ -114,7 +115,7 @@ const PdfPreviewDrawer = () => {
       case "pdf":
         return (
           <Box sx={{ height: "100%", backgroundColor: "background.paper" }}>
-            <Worker workerUrl="https://unpkg.com/pdfjs-dist@3.11.174/build/pdf.worker.min.js">
+            <Worker workerUrl={pdfjsWorkerUrl}>
               <Viewer
                 fileUrl={fileUrl}
                 plugins={[defaultLayoutPluginInstance]}

--- a/frontend/src/components/PdfPreviewDrawer.test.jsx
+++ b/frontend/src/components/PdfPreviewDrawer.test.jsx
@@ -1,0 +1,57 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { render, screen } from "src/utils/test-utils";
+import { usePdfPreviewStore } from "src/utils/CommonStores/pdfPreviewStore";
+import PdfPreviewDrawer from "./PdfPreviewDrawer";
+
+vi.mock("@react-pdf-viewer/core", () => ({
+  Worker: ({ workerUrl, children }) => (
+    <div data-testid="pdfjs-worker" data-worker-url={workerUrl}>
+      {children}
+    </div>
+  ),
+  Viewer: ({ fileUrl }) => (
+    <div data-testid="pdfjs-viewer" data-file-url={fileUrl} />
+  ),
+}));
+
+vi.mock("@react-pdf-viewer/default-layout", () => ({
+  defaultLayoutPlugin: () => ({}),
+}));
+
+vi.mock("@mui/material", async (importOriginal) => {
+  const actual = await importOriginal();
+  return {
+    ...actual,
+    Drawer: ({ open, children }) => (open ? <div>{children}</div> : null),
+  };
+});
+
+describe("PdfPreviewDrawer", () => {
+  afterEach(() => {
+    usePdfPreviewStore.setState({ openPdfPreviewDrawer: null });
+  });
+
+  it("loads the pdf.js worker from local pdfjs-dist instead of a CDN", () => {
+    usePdfPreviewStore.setState({
+      openPdfPreviewDrawer: {
+        url: "/files/sample.pdf",
+        name: "sample.pdf",
+        type: "pdf",
+        isPublic: true,
+      },
+    });
+
+    render(<PdfPreviewDrawer />);
+
+    const worker = screen.getByTestId("pdfjs-worker");
+    const workerUrl = worker.getAttribute("data-worker-url") || "";
+
+    expect(workerUrl).toBeTruthy();
+    expect(workerUrl).toMatch(/pdf\.worker(\.min)?\.(js|mjs)/i);
+    expect(workerUrl).not.toMatch(/unpkg|jsdelivr|cdnjs|cdn\./i);
+    expect(screen.getByTestId("pdfjs-viewer")).toHaveAttribute(
+      "data-file-url",
+      "/files/sample.pdf",
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- Load the pdf.js worker from the local `pdfjs-dist` dependency (`pdf.worker.min.js?url`) instead of unpkg.
- Matches the pinned 3.11.174 package so offline self-host and strict CSP no longer depend on a CDN.

Closes #2339

## Test plan
- [x] Unit test: PdfPreviewDrawer worker URL is local, not unpkg/jsdelivr/cdn
- [ ] Open a PDF preview in the app and confirm the worker request is same-origin / bundled, not unpkg