### PR TITLE
fix(falcon-ai): pass the configured provider to the agent's LLM client

### DIFF
--- a/futureagi/ee/falcon_ai/agent.py
+++ b/futureagi/ee/falcon_ai/agent.py
@@ -1,5 +1,6 @@
 import asyncio
 import json
+import os
 import re
 import traceback
 import uuid
@@ -43,7 +44,9 @@ class AgentLoop:
     def __init__(self, tool_context: ToolContext, conversation):
         self.tool_context = tool_context
         self.conversation = conversation
-        self.llm_client = FalconLLMClient()
+        self.llm_client = FalconLLMClient(
+            provider=os.environ.get("FALCON_AI_PROVIDER") or None
+        )
         self.prompt_builder = PromptBuilder()
         self.context_manager = ContextManager()
         self.tools = []

--- a/futureagi/ee/falcon_ai/tests/test_agent.py
+++ b/futureagi/ee/falcon_ai/tests/test_agent.py
@@ -256,3 +256,21 @@ class TestAgentRun:
     async def test_max_iterations_constant(self):
         """MAX_ITERATIONS should be a reasonable limit."""
         assert AgentLoop.MAX_ITERATIONS == 200
+
+
+class TestAgentLoopProviderRouting:
+    def test_env_provider_disables_managed_gateway(self, monkeypatch):
+        """A configured provider must reach the client the agent actually builds."""
+        monkeypatch.setenv("FALCON_AI_PROVIDER", "openai")
+
+        agent = AgentLoop(MagicMock(), MagicMock())
+
+        assert agent.llm_client.use_managed_gateway is False
+        assert agent.llm_client.provider == "openai"
+
+    def test_no_env_provider_keeps_managed_gateway(self, monkeypatch):
+        monkeypatch.delenv("FALCON_AI_PROVIDER", raising=False)
+
+        agent = AgentLoop(MagicMock(), MagicMock())
+
+        assert agent.llm_client.use_managed_gateway is True


### PR DESCRIPTION
## Problem / Summary

`AgentLoop.__init__` constructed `FalconLLMClient()` with no arguments. `FalconLLMClient` accepts a `provider`, and when one is supplied it turns off the managed gateway and routes directly to that provider. Because the agent never passed one, a configured `FALCON_AI_PROVIDER` had no effect on the agent path: every agent turn stayed on the managed gateway regardless of how the deployment was configured.

The setting was not ignored everywhere, which is why this was easy to miss. It reached other call sites that construct the client themselves. The agent, which is the path that actually runs the turns, was the one that dropped it.

## Fix / Changes

- `ee/falcon_ai/agent.py` — pass `provider=os.environ.get("FALCON_AI_PROVIDER") or None` into `FalconLLMClient`. The `or None` keeps an empty or unset variable falling back to the managed gateway exactly as before, so the default path is unchanged.
- `ee/falcon_ai/tests/test_agent.py` — two behavioural tests on the real construction path, asserting the resulting client's state rather than the call arguments:
  - provider set means `use_managed_gateway is False` and `provider == "openai"`
  - provider unset means `use_managed_gateway is True`

## Verification / Test plan

Run against the shared test stack, `DJANGO_SETTINGS_MODULE=tfc.settings.test`.

Before the fix, with the new tests in place and `agent.py` reverted:

```
ee/falcon_ai/tests/test_agent.py F.                                      [100%]
E   assert True is False
E    +  where True = <FalconLLMClient object>.use_managed_gateway
1 failed, 1 passed in 0.16s
```

After the fix, the whole file:

```
collected 18 items
ee/falcon_ai/tests/test_agent.py ..................                      [100%]
18 passed in 1.36s
```

## Screenshots

Backend only, so the proof is the captured test output rendered side by side. Left is the same test file with the fix reverted; right is with it applied.

![before and after](https://github.com/user-attachments/assets/ac163cc0-0ff9-4e65-9755-7818136dfd5a)


## Out of scope

- The other construction sites of `FalconLLMClient` already pass a provider and are untouched.
- Model selection (`FALCON_AI_MODEL`) is a separate setting and is not changed here.


