### PR TITLE
fix(frontend): read the credit-exhaustion code from the field axios actually sets

### DIFF
--- a/frontend/src/hooks/use-credit-exhaustion.js
+++ b/frontend/src/hooks/use-credit-exhaustion.js
@@ -16,8 +16,9 @@ const CREDIT_ERROR_CODES = [
  */
 export function isCreditExhaustionError(error) {
   if (!error) return false;
+  const errorCode = error.errorCode || error.code;
   return (
-    error.statusCode === 402 || CREDIT_ERROR_CODES.includes(error.errorCode)
+    error.statusCode === 402 || CREDIT_ERROR_CODES.includes(errorCode)
   );
 }
 
@@ -47,9 +48,10 @@ export function useCreditExhaustion({ feature = "unknown" } = {}) {
     (error) => {
       if (isCreditExhaustionError(error)) {
         setExhaustionError(error);
+        const errorCode = error.errorCode || error.code;
         trackPostHogEvent("credits_nudge_shown", {
           feature,
-          error_code: error.errorCode,
+          error_code: errorCode,
           dimension: error.dimension,
           current_usage: error.currentUsage,
           limit: error.limit,
@@ -65,9 +67,10 @@ export function useCreditExhaustion({ feature = "unknown" } = {}) {
     // The pricing route is a frontend concern; don't accept a URL from the
     // server — it can rot when routes move, and would be an open-redirect
     // if an attacker-controlled string ever landed in the payload.
+    const errorCode = exhaustionError?.errorCode || exhaustionError?.code;
     trackPostHogEvent("credits_upgrade_clicked", {
       feature,
-      error_code: exhaustionError?.errorCode,
+      error_code: errorCode,
       target_plan: exhaustionError?.upgradeCta?.plan,
     });
     navigate(paths.dashboard.settings.pricing);
@@ -75,9 +78,10 @@ export function useCreditExhaustion({ feature = "unknown" } = {}) {
   }, [exhaustionError, feature, navigate]);
 
   const handleDismiss = useCallback(() => {
+    const errorCode = exhaustionError?.errorCode || exhaustionError?.code;
     trackPostHogEvent("credits_nudge_dismissed", {
       feature,
-      error_code: exhaustionError?.errorCode,
+      error_code: errorCode,
     });
     setExhaustionError(null);
   }, [exhaustionError, feature]);


### PR DESCRIPTION
## What does this PR do?

Fixes the credit-exhaustion error detection to read the error code from the field that axios actually sets (`error.code`) instead of the field it never sets (`error.errorCode`).

## Why is this needed?

`isCreditExhaustionError` keyed the credit/usage-error detection off `error.errorCode` — a field the axios error interceptor never sets. The interceptor spreads the response body onto the rejected error (`{ ...errData, statusCode }`), and the backend error envelope carries its code in the top-level `code` field.

Consequences while `error.errorCode` is always `undefined`:
- credit-exhaustion was only detected on HTTP **402**, but the billing/entitlement taxonomy returns most codes on **403** — `FREE_TIER_LIMIT`, `BUDGET_PAUSED`, `ENTITLEMENT_LIMIT`, `ENTITLEMENT_DENIED` — so those never triggered the upgrade banner

## Changes

- Updated `isCreditExhaustionError` to check for both `error.errorCode` and `error.code`
- Updated `handleError`, `handleUpgradeClick`, and `handleDismiss` to use the correct field

## Testing

- Verified that credit exhaustion errors are now correctly detected for both 402 and 403 status codes
- Verified that the upgrade banner appears for all credit exhaustion error codes

Fixes #2397