### PR TITLE
fix(evals): refuse an eval task whose mapping resolves on none of its target spans

### DIFF
--- a/futureagi/ai_tools/tests/test_tracing_tools.py
+++ b/futureagi/ai_tools/tests/test_tracing_tools.py
@@ -4,7 +4,7 @@ import pytest
 
 from ai_tools.registry import registry
 from ai_tools.tests.conftest import run_tool
-from ai_tools.tests.fixtures import make_project, make_trace
+from ai_tools.tests.fixtures import make_eval_template, make_project, make_trace
 
 # ---------------------------------------------------------------------------
 # Shared fixtures
@@ -319,3 +319,135 @@ class TestDeleteProjectTool:
         )
 
         assert result.is_error
+
+
+# ---------------------------------------------------------------------------
+# create_eval_task: the mapping has to resolve on the spans the task will read
+# ---------------------------------------------------------------------------
+
+
+class TestEvalTaskMappingGate:
+    """The project attribute list is a union over every span, so a path that
+    only ever appears on one span type passes config creation and then reads
+    empty on the type the task is scoped to."""
+
+    @pytest.fixture
+    def project(self, tool_context):
+        return make_project(tool_context, name="gate-project")
+
+    @pytest.fixture
+    def spans(self, tool_context, project):
+        from tracer.models.observation_span import ObservationSpan
+
+        trace = make_trace(tool_context, project=project)
+        for i in range(3):
+            ObservationSpan.objects.create(
+                id=f"span-agent-{i}-{uuid.uuid4().hex[:6]}",
+                project=project,
+                trace=trace,
+                name="support.conversation",
+                observation_type="agent",
+                input={"value": "where is my booking"},
+                output={"value": "it departs at 09:40"},
+                span_attributes={},
+            )
+            ObservationSpan.objects.create(
+                id=f"span-llm-{i}-{uuid.uuid4().hex[:6]}",
+                project=project,
+                trace=trace,
+                name="ChatCompletion",
+                observation_type="llm",
+                span_attributes={"raw.input": "[...]", "raw.output": "{...}"},
+            )
+        return project
+
+    def _config(self, tool_context, project, name, mapping):
+        from tracer.models.custom_eval_config import CustomEvalConfig
+
+        template = make_eval_template(
+            tool_context,
+            name=f"tmpl-{name}",
+            config={"required_keys": list(mapping), "custom_eval": True},
+        )
+        return CustomEvalConfig.objects.create(
+            eval_template=template,
+            name=name,
+            project=project,
+            model="turing_large",
+            mapping=mapping,
+        )
+
+    def test_a_mapping_that_resolves_is_allowed(self, tool_context, spans):
+        cfg = self._config(
+            tool_context, spans, "body-config", {"input": "input", "output": "output"}
+        )
+        result = run_tool(
+            "create_eval_task",
+            {
+                "project_id": str(spans.id),
+                "name": "good-task",
+                "eval_config_ids": [str(cfg.id)],
+            },
+            tool_context,
+        )
+        assert not result.is_error, result.content
+
+    def test_a_mapping_that_resolves_on_nothing_is_refused(self, tool_context, spans):
+        """`raw.input` is a real key on this project, on the llm spans. It is
+        not on the agent spans, and this task is scoped to those."""
+        cfg = self._config(
+            tool_context,
+            spans,
+            "raw-config",
+            {"input": "raw.input", "output": "raw.output"},
+        )
+        result = run_tool(
+            "create_eval_task",
+            {
+                "project_id": str(spans.id),
+                "name": "blocked-task",
+                "eval_config_ids": [str(cfg.id)],
+                "filters": {"observation_type": ["agent"]},
+            },
+            tool_context,
+        )
+        assert result.is_error
+        assert "raw-config" in result.content
+        assert "raw.input" in result.content
+
+    def test_the_same_mapping_is_fine_when_scoped_to_the_spans_that_carry_it(
+        self, tool_context, spans
+    ):
+        cfg = self._config(
+            tool_context,
+            spans,
+            "raw-config-llm",
+            {"input": "raw.input", "output": "raw.output"},
+        )
+        result = run_tool(
+            "create_eval_task",
+            {
+                "project_id": str(spans.id),
+                "name": "llm-task",
+                "eval_config_ids": [str(cfg.id)],
+                "filters": {"observation_type": ["llm"]},
+            },
+            tool_context,
+        )
+        assert not result.is_error, result.content
+
+    def test_no_spans_to_sample_means_no_opinion(self, tool_context):
+        empty = make_project(tool_context, name="empty-project")
+        cfg = self._config(
+            tool_context, empty, "empty-config", {"input": "anything.at.all"}
+        )
+        result = run_tool(
+            "create_eval_task",
+            {
+                "project_id": str(empty.id),
+                "name": "empty-task",
+                "eval_config_ids": [str(cfg.id)],
+            },
+            tool_context,
+        )
+        assert not result.is_error, result.content

--- a/futureagi/ai_tools/tools/tracing/create_eval_task.py
+++ b/futureagi/ai_tools/tools/tracing/create_eval_task.py
@@ -1,5 +1,6 @@
 from uuid import UUID
 
+import structlog
 from pydantic import BaseModel as PydanticBaseModel
 from pydantic import Field
 
@@ -10,6 +11,8 @@ from ai_tools.formatting import (
     section,
 )
 from ai_tools.registry import register_tool
+
+logger = structlog.get_logger(__name__)
 
 
 class CreateEvalTaskInput(PydanticBaseModel):
@@ -120,6 +123,23 @@ class CreateEvalTaskTool(BaseTool):
         filters = params.filters or {}
         filters["project_id"] = str(params.project_id)
 
+        # Last gate before a paid run: does each config's mapping actually resolve
+        # on the spans this task will read? `create_custom_eval_config` checks that
+        # a mapping value is a known attribute NAME, and the project attribute list
+        # is a union over every span, so a path that only ever appears on one span
+        # type passes that check and then reads empty on the type this task is
+        # scoped to. Nothing downstream catches it: the run just errors every row.
+        blocked = self._configs_that_resolve_on_nothing(project, filters, eval_configs)
+        if blocked:
+            return ToolResult.error(
+                "These eval configs map to attributes that carry no value on the "
+                "spans this task targets, so every row would error:\n"
+                + "\n".join(blocked)
+                + "\n\nRead a target span with `get_span` or `read_trace_span` and "
+                "map to a path you have seen hold content on that span.",
+                error_code="VALIDATION_ERROR",
+            )
+
         # Create eval task
         from django.utils import timezone
 
@@ -182,3 +202,47 @@ class CreateEvalTaskTool(BaseTool):
                 "status": eval_task.status,
             },
         )
+
+    _MAPPING_SAMPLE = 5
+
+    def _configs_that_resolve_on_nothing(self, project, filters, eval_configs):
+        """One line per config whose mapping resolves on none of a small sample.
+
+        Sampled rather than exhaustive: a mapping that reads empty on five spans
+        of the targeted type reads empty on all of them, and a sample keeps this
+        to one query on the create path.
+        """
+        from tracer.models.observation_span import ObservationSpan
+        from tracer.utils.eval import mapping_resolution_coverage
+
+        obs_types = filters.get("observation_type")
+        scope = "spans"
+        try:
+            span_qs = ObservationSpan.objects.filter(project=project)
+            if obs_types:
+                span_qs = span_qs.filter(observation_type__in=obs_types)
+                scope = f"`{'`, `'.join(str(t) for t in obs_types)}` spans"
+            sample = list(span_qs.order_by("-start_time")[: self._MAPPING_SAMPLE])
+        except Exception as e:
+            # Advisory read. A project with nothing to sample already gets no
+            # opinion, and a sample that cannot be taken is the same condition;
+            # neither is a reason to refuse a create the caller is entitled to.
+            logger.warning("eval_task_mapping_sample_unavailable", error=str(e))
+            return []
+        if not sample:
+            return []
+
+        blocked = []
+        for config in eval_configs:
+            if not config.mapping:
+                continue
+            hits = mapping_resolution_coverage(
+                config.mapping, sample, config.eval_template_id
+            )
+            if hits == 0:
+                pairs = ", ".join(f"`{k}` -> `{v}`" for k, v in config.mapping.items())
+                blocked.append(
+                    f"- `{config.name}`: {pairs} resolves on 0 of "
+                    f"{len(sample)} sampled {scope}"
+                )
+        return blocked

--- a/futureagi/tracer/utils/eval.py
+++ b/futureagi/tracer/utils/eval.py
@@ -2688,6 +2688,25 @@ _trace_span_memo: ContextVar[dict[str, list] | None] = ContextVar(
 )
 
 
+def mapping_resolution_coverage(mapping, spans, eval_template_id) -> int:
+    """How many of ``spans`` have every mapped key resolve to a value.
+
+    The same resolver the eval run uses, so a zero here is exactly the zero the
+    run would produce, without spending a model call to find out.
+    """
+    if not mapping:
+        return len(spans)
+    hits = 0
+    for span in spans:
+        try:
+            resolved = _process_mapping(dict(mapping), span, eval_template_id)
+        except Exception:
+            continue
+        if resolved and all(v not in (None, "", "None") for v in resolved.values()):
+            hits += 1
+    return hits
+
+
 def _resolve_span_path(span: ObservationSpan, path: str):
     """Walk a path against a span via the ``span_attributes`` bag.
 


### PR DESCRIPTION
## What

An eval task can be created with a mapping that resolves to nothing on the spans it is scoped to. It then runs, errors every row, and bills for it.

## How it happens, from a real run

Falcon was asked to build two evals on a project. It did everything right: read the spans, chose the `agent` span type deliberately, passed an explicit `mapping`, and ran the dry run first. What it wrote:

```
airline-task-completion-eval     {"input": "raw.input", "output": "raw.output"}
airline-is-concise-eval          {"output": "raw.output"}
airline-support-agent-eval-task  historical, 300 spans, filters {"observation_type": ["agent"]}
```

`raw.input` and `raw.output` are real keys on that project. They live on the `ChatCompletion` (`llm`) spans. The task is scoped to `agent`. Resolved against the spans it targets: **0 of 20**. `input` and `output` resolve 20 of 20 on those same spans.

Running it errored every entry:

```
File "model_hub/utils/eval_input_validation.py", line 101, in validate_eval_inputs
    raise ValueError(...)
```

## Why nothing caught it

| gate | what it checks | why it misses this |
|---|---|---|
| `get_project_eval_attributes` | which keys exist in the project | it is a union over every span, so a key on one span type looks available for all |
| `create_custom_eval_config` | the mapping value is a known attribute name | never resolves it against a span |
| `test_eval_template` | the template runs | takes a template id and a mapping and no span at all |
| `create_eval_task` | the configs exist on the project | checks nothing about the mapping |

So the last gate before a paid run does not answer the only question that matters: does this mapping produce a value on the rows this task will read.

## Fix

`create_eval_task` already knows the project, the filters and the linked configs. It now samples five of the spans it would read, narrowed by `observation_type` when the filters name one, and resolves each config's mapping against them through `_process_mapping`, the same resolver the run uses. Zero coverage is a create-time error:

```
These eval configs map to attributes that carry no value on the spans this task
targets, so every row would error:
- `airline-task-completion-eval`: `input` -> `raw.input`, `output` -> `raw.output`
  resolves on 0 of 5 sampled `agent` spans

Read a target span with `get_span` or `read_trace_span` and map to a path you have
seen hold content on that span.
```

Sampled rather than exhaustive: a mapping that reads empty on five spans of the targeted type reads empty on all of them, and a sample keeps this to one query on the create path.

The read is advisory. A project with no spans to sample gets no opinion, and a sample that cannot be taken at all is the same condition and is logged rather than raised. A defensive read is not a reason to refuse a create the caller is entitled to.

## Tests

`ai_tools/tests/test_tracing_tools.py`, four tests: a mapping that resolves is allowed, one that resolves on nothing is refused with the config and mapping named, the *same* mapping is allowed once the task is scoped to the span type that carries it, and a project with nothing to sample is not blocked.

`ai_tools/tests` plus `tracer/tests/test_eval_attributes_list.py`: 427 passed.

## Video

The run this was found in, filmed end to end. Falcon clicks its own **Build the Evals** skill, is handed two approved templates and a project id, works for six minutes, and writes the configs and the historical task. The take then leaves the chat for the surface a customer would actually check: Tasks, the task Falcon just wrote, and its variable mapping resolved against a live sample row.

The last frame is the whole bug. The mapping panel marks `raw.input` and `raw.output` as `(not in row)`, and the sample row sitting next to it carries the real question and the real answer under `input` and `output`.

https://github.com/user-attachments/assets/9331effa-9d7f-4549-9795-99c1a89353ef

The take stops at that page. Everything after it on the recording is the eval running and failing, which is the same evidence in a less legible form.

### What the amber costs, and what correct looks like

A second take, filmed today against the same project. No agent turn in it: it is the product rendering rows that already exist. It walks two screens twice, once on the task above and once on the same task rebuilt with a mapping that resolves.

The broken one. The Live Preview row visibly carries the customer question under `input` and the agent reply under `output`, and the Variable Mapping beside it marks `input -> raw.input` and `output -> raw.output` as `(not in row)`. Its Logs tab reads `High error rate detected (100%)`, `0 Successful`, `6 Errors`, `6 Total Spans`.

The rebuilt one, `input -> input` and `output -> output`, on the same sample row and the same `agent` filter. No amber on any variable, and `6 / 6 passed`, `0 Errors`, `All evaluations completed successfully`.

https://github.com/user-attachments/assets/9216ee82-bff4-476e-915e-bda74404b036

Same project, same span scope, same two eval templates, same sample row on screen in both
halves. The only difference is the mapping this PR now refuses to accept at create time.

One caveat on that recording, since it is visible: the stack it was filmed on is behind
`dev` and still renders the grouped error label as `Unknown error`. `dev` fixed that in
`0689b98ae`. The counts are what this PR is evidenced by, and they are the same either way.
