### PR TITLE
fix: actually cancel async jobs on DELETE /v1/async (#2335)

### DIFF
--- a/agentcc-gateway/internal/async/store.go
+++ b/agentcc-gateway/internal/async/store.go
@@ -140,6 +140,33 @@ func (s *Store) Update(id string, fn func(job *Job)) bool {
 	return true
 }
 
+// Cancel invokes the live job's CancelFn (if any), marks it cancelled when
+// it is still queued or processing, and removes it from the store.
+// The cancel function is called after releasing the lock so a cancel
+// callback cannot deadlock on s.mu. Returns false if the job was not found.
+func (s *Store) Cancel(id string) bool {
+	s.mu.Lock()
+	job := s.jobs[id]
+	if job == nil {
+		s.mu.Unlock()
+		return false
+	}
+	cancel := job.CancelFn
+	if job.Status == StatusQueued || job.Status == StatusProcessing {
+		now := time.Now()
+		job.Status = StatusCancelled
+		job.CompletedAt = &now
+	}
+	job.CancelFn = nil
+	delete(s.jobs, id)
+	s.mu.Unlock()
+
+	if cancel != nil {
+		cancel()
+	}
+	return true
+}
+
 // Delete removes a job.
 func (s *Store) Delete(id string) bool {
 	s.mu.Lock()

--- a/agentcc-gateway/internal/async/store_test.go
+++ b/agentcc-gateway/internal/async/store_test.go
@@ -118,3 +118,74 @@ func TestStore_Count(t *testing.T) {
 		t.Errorf("Count = %d, want 2", s.Count())
 	}
 }
+
+func TestStore_GetDoesNotLeakCancelFn(t *testing.T) {
+	s := NewStore()
+	s.Put(&Job{
+		ID:       "job-1",
+		Status:   StatusProcessing,
+		CancelFn: func() {},
+	})
+
+	got := s.Get("job-1")
+	if got == nil {
+		t.Fatal("expected job snapshot, got nil")
+	}
+	if got.CancelFn != nil {
+		t.Fatal("Get snapshot leaked CancelFn")
+	}
+	got = s.GetForOrg("job-1", "")
+	if got == nil || got.CancelFn != nil {
+		t.Fatal("GetForOrg snapshot leaked CancelFn")
+	}
+}
+
+func TestStore_CancelInvokesLiveCancelFn(t *testing.T) {
+	s := NewStore()
+	called := false
+	s.Put(&Job{
+		ID:     "job-1",
+		Status: StatusProcessing,
+		CancelFn: func() {
+			called = true
+		},
+	})
+
+	// The snapshot path used by GET (and previously by DELETE) must not
+	// be enough to cancel: CancelFn is stripped.
+	snap := s.Get("job-1")
+	if snap == nil {
+		t.Fatal("expected snapshot")
+	}
+	if snap.CancelFn != nil {
+		t.Fatal("Get snapshot leaked CancelFn")
+	}
+
+	if !s.Cancel("job-1") {
+		t.Fatal("Cancel returned false for existing job")
+	}
+	if !called {
+		t.Fatal("live CancelFn was not invoked")
+	}
+	if s.Get("job-1") != nil {
+		t.Fatal("job should be removed after Cancel")
+	}
+}
+
+func TestStore_CancelMissing(t *testing.T) {
+	s := NewStore()
+	if s.Cancel("missing") {
+		t.Fatal("expected false for missing job")
+	}
+}
+
+func TestStore_CancelQueuedWithoutCancelFn(t *testing.T) {
+	s := NewStore()
+	s.Put(&Job{ID: "job-1", Status: StatusQueued})
+	if !s.Cancel("job-1") {
+		t.Fatal("Cancel queued job should succeed")
+	}
+	if s.Get("job-1") != nil {
+		t.Fatal("job should be deleted")
+	}
+}

--- a/agentcc-gateway/internal/server/handlers_async.go
+++ b/agentcc-gateway/internal/server/handlers_async.go
@@ -131,25 +131,12 @@ func (h *Handlers) DeleteAsyncJob(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Try to cancel a running job.
-	job := h.asyncStore.Get(jobID)
-	if job == nil {
+	// Cancel via the store so the live CancelFn is invoked (Get returns a
+	// snapshot with CancelFn stripped). Cancel also removes the job.
+	if !h.asyncStore.Cancel(jobID) {
 		models.WriteError(w, models.ErrNotFound("job_not_found", "Async job not found"))
 		return
 	}
-
-	// Cancel if still running.
-	if job.Status == async.StatusQueued || job.Status == async.StatusProcessing {
-		now := time.Now()
-		job.Status = async.StatusCancelled
-		job.CompletedAt = &now
-		if job.CancelFn != nil {
-			job.CancelFn()
-		}
-	}
-
-	// Delete from store.
-	h.asyncStore.Delete(jobID)
 
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusOK)

--- a/agentcc-gateway/internal/server/handlers_async_test.go
+++ b/agentcc-gateway/internal/server/handlers_async_test.go
@@ -1,0 +1,62 @@
+package server
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/futureagi/agentcc-gateway/internal/async"
+)
+
+func TestDeleteAsyncJob_InvokesLiveCancelFn(t *testing.T) {
+	store := async.NewStore()
+	h := &Handlers{asyncStore: store}
+
+	called := false
+	store.Put(&async.Job{
+		ID:     "job-1",
+		Status: async.StatusProcessing,
+		CancelFn: func() {
+			called = true
+		},
+	})
+
+	req := httptest.NewRequest(http.MethodDelete, "/v1/async?job_id=job-1", nil)
+	rec := httptest.NewRecorder()
+	h.DeleteAsyncJob(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body = %s", rec.Code, rec.Body.String())
+	}
+	if !called {
+		t.Fatal("DELETE did not invoke the live CancelFn")
+	}
+	if store.Get("job-1") != nil {
+		t.Fatal("job still in store after DELETE")
+	}
+
+	var body map[string]interface{}
+	if err := json.NewDecoder(rec.Body).Decode(&body); err != nil {
+		t.Fatal(err)
+	}
+	if body["status"] != "cancelled" {
+		t.Errorf("status = %v, want cancelled", body["status"])
+	}
+	if body["deleted"] != true {
+		t.Errorf("deleted = %v, want true", body["deleted"])
+	}
+}
+
+func TestDeleteAsyncJob_NotFound(t *testing.T) {
+	store := async.NewStore()
+	h := &Handlers{asyncStore: store}
+
+	req := httptest.NewRequest(http.MethodDelete, "/v1/async?job_id=missing", nil)
+	rec := httptest.NewRecorder()
+	h.DeleteAsyncJob(rec, req)
+
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("status = %d, want 404", rec.Code)
+	}
+}


### PR DESCRIPTION
## Summary
- DELETE /v1/async reported cancelled but never stopped the running job: the handler called CancelFn on a Get() snapshot that always strips it.
- Cancel now goes through Store.Cancel, which invokes the live CancelFn under the store lock (then after unlock) and removes the job. Get/GetForOrg snapshots still nil out CancelFn.

Closes #2335

## Test plan
- [x] `cd agentcc-gateway && go test ./internal/async/ ./internal/server/ -count=1`
- [ ] DELETE a running async job and confirm the worker actually stops (context cancelled), not just the API status