### PR TITLE
ci(e2e): run the coverage classifier on every PR

### DIFF
--- a/.github/workflows/e2e-coverage-check.yml
+++ b/.github/workflows/e2e-coverage-check.yml
@@ -1,0 +1,99 @@
+# Every PR either carries an E2E flow for the behaviour it changes, or says why
+# it does not. `e2e/scripts/e2e-coverage.mjs` classifies the diff and verifies the
+# `E2E:` line in the PR body against that classification; this job is the wall
+# that makes the declaration mechanical instead of a thing reviewers remember.
+#
+# INFORMATIONAL FOR NOW. The job goes red when a behaviour change carries no
+# declaration, but it is deliberately NOT in the `general-branch-protect-approval`
+# ruleset's required checks, so it cannot block a merge yet. Ratchet it by adding
+# "E2E coverage declared" to that ruleset once the red/green signal has been
+# watched for a couple of weeks — no change to this file is needed.
+#
+# `edited` is in the trigger list on purpose: the fix for a missing declaration is
+# a PR-body edit, and without that event the check would stay red until an
+# unrelated push.
+name: e2e-coverage
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize, reopened]
+    branches: [dev, main]
+
+permissions:
+  contents: read
+
+jobs:
+  declared:
+    name: E2E coverage declared
+    runs-on: ubuntu-latest
+    # Bot and integration traffic declares nothing, because none of it is where a
+    # behaviour change is authored: release-please assembles other people's merged
+    # work, dependabot bumps dependencies, and both directions of the dev<->main
+    # sync replay commits that were each classified on the way in. Verified
+    # against real traffic — `chore/merge-main-into-dev-20260825` (#2324) is why
+    # the merge-back pattern is here and not just the dev->main case.
+    if: >-
+      !startsWith(github.head_ref, 'release-please--') &&
+      !startsWith(github.head_ref, 'dependabot/') &&
+      !startsWith(github.head_ref, 'chore/merge-main-into-dev') &&
+      !(github.head_ref == 'dev' && github.base_ref == 'main')
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22.18"
+
+      # The classifier reads the base as a git ref. checkout gives us the PR's
+      # merge commit but not necessarily the base branch, so fetch it by name.
+      - name: Fetch base branch
+        env:
+          BASE_REF: ${{ github.base_ref }}
+        run: git fetch --no-tags origin "+refs/heads/$BASE_REF:refs/remotes/origin/$BASE_REF"
+
+      # Through a file and an env var, never interpolated into the shell: a PR
+      # body is attacker-controlled text.
+      - name: Write PR body
+        env:
+          PR_BODY: ${{ github.event.pull_request.body }}
+        run: printf '%s' "$PR_BODY" > /tmp/pr-body.txt
+
+      # Exits 1 on `block` / `needs-marker`, which fails this step and turns the
+      # check red. pipefail keeps `tee` from swallowing that.
+      - name: Classify the diff and verify the declaration
+        shell: bash
+        env:
+          BASE_REF: ${{ github.base_ref }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
+        run: |
+          node e2e/scripts/e2e-coverage.mjs \
+            --base "origin/$BASE_REF" \
+            --title "$PR_TITLE" \
+            --body /tmp/pr-body.txt \
+            | tee /tmp/coverage.txt
+
+      # The verdict belongs where the author already is, not four clicks into a
+      # log. Runs on success and failure.
+      - name: Summarise
+        if: always()
+        run: |
+          {
+            echo '## E2E coverage'
+            echo
+            echo '```'
+            cat /tmp/coverage.txt 2>/dev/null || echo '(classifier produced no output)'
+            echo '```'
+            echo
+            echo 'Declare coverage with one line in the PR body:'
+            echo
+            echo '| line | when |'
+            echo '| --- | --- |'
+            echo '| `E2E: new <ID>` | this PR adds the flow (it must appear in the `e2e/FLOWS.md` diff) |'
+            echo '| `E2E: updated <ID>` | this PR changes an existing flow |'
+            echo '| `E2E: covered-by <ID>` | an existing, unchanged flow already proves it |'
+            echo '| `E2E: exempt (<reason>)` | no flow needed — see `e2e/README.md` for the reasons |'
+            echo
+            echo 'Details: `e2e/README.md` § "Declaring coverage on a PR".'
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -415,6 +415,17 @@ yourself — the `feat`-in-an-uncovered-area signal reads it, and nothing else p
 yarn coverage --base origin/<base> --title "<branch or PR title>" --body <file>
 ```
 
+CI runs the same check on every PR into `dev` and `main`
+(`.github/workflows/e2e-coverage-check.yml`, the **E2E coverage declared** check). It classifies the
+PR's diff, verifies the `E2E:` line against it, and puts the verdict in the job summary. Because the
+fix for a missing line is a body edit, the workflow re-runs on `edited` — correct the body and the
+check goes green without a push. Release-please, dependabot and the `dev`↔`main` sync PRs are
+skipped: they replay commits that were each classified on the way in.
+
+The check is **informational for now** — it goes red, but it is not in the branch ruleset's required
+checks, so it cannot block a merge yet. Ratcheting it to required is a ruleset change, not a change
+to the workflow.
+
 ---
 
 ## Quarantine and the flake policy

--- a/e2e/scripts/e2e-coverage.mjs
+++ b/e2e/scripts/e2e-coverage.mjs
@@ -773,6 +773,17 @@ export function renderHuman(result) {
     lines.push(
       `Areas with no flows yet: ${result.areasWithoutFlows.join(", ")}`,
     );
+  // UNDETERMINED is the commonest verdict, and on its own it only says "behaviour
+  // files changed" — on a large diff that leaves the author guessing which ones.
+  // Name them, so the answer to "why is this asking me?" is on screen.
+  if (result.classification === "UNDETERMINED") {
+    const behaviour = result.files.filter((f) => /^B[1-6]$/.test(f.cls));
+    const shown = behaviour.slice(0, 5).map((f) => `${f.path} (${f.cls})`);
+    const rest = behaviour.length - shown.length;
+    lines.push(
+      `Why: ${behaviour.length} behaviour file${behaviour.length === 1 ? "" : "s"} — ${shown.join(", ")}${rest > 0 ? `, +${rest} more` : ""}`,
+    );
+  }
   lines.push(`Marker: ${result.marker ? result.marker.raw : "missing"}`);
   lines.push(`Verdict: ${result.verdict} — ${result.explanation}`);
   return lines;

--- a/e2e/scripts/e2e-coverage.test.mjs
+++ b/e2e/scripts/e2e-coverage.test.mjs
@@ -949,6 +949,56 @@ test("renderHuman marks pinned hits under a passing EXEMPT as informational", ()
   assert.doesNotMatch(update, /informational/);
 });
 
+test("renderHuman names the behaviour files behind an UNDETERMINED verdict", () => {
+  const base = {
+    classification: "UNDETERMINED",
+    autoReason: null,
+    areas: ["observe"],
+    hits: [],
+    newSurfaceSignals: [],
+    areasWithoutFlows: [],
+    marker: null,
+    verdict: "needs-marker",
+    explanation: "behaviour files changed with no recognised signal",
+  };
+  const file = (path, cls) => ({ path, cls, area: "observe" });
+
+  // "behaviour files changed" is unactionable on a large diff unless the files
+  // are named; exempt classes must not be listed as the reason.
+  const one = renderHuman({
+    ...base,
+    files: [
+      file("frontend/src/components/traceDetail/SpanDetailPane.jsx", "B2"),
+      file("README.md", "E1"),
+    ],
+  }).join("\n");
+  assert.match(
+    one,
+    /Why: 1 behaviour file — frontend\/src\/components\/traceDetail\/SpanDetailPane\.jsx \(B2\)/,
+  );
+  assert.doesNotMatch(one, /README\.md/);
+
+  // Long lists are capped so the line stays readable, with the remainder counted.
+  const many = renderHuman({
+    ...base,
+    files: Array.from({ length: 7 }, (_, i) =>
+      file(`frontend/src/sections/observe/f${i}.jsx`, "B2"),
+    ),
+  }).join("\n");
+  assert.match(many, /Why: 7 behaviour files —/);
+  assert.match(many, /\+2 more/);
+
+  // Only UNDETERMINED needs the explanation; the others already say why.
+  const exempt = renderHuman({
+    ...base,
+    classification: "EXEMPT",
+    autoReason: "docs",
+    verdict: "pass",
+    files: [file("README.md", "E1")],
+  }).join("\n");
+  assert.doesNotMatch(exempt, /Why:/);
+});
+
 for (const n of [2265, 2182, 1976, 2321, 2358, 2300]) {
   test(`fixture PR #${n} classifies as recorded`, async () => {
     const fx = JSON.parse(


### PR DESCRIPTION
## Summary

Wires `e2e/scripts/e2e-coverage.mjs` into CI. Every PR into `dev`/`main` now gets its diff classified and its `E2E:` declaration verified, with the verdict in the job summary. **Informational for now** — the check goes red, but it is deliberately not in the branch ruleset's required checks, so it cannot block a merge yet.

## Linked issues

Closes #
Linear: —

## Type of change

- [x] 🧹 Chore / refactor (no user-visible change)

## E2E coverage

E2E: exempt (tooling)

---

## 1) What changes were done

**A. `.github/workflows/e2e-coverage-check.yml` (new)** — job **E2E coverage declared**, on `pull_request` `[opened, edited, synchronize, reopened]` into `dev`/`main`.

- `edited` is in the trigger list on purpose: the fix for a missing declaration is a PR-body edit, and without it the check would stay red until an unrelated push.
- Skips bot and integration traffic that authors no behaviour: `release-please--*`, `dependabot/*`, `chore/merge-main-into-dev*`, and `dev`→`main`.
- Fetches the base branch by name (checkout gives the merge commit, not necessarily the base), passes the PR body through a file and the title through an env var — a PR body is attacker-controlled text and is never interpolated into the shell.
- Writes the classifier's verdict plus the four declaration lines to `$GITHUB_STEP_SUMMARY`, so the author reads it where they already are.

**B. `e2e/scripts/e2e-coverage.mjs`** — `renderHuman` now names the behaviour files behind an `UNDETERMINED` verdict:

```
Why: 6 behaviour files — .../EditAgentDetails.jsx (B2), .../AgentVoiceForm.jsx (B2), …, +1 more
```

Capped at five with a remainder count, exempt files excluded, and only for `UNDETERMINED` — the other verdicts already explain themselves.

**C. `e2e/scripts/e2e-coverage.test.mjs`** — a test for that line: it names the behaviour file, omits exempt files, truncates long lists, and stays absent on non-`UNDETERMINED` verdicts.

**D. `e2e/README.md`** — documents that CI runs the check, why it re-runs on `edited`, what is skipped, and that it is informational until the ruleset is changed.

## 2) Why the changes were done

- **Product/UX:** none — developer tooling.
- **Technical:** the classifier shipped in #2467 but nothing invoked it, so the coverage rule was only as good as a reviewer's memory. As `CODE-REVIEW-PLAYBOOK.md` puts it, a bot only forces anything when it is wired as a required status check — this is the first half of that, deliberately stopping short of required.
- **Architectural:** ratcheting to required is a ruleset change, not an edit to this workflow. The playbook's own advice is informational first, tune, then ratchet.

## 3) Tests written + scenarios each covers

| Test | Scenario |
| --- | --- |
| `renderHuman names the behaviour files behind an UNDETERMINED verdict` | the `Why:` line names the behaviour file; exempt files are not listed as the reason; >5 files truncate with `+N more`; no `Why:` on `EXEMPT` |

Verified RED before GREEN: with the `Why:` block removed the suite is 106/107 with exactly that test failing; restored, 107/107.

The workflow itself is not unit-testable, so it was verified by running the exact command it runs, against real merged PRs (below).

## 4) How to run / test

```bash
cd e2e && yarn selftest        # 107/107
printf 'body\n' > /tmp/b.txt
node e2e/scripts/e2e-coverage.mjs --base <base>^1 --head <base> --title "fix(x): y" --body /tmp/b.txt
```

### UI steps (manual)

None.

## 5) Screenshots / recordings

### Test output

The three paths, run with the exact invocation the workflow uses:

```
# no declaration on a behaviour change
Verdict: needs-marker — behaviour files changed with no recognised signal …      exit 1

# declared exemption
Marker: E2E: exempt (cosmetic)
Verdict: pass — declared E2E: exempt (cosmetic)                                   exit 0

# a claim that is not true
Marker: E2E: covered-by NOPE-E2E-999
Verdict: block — covered-by names flows not in FLOWS.md: NOPE-E2E-999             exit 1
```

Suite: `tests 107 · pass 107 · fail 0`. Prettier clean on all four files.

## 6) Edge cases & considerations

**Swept the last 25 merged PRs through the check.** 11 pass, 14 would go red — and the breakdown matters:

| Verdict | Count | What the author does |
| --- | --- | --- |
| `EXEMPT` (pass) | 11 | nothing |
| `UNDETERMINED` | 11 | add one line, e.g. `E2E: exempt (refactor)` |
| `UPDATE-EXISTING` | 1 | `updated`/`covered-by`/`exempt` |
| `NEW-FLOW` | 2 | a flow, or an exemption a reviewer accepts |

So **2 of 25 are actually pushed toward writing a flow**; the rest need one line of prose. That is the intended policy — silence blocks, a stated reason does not — and it is the reason this ships informational rather than required.

The sweep also caught a real bug in the first draft: `#2324 chore: merge main into dev` was asked to declare, when a merge-back replays commits already classified on the way in. Hence the `chore/merge-main-into-dev*` skip.

## 7) Pre-existing issues (NOT introduced by this PR)

Known follow-ups from the branch review, untouched here: deleting a flow still passes as `EXEMPT (tests-only)`; `reviewing-prs` portability predicates; the Task 10 acceptance run against a booted stack.

## 8) Architectural / important decisions

- **Red but not required.** The signal is real from day one; the wall comes later, by adding **E2E coverage declared** to `general-branch-protect-approval`.
- **Skips are for authorship, not convenience** — every skipped head either assembles other people's classified commits or is a dependency bump.
- **The PR body is untrusted input**, passed via file and env, never interpolated.

## Checklist

- [x] Code follows the project style guide (prettier clean)
- [x] Tests added
- [ ] `bin/test` passes — N/A, no backend change
- [ ] `yarn test:run` passes — N/A, no frontend change
- [ ] `yarn contracts:check` — N/A, no API surface change
- [x] Documentation updated (`e2e/README.md`)
- [x] No secrets, hardcoded URLs or PII
- [x] PR title follows Conventional Commits
- [ ] Linear issue linked — none created
