### PR TITLE
fix(observe): say Error Feed, not agent compass, on the sampling rate copy [TH-7797]

### DIFF
--- a/frontend/src/sections/project-detail/ConfigureProject.jsx
+++ b/frontend/src/sections/project-detail/ConfigureProject.jsx
@@ -232,8 +232,9 @@ const ConfigureProject = ({ open, onClose, id, refreshGrid, module }) => {
                         fontWeight={"fontWeightRegular"}
                         color={"text.secondary"}
                       >
-                        Defines the percentage of data processed for agent
-                        compass
+                        Controls Error Feed only. Eval tasks have their own
+                        sampling rate and are not affected by this. Error Feed
+                        uses very few credits.
                       </Typography>
                       <a
                         href="https://docs.futureagi.com/docs/error-feed/features/sampling"

--- a/frontend/src/sections/settings/UsageSummaryView/Workspacestable.jsx
+++ b/frontend/src/sections/settings/UsageSummaryView/Workspacestable.jsx
@@ -165,7 +165,7 @@ export default function WorkspaceUsageTable({
           params.node.rowPinned ? { component: TotalCellRenderer } : undefined,
       },
       {
-        headerName: "Agent compass",
+        headerName: "Error Feed",
         field: "agent_compass",
         flex: 1,
         valueGetter: (params) =>

--- a/frontend/src/sections/settings/UsageSummaryView/common.js
+++ b/frontend/src/sections/settings/UsageSummaryView/common.js
@@ -110,7 +110,7 @@ const titlesMap = {
   traces: "Cost of traces (Count)",
   evaluations: "Cost of evaluations (Count)",
   error_localizations: "Cost of error localization (Count)",
-  agent_compass: "Cost of agent compass (Count)",
+  agent_compass: "Cost of Error Feed (Count)",
   simulate: "Simulate (Count)",
 };
 


### PR DESCRIPTION
## Summary

The project settings sampling slider read **"Defines the percentage of data processed for agent compass"**. Two things wrong with that line: `agent compass` is our internal name for what customers see as **Error Feed**, and it never said what the slider leaves alone.

Harish Potabathula (Whatfix) asked us on the 1 Sep call which of the two "Sampling rate" settings applied when he had both Error Feed and his own eval tasks running. We could not answer it from the screen, and neither could he.

Copy only. No logic, no API, no backend change.

## Why the two settings are actually unrelated

- The project slider posts to the **Error Feed** task — `ConfigureProject.jsx:99` sends `sampling_rate`, and `futureagi/tracer/views/error_analysis.py:625-631` writes it onto `TraceErrorAnalysisTask.sampling_rate`.
- Eval tasks keep their own number — `futureagi/tracer/models/eval_task.py:55`, `EvalTask.sampling_rate`.
- They are not even on the same scale: project is 0–1 (`serializers/project.py:137`), eval task is 1–100 (`serializers/eval_task.py:310`).

Kartik confirmed the substance on Slack (1–2 Sep): evals don't depend on Error Feed sampling, they cluster separately, and the Error Feed credit share is minimal. **Vel signed off on the exact wording on TH-7797.**

## What changed

### 1. `frontend/src/sections/project-detail/ConfigureProject.jsx`

```diff
- Defines the percentage of data processed for agent compass
+ Controls Error Feed only. Eval tasks have their own sampling rate and are
+ not affected by this. Error Feed uses very few credits.
```

The `Docs` link beside it is unchanged — it already pointed at `docs.futureagi.com/docs/error-feed/features/sampling`, so the copy and the link now agree instead of contradicting each other.

### 2 & 3. `frontend/src/sections/settings/UsageSummaryView/`

Ticket item 2 says stop using "agent compass" anywhere a customer can read it, so the last two instances go too:

| File | Before | After |
| -- | -- | -- |
| `Workspacestable.jsx:168` | `headerName: "Agent compass"` | `headerName: "Error Feed"` |
| `common.js:113` | `agent_compass: "Cost of agent compass (Count)"` | `agent_compass: "Cost of Error Feed (Count)"` |

`grep -rni "agent compass" frontend/src` now returns nothing.

## The eval task slider is deliberately untouched

Ticket item 3 asks for the eval slider to be reworded too. It quotes this tooltip:

> Sampling rate (%) defines the percentage of data sampled for the task, ranging from 0 to 100. For example, 50% means half of the data is used

**That string does not render anywhere.** It lives in `NewTaskDrawer/NewTaskSlider.jsx`, reachable only via `ScheduledRuns` → `NewTaskDrawer`/`EditTaskDrawer` → `EvalsTasksView` — and `EvalsTasksView` has zero importers. The live routes (`dashboard.jsx:266-272`) go to `TasksPage` → `EvalsTasksViewV2` and `TaskCreate` → `TaskCreatePage`, whose copy comes from `sections/tasks/components/TaskSchedulingSection.jsx` and already reads:

> What percentage of matching rows to actually evaluate — lower values run faster and use less budget

So the "both sentences begin *defines the percentage of data*" collision the ticket describes is already gone. Called this out on the ticket before building; Vel approved.

## Screenshots

**Project settings — before**

![Sampling rate slider before — "Defines the percentage of data processed for agent compass"](https://github.com/user-attachments/assets/3fac00d3-36e1-4a8d-90b3-6e952fc98885)

**Project settings — after**

![Sampling rate slider after — "Controls Error Feed only. Eval tasks have their own sampling rate and are not affected by this. Error Feed uses very few credits."](https://github.com/user-attachments/assets/58efc1b3-db1c-4af9-a92a-8c3da88c4108)

The usage-summary labels are not screenshotted: `WorkspaceUsageTable` only renders when the org has more than one workspace (`TableView.jsx:135`), and the local org has one, so that page falls through to `EvalutionsBreakdownTable`. Both changes there are literal string swaps visible in the diff.

## Verification

- **Nothing keys off these strings.** Repo-wide grep for all three literals (including `e2e/`) returns zero consumers. The AG Grid column sets no `colId`, so identity derives from `field: "agent_compass"` — `headerName` never participates in column identity, and the grid has no column-state persistence, column picker or saved views. For `titlesMap`, both consumers use `id: key` as the React key and for icon lookups; `title` is rendered once as text and never parsed or used as a key.
- **The stable identifier is untouched end to end.** `futureagi/ee/usage/utils/usage_sqls.py:38` maps `trace_error_analysis` → `agent_compass`, and the frontend still reads `agent_compass`. No contract drift.
- **No i18n impact** — these were hardcoded in JSX, never translation keys; no locale file contains them.
- `yarn test:run src/sections/settings` — **42/42 pass**
- `yarn test:run src/sections/project-detail` — **14/14 pass**
- ESLint on all three files — **0 errors**. The one `react-refresh/only-export-components` warning on `ConfigureProject.jsx` is pre-existing on `dev` (verified by running the `HEAD` version through `eslint --stdin`).
- **Layout checked in a real browser**, since `DialogContent` has `overflow: hidden` under a `maxHeight: 450` Paper and would clip rather than scroll. Measured `scrollHeight` vs `clientHeight` at both 1500px and 560px viewports: **0px clipped in both**, slider and its `0%`/`100%` ticks fully visible, ~140px of headroom.

## Notes for reviewers

- The label now reads "Error Feed" while the field, the icon map key, the SQL, the Celery queue and the Temporal workflow names all remain `agent_compass`. That is intended, but worth knowing when debugging a usage discrepancy — "Error Feed" and `agent_compass` are the same thing.
- A user-initiated CSV export or "Copy with Headers" from the workspace usage grid will now write `Error Feed` in the header row. Nothing in the codebase reads that output.
- Unrelated to this PR, but next door: that dialog's `overflow: "hidden"` (`ConfigureProject.jsx:172`) means any future content growth clips instead of scrolling. Changing it to `auto` would be a strict improvement — happy to raise it separately.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Linear

Closes TH-7797

