### PR TITLE
fix: skip max cell value length check for media type uploads

### DIFF
--- a/futureagi/model_hub/views/develop_dataset.py
+++ b/futureagi/model_hub/views/develop_dataset.py
@@ -5331,8 +5331,19 @@ class UpdateCellValueView(APIView):
             if not is_editable:
                 return self._gm.bad_request(edit_err)
 
-            # Check max value length
-            if isinstance(new_value, str) and len(new_value) > MAX_CELL_VALUE_LENGTH:
+            # Check max value length (skip for media types — their base64 data
+            # is uploaded to S3, not stored in the cell)
+            MEDIA_TYPES = {
+                DataTypeChoices.IMAGE.value,
+                DataTypeChoices.IMAGES.value,
+                DataTypeChoices.AUDIO.value,
+                DataTypeChoices.DOCUMENT.value,
+            }
+            if (
+                isinstance(new_value, str)
+                and len(new_value) > MAX_CELL_VALUE_LENGTH
+                and column_data_type not in MEDIA_TYPES
+            ):
                 return self._gm.bad_request(
                     f"Value exceeds maximum length of {MAX_CELL_VALUE_LENGTH} characters"
                 )


### PR DESCRIPTION
## Summary

The `UpdateCellValueView` was rejecting image, audio, and document uploads with a 400 "Value exceeds maximum length of 100000 characters" error. The generic max-length check on cell values ran before the type-specific handling, so base64-encoded media data (which easily exceeds 100K chars) was blocked before it could reach the S3 upload logic. The fix skips the length check for media column types (image, images, audio, document) since their base64 payloads are uploaded to S3 and only the resulting URL is stored in the cell.

Closes TH-7793

## Test plan
- [ ] Add an image column to a dataset and upload an image — should succeed without 400 error
- [ ] Add an images column and upload multiple images — should succeed
- [ ] Add an audio column and upload an audio file — should succeed
- [ ] Add a document column and upload a PDF — should succeed (backend; UI issues tracked separately in TH-7793)
- [ ] Add a text column and paste a string longer than 100K chars — should still be rejected with the max-length error

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)