### PR TITLE
docs: add AGENTS.md and project.faf (#2443)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,14 +27,16 @@ cd frontend && yarn check-all
 
 ## Where things live
 
-- `futureagi/` — Django backend
-- `frontend/` — React + Vite frontend
-- `agentcc-gateway/` — Go, OpenAI-compatible gateway
-- `fi-collector/` — Go, OTLP→ClickHouse collector
-- `e2e/` — Playwright full-stack flows
-- `.agents/skills/` — repo agent skills (writing-e2e-flows, reviewing-prs)
-- `CONTRIBUTING.md`
-- `TESTING.md`
+| Path | Role |
+|------|------|
+| `futureagi/` | Django 5.1 + DRF backend — tracer, agentic_eval, simulate, accounts, model_hub, mcp_server, tfc |
+| `frontend/` | React 18 + Vite 5 (JavaScript, ESM) — MUI v5, TanStack Query, Zustand |
+| `agentcc-gateway/` | Go — OpenAI-compatible LLM gateway |
+| `fi-collector/` | Go — OTLP→ClickHouse span collector |
+| `e2e/` | Playwright full-stack flows (`bin/e2e`) |
+| `.agents/skills/` | Repo agent skills — writing-e2e-flows, reviewing-prs |
+| `CONTRIBUTING.md` | Setup, code style, PR checklist, project layout |
+| `TESTING.md` | Test runners, git hooks, CI matrix, coverage thresholds |
 
 ## Conventions
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,99 @@
+<!-- faf:start -->
+<!-- faf: future-agi | Python | fullstack | Open-source, end-to-end platform for evaluating, observing and improving LLM and AI-agent applications — tracing, evals, simulations, guardrails, an OpenAI-compatible gateway and optimization, on one platform and one feedback loop from first prototype to live deployment. Self-hostable (Apache-2.0) or managed Future AGI Cloud. -->
+<!-- faf: claim=project.faf | family=FAF -->
+
+# AGENTS.md — future-agi
+
+Open-source, end-to-end platform for evaluating, observing and improving LLM and AI-agent applications — tracing, evals, simulations, guardrails, an OpenAI-compatible gateway and optimization, on one platform and one feedback loop from first prototype to live deployment. Self-hostable (Apache-2.0) or managed Future AGI Cloud. — Python · type: fullstack
+
+> Authored by faf — do not edit the managed block; refresh with `faf export --agents`. Hand content outside `<!-- faf:start -->` … `<!-- faf:end -->` is preserved.
+
+## Setup & build
+
+```bash
+yarn install    # install
+cp futureagi/.env.example futureagi/.env && docker compose up -d    # boot
+cd futureagi && make pre-commit-install    # hooks
+```
+
+## Run the tests
+
+```bash
+cd futureagi && make test
+cd frontend && yarn test
+cd futureagi && make check-all
+cd frontend && yarn check-all
+```
+
+## Where things live
+
+- `futureagi/` — Django backend
+- `frontend/` — React + Vite frontend
+- `agentcc-gateway/` — Go, OpenAI-compatible gateway
+- `fi-collector/` — Go, OTLP→ClickHouse collector
+- `e2e/` — Playwright full-stack flows
+- `.agents/skills/` — repo agent skills (writing-e2e-flows, reviewing-prs)
+- `CONTRIBUTING.md`
+- `TESTING.md`
+
+## Conventions
+
+- Python — Ruff + Black (line length 88), isort (Black profile), mypy on new code; CI rejects new type errors.
+- JavaScript — ESLint (Airbnb) + Prettier. No tsconfig.json yet, so `yarn type-check` is a no-op.
+- Commits — Conventional Commits (`feat` / `fix` / `chore` / `docs` / `refactor` / `test` / `perf`).
+- Branches — `type/short-description` off `dev`, validated on `git push` (see BRANCH_NAMING_CONVENTION.md).
+- PRs — base from `dev`, keep the diff focused, add a regression test for every bug fix, sign the CLA on your first PR.
+- Evaluators — live under `futureagi/agentic_eval/core_evals/fi_evals/`: a class, a rubric prompt (if LLM-judge), a registration in `eval_type.py`, and tests.
+- Backend and frontend have independent test runners — you rarely need to run both.
+
+## Guardrails
+
+- Base branch is `dev`, not `main` — branch from `dev` and open PRs into `dev`.
+- Polyglot repo — Django in `futureagi/`, React in `frontend/`, Go in `agentcc-gateway/` + `fi-collector/`. Don't edit the frontend for a backend bug.
+- Framework instrumentors are NOT in this repo — they live in `future-agi/traceAI`. Evaluator reference docs live in the docs repo.
+- This file and `project.faf` are a briefing, not policy — README / CONTRIBUTING / TESTING stay authoritative.
+- **Always OK:** read the tree · run the tests (`cd futureagi && make test`) · `cd futureagi && make check-all`.
+- **Ask first:** dependency installs, deletions, migrations, schema changes, publish/release.
+- **Never:** force-push · push straight to `dev` (branch and open a PR) · commit secrets.
+
+## Definition of Done
+
+Done when: `cd futureagi && make check-all` exits 0 · `cd frontend && yarn check-all` exits 0 · `cd futureagi && make test` passes · `cd frontend && yarn test` passes · changes committed with a conventional message.
+
+## When stuck
+
+Ask a clarifying question, propose a short plan, or open a draft PR with notes — do not push large speculative changes to `dev`.
+
+## Security & secrets
+
+- Secrets live in `futureagi/.env` (see `futureagi/.env.example`). Never read or commit them.
+- Never read or commit `futureagi/.env`.
+
+## Commit & PR
+
+- Conventional Commits preferred (`feat:`, `fix:`, `chore:`, …).
+- Branch off `dev` and open a PR — never commit to `dev` directly.
+- If build/test scripts or layout change, refresh this file in the **same PR** (`faf export --agents`).
+
+## Stack
+
+- **Framework:** React 18 + Vite 5 (JavaScript, ESM) — frontend/
+- **CSS:** Emotion (CSS-in-JS, via MUI)
+- **UI Library:** MUI v5 (@mui/material, @mui/lab, @mui/x-data-grid, @mui/x-date-pickers), AG Grid
+- **State:** TanStack Query v5 (server state) + Zustand v5 (client state); react-hook-form
+- **Backend:** Django 5.1 + Django REST Framework (Python >=3.11) — futureagi/; Granian ASGI server; Celery + Temporal workers
+- **API:** REST (Django REST Framework); OpenAI-compatible HTTP at the gateway; OTLP ingest for traces
+- **Runtime:** Docker / Docker Compose (backend :8000, frontend :3031)
+- **Database:** PostgreSQL (primary) · ClickHouse (spans / traces) · Redis (cache + broker) · Temporal (workflows) · Kafka (property-catalog pipeline)
+- **Connection:** Django ORM + psycopg; clickhouse-connect / clickhouse-driver for ClickHouse
+- **Hosting:** Self-hostable via Docker Compose, or managed Future AGI Cloud
+- **Build:** Vite (frontend) · Make + Docker (backend) · Go toolchain (agentcc-gateway, fi-collector) · release-please for versioning
+- **CI/CD:** GitHub Actions — per-branch frontend workflows (feature / develop / main) + e2e-ci.yml Playwright on dev/main
+- **Package Manager:** yarn (repo root + frontend/) · uv / pip (futureagi/, pyproject.toml) · Go modules (agentcc-gateway/, fi-collector/)
+- **Admin:** Django admin
+- **Cache:** Redis
+- **Search:** ChromaDB / Qdrant / Weaviate client libraries (vector stores for eval + RAG)
+- **Storage:** MinIO (S3-compatible object storage)
+
+*Context authored: 2026-09-01*
+<!-- faf:end -->

--- a/project.faf
+++ b/project.faf
@@ -117,13 +117,13 @@ tech_stack:
   - Temporal
 
 key_files:
-  - futureagi/ — Django backend
-  - frontend/ — React + Vite frontend
-  - agentcc-gateway/ — Go, OpenAI-compatible gateway
-  - fi-collector/ — Go, OTLP→ClickHouse collector
-  - e2e/ — Playwright full-stack flows
-  - .agents/skills/ — repo agent skills (writing-e2e-flows, reviewing-prs)
-  - CONTRIBUTING.md
-  - TESTING.md
+  - futureagi/ — Django 5.1 + DRF backend — tracer, agentic_eval, simulate, accounts, model_hub, mcp_server, tfc
+  - frontend/ — React 18 + Vite 5 (JavaScript, ESM) — MUI v5, TanStack Query, Zustand
+  - agentcc-gateway/ — Go — OpenAI-compatible LLM gateway
+  - fi-collector/ — Go — OTLP→ClickHouse span collector
+  - e2e/ — Playwright full-stack flows (`bin/e2e`)
+  - .agents/skills/ — Repo agent skills — writing-e2e-flows, reviewing-prs
+  - CONTRIBUTING.md — Setup, code style, PR checklist, project layout
+  - TESTING.md — Test runners, git hooks, CI matrix, coverage thresholds
 
 generated: "2026-09-01"

--- a/project.faf
+++ b/project.faf
@@ -1,0 +1,129 @@
+# project.faf — IANA application/vnd.faf+yaml
+# Structured project context for future-agi/future-agi. AGENTS.md is authored from this file
+# (`faf-cli export --agents`). Faithful distillation of README.md, CONTRIBUTING.md, TESTING.md,
+# INSTALLATION.md, BRANCH_NAMING_CONVENTION.md, pyproject.toml, frontend/package.json, the two
+# go.mod files, and docker-compose.yml — no new claims, no policy.
+# Not a replacement for README / CONTRIBUTING / TESTING — those stay the human source of truth.
+# Slots that genuinely do not apply to a repo this shape are marked `slotignored`.
+
+faf_version: "3.0"
+
+project:
+  name: future-agi
+  goal: >
+    Open-source, end-to-end platform for evaluating, observing and improving LLM and
+    AI-agent applications — tracing, evals, simulations, guardrails, an OpenAI-compatible
+    gateway and optimization, on one platform and one feedback loop from first prototype
+    to live deployment. Self-hostable (Apache-2.0) or managed Future AGI Cloud.
+  main_language: Python
+  type: fullstack
+  default_branch: dev
+
+human_context:
+  who: Contributors and teams building, evaluating and operating LLM / AI-agent applications
+  what: >
+    An open-source AI evaluation and observability platform — OpenTelemetry tracing,
+    LLM-as-judge and code evaluators, agent simulation, real-time guardrails and an
+    OpenAI-compatible gateway — across a Django + React + Go codebase.
+  why: >
+    Most AI agents fail in production and teams end up stitching together evals,
+    observability and guardrails that never close the loop. Future AGI collapses all of
+    it into one platform and one feedback loop, so agents self-improve instead of only
+    being monitored.
+  where: >
+    Self-hosted via Docker Compose (`./bin/install`; backend http://localhost:8000,
+    frontend http://localhost:3031) or managed Future AGI Cloud (app.futureagi.com).
+    Apache-2.0, source at github.com/future-agi/future-agi.
+  when: >
+    Nightly releases for early testing; Docker images tagged roughly every two weeks and
+    SDK minor versions as features land (SemVer). Stable release forthcoming.
+  how: >
+    Django backend under `futureagi/` (tracer, agentic_eval, simulate, accounts,
+    model_hub, mcp_server), React + Vite frontend under `frontend/`, Go gateway under
+    `agentcc-gateway/` and OTLP→ClickHouse collector under `fi-collector/`. Bring the
+    stack up with `./bin/install` or `docker compose up -d`.
+
+stack:
+  frontend: React 18 + Vite 5 (JavaScript, ESM) — frontend/
+  css_framework: Emotion (CSS-in-JS, via MUI)
+  ui_library: MUI v5 (@mui/material, @mui/lab, @mui/x-data-grid, @mui/x-date-pickers), AG Grid
+  state_management: TanStack Query v5 (server state) + Zustand v5 (client state); react-hook-form
+  backend: Django 5.1 + Django REST Framework (Python >=3.11) — futureagi/; Granian ASGI server; Celery + Temporal workers
+  api_type: REST (Django REST Framework); OpenAI-compatible HTTP at the gateway; OTLP ingest for traces
+  runtime: Docker / Docker Compose (backend :8000, frontend :3031)
+  database: PostgreSQL (primary) · ClickHouse (spans / traces) · Redis (cache + broker) · Temporal (workflows) · Kafka (property-catalog pipeline)
+  connection: Django ORM + psycopg; clickhouse-connect / clickhouse-driver for ClickHouse
+  hosting: Self-hostable via Docker Compose, or managed Future AGI Cloud
+  build: Vite (frontend) · Make + Docker (backend) · Go toolchain (agentcc-gateway, fi-collector) · release-please for versioning
+  cicd: GitHub Actions — per-branch frontend workflows (feature / develop / main) + e2e-ci.yml Playwright on dev/main
+  monorepo_tool: slotignored
+  package_manager: yarn (repo root + frontend/) · uv / pip (futureagi/, pyproject.toml) · Go modules (agentcc-gateway/, fi-collector/)
+  workspaces: slotignored
+  admin: Django admin
+  cache: Redis
+  search: ChromaDB / Qdrant / Weaviate client libraries (vector stores for eval + RAG)
+  storage: MinIO (S3-compatible object storage)
+
+monorepo:
+  packages_count: "4 deployable services (futureagi, frontend, agentcc-gateway, fi-collector)"
+  build_orchestrator: slotignored
+  versioning_strategy: release-please, SemVer, per-service
+  shared_configs: slotignored
+  remote_cache: slotignored
+
+commands:
+  install: yarn install
+  boot: cp futureagi/.env.example futureagi/.env && docker compose up -d
+  hooks: cd futureagi && make pre-commit-install
+  test_backend: cd futureagi && make test
+  test_frontend: cd frontend && yarn test
+  check_backend: cd futureagi && make check-all
+  check_frontend: cd frontend && yarn check-all
+
+conventions:
+  - "Python — Ruff + Black (line length 88), isort (Black profile), mypy on new code; CI rejects new type errors."
+  - "JavaScript — ESLint (Airbnb) + Prettier. No tsconfig.json yet, so `yarn type-check` is a no-op."
+  - "Commits — Conventional Commits (`feat` / `fix` / `chore` / `docs` / `refactor` / `test` / `perf`)."
+  - "Branches — `type/short-description` off `dev`, validated on `git push` (see BRANCH_NAMING_CONVENTION.md)."
+  - "PRs — base from `dev`, keep the diff focused, add a regression test for every bug fix, sign the CLA on your first PR."
+  - "Evaluators — live under `futureagi/agentic_eval/core_evals/fi_evals/`: a class, a rubric prompt (if LLM-judge), a registration in `eval_type.py`, and tests."
+  - "Backend and frontend have independent test runners — you rarely need to run both."
+
+security:
+  secrets: futureagi/.env
+  example: futureagi/.env.example
+  never:
+    - futureagi/.env
+
+ai_instructions:
+  warnings:
+    - "Base branch is `dev`, not `main` — branch from `dev` and open PRs into `dev`."
+    - "Polyglot repo — Django in `futureagi/`, React in `frontend/`, Go in `agentcc-gateway/` + `fi-collector/`. Don't edit the frontend for a backend bug."
+    - "Framework instrumentors are NOT in this repo — they live in `future-agi/traceAI`. Evaluator reference docs live in the docs repo."
+    - "This file and `project.faf` are a briefing, not policy — README / CONTRIBUTING / TESTING stay authoritative."
+
+tech_stack:
+  - Python
+  - Django
+  - JavaScript
+  - React
+  - Vite
+  - Go
+  - PostgreSQL
+  - ClickHouse
+  - Redis
+  - OpenTelemetry
+  - Docker
+  - Temporal
+
+key_files:
+  - futureagi/ — Django backend
+  - frontend/ — React + Vite frontend
+  - agentcc-gateway/ — Go, OpenAI-compatible gateway
+  - fi-collector/ — Go, OTLP→ClickHouse collector
+  - e2e/ — Playwright full-stack flows
+  - .agents/skills/ — repo agent skills (writing-e2e-flows, reviewing-prs)
+  - CONTRIBUTING.md
+  - TESTING.md
+
+generated: "2026-09-01"


### PR DESCRIPTION
## What

Two new files at repo root, nothing else touched:

- **`AGENTS.md`** — the file coding agents (Codex, Cursor, Copilot, Claude, Zed, Aider) read on arrival. The repo doesn't have one, so an agent lands on the marketing README and re-derives the stack every session — wrong test command, edits `frontend/` for a backend bug, PRs against `main` not `dev`. This is a plain briefing: layout, setup, `make test` / `yarn test`, the Ruff/Black/ESLint-Airbnb conventions, what's out of scope. It defers to README / CONTRIBUTING / TESTING explicitly — those stay authoritative.
- **`project.faf`** — `application/vnd.faf+yaml`, the structured source `AGENTS.md` is authored from. Keyed project facts (goal, stack, layout) so "is this still current?" is a one-line diff, not a re-read. Think `package.json`, but for project context.

## Why

`CONTRIBUTING.md` + `TESTING.md` already hold these facts; nothing routes an agent (or a new contributor) to them. This is a faithful distillation — no new claims, no policy.

Every `project.faf` slot was hand-verified against the repo (`futureagi/pyproject.toml`, `frontend/package.json`, `agentcc-gateway/go.mod`, `fi-collector/go.mod`, `docker-compose.yml`, CONTRIBUTING, TESTING). It scores 100% on `faf-cli` (`bunx faf-cli score project.faf`).

## Notes

- Opened per the green-light ask in #2443 (Discord thread with the team).
- No dependency, no CI change, no service — two static files. `faf-cli` authors/refreshes them on demand (`bunx faf-cli …`), never installed or imported.
- #2456 proposed the same two files; this PR carries the hand-verified content, authored from `project.faf`, and targets `dev`.
- CLA-ready.

Closes #2443

_(Supersedes #2481 — closed after a force-push didn't re-sync; same two files.)_
