### PR TITLE
fix: honor fi-collector admin.addr and serve /metrics (#2135)

### DIFF
--- a/fi-collector/cmd/fi-collector/admin.go
+++ b/fi-collector/cmd/fi-collector/admin.go
@@ -1,0 +1,64 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"runtime"
+	"strings"
+	"time"
+
+	"github.com/future-agi/future-agi/fi-collector/pkg/chwriter"
+)
+
+// runAdmin serves /healthz and /metrics on the internal admin listener.
+func runAdmin(addr string, w *chwriter.Writer, log *slog.Logger) {
+	srv := &http.Server{Addr: addr, Handler: adminMux(w), ReadHeaderTimeout: 5 * time.Second}
+	if err := srv.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+		log.Warn("admin server stopped", "err", err)
+	}
+}
+
+func adminMux(w *chwriter.Writer) *http.ServeMux {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/healthz", func(rw http.ResponseWriter, r *http.Request) {
+		s := w.Snapshot()
+		denom := s.BatchesInserted + s.BatchesFailed
+		if denom > 100 && s.BatchesFailed*2 > denom {
+			rw.WriteHeader(http.StatusServiceUnavailable)
+			_ = json.NewEncoder(rw).Encode(map[string]any{"status": "unhealthy", "stats": s})
+			return
+		}
+		rw.WriteHeader(http.StatusOK)
+		_ = json.NewEncoder(rw).Encode(map[string]any{"status": "ok", "stats": s})
+	})
+	mux.HandleFunc("/metrics", func(rw http.ResponseWriter, r *http.Request) {
+		writePrometheusMetrics(rw, w.Snapshot())
+	})
+	return mux
+}
+
+func writePrometheusMetrics(rw http.ResponseWriter, s chwriter.Stats) {
+	var mem runtime.MemStats
+	runtime.ReadMemStats(&mem)
+	rw.Header().Set("Content-Type", "text/plain; version=0.0.4; charset=utf-8")
+	var b strings.Builder
+	counter := func(name, help string, v uint64) {
+		fmt.Fprintf(&b, "# HELP %s %s\n# TYPE %s counter\n%s %d\n", name, help, name, name, v)
+	}
+	gauge := func(name, help string, v uint64) {
+		fmt.Fprintf(&b, "# HELP %s %s\n# TYPE %s gauge\n%s %d\n", name, help, name, name, v)
+	}
+	counter("fi_collector_batches_inserted_total", "ClickHouse span batches inserted successfully.", s.BatchesInserted)
+	counter("fi_collector_rows_inserted_total", "ClickHouse span rows inserted successfully.", s.RowsInserted)
+	counter("fi_collector_batches_retried_total", "ClickHouse span batches that required a retry.", s.BatchesRetried)
+	counter("fi_collector_rows_dead_lettered_total", "Span rows written to the dead-letter file.", s.RowsDeadLettered)
+	counter("fi_collector_batches_failed_total", "ClickHouse span batches that exhausted retries.", s.BatchesFailed)
+	counter("fi_collector_curated_batches_inserted_total", "Best-effort curated-dimension batches inserted.", s.CuratedBatchesInserted)
+	counter("fi_collector_curated_batches_failed_total", "Best-effort curated-dimension batches that failed.", s.CuratedBatchesFailed)
+	gauge("go_goroutines", "Number of goroutines that currently exist.", uint64(runtime.NumGoroutine()))
+	gauge("go_memstats_alloc_bytes", "Number of bytes allocated and still in use.", mem.Alloc)
+	gauge("go_memstats_sys_bytes", "Number of bytes obtained from the system.", mem.Sys)
+	_, _ = rw.Write([]byte(b.String()))
+}

--- a/fi-collector/cmd/fi-collector/admin_test.go
+++ b/fi-collector/cmd/fi-collector/admin_test.go
@@ -1,0 +1,110 @@
+package main
+
+import (
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/future-agi/future-agi/fi-collector/pkg/chwriter"
+)
+
+func testWriter(t *testing.T) *chwriter.Writer {
+	t.Helper()
+	w, err := chwriter.New(chwriter.Config{
+		URL:            "http://127.0.0.1:1",
+		DeadLetterFile: filepath.Join(t.TempDir(), "dead_letter.jsonl"),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = w.Close() })
+	return w
+}
+
+func TestLoadConfig_AdminAddr(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "cfg.yaml")
+	if err := os.WriteFile(path, []byte("admin:\n  addr: \":19464\"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	cfg := loadConfig(slog.New(slog.NewJSONHandler(io.Discard, nil)), path)
+	if cfg.Admin.Addr != ":19464" {
+		t.Fatalf("admin.addr=%q, want :19464 (yaml key was discarded)", cfg.Admin.Addr)
+	}
+}
+
+func TestLoadConfig_ShippedCollectorYAMLAdminAddr(t *testing.T) {
+	cfg := loadConfig(slog.New(slog.NewJSONHandler(io.Discard, nil)), filepath.Join("..", "..", "config", "collector.yaml"))
+	if cfg.Admin.Addr != "127.0.0.1:9464" {
+		t.Fatalf("shipped admin.addr=%q, want 127.0.0.1:9464", cfg.Admin.Addr)
+	}
+}
+
+func TestApplyEnvOverrides_AdminAddr(t *testing.T) {
+	t.Setenv("FI_ADMIN_ADDR", ":19464")
+	var cfg rootConfig
+	if err := applyEnvOverrides(slog.Default(), &cfg); err != nil {
+		t.Fatal(err)
+	}
+	if cfg.Admin.Addr != ":19464" {
+		t.Fatalf("admin.addr=%q, want :19464", cfg.Admin.Addr)
+	}
+}
+
+func TestResolveAdminAddr(t *testing.T) {
+	if got := resolveAdminAddr(rootConfig{}); got != "127.0.0.1:9464" {
+		t.Fatalf("empty addr default=%q", got)
+	}
+	if got := resolveAdminAddr(rootConfig{Admin: adminConfig{Addr: "  "}}); got != "127.0.0.1:9464" {
+		t.Fatalf("whitespace addr default=%q", got)
+	}
+	if got := resolveAdminAddr(rootConfig{Admin: adminConfig{Addr: ":19464"}}); got != ":19464" {
+		t.Fatalf("configured addr=%q", got)
+	}
+}
+
+func TestAdminMux_ServesHealthzAndMetrics(t *testing.T) {
+	mux := adminMux(testWriter(t))
+
+	rr := httptest.NewRecorder()
+	mux.ServeHTTP(rr, httptest.NewRequest(http.MethodGet, "/healthz", nil))
+	if rr.Code != http.StatusOK {
+		t.Fatalf("healthz status=%d body=%s", rr.Code, rr.Body.String())
+	}
+	if !strings.Contains(rr.Body.String(), `"status":"ok"`) {
+		t.Fatalf("healthz body=%s", rr.Body.String())
+	}
+
+	rr = httptest.NewRecorder()
+	mux.ServeHTTP(rr, httptest.NewRequest(http.MethodGet, "/metrics", nil))
+	if rr.Code != http.StatusOK {
+		t.Fatalf("metrics status=%d body=%s", rr.Code, rr.Body.String())
+	}
+	body := rr.Body.String()
+	for _, want := range []string{
+		"fi_collector_batches_inserted_total",
+		"fi_collector_batches_failed_total",
+		"# TYPE fi_collector_batches_inserted_total counter",
+		"go_goroutines",
+	} {
+		if !strings.Contains(body, want) {
+			t.Errorf("metrics missing %q", want)
+		}
+	}
+	if ct := rr.Header().Get("Content-Type"); !strings.Contains(ct, "text/plain") {
+		t.Errorf("content-type=%q", ct)
+	}
+}
+
+func TestAdminMux_UnknownPathNotFound(t *testing.T) {
+	mux := adminMux(testWriter(t))
+	rr := httptest.NewRecorder()
+	mux.ServeHTTP(rr, httptest.NewRequest(http.MethodGet, "/not-a-route", nil))
+	if rr.Code != http.StatusNotFound {
+		t.Fatalf("status=%d, want 404", rr.Code)
+	}
+}

--- a/fi-collector/cmd/fi-collector/main.go
+++ b/fi-collector/cmd/fi-collector/main.go
@@ -11,20 +11,20 @@
 //  1. Defaults coded into chwriter.New / server.New
 //  2. YAML file path from --config (or /etc/fi-collector/config.yaml)
 //  3. Environment overrides (FI_CH_URL, FI_GRPC_ADDR, FI_HTTP_ADDR,
-//     FI_GRPC_MAX_RECV_MIB, FI_DEAD_LETTER_FILE, ...)
+//     FI_GRPC_MAX_RECV_MIB, FI_DEAD_LETTER_FILE, FI_ADMIN_ADDR, ...)
 //
-// Health surfaces:
+// Health surfaces (internal-only admin listener, default 127.0.0.1:9464,
+// configurable via admin.addr or FI_ADMIN_ADDR):
 //   - /healthz (HTTP 200 unless writer dead-letter rate > threshold)
+//   - /metrics (Prometheus text exposition of writer + Go runtime stats)
 //   - Structured logs on stderr (JSON lines)
 package main
 
 import (
 	"context"
-	"encoding/json"
 	"flag"
 	"fmt"
 	"log/slog"
-	"net/http"
 	"os"
 	"os/signal"
 	"strconv"
@@ -43,12 +43,28 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
+type adminConfig struct {
+	Addr string `yaml:"addr"`
+}
+
 type rootConfig struct {
 	Writer          chwriter.Config               `yaml:"writer"`
 	Server          server.Config                 `yaml:"server"`
 	Auth            auth.Config                   `yaml:"auth"`
 	Catalog         catalogwriter.RuntimeConfig   `yaml:"catalog"`
 	PropertyCatalog propertycatalog.RuntimeConfig `yaml:"property_catalog"`
+	Admin           adminConfig                   `yaml:"admin"`
+}
+
+// defaultAdminAddr is the internal-only admin listener (loopback default).
+const defaultAdminAddr = "127.0.0.1:9464"
+
+// resolveAdminAddr returns the configured admin address or the loopback default.
+func resolveAdminAddr(cfg rootConfig) string {
+	if addr := strings.TrimSpace(cfg.Admin.Addr); addr != "" {
+		return addr
+	}
+	return defaultAdminAddr
 }
 
 const (
@@ -302,14 +318,15 @@ func main() {
 		go logCatalogSubmissionGaps(ctx, catalogSubmitter, log)
 	}
 
-	// Admin HTTP server — internal only, health check endpoint.
-	go runAdmin(":9464", writer, log)
+	// Admin HTTP server — internal only, honors admin.addr / FI_ADMIN_ADDR.
+	go runAdmin(resolveAdminAddr(cfg), writer, log)
 
 	go authenticator.WatchRevocations(ctx)
 
 	log.Info("starting",
 		"grpc_addr", cfg.Server.GRPCAddr,
 		"http_addr", cfg.Server.HTTPAddr,
+		"admin_addr", resolveAdminAddr(cfg),
 		"ch_url", cfg.Writer.URL,
 	)
 	runErr := srv.Run(ctx)
@@ -515,6 +532,9 @@ func applyEnvOverrides(log *slog.Logger, c *rootConfig) error {
 	}
 	if v := os.Getenv("FI_DEAD_LETTER_FILE"); v != "" {
 		c.Writer.DeadLetterFile = v
+	}
+	if v := os.Getenv("FI_ADMIN_ADDR"); v != "" {
+		c.Admin.Addr = v
 	}
 	// Auth overrides (auth is active when PG_WRITE is set)
 	if v := os.Getenv("FI_PG_WRITE"); v != "" {
@@ -741,24 +761,4 @@ func sameClickHouseIdentity(canonical, catalog string) bool {
 		catalog = "default"
 	}
 	return canonical == catalog
-}
-
-// runAdmin serves /healthz for container health checks.
-func runAdmin(addr string, w *chwriter.Writer, log *slog.Logger) {
-	mux := http.NewServeMux()
-	mux.HandleFunc("/healthz", func(rw http.ResponseWriter, r *http.Request) {
-		s := w.Snapshot()
-		denom := s.BatchesInserted + s.BatchesFailed
-		if denom > 100 && s.BatchesFailed*2 > denom {
-			rw.WriteHeader(503)
-			_ = json.NewEncoder(rw).Encode(map[string]any{"status": "unhealthy", "stats": s})
-			return
-		}
-		rw.WriteHeader(200)
-		_ = json.NewEncoder(rw).Encode(map[string]any{"status": "ok", "stats": s})
-	})
-	srv := &http.Server{Addr: addr, Handler: mux, ReadHeaderTimeout: 5 * time.Second}
-	if err := srv.ListenAndServe(); err != nil && err != http.ErrServerClosed {
-		log.Warn("admin server stopped", "err", err)
-	}
 }

--- a/fi-collector/config/collector.yaml
+++ b/fi-collector/config/collector.yaml
@@ -75,4 +75,6 @@ catalog:
     topic: ""
 
 admin:
-  addr: ":9464" # /healthz and /metrics
+  # Internal-only admin listener, loopback by default. Override via FI_ADMIN_ADDR
+  # (compose sets ":9464" so published container ports still bind the wire).
+  addr: "127.0.0.1:9464" # /healthz and /metrics


### PR DESCRIPTION
## Summary
- Parse `admin.addr` into `rootConfig` and pass it to the admin listener (default `127.0.0.1:9464`). `FI_ADMIN_ADDR` overrides.
- Serve `/metrics` as Prometheus 0.0.4 text from the writer snapshot, matching the yaml comment. `/healthz` unchanged.
- Shipped `collector.yaml` default is loopback; compose can still set `FI_ADMIN_ADDR=:9464` to publish the port.

Closes #2135

## Test plan
- [x] `cd fi-collector && go test ./cmd/fi-collector/ -count=1`
- [ ] Set `admin.addr: ":19464"`, confirm listen address changes
- [ ] `curl 127.0.0.1:9464/metrics` is 200 Prometheus text, not 404