### PR TITLE
fix: synchronize A2A Agent.Card writes in the registry (#2337)

### DIFF
--- a/agentcc-gateway/internal/a2a/registry.go
+++ b/agentcc-gateway/internal/a2a/registry.go
@@ -12,13 +12,19 @@ import (
 
 // Agent represents a configured external A2A agent.
 type Agent struct {
-	Name        string   `json:"name"`
-	URL         string   `json:"url"`
-	Auth        A2AAuth  `json:"-"`
-	Card        *AgentCard `json:"card,omitempty"`
-	Description string   `json:"description,omitempty"`
-	Skills      []Skill  `json:"skills,omitempty"`
+	Name        string  `json:"name"`
+	URL         string  `json:"url"`
+	Auth        A2AAuth `json:"-"`
+	Description string  `json:"description,omitempty"`
+	Skills      []Skill `json:"skills,omitempty"`
+	card        atomic.Pointer[AgentCard]
 	healthy     atomic.Bool
+}
+
+// Card returns the last fetched agent card, if any.
+// Safe for concurrent use with FetchCards.
+func (a *Agent) Card() *AgentCard {
+	return a.card.Load()
 }
 
 // Healthy returns whether this agent is reachable.
@@ -138,7 +144,7 @@ func (r *Registry) FetchCards(ctx context.Context) {
 				return
 			}
 
-			a.Card = &card
+			a.card.Store(&card)
 			a.healthy.Store(true)
 			slog.Info("a2a: fetched agent card", "agent", a.Name, "skills", len(card.Skills))
 		}(agent)

--- a/agentcc-gateway/internal/a2a/registry_test.go
+++ b/agentcc-gateway/internal/a2a/registry_test.go
@@ -1,7 +1,13 @@
 package a2a
 
 import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"sync"
 	"testing"
+	"time"
 )
 
 func TestRegistryGet(t *testing.T) {
@@ -103,4 +109,120 @@ func TestRegistryWithSkills(t *testing.T) {
 	if a.Skills[0].ID != "book" {
 		t.Fatalf("expected skill id 'book', got %s", a.Skills[0].ID)
 	}
+}
+
+func TestAgentCardNilByDefault(t *testing.T) {
+	r := NewRegistry(map[string]AgentConfig{
+		"test": {URL: "http://test.local"},
+	})
+	a, _ := r.Get("test")
+	if a.Card() != nil {
+		t.Fatal("expected nil card before fetch")
+	}
+}
+
+func TestFetchCardsStoresCard(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/.well-known/agent.json" {
+			http.NotFound(w, r)
+			return
+		}
+		json.NewEncoder(w).Encode(AgentCard{
+			Name:    "travel",
+			URL:     "http://travel.local",
+			Version: "1.0",
+			Skills:  []Skill{{ID: "book", Name: "Book"}},
+		})
+	}))
+	defer srv.Close()
+
+	reg := NewRegistry(map[string]AgentConfig{
+		"travel": {URL: srv.URL},
+	})
+	reg.FetchCards(context.Background())
+
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		a, ok := reg.Get("travel")
+		if !ok {
+			t.Fatal("agent missing")
+		}
+		card := a.Card()
+		if card != nil {
+			if card.Name != "travel" {
+				t.Fatalf("expected name travel, got %s", card.Name)
+			}
+			if len(card.Skills) != 1 || card.Skills[0].ID != "book" {
+				t.Fatalf("unexpected skills: %+v", card.Skills)
+			}
+			if !a.Healthy() {
+				t.Fatal("expected healthy after successful card fetch")
+			}
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("timed out waiting for agent card")
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}
+
+func TestFetchCardsAndListRace(t *testing.T) {
+	// Keep readers live until a background Store is observed so -race can
+	// see concurrent Card() loads vs FetchCards stores.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(AgentCard{Name: "race", Version: "1.0"})
+	}))
+	defer srv.Close()
+
+	reg := NewRegistry(map[string]AgentConfig{
+		"race": {URL: srv.URL},
+	})
+	ctx := context.Background()
+
+	stop := make(chan struct{})
+	var wg sync.WaitGroup
+	for i := 0; i < 8; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for {
+				select {
+				case <-stop:
+					return
+				default:
+					for _, a := range reg.List() {
+						_ = a.Card()
+						_ = a.Healthy()
+					}
+				}
+			}
+		}()
+	}
+
+	for i := 0; i < 20; i++ {
+		reg.FetchCards(ctx)
+	}
+
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		a, ok := reg.Get("race")
+		if !ok {
+			close(stop)
+			wg.Wait()
+			t.Fatal("agent missing")
+		}
+		if a.Card() != nil {
+			break
+		}
+		if time.Now().After(deadline) {
+			close(stop)
+			wg.Wait()
+			t.Fatal("timed out waiting for agent card during race test")
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+
+	close(stop)
+	wg.Wait()
 }

--- a/agentcc-gateway/internal/a2a/server.go
+++ b/agentcc-gateway/internal/a2a/server.go
@@ -143,7 +143,7 @@ func (s *Server) ListAgents(w http.ResponseWriter, r *http.Request) {
 			Description: a.Description,
 			Skills:      a.Skills,
 			Healthy:     a.Healthy(),
-			Card:        a.Card,
+			Card:        a.Card(),
 		})
 	}
 

--- a/agentcc-gateway/internal/a2a/server_test.go
+++ b/agentcc-gateway/internal/a2a/server_test.go
@@ -2,10 +2,14 @@ package a2a
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"sync"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/futureagi/agentcc-gateway/internal/mcp"
 )
@@ -298,4 +302,71 @@ func TestTasksCancel(t *testing.T) {
 	if task.Status.State != TaskStatusCanceled {
 		t.Fatalf("expected canceled, got %s", task.Status.State)
 	}
+}
+
+func TestListAgentsConcurrentWithFetchCards(t *testing.T) {
+	cardSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(AgentCard{Name: "travel", Version: "1.0"})
+	}))
+	defer cardSrv.Close()
+
+	reg := NewRegistry(map[string]AgentConfig{
+		"travel": {URL: cardSrv.URL, Description: "Travel agent"},
+	})
+	s := NewServer(CardConfig{Name: "test"}, reg)
+
+	stop := make(chan struct{})
+	var wg sync.WaitGroup
+	var sawCard atomic.Bool
+	for i := 0; i < 8; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			type agentInfo struct {
+				Name string     `json:"name"`
+				Card *AgentCard `json:"card"`
+			}
+			for {
+				select {
+				case <-stop:
+					return
+				default:
+					req := httptest.NewRequest("GET", "/v1/agents", nil)
+					w := httptest.NewRecorder()
+					s.ListAgents(w, req)
+					if w.Code != http.StatusOK {
+						t.Errorf("expected 200, got %d", w.Code)
+						return
+					}
+					var result []agentInfo
+					if err := json.NewDecoder(w.Body).Decode(&result); err != nil {
+						t.Errorf("decode: %v", err)
+						return
+					}
+					for _, info := range result {
+						if info.Card != nil {
+							sawCard.Store(true)
+						}
+					}
+				}
+			}
+		}()
+	}
+
+	for i := 0; i < 20; i++ {
+		reg.FetchCards(context.Background())
+	}
+
+	deadline := time.Now().Add(2 * time.Second)
+	for !sawCard.Load() {
+		if time.Now().After(deadline) {
+			close(stop)
+			wg.Wait()
+			t.Fatal("timed out waiting for card in GET /v1/agents")
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+
+	close(stop)
+	wg.Wait()
 }


### PR DESCRIPTION
## Summary
- Store fetched A2A agent cards in `atomic.Pointer[AgentCard]` and expose `Agent.Card()`, matching `healthy`.
- `GET /v1/agents` reads via `Card()` so background `FetchCards` no longer races the `*AgentCard` pointer.
- Adds `-race` tests for List/Card and ListAgents vs FetchCards.

`List()`/`Get()` return `*Agent` after releasing the registry lock, so locking only the write would still race post-unlock readers.

Closes #2337

## Test plan
- [x] `cd agentcc-gateway && go test -race -count=1 ./internal/a2a/`