### PR TITLE
fix(ai-tools): let eval-template lookups see the system templates

### DIFF
--- a/futureagi/ai_tools/resolvers.py
+++ b/futureagi/ai_tools/resolvers.py
@@ -12,6 +12,7 @@ import uuid
 from typing import Optional
 
 import structlog
+from django.db.models import Q
 
 # Module-scope imports so unit tests can patch these symbols
 from model_hub.models.develop_dataset import Dataset
@@ -117,27 +118,36 @@ def resolve_project(identifier: str, organization, workspace=None):
     return None, f"No project found matching '{identifier}'."
 
 
+def visible_eval_templates(organization):
+    """The set a caller is allowed to READ: this organization's templates, plus the
+    system ones, which carry no organization and no workspace.
+
+    This is the predicate `list_eval_templates` and `run_evaluation` already use. It has
+    to be `no_workspace_objects`, because the default manager filters by the current
+    workspace and a system template has none, so `EvalTemplate.objects` cannot see one at
+    all. Write paths stay on `EvalTemplate.objects` on purpose: a system template is not
+    yours to edit or delete.
+    """
+    return EvalTemplate.no_workspace_objects.filter(
+        Q(organization=organization) | Q(organization__isnull=True),
+        deleted=False,
+    )
+
+
 def resolve_eval_template(identifier: str, organization, workspace=None):
     """Resolve an eval template by name or UUID."""
     if not identifier:
         return None, "Eval template identifier is required."
 
+    visible = visible_eval_templates(organization)
+
     if is_uuid(identifier):
         try:
-            return (
-                EvalTemplate.objects.get(
-                    id=identifier, organization=organization, deleted=False
-                ),
-                None,
-            )
+            return visible.get(id=identifier), None
         except EvalTemplate.DoesNotExist:
             return None, f"Eval template with ID `{identifier}` not found."
 
-    matches = EvalTemplate.objects.filter(
-        name__iexact=identifier.strip(),
-        organization=organization,
-        deleted=False,
-    )
+    matches = visible.filter(name__iexact=identifier.strip())
     if matches.count() == 1:
         return matches.first(), None
     elif matches.count() > 1:
@@ -145,11 +155,7 @@ def resolve_eval_template(identifier: str, organization, workspace=None):
         return None, f"Multiple templates match '{identifier}': {', '.join(names)}."
 
     # Try fuzzy
-    fuzzy = EvalTemplate.objects.filter(
-        name__icontains=identifier.strip(),
-        organization=organization,
-        deleted=False,
-    )[:5]
+    fuzzy = visible.filter(name__icontains=identifier.strip())[:5]
     if fuzzy.exists():
         suggestions = [f"`{t.name}` (ID: {t.id})" for t in fuzzy]
         return (

--- a/futureagi/ai_tools/tests/test_dataset_tools.py
+++ b/futureagi/ai_tools/tests/test_dataset_tools.py
@@ -4,7 +4,11 @@ import pytest
 
 from ai_tools.registry import registry
 from ai_tools.tests.conftest import run_tool
-from ai_tools.tests.fixtures import make_dataset, make_dataset_with_rows
+from ai_tools.tests.fixtures import (
+    make_dataset,
+    make_dataset_with_rows,
+    make_eval_template,
+)
 
 # ---------------------------------------------------------------------------
 # Shared fixtures
@@ -689,3 +693,90 @@ class TestUpdateCellValueTool:
 
         assert not result.is_error
         assert result.data["updated"] == 2
+
+
+class TestSystemEvalTemplateResolution:
+    """A system template carries no organization and no workspace, which is exactly what
+    the default manager filters out. `list_eval_templates` hands those ids to the caller,
+    so every tool that consumes one has to be able to resolve it."""
+
+    @staticmethod
+    def _make_global(template):
+        """A pre_save signal back-fills organization and workspace from the current
+        context, so a system template cannot be created by passing None. A queryset
+        update writes the row without firing it."""
+        from model_hub.models.evals_metric import EvalTemplate
+
+        EvalTemplate.all_objects.filter(id=template.id).update(
+            organization=None, workspace=None
+        )
+        template.refresh_from_db()
+        assert template.organization_id is None and template.workspace_id is None
+        return template
+
+    @pytest.fixture
+    def system_template(self, tool_context):
+        return self._make_global(
+            make_eval_template(
+                tool_context,
+                name="is_concise",
+                config={"required_keys": ["output"]},
+            )
+        )
+
+    def test_listed_template_can_be_added_to_a_dataset_by_id(
+        self, tool_context, writable_dataset, system_template
+    ):
+        listed = registry.get("list_eval_templates").run(
+            {"search": "is_concise"}, tool_context
+        )
+        assert not listed.is_error
+        assert "is_concise" in listed.content
+
+        result = registry.get("add_dataset_eval").run(
+            {
+                "dataset_id": str(writable_dataset.id),
+                "template_id": str(system_template.id),
+                "mapping": {"output": "output"},
+            },
+            tool_context,
+        )
+        assert not result.is_error, result.content
+
+    def test_listed_template_can_be_added_by_name(
+        self, tool_context, writable_dataset, system_template
+    ):
+        result = registry.get("add_dataset_eval").run(
+            {
+                "dataset_id": str(writable_dataset.id),
+                "template_id": "is_concise",
+                "mapping": {"output": "output"},
+            },
+            tool_context,
+        )
+        assert not result.is_error, result.content
+
+    def test_get_eval_template_resolves_a_system_template(
+        self, tool_context, system_template
+    ):
+        result = registry.get("get_eval_template").run(
+            {"eval_template_id": str(system_template.id)}, tool_context
+        )
+        assert not result.is_error, result.content
+        assert "is_concise" in result.content
+
+    def test_another_organizations_template_stays_invisible(self, tool_context):
+        from accounts.models.organization import Organization
+
+        from ai_tools.resolvers import resolve_eval_template
+
+        other = Organization.objects.create(name="Someone Else")
+        theirs = make_eval_template(
+            tool_context, name="their_private_eval", organization=other, workspace=None
+        )
+
+        found, error = resolve_eval_template(
+            str(theirs.id), tool_context.organization
+        )
+        assert found is None
+        assert "not found" in error

--- a/futureagi/ai_tools/tests/test_resolvers.py
+++ b/futureagi/ai_tools/tests/test_resolvers.py
@@ -287,21 +287,46 @@ class TestResolveProject:
 
 
 class TestResolveEvalTemplate:
+    """The resolver reads through `no_workspace_objects`, filtered to this org or no org.
+
+    That is deliberate and these tests pin it: a system template carries no organization
+    and no workspace, so the default manager cannot see one, and every id
+    `list_eval_templates` hands out would be unresolvable.
+    """
+
+    @staticmethod
+    def _visible(MockTemplate):
+        """Stand in for `EvalTemplate.no_workspace_objects.filter(org-or-null)`."""
+        qs = MagicMock()
+        MockTemplate.no_workspace_objects.filter.return_value = qs
+        return qs
+
     @patch("ai_tools.resolvers.EvalTemplate")
     def test_resolve_by_uuid_found(self, MockTemplate):
         org = _make_mock_org()
         tmpl = _make_mock_obj("Faithfulness", obj_id=VALID_UUID)
-        MockTemplate.objects.get.return_value = tmpl
+        self._visible(MockTemplate).get.return_value = tmpl
 
         result, err = resolve_eval_template(VALID_UUID, org)
         assert result is tmpl
         assert err is None
 
     @patch("ai_tools.resolvers.EvalTemplate")
+    def test_reads_the_unscoped_manager(self, MockTemplate):
+        """The whole bug in one assertion: `objects` cannot see a system template."""
+        org = _make_mock_org()
+        self._visible(MockTemplate).get.return_value = _make_mock_obj("Faithfulness")
+
+        resolve_eval_template(VALID_UUID, org)
+        assert MockTemplate.no_workspace_objects.filter.called
+        assert not MockTemplate.objects.filter.called
+        assert not MockTemplate.objects.get.called
+
+    @patch("ai_tools.resolvers.EvalTemplate")
     def test_resolve_by_uuid_not_found(self, MockTemplate):
         org = _make_mock_org()
         MockTemplate.DoesNotExist = type("DoesNotExist", (Exception,), {})
-        MockTemplate.objects.get.side_effect = MockTemplate.DoesNotExist
+        self._visible(MockTemplate).get.side_effect = MockTemplate.DoesNotExist
 
         result, err = resolve_eval_template(VALID_UUID, org)
         assert result is None
@@ -315,7 +340,7 @@ class TestResolveEvalTemplate:
         qs = MagicMock()
         qs.count.return_value = 1
         qs.first.return_value = tmpl
-        MockTemplate.objects.filter.return_value = qs
+        self._visible(MockTemplate).filter.return_value = qs
 
         result, err = resolve_eval_template("Hallucination", org)
         assert result is tmpl
@@ -330,7 +355,7 @@ class TestResolveEvalTemplate:
         qs = MagicMock()
         qs.count.return_value = 2
         qs.__getitem__ = MagicMock(return_value=[t1, t2])
-        MockTemplate.objects.filter.return_value = qs
+        self._visible(MockTemplate).filter.return_value = qs
 
         result, err = resolve_eval_template("Custom Eval", org)
         assert result is None
@@ -343,14 +368,14 @@ class TestResolveEvalTemplate:
 
         exact_qs = MagicMock()
         exact_qs.count.return_value = 0
-        # Resolver does `EvalTemplate.objects.filter(...)[:5]` — make __getitem__
-        # return the same mock so configured exists/__iter__ stay applied.
+        # The resolver slices the fuzzy queryset, so __getitem__ returns the same mock
+        # and the configured exists/__iter__ stay applied.
         fuzzy_qs = MagicMock()
         fuzzy_qs.exists.return_value = True
         fuzzy_qs.__iter__ = MagicMock(return_value=iter([tmpl]))
         fuzzy_qs.__getitem__ = MagicMock(return_value=fuzzy_qs)
 
-        MockTemplate.objects.filter.side_effect = [exact_qs, fuzzy_qs]
+        self._visible(MockTemplate).filter.side_effect = [exact_qs, fuzzy_qs]
 
         result, err = resolve_eval_template("hallucination", org)
         assert result is None
@@ -367,7 +392,7 @@ class TestResolveEvalTemplate:
         fuzzy_qs.exists.return_value = False
         fuzzy_qs.__getitem__ = MagicMock(return_value=fuzzy_qs)
 
-        MockTemplate.objects.filter.side_effect = [exact_qs, fuzzy_qs]
+        self._visible(MockTemplate).filter.side_effect = [exact_qs, fuzzy_qs]
 
         result, err = resolve_eval_template("nonexistent", org)
         assert result is None

--- a/futureagi/ai_tools/tools/datasets/add_dataset_eval.py
+++ b/futureagi/ai_tools/tools/datasets/add_dataset_eval.py
@@ -63,7 +63,7 @@ class AddDatasetEvalTool(BaseTool):
 
         from ai_tools.resolvers import resolve_dataset, resolve_eval_template
         from model_hub.models.develop_dataset import Column
-        from model_hub.models.evals_metric import EvalTemplate, UserEvalMetric
+        from model_hub.models.evals_metric import UserEvalMetric
         from model_hub.utils.eval_result_columns import infer_eval_result_column_data_type
         from model_hub.utils.eval_validators import validate_eval_template_org_access
 
@@ -78,31 +78,12 @@ class AddDatasetEvalTool(BaseTool):
         template_obj, error = resolve_eval_template(
             params.template_id, context.organization, context.workspace
         )
-        if template_obj:
-            try:
-                template = EvalTemplate.objects.get(id=template_obj.id)
-            except EvalTemplate.DoesNotExist:
-                template = EvalTemplate.objects.filter(name=template_obj.name).first()
-                if not template:
-                    return ToolResult.not_found("EvalTemplate", params.template_id)
-        else:
-            # Try direct EvalTemplate lookup (system templates)
-            try:
-                from ai_tools.resolvers import is_uuid
-
-                if is_uuid(params.template_id):
-                    template = EvalTemplate.objects.get(id=params.template_id)
-                else:
-                    template = EvalTemplate.objects.filter(
-                        name__iexact=params.template_id
-                    ).first()
-                    if not template:
-                        return ToolResult.error(
-                            error or f"Eval template '{params.template_id}' not found.",
-                            error_code="NOT_FOUND",
-                        )
-            except EvalTemplate.DoesNotExist:
-                return ToolResult.not_found("EvalTemplate", params.template_id)
+        if not template_obj:
+            return ToolResult.error(
+                error or f"Eval template '{params.template_id}' not found.",
+                error_code="NOT_FOUND",
+            )
+        template = template_obj
 
         # Auto-generate name if not provided
         eval_name = params.name or f"{template.name}"

--- a/futureagi/ai_tools/tools/evaluations/get_eval_template.py
+++ b/futureagi/ai_tools/tools/evaluations/get_eval_template.py
@@ -44,10 +44,7 @@ class GetEvalTemplateTool(BaseTool):
         if err:
             return ToolResult.error(err, error_code="NOT_FOUND")
 
-        try:
-            template = EvalTemplate.objects.get(id=template_obj.id)
-        except EvalTemplate.DoesNotExist:
-            return ToolResult.not_found("Eval Template", str(template_obj.id))
+        template = template_obj
 
         config = template.config or {}
         required_keys = (

--- a/futureagi/ai_tools/tools/experiments/add_experiment_eval.py
+++ b/futureagi/ai_tools/tools/experiments/add_experiment_eval.py
@@ -83,10 +83,7 @@ class AddExperimentEvalTool(BaseTool):
         if err:
             return ToolResult.error(err, error_code="NOT_FOUND")
 
-        try:
-            template = EvalTemplate.objects.get(id=template_obj.id)
-        except EvalTemplate.DoesNotExist:
-            return ToolResult.not_found("EvalTemplate", str(template_obj.id))
+        template = template_obj
 
         # Check for duplicate
         if UserEvalMetric.objects.filter(


### PR DESCRIPTION
## Problem / Summary

An agent cannot use any of the platform's built-in eval templates. It can list them, it just cannot then do anything with one.

`list_eval_templates` reads the set a caller is allowed to see:

```python
qs = EvalTemplate.no_workspace_objects.filter(
    Q(organization=context.organization) | Q(organization__isnull=True),
    deleted=False,
)
```

`resolve_eval_template`, which every consuming tool goes through, read a different set:

```python
EvalTemplate.objects.get(id=identifier, organization=organization, deleted=False)
```

A system template carries no organization and no workspace, so that lookup excludes it twice. `EvalTemplate.objects` is `BaseModelManager`, which filters by the current workspace, and a system template has none. Then `organization=organization` excludes it again, because the column is null.

So the id the listing hands out is not resolvable by the tool that is supposed to consume it. Found while an agent worked a real project end to end: it read the template ids out of `list_eval_templates`, passed them straight to `add_dataset_eval`, and got back

```
Not Found: EvalTemplate with ID `fe11d9fb-4112-47ad-b8f1-4ba7423aed3f` was not found in this workspace.
Error:     No eval template found matching 'is_concise'.
```

for templates that are present, undeleted, and were listed to it seconds earlier. On this instance that is 156 of the 160 templates: every built-in one.

The correct predicate was already written twice in the codebase. `run_evaluation.py` guards with `EvalTemplate.no_workspace_objects.get(...)` and an org-or-null check, and `tfc/ee_gates.py` does the same. Only the shared resolver disagreed, which is why the failure reaches every caller.

## Fix / Changes

- `resolvers.py` — `visible_eval_templates(organization)` states the read set once, as `no_workspace_objects` plus `organization is this org or null`, the same predicate `list_eval_templates` and `run_evaluation` already use. All three lookups in `resolve_eval_template` (uuid, exact name, fuzzy) go through it.
- `add_dataset_eval.py` — the resolver already returns an `EvalTemplate`, so the re-fetch through the scoped manager and the "try direct lookup (system templates)" fallback are both gone. That fallback also used the scoped manager, so it never worked for the case it was written for.
- `get_eval_template.py`, `add_experiment_eval.py` — same redundant re-fetch dropped.
- Net 19 fewer lines.

Write paths are deliberately untouched. `create_eval_template`, `update_eval_template`, `delete_eval_template` and `duplicate_eval_template` stay on `EvalTemplate.objects`: a system template is readable by everyone and editable by no one, and this change must not open that.

## Verification / Test plan

Four behavioural tests through `run_tool`, asserting on tool results rather than call arguments. A signal back-fills organization and workspace on save, so the fixture writes the row through a queryset update to produce a genuinely global template, and asserts both columns are null before the test runs.

The fourth test is the tenancy guard: another organization's template must stay invisible. It passes both before and after, which is the point.

Before, with only the source files reverted:

```
3 failed, 1 passed, 46 deselected in 1.07s

E   AssertionError: **Not Found:** EvalTemplate with ID `4f66a6e4-...` was not found in this workspace.
E   AssertionError: **Error:** No eval template found matching 'is_concise'.
E   AssertionError: **Error:** Eval template with ID `044a1e38-...` not found.
```

Those are the same three messages the agent hit against the running stack.

After, with the surrounding suites for regression:

```
collected 117 items
ai_tools/tests/test_dataset_tools.py ...................................
ai_tools/tests/test_evaluation_tools.py ...............................
ai_tools/tests/test_tracing_tools.py ..........................
ai_tools/tests/test_experiment_tools.py ..........
117 passed in 3.55s
```

## Screenshots

Backend only, so the proof is the captured test output side by side. Left is the resolver as it is on `dev`, right is with the fix.

![before and after](https://github.com/user-attachments/assets/e00520df-ec64-4f08-ae0f-4b49acc7a96a)

## Out of scope

- The tools that create, edit, delete or duplicate a template keep the workspace-scoped manager on purpose, as above.
- `read_schema` and `read_taxonomy` also list templates through `EvalTemplate.objects` and will therefore under-report system templates in the context they build. That is a reporting gap rather than a hard failure, and it is left for a follow-up so this change stays to the resolve path.
