### PR TITLE
docs: add AGENTS.md and project.faf (#2443)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,58 @@
+# AGENTS.md — future-agi
+
+Typed structured definitions live in [`project.faf`](project.faf) (`application/vnd.faf+yaml`), not in this prose. This file is the briefing; `project.faf` is the source it is authored from. The two are maintained together — update both when the stack or layout changes (`faf-cli` can re-author this file from `project.faf`; nothing is added to dependencies or the build).
+
+Human source of truth stays [README.md](README.md), [CONTRIBUTING.md](CONTRIBUTING.md), [TESTING.md](TESTING.md), [INSTALLATION.md](INSTALLATION.md). This file distils them for agents; it does not replace them.
+
+## What this project is
+
+Open-source, end-to-end platform for evaluating, observing and improving LLM and AI-agent apps — OpenTelemetry tracing, LLM-as-judge and code evaluators, agent simulation, real-time guardrails, and an OpenAI-compatible gateway — on one platform and one feedback loop. Self-hostable (Apache-2.0) or managed Future AGI Cloud. Polyglot monorepo: Python (Django), JavaScript (React), Go.
+
+## Where things live
+
+| Path                | Role                                                                                                       |
+| ------------------- | -------------------------------------------------------------------------------------------------------- |
+| `futureagi/`        | Django 5.1 + DRF backend (Python ≥3.11) — `tracer/`, `agentic_eval/`, `simulate/`, `accounts/`, `model_hub/`, `mcp_server/`, `tfc/` (settings) |
+| `frontend/`         | React 18 + Vite 5 (JavaScript, ESM) — MUI v5, TanStack Query, Zustand                                    |
+| `agentcc-gateway/`  | Go — OpenAI-compatible LLM gateway ("Agent Command Center")                                              |
+| `fi-collector/`     | Go — OTLP → ClickHouse span collector                                                                    |
+| `e2e/`              | Playwright full-stack flows (`bin/e2e`)                                                                  |
+| `.agents/skills/`   | Repo agent skills — `writing-e2e-flows`, `reviewing-prs` (read these before those tasks)                 |
+
+Framework instrumentors live in the separate `future-agi/traceAI` repo. Evaluator reference docs live in the docs repo.
+
+## Setup
+
+```bash
+cp futureagi/.env.example futureagi/.env
+docker compose up -d          # or: ./bin/install  (copies .env, boots the stack, waits for health)
+yarn install                  # repo root — installs husky git hooks + lint-staged
+cd futureagi && make pre-commit-install   # Python hooks: Black, isort, Ruff, mypy, Django checks
+```
+
+Backend: `http://localhost:8000`. Frontend: `http://localhost:3031`.
+
+## Tests
+
+```bash
+cd futureagi && make test     # backend — pytest in an isolated Docker Compose stack
+cd frontend && yarn test      # frontend — Vitest + React Testing Library
+```
+
+Before requesting review: `make check-all` (backend) or `yarn check-all` (frontend). End-to-end: `bin/e2e up && bin/e2e test` (cold first boot ~8–9 min). Full workflow, CI matrix and coverage thresholds: [TESTING.md](TESTING.md).
+
+## Conventions
+
+- **Python:** Ruff + Black (line length 88), isort (Black profile), mypy on new code (baseline-driven — CI rejects new type errors). Obey `futureagi/pyproject.toml` and `futureagi/.pre-commit-config.yaml`.
+- **JS:** ESLint (Airbnb) + Prettier. Obey the `frontend/` configs. No `tsconfig.json` today — `yarn type-check` is a no-op until someone adds TypeScript.
+- **Commits:** [Conventional Commits](https://www.conventionalcommits.org/) — `feat:`, `fix:`, `chore:`, `docs:`, `refactor:`, `test:`, `perf:`.
+- **Branches:** `type/short-description` (or `type/TICKET-short-description`), branched from `dev`. Validated on `git push` — see [BRANCH_NAMING_CONVENTION.md](BRANCH_NAMING_CONVENTION.md).
+- **PRs:** base from **`dev`**, not `main`. Keep the diff focused, add tests (every bug fix needs a regression test), explain *what* and *why*. Sign the CLA when the bot prompts on your first PR. A maintainer reviews within 3 business days.
+
+Every evaluator lives under `futureagi/agentic_eval/core_evals/fi_evals/` with a class, a rubric prompt (if LLM-judge), a registration in `eval_type.py`, and tests. No hardcoded secrets, URLs, or PII.
+
+## Out of scope for this repo
+
+- Framework instrumentors → `future-agi/traceAI`
+- Evaluator reference docs → the docs repo
+- This file and `project.faf` are a briefing, not policy — CONTRIBUTING / TESTING remain authoritative.

--- a/project.faf
+++ b/project.faf
@@ -1,0 +1,98 @@
+# project.faf — IANA application/vnd.faf+yaml
+# Structured project context for future-agi/future-agi. AGENTS.md is authored from this file.
+# Faithful distillation of README.md, CONTRIBUTING.md, TESTING.md, INSTALLATION.md, pyproject.toml,
+# frontend/package.json, the two go.mod files, and docker-compose.yml — no new claims, no policy.
+# Not a replacement for README / CONTRIBUTING / TESTING — those stay the human source of truth.
+# Slots that genuinely do not apply to a repo this shape are marked `slotignored`.
+
+faf_version: "3.0"
+
+project:
+  name: future-agi
+  goal: >
+    Open-source, end-to-end platform for evaluating, observing and improving LLM and
+    AI-agent applications — tracing, evals, simulations, guardrails, an OpenAI-compatible
+    gateway and optimization, on one platform and one feedback loop from first prototype
+    to live deployment. Self-hostable (Apache-2.0) or managed Future AGI Cloud.
+  main_language: Python
+  type: fullstack
+
+human_context:
+  who: Contributors and teams building, evaluating and operating LLM / AI-agent applications
+  what: >
+    An open-source AI evaluation and observability platform — OpenTelemetry tracing,
+    LLM-as-judge and code evaluators, agent simulation, real-time guardrails and an
+    OpenAI-compatible gateway — across a Django + React + Go codebase.
+  why: >
+    Most AI agents fail in production and teams end up stitching together evals,
+    observability and guardrails that never close the loop. Future AGI collapses all of
+    it into one platform and one feedback loop, so agents self-improve instead of only
+    being monitored.
+  where: >
+    Self-hosted via Docker Compose (`./bin/install`; backend http://localhost:8000,
+    frontend http://localhost:3031) or managed Future AGI Cloud (app.futureagi.com).
+    Apache-2.0, source at github.com/future-agi/future-agi.
+  when: >
+    Nightly releases for early testing; Docker images tagged roughly every two weeks and
+    SDK minor versions as features land (SemVer). Stable release forthcoming.
+  how: >
+    Django backend under `futureagi/` (tracer, agentic_eval, simulate, accounts,
+    model_hub, mcp_server), React + Vite frontend under `frontend/`, Go gateway under
+    `agentcc-gateway/` and OTLP→ClickHouse collector under `fi-collector/`. Bring the
+    stack up with `./bin/install` or `docker compose up -d`.
+
+stack:
+  frontend: React 18 + Vite 5 (JavaScript, ESM) — frontend/
+  css_framework: Emotion (CSS-in-JS, via MUI)
+  ui_library: MUI v5 (@mui/material, @mui/lab, @mui/x-data-grid, @mui/x-date-pickers), AG Grid
+  state_management: TanStack Query v5 (server state) + Zustand v5 (client state); react-hook-form
+  backend: Django 5.1 + Django REST Framework (Python >=3.11) — futureagi/; Granian ASGI server; Celery + Temporal workers
+  api_type: REST (Django REST Framework); OpenAI-compatible HTTP at the gateway; OTLP ingest for traces
+  runtime: Docker / Docker Compose (backend :8000, frontend :3031)
+  database: PostgreSQL (primary) · ClickHouse (spans / traces) · Redis (cache + broker) · Temporal (workflows) · Kafka (property-catalog pipeline)
+  connection: Django ORM + psycopg; clickhouse-connect / clickhouse-driver for ClickHouse
+  hosting: Self-hostable via Docker Compose, or managed Future AGI Cloud
+  build: Vite (frontend) · Make + Docker (backend) · Go toolchain (agentcc-gateway, fi-collector) · release-please for versioning
+  cicd: GitHub Actions — per-branch frontend workflows (feature / develop / main) + e2e-ci.yml Playwright on dev/main
+  monorepo_tool: slotignored
+  package_manager: yarn (repo root + frontend/) · uv / pip (futureagi/, pyproject.toml) · Go modules (agentcc-gateway/, fi-collector/)
+  workspaces: slotignored
+  admin: Django admin
+  cache: Redis
+  search: ChromaDB / Qdrant / Weaviate client libraries (vector stores for eval + RAG)
+  storage: MinIO (S3-compatible object storage)
+
+monorepo:
+  packages_count: "4 deployable services (futureagi, frontend, agentcc-gateway, fi-collector)"
+  build_orchestrator: slotignored
+  versioning_strategy: release-please, SemVer, per-service
+  shared_configs: slotignored
+  remote_cache: slotignored
+
+tech_stack:
+  - Python
+  - Django
+  - JavaScript
+  - React
+  - Vite
+  - Go
+  - PostgreSQL
+  - ClickHouse
+  - Redis
+  - OpenTelemetry
+  - Docker
+  - Temporal
+
+key_files:
+  - README.md
+  - CONTRIBUTING.md
+  - TESTING.md
+  - INSTALLATION.md
+  - BRANCH_NAMING_CONVENTION.md
+  - docker-compose.yml
+  - futureagi/pyproject.toml
+  - futureagi/Makefile
+  - frontend/package.json
+  - agentcc-gateway/go.mod
+  - fi-collector/go.mod
+  - .agents/skills/


### PR DESCRIPTION
## What

Two new files at repo root, nothing else touched:

- **`AGENTS.md`** — the file coding agents (Codex, Cursor, Copilot, Claude, Zed, Aider) read on arrival. The repo doesn't have one, so an agent lands on the marketing README and re-derives the stack every session — wrong test command, edits `frontend/` for a backend bug, PRs against `main` not `dev`. This is a plain briefing: layout, setup, `make test` / `yarn test`, the Ruff/Black/ESLint-Airbnb conventions, what's out of scope. It defers to README / CONTRIBUTING / TESTING explicitly — those stay authoritative.
- **`project.faf`** — `application/vnd.faf+yaml`, the structured source `AGENTS.md` is authored from. Keyed project facts (goal, stack, layout) so "is this still current?" is a one-line diff, not a re-read. Think `package.json`, but for project context.

## Why

`CONTRIBUTING.md` + `TESTING.md` already hold these facts; nothing routes an agent (or a new contributor) to them. This is a faithful distillation — no new claims, no policy.

Every `project.faf` slot was hand-verified against the repo (`futureagi/pyproject.toml`, `frontend/package.json`, `agentcc-gateway/go.mod`, `fi-collector/go.mod`, `docker-compose.yml`, CONTRIBUTING, TESTING). It scores 100% on `faf-cli` (`bunx faf-cli score project.faf`).

## Notes

- Opened per the green-light ask in #2443 (Discord thread with the team).
- No dependency, no CI change, no service — two static files. `faf-cli` authors/refreshes them on demand (`bunx faf-cli …`), never installed or imported.
- #2456 proposed the same two files; this PR carries the hand-verified content, authored from `project.faf`, and targets `dev`.
- CLA-ready.

Closes #2443
