### PR TITLE
feat(experiment): map prompt variables to dataset columns

### DIFF
--- a/frontend/src/sections/develop-detail/Experiment/StepperComponentExperiment/AgentPromptRenderer.jsx
+++ b/frontend/src/sections/develop-detail/Experiment/StepperComponentExperiment/AgentPromptRenderer.jsx
@@ -149,22 +149,26 @@ const AgentPromptRenderer = ({
     }
   }, [variableNames, allColumns, fieldPrefix, getValues, setValue]);
 
-  // Derive variablesInfo from the mapping and store unmapped count in form
-  const prevNotMappedRef = useRef(null);
+  // Derive variablesInfo from the mapping
   const variablesInfo = useMemo(() => {
     const total = variableNames.length;
     const notMapped = variableNames.filter(
       (name) => !variableMapping?.[name],
     ).length;
-
-    if (prevNotMappedRef.current !== notMapped) {
-      prevNotMappedRef.current = notMapped;
-      setValue(`${fieldPrefix}.unmappedVariables`, notMapped, {
-        shouldValidate: false,
-      });
-    }
     return { total, notMapped };
-  }, [variableNames, variableMapping, setValue, fieldPrefix]);
+  }, [variableNames, variableMapping]);
+
+  // Mirror the unmapped count into the form, which is what gates the run.
+  // Kept in an effect rather than in the memo above: writing to the form
+  // while rendering warns about updating a component mid-render.
+  const prevNotMappedRef = useRef(null);
+  useEffect(() => {
+    if (prevNotMappedRef.current === variablesInfo.notMapped) return;
+    prevNotMappedRef.current = variablesInfo.notMapped;
+    setValue(`${fieldPrefix}.unmappedVariables`, variablesInfo.notMapped, {
+      shouldValidate: false,
+    });
+  }, [variablesInfo.notMapped, setValue, fieldPrefix]);
 
   // Set initial prompt version
   useEffect(() => {

--- a/frontend/src/sections/develop-detail/Experiment/StepperComponentExperiment/AgentPromptRenderer.jsx
+++ b/frontend/src/sections/develop-detail/Experiment/StepperComponentExperiment/AgentPromptRenderer.jsx
@@ -122,14 +122,14 @@ const AgentPromptRenderer = ({
 
   const variableMapping = useWatch({
     control,
-    name: `${fieldPrefix}.variableMapping`,
+    name: `${fieldPrefix}.configuration.variableMapping`,
   });
 
   // Seed the mapping with the exact-name match, so a dataset whose columns
   // already line up with the variables keeps working without any picking.
   useEffect(() => {
     if (!variableNames.length) return;
-    const current = getValues(`${fieldPrefix}.variableMapping`) || {};
+    const current = getValues(`${fieldPrefix}.configuration.variableMapping`) || {};
     const next = { ...current };
     let changed = false;
     variableNames.forEach((name) => {
@@ -143,7 +143,7 @@ const AgentPromptRenderer = ({
       }
     });
     if (changed) {
-      setValue(`${fieldPrefix}.variableMapping`, next, {
+      setValue(`${fieldPrefix}.configuration.variableMapping`, next, {
         shouldValidate: false,
       });
     }
@@ -523,7 +523,7 @@ const AgentPromptRenderer = ({
                   field={name}
                   allColumns={allColumns || []}
                   control={control}
-                  fieldName={`${fieldPrefix}.variableMapping.${name}`}
+                  fieldName={`${fieldPrefix}.configuration.variableMapping.${name}`}
                   placeholder="Map to column"
                   fullWidth
                 />

--- a/frontend/src/sections/develop-detail/Experiment/StepperComponentExperiment/AgentPromptRenderer.jsx
+++ b/frontend/src/sections/develop-detail/Experiment/StepperComponentExperiment/AgentPromptRenderer.jsx
@@ -15,6 +15,7 @@ import SvgColor from "src/components/svg-color";
 import NewModelRenderWithParamsTool from "./NewModelRenderWithParamsTool";
 import CustomTooltip from "src/components/tooltip";
 import ChipForVariables from "./chipForVariables.jsx";
+import FieldSelection from "src/sections/develop-detail/Common/FieldSelection";
 import CustomModelDropdownControl from "src/components/custom-model-dropdown/CustomModelDropdownControl";
 import { getOutputOptions, PROMPT_CONFIG_TYPE } from "../common";
 import { useGetAgentVersions } from "../../../../api/experiment/use-get-agents.js";
@@ -94,68 +95,76 @@ const AgentPromptRenderer = ({
     name: `${fieldPrefix}.agentVersion`,
   });
 
-  // Memoize column headers to prevent unnecessary re-renders
-  const columnHeaders = useMemo(() => {
-    return allColumns?.map((col) => col.headerName ?? col?.name) || [];
-  }, [allColumns]);
-
-  // Derive variablesInfo from data and store unmapped count in form
-  const prevNotMappedRef = useRef(null);
-  const variablesInfo = useMemo(() => {
-    let result;
-    let selectedVersion;
+  // The variables the selected version declares, in declaration order.
+  const variableNames = useMemo(() => {
     if (type === "prompt") {
-      selectedVersion = versionsOptions?.find(
+      const selectedVersion = versionsOptions?.find(
         (v) => v.id === watchedPromptVersion,
       );
-      if (!selectedVersion?.variable_names) {
-        result = { total: 0, notMapped: 0 };
-      } else {
-        const versionVariables = Object.keys(selectedVersion.variable_names);
-        const missingCount = versionVariables.filter(
-          (variable) => !columnHeaders.includes(variable),
-        ).length;
-        result = { total: versionVariables.length, notMapped: missingCount };
-      }
-    } else if (type === "agent") {
-      selectedVersion = agentVersionsOptions?.find(
+      return selectedVersion?.variable_names
+        ? Object.keys(selectedVersion.variable_names)
+        : [];
+    }
+    if (type === "agent") {
+      const selectedVersion = agentVersionsOptions?.find(
         (v) => v.id === watchedAgentVersion,
       );
-      if (
-        !selectedVersion?.global_variables ||
-        selectedVersion.global_variables.length === 0
-      ) {
-        result = { total: 0, notMapped: 0 };
-      } else {
-        const missingCount = selectedVersion.global_variables.filter(
-          (variable) => !columnHeaders.includes(variable),
-        ).length;
-        result = {
-          total: selectedVersion.global_variables.length,
-          notMapped: missingCount,
-        };
-      }
-    } else {
-      result = { total: 0, notMapped: 0 };
+      return selectedVersion?.global_variables || [];
     }
-
-    if (prevNotMappedRef.current !== result.notMapped) {
-      prevNotMappedRef.current = result.notMapped;
-      setValue(`${fieldPrefix}.unmappedVariables`, result.notMapped, {
-        shouldValidate: false,
-      });
-    }
-    return result;
+    return [];
   }, [
+    type,
     versionsOptions,
     agentVersionsOptions,
     watchedPromptVersion,
     watchedAgentVersion,
-    columnHeaders,
-    type,
-    setValue,
-    fieldPrefix,
   ]);
+
+  const variableMapping = useWatch({
+    control,
+    name: `${fieldPrefix}.variableMapping`,
+  });
+
+  // Seed the mapping with the exact-name match, so a dataset whose columns
+  // already line up with the variables keeps working without any picking.
+  useEffect(() => {
+    if (!variableNames.length) return;
+    const current = getValues(`${fieldPrefix}.variableMapping`) || {};
+    const next = { ...current };
+    let changed = false;
+    variableNames.forEach((name) => {
+      if (next[name]) return;
+      const match = allColumns?.find(
+        (col) => (col.headerName ?? col?.name) === name,
+      );
+      if (match?.field) {
+        next[name] = match.field;
+        changed = true;
+      }
+    });
+    if (changed) {
+      setValue(`${fieldPrefix}.variableMapping`, next, {
+        shouldValidate: false,
+      });
+    }
+  }, [variableNames, allColumns, fieldPrefix, getValues, setValue]);
+
+  // Derive variablesInfo from the mapping and store unmapped count in form
+  const prevNotMappedRef = useRef(null);
+  const variablesInfo = useMemo(() => {
+    const total = variableNames.length;
+    const notMapped = variableNames.filter(
+      (name) => !variableMapping?.[name],
+    ).length;
+
+    if (prevNotMappedRef.current !== notMapped) {
+      prevNotMappedRef.current = notMapped;
+      setValue(`${fieldPrefix}.unmappedVariables`, notMapped, {
+        shouldValidate: false,
+      });
+    }
+    return { total, notMapped };
+  }, [variableNames, variableMapping, setValue, fieldPrefix]);
 
   // Set initial prompt version
   useEffect(() => {
@@ -450,97 +459,76 @@ const AgentPromptRenderer = ({
               backgroundColor: "background.paper",
             }}
           >
-            <ShowComponent condition={variablesInfo.notMapped === 0}>
-              <Box
-                sx={{
-                  display: "flex",
-                  flexDirection: "row",
-                  alignItems: "center",
-                  gap: 1,
-                }}
-              >
-                <Typography typography="s2" fontWeight={"fontWeightMedium"}>
-                  {`${`${variablesInfo?.total}/${variablesInfo?.total} variables mapped to dataset columns`}`}
-                </Typography>
-                <ChipForVariables status="all" />
-              </Box>
-            </ShowComponent>
-            <ShowComponent condition={variablesInfo.notMapped > 0}>
-              <Box
-                sx={{
-                  display: "flex",
-                  flexDirection: "row",
-                  alignItems: "center",
-                  gap: 1,
-                }}
-              >
-                <Typography typography="s2" fontWeight={"fontWeightMedium"}>
-                  {`${variablesInfo?.total - variablesInfo?.notMapped}/${variablesInfo?.total} variables mapped to dataset columns`}
-                </Typography>
-                <ChipForVariables
-                  status={
-                    variablesInfo?.total === variablesInfo?.notMapped
+            <Box
+              sx={{
+                display: "flex",
+                flexDirection: "row",
+                alignItems: "center",
+                gap: 1,
+              }}
+            >
+              <Typography typography="s2" fontWeight={"fontWeightMedium"}>
+                <Box
+                  component="span"
+                  sx={{
+                    color:
+                      variablesInfo.notMapped === 0
+                        ? "green.700"
+                        : variablesInfo.notMapped === variablesInfo.total
+                          ? "red.700"
+                          : "orange.700",
+                  }}
+                >
+                  {variablesInfo.total - variablesInfo.notMapped}
+                </Box>
+                {`/${variablesInfo.total} variables mapped to dataset columns`}
+              </Typography>
+              <ChipForVariables
+                status={
+                  variablesInfo.notMapped === 0
+                    ? "all"
+                    : variablesInfo.notMapped === variablesInfo.total
                       ? "none"
                       : "partial"
-                  }
-                />
-                <Button
-                  size="small"
-                  sx={{ color: "blue.500", bgcolor: "background.paper" }}
-                  startIcon={
-                    <SvgColor
-                      sx={{
-                        height: 16,
-                        width: 16,
-                      }}
-                      src="/assets/icons/ic_reload.svg"
-                    />
-                  }
-                  onClick={() => {
-                    refetchVersions();
-                    pickupLatestVersion.current = true;
-                  }}
-                >
-                  Refresh
-                </Button>
-              </Box>
-              <Box
-                sx={{
-                  display: "flex",
-                  flexDirection: "row",
-                  alignItems: "center",
-                  gap: 1,
-                  mt: 1,
+                }
+              />
+              <Button
+                size="small"
+                sx={{ color: "blue.500", bgcolor: "background.paper" }}
+                startIcon={
+                  <SvgColor
+                    sx={{
+                      height: 16,
+                      width: 16,
+                    }}
+                    src="/assets/icons/ic_reload.svg"
+                  />
+                }
+                onClick={() => {
+                  refetchVersions();
+                  pickupLatestVersion.current = true;
                 }}
               >
-                <Typography typography="s2" fontWeight={"fontWeightMedium"}>
-                  {type === "prompt"
-                    ? "Update variable names in workbench to match dataset columns."
-                    : "Update global variables in agent to match dataset columns."}
-                </Typography>
-                <Button
-                  variant="outlined"
-                  sx={{
-                    bgcolor: "background.paper",
-                    px: 1.5,
-                    borderColor: "border.light",
-                  }}
-                  onClick={() => {
-                    const url =
-                      type === "prompt"
-                        ? `/dashboard/workbench/create/${prompt?.promptId}`
-                        : `/dashboard/agents/playground/${prompt?.agentId}`;
-                    window.open(url, "_blank");
-                  }}
-                  startIcon={
-                    <SvgColor src="/assets/icons/ic_arrow_top_right.svg" />
-                  }
-                >
-                  {type === "prompt"
-                    ? "Go to Workbench"
-                    : "Go to Agent Playground"}
-                </Button>
-              </Box>
+                Refresh
+              </Button>
+            </Box>
+            <Stack spacing={1} sx={{ mt: 1.5 }}>
+              {variableNames.map((name) => (
+                <FieldSelection
+                  key={name}
+                  field={name}
+                  allColumns={allColumns || []}
+                  control={control}
+                  fieldName={`${fieldPrefix}.variableMapping.${name}`}
+                  placeholder="Map to column"
+                  fullWidth
+                />
+              ))}
+            </Stack>
+            <ShowComponent condition={variablesInfo.notMapped > 0}>
+              <Typography typography="s2" color="error.main" sx={{ mt: 1.5 }}>
+                Please map the unmapped variables to your dataset columns
+              </Typography>
             </ShowComponent>
           </Box>
         </ShowComponent>

--- a/frontend/src/sections/develop-detail/Experiment/StepperComponentExperiment/__tests__/AgentPromptRenderer.variableMapping.test.jsx
+++ b/frontend/src/sections/develop-detail/Experiment/StepperComponentExperiment/__tests__/AgentPromptRenderer.variableMapping.test.jsx
@@ -79,7 +79,11 @@ vi.mock("src/sections/develop-detail/Common/FieldSelection", () => ({
 function Harness({ allColumns, onState }) {
   const { control, setValue, getValues, watch, unregister } = useForm({
     defaultValues: {
-      config: { promptVersion: "v1", model: [], variableMapping: {} },
+      config: {
+        promptVersion: "v1",
+        model: [],
+        configuration: { variableMapping: {} },
+      },
     },
   });
   control.setValue = setValue;
@@ -122,7 +126,7 @@ describe("AgentPromptRenderer variable mapping", () => {
     ]);
 
     await waitFor(() => {
-      expect(state.getValues("config.variableMapping")).toEqual({
+      expect(state.getValues("config.configuration.variableMapping")).toEqual({
         question: "col_question",
       });
       expect(state.getValues("config.unmappedVariables")).toBe(0);
@@ -137,7 +141,7 @@ describe("AgentPromptRenderer variable mapping", () => {
     await waitFor(() => {
       expect(state.getValues("config.unmappedVariables")).toBe(1);
     });
-    expect(state.getValues("config.variableMapping")).toEqual({});
+    expect(state.getValues("config.configuration.variableMapping")).toEqual({});
     expect(
       screen.getByText(/1 variables mapped to dataset columns/),
     ).toBeTruthy();
@@ -156,7 +160,7 @@ describe("AgentPromptRenderer variable mapping", () => {
     await user.click(screen.getByText("map question to Question"));
 
     await waitFor(() => {
-      expect(state.getValues("config.variableMapping")).toEqual({
+      expect(state.getValues("config.configuration.variableMapping")).toEqual({
         question: "col_question",
       });
       expect(state.getValues("config.unmappedVariables")).toBe(0);

--- a/frontend/src/sections/develop-detail/Experiment/StepperComponentExperiment/__tests__/AgentPromptRenderer.variableMapping.test.jsx
+++ b/frontend/src/sections/develop-detail/Experiment/StepperComponentExperiment/__tests__/AgentPromptRenderer.variableMapping.test.jsx
@@ -1,0 +1,165 @@
+/* eslint-disable react/prop-types */
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { useForm } from "react-hook-form";
+import AgentPromptRenderer from "../AgentPromptRenderer";
+
+// ---- Mocks ----
+
+const promptVersion = {
+  id: "v1",
+  version: "v1.0",
+  status: "published",
+  variable_names: { question: "" },
+};
+
+vi.mock("src/api/develop/prompt", () => ({
+  usePromptVersions: () => ({
+    data: { pages: [{ results: [promptVersion] }] },
+    isPending: false,
+    refetch: vi.fn(),
+    fetchNextPage: vi.fn(),
+    hasNextPage: false,
+    isFetchingNextPage: false,
+  }),
+}));
+
+vi.mock("src/api/experiment/use-get-agents.js", () => ({
+  useGetAgentVersions: () => ({
+    data: undefined,
+    isPending: false,
+    fetchNextPage: vi.fn(),
+    hasNextPage: false,
+    isFetchingNextPage: false,
+  }),
+}));
+
+// Heavy children that are irrelevant to the mapping behaviour.
+vi.mock("../NewModelRenderWithParamsTool", () => ({ default: () => null }));
+vi.mock(
+  "src/components/custom-model-dropdown/CustomModelDropdownControl",
+  () => ({
+    default: () => null,
+  }),
+);
+vi.mock(
+  "src/components/searchable-select-control/SearchableSelectControl",
+  () => ({
+    default: () => null,
+  }),
+);
+vi.mock("src/components/FromSearchSelectField", () => ({
+  FormSearchSelectFieldControl: () => null,
+}));
+
+// Stand-in for the column picker: exposes one button per option that writes
+// the chosen column into the same form field the real control writes to.
+vi.mock("src/sections/develop-detail/Common/FieldSelection", () => ({
+  default: ({ field, fieldName, control, allColumns }) => (
+    <div data-testid={`picker-${field}`}>
+      {allColumns.map((col) => (
+        <button
+          key={col.field}
+          type="button"
+          onClick={() =>
+            control._formValues &&
+            control.setValue?.(fieldName, col.field, { shouldValidate: false })
+          }
+        >
+          {`map ${field} to ${col.headerName}`}
+        </button>
+      ))}
+    </div>
+  ),
+}));
+
+// ---- Helpers ----
+
+function Harness({ allColumns, onState }) {
+  const { control, setValue, getValues, watch, unregister } = useForm({
+    defaultValues: {
+      config: { promptVersion: "v1", model: [], variableMapping: {} },
+    },
+  });
+  control.setValue = setValue;
+  onState({ getValues });
+  return (
+    <AgentPromptRenderer
+      prompt={{ name: "P", promptId: "p1" }}
+      onRemove={vi.fn()}
+      setValue={setValue}
+      control={control}
+      index={0}
+      getValues={getValues}
+      watch={watch}
+      unregister={unregister}
+      allColumns={allColumns}
+      errors={{}}
+      fieldPrefix="config"
+      type="prompt"
+    />
+  );
+}
+
+function renderWith(allColumns) {
+  const state = {};
+  render(
+    <Harness
+      allColumns={allColumns}
+      onState={(s) => Object.assign(state, s)}
+    />,
+  );
+  return state;
+}
+
+// ---- Tests ----
+
+describe("AgentPromptRenderer variable mapping", () => {
+  it("seeds the mapping when a column name matches the variable exactly", async () => {
+    const state = renderWith([
+      { headerName: "question", field: "col_question" },
+    ]);
+
+    await waitFor(() => {
+      expect(state.getValues("config.variableMapping")).toEqual({
+        question: "col_question",
+      });
+      expect(state.getValues("config.unmappedVariables")).toBe(0);
+    });
+  });
+
+  it("leaves a case-different column unmapped instead of matching it", async () => {
+    const state = renderWith([
+      { headerName: "Question", field: "col_question" },
+    ]);
+
+    await waitFor(() => {
+      expect(state.getValues("config.unmappedVariables")).toBe(1);
+    });
+    expect(state.getValues("config.variableMapping")).toEqual({});
+    expect(
+      screen.getByText(/1 variables mapped to dataset columns/),
+    ).toBeTruthy();
+  });
+
+  it("clears the run gate once the variable is mapped by hand", async () => {
+    const user = userEvent.setup();
+    const state = renderWith([
+      { headerName: "Question", field: "col_question" },
+    ]);
+
+    await waitFor(() => {
+      expect(state.getValues("config.unmappedVariables")).toBe(1);
+    });
+
+    await user.click(screen.getByText("map question to Question"));
+
+    await waitFor(() => {
+      expect(state.getValues("config.variableMapping")).toEqual({
+        question: "col_question",
+      });
+      expect(state.getValues("config.unmappedVariables")).toBe(0);
+    });
+  });
+});

--- a/frontend/src/sections/develop-detail/Experiment/schema.js
+++ b/frontend/src/sections/develop-detail/Experiment/schema.js
@@ -311,6 +311,10 @@ export const getNewExperimentValidationSchema = (
                 .object({
                   toolChoice: z.string().default("auto"),
                   tools: z.array(z.any()),
+                  // Maps each prompt/agent variable to the dataset column that
+                  // feeds it, keyed by variable name. Lives here so it reaches
+                  // populate_placeholders through prompt_config.configuration.
+                  variableMapping: z.record(z.string()).optional().default({}),
                 })
                 .optional(),
               outputFormat: z.enum(["string", "json"]).optional(),
@@ -320,10 +324,6 @@ export const getNewExperimentValidationSchema = (
               isDraft: z.boolean().optional().default(false),
               versionLabel: z.string().optional(),
               name: z.string().optional(),
-              // Maps each prompt/agent variable to the dataset column that
-              // feeds it, keyed by variable name. Seeded from an exact-name
-              // match so datasets that already line up need no picking.
-              variableMapping: z.record(z.string()).optional().default({}),
               unmappedVariables: z
                 .number()
                 .default(0)

--- a/frontend/src/sections/develop-detail/Experiment/schema.js
+++ b/frontend/src/sections/develop-detail/Experiment/schema.js
@@ -320,12 +320,16 @@ export const getNewExperimentValidationSchema = (
               isDraft: z.boolean().optional().default(false),
               versionLabel: z.string().optional(),
               name: z.string().optional(),
+              // Maps each prompt/agent variable to the dataset column that
+              // feeds it, keyed by variable name. Seeded from an exact-name
+              // match so datasets that already line up need no picking.
+              variableMapping: z.record(z.string()).optional().default({}),
               unmappedVariables: z
                 .number()
                 .default(0)
                 .refine((val) => val === 0, {
                   message:
-                    "Variable mismatch: The prompt variables don't match the dataset columns.",
+                    "Map every prompt variable to a dataset column before running.",
                 }),
             }),
             z.object({

--- a/futureagi/model_hub/tests/test_run_prompt_variable_mapping.py
+++ b/futureagi/model_hub/tests/test_run_prompt_variable_mapping.py
@@ -1,0 +1,124 @@
+"""Variable-to-column mapping coverage for prompt rendering.
+
+``populate_placeholders`` used to key its render context by column name only, so
+a prompt variable resolved only when a column happened to carry the same name.
+These tests pin the mapping path that lets a column feed a variable it does not
+share a name with, and pin that the name-keyed behaviour still works untouched.
+"""
+
+from __future__ import annotations
+
+import uuid
+from unittest import mock
+
+import pytest
+
+from model_hub.views.run_prompt import populate_placeholders
+
+
+class _Column:
+    def __init__(self, col_id, name, data_type="text"):
+        self.id = col_id
+        self.name = name
+        self.data_type = data_type
+
+
+class _Cell:
+    def __init__(self, value):
+        self.value = value
+
+
+def _render(messages, columns, cells, variable_mapping=None):
+    """Run populate_placeholders against an in-memory dataset.
+
+    ``columns`` maps column id to _Column, ``cells`` maps column id to its value
+    for the single row under test.
+    """
+    dataset = mock.Mock()
+    dataset.column_order = list(columns.keys())
+    output_col_id = str(uuid.uuid4())
+
+    def _get_column(id):  # noqa: A002 - mirrors Column.objects.get(id=...)
+        return columns[str(id)]
+
+    def _filter_cells(dataset, column, row__id):
+        value = cells.get(str(column.id))
+        result = mock.Mock()
+        result.first.return_value = _Cell(value) if value is not None else None
+        return result
+
+    with (
+        mock.patch(
+            "model_hub.views.run_prompt.Dataset.objects.get", return_value=dataset
+        ),
+        mock.patch(
+            "model_hub.views.run_prompt.Column.objects.get", side_effect=_get_column
+        ),
+        mock.patch(
+            "model_hub.views.run_prompt.Cell.objects.filter", side_effect=_filter_cells
+        ),
+    ):
+        return populate_placeholders(
+            messages,
+            dataset_id=str(uuid.uuid4()),
+            row_id=str(uuid.uuid4()),
+            col_id=output_col_id,
+            model_name="gpt-4o",
+            variable_mapping=variable_mapping,
+        )
+
+
+def _text_of(messages):
+    content = messages[0]["content"]
+    if isinstance(content, str):
+        return content
+    return " ".join(part.get("text", "") for part in content if isinstance(part, dict))
+
+
+COLUMN_ID = "11111111-1111-1111-1111-111111111111"
+
+
+@pytest.fixture
+def columns():
+    return {COLUMN_ID: _Column(COLUMN_ID, "Question")}
+
+
+@pytest.fixture
+def cells():
+    return {COLUMN_ID: "why is the sky blue"}
+
+
+def test_mapped_column_feeds_a_variable_with_a_different_name(columns, cells):
+    """The whole point of the mapping: `Question` can feed `{{question}}`."""
+    messages = [{"role": "user", "content": "Answer {{question}}"}]
+
+    out = _render(messages, columns, cells, variable_mapping={"question": COLUMN_ID})
+
+    assert "why is the sky blue" in _text_of(out)
+
+
+def test_without_a_mapping_the_mismatched_name_does_not_resolve(columns, cells):
+    """Guards the bug this feature fixes: name equality alone leaves it unfilled."""
+    messages = [{"role": "user", "content": "Answer {{question}}"}]
+
+    out = _render(messages, columns, cells, variable_mapping=None)
+
+    assert "why is the sky blue" not in _text_of(out)
+
+
+def test_matching_column_names_still_resolve_without_a_mapping(columns, cells):
+    """Backwards compatibility: prompts that already line up are untouched."""
+    messages = [{"role": "user", "content": "Answer {{Question}}"}]
+
+    out = _render(messages, columns, cells, variable_mapping=None)
+
+    assert "why is the sky blue" in _text_of(out)
+
+
+def test_mapping_falls_back_to_the_column_name(columns, cells):
+    """A mapping stored as a column name still resolves."""
+    messages = [{"role": "user", "content": "Answer {{question}}"}]
+
+    out = _render(messages, columns, cells, variable_mapping={"question": "Question"})
+
+    assert "why is the sky blue" in _text_of(out)

--- a/futureagi/model_hub/views/experiment_runner.py
+++ b/futureagi/model_hub/views/experiment_runner.py
@@ -1291,8 +1291,13 @@ class ExperimentRunner:
 
             try:
                 messages = populate_placeholders(
-                    messages, self.dataset.id, row.id, column.id, model_name=model,
+                    messages,
+                    self.dataset.id,
+                    row.id,
+                    column.id,
+                    model_name=model,
                     template_format=model_config.get("template_format"),
+                    variable_mapping=model_config.get("variableMapping"),
                 )
                 if output_format != "audio":
                     messages = remove_empty_text_from_messages(messages)
@@ -1570,8 +1575,13 @@ def _process_row_impl(
 
         try:
             messages = populate_placeholders(
-                messages, dataset_id, row_id, column_id, model_name=model,
+                messages,
+                dataset_id,
+                row_id,
+                column_id,
+                model_name=model,
                 template_format=model_config.get("template_format"),
+                variable_mapping=model_config.get("variableMapping"),
             )
             if output_format != "audio":
                 messages = remove_empty_text_from_messages(messages)

--- a/futureagi/model_hub/views/run_prompt.py
+++ b/futureagi/model_hub/views/run_prompt.py
@@ -494,7 +494,13 @@ class JsonStr(dict):
 
 
 def populate_placeholders(
-    messages: list[dict], dataset_id, row_id, col_id, model_name, template_format=None
+    messages: list[dict],
+    dataset_id,
+    row_id,
+    col_id,
+    model_name,
+    template_format=None,
+    variable_mapping=None,
 ):
     try:
         media_error = None
@@ -508,6 +514,7 @@ def populate_placeholders(
         context: dict[str, Any] = {}
         column_info = {}  # For image handling
         raw_values = {}  # For debugging
+        value_by_column_id = {}  # For variable mapping, keyed by column id
 
         # Collect column values
         for column_id in column_ids:
@@ -571,6 +578,7 @@ def populate_placeholders(
                     # Store at sanitized column_id level (hyphens -> underscores for Jinja2)
                     sanitized_col_id = sanitize_uuid_for_jinja(column_id)
                     context[sanitized_col_id] = cell_value
+                    value_by_column_id[str(column_id)] = cell_value
 
                     # Debug: Log what we're adding to context
                     logger.info(
@@ -583,6 +591,35 @@ def populate_placeholders(
                     f"Error processing column {column_id} ({column.name if 'column' in locals() else 'unknown'}): {e}"
                 )
                 continue
+
+        # Expose each mapped variable under its own name, so a prompt variable can
+        # be fed by a column whose name does not match it. The name-keyed entries
+        # built above are left in place, so prompts whose variables already match a
+        # column resolve exactly as they did before.
+        for variable_name, mapped_column in (variable_mapping or {}).items():
+            if not variable_name or not mapped_column:
+                continue
+            mapped_column = str(mapped_column)
+            if mapped_column in value_by_column_id:
+                context[variable_name] = value_by_column_id[mapped_column]
+                continue
+            # Fall back to matching by column name, for mappings stored before
+            # column ids were used.
+            match = next(
+                (
+                    cid
+                    for cid, info in column_info.items()
+                    if info["name"] == mapped_column
+                ),
+                None,
+            )
+            if match is not None and str(match) in value_by_column_id:
+                context[variable_name] = value_by_column_id[str(match)]
+            else:
+                logger.warning(
+                    "variable_mapping_unresolved",
+                    extra={"variable": variable_name, "mapped_to": mapped_column},
+                )
 
         # Debug: Log final context structure
         logger.info(f"Final context keys: {list(context.keys())}")
@@ -1744,7 +1781,9 @@ class AddRunPromptColumnView(APIView):
                 return self._gm.bad_request(get_error_message("COLUMN_NAME_EXISTS"))
 
             model_name = config.get("model")
-            if model_name and not is_model_in_catalog(model_name, organization_id=organization.id):
+            if model_name and not is_model_in_catalog(
+                model_name, organization_id=organization.id
+            ):
                 return self._gm.bad_request(
                     f"Model '{model_name}' is no longer available. "
                     "Please select a supported model."
@@ -2021,7 +2060,9 @@ class EditRunPromptColumnView(APIView):
                 return self._gm.not_found("Column or dataset not found")
 
             model_name = config.get("model")
-            if model_name and not is_model_in_catalog(model_name, organization_id=dataset.organization_id):
+            if model_name and not is_model_in_catalog(
+                model_name, organization_id=dataset.organization_id
+            ):
                 return self._gm.bad_request(
                     f"Model '{model_name}' is no longer available. "
                     "Please select a supported model."
@@ -2788,8 +2829,10 @@ class RunPromptForRowsView(APIView):
                     return self._gm.not_found("Row not found")
 
             deprecated_models = [
-                rp.model for rp in run_prompters
-                if rp.model and not is_model_in_catalog(rp.model, organization_id=user_org_id)
+                rp.model
+                for rp in run_prompters
+                if rp.model
+                and not is_model_in_catalog(rp.model, organization_id=user_org_id)
             ]
             if deprecated_models:
                 names = ", ".join(f"'{m}'" for m in set(deprecated_models))


### PR DESCRIPTION
Closes #2312.

Variables were matched to dataset columns by exact name only, so a column called `Question` never fed a variable called `question`, and the run was blocked with no way forward except renaming the prompt in the workbench. Datasets and prompts are usually authored separately, so the names not matching is normal rather than a mistake.

## The part that is easy to miss

The name matching happens in **two** places, and fixing only the visible one would have made things worse.

- **UI** — `AgentPromptRenderer.jsx` built `variablesInfo` from `!columnHeaders.includes(variable)` and wrote `notMapped` into the form as `unmappedVariables`, which is what gates the run.
- **Run** — `populate_placeholders()` in `model_hub/views/run_prompt.py` builds its render context keyed by `column.name` (L507-560). A variable only ever resolved when a column happened to carry the same name.

A picker that satisfied only the front-end gate would let a run start and resolve nothing, which is worse than today's hard block. Both sides are changed here.

## What changed

**Front end**
- One column picker per variable, reusing `Common/FieldSelection` — the same control the evaluation mapping form uses, so this adds no new component
- The three states and the run gate now derive from how many mapping entries are filled, not from name equality
- The mapping is seeded from the exact-name match on first render, so datasets that already line up need no picking and keep working untouched
- `variableMapping` added to the zod schema: `z.object` strips unknown keys, so without it the mapping would have been built in the UI and silently dropped before reaching the payload

**Back end**
- `populate_placeholders()` takes an optional `variable_mapping` and seeds the context with one entry per mapped variable, from the mapped column's cell. The name-keyed entries are still built, so nothing regresses
- Lookup is by column id, falling back to column name; an unresolved mapping is logged rather than silently dropped
- The mapping travels inside `prompt_config.configuration`, which already reaches both call sites in `experiment_runner` and is persisted on `PendingRowTask`, so **no migration is needed**

## Tests

Seven new, and I checked that they bite rather than just pass.

- `AgentPromptRenderer.variableMapping.test.jsx` (3): exact-name seeding, a case-different column staying unmapped, and picking it by hand clearing the gate
- `test_run_prompt_variable_mapping.py` (4): the mapped column feeding a differently-named variable, the mismatch staying unresolved without a mapping, backwards compatibility for names that already match, and the column-name fallback. The ORM is mocked, so they need no database
- Removing the mapping block makes 2 of the 4 back-end tests fail while the two compatibility cases keep passing

`pytest model_hub/tests/test_run_prompt_api.py` plus the new file: **125 passed** against the compose test stack. `ruff check` on the touched files reports the same 58 pre-existing errors as `dev`, none in the changed lines; the new test file is clean. `eslint` has no errors and `prettier --check` is clean.

## Two things worth your call

1. **Where the mapping lives.** I put it in `prompt_config.configuration` because that object already reaches both call sites and is persisted, which avoids a migration. The trade-off is that `configuration` was model config and now also carries a data mapping. A field on `PendingRowTask` would be cleaner and would need a migration.

2. **How the mapping reaches `populate_placeholders`.** I asked this on the issue and went with passing it as an optional argument, which keeps the function a pure function of its inputs. Resolving it inside from the `RunPrompter` row would keep the signature untouched. Happy to switch if you prefer that.

Also note I kept the **Refresh** button, moved into the card header. The design does not show it, but removing it would have orphaned `refetchVersions` and the `pickupLatestVersion` flow, which is how a version edited in another tab gets picked up. Easy to drop if that was intentional.

Not covered: I did not exercise this against a live experiment run end to end, only the unit and API suites.