### PR TITLE
fix(anthropic):normalize empty tool call arguments

### DIFF
--- a/agentcc-gateway/internal/providers/anthropic/translate.go
+++ b/agentcc-gateway/internal/providers/anthropic/translate.go
@@ -263,11 +263,18 @@ func translateMessage(msg models.Message) (anthropicMessage, error) {
 
 		// Add tool use blocks.
 		for _, tc := range msg.ToolCalls {
+			var input json.RawMessage
+			if tc.Function.Arguments == "" || tc.Function.Arguments == "null" {
+				input = json.RawMessage("{}")
+			} else {
+				input = json.RawMessage(tc.Function.Arguments)
+			}
+
 			blocks = append(blocks, anthropicContentBlock{
 				Type:  "tool_use",
 				ID:    tc.ID,
 				Name:  tc.Function.Name,
-				Input: json.RawMessage(tc.Function.Arguments),
+				Input: input,
 			})
 		}
 

--- a/agentcc-gateway/internal/providers/anthropic/translate_test.go
+++ b/agentcc-gateway/internal/providers/anthropic/translate_test.go
@@ -1795,6 +1795,62 @@ func TestTranslateResponse_ServerToolUseIsNotAClientToolCall(t *testing.T) {
 	}
 }
 
+func TestTranslateMessage_AssistantToolCallWithEmptyArguments(t *testing.T) {
+	tests := []struct {
+		name      string
+		arguments string
+	}{
+		{
+			name:      "empty arguments",
+			arguments: "",
+		},
+		{
+			name:      "null arguments",
+			arguments: "null",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			msg := models.Message{
+				Role: "assistant",
+				ToolCalls: []models.ToolCall{
+					{
+						ID:   "toolu_empty",
+						Type: "function",
+						Function: models.FunctionCall{
+							Name:      "ping",
+							Arguments: tt.arguments,
+						},
+					},
+				},
+			}
+
+			am, err := translateMessage(msg)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			var blocks []anthropicContentBlock
+			if err := json.Unmarshal(am.Content, &blocks); err != nil {
+				t.Fatalf("failed to unmarshal content: %v", err)
+			}
+
+			if len(blocks) != 1 {
+				t.Fatalf("blocks length = %d, want 1", len(blocks))
+			}
+
+			if blocks[0].Type != "tool_use" {
+				t.Fatalf("block type = %q, want %q", blocks[0].Type, "tool_use")
+			}
+
+			if string(blocks[0].Input) != `{}` {
+				t.Errorf("tool_use input = %q, want %q", string(blocks[0].Input), `{}`)
+			}
+		})
+	}
+}
+
 // Searches are billed per call on top of tokens, so a response reporting tokens
 // alone understates the cost.
 func TestTranslateResponse_CarriesServerToolUsage(t *testing.T) {


### PR DESCRIPTION
# Fix invalid Anthropic tool_use input for empty tool arguments

## Description

Fixes an issue where OpenAI-format tool calls with empty or `null` arguments were translated into invalid Anthropic `tool_use` blocks.

Anthropic expects `tool_use.input` to be a JSON object, but empty arguments were previously passed through as an empty `json.RawMessage`, resulting in an invalid request.

### Changes

* Normalize empty tool-call arguments (`""`) to `{}`.
* Normalize `null` tool-call arguments to `{}`.
* Preserve existing valid JSON arguments unchanged.
* Add regression coverage for both empty and `null` arguments.

### Testing

* `go test ./internal/providers/anthropic` ✅
* `go test ./internal/providers/anthropic -run TestTranslateMessage_AssistantToolCallWithEmptyArguments -v` ✅
* `git diff --check` ✅
* `go test ./...` ⚠️

The full test suite passes except for the existing Redis-dependent test:

`internal/redisstate/TestBudgetStore_Redis_RecordAndGetSpend`

It fails because the test environment cannot connect to Redis at `127.0.0.1:1`.

Fixes #2463
