### PR TITLE
fix(frontend): sanitize synthetic dataset requests

### DIFF
--- a/frontend/src/sections/develop/AddRowDrawer/CreateSyntheticData.jsx
+++ b/frontend/src/sections/develop/AddRowDrawer/CreateSyntheticData.jsx
@@ -241,7 +241,8 @@ const SyntheticDataDrawer = ({
           cols[item.name] = item.description;
         }
         const newItem = {
-          ...item,
+          name: item.name,
+          data_type: item.data_type,
           description: replaceColumn(item.description, item.name),
           property,
           ...(datasetId && { is_new: true, skip: true }),

--- a/frontend/src/sections/develop/AddRowDrawer/CreateSyntheticDataView.jsx
+++ b/frontend/src/sections/develop/AddRowDrawer/CreateSyntheticDataView.jsx
@@ -293,7 +293,8 @@ const CreateSyntheticDataView = ({
           cols[item.name] = item.description;
         }
         const newItem = {
-          ...item,
+          name: item.name,
+          data_type: item.data_type,
           description: replaceColumn(item.description, item.name),
           property,
           // ...(datasetId && { is_new: true, skip: true }),  // It need for the perticular dataset


### PR DESCRIPTION
## What does this PR do?

Sanitizes synthetic dataset column requests to only include fields accepted by the API, preventing validation errors from server metadata.

## Why is this needed?

The synthetic dataset form reused API response column objects when building create and update requests. In edit flows, those objects can contain server metadata such as `status`, which the API intentionally rejects as an unknown field.

## Changes

- Build synthetic column requests from only the fields accepted by the API (name, data_type, description, property)
- Preserve existing dataType compatibility and drawer-specific flags
- Applied to both CreateSyntheticData.jsx and CreateSyntheticDataView.jsx

## Testing

- Verified that synthetic dataset creation works without errors
- Verified that synthetic dataset update works without errors
- Verified that server metadata is not included in API requests

Fixes #2313