### PR TITLE
fix(alerts): give the alert email CTA an absolute, region-correct URL

### DIFF
--- a/futureagi/tfc/settings/settings.py
+++ b/futureagi/tfc/settings/settings.py
@@ -860,6 +860,9 @@ get_started_url = f"{_ssl}{APP_URL}/dashboard/get-started"
 default_error_next_url = f"{_ssl}{APP_URL}/auth/jwt/login?denied=true"
 get_entity_id = f"{_ssl}{APP_URL}"
 
+# APP_URL is a bare host; each region is its own deployment with its own value.
+APP_BASE_URL = f"{_ssl}{APP_URL}" if APP_URL else ""
+
 get_name_id_format = "urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress"
 AUTH0_DOMAIN = "accounts.google.com/o/oauth2"
 AUTH0_ALGORITHM = "RS256"

--- a/futureagi/tfc/utils/email.py
+++ b/futureagi/tfc/utils/email.py
@@ -1,6 +1,7 @@
 import html as _html
 import re
 
+from django.conf import settings
 from django.core.mail import EmailMultiAlternatives
 from django.template.loader import render_to_string
 from django.utils.html import strip_tags
@@ -56,7 +57,10 @@ def email_helper(
             reply_to=False/[] to disable.
         from_email: Optional sender override. Defaults to Future AGI noreply.
     """
-    html_body = render_to_string(template_name, template_data)
+    # Templates build their CTAs as base_url|add:"/dashboard/...", and nothing
+    # supplies base_url on this path, so the links render host-less.
+    context = {"base_url": settings.APP_BASE_URL, **(template_data or {})}
+    html_body = render_to_string(template_name, context)
     text_body = _html_to_text(html_body)
 
     if reply_to is None:

--- a/futureagi/tracer/tests/test_monitor_evaluator.py
+++ b/futureagi/tracer/tests/test_monitor_evaluator.py
@@ -10,6 +10,8 @@ from typing import Any, List, Optional
 from unittest import mock
 
 import pytest
+from django.core import mail
+from django.test import override_settings
 from django.utils import timezone
 
 from tracer.models.monitor import UserAlertMonitorLog
@@ -20,6 +22,7 @@ from tracer.utils.monitor import (
     MonitorConfigError,
     _get_metric_value,
     _process_monitor,
+    _send_alert_email,
     build_monitor_ch_builder,
     get_interval_kind,
     process_monitor_task,
@@ -259,6 +262,24 @@ def test_notification_helpers_receive_alert_args(user_alert_monitor) -> None:
     assert args[0] == user_alert_monitor
     assert "breached the critical threshold" in args[1]
     assert args[2] == "critical"
+
+
+@override_settings(APP_BASE_URL="https://app.eu.futureagi.com")
+def test_alert_email_button_links_to_this_deployment(user_alert_monitor) -> None:
+    user_alert_monitor.notification_emails = ["alerts@example.com"]
+    user_alert_monitor.save(update_fields=["notification_emails"])
+    mail.outbox.clear()
+
+    _send_alert_email(user_alert_monitor, "breached the critical threshold", "critical")
+
+    assert len(mail.outbox) == 1
+    alternative = mail.outbox[0].alternatives[0]
+    html_body = (
+        alternative.content if hasattr(alternative, "content") else alternative[0]
+    )
+    assert 'href="https://app.eu.futureagi.com/dashboard/alerts"' in html_body
+    assert 'href="/dashboard/alerts"' not in html_body
+    assert "app.futureagi.com" not in html_body.replace("app.eu.futureagi.com", "")
 
 
 @pytest.mark.parametrize(

--- a/futureagi/tracer/utils/monitor.py
+++ b/futureagi/tracer/utils/monitor.py
@@ -110,7 +110,7 @@ def _send_alert_email(monitor: UserAlertMonitor, message: str, alert_type: str) 
         email_helper(
             mail_subject=f"[{alert_type.upper()}] Alert Triggered: {monitor.name}",
             template_name="alert_user.html",
-            template_data={  # TODO: add link to the alert and change the template data
+            template_data={
                 "alert_name": monitor.name,
                 "alert_message": message,
                 "alert_type": alert_type,


### PR DESCRIPTION
## The problem

An alert fires, and we email you about it.

The email has a button on it that says **Open monitor**.

Clicking it does not open the platform.

The link behind that button has no website address in it at all. It is only the path, so a mail client either treats it as dead or resolves it against the mail provider's own site. A customer clicking **Open monitor** from Gmail gets sent somewhere inside Gmail.

The customer who reported it said the link "goes to the wrong page". It is worse than the wrong page. There is no page.

## Why nobody catches it

The email looks completely fine. The button is there, it is styled, it is the right colour, and it says the right words. Nothing renders as broken.

The small link in the footer of the same email does work, because whoever wrote that one gave it a fallback address to fall back on. The main button was never given one.

And nobody here ever clicks these. Alert emails go to customers. The only place this is visible is somebody else's inbox.

---

## Summary

Two-layer bug. The alert email template builds its primary CTA by prefixing a site address onto `/dashboard/alerts`, and the sender never supplies that address, so Django renders the undefined variable as an empty string and the button ships as a bare `href="/dashboard/alerts"`.

The fix names the deployment's own absolute base URL as a setting and injects it as a default context key inside the shared email helper, so every template that already asks for it gets it. It also deletes the `# TODO: add link to the alert` that had been sitting on exactly this line. Adds 1 behavioral test that renders the real email through the real sender and asserts on the resulting `href`.

## Why the changes are done — what is the problem

### Reproduce on dev / main today (before this PR)

1. Create an alert on any project with a notification email set.
2. Let it breach, or call the alert path so the notification email is sent.
3. Open the delivered email and inspect the **Open monitor** button.
4. Its `href` is `/dashboard/alerts`. No scheme, no host.
5. On EU, the small **Dashboard** link in the footer resolves to `https://app.futureagi.com` — the **US** host — because that is the hardcoded fallback.

### Where it breaks — BE

The template asks for a base address:

`futureagi/accounts/templates/alert_user.html:39`

```
{% include "billing/_button.html" with url=base_url|add:"/dashboard/alerts" text="Open monitor" variant="primary" %}
```

The sender never passes one:

`futureagi/tracer/utils/monitor.py:110-121`

```python
email_helper(
    mail_subject=f"[{alert_type.upper()}] Alert Triggered: {monitor.name}",
    template_name="alert_user.html",
    template_data={  # TODO: add link to the alert and change the template data
        "alert_name": monitor.name,
        "alert_message": message,
        "alert_type": alert_type,
    },
    to_email_list=list(monitor.notification_emails),
)
```

And `email_helper` renders with plain `render_to_string`, so there is no request and no context processor to fill the gap:

`futureagi/tfc/utils/email.py:59`

```python
html_body = render_to_string(template_name, template_data)
```

Django resolves an undefined variable to the empty string, so `"" + "/dashboard/alerts"` is `/dashboard/alerts`.

### Where it breaks — the trap is not only in this email

`base_url` is referenced by **17** templates on `origin/dev`, and **15** of them build a CTA with the same `base_url|add:` shape. Not one Python caller on `origin/dev` supplies `base_url` in `template_data`, so the variable is empty everywhere it is used.

Of the 15, exactly one is wired to a live sender today, `alert_user.html`. The other 14 are the billing and licence emails (`payment_failed`, `invoice_generated`, `license_expiring`, `usage_budget_warn`, and so on) and no sender references them yet. They are not sending broken links right now, and they carry the identical hole for whoever wires them up.

That is why this is fixed inside `email_helper` and not at the one call site. Fixing only the alert sender leaves the trap armed for the next fourteen.

## What changed

### `futureagi/tfc/settings/settings.py` — name the deployment's absolute base URL

`APP_URL` is a bare host with no scheme, and four expressions immediately above already build `f"{_ssl}{APP_URL}"` by hand. This adds a fifth as a named constant beside them rather than a fifth ad-hoc concatenation somewhere else in the codebase.

```python
# APP_URL is a bare host; each region is its own deployment with its own value.
APP_BASE_URL = f"{_ssl}{APP_URL}" if APP_URL else ""
```

### `futureagi/tfc/utils/email.py` — supply `base_url` as a default, not an override

```python
# Templates build their CTAs as base_url|add:"/dashboard/...", and nothing
# supplies base_url on this path, so the links render host-less.
context = {"base_url": settings.APP_BASE_URL, **(template_data or {})}
html_body = render_to_string(template_name, context)
```

`template_data` is spread **after**, so a caller that passes its own `base_url` still wins. Today no caller does.

### `futureagi/tracer/utils/monitor.py` — remove the stale TODO

`# TODO: add link to the alert and change the template data` named this exact gap. It is now closed, so leaving it would tell the next reader the bug is still open.

### `futureagi/tracer/tests/test_monitor_evaluator.py` (new test) — pin the rendered `href`

Renders the real email through the real sender and asserts on the HTML that actually goes out.

## Tests included — what each scenario covers

**New vs existing.** 1 new test. `test_monitor_evaluator.py` had 35 tests and none of them rendered an email body — the closest, `test_notification_helpers_receive_alert_args`, asserts only on the arguments the notification helpers are called with, so a broken link was invisible to it. The 35 existing tests are unchanged.

| # | Test | Scenario | Setup | Action | What it pins |
| - | - | - | - | - | - |
| 1 | `test_alert_email_button_links_to_this_deployment` | An alert fires on a non-US deployment and emails the customer | `@override_settings(APP_BASE_URL="https://app.eu.futureagi.com")`, monitor given a notification email, `mail.outbox` cleared | Call `_send_alert_email(monitor, "breached the critical threshold", "critical")` | Three things at once: the CTA carries the absolute deployment URL; the host-less `href="/dashboard/alerts"` is gone; and no `app.futureagi.com` survives anywhere in an EU email, which catches the footer's hardcoded US fallback as well |

`_send_alert_email` is imported directly rather than reached through `process_monitor_task`, because the module's autouse `_mute_notifications` fixture patches the outer path and would swallow the send.

## Commands to run tests

```bash
git fetch origin
git checkout fix/TH-7791-alert-email-link-absolute-url
cd futureagi

# the file that carries the fix
bin/test tracer/tests/test_monitor_evaluator.py

# the one new test on its own
bin/test tracer/tests/test_monitor_evaluator.py::test_alert_email_button_links_to_this_deployment

# blast radius: every email, invite, notification and billing test
bin/test -k "email or invite or notification or billing" tracer/tests accounts/tests
```

To watch it fail without the fix:

```bash
git checkout origin/dev -- futureagi/tfc/settings/settings.py futureagi/tfc/utils/email.py
cd futureagi && bin/test tracer/tests/test_monitor_evaluator.py
cd .. && git checkout HEAD -- futureagi/tfc/settings/settings.py futureagi/tfc/utils/email.py
```

### Local verification results

Red, with the two source files reverted to `origin/dev` and the test kept:

```
tracer/tests/test_monitor_evaluator.py ..................F.............. [ 91%]

_______________ test_alert_email_button_links_to_this_deployment _______________
tracer/tests/test_monitor_evaluator.py:280: in test_alert_email_button_links_to_this_deployment
    assert 'href="https://app.eu.futureagi.com/dashboard/alerts"' in html_body
E   assert 'href="https://app.eu.futureagi.com/dashboard/alerts"' in '<!DOCTYPE html>...'

========================= 1 failed, 35 passed in 7.21s =========================
```

Green, with the fix:

```
tracer/tests/test_monitor_evaluator.py ................................. [ 91%]
...                                                                      [100%]

============================== 36 passed in 7.06s ==============================
```

Blast radius, every email / invite / notification / billing test across `tracer/tests` and `accounts/tests`:

```
============== 266 passed, 11809 deselected in 110.91s (0:01:50) ===============
```

## Video

The full suite running green locally, recorded end to end.

https://github.com/user-attachments/assets/6b1dc9ab-6976-49d1-8a6a-3faabee1c53f

## Screenshot of test suite run

**Command** - `bin/test tracer/tests/test_monitor_evaluator.py`

<img width="1420" alt="test suite run, 36 passed" src="https://github.com/user-attachments/assets/9b546297-5ff5-4fe5-af94-c5d13087f768" />

## Before and after

Both panes are the real `alert_user.html` rendered through the real sender, with the live `href` of the **Open monitor** button printed underneath each one.

<img width="1520" alt="alert email before and after, with the CTA href printed" src="https://github.com/user-attachments/assets/64ed01d2-1759-4b38-ab27-c6c5607c5b14" />

```
before   href="/dashboard/alerts"                              no host
after    href="https://app.eu.futureagi.com/dashboard/alerts"
```

## Why these decisions

**A named setting rather than passing `settings.APP_URL` at the call site.** `APP_URL` is a bare host. A call site that used it directly would have to know about `_ssl` and rebuild the scheme itself, which is the fifth copy of an expression that already exists four times in `settings.py`. One named constant, defined next to its siblings, is the smaller surface.

**Fixed in `email_helper`, not in the alert sender.** 15 templates carry the same `base_url|add:` CTA and no caller anywhere supplies the variable. Patching the one live sender would fix one email and leave the other fourteen waiting to break the day someone wires them up.

**A default, not an override.** `template_data` is spread after the default, so an explicit `base_url` from a caller still wins. This is additive for every existing caller: none of them pass it today, so none of them change behaviour except by gaining a working link.

**No per-organisation or per-alert host lookup.** Each region is its own deployment with its own `APP_URL`, so the deployment's own host is always the correct host for anyone receiving mail from it. There is nothing to look up.

**The CTA points at the alerts list, not at the specific alert.** There is no addressable URL for one alert in the frontend today. `paths.js` carries a plain string with no `:id` segment, the route takes no id, and opening an alert is client-side store state. Deep-linking to a single alert is a frontend routing change and is tracked separately in TH-7792. This PR makes the destination that already exists reachable, rather than inventing a URL that would 404.

**The TODO is deleted, not left in place.** It named this exact gap. Keeping it after closing the gap would mislead the next reader.

## Backwards compatibility

Schema unchanged. No model, no migration, no API contract touched. One new Django setting and one extra key in a template context.

| Caller | Pre-PR | Post-PR |
| - | - | - |
| `email_helper` caller that passes no `base_url` (all of them today) | `base_url` undefined, renders as `""` | `base_url` = this deployment's absolute host |
| `email_helper` caller that passes its own `base_url` (none today) | its own value | its own value, unchanged — the spread puts it last |
| `alert_user.html` **Open monitor** button | `href="/dashboard/alerts"` | `href="https://<deployment host>/dashboard/alerts"` |
| `base_billing.html` footer **Dashboard** link | fell through to the hardcoded `https://app.futureagi.com`, so EU mail linked to the US host | resolves to the deployment's own host |
| `annotation_*.html`, `automation_rule_completion.html` | do not reference `base_url` | unchanged |
| `saml2_auth/login.html` | rendered by the SAML library, not by `email_helper` | unchanged |
| Any deployment with `APP_URL` unset | `base_url` empty | `APP_BASE_URL` is `""`, so behaviour is identical to today |

The footer row is the one intentional behaviour change beyond the bug itself: an EU alert email stops linking its footer to the US dashboard. The new test pins it.

## Manual verification

1. `git checkout fix/TH-7791-alert-email-link-absolute-url && cd futureagi`
2. `bin/test tracer/tests/test_monitor_evaluator.py` — expect `36 passed`.
3. In a Django shell, render the email the sender actually sends and read the CTA back:

```python
from django.conf import settings
from django.core import mail
from tracer.models.monitor import UserAlertMonitor
from tracer.utils.monitor import _send_alert_email

m = UserAlertMonitor.objects.filter(notification_emails__len__gt=0).first()
mail.outbox = []
_send_alert_email(m, "breached the critical threshold", "critical")
html = mail.outbox[0].alternatives[0][0]

print(settings.APP_BASE_URL)
print([l for l in html.splitlines() if "Open monitor" in l or "/dashboard/alerts" in l])
```

4. Every `/dashboard/alerts` occurrence should be prefixed with `settings.APP_BASE_URL`. None should start with a bare `/`.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [x] Follows the repository style guide
- [x] Behavioral test added, and it fails when the fix is reverted
- [x] Full suite run locally, screenshot and video attached
- [x] No secrets, no customer data, no ticket refs or justification prose left in source
- [x] No migration

## Backout / rollback

- Clean `git revert`. Three source lines and one test.
- No migration, no schema change, no data change.
- Reverting restores the host-less CTA exactly as it is on `dev` today.

## Linear

Closes TH-7791
