### PR TITLE
fix(evals): bind eval configs to the fields the eval runner resolves

### DIFF
--- a/futureagi/ai_tools/tests/test_tracing_tools.py
+++ b/futureagi/ai_tools/tests/test_tracing_tools.py
@@ -4,7 +4,7 @@ import pytest
 
 from ai_tools.registry import registry
 from ai_tools.tests.conftest import run_tool
-from ai_tools.tests.fixtures import make_project, make_trace
+from ai_tools.tests.fixtures import make_eval_template, make_project, make_trace
 
 # ---------------------------------------------------------------------------
 # Shared fixtures
@@ -319,3 +319,141 @@ class TestDeleteProjectTool:
         )
 
         assert result.is_error
+
+
+# ---------------------------------------------------------------------------
+# create_custom_eval_config: what a mapping is allowed to bind to
+# ---------------------------------------------------------------------------
+
+
+class TestEvalConfigMapping:
+    """A config may bind to anything the eval runner can resolve, and the
+    auto-mapper never guesses a binding it cannot defend."""
+
+    @pytest.fixture
+    def project_with_spans(self, tool_context):
+        from tracer.models.observation_span import ObservationSpan
+
+        project = make_project(tool_context, name="mapping-project")
+        trace = make_trace(tool_context, project=project)
+        for i in range(3):
+            ObservationSpan.objects.create(
+                id=f"span-{uuid.uuid4().hex[:8]}",
+                project=project,
+                trace=trace,
+                name="support.turn.0",
+                observation_type="chain",
+                input={"value": "where is my booking"},
+                output={"value": "it departs at 09:40"},
+                span_attributes={
+                    f"llm.input_messages.{i}.message.role": "user",
+                    f"llm.input_messages.{i}.message.content": "where is my booking",
+                    "input.mime_type": "application/json",
+                },
+            )
+        return project
+
+    @pytest.fixture
+    def template(self, tool_context):
+        return make_eval_template(
+            tool_context,
+            name="turn-quality",
+            config={"required_keys": ["input", "output"], "custom_eval": True},
+        )
+
+    def test_auto_map_binds_the_span_body(
+        self, tool_context, project_with_spans, template
+    ):
+        """The whole bug in one assertion: the content lives on the span body,
+        so that is what the mapping has to name."""
+        result = run_tool(
+            "create_custom_eval_config",
+            {
+                "project_id": str(project_with_spans.id),
+                "eval_template_id": str(template.id),
+                "name": "turn-quality-config",
+            },
+            tool_context,
+        )
+        assert not result.is_error, result.content
+        assert result.data["mapping"] == {"input": "input", "output": "output"}
+
+    def test_explicit_body_mapping_is_accepted(
+        self, tool_context, project_with_spans, template
+    ):
+        result = run_tool(
+            "create_custom_eval_config",
+            {
+                "project_id": str(project_with_spans.id),
+                "eval_template_id": str(template.id),
+                "name": "explicit-config",
+                "mapping": {"input": "input", "output": "output"},
+            },
+            tool_context,
+        )
+        assert not result.is_error, result.content
+
+    def test_unmappable_required_key_fails_closed(
+        self, tool_context, project_with_spans
+    ):
+        """A key with no defensible candidate is named back to the caller
+        rather than bound to whatever shares a substring with it."""
+        tmpl = make_eval_template(
+            tool_context,
+            name="needs-a-transcript",
+            config={"required_keys": ["transcript"], "custom_eval": True},
+        )
+        result = run_tool(
+            "create_custom_eval_config",
+            {
+                "project_id": str(project_with_spans.id),
+                "eval_template_id": str(tmpl.id),
+                "name": "transcript-config",
+            },
+            tool_context,
+        )
+        assert result.is_error
+        assert "transcript" in result.content
+
+
+class TestEvalConfigAutoMapRanking:
+    """Pure ranking, no database: the candidate list arrives from an unordered
+    SQL DISTINCT, so order must not decide the answer."""
+
+    CANDIDATES = [
+        "eval.input",
+        "input.mime_type",
+        "raw.input",
+        "llm.input_messages.0.message.role",
+        "llm.input_messages.0.message.content",
+        "llm.input_messages.4.message.role",
+        "input",
+        "output",
+        "fi.llm.output",
+    ]
+
+    def test_same_answer_whatever_the_order(self):
+        import random
+
+        from ai_tools.tools.tracing.create_custom_eval_config import _auto_map_keys
+
+        answers = set()
+        for _ in range(25):
+            shuffled = self.CANDIDATES[:]
+            random.shuffle(shuffled)
+            answers.add(
+                tuple(sorted(_auto_map_keys(["input", "output"], [], shuffled).items()))
+            )
+        assert answers == {(("input", "input"), ("output", "output"))}
+
+    def test_a_role_never_wins_over_content(self):
+        from ai_tools.tools.tracing.create_custom_eval_config import _auto_map_keys
+
+        no_body = [c for c in self.CANDIDATES if c not in ("input", "output")]
+        mapping = _auto_map_keys(["input"], [], no_body)
+        assert mapping["input"] == "raw.input"
+
+    def test_no_candidate_leaves_the_key_unmapped(self):
+        from ai_tools.tools.tracing.create_custom_eval_config import _auto_map_keys
+
+        assert _auto_map_keys(["transcript"], [], ["cost", "latency_ms"]) == {}

--- a/futureagi/ai_tools/tools/tracing/create_custom_eval_config.py
+++ b/futureagi/ai_tools/tools/tracing/create_custom_eval_config.py
@@ -38,18 +38,43 @@ def _similarity_score(a: str, b: str) -> float:
     return ratio
 
 
-def _find_best_match(key: str, available_attributes: list[str]) -> tuple[str, float]:
-    """Find the best matching attribute for a given eval template key."""
-    best_match = ""
-    best_score = 0.0
+# Leaf segments that never carry the text an eval reads. `input` scores 0.8
+# against `llm.input_messages.4.message.role` on containment alone, and that
+# path resolves to the literal string "assistant".
+_NON_CONTENT_LEAVES = frozenset(
+    {"role", "id", "tool_call_id", "mime_type", "json_schema", "index", "type"}
+)
 
-    for attr in available_attributes:
-        score = _similarity_score(key, attr)
-        if score > best_score:
-            best_score = score
-            best_match = attr
 
-    return best_match, best_score
+def _match_rank(key: str, attr: str) -> tuple:
+    """Rank one candidate attribute for a template key. Larger is better.
+
+    The tier outranks the similarity score so an exact name always wins, and
+    the last two members break ties deterministically: the candidate list comes
+    from an unordered SQL DISTINCT, so ranking on the score alone let the same
+    call map differently from one run to the next.
+    """
+    k, a = key.lower(), attr.lower()
+    leaf = a.rsplit(".", 1)[-1]
+    if a == k:
+        tier = 4
+    elif a == f"{k}.value":
+        tier = 3
+    elif leaf == k:
+        tier = 2
+    elif leaf not in _NON_CONTENT_LEAVES:
+        tier = 1
+    else:
+        tier = 0
+    return (tier, _similarity_score(k, a), -len(a), a)
+
+
+def _find_best_match(key: str, available_attributes: list[str]) -> tuple[str, tuple]:
+    """Best matching attribute for an eval template key, with its rank."""
+    if not available_attributes:
+        return "", (0, 0.0, 0, "")
+    best = max(available_attributes, key=lambda a: _match_rank(key, a))
+    return best, _match_rank(key, best)
 
 
 def _auto_map_keys(
@@ -59,24 +84,17 @@ def _auto_map_keys(
 ) -> dict[str, str]:
     """Auto-map eval template keys to the closest matching span attributes.
 
-    Uses string similarity to find the best match for each required/optional key.
-    Only includes optional keys if a sufficiently good match (>= 0.4) is found.
+    A structural match (tier 2 and up) is taken on its shape. Anything else has
+    to clear a real similarity floor, and a key that clears nothing is left
+    unmapped: the caller fails closed on a missing required key, which the
+    caller can recover from, where a wrong binding is not recoverable.
     """
     mapping = {}
-    min_score_required = 0.3
-    min_score_optional = 0.4
+    min_similarity = 0.6
 
-    for key in required_keys:
-        best_match, score = _find_best_match(key, available_attributes)
-        if score >= min_score_required and best_match:
-            mapping[key] = best_match
-        # Still include with empty value so caller knows it was not matched
-        elif best_match:
-            mapping[key] = best_match
-
-    for key in optional_keys:
-        best_match, score = _find_best_match(key, available_attributes)
-        if score >= min_score_optional and best_match:
+    for key in required_keys + optional_keys:
+        best_match, (tier, score, _, _) = _find_best_match(key, available_attributes)
+        if best_match and (tier >= 2 or (tier == 1 and score >= min_similarity)):
             mapping[key] = best_match
 
     return mapping
@@ -148,6 +166,7 @@ class CreateCustomEvalConfigTool(BaseTool):
         from model_hub.models.evals_metric import EvalTemplate
         from tracer.models.custom_eval_config import CustomEvalConfig
         from tracer.models.project import Project
+        from tracer.utils.eval import with_span_body_fields
         from tracer.utils.sql_queries import SQL_query_handler
 
         # Validate project
@@ -176,9 +195,10 @@ class CreateCustomEvalConfigTool(BaseTool):
                 error_code="VALIDATION_ERROR",
             )
 
-        # Fetch available eval attributes for the project
-        available_attributes = SQL_query_handler.get_span_attributes_for_project(
-            str(params.project_id)
+        # Everything the eval runner can resolve on a span: the project's own
+        # span_attributes keys plus the span body fields (`input`, `output`, …).
+        available_attributes = with_span_body_fields(
+            SQL_query_handler.get_span_attributes_for_project(str(params.project_id))
         )
 
         # Get required and optional keys from the eval template config
@@ -233,6 +253,25 @@ class CreateCustomEvalConfigTool(BaseTool):
                     template_id=str(params.eval_template_id),
                     mapping=final_mapping,
                 )
+                unmapped = [k for k in required_keys if k not in final_mapping]
+                if unmapped:
+                    lines = []
+                    for key in unmapped:
+                        ranked = sorted(
+                            available_attributes,
+                            key=lambda a: _match_rank(key, a),
+                            reverse=True,
+                        )[:5]
+                        lines.append(
+                            f"- `{key}`: closest are "
+                            + ", ".join(f"`{a}`" for a in ranked)
+                        )
+                    return ToolResult.error(
+                        "Could not auto-map every required key for template "
+                        f"'{template.name}'. Call again with an explicit "
+                        "`mapping` for:\n" + "\n".join(lines),
+                        error_code="VALIDATION_ERROR",
+                    )
             else:
                 final_mapping = {}
 

--- a/futureagi/tracer/utils/eval.py
+++ b/futureagi/tracer/utils/eval.py
@@ -647,7 +647,7 @@ def _process_mapping(
                 resolved_value = value
                 break
 
-        if resolved_value is _MISSING and attribute in _SPAN_PUBLIC_FIELDS:
+        if resolved_value is _MISSING and attribute in SPAN_PUBLIC_FIELDS:
             model_val = getattr(span, attribute, _MISSING)
             if model_val is not _MISSING:
                 resolved_value = model_val
@@ -2658,7 +2658,7 @@ _SESSION_PUBLIC_FIELDS = frozenset({"name", "bookmarked"})
 # ``_resolve_attr(span_attrs, …)`` because they live on the Django model,
 # not in the JSON bag.  This allow-list mirrors the pattern used by
 # ``_TRACE_PUBLIC_FIELDS`` above.
-_SPAN_PUBLIC_FIELDS = frozenset(
+SPAN_PUBLIC_FIELDS = frozenset(
     {
         "latency_ms",
         "prompt_tokens",
@@ -2686,6 +2686,18 @@ _task_filter_witnesses: ContextVar[tuple[dict, ...]] = ContextVar(
 _trace_span_memo: ContextVar[dict[str, list] | None] = ContextVar(
     "eval_trace_span_memo", default=None
 )
+
+
+def with_span_body_fields(keys) -> list[str]:
+    """Every attribute path an eval mapping may bind to on a span.
+
+    The project's own ``span_attributes`` keys plus the model fields
+    ``_process_mapping`` already resolves. Creation surfaces pass their own key
+    inventory through this so they offer exactly what the runner can resolve.
+    ``input`` and ``output`` carry the span body and were offered by neither,
+    which left a project whose content lives there with no valid mapping to pick.
+    """
+    return sorted(set(keys) | SPAN_PUBLIC_FIELDS)
 
 
 def _resolve_span_path(span: ObservationSpan, path: str):
@@ -2724,7 +2736,7 @@ def _resolve_span_path(span: ObservationSpan, path: str):
     if result is not _MISSING:
         return result
 
-    if head in _SPAN_PUBLIC_FIELDS and not rest:
+    if head in SPAN_PUBLIC_FIELDS and not rest:
         value = getattr(span, head, _MISSING)
         if value is not _MISSING:
             return value
@@ -3099,7 +3111,7 @@ _heavy_span_ids: ContextVar[frozenset[str] | None] = ContextVar(
 def _is_heavy_span_tail(tail: str) -> bool:
     """True iff ``tail`` is NOT a bare public field — i.e. lives in the
     heavy JSON bag and won't be present in a lean span."""
-    return tail not in _SPAN_PUBLIC_FIELDS
+    return tail not in SPAN_PUBLIC_FIELDS
 
 
 def _selector_index(sel: str, n: int) -> int | None:


### PR DESCRIPTION
## What

An eval config could not be bound to a span's `input` and `output`, the two fields the eval runner has always resolved and the two a customer expects to map to.

## Why it matters

`_process_mapping` resolves a mapping value in three passes: the span attribute bag, then `<value>.value`, then the span's own model fields via `SPAN_PUBLIC_FIELDS`, which contains `input` and `output`. The two creation surfaces offered only the first of those three. So on a project whose content lives on the span body, every valid mapping was rejected as "not a valid span attribute".

Measured on a 1,229 span project: `input` -> `input` and `output` -> `output` resolve on 30 of 30 spans of every span type and carry the customer's question and the agent's reply. Neither was offerable.

## Root cause

`create_custom_eval_config` and the EvalPicker's spans branch both read `get_span_attributes_for_project`, a `SELECT DISTINCT key FROM ... jsonb_object_keys(span_attributes)`. The reader and the writer disagreed about what a mapping is allowed to name.

The auto-mapper then made it worse. `_similarity_score` returns a flat `0.8` for any candidate that merely *contains* the key, so on a project with thirty `llm.input_messages.*` keys every one of them ties, and the winner is decided by the order an unordered `SELECT DISTINCT` returned rows in. Four hundred shuffles of the same seven candidates for the key `input`:

```
  68x  input.mime_type
  65x  eval.input
  58x  raw.input
  58x  llm.input_messages.4.message.content
  53x  llm.input_messages.4.message.role
  51x  llm.input_messages.0.message.role
  47x  llm.input_messages.0.message.content
```

`llm.input_messages.4.message.role` resolves to the literal string `assistant`. A config bound to it is created successfully, reports a mapping, and evaluates nothing.

## Fix

One predicate answers what a mapping may bind to, and the tool passes its own key inventory through it. It takes the keys rather than fetching them so a caller keeps its own store.

```python
def with_span_body_fields(keys) -> list[str]:
    return sorted(set(keys) | SPAN_PUBLIC_FIELDS)
```

**Scoped to the agent tool on purpose.** The EvalPicker's spans branch has the same gap, and it is deliberately not touched here. That endpoint has just been reworked to publish only attributes it has verified from a labelled sample, and it returns an "unavailable" response rather than guess. Fourteen always-present model fields are not a labelled sample, so bolting them on breaks three tests in `test_attribute_reads_recut.py` that exist to enforce exactly that. That is a real question for whoever owns the picker, not something to settle inside this PR.

Auto-mapping is now ranked by tier before similarity, and the rank carries its own total order so the candidate list's arrival order cannot decide the answer:

| tier | rule | example for key `input` |
|---|---|---|
| 4 | the attribute is the key | `input` |
| 3 | the attribute is `<key>.value` | `input.value` |
| 2 | the leaf is the key | `raw.input` |
| 1 | similarity, content-bearing leaf | `llm.input_messages.0.message.content` |
| 0 | leaf is `role`, `id`, `mime_type`, ... | `llm.input_messages.4.message.role` |

Tier 0 never auto-maps and tier 1 has to clear a real similarity floor. A required key that clears nothing is left unmapped and the tool returns an error naming the key and its five closest candidates, because a caller can recover from a missing mapping and cannot recover from a wrong one. That replaces an `elif` whose own comment said it was including the key "with empty value" while the code assigned the best match.

## Tests

`ai_tools/tests/test_tracing_tools.py`, six new tests: auto-map binds the span body, an explicit body mapping is accepted, an unmappable required key fails closed, the answer is the same under 25 shuffles of the candidate list, a `role` never beats content, and no candidate leaves the key unmapped.

`ai_tools/tests` plus `tracer/tests/test_attribute_reads_recut.py`, `test_e2e_eval_lifecycle.py` and `test_eval_attributes_list.py`: 370 passed.

## Proof

The same project, the same eval templates, the same tool call with no `mapping` argument. Left is what the tool produced before this change; the mapping picker marks the bound path `(not in row)` on the sample row it is showing. Right is what it produces after.

![eval task mapping, before and after](https://github.com/user-attachments/assets/740e83ae-5c9f-48f4-b6f4-a5e32df5b115)

Resolved against real spans, no evaluator called:

| mapping | spans with every key populated |
|---|---|
| `input` -> `llm.input_messages.4.message.role`, `output` -> `...tool_calls.1.tool_call.function.arguments` | 0 of 20 |
| `input` -> `input`, `output` -> `output` | 20 of 20 |

Then run for real on the `airline-support-agent` project, 3 spans x 2 configs: 6 of 6 entries `completed`, 0 errored. Five Pass and one Fail, and the Fail is correct. Customer: `give me the policy reference, not a maybe`. Agent: `Your case has been escalated to our Tier 2 support team. You'll receive a callback within 24 hours with the specific policy reference`. The judge's reason: "This is precisely the kind of non-committal, deferred response the user explicitly rejected."
