### PR TITLE
fix(ai-tools): stop eval creation from silently binding the wrong data

### DIFF
--- a/futureagi/ai_tools/tests/test_tracing_tools.py
+++ b/futureagi/ai_tools/tests/test_tracing_tools.py
@@ -319,3 +319,167 @@ class TestDeleteProjectTool:
         )
 
         assert result.is_error
+
+
+# ---------------------------------------------------------------------------
+# Eval config + eval task creation
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def span_attributes(monkeypatch):
+    """Pin the project's attribute union so mapping behaviour is deterministic."""
+    from tracer.utils.sql_queries import SQL_query_handler
+
+    attrs = ["llm.input_messages", "llm.output_messages"]
+    monkeypatch.setattr(
+        SQL_query_handler,
+        "get_span_attributes_for_project",
+        staticmethod(lambda project_id: attrs),
+    )
+    return attrs
+
+
+class TestCreateCustomEvalConfigMapping:
+    def _template(self, tool_context, required):
+        from ai_tools.tests.fixtures import make_eval_template
+
+        return make_eval_template(
+            tool_context,
+            name=f"tmpl-{uuid.uuid4().hex[:6]}",
+            config={"required_keys": required},
+        )
+
+    def test_unmatchable_required_key_is_not_silently_guessed(
+        self, tool_context, project, span_attributes
+    ):
+        """`grading_rubric` has no counterpart, so nothing may be created."""
+        from tracer.models.custom_eval_config import CustomEvalConfig
+
+        template = self._template(tool_context, ["grading_rubric"])
+
+        result = run_tool(
+            "create_custom_eval_config",
+            {
+                "project_id": str(project.id),
+                "eval_template_id": str(template.id),
+                "name": "rubric-eval",
+            },
+            tool_context,
+        )
+
+        assert result.is_error
+        assert "grading_rubric" in result.content
+        assert not CustomEvalConfig.objects.filter(
+            project=project, name="rubric-eval"
+        ).exists()
+
+    def test_supplied_mapping_must_cover_every_required_key(
+        self, tool_context, project, span_attributes
+    ):
+        from tracer.models.custom_eval_config import CustomEvalConfig
+
+        template = self._template(tool_context, ["input", "output"])
+
+        result = run_tool(
+            "create_custom_eval_config",
+            {
+                "project_id": str(project.id),
+                "eval_template_id": str(template.id),
+                "name": "half-mapped",
+                "mapping": {"input": "llm.input_messages"},
+            },
+            tool_context,
+        )
+
+        assert result.is_error
+        assert "output" in result.content
+        assert not CustomEvalConfig.objects.filter(
+            project=project, name="half-mapped"
+        ).exists()
+
+    def test_complete_mapping_creates_the_config(
+        self, tool_context, project, span_attributes
+    ):
+        template = self._template(tool_context, ["input", "output"])
+
+        result = run_tool(
+            "create_custom_eval_config",
+            {
+                "project_id": str(project.id),
+                "eval_template_id": str(template.id),
+                "name": "fully-mapped",
+                "mapping": {
+                    "input": "llm.input_messages",
+                    "output": "llm.output_messages",
+                },
+            },
+            tool_context,
+        )
+
+        assert not result.is_error
+        assert result.data["mapping"] == {
+            "input": "llm.input_messages",
+            "output": "llm.output_messages",
+        }
+
+
+class TestCreateEvalTaskFilters:
+    @pytest.fixture
+    def eval_config(self, tool_context, project):
+        from ai_tools.tests.fixtures import make_eval_template
+        from tracer.models.custom_eval_config import CustomEvalConfig
+
+        return CustomEvalConfig.objects.create(
+            eval_template=make_eval_template(
+                tool_context, name=f"tmpl-{uuid.uuid4().hex[:6]}"
+            ),
+            name="cfg",
+            project=project,
+            model="turing_large",
+            mapping={"input": "llm.input_messages"},
+            config={},
+        )
+
+    def test_key_the_dispatcher_cannot_read_is_rejected(
+        self, tool_context, project, eval_config
+    ):
+        """`span_type` is not a dispatcher key; it must not reach the task."""
+        from tracer.models.eval_task import EvalTask
+
+        result = run_tool(
+            "create_eval_task",
+            {
+                "project_id": str(project.id),
+                "name": "wrongly-scoped",
+                "eval_config_ids": [str(eval_config.id)],
+                "filters": {"span_type": "llm"},
+            },
+            tool_context,
+        )
+
+        assert result.is_error
+        assert not EvalTask.objects.filter(
+            project=project, name="wrongly-scoped"
+        ).exists()
+
+    def test_observation_type_filter_reaches_the_task(
+        self, tool_context, project, eval_config
+    ):
+        from tracer.models.eval_task import EvalTask
+
+        result = run_tool(
+            "create_eval_task",
+            {
+                "project_id": str(project.id),
+                "name": "llm-only",
+                "eval_config_ids": [str(eval_config.id)],
+                "filters": {"observation_type": ["llm"]},
+            },
+            tool_context,
+        )
+
+        assert not result.is_error
+        task = EvalTask.objects.get(id=result.data["id"])
+        assert task.filters["observation_type"] == ["llm"]
+        assert task.filters["project_id"] == str(project.id)

--- a/futureagi/ai_tools/tools/tracing/create_custom_eval_config.py
+++ b/futureagi/ai_tools/tools/tracing/create_custom_eval_config.py
@@ -14,6 +14,7 @@ from ai_tools.formatting import (
 )
 from ai_tools.registry import register_tool
 from model_hub.utils.eval_mapping import non_path_mapping_keys
+from model_hub.utils.eval_validators import validate_required_key_mapping
 
 logger = structlog.get_logger(__name__)
 
@@ -69,9 +70,6 @@ def _auto_map_keys(
     for key in required_keys:
         best_match, score = _find_best_match(key, available_attributes)
         if score >= min_score_required and best_match:
-            mapping[key] = best_match
-        # Still include with empty value so caller knows it was not matched
-        elif best_match:
             mapping[key] = best_match
 
     for key in optional_keys:
@@ -132,9 +130,10 @@ class CreateCustomEvalConfigTool(BaseTool):
         "Creates an evaluation config on a tracing project. "
         "This configures an eval template to run on spans in the project. "
         "Once created, use create_eval_task to run the eval on historical or incoming spans. "
-        "If mapping is not provided, it auto-maps template keys to the closest matching "
-        "span attributes in the project. If mapping is provided, it validates that all "
-        "attribute values exist in the project's spans."
+        "Always pass an explicit mapping: values must be attribute keys that exist "
+        "on the spans this eval will run against. Without one the tool falls back to "
+        "name-similarity guessing and refuses to create the config if any required "
+        "key cannot be matched confidently."
     )
     category = "tracing"
     input_model = CreateCustomEvalConfigInput
@@ -235,6 +234,26 @@ class CreateCustomEvalConfigTool(BaseTool):
                 )
             else:
                 final_mapping = {}
+
+        # Required keys must all be mapped, whether the caller supplied the
+        # mapping or it was auto-mapped. Same shared validator and same
+        # user-custom-eval carve-out as add_dataset_eval.
+        is_user_custom_eval = bool(template_config.get("custom_eval", False))
+        if not is_user_custom_eval:
+            missing_keys = validate_required_key_mapping(final_mapping, required_keys)
+            if missing_keys:
+                missing_list = ", ".join(f"`{k}`" for k in missing_keys)
+                required_list = ", ".join(f"`{k}`" for k in required_keys)
+                available_list = ", ".join(f"`{a}`" for a in sorted(available_attributes))
+                return ToolResult.error(
+                    f"Missing required mapping keys: {missing_list}. "
+                    f"Required: {required_list}.\n\n"
+                    f"Available attributes: {available_list}\n\n"
+                    "Pass an explicit `mapping` naming a real span attribute for "
+                    "every required key. Use `get_project_eval_attributes` to see "
+                    "the keys this project carries.",
+                    error_code="VALIDATION_ERROR",
+                )
 
         # Clean up optional keys with empty values from mapping
         if optional_keys:

--- a/futureagi/ai_tools/tools/tracing/create_eval_task.py
+++ b/futureagi/ai_tools/tools/tracing/create_eval_task.py
@@ -50,8 +50,11 @@ class CreateEvalTaskInput(PydanticBaseModel):
     filters: Optional[dict] = Field(
         default=None,
         description=(
-            "Optional filters to narrow which spans to evaluate. "
-            "Example: {'span_type': 'llm', 'model': 'gpt-4o'}"
+            "Optional filters to narrow which spans to evaluate. Only the keys "
+            "the eval dispatcher reads are accepted; anything else is rejected. "
+            "Span type is `observation_type`, not `span_type`. "
+            "Example: {'observation_type': ['llm'], 'date_range': "
+            "['2026-01-01T00:00:00Z', '2026-02-01T00:00:00Z']}"
         ),
     )
 
@@ -114,8 +117,20 @@ class CreateEvalTaskTool(BaseTool):
                 error_code="NOT_FOUND",
             )
 
-        # Build filters
-        filters = params.filters or {}
+        # Build filters. Route them through the same strict field the eval-task
+        # API uses, so an unknown key is rejected here instead of being stored
+        # and then silently dropped by parsing_evaltask_filters at run time.
+        from rest_framework.exceptions import ValidationError as DRFValidationError
+
+        from tracer.serializers.filters import eval_task_filters_field
+
+        try:
+            filters = eval_task_filters_field().run_validation(params.filters or {})
+        except DRFValidationError as exc:
+            return ToolResult.error(
+                f"Invalid filters: {exc.detail}",
+                error_code="VALIDATION_ERROR",
+            )
         filters["project_id"] = str(params.project_id)
 
         # Create eval task
@@ -155,7 +170,12 @@ class CreateEvalTaskTool(BaseTool):
                 ("Run Type", params.run_type),
                 ("Evals", ", ".join(eval_names)),
                 ("Sampling Rate", f"{params.sampling_rate}%"),
-                ("Spans Limit", str(params.spans_limit)),
+                (
+                    "Spans Limit",
+                    str(params.spans_limit)
+                    if params.run_type == "historical"
+                    else "n/a for a continuous run",
+                ),
                 ("Status", eval_task.status),
                 ("Created", format_datetime(eval_task.created_at)),
             ]


### PR DESCRIPTION
## Problem / Summary

Three independent defects on the eval-creation path let an agent build an eval that looks configured, validates, runs to completion, and scores the wrong data. None of them produce an error, so the failure only surfaces later as numbers nobody can explain.

**1. Auto-mapping bound required keys below its own confidence threshold.** `_auto_map_keys` computes a similarity score and compares it against `min_score_required`. On the failing branch it still assigned the nearest attribute:

```python
if score >= min_score_required and best_match:
    mapping[key] = best_match
# Still include with empty value so caller knows it was not matched
elif best_match:
    mapping[key] = best_match
```

The comment describes an empty value; the code assigns the same match as the passing branch, so the threshold had no effect for required keys. A template key with no real counterpart in the project came back bound to whatever was nearest. Optional keys were handled correctly, which is part of why this stayed hidden.

**2. A caller-supplied mapping was never checked for required-key completeness.** `validate_required_key_mapping` already exists and is used by `add_dataset_eval` and the eval views. This one tool skipped it, so a mapping omitting a required key was accepted. At run time the missing key is filled with an empty string, so the eval scores against nothing rather than failing.

**3. `create_eval_task` bypassed the strict filter field.** The API routes eval-task filters through `EvalTaskFiltersField`, which rejects unknown keys precisely so they are not silently dropped later. The tool wrote `params.filters` straight to the model. Its own docstring told callers to pass `{'span_type': 'llm', 'model': 'gpt-4o'}`, and neither key is one the dispatcher reads: `parsing_evaltask_filters` is an if/elif chain with no fallback, so both are ignored and the task evaluates every span up to `spans_limit` instead of the intended subset.

## Fix / Changes

- `create_custom_eval_config.py`
  - Auto-mapping no longer assigns a match that scored below the threshold.
  - Both mapping paths, supplied and auto-mapped, now run through the shared `validate_required_key_mapping`, keeping the same user-custom-eval carve-out `add_dataset_eval` uses so partial mappings on user-built evals still work. The error names the missing keys and the attributes the project actually has.
  - Tool description no longer advertises auto-mapping as a safe default.
- `create_eval_task.py`
  - Filters run through `eval_task_filters_field()`, the same field the API uses, so an unreadable key is rejected at creation instead of stored and ignored.
  - Description names `observation_type` rather than the two keys that do nothing.
  - The result block no longer reports a spans limit on a continuous run, where it is never applied.
- `test_tracing_tools.py` — five behavioural tests through `run_tool`, asserting on stored rows rather than call arguments.

## Verification / Test plan

Shared test stack, `DJANGO_SETTINGS_MODULE=tfc.settings.test`.

Before, with the tests in place and only the two tool files reverted:

```
3 failed, 2 passed, 26 deselected in 1.11s

test_supplied_mapping_must_cover_every_required_key
E   AssertionError: assert False
    ToolResult(content='## Custom Eval Config Created ... 'mapping': {'input': 'llm.input_messages'}}, is_error=False)

test_key_the_dispatcher_cannot_read_is_rejected
E   AssertionError: assert False
    ToolResult(content='## Eval Task Created ... **Name:** wrongly-scoped ... is_error=False)
```

The half-mapped config and the wrongly scoped task were both created, exactly as described above.

After, with the fixes and the surrounding suites for regression:

```
collected 111 items
ai_tools/tests/test_tracing_tools.py ...............................     [ 27%]
ai_tools/tests/test_workflows_eval_tracing.py ...                        [ 30%]
ai_tools/tests/test_evaluation_tools.py ...............................  [ 58%]
ai_tools/tests/test_dataset_tools.py ...........................         [100%]
111 passed in 3.51s
```

## Screenshots

Backend only, so the proof is the captured test output rendered side by side. Left is the same test file with the fix reverted; right is with it applied.

![before and after](https://github.com/user-attachments/assets/f23d3c3f-df24-49de-bb88-4fa35844ef7c)


## Video

The same fix exercised end to end through the product, on a project with 1,229 spans. An agent is asked for an eval readiness pack, writes it, and is then asked to build the evals it recommended. It creates two custom eval configs and one historical eval task.

https://github.com/user-attachments/assets/1d9f9d92-dff1-4765-b28d-31beb72fb421

The task it created carries `{"project_id": "..."}` and nothing else, which is this PR's second change working: before it, the filter dict was written straight to the model, so a key the dispatcher cannot read was stored and silently ignored. Both configs were created with an explicit mapping, which is the first change: an omitted or incomplete mapping is now refused instead of being guessed at.

Recorded headless at 2800x1784 and time-compressed. The agent skill driving it is a local development row and is not part of this PR.


## Out of scope

- Mapping slots that exist in the project but never co-occur on the same span still pass. The attribute list is a union over the project, so co-occurrence cannot be established from it, and an eval bound across two span types scores nothing. That needs a per-span check and is left for a follow-up.
- The `filters` shape accepted by `EvalTaskFiltersField` is unchanged; this only stops the tool from writing around it.



