### PR TITLE
chore(skills): reviewing-prs

### DIFF
--- a/.agents/skills/reviewing-prs/SKILL.md
+++ b/.agents/skills/reviewing-prs/SKILL.md
@@ -1,0 +1,273 @@
+---
+name: reviewing-prs
+description: "Use when asked to review a pull request, branch, or diff — before approving, as a self-review before opening a PR, to judge whether a PR is ready — 'is PR 123 mergeable?', 'anything blocking here?' — or to answer 'does this change need an E2E flow'. Applies the FutureAGI coding standards and, in repos with an e2e/ harness, the E2E coverage gate. Not for reviewing a design doc or a single file in isolation, and not for carrying out git or GitHub operations on a PR such as merging, rebasing or landing it."
+metadata:
+  short-description: Review a PR against the coding standards with the E2E coverage gate
+---
+
+# Reviewing PRs
+
+## Overview
+
+The review is read-only until the human says post. Nothing is edited, staged, committed, pushed, or
+sent to GitHub from inside this procedure.
+
+The job is to move the catch from production into the diff. A finding is worth writing when it is
+concrete, introduced by this change, demonstrable from the code, and something the author would fix
+if they knew. Everything else is noise that costs the author's attention and your credibility.
+
+Track the seven procedure steps as todos and work them in order. Steps 3 and 4 are conditional on
+observable predicates; when a predicate is false, say so in the review rather than skipping
+silently.
+
+## Inputs
+
+The user supplies a PR number, a branch, or nothing (= the current branch against its base). If the
+base cannot be resolved by step 1, stop and ask which base to diff against. Do not guess.
+
+## Procedure
+
+### 1. Get the real diff
+
+Resolve the base in this order, first success wins:
+
+1. `gh pr view <n> --json baseRefName,body,title,headRefName,url` when a PR number or URL is known.
+2. The branch's upstream merge-base (`git rev-parse --abbrev-ref @{u}` → `git merge-base HEAD <upstream>`).
+3. Ask the user.
+
+**Never assume `dev` or `main`.** Stacked PRs target a feature branch, and a base guessed wrong turns
+someone else's merged work into your findings.
+
+Then, from a checkout of the head being reviewed:
+
+```
+git fetch origin <base> <head>
+git diff origin/<base>...HEAD            # the real diff (three dots)
+git diff --stat -w                       # mechanical churn vs real change
+git rev-list --left-right --count origin/<base>...HEAD
+```
+
+Record behind/ahead. A branch hundreds of commits behind its base is itself a finding, because every
+other conclusion in the review is drawn against stale code.
+
+Reviewing a PR you do not have checked out: fetch its head (`git fetch origin pull/<n>/head`) and
+diff that SHA, or check it out in a separate worktree. Do not switch the branch of the checkout you
+were handed.
+
+Reviewing a PR that has **already merged**: its base branch now contains its head, so
+`origin/<base>...HEAD` is empty and the behind/ahead counts describe history since the merge. Diff
+the branch point against the head instead (`git merge-base <base-at-merge> <head>`), and say in the
+review that the counts are as-of-merge.
+
+### 2. Read the body and the ticket; list every claimed behaviour change
+
+Write the list down before looking for bugs. Each entry is either confirmed against the diff in the
+later steps or reported as unsupported. Bodies lie by omission more often than by invention: a claim
+of tests, of a verification run, of "no migration", or of "moved verbatim" is a claim you check.
+
+A claimed verification with nothing in the diff to re-run it (a manual test plan, a screenshot, a
+browser session) is not evidence. Say so under **Should fix** with the concrete thing that would make
+it re-runnable.
+
+### 3. E2E coverage gate — only if `e2e/scripts/e2e-coverage.mjs` exists
+
+If the file is absent, the review still carries the block — same two-line shape as every other
+review, so the section is never missing:
+
+```
+## E2E coverage
+not applicable (no e2e/ harness) · flows hit: n/a · marker: n/a · verdict: not applicable
+```
+
+then go to step 4. If it exists, run it from the repo root:
+
+```
+node e2e/scripts/e2e-coverage.mjs --pr <n> --json          # a PR exists
+node e2e/scripts/e2e-coverage.mjs --base origin/<base> --body <file> --title "<branch or PR title>" --json
+```
+
+**The no-PR form needs `--title`.** A `feat` title in an area with no flows is one of the
+new-surface signals, so omitting the title silently weakens the classification — `--pr` supplies it
+from GitHub, nothing else does.
+
+**Pass `--pr` without `--base`.** The script resolves the base itself — explicit `--base`, else the
+PR's own base branch, else `origin/dev` — so supplying `--base` alongside `--pr` overrides the PR's
+real base and silently mis-classifies a stacked PR. Use `--base` only in the no-PR form. Add
+`--head <sha>` when the head being reviewed is not `HEAD`.
+
+`--pr` reads the title, body and base from GitHub but classifies **the local checkout's diff** — so
+the checkout must be at the PR's head. A result of `EXEMPT` with `autoReason: "no-changes"` means the
+checkout is wrong, not that the PR is exempt; fix the checkout and rerun.
+
+The one case that needs `--base` alongside `--pr` is an **already-merged** PR, where the PR's own
+base branch has since absorbed the head and resolves to an empty diff. Pin both ends explicitly —
+`--pr <n> --base <branch-point-sha> --head <head-sha>` — and say in the review that you did.
+
+Map `verdict` to a finding with the table in
+[references/e2e-coverage-policy.md](references/e2e-coverage-policy.md) — read it whenever the verdict
+is anything but `pass`, when the classification looks wrong for the diff you just read, or when a
+passing `EXEMPT` still names flows it hit:
+
+The script returns exactly three verdicts:
+
+| `verdict`      | What goes in the review                                                                                                                                                                                                                                                                                                              |
+| -------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `pass`         | The E2E block, with the classification and the flows hit. No finding — **unless** the classification is `EXEMPT` and the line still names flows. `EXEMPT` is decided before hits are consulted, so that pairing is real and informational: read the diff and see the policy reference's `backend-internal` row before you accept it. |
+| `needs-marker` | P1 "E2E coverage undeclared" — name the classification, the area(s), and the `E2E:` line the author should add.                                                                                                                                                                                                                      |
+| `block`        | P1 "Declared exemption contradicts the diff" — quote the marker and the signal that contradicts it.                                                                                                                                                                                                                                  |
+
+**`NEW-FLOW` passes on exactly one marker kind: `E2E: new <ID>`, with the `FLOWS.md` diff adding that
+id.** `updated`, `covered-by` and `exempt` all come back `block`. `NEW-FLOW` answered with
+`E2E: exempt (...)` is a reviewer override, not an author decision: ask the human one question —
+accept the override, or hold the PR for a flow — and put their answer in the review.
+
+If the coverage gate itself post-dates the PR you are reviewing (the script is absent from the base
+you diffed against), the classification still goes in the E2E block, but the missing marker is a
+**P2**, not a P1: the author could not declare against a gate that did not exist. Say which it is.
+
+If any file under `e2e/` changed, also apply
+[references/e2e-flow-review.md](references/e2e-flow-review.md) — the checklist for spec, catalog and
+quarantine diffs. Read it only when `e2e/` is in the diff.
+
+### 4. Mechanical gates with attribution — each keyed to a predicate
+
+Run them; never eyeball them. Run each gate on the base's version of the same files first, and report
+**only the delta**. A violation that exists identically on the base is pre-existing, and it is
+reported as pre-existing — not deleted from the review because CI happens not to run that gate.
+
+| Predicate                                                                         | Gate                                                                                                                                                          |
+| --------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| A `pyproject.toml` configures `[tool.ruff]` and `.py` files changed               | `ruff check` and `ruff format --check` on the changed files. A new F405 or F821 is a probable runtime `NameError` — treat it as P0 until you prove otherwise. |
+| A file under a `migrations/` directory changed                                    | `makemigrations --check --dry-run` with the test settings. A second leaf node blocks.                                                                         |
+| Any test file changed                                                             | Run the PR's own new tests. A failing new test ends the review until it is fixed.                                                                             |
+| `frontend/package.json` defines the scripts, and serializers or contracts changed | `yarn lint`, and the contract check the repo defines (`yarn contracts:check`).                                                                                |
+
+Never cite `yarn type-check` as evidence: without a `tsconfig.json` it is a no-op and proves nothing.
+
+State in the review what you ran and what you did not run, with the predicate that decided it.
+
+### 5. Trace the load-bearing path, then fan out by lens
+
+Trace the main changed path end to end yourself first — inputs, the branch that changed, the value
+written, the value read back. Then fan out.
+
+The rules live in [references/standards-checklist.md](references/standards-checklist.md), grouped by
+lens; load the section for the lens you are working, not the whole file. Dispatch one subagent per
+lens when subagents are available, each carrying that lens's section; otherwise work the lenses
+yourself in this order.
+
+| Lens                   | Checklist sections                                              |
+| ---------------------- | --------------------------------------------------------------- |
+| Migrations & data      | Migrations & data · Data modelling                              |
+| OSS/EE boundary        | OSS/EE boundary                                                 |
+| Contracts & types      | Contracts, types & codegen                                      |
+| Server/API layer       | Server/API layer                                                |
+| Correctness & logic    | Correctness & logic                                             |
+| Performance            | Performance                                                     |
+| Errors & failure modes | Errors & failure modes                                          |
+| Frontend               | Frontend                                                        |
+| Naming, git & comments | Naming & git · Comments                                         |
+| Testing & scenarios    | Testing & scenarios                                             |
+| PR hygiene & shape     | PR hygiene · File size & structure · Infra & rollout · Security |
+
+Run `git diff -w` over the diff as its own pass: a hunk that shrinks to nothing under `-w` is a
+reindent, and a hunk that does not is a logic change hiding inside one. For every new indentation
+level wrapped around old code, ask what now skips this.
+
+If `../internal-docs/coding-standards/` exists, or `$FUTUREAGI_INTERNAL_DOCS` points at a checkout,
+read the full standard behind a rule before writing the finding that cites it. Otherwise the
+checklist row is the citation.
+
+### 6. Adversarially verify every P0 and P1 before it is written down
+
+Reproduce the mechanism, grep the claim across the repo, or read the framework's own code. A wrong P0
+on a public review is worse than a missed P3.
+
+If verification kills the finding, it does not go in the review — not as a hedged paragraph, not as
+"defence in depth", not as a nit. If verification only weakens it, it goes in at the severity the
+evidence supports.
+
+### 7. Write the review
+
+Fill every slot. `No findings.` replaces an empty findings section; never invent a finding to fill
+one.
+
+```
+## E2E coverage
+<classification> · <flows hit or "none"> · marker: <verified | missing | contradicts | n/a> · verdict: <pass | BLOCK | not applicable (no e2e/ harness)>
+
+## Blocks merge
+[P0|P1] <imperative title> — <file:line> — §NN — <one-line fix>   (introduced by this PR)
+
+## Should fix
+[P2|P3] <title> — <file:line> — §NN — <fix>   (introduced | pre-existing, touched | pre-existing, elsewhere)
+
+## Good
+- <specific thing done right, with file:line>
+
+## Ready to merge?  Yes | With the fixes above | No
+```
+
+Rules for filling it:
+
+- Lead with what blocks. Validation, praise and context come after the findings, in **Good**.
+- Every finding carries `file:line`, a `§NN` reference from the checklist, and a one-line fix.
+- Every finding carries its attribution. Only findings **introduced by this PR** may appear under
+  **Blocks merge**.
+- Name what is genuinely good with the same specificity as the bugs, and say plainly when the PR is
+  mergeable with small fixes.
+- Write it like a person: vary the voice, no reused scaffolding, no tooling attribution.
+
+Then hand the review to the user. **The message you hand back ends with the posting question** — one
+line, always present, including when nothing blocks and including when the PR has already merged:
+
+> Post this on #NNNN as a comment / as request-changes, or hold it?
+
+Match the kind to the severity: `comment` when nothing blocks, `request-changes` when something does.
+Nothing reaches GitHub until the user answers that question.
+
+## Severity
+
+- **P0 — blocks.** Broken new code this PR introduced, the open build cannot deploy or migrate, data
+  loss or corruption.
+- **P1 — blocks.** A verified correctness or contract bug: wrong value recorded, response drift, a
+  crash on a scheduled path, undeclared E2E coverage on a behaviour change.
+- **P2 / P3 — should fix, does not block.** Edge cases, performance, consistency, hygiene.
+- **Severity is not blocking.** A pre-existing P1 in a file this PR touches is a judgement call —
+  "fix it while you are in here" or "file it urgently" — but the block is anchored on what this PR
+  breaks. Do not draw an arbitrary line between two identical bugs.
+
+## Red flags — STOP
+
+Each of these means: go back to the step named and do it.
+
+| Rationalization                                                                         | Reality                                                                                                   |
+| --------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------- |
+| "Small diff, skip the standards pass."                                                  | Diff size predicts nothing about severity. A one-line guard is the classic P0. Step 5.                    |
+| "The body says it was tested."                                                          | A claim is not evidence. Step 2 lists it; step 4 runs it.                                                 |
+| "A flow exists in that area, so it's covered."                                          | Coverage is per pinned surface, not per area. Step 3 answers this; guessing does not.                     |
+| "It's only a refactor."                                                                 | Run `git diff -w`. A refactor that drops a handler, a prop or a branch is a behaviour change.             |
+| "The migration is trivial."                                                             | Trivial migrations take locks, dangle leaves, and depend on enterprise-only apps. Run the gate.           |
+| "Type-check passed."                                                                    | Without a `tsconfig.json` it is a no-op. Never cite it.                                                   |
+| "I'll post it and fix the wording later."                                               | It goes out under a human's name. Show it, get the yes, then post.                                        |
+| "Since this is already merged, these are tickets rather than findings."                 | Merge status changes the remedy, not the severity or the attribution. Report them at their real severity. |
+| "CI doesn't run that gate, so it's not on this PR."                                     | Attribute it, don't delete it. Pre-existing is a label; silence is a miss.                                |
+| "The PR's count presumably includes the file I didn't run."                             | Run it or say the number is unverified. Do not reconcile evidence by assumption.                          |
+| "This isn't an active leak, but the sibling has it — leaving it in."                    | Verification killed it. It does not go in the review. Step 6.                                             |
+| "It's pre-existing, but fix this first."                                                | Pre-existing findings do not lead the review and do not block. Rank by what this PR breaks.               |
+| "None of these block, but here are five follow-ups."                                    | On an exempt or tooling diff, the honest output is `No findings.` plus **Good**.                          |
+| "Unlikely — I confirmed the trigger doesn't exist — but free to close."                 | A finding whose trigger you proved absent is speculation. Drop it.                                        |
+| "It conflicts with the convention, but I didn't want to raise it on someone else's PR." | Attribution is how you raise it fairly. Write it at its real severity.                                    |
+| "The claim is unverifiable, so I'll suggest a body edit."                               | Unsupported body claims are findings, not copy-editing.                                                   |
+| "The gate didn't exist when this merged, so I'll drop it."                              | It changes the severity, not whether it is reported. Record it at P2 with the reason.                     |
+| "The review is written, so the job is done."                                            | The last line is the posting question. A review nobody was asked about cannot be posted.                  |
+
+## Out of scope
+
+- No fixes applied. This procedure produces a review, not a commit; do not edit the working tree,
+  stage anything, or push.
+- Nothing is posted, commented, approved, labelled or requested-changes on GitHub without an explicit
+  yes from the user for that specific action.
+- Not for reviewing a design doc, a spec, or a single file with no diff behind it.
+- Not for writing the E2E flow the gate asks for — that is the authoring skill's job; this one names
+  the gap and stops.

--- a/.agents/skills/reviewing-prs/references/e2e-coverage-policy.md
+++ b/.agents/skills/reviewing-prs/references/e2e-coverage-policy.md
@@ -1,0 +1,213 @@
+# E2E coverage policy
+
+Read this when `node e2e/scripts/e2e-coverage.mjs` returns anything but `pass`, when the
+classification looks wrong for the diff you just read, or when a passing `EXEMPT` still names flows
+it hit.
+
+The policy is **strict with declared exemptions**: a change the classifier says needs a flow must
+either show the flow in the `e2e/FLOWS.md` diff or carry an `E2E:` line in the PR body giving a
+reason. **Silence blocks; a stated reason does not.**
+
+## Invoking it
+
+```
+node e2e/scripts/e2e-coverage.mjs --pr <n> --json                            # a PR exists
+node e2e/scripts/e2e-coverage.mjs --base origin/<base> --body <file> --title "<branch or PR title>" --json
+```
+
+`--title` is not optional in the no-PR form: a `feat` title with behaviour files in an area that has
+no flow is one of the new-surface signals, and with no title that signal is dead, so the same diff
+comes back a classification weaker than the one the reviewer's `--pr` run will produce. Unknown flags
+are rejected with exit 2 rather than ignored, so a typo cannot quietly become the no-title case.
+
+Base resolution inside the script is: an explicit `--base` wins, else the base branch of the PR named
+by `--pr`, else `origin/dev`. So **do not pass `--base` together with `--pr`** — it overrides the
+PR's real base, and on a stacked PR that turns the parent branch's merged work into this PR's diff.
+`--head <sha>` selects a head other than `HEAD`.
+
+`--pr` fetches the title, body and base from GitHub, but the diff it classifies is the **local
+checkout's**. The checkout must therefore be at the PR's head; `EXEMPT (no-changes)` is the symptom
+of getting that wrong.
+
+The exception is an **already-merged** PR: its base branch now contains its head, so the
+PR-resolved base yields an empty diff. Pin both ends —
+`--pr <n> --base <branch-point-sha> --head <head-sha>` — and say so in the review.
+
+## Path classes
+
+Every changed file gets exactly one class — **the table is ordered and the first match wins**, so read
+it top to bottom. Behaviour classes that decide coverage are **B1–B6**; everything else is exempt from
+the flow requirement. Note where **B7 sits**: it is matched before the exempt classes, so a compose
+file or anything under `e2e/stack/**` never reaches E2, E3 or E5.
+
+| Class  | What it covers                                                                                                                                                                                                                                                                                                                                                                                                                                    | Effect                                                                                                                                                                                   |
+| ------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **E0** | Generated and lock files: the OpenAPI schema, generated contracts and types, gateway generated contracts, lockfiles, pinned test durations, `e2e/FLOWS.md`                                                                                                                                                                                                                                                                                        | Evidence only — never decides, but the `FLOWS.md` diff is the proof a flow was added                                                                                                     |
+| **E1** | Docs: `**/*.md`, `**/*.mdx`, `docs/**`, issue templates, licence and notice files                                                                                                                                                                                                                                                                                                                                                                 | Exempt · `docs`                                                                                                                                                                          |
+| **B7** | Stack shape: `docker-compose*.yml` at the root and under `futureagi/`, **all of `e2e/stack/**`\*\*, the backend entrypoint                                                                                                                                                                                                                                                                                                                        | **Not** counted as behaviour · `stack-shape` — no flow required, but the suite must still boot. Matched **before** E2–E5, so these paths never fall through to `tooling` or `tests-only` |
+| **E2** | Repo tooling: `.github/**`, hooks, `scripts/**`, root `package.json`, release config, `deploy/**`, env examples, agent-config directories                                                                                                                                                                                                                                                                                                         | Exempt · `tooling`                                                                                                                                                                       |
+| **E3** | Tests only: `futureagi/**/tests/**`, `__tests__`, `*.test.*`, `*_test.go`, `conftest.py`, storybook, mocks, and `e2e/**` plus `bin/e2e` — **except `e2e/stack/**`, which B7 already claimed**. A test lives in a test *directory*: `test\_\*.py`is deliberately **not** a rule of its own, because`futureagi/simulate/\*\*/test_execution.py`is the product's test-execution domain, and`frontend/src/api/tests/` is a production API module (B2) | Exempt · `tests-only`                                                                                                                                                                    |
+| **E4** | Services the E2E stack does not start: model serving, code executor, the simulation runner                                                                                                                                                                                                                                                                                                                                                        | Exempt · `not-in-stack`                                                                                                                                                                  |
+| **E5** | Backend internals with no request, response or UI effect: settings, logging, telemetry, licensing, management commands, constants, types, requirements, Dockerfiles — plus every backend path not matched by a behaviour rule                                                                                                                                                                                                                     | Exempt · `backend-internal`                                                                                                                                                              |
+| **E6** | Gateway code off the exercised path (everything under the gateway that is not B6)                                                                                                                                                                                                                                                                                                                                                                 | Exempt · `gateway-internal`                                                                                                                                                              |
+| **E7** | Frontend non-behaviour: theme, styles, assets, locales, build config, `package.json`, presentational leaf components                                                                                                                                                                                                                                                                                                                              | Exempt · `cosmetic`                                                                                                                                                                      |
+| **E9** | Anything the table does not match                                                                                                                                                                                                                                                                                                                                                                                                                 | Exempt · `unclassified` — inspect it yourself; an unclassified behaviour file is a classifier gap worth reporting                                                                        |
+| **B1** | Frontend routes, pages, dashboard navigation config                                                                                                                                                                                                                                                                                                                                                                                               | Behaviour — strong new-surface signal on additions                                                                                                                                       |
+| **B2** | Everything else under `frontend/src/**` — feature sections, API modules, hooks, contexts, data-bearing shared components                                                                                                                                                                                                                                                                                                                          | Behaviour, mapped to an area by directory                                                                                                                                                |
+| **B3** | Backend API surface: `urls.py`, `views/`, `serializers/`, `contracts.py`, routers, permissions, middleware, capabilities, authentication                                                                                                                                                                                                                                                                                                          | Behaviour, mapped to an area by app                                                                                                                                                      |
+| **B4** | Migrations and the ClickHouse schema tree                                                                                                                                                                                                                                                                                                                                                                                                         | Behaviour                                                                                                                                                                                |
+| **B5** | The collector (`fi-collector/**`)                                                                                                                                                                                                                                                                                                                                                                                                                 | Behaviour — the ingest path two observe flows pin                                                                                                                                        |
+| **B6** | Gateway on the exercised path: the chat handler, the OpenAI provider, registry, pipeline, routing, models, streaming, config                                                                                                                                                                                                                                                                                                                      | Behaviour                                                                                                                                                                                |
+
+## Decision procedure
+
+1. Partition the changed files into classes. Let `R` = the files in B1–B6.
+2. `R` empty → **`EXEMPT`**, with `autoReason` taken from the dominant exempt class (generated files
+   never win the tie). No marker required, and no nagging: a docs or tooling PR passes in silence.
+3. `R` non-empty and a **new-surface signal** fired → **`NEW-FLOW`**, naming the area(s). Signals: an
+   added `path:` entry in a routes file, a genuinely new key in `frontend/src/routes/paths.js` (a key
+   that is added and not also removed — editing a value is not a signal), a new file under `pages/`,
+   an added `path(` / `re_path(` / `.register(` line in a `urls.py`, a new file under `views/`, a
+   migration creating a model or a field a same-PR serializer exposes, a new collector endpoint, or a
+   `feat` title with behaviour files in an area that has no flow. Files the table classes as E0–E3 —
+   specs, unit tests, docs, tooling — never raise a signal, whatever their path looks like.
+
+   `areas` can be empty on a `NEW-FLOW`: it is derived from B-class files that map to an area, and a
+   route-only diff (`frontend/src/routes/**` is B1, which carries no area) has none. An empty `areas`
+   list is not evidence the classification is wrong.
+
+4. `R` non-empty, no signal, but the diff **hits a pinned surface** → **`UPDATE-EXISTING`**, naming
+   the flow ids. A hit means an added or removed line contains a string literal one of the flows
+   pins: an API path, an app route, a table name, a grid or filter selector, the gateway route.
+5. Otherwise → **`UNDETERMINED`**: behaviour files in an area, no signal, no hit. The author declares.
+
+A new-surface signal outranks a pinned-surface hit: a PR that both adds a route and touches a pinned
+endpoint is `NEW-FLOW`, because the new screen is the thing with no coverage.
+
+## Verdicts
+
+Each marker kind carries its own check, and the kind's check has to pass too — a well-formed marker is
+necessary, never sufficient. The exception is `EXEMPT`, where no declaration is owed at all and the
+marker is not examined.
+
+| Marker kind         | Its own check                                                                 |
+| ------------------- | ----------------------------------------------------------------------------- |
+| `new <ID>`          | The `FLOWS.md` diff adds a `### <ID>` heading                                 |
+| `updated <ID>`      | A changed file under `e2e/flows/**` contains `<ID>`                           |
+| `covered-by <ID>`   | `<ID>` already exists in `FLOWS.md` (spec unchanged; the CI run is the proof) |
+| `exempt (<reason>)` | `<reason>` is one of the known reasons, or `harness-gap <what>`               |
+
+| Classification    | Passes when                                                                           | Otherwise                                                                                             |
+| ----------------- | ------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------- |
+| `EXEMPT` (auto)   | Always — no marker needed, none requested, and a malformed one is not held against it | —                                                                                                     |
+| `UPDATE-EXISTING` | Any marker kind whose own check passes — including `E2E: exempt (<reason>)`           | No marker → `needs-marker`. A marker whose own check fails → `block`                                  |
+| `NEW-FLOW`        | **`E2E: new <ID>` only**, with its own check passing                                  | Any other kind, `exempt` included → `block`, "reviewer override required". No marker → `needs-marker` |
+| `UNDETERMINED`    | Any marker kind whose own check passes — including `E2E: exempt (<reason>)`           | No marker → `needs-marker`. A marker whose own check fails → `block`                                  |
+
+`NEW-FLOW` is the only classification that restricts the kind; everywhere else a declared exemption
+passes. A malformed marker is a `block` on every classification that owes a declaration — and so is a
+second `E2E:` line — but not on `EXEMPT`, so an author who copies the exemption word the tool just
+printed is never blocked on a diff that needed no marker in the first place.
+
+Exit code is 0 on `pass`, 1 on everything else.
+
+### Mapping a verdict into the review
+
+- `pass` → fill the `## E2E coverage` line and write no finding.
+- `needs-marker` → **P1 "E2E coverage undeclared"**. Quote the classification, the areas, and the
+  exact `E2E:` line the author should add (the script's `explanation` already spells it out).
+- `block` → **P1**, titled for the cause: "Declared exemption contradicts the diff" for a `NEW-FLOW`
+  answered with `exempt`, "Declared flow is not in the catalog" when `FLOWS.md` does not add it,
+  "Malformed E2E declaration" for a grammar problem.
+- `NEW-FLOW` + `E2E: exempt (...)` is the one case that is not the author's to decide. Ask the human
+  one question — accept the override, or hold the PR for a flow — and record their answer.
+- `EXEMPT` with `autoReason: no-changes` **reports `pass` and exits 0, and you must not accept it**.
+  It means the checkout has no diff against the base: the review is being run on the wrong ref. The
+  green exit code is the trap, not the answer. Fix the checkout and rerun.
+- **When the gate post-dates the PR** — the script is absent from the base you diffed against — the
+  classification still goes in the E2E block, but a missing marker is a **P2**, not a P1. The author
+  could not declare against a gate that did not exist. State that reason; do not drop the finding.
+
+## Marker grammar
+
+One line in the PR body. Text inside HTML comments is ignored, so a template's example does not
+count; a second live `E2E:` line is an error.
+
+```
+E2E: new <ID>[, <ID>…]
+E2E: updated <ID>[, <ID>…]
+E2E: covered-by <ID>[, <ID>…]
+E2E: exempt (<reason>)
+```
+
+`<ID>` matches `^[A-Z]+-E2E-\d{3}$`. `covered-by` ids must already exist in `FLOWS.md`.
+
+`<reason>` is one of `docs`, `tooling`, `tests-only`, `not-in-stack`, `backend-internal`,
+`gateway-internal`, `cosmetic`, `generated`, `stack-shape`, `merge-back`, `unclassified`, `refactor`,
+`test-support`, or `harness-gap <what>` — the last one naming the missing harness capability, so the
+gap is a countdown rather than a shrug. Every `autoReason` the tool prints is in that list except
+`no-changes`, which names an empty diff — a wrong checkout to fix, never a reason to declare.
+
+## Worked examples
+
+### `UPDATE-EXISTING` — a fix inside a pinned surface
+
+A one-file frontend change to the trace-detail pane (`frontend/src/components/traceDetail/…`).
+Classes: one B2 file. No new-surface signal. The diff's hunks touch a route and a grid selector the
+observe trace-ingestion flow pins → `UPDATE-EXISTING OBS-E2E-001`.
+
+The author's options are `E2E: updated OBS-E2E-001` if the pinned literal itself moved and the spec
+was edited to match, or `E2E: covered-by OBS-E2E-001` if the flow is unchanged and the CI run is the
+proof. Silence is `needs-marker` → P1. As reviewer, also confirm the flow's assertions still mean
+something: if the PR added a user-visible outcome inside the same user goal, the flow should have
+grown an assertion rather than stayed still.
+
+### `NEW-FLOW` — a feature that adds surface
+
+A large PR adding a simulation-ingestion endpoint: a new `views/` file, four added lines in
+`urls.py`, a new migration, new frontend sections, plus a compose change. Classes: B3, B4, B2, B7 —
+`R` is non-empty and the added `urls.py` lines and the new `views/` file are new-surface signals →
+`NEW-FLOW`, area `simulate`.
+
+Passing needs `E2E: new SIM-E2E-001` **and** a `### SIM-E2E-001` heading added in the `FLOWS.md`
+diff. `E2E: exempt (refactor)` on this diff is a `block` you must escalate to the human, not accept
+quietly. The B7 compose file adds no flow requirement of its own but does mean the suite has to
+still boot.
+
+### `EXEMPT` — and which flavour of exempt it is
+
+A PR touching only `.github/workflows/*.yml`: every file is E2, `R` is empty → `EXEMPT (tooling)`,
+verdict `pass`, no marker required and none requested. The E2E block reads
+`EXEMPT (tooling) · none · marker: n/a · verdict: pass` and the review contains **no** E2E finding.
+
+The `autoReason` is worth reading, because the ordered table makes neighbouring diffs land in
+different flavours:
+
+| PR touches only…                                                  | Class                        | Block reads                                                                 |
+| ----------------------------------------------------------------- | ---------------------------- | --------------------------------------------------------------------------- |
+| `.github/workflows/**`                                            | E2                           | `EXEMPT (tooling) · none · marker: n/a · verdict: pass`                     |
+| `**/*.md`                                                         | E1                           | `EXEMPT (docs) · none · marker: n/a · verdict: pass`                        |
+| `e2e/flows/**`, `e2e/lib/**`, `bin/e2e`                           | E3                           | `EXEMPT (tests-only) · none · marker: n/a · verdict: pass`                  |
+| `e2e/stack/**` or `docker-compose*.yml`                           | **B7**, matched before E2–E5 | `EXEMPT (stack-shape) · none · marker: n/a · verdict: pass`                 |
+| backend internals — a ClickHouse query builder, a service, a task | E5                           | `EXEMPT (backend-internal) · <flows, if any> · marker: n/a · verdict: pass` |
+
+**`backend-internal` is the flavour that still needs your eyes.** Pinned hits are computed for every
+non-exempt-class file, including E5 ones, but the `EXEMPT` verdict is decided before hits are
+consulted — so this row is the one place where the script can name flows on the same line as
+`verdict: pass`. That is not a contradiction to reconcile: the classifier is saying "no B-class file
+changed, so I am not asking for a declaration", while the hit list is saying "these flows pin a
+literal your diff moved". When hits appear under `EXEMPT`, **read the diff yourself** before writing
+the block. A backend service change with no `views/` or `serializers/` file beside it can still alter
+what a user sees — a filter, a dropdown's contents, a chart's numbers — and if it did, the honest
+output is a P2 naming the flow whose assertion should have grown, not a silent `pass`. The script
+labels the list `informational` for exactly this reason. Hits under `EXEMPT (docs)`, `(tooling)` or
+`(tests-only)` mean nothing by contrast: those classes are excluded from hit scanning entirely.
+
+The `tests-only` and `stack-shape` rows are the pair to keep straight. A spec-only change is `tests-only` — the PR _is_ the E2E
+change, so review it with the flow-review checklist rather than asking it for coverage. A change to
+`e2e/stack/**` or a compose file is `stack-shape`: no flow is owed either, but the obligation that
+replaces it is that the suite still boots, so the question to ask is whether CI ran the harness on
+this diff, not whether a flow exists.
+
+Do not manufacture a coverage finding on any of them. "Tooling PRs should have flows too" is not this
+policy.

--- a/.agents/skills/reviewing-prs/references/e2e-flow-review.md
+++ b/.agents/skills/reviewing-prs/references/e2e-flow-review.md
@@ -1,0 +1,117 @@
+# Reviewing a change under `e2e/`
+
+Read this when any file under `e2e/` is in the diff. It is the checklist for flow specs, the
+generated catalog, and the quarantine file — not for the product code the flow exercises.
+
+A flow is **one user goal, start to finish, asserted in the UI and in the backend state behind it**.
+Everything below follows from that sentence. When a new flow arrives without a plan behind it, the
+shape it should have had is the flow-plan template in the authoring skill
+(`references/flow-plan-template.md` under `writing-e2e-flows`).
+
+## The annotation is a contract
+
+`FLOWS.md` is generated from the annotation, so the annotation is documentation the team will trust
+without opening the spec. Review it as strictly as an assertion.
+
+- **Every `steps` entry is actually performed** by the spec body, in that order. A step listing a UI
+  action the spec never takes is a false catalog entry.
+- **Every `backendChecks` entry is actually asserted.** A check the spec merely polls for, or reads
+  and discards, is not asserted.
+- Nothing the spec does that matters is **missing** from the annotation.
+- The `@flow` tag is present. Without it the test never reaches the catalog, whatever the annotation
+  says.
+- `id` matches `<AREA>-E2E-<nnn>`, is unique across the suite, and `area` equals the `flows/<area>/`
+  directory the file lives in.
+- The test title **starts with the id** (`"OBS-E2E-001: …"`), because quarantine matches on a
+  substring of the composed title.
+- `userGoal` names a user's goal, not a mechanism. "A developer sends a trace and inspects it" is a
+  goal; "exercise the span list endpoint" is not.
+
+## Assertions that can fail
+
+An assertion that cannot fail is worse than no assertion, because it reads as coverage.
+
+- **Exact sets, not substrings.** `toHaveText([alpha])` proves the filter excluded the other row;
+  `toContainText` passes with the filter broken.
+- **Anchored on a minted value** that exists nowhere else — a name or token this test generated —
+  rather than on "the first row" or "the count".
+- **Deltas** where a pre-existing row would satisfy the check: count before, act, require growth.
+- **A state, not a count**, wherever failure has a state: poll for the terminal status so a row that
+  arrived and failed is distinguishable from one that has not arrived.
+- Every read of a ClickHouse ReplacingMergeTree — the spans table and every CDC-fed table — uses
+  `FINAL`. Without it an unmerged read hands back the stale version and the assertion passes on the
+  wrong row.
+- API-lane reads go through the same list endpoint the UI calls, and the response is typed against
+  the one real envelope. **No `||` or `??` fallback chains on response fields**: read the serializer,
+  or capture a live request, and code against what it actually returns.
+- The flow does not assert on unfiltered eval graphs. That surface reads a table the stack's schema
+  flag removes and is expected to fail locally and on the open build.
+- **The PR body shows the flow failing.** The authoring skill's definition of done is a fallibility
+  proof per `backendCheck`: the anchor perturbed on **one side only**, the run re-run, and the
+  resulting failure quoted. Ask for it if it is absent, and check that what is quoted is a real
+  assertion failure naming the minted value — not a timeout, and not a perturbation of a constant
+  that feeds both the input and the assertion, which moves expected and actual together and leaves
+  the run green. A green run and a passing catalog check say the spec is well-formed; only this says
+  the assertion can fail. An author who says which of the runs they skipped, and why, has met the
+  bar; silence about it has not.
+
+## Waiting
+
+- Waits on a store or an async job use the shared `POLL` budgets from `lib/state-probe.ts`, chosen by
+  **what is being waited on** — collector writes, an eval task's own status, any CDC-fed table,
+  generic async work — not by which flow is being written. A literal timeout on one of _those_ waits
+  is a finding: it means a budget was retuned for one flow instead of at its source.
+- Browser waits are the exception, and they have their own convention: every `expect`, `toHaveURL`
+  and `waitForResponse` passes `{ timeout: UI_READY }`, where `UI_READY` is a named per-spec constant
+  (60 s in the observe flows). The number appearing once, at the constant's declaration, is correct;
+  the finding is a bare literal at the call site, or a `UI_READY` whose value drifts from its
+  siblings without a reason next to it.
+- A flow whose chained budgets can outrun the per-test timeout raises its **own** ceiling with
+  `test.setTimeout(...)`, never the project default. The value should be justified as the sum of the
+  budgets it chains plus seeding and UI time; if the arithmetic is not stated next to the call, ask
+  for it.
+
+## Isolation
+
+- Anything the spec creates is named uniquely per worker and per run — the minted `e2e-<flow>-…`
+  shape — and the assertions anchor on that minted value.
+- No spec deletes anything global or tears down another flow's data. Isolation comes from the
+  per-worker organization plus unique names.
+- A spec that tests the login or signup UI itself must **not** import the authenticated fixtures from
+  `lib/fixtures`; it uses Playwright's base test, because the shared fixture arrives already signed
+  in and would make the assertion vacuous.
+- Seeded identifiers are attached with `testInfo.attach` so a CI failure is diagnosable from the
+  report alone, without re-running anything.
+
+## Locators
+
+Role, label and text first. `data-testid` only where the semantics are genuinely ambiguous — grid
+cells, chart toolbars, option lists — and a new `data-testid` in product code ships as **its own
+small PR**, not bundled into the flow PR.
+
+## The catalog
+
+- `FLOWS.md` is generated. It is never hand-edited, and any change to a spec's annotation comes with
+  a regenerated `FLOWS.md` **in the same commit**. A spec-only diff means the catalog check fails.
+- A `FLOWS.md` diff with no corresponding change under `e2e/flows/**` is the reverse error: the
+  catalog was edited by hand.
+
+## Flake policy and quarantine
+
+- **No retries.** A retry count above zero anywhere — config, spec, or command — throws away the
+  signal the flake carries.
+- **No `test.only`**, and no `--grep-invert` on the command line: the config builds its exclusions
+  from one function, and a command-line invert replaces the whole value, silently un-quarantining
+  everything.
+- Every quarantine entry carries `id`, `reason`, `owner`, `issue`, `added` and `expires`, with
+  `expires` **within 45 days** of `added`. Quarantine is a countdown, not a parking space.
+- A quarantine entry added in the same PR as the flow it disables needs an explanation in the body;
+  shipping a flow already quarantined is shipping nothing.
+- Removing a quarantine entry should come with evidence the flow now passes.
+
+## Harness changes
+
+A change under `e2e/lib/`, `e2e/stack/` or `bin/e2e` affects every flow. Check that the harness
+self-tests under `e2e/harness/` still cover the primitive that changed, and that a new primitive
+arrives with one. A flow that needed a harness extension should show that extension as its own
+reviewable change, not hacked into the spec.

--- a/.agents/skills/reviewing-prs/references/standards-checklist.md
+++ b/.agents/skills/reviewing-prs/references/standards-checklist.md
@@ -1,0 +1,264 @@
+synced-from: internal-docs@6cd9e3b (2026-08-27)
+
+# Standards checklist
+
+Distilled rules, grouped by review lens. Load the section for the lens you are working — not the
+whole file.
+
+Rules a linter or formatter already enforces are **not** here: the mechanical gates in step 4 cover
+import order, formatting, unused names, bare `except:`, missing React keys, and exhaustive-deps
+warnings. What remains is what a machine cannot decide.
+
+`§ref` legend — `01` minimal code · `02` API design · `03` architecture & layers · `04` OSS/EE
+boundary · `05` typing · `06` errors & failure modes · `07` pull requests & review · `08` naming &
+git · `09` testing & scenarios · `10` API contracts & types · `PB` review playbook · `CB` review
+bible. Severity is the **default** for a rule; the actual call depends on blast radius and on
+attribution (see the foot of this file).
+
+## Migrations & data
+
+| §ref | Rule                                                                                     | How it shows in a diff                                                                                                    | Severity |
+| ---- | ---------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------- | -------- |
+| PB   | A migration must not depend on an enterprise-only app                                    | `dependencies = [("<ee app>", …)]` in a migration outside the enterprise tree; an in-function try/except does not save it | P0       |
+| PB   | A new migration parents on the app's current tail                                        | `makemigrations --check --dry-run` reports two leaf nodes                                                                 | P0       |
+| PB   | Large-table migrations set `atomic = False` and batch                                    | `RunPython` iterating a large table, or `.update()` over a full queryset, in one transaction                              | P1       |
+| PB   | One bad row must not abort the whole run                                                 | `RunPython` loop with no per-row error handling                                                                           | P2       |
+| PB   | Never backfill guessed values into log, audit or append-only tables                      | Migration computing approximations into history; prefer null                                                              | P2       |
+| PB   | Migrations are idempotent, re-runnable and reverse-safe                                  | `RunPython` without `reverse_code`; inserts with no uniqueness guard                                                      | P2       |
+| PB   | A data migration runs only after the reading code is deployed everywhere                 | PR body silent on deploy ordering for a schema-plus-code change                                                           | P2       |
+| 09   | A migration PR answers: table size and lock, rollback, open-build behaviour, boots after | `migrations/*.py` in the diff and the body answers none of these                                                          | P2       |
+| 09   | Cover rollback: migration down, flag off, old client still served                        | Forward-only migration with no reverse and no stated rollback plan                                                        | P2       |
+
+## OSS/EE boundary
+
+| §ref | Rule                                                                                           | How it shows in a diff                                                            | Severity |
+| ---- | ---------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------- | -------- |
+| 04   | No enterprise imports outside registered boundary modules and the enterprise tree              | An `import` of the enterprise package appearing in an open-source module          | P1       |
+| 04   | The enterprise-import allowlist may only shrink                                                | The diff adds an entry to the boundary allowlist                                  | P1       |
+| 04   | New code defaults to open; the enterprise tree is for genuine enterprise capability            | New files under the enterprise tree with no enterprise-only rationale in the body | P2       |
+| 04   | No per-call-site guarded import plus `if X is not None` scattered through the code             | `except ImportError:` then `X = None`, then a presence check at each use          | P2       |
+| 04   | A guard covers every enterprise symbol the file imports                                        | One guarded import plus a second bare enterprise import in the same file          | P1       |
+| 04   | The failure arm binds every guarded name                                                       | An `except ImportError` branch that leaves one imported name unassigned           | P1       |
+| 04   | Fallback stubs match the real symbol's spelling, arity and shape                               | Stub signature differs from the symbol it stands in for                           | P1       |
+| 04   | Define a typed port with an enterprise adapter and an open null-object, selected once          | A capability wired by raw enterprise symbols at each call site                    | P2       |
+| 04   | Fail-closed vs fail-open for a capability is decided once, in the null-object                  | Two call sites choosing different defaults for the same missing capability        | P2       |
+| 04   | Gate on the deployment-mode helper at the boundary, never on an enterprise-imported symbol     | Enterprise enum or class used as the condition that gates open code               | P1       |
+| 04   | Do not thread the mode check through business logic or extend open paths with inline branches  | Mode checks appearing inside services, views or serializers                       | P2       |
+| 04   | The open build boots, serves, registers workflows and migrates with the enterprise tree absent | A boundary or guard change with no assertion that the open path works             | P0       |
+
+## Contracts, types & codegen
+
+| §ref | Rule                                                                                                        | How it shows in a diff                                                                                                                         | Severity |
+| ---- | ----------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------- | -------- |
+| 10   | Request and response shapes live in serializers and nowhere else                                            | A view returning a dict literal, or mutating `serializer.data` after the fact                                                                  | P1       |
+| 10   | Regenerate and commit the generated client artifacts in the same diff as the serializer                     | A serializer changed while the generated contract and schema files are untouched                                                               | P1       |
+| 10   | Never hand-edit a generated contract or type artifact                                                       | A generated file edited without its generator header changing                                                                                  | P1       |
+| 10   | Never read a typed response through a `??` or `\|\|` fallback chain                                         | Two candidate field names coalesced on an API result                                                                                           | P1       |
+| 02   | Never rename a field, param, route or enum value in place                                                   | Serializer field or `source=` renamed, path string edited, enum member value changed                                                           | P1       |
+| 02   | Never change a field's type or nullability in place                                                         | Field class swapped, `allow_null` flipped, model field retyped with no new sibling                                                             | P1       |
+| 02   | Never make an optional input required, and never tighten validation on existing input                       | `required=True` added, default removed, choices narrowed, `max_length` reduced                                                                 | P1       |
+| 02   | Never remove a field, route, param or enum value without the deprecation contract                           | Deleted serializer field or route; the schema diff shows a removal                                                                             | P1       |
+| 02   | Design enums open so clients tolerate unknown values                                                        | An exhaustive frontend switch with no default over a response enum                                                                             | P3       |
+| 05   | Public service and selector signatures are fully annotated; `Any` must not pass through more than one layer | A new or changed cross-module `def` missing param or return annotations; an `Any`-typed value forwarded through two or more layers unvalidated | P2       |
+| 10   | A JSON field with known keys becomes a typed nested serializer                                              | New JSON field whose keys are documented, or read by name downstream                                                                           | P2       |
+| 10   | New endpoints are registered in the contract-coverage set in the same diff                                  | A route added while the coverage registry is unchanged                                                                                         | P1       |
+
+## Server/API layer
+
+| §ref | Rule                                                                                        | How it shows in a diff                                                                                                                    | Severity |
+| ---- | ------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------- | -------- |
+| 02   | Exhaust extend, optimize and batch before adding a route                                    | A new route whose handler re-queries resources that already have endpoints                                                                | P2       |
+| 02   | Do not publish experimental, internal, debug or UI-control surface                          | A new public route or field exposing internals; the body says it may change                                                               | P2       |
+| 02   | Version branching lives in serializers and request adapters, never in services              | A version check inside a service, selector or domain module                                                                               | P2       |
+| 03   | Views, handlers and activities route and (de)serialize, then delegate                       | A view gaining loops, ORM filters, multi-branch policy or transaction management                                                          | P2       |
+| 03   | Business logic lives in services (writes) and selectors (reads) as HTTP-free functions      | A service taking the request object, or importing serializers                                                                             | P2       |
+| 03   | Never put business logic in serializers, model save, signals or managers                    | Diff touches `save()`, a signal receiver, serializer `create/update/validate`, or a manager                                               | P2       |
+| 03   | Models own their own shape and self-only validation, with no cross-entity orchestration     | A model module importing services or HTTP clients; `save()` writing other rows                                                            | P2       |
+| 03   | Reads do not write: a `get_*`, `resolve_*` or `find_*` never mutates state as a side effect | Such a function's body containing `.save()`, `.update(`, `.create(` or an in-place counter bump; record usage in a separate explicit call | P1       |
+| 09   | New API surface denies by default and paginates                                             | A new route with no permission classes, or an unpaginated list response                                                                   | P1       |
+| PB   | The declared query serializer is consumed; no raw re-parse of query params                  | Direct `request.GET` integer parsing in a view that declares a query serializer                                                           | P2       |
+| CB   | Query params come from the validated container; non-numeric input 400s; page size is capped | Manual parse of paging params with no maximum enforced                                                                                    | P2       |
+
+## Correctness & logic
+
+| §ref | Rule                                                                                                    | How it shows in a diff                                                                                                                    | Severity |
+| ---- | ------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------- | -------- |
+| CB   | Grade a new F821 or F405 in the gate delta as P0 — it is a probable runtime `NameError`, not a lint nit | The gate already reports it; this row sets the severity. Settle a star-import F405 by importing the module and checking the name resolves | P0       |
+| CB   | A computed value must be used in the decision it feeds                                                  | A value computed then ignored while a different quantity is passed on                                                                     | P0       |
+| PB   | The value recorded must equal the value that actually ran                                               | A log row or audit record writing a configured default while execution used a resolved one                                                | P1       |
+| PB   | Save-then-hydrate round-trips are symmetric                                                             | Serialize and deserialize transforms that do not mirror each other; a reload that flips grouping or boolean logic                         | P1       |
+| PB   | Soft-delete filters are consistent across primary path, fallback path and migration                     | A deleted-flag filter present in one branch and absent from its sibling                                                                   | P2       |
+| PB   | An auth failure must never silently downgrade to a weaker path                                          | A catch around authentication falling through to an anonymous branch                                                                      | P1       |
+| PB   | A guard is dead if the failure happens a layer above it                                                 | try/except around a call whose module import or graph build fails first                                                                   | P1       |
+| CB   | Code must match its own tests; if they disagree, decide which is the spec                               | A new test's expectation contradicts the behaviour you traced                                                                             | P1       |
+| CB   | Display-path transforms prove nothing about the wire path                                               | A hydration map changed with no matching change to the request builder                                                                    | P2       |
+| CB   | Empty and zero inputs fall through sanely                                                               | A `None` stringified into a query; an empty collection rendered as an empty `IN ()`                                                       | P2       |
+| PB   | Use `git diff -w` to surface logic hidden inside reindents                                              | A reindent hunk that still contains changed statements                                                                                    | P2       |
+
+## Data modelling
+
+| §ref | Rule                                                                            | How it shows in a diff                                                                     | Severity |
+| ---- | ------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------ | -------- |
+| PB   | A queryable dimension is a column or foreign key, not a key inside a JSON blob  | Filtering on a nested JSON key with no functional index                                    | P2       |
+| CB   | Filterable dimensions such as status, mode or version are columns               | List filters reading JSON keys                                                             | P2       |
+| CB   | No schema-less blobs across layers                                              | A dict written in one module and read by key in another with no declared type              | P2       |
+| 03   | Pass the object or key you already hold; do not launder identity and re-query   | An id passed down, then re-fetched with `.filter(...).first()` — unordered, over many rows | P2       |
+| 03   | Return values; do not mutate arguments, `self` or the request as a side channel | A helper setting attributes on the request and returning nothing                           | P2       |
+
+## Performance
+
+| §ref | Rule                                                                                    | How it shows in a diff                                                                 | Severity |
+| ---- | --------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------- | -------- |
+| 02   | Kill N+1s: annotate aggregates, and prefetch everything the serializer touches          | A method field or nested serializer dereferencing a relation with no matching prefetch | P2       |
+| 02   | No unbounded full-queryset serialization, and no per-item external call in a loop       | A whole queryset handed to a many-serializer; an HTTP or model call inside a `for`     | P2       |
+| 02   | Every collection endpoint paginates by default                                          | A list view with pagination disabled, or a bare many-serializer response               | P2       |
+| PB   | No deep offset paging; paginate the heavy part, charts included                         | Offset growing with page number; a chart endpoint scanning the whole period            | P2       |
+| PB   | No payload bloat: keep truncation on multi-kilobyte per-row blobs                       | A removed slice on serialized text; a new filter on an unindexed column                | P2       |
+| CB   | Aggregate in the database, not in a Python loop over the period's rows                  | A `for` loop accumulating counts or sums in a view or service                          | P2       |
+| CB   | No export that materializes a whole table in memory                                     | A full queryset realized into a list inside an export view                             | P2       |
+| CB   | Cache changes state the staleness window and blast radius; the key includes every input | A cache key missing the tenant, mode or version the value depends on                   | P2       |
+
+## Errors & failure modes
+
+| §ref | Rule                                                                                               | How it shows in a diff                                                                | Severity |
+| ---- | -------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------- | -------- |
+| 06   | Fail-open or fail-closed is chosen on purpose, stated at the call site, consistent across siblings | A new try/except with no comment or log stating the stance                            | P2       |
+| 06   | Security, permission, auth and quota checks fail closed                                            | A catch around an entitlement check that returns allowed, or treats absent as allowed | P1       |
+| 06   | Best-effort side effects fail open but log the exception                                           | A catch around metering or telemetry that passes silently                             | P2       |
+| 06   | Any absorbed exception is logged with its stack trace                                              | `except Exception:` followed by pass, return or continue with no exception log        | P2       |
+| 06   | Catch the specific exception you can handle                                                        | A broad `except Exception` in new code where a specific one is available              | P2       |
+| 06   | Re-raise what you cannot meaningfully handle                                                       | A catch converting an unrecoverable error into a default return                       | P2       |
+| 06   | Initialize to a safe default before any try, branch or loop that might assign it                   | A name assigned only inside a `try` and read in the `except` or after it              | P1       |
+| 06   | Make the null branch a real handled case: log, return or raise                                     | A default of `None` whose attribute is then read unconditionally downstream           | P2       |
+| 06   | Wrapping existing code in a new conditional is a behaviour change; call it out                     | Previously unconditional statements now under a new guard, with a silent body         | P2       |
+| CB   | Swallowed errors log at warning or exception level, never debug, on billing or auth paths          | A debug-level log inside a catch on a money or access path                            | P2       |
+| CB   | Streaming and long responses handle or signal errors after headers are sent                        | A streaming generator with no error sentinel                                          | P2       |
+
+## Frontend
+
+| §ref | Rule                                                                                        | How it shows in a diff                                                                   | Severity |
+| ---- | ------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------- | -------- |
+| PB   | A refactor must not drop behaviour versus base                                              | `git diff -w` shows removed handlers, props or branches in a PR labelled refactor        | P2       |
+| PB   | No local fork of a shared export                                                            | A copied helper alongside a comment discouraging re-import of the original               | P2       |
+| PB   | Delete dead frontend code                                                                   | Config arrays that are always empty; hook fields the API never returns; orphaned banners | P3       |
+| PB   | URL and local-storage persistence preserve the user's choice and never erase unknown values | A decoder that drops unrecognized tokens; a write that overwrites with partial state     | P2       |
+| PB   | An `eslint-disable` is a silenced alarm — fix the smell instead                             | A disable comment added, especially for prop types or component-export rules             | P2       |
+| CB   | Effects are not a state machine                                                             | Competing hydration effects coordinated by refs and dirty flags                          | P2       |
+| CB   | Dependency arrays are honest; a very long one is a refactor signal                          | An effect with a sprawling dependency list, or a silenced exhaustive-deps warning        | P2       |
+| CB   | Every mutation invalidates exactly the query keys it stales                                 | A mutation with no invalidation, or one that invalidates everything                      | P2       |
+| CB   | Component files stay component-sized; helper files do not export components                 | A helpers module exporting markup; a component-export rule disabled                      | P3       |
+
+## Comments
+
+| §ref | Rule                                                                  | How it shows in a diff                                                                  | Severity |
+| ---- | --------------------------------------------------------------------- | --------------------------------------------------------------------------------------- | -------- |
+| PB   | No stale or lying comments asserting behaviour the code does not have | A comment describing what a value tracks beside code recording something else           | P2       |
+| PB   | No commented-out code, and no leftover TODO, FIXME or HACK            | Commented-out blocks or a new marker comment with no ticket                             | P3       |
+| 01   | Comments are held to the same liability bar as code                   | A paragraph of justification added above a one-line change; that belongs in the PR body | P3       |
+
+## Naming & git
+
+| §ref | Rule                                                                         | How it shows in a diff                                                       | Severity |
+| ---- | ---------------------------------------------------------------------------- | ---------------------------------------------------------------------------- | -------- |
+| 08   | One ticket per branch, and the ticket is linked so it closes on merge        | The body has no closing reference, or carries an unfilled placeholder        | P2       |
+| 08   | Identifiers match the surrounding idiom: casing, prefixes, domain vocabulary | A foreign casing convention, or a new synonym for an existing domain term    | P3       |
+| 08   | Name for meaning, not type; no undecodable abbreviations                     | Names such as `tmp`, `data2`, `orig`, or single letters outside a tight loop | P3       |
+| 08   | Booleans read as predicates; functions read as verbs                         | A boolean without an `is_`/`has_`/`can_` prefix; a function named as a noun  | P3       |
+| 08   | Rename when meaning drifts — a stale name is a lie that compiles             | A function body changed so its name no longer describes it                   | P3       |
+
+## File size & structure
+
+| §ref | Rule                                                                            | How it shows in a diff                                                                         | Severity |
+| ---- | ------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------- | -------- |
+| PB   | Do not pile onto monster files or hundred-line methods; push work into services | Lines added to a module already thousands of lines long, or to an oversized method             | P2       |
+| CB   | This PR must not make the biggest file bigger                                   | The diff's largest addition lands in the app's largest existing module                         | P2       |
+| 03   | If a unit needs "and" to describe, split it                                     | One function that parses input, decides policy and persists; its test needs everything at once | P2       |
+| 03   | Prefer narrow typed arguments over keyword grab-bags                            | A new signature taking `**kwargs`, or a dict parameter with documented keys                    | P2       |
+| 03   | No shared utils, helpers or base class before a second real caller              | A new helpers module or base class with a single consumer                                      | P3       |
+
+## Testing & scenarios
+
+| §ref | Rule                                                                                          | How it shows in a diff                                                             | Severity |
+| ---- | --------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------- | -------- |
+| 09   | Tests land in the same PR as the code; no "tests in a follow-up"                              | Source files changed, no test files changed, and the body promises tests later     | P2       |
+| 09   | A PR with no tests and no stated reason is not ready for review                               | No test diff and no justification anywhere in the body                             | P2       |
+| 09   | Cover the failure and fallback path first, not just the happy path                            | New error branches with no test that reaches them                                  | P2       |
+| 09   | A test must fail if the change is reverted                                                    | Assertions that do not touch the changed behaviour; status-code-only checks        | P2       |
+| 09   | A manual test-plan checkbox is not a test                                                     | The body says "tested manually" or ticks a checklist with no test file in the diff | P2       |
+| 09   | Cover boundary, empty and null: zero, one, max, off-by-one, absent where a value was expected | No test with an empty collection or a null input for the changed function          | P2       |
+| 09   | Cover invalid input: malformed, out-of-range, wrong type, hostile                             | New input parsing with no negative test                                            | P2       |
+| 09   | Cover dependency failure and assert the chosen stance                                         | A new external call with no test of its failure                                    | P2       |
+| 09   | Cover concurrency, idempotency and re-run: the second delivery is safe                        | A new emit, charge or create path with no duplicate-call test                      | P2       |
+| 09   | Cover the open build with the enterprise tree stripped, as a real assertion                   | A boundary change with no test that runs without the enterprise package            | P2       |
+| 09   | Cover realistic volume, not three rows                                                        | A list or aggregation change tested only at toy scale                              | P2       |
+| 09   | A bug fix adds the exact reproducing test                                                     | A fix PR with no new test function                                                 | P2       |
+| CB   | Tests assert content, not just status; assert what is returned and what is excluded           | A test body whose only assertion is a status code                                  | P2       |
+| CB   | Do not stub out the exact path the test claims to protect                                     | A patch applied to the resolver under test, leaving its real branches uncovered    | P2       |
+
+## PR hygiene
+
+| §ref | Rule                                                                                  | How it shows in a diff                                                                             | Severity |
+| ---- | ------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------- | -------- |
+| 07   | One PR, one logical change; split it if the title needs "and"                         | A title joining two changes; a diff spanning unrelated modules                                     | P2       |
+| 07   | Size the PR so a reviewer can read, reason about and QA it in about a day             | A diff in the thousands of lines with mixed concerns                                               | P2       |
+| 07   | Bulk reindents, formatter sweeps, moves and renames go in their own commit or PR      | `git diff --stat -w` far smaller than `git diff --stat`                                            | P2       |
+| 01   | No drive-by refactors or "while I'm here" cleanups bundled with a feature change      | Hunks in files unrelated to the ticket                                                             | P2       |
+| 07   | Stacked PRs each build, pass and stand alone                                          | The body says tests pass only once another PR lands                                                | P2       |
+| 07   | The body states what changed, why, and how it was verified                            | An empty or untouched template body; no verification section                                       | P2       |
+| PB   | Body claims must match the diff                                                       | A claimed change absent from the diff, a test count that does not match, or a claim already merged | P2       |
+| PB   | The type-of-change declaration matches the diff                                       | A feature diff declared as a bug fix                                                               | P3       |
+| PB   | Check for another open PR touching the same files with the opposite approach          | Overlapping open PRs on the same paths                                                             | P2       |
+| PB   | The branch must not be behind its base; verify base currency before trusting the diff | A large behind-count from the left-right rev-list                                                  | P2       |
+| CB   | Cross-repo coupling makes deployment ordering part of the review                      | A referenced paired change elsewhere with no ordering statement                                    | P2       |
+
+## Infra & rollout
+
+| §ref | Rule                                                                                       | How it shows in a diff                                                                   | Severity |
+| ---- | ------------------------------------------------------------------------------------------ | ---------------------------------------------------------------------------------------- | -------- |
+| CB   | Name the images and services that build from a touched Dockerfile or compose file          | A shared build file edited without the body listing its consumers                        | P2       |
+| CB   | No per-build work that belongs in the base image                                           | Dependency installation placed after the source copy                                     | P2       |
+| CB   | Flag irreversible state transitions such as a database major-version bump on a live volume | An image tag major bump on a volume-backed data service                                  | P1       |
+| CB   | One change per pin: a version bump and a base-image switch are two changes                 | A tag diff changing both the version and the variant suffix                              | P2       |
+| CB   | Config mounts read-only; compose defaults explicit; empty-variable fallbacks fail loudly   | A mount without the read-only flag; a default that silently points at the wrong database | P2       |
+| CB   | State dirty-data interaction, deploy ordering, rollback and retry idempotency              | A migration, billing or emit change whose body answers none of these                     | P2       |
+| 01   | Justify every new dependency, abstraction or pattern with a present requirement            | A new package added; a new base class, registry or plugin hook with one user             | P2       |
+
+## Security
+
+| §ref | Rule                                                                                          | How it shows in a diff                                                                                      | Severity |
+| ---- | --------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------- | -------- |
+| 08   | Never commit secrets or known-default tokens                                                  | Placeholder credentials or high-entropy strings in config, env or compose files                             | P0       |
+| 08   | Committed config references a secret's name, never its value                                  | A literal key or password in settings, compose, or a committed env file                                     | P0       |
+| CB   | No secret defaults that look real; credentials are encrypted at rest, not merely encoded      | Base64 applied to a credential; a realistic-looking key literal as a default                                | P1       |
+| CB   | Escape user-controlled strings for their sink                                                 | CSV writes without neutralising leading formula characters; interpolated SQL; shell invocation with a shell | P1       |
+| CB   | Authorization scope comes from the membership-checked queryset, never a raw tenant filter     | A filter taken straight from a request header with no membership check                                      | P1       |
+| CB   | No network rule wider than needed; no password-less user beyond localhost; host ports audited | An open CIDR in compose or a security group; trust authentication enabled                                   | P1       |
+| CB   | Egress from sandboxed execution is proxied or allowlisted                                     | Sandbox network configuration with unrestricted outbound access                                             | P1       |
+
+---
+
+## Severity
+
+- **P0 — blocks.** Broken new code this PR introduced, the open build cannot deploy or migrate, data
+  loss or corruption, a committed secret.
+- **P1 — blocks.** A verified correctness or contract bug: wrong value recorded, response drift, a
+  crash on a scheduled path, a boundary that breaks the open build, undeclared E2E coverage on a
+  behaviour change.
+- **P2 / P3 — should fix, does not block.** Edge cases, performance, consistency, hygiene.
+
+The severity in each row is the default. Raise it when the blast radius is money, access or data;
+lower it when the affected path is unreachable in practice — and say which you did.
+
+## Attribute every finding
+
+Every finding carries one of three labels, and only the first may block:
+
+- **introduced by this PR** — the diff created it.
+- **pre-existing, touched** — it is in a file or function this PR changes. Worth raising, worth
+  fixing here, but it is not what this PR broke.
+- **pre-existing, elsewhere** — found while reading around the change. Report it once, at the bottom,
+  and do not let it lead the review.
+
+A pre-existing finding does not become blocking because it is severe, and an introduced finding does
+not become non-blocking because the PR already merged. Merge status changes the remedy, not the
+attribution.

--- a/.claude/skills/reviewing-prs
+++ b/.claude/skills/reviewing-prs
@@ -1,0 +1,1 @@
+../../.agents/skills/reviewing-prs


### PR DESCRIPTION
## Summary

Adds the `reviewing-prs` agent skill — one body, loaded by both Claude Code (`/reviewing-prs`) and Codex (`$reviewing-prs`) — that reviews a PR, branch or diff against the team coding standards with a positive output contract, and, in repos that have the `e2e/` harness, applies the E2E-coverage gate first. Works outside `future-agi`: every repo-specific step is keyed to an observable predicate. Third PR of the stack.

## Linked issues

Closes #
Linear: —

## Type of change

- [x] 🧹 Chore / refactor (no user-visible change)

## E2E coverage

E2E: exempt (tooling)

---

## 1) What changes were done

**A. `.agents/skills/reviewing-prs/SKILL.md` (268 lines)** — read-only until the human says post. Procedure: (1) get the real diff — base from `gh pr view --json baseRefName`, else the upstream merge-base, else ask; never assume `dev`; (2) list the body's claims; (3) **E2E coverage gate**, only if `e2e/scripts/e2e-coverage.mjs` exists — `node e2e/scripts/e2e-coverage.mjs --pr <n> --json` (no `--base`; the PR's base comes from GitHub; classifies the local checkout) or `--base origin/<base> --json` without a PR; verdict → finding mapping (`needs-marker`/`block` → P1 "E2E coverage undeclared"; `NEW-FLOW` + `exempt` → ask the human whether to accept the override); when the script is absent, "not applicable (no e2e/ harness)"; (4) mechanical gates keyed to predicates (ruff on changed `.py` if `pyproject.toml` configures it; `makemigrations --check` if a migration changed; the PR's own tests; `yarn lint` + contract check if `frontend/package.json` defines them; never cite `yarn type-check`); (5) trace the load-bearing path, then fan out across eleven lenses, each mapped to one section of the standards checklist, reading the full private standard first when `../internal-docs/coding-standards/` or `$FUTUREAGI_INTERNAL_DOCS` exists; (6) adversarially verify every P0/P1; (7) write the review in the exact contract — `## E2E coverage` → `## Blocks merge` → `## Should fix` → `## Good` → `Ready to merge?`, each finding `[P1] title — file:line — §NN — fix`, attributed introduced / pre-existing-touched / pre-existing-elsewhere, `No findings.` for an empty section — then show it and post only after an explicit yes. Plus severity rules, an 18-row red-flags table, and an out-of-scope list.

**B. `references/standards-checklist.md`** — 140 rows distilled from `coding-standards/01–10`, `CODE-REVIEW-PLAYBOOK.md` and `CODING-BIBLE.md`, grouped into 16 lens sections, each row `§ref · rule (≤20 words) · how it shows in a diff · severity`; header `synced-from: internal-docs@6cd9e3b`; rules only (no private prose, incidents, or names); linter-enforced rules excluded. **`references/e2e-coverage-policy.md`** — the classes, decision procedure, verdict table, marker grammar and three worked examples, documenting the classifier as shipped (signals outrank hits; B7 before E2–E5; per-kind marker checks). **`references/e2e-flow-review.md`** — the checklist for spec/`FLOWS.md`/quarantine diffs (annotation ⇔ spec, `FINAL`, shared POLL budgets, fallible assertions, no retries, catalog regenerated, quarantine expiry ≤ 45 days, …).

**C. `.claude/skills/reviewing-prs → ../../.agents/skills/reviewing-prs`**.

## 2) Why the changes were done

- **Product/UX:** none — developer tooling.
- **Technical:** the standards live in a private repo and are applied only when a reviewer remembers them; baseline reviews without the skill (three scenarios) missed the same four things every time — no E2E-coverage consideration, gates eyeballed instead of run, blockers asserted without verification, findings not attributed introduced vs pre-existing — and none ended by asking before posting. The skill makes the output shape and the gate mechanical.
- **Architectural:** the checklist is the public, distilled artifact of private standards (owner's decision: embed a distilled checklist rather than require an `internal-docs` checkout), with a `synced-from` marker and a conditional full read when the checkout exists. Design: `internal-docs/e2e-testing-setup/06-authoring-and-review-skills-design.md` §5.

## 3) Tests written + scenarios each covers

Documentation-TDD, three scenarios, fresh agents:

| Scenario | Without the skill (RED) | With the skill (GREEN) |
| --- | --- | --- |
| R1 — "Review PR #2265" (touches the trace-detail surface OBS-E2E-001 pins) | narrative review; no coverage question; gates not run; no attribution | base resolved via `gh`; classifier run and its verdict in the E2E block; gates run with attribution; findings cite `§`; every P1 carries a verification note; ends by asking before posting |
| R2 — "Review PR #2300" (workflow-only) | manufactured findings | `EXEMPT (tooling) · pass`; `Blocks merge: No findings.` |
| R3 — last merged PR touching `tracer/serializers/`: do the body's test claims match the diff? | took the body at face value | flagged four unsupported body claims against the diff |

Two REFACTOR rounds (the closing posting question; the merged-PR base exception; severity when the gate post-dates the PR) with R2/R3 re-runs, then a task review that verified ~95 of the 140 checklist rows against the source standards (zero misstatements) and found two documentation-drift issues in the policy reference, both fixed and re-verified against the shipped script. Static checks: `quick_validate.py` → valid; 268 lines; 140 rows all ≤ 20 words with severities in P0–P3; no Claude-only syntax or tool names; symlink resolves.

Trigger tests (Task 9): **Codex 10/10 should-trigger, 9/10 shouldn't-trigger;
Claude Code 10/10 should-trigger.** The single negative deviation is `"summarise
the PR"`, which the task brief designates borderline and says to record rather
than tune to — summarising a PR is arguably within the skill's remit, and
narrowing the description enough to exclude it would put the genuine review
prompts at risk. Recorded as a known, accepted deviation. Full method and
per-prompt tables: `.tmp/skill-research/trigger-tests.md`.

Existing tests: none affected.

## 4) How to run / test

```bash
# Claude Code / Codex, from any repo root that has the skill
/reviewing-prs 2265          # or: $reviewing-prs 2265
/reviewing-prs               # current branch vs its base

# personal install for another repo
ln -s "$PWD/.agents/skills/reviewing-prs" ~/.agents/skills/reviewing-prs
ln -s "$PWD/.agents/skills/reviewing-prs" ~/.claude/skills/reviewing-prs

# static validation
python3 ~/.codex/skills/.system/skill-creator/scripts/quick_validate.py .agents/skills/reviewing-prs
grep -c '^| §' .agents/skills/reviewing-prs/references/standards-checklist.md     # 140
grep -nE '\$ARGUMENTS|\$\{CLAUDE_|AskUserQuestion|TaskCreate|spawn_agent|^!`' .agents/skills/reviewing-prs/SKILL.md   # must be empty
```

### UI steps (manual)

None.

## 5) Screenshots / recordings

### Test output

```
$ python3 ~/.codex/skills/.system/skill-creator/scripts/quick_validate.py .agents/skills/reviewing-prs
Skill is valid!

$ wc -l .agents/skills/reviewing-prs/SKILL.md .agents/skills/reviewing-prs/references/*.md
     268 SKILL.md · 180 e2e-coverage-policy.md · 103 e2e-flow-review.md · 264 standards-checklist.md

$ grep -nE '\$ARGUMENTS|\$\{CLAUDE_|AskUserQuestion|TaskCreate|spawn_agent|^!`' .agents/skills/reviewing-prs/SKILL.md
(no output)

$ ls -la .claude/skills/
reviewing-prs -> ../../.agents/skills/reviewing-prs
```

## 6) Edge cases & considerations

- **No harness in the repo:** the E2E block prints "not applicable (no e2e/ harness)" and the standards pass runs unchanged.
- **Stacked PRs:** the base comes from `gh pr view`, never assumed; passing `--base` alongside `--pr` would override the PR's real base and is called out as wrong.
- **Wrong checkout:** the classifier classifies the local diff; `EXEMPT (no-changes)` means "you are not on the PR branch", not a pass.
- **Already-merged PRs** (the only case where `--pr` is combined with `--base`/`--head` SHAs) are documented as the one exception.
- **`NEW-FLOW` + `E2E: exempt`** blocks with "reviewer override required" — the skill asks the human, never passes new surface silently.
- **Standards drift:** the `synced-from` header names the `internal-docs` commit; when the private checkout exists the cited standard is read before a finding is written.

## 7) Pre-existing issues (NOT introduced by this PR)

None in touched code. Known minors for follow-up: one checklist row (the F821/F405 severity guidance) is 23 words against a 20-word rule; the script-absent E2E block's field labels differ slightly from the output template; one row carries a remedy in the diff-signal column; the policy reference's "read the table top to bottom" sentence is stricter than the shipped rule order for E5/E6. The `--pr <n>` form on an open PR has been verified by code reading and `resolveBase` tests but not by a live run (all GREEN targets were merged PRs).

## 8) Architectural / important decisions

- **Positive output contract, not prohibitions** — a review is the seven-block shape or it is not done; `No findings.` is the empty form, so nothing gets invented.
- **Only PR-introduced findings block**; severity is attributed, not inferred from tone.
- **Predicates, not repo names** — every future-agi-specific step is conditional on a file or variable existing, so the same body reviews any repo.
- **The checklist is public by decision** — distilled rules with §-refs, no private prose; the full standard is read when the private checkout is present.

## Checklist

- [x] Code follows the project style guide
- [x] Tests added — documentation-TDD evidence above
- [ ] `bin/test` passes — N/A
- [ ] `yarn test:run` passes — N/A
- [ ] `yarn contracts:check` — N/A
- [x] Documentation updated (pointers landed in the classifier PR)
- [x] No secrets, hardcoded URLs or PII
- [x] PR title follows Conventional Commits
- [ ] Linear issue linked — none created
