### PR TITLE
fix(dashboards): stop minute-granularity widgets freezing the browser [TH-7757]

### DIFF
--- a/frontend/src/sections/dashboards/WidgetChart.jsx
+++ b/frontend/src/sections/dashboards/WidgetChart.jsx
@@ -14,6 +14,10 @@ import {
   getExactDashboardResult,
   getDashboardMetricSeriesState,
   getPlottedChartSeries,
+  getChartTimeWindow,
+  getTableBucketPlan,
+  describeTableBuckets,
+  isDenseChartSeries,
   getSeriesScalar,
   getSuggestedUnitConfig,
   getUnitRendering,
@@ -23,7 +27,6 @@ import {
   groupPieSeries,
   resolveSavedSelection,
   seriesHasDataPoints,
-  shouldConnectAcrossMissingBuckets,
 } from "./widgetUtils";
 import WidgetPieCharts from "./WidgetPieCharts";
 import { toTimeRangePayload } from "./dashboardDateRange";
@@ -38,6 +41,7 @@ import {
   getQueryCompletedAt,
 } from "src/utils/queryReadState";
 import { NO_DATA_FOR_RANGE_MESSAGE } from "./constants";
+import useClampedChartTooltips from "./hooks/useClampedChartTooltips";
 
 const CHART_HEIGHT_FALLBACK = 280;
 const COLORS = [
@@ -177,41 +181,12 @@ export default function WidgetChart({
   const isTable = chartType === "table";
   const isMetricCard = chartType === "metric";
   const isLineChart = apexType === "line";
-  const connectsAcrossMissingBuckets =
-    shouldConnectAcrossMissingBuckets(apexType);
 
   // Measure container height so charts fill available space
   const containerRef = useRef(null);
   const [chartHeight, setChartHeight] = useState(CHART_HEIGHT_FALLBACK);
 
-  // ApexCharts places the tooltip entirely above the cursor — `cursorY - gridTop -
-  // tooltipHeight` — and never clamps that at 0; it clamps x three ways and clamps y
-  // only against the grid's bottom. Any point in the top `tooltipHeight` px of the
-  // plot therefore gets a negative top and is drawn above the canvas, where the
-  // widget card's `overflow: hidden` slices it. On these cards that is most of the
-  // plot: 134px of tooltip against a 230px grid. The card cannot drop the overflow
-  // (the chart's ResizeObserver then loses its height constraint and the canvas
-  // grows unbounded), `tooltip.fixed` is ignored on the intersect path these charts
-  // use, and a chart-level `mouseMove` hook loses the race — Apex rewrites the style
-  // after it, even a frame later. Watching the attribute is what reliably catches
-  // the write, whenever Apex makes it.
-  useEffect(() => {
-    const el = containerRef.current;
-    if (!el) return;
-    const clampTooltips = () => {
-      el.querySelectorAll(".apexcharts-tooltip").forEach((tip) => {
-        const top = Number.parseFloat(tip.style.top);
-        if (Number.isFinite(top) && top < 0) tip.style.top = "0px";
-      });
-    };
-    const mo = new MutationObserver(clampTooltips);
-    mo.observe(el, {
-      attributes: true,
-      subtree: true,
-      attributeFilter: ["style"],
-    });
-    return () => mo.disconnect();
-  }, []);
+  useClampedChartTooltips(containerRef);
 
   useEffect(() => {
     const el = containerRef.current;
@@ -543,9 +518,11 @@ export default function WidgetChart({
 
   // A missing aggregate bucket is not a zero: line and area charts drop the
   // null points so Apex connects the neighbouring observed ones.
+  const chartTimeWindow = getChartTimeWindow(result);
+
   const plottedChartSeries = useMemo(
-    () => getPlottedChartSeries(chartSeries, connectsAcrossMissingBuckets),
-    [chartSeries, connectsAcrossMissingBuckets],
+    () => getPlottedChartSeries(chartSeries, { stacked: isStacked }),
+    [chartSeries, isStacked],
   );
 
   // Build from the full `series` list (not filtered chartSeries) so a
@@ -764,6 +741,9 @@ export default function WidgetChart({
   if (isTable) {
     // Time as rows, Segments as columns
     const timeData = series[0]?.data || [];
+    // One row per bucket becomes thousands of rows at minute granularity, so
+    // empty buckets are dropped and the remainder capped (TH-7757).
+    const bucketPlan = getTableBucketPlan(series);
     const granLabel = (queryConfig?.granularity || "day").toLowerCase();
     const dateFmt =
       granLabel === "minute"
@@ -818,6 +798,20 @@ export default function WidgetChart({
                 }}
               >
                 Time
+                {describeTableBuckets(bucketPlan) && (
+                  <Box
+                    component="span"
+                    sx={{
+                      display: "block",
+                      fontWeight: 400,
+                      fontSize: "10px",
+                      color: "text.disabled",
+                      whiteSpace: "nowrap",
+                    }}
+                  >
+                    {describeTableBuckets(bucketPlan)}
+                  </Box>
+                )}
               </th>
               {series.map((s, i) => (
                 <th
@@ -871,7 +865,9 @@ export default function WidgetChart({
             </tr>
           </thead>
           <tbody>
-            {timeData.map((pt, ri) => {
+            {bucketPlan.indices.map((ri) => {
+              const pt = timeData[ri];
+              if (!pt) return null;
               const hasNonZero = series.some(
                 (s) => s.data[ri]?.y != null && s.data[ri].y !== 0,
               );
@@ -1182,7 +1178,11 @@ export default function WidgetChart({
       toolbar: { show: false },
       zoom: { enabled: true },
       stacked: isStacked,
-      animations: { enabled: true, easing: "easeinout", speed: 400 },
+      animations: {
+        enabled: !isDenseChartSeries(plottedChartSeries),
+        easing: "easeinout",
+        speed: 400,
+      },
       events: {
         mouseMove: (event, chartContext, config) => {
           const el = chartContext?.el;
@@ -1292,6 +1292,8 @@ export default function WidgetChart({
     plotOptions: { bar: { horizontal: isHorizontal } },
     xaxis: {
       type: isHorizontal ? undefined : "datetime",
+      // Span the window that was queried, not just the buckets that reported.
+      ...(!isHorizontal && chartTimeWindow ? chartTimeWindow : {}),
       tickAmount: Math.min(chartSeries[0]?.data?.length || 10, 12),
       labels: {
         show: axisConfig?.xAxis?.visible !== false,
@@ -1390,7 +1392,12 @@ export default function WidgetChart({
       });
     })(),
     stroke: {
-      curve: "monotoneCubic",
+      // Not monotoneCubic: it derives each control handle from the
+      // neighbouring gap widths, so a tight cluster beside a long empty
+      // stretch gets a handle hundreds of px past its own segment and the
+      // line visibly runs forward then doubles back. "smooth" does not, and
+      // is what every other chart in the app already uses.
+      curve: "smooth",
       width: apexType === "area" ? 2 : apexType === "line" ? 2.5 : 0,
     },
     fill: (() => {

--- a/frontend/src/sections/dashboards/WidgetChart.jsx
+++ b/frontend/src/sections/dashboards/WidgetChart.jsx
@@ -543,6 +543,41 @@ export default function WidgetChart({
   );
   const pieColorFor = (name) => getSeriesColorFromMap(pieColorMap, name);
 
+  // Past the animation budget, a marker per point costs real render time for
+  // a signal a coarse, evenly spaced sampling already conveys. Thinned to
+  // ~60 dots per series via `discrete` rather than dropped outright — see
+  // CHART_DENSE_POINT_BUDGET for why resting markers stay on a sparse series.
+  const isDenseSeries = isDenseChartSeries(plottedChartSeries);
+  const normalMarkerSize = isLineChart ? 5 : apexType === "area" ? 4 : 0;
+  const discreteMarkers = useMemo(() => {
+    if (!isDenseSeries || normalMarkerSize === 0) return [];
+    const points = [];
+    plottedChartSeries.forEach((s, si) => {
+      const data = s?.data || [];
+      const stride = Math.max(1, Math.ceil(data.length / 60));
+      const color = colorFor(s?.name);
+      for (let j = 0; j < data.length; j += stride) {
+        if (!Number.isFinite(data[j]?.y)) continue;
+        points.push({
+          seriesIndex: si,
+          dataPointIndex: j,
+          size: normalMarkerSize,
+          fillColor: color,
+          strokeColor: color,
+        });
+      }
+    });
+    return points;
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [
+    plottedChartSeries,
+    seriesColorMap,
+    apexType,
+    isLineChart,
+    isDenseSeries,
+    normalMarkerSize,
+  ]);
+
   const outOfRangeWarning = useMemo(
     () => getYAxisRangeWarning(chartSeries, axisConfig),
     [chartSeries, axisConfig],
@@ -1181,7 +1216,7 @@ export default function WidgetChart({
       zoom: { enabled: true },
       stacked: isStacked,
       animations: {
-        enabled: !isDenseChartSeries(plottedChartSeries),
+        enabled: !isDenseSeries,
         easing: "easeinout",
         speed: 400,
       },
@@ -1416,7 +1451,8 @@ export default function WidgetChart({
       };
     })(),
     markers: {
-      size: isLineChart ? 5 : apexType === "area" ? 4 : 0,
+      size: isDenseSeries ? 0 : normalMarkerSize,
+      discrete: discreteMarkers,
       strokeWidth: 2,
       strokeColors: isDark ? theme.palette.background.paper : "#fff",
       hover: isLineChart

--- a/frontend/src/sections/dashboards/WidgetChart.jsx
+++ b/frontend/src/sections/dashboards/WidgetChart.jsx
@@ -740,7 +740,6 @@ export default function WidgetChart({
   // Table
   if (isTable) {
     // Time as rows, Segments as columns
-    const timeData = series[0]?.data || [];
     // One row per bucket becomes thousands of rows at minute granularity, so
     // empty buckets are dropped and the remainder capped (TH-7757).
     const bucketPlan = getTableBucketPlan(series);
@@ -866,7 +865,9 @@ export default function WidgetChart({
           </thead>
           <tbody>
             {bucketPlan.indices.map((ri) => {
-              const pt = timeData[ri];
+              // The plan is sized by the widest series, so a shorter series[0]
+              // must not drop a row another series still reports (TH-7757 review).
+              const pt = series.find((s) => s?.data?.[ri])?.data?.[ri];
               if (!pt) return null;
               const hasNonZero = series.some(
                 (s) => s.data[ri]?.y != null && s.data[ri].y !== 0,

--- a/frontend/src/sections/dashboards/WidgetChart.jsx
+++ b/frontend/src/sections/dashboards/WidgetChart.jsx
@@ -186,7 +186,8 @@ export default function WidgetChart({
   const containerRef = useRef(null);
   const [chartHeight, setChartHeight] = useState(CHART_HEIGHT_FALLBACK);
 
-  useClampedChartTooltips(containerRef);
+  // Mounted on first render, so this doubles as the tooltip observer's root.
+  useClampedChartTooltips(containerRef, containerRef);
 
   useEffect(() => {
     const el = containerRef.current;

--- a/frontend/src/sections/dashboards/WidgetChart.jsx
+++ b/frontend/src/sections/dashboards/WidgetChart.jsx
@@ -1296,7 +1296,6 @@ export default function WidgetChart({
       type: isHorizontal ? undefined : "datetime",
       // Span the window that was queried, not just the buckets that reported.
       ...(!isHorizontal && chartTimeWindow ? chartTimeWindow : {}),
-      tickAmount: Math.min(chartSeries[0]?.data?.length || 10, 12),
       labels: {
         show: axisConfig?.xAxis?.visible !== false,
         style: { colors: theme.palette.text.secondary, fontSize: "11px" },

--- a/frontend/src/sections/dashboards/WidgetEditorView.jsx
+++ b/frontend/src/sections/dashboards/WidgetEditorView.jsx
@@ -77,6 +77,7 @@ import {
   useLegacyCursorAttributeInventory,
 } from "src/sections/projects/LLMTracing/useCursorAttributeInventory";
 import useCanEditDashboard from "./hooks/useCanEditDashboard";
+import useClampedChartTooltips from "./hooks/useClampedChartTooltips";
 import {
   coerceFilterValue,
   FILTER_STRING_MAX_UTF8_BYTES,
@@ -102,6 +103,10 @@ import {
   getExactDashboardResult,
   getDashboardMetricSeriesState,
   getPlottedChartSeries,
+  getChartTimeWindow,
+  getTableBucketPlan,
+  describeTableBuckets,
+  isDenseChartSeries,
   getSeriesScalar,
   groupPieSeries,
   getSuggestedUnitConfig,
@@ -110,7 +115,6 @@ import {
   getVisibleIndices,
   resolveWidgetAxisPlan,
   makeSeriesKey,
-  shouldConnectAcrossMissingBuckets,
   resolveSavedSelection,
   toAxisConfigPayload,
 } from "./widgetUtils";
@@ -3487,8 +3491,6 @@ export default function WidgetEditorView() {
   const isTable = chartType === "table";
   const isMetricCard = chartType === "metric";
   const isLineChart = apexType === "line";
-  const connectsAcrossMissingBuckets =
-    shouldConnectAcrossMissingBuckets(apexType);
 
   const aggColumnLabel = useMemo(
     () => getAggColumnLabel(metrics, ALL_AGGREGATIONS),
@@ -3509,9 +3511,11 @@ export default function WidgetEditorView() {
 
   // Match the saved-dashboard renderer: null means an absent aggregate
   // bucket, not zero, so line previews connect the neighbouring exact points.
+  const chartTimeWindow = getChartTimeWindow(previewResult);
+
   const plottedChartSeries = useMemo(
-    () => getPlottedChartSeries(chartSeries, connectsAcrossMissingBuckets),
-    [chartSeries, connectsAcrossMissingBuckets],
+    () => getPlottedChartSeries(chartSeries, { stacked: isStacked }),
+    [chartSeries, isStacked],
   );
 
   const outOfRangeWarning = useMemo(
@@ -3611,6 +3615,8 @@ export default function WidgetEditorView() {
     [isPie, pieHasBreakdown, previewSeries],
   );
 
+  useClampedChartTooltips(lineChartRef);
+
   // Legend hover → highlight series by dimming others via SVG opacity
   const handleLegendHover = useCallback((seriesIndex) => {
     const el = lineChartRef.current;
@@ -3652,7 +3658,11 @@ export default function WidgetEditorView() {
         toolbar: { show: false },
         zoom: { enabled: true },
         stacked: isStacked,
-        animations: { enabled: true, easing: "easeinout", speed: 400 },
+        animations: {
+          enabled: !isDenseChartSeries(plottedChartSeries),
+          easing: "easeinout",
+          speed: 400,
+        },
         events: {
           mouseMove: (event, chartContext, config) => {
             const el = chartContext?.el;
@@ -3790,6 +3800,9 @@ export default function WidgetEditorView() {
           }
         : {
             type: "datetime",
+            // Span the window that was queried, not just the buckets that
+            // reported.
+            ...(chartTimeWindow || {}),
             tickAmount: Math.min(chartSeries[0]?.data?.length || 10, 12),
             labels: {
               show: axisConfig.xAxis.visible,
@@ -3892,7 +3905,12 @@ export default function WidgetEditorView() {
         });
       })(),
       stroke: {
-        curve: "monotoneCubic",
+        // Not monotoneCubic: it derives each control handle from the
+        // neighbouring gap widths, so a tight cluster beside a long empty
+        // stretch gets a handle hundreds of px past its own segment and the
+        // line visibly runs forward then doubles back. "smooth" does not, and
+        // is what every other chart in the app already uses.
+        curve: "smooth",
         width: apexType === "area" ? 2 : apexType === "line" ? 2.5 : 0,
       },
       fill: (() => {
@@ -3998,6 +4016,8 @@ export default function WidgetEditorView() {
     isStacked,
     isHorizontal,
     chartSeries,
+    plottedChartSeries,
+    chartTimeWindow,
     chartSeriesIndices,
     chartColors,
     theme,
@@ -5239,6 +5259,10 @@ export default function WidgetEditorView() {
                       /* Data table — Time as rows, Segments as columns */
                       (() => {
                         const timeData = chartSeries[0]?.data || [];
+                        // One row per bucket becomes thousands of rows at
+                        // minute granularity, so empty buckets are dropped and
+                        // the remainder capped (TH-7757).
+                        const bucketPlan = getTableBucketPlan(chartSeries);
                         const dateFmt =
                           granularity === "minute"
                             ? "HH:mm"
@@ -5283,6 +5307,19 @@ export default function WidgetEditorView() {
                                     }}
                                   >
                                     Time
+                                    {describeTableBuckets(bucketPlan) && (
+                                      <Box
+                                        component="span"
+                                        sx={{
+                                          display: "block",
+                                          fontWeight: 400,
+                                          fontSize: "11px",
+                                          color: "text.disabled",
+                                                                       }}
+                                      >
+                                        {describeTableBuckets(bucketPlan)}
+                                      </Box>
+                                    )}
                                   </th>
                                   {chartSeries.map((s, i) => (
                                     <th
@@ -5329,7 +5366,9 @@ export default function WidgetEditorView() {
                                 </tr>
                               </thead>
                               <tbody>
-                                {timeData.map((pt, ri) => {
+                                {bucketPlan.indices.map((ri) => {
+                                  const pt = timeData[ri];
+                                  if (!pt) return null;
                                   const hasData = chartSeries.some(
                                     (s) =>
                                       s.data[ri]?.y != null &&
@@ -5645,12 +5684,15 @@ export default function WidgetEditorView() {
                   visibleSeries !== null &&
                   visibleSeries.size > 0 &&
                   visibleSeries.size < previewSeries.length;
-                // Show all time columns — the table scrolls horizontally
+                // Empty buckets are dropped and the remainder capped, so a
+                // minute-granularity range cannot render thousands of columns.
+                // The CSV export above still writes every bucket.
                 const allDataPoints = previewSeries[0]?.data || [];
-                const displayData = allDataPoints;
-                const displayIndicesSet = new Set(
-                  allDataPoints.map((_, i) => i),
-                );
+                const bucketPlan = getTableBucketPlan(previewSeries);
+                const displayData = bucketPlan.indices
+                  .map((i) => allDataPoints[i])
+                  .filter(Boolean);
+                const displayIndicesSet = new Set(bucketPlan.indices);
 
                 const toggleSeries = (si) => {
                   const current = visibleSeries || new Set(allIndices);
@@ -5807,6 +5849,20 @@ export default function WidgetEditorView() {
                               }}
                             >
                               {aggColumnLabel}
+                              {describeTableBuckets(bucketPlan) && (
+                                <Box
+                                  component="span"
+                                  sx={{
+                                    display: "block",
+                                    fontWeight: 400,
+                                    fontSize: "11px",
+                                    color: "text.disabled",
+                                    whiteSpace: "nowrap",
+                                  }}
+                                >
+                                  {describeTableBuckets(bucketPlan)}
+                                </Box>
+                              )}
                             </th>
                             {displayData.map((pt, ci) => (
                               <th

--- a/frontend/src/sections/dashboards/WidgetEditorView.jsx
+++ b/frontend/src/sections/dashboards/WidgetEditorView.jsx
@@ -3647,6 +3647,34 @@ export default function WidgetEditorView() {
   }, []);
 
   const isDark = theme.palette.mode === "dark";
+
+  // Past the animation budget, a marker per point costs real render time for
+  // a signal a coarse, evenly spaced sampling already conveys. Thinned to
+  // ~60 dots per series via `discrete` rather than dropped outright — see
+  // CHART_DENSE_POINT_BUDGET for why resting markers stay on a sparse series.
+  const discreteMarkers = useMemo(() => {
+    const isDenseSeries = isDenseChartSeries(plottedChartSeries);
+    const normalMarkerSize = isLineChart ? 5 : apexType === "area" ? 4 : 0;
+    if (!isDenseSeries || normalMarkerSize === 0) return [];
+    const points = [];
+    plottedChartSeries.forEach((s, si) => {
+      const data = s?.data || [];
+      const stride = Math.max(1, Math.ceil(data.length / 60));
+      const color = chartColors[si];
+      for (let j = 0; j < data.length; j += stride) {
+        if (!Number.isFinite(data[j]?.y)) continue;
+        points.push({
+          seriesIndex: si,
+          dataPointIndex: j,
+          size: normalMarkerSize,
+          fillColor: color,
+          strokeColor: color,
+        });
+      }
+    });
+    return points;
+  }, [plottedChartSeries, chartColors, apexType, isLineChart]);
+
   const formatValFn = useCallback(
     (val) =>
       formatValueWithConfig(val, leftAxisFormatConfig, {
@@ -3661,6 +3689,8 @@ export default function WidgetEditorView() {
       (val) =>
         formatValueWithConfig(val, cfg, { fallbackDecimals, includeUnit });
     const formatVal = makeFormatter(leftAxisFormatConfig);
+    const isDenseSeries = isDenseChartSeries(plottedChartSeries);
+    const normalMarkerSize = isLineChart ? 5 : apexType === "area" ? 4 : 0;
     return {
       chart: {
         type: apexType,
@@ -3668,7 +3698,7 @@ export default function WidgetEditorView() {
         zoom: { enabled: true },
         stacked: isStacked,
         animations: {
-          enabled: !isDenseChartSeries(plottedChartSeries),
+          enabled: !isDenseSeries,
           easing: "easeinout",
           speed: 400,
         },
@@ -3936,7 +3966,8 @@ export default function WidgetEditorView() {
         };
       })(),
       markers: {
-        size: isLineChart ? 5 : apexType === "area" ? 4 : 0,
+        size: isDenseSeries ? 0 : normalMarkerSize,
+        discrete: discreteMarkers,
         strokeWidth: 2,
         strokeColors: isDark ? theme.palette.background.paper : "#fff",
         hover: isLineChart
@@ -4028,6 +4059,7 @@ export default function WidgetEditorView() {
     chartTimeWindow,
     chartSeriesIndices,
     chartColors,
+    discreteMarkers,
     theme,
     axisConfig,
     autoDecimals,

--- a/frontend/src/sections/dashboards/WidgetEditorView.jsx
+++ b/frontend/src/sections/dashboards/WidgetEditorView.jsx
@@ -3812,7 +3812,6 @@ export default function WidgetEditorView() {
             // Span the window that was queried, not just the buckets that
             // reported.
             ...(chartTimeWindow || {}),
-            tickAmount: Math.min(chartSeries[0]?.data?.length || 10, 12),
             labels: {
               show: axisConfig.xAxis.visible,
               style: { colors: theme.palette.text.secondary, fontSize: "11px" },
@@ -5324,7 +5323,8 @@ export default function WidgetEditorView() {
                                           fontWeight: 400,
                                           fontSize: "11px",
                                           color: "text.disabled",
-                                                                       }}
+                                          whiteSpace: "nowrap",
+                                        }}
                                       >
                                         {describeTableBuckets(bucketPlan)}
                                       </Box>
@@ -7718,15 +7718,15 @@ export default function WidgetEditorView() {
                     </InputAdornment>
                   ) : !cursorAttributePickerActive &&
                     Number.isSafeInteger(paginatedTotal) ? (
-                      <InputAdornment position="end">
-                        <Typography
-                          variant="caption"
-                          sx={{ color: "text.disabled", fontSize: 11 }}
-                        >
-                          {paginatedTotal} results
-                        </Typography>
-                      </InputAdornment>
-                    ) : null,
+                    <InputAdornment position="end">
+                      <Typography
+                        variant="caption"
+                        sx={{ color: "text.disabled", fontSize: 11 }}
+                      >
+                        {paginatedTotal} results
+                      </Typography>
+                    </InputAdornment>
+                  ) : null,
                 }}
               />
             </Box>

--- a/frontend/src/sections/dashboards/WidgetEditorView.jsx
+++ b/frontend/src/sections/dashboards/WidgetEditorView.jsx
@@ -5258,7 +5258,6 @@ export default function WidgetEditorView() {
                     ) : isTable ? (
                       /* Data table — Time as rows, Segments as columns */
                       (() => {
-                        const timeData = chartSeries[0]?.data || [];
                         // One row per bucket becomes thousands of rows at
                         // minute granularity, so empty buckets are dropped and
                         // the remainder capped (TH-7757).
@@ -5367,7 +5366,13 @@ export default function WidgetEditorView() {
                               </thead>
                               <tbody>
                                 {bucketPlan.indices.map((ri) => {
-                                  const pt = timeData[ri];
+                                  // The plan is sized by the widest series, so
+                                  // a shorter chartSeries[0] must not drop a
+                                  // row another series still reports
+                                  // (TH-7757 review).
+                                  const pt = chartSeries.find(
+                                    (s) => s?.data?.[ri],
+                                  )?.data?.[ri];
                                   if (!pt) return null;
                                   const hasData = chartSeries.some(
                                     (s) =>
@@ -5687,10 +5692,14 @@ export default function WidgetEditorView() {
                 // Empty buckets are dropped and the remainder capped, so a
                 // minute-granularity range cannot render thousands of columns.
                 // The CSV export above still writes every bucket.
-                const allDataPoints = previewSeries[0]?.data || [];
                 const bucketPlan = getTableBucketPlan(previewSeries);
+                // The plan is sized by the widest series, so a shorter
+                // previewSeries[0] must not drop a row another series still
+                // reports (TH-7757 review).
                 const displayData = bucketPlan.indices
-                  .map((i) => allDataPoints[i])
+                  .map(
+                    (i) => previewSeries.find((s) => s?.data?.[i])?.data?.[i],
+                  )
                   .filter(Boolean);
                 const displayIndicesSet = new Set(bucketPlan.indices);
 

--- a/frontend/src/sections/dashboards/WidgetEditorView.jsx
+++ b/frontend/src/sections/dashboards/WidgetEditorView.jsx
@@ -2256,6 +2256,10 @@ export default function WidgetEditorView() {
   const [customDateRange, setCustomDateRange] = useState(null); // [startDate, endDate]
   const customDateAnchorRef = useRef(null);
   const lineChartRef = useRef(null);
+  // Stable ancestor for the tooltip-clamp observer: lineChartRef only mounts
+  // once the preview query resolves, but this container is present from the
+  // first render.
+  const chartAncestorRef = useRef(null);
   const saveNavTimerRef = useRef(null);
   useEffect(() => () => clearTimeout(saveNavTimerRef.current), []);
 
@@ -3620,7 +3624,7 @@ export default function WidgetEditorView() {
     [isPie, pieHasBreakdown, previewSeries],
   );
 
-  useClampedChartTooltips(lineChartRef);
+  useClampedChartTooltips(lineChartRef, chartAncestorRef);
 
   // Legend hover → highlight series by dimming others via SVG opacity
   const handleLegendHover = useCallback((seriesIndex) => {
@@ -4788,6 +4792,7 @@ export default function WidgetEditorView() {
 
           {/* Chart + View toggles + Data table */}
           <Box
+            ref={chartAncestorRef}
             sx={{
               flex: 1,
               border: `1px solid ${theme.palette.divider}`,

--- a/frontend/src/sections/dashboards/WidgetEditorView.jsx
+++ b/frontend/src/sections/dashboards/WidgetEditorView.jsx
@@ -115,7 +115,6 @@ import {
   getVisibleIndices,
   resolveWidgetAxisPlan,
   makeSeriesKey,
-  shouldConnectAcrossMissingBuckets,
   resolveSavedSelection,
   toAxisConfigPayload,
 } from "./widgetUtils";

--- a/frontend/src/sections/dashboards/WidgetEditorView.jsx
+++ b/frontend/src/sections/dashboards/WidgetEditorView.jsx
@@ -3511,7 +3511,12 @@ export default function WidgetEditorView() {
 
   // Match the saved-dashboard renderer: null means an absent aggregate
   // bucket, not zero, so line previews connect the neighbouring exact points.
-  const chartTimeWindow = getChartTimeWindow(previewResult);
+  // Memoized so the big chartOptions memo below (which depends on this
+  // object) doesn't recompute on every render from a fresh {min,max}.
+  const chartTimeWindow = useMemo(
+    () => getChartTimeWindow(previewResult),
+    [previewResult],
+  );
 
   const plottedChartSeries = useMemo(
     () => getPlottedChartSeries(chartSeries, { stacked: isStacked }),

--- a/frontend/src/sections/dashboards/__tests__/WidgetChart.test.jsx
+++ b/frontend/src/sections/dashboards/__tests__/WidgetChart.test.jsx
@@ -2,6 +2,7 @@ import React from "react";
 import { afterEach, describe, it, expect, vi, beforeEach } from "vitest";
 import { act, render, screen, waitFor } from "src/utils/test-utils";
 import WidgetChart from "../WidgetChart";
+import { TABLE_BUCKET_LIMIT } from "../widgetUtils";
 import {
   AGGREGATION_POLL_MAX_ATTEMPTS,
   AGGREGATION_POLLING_PAUSED_MESSAGE,
@@ -1618,5 +1619,124 @@ describe("WidgetChart — dual axis follows the visible series (TH-7680)", () =>
     expect(Array.isArray(yaxis)).toBe(false);
     // Identical to the plain single-axis widget on the same data.
     expect(yaxis).toMatchObject({ min: 0, max: 7500 });
+  });
+});
+
+describe("WidgetChart — dense-series budget (TH-7757)", () => {
+  const pointsAt = (count, { everyNthHasValue = 1 } = {}) =>
+    Array.from({ length: count }, (_, i) => ({
+      timestamp: new Date(Date.UTC(2026, 6, 9) + i * 60_000).toISOString(),
+      value: i % everyNthHasValue === 0 ? 1 : null,
+    }));
+
+  const lastChart = () => h.apex.mock.calls.at(-1)[0];
+
+  it("animates a chart that stays within the budget", () => {
+    h.query.data = queryResult(pointsAt(120));
+    render(<WidgetChart widget={baseWidget} globalDateRange={null} />);
+
+    expect(lastChart().options.chart.animations).toMatchObject({
+      enabled: true,
+      speed: 400,
+    });
+    expect(lastChart().options.markers.size).toBeGreaterThan(0);
+  });
+
+  it("draws a dense chart in one static pass", () => {
+    h.query.data = queryResult(pointsAt(1200));
+    render(<WidgetChart widget={baseWidget} globalDateRange={null} />);
+
+    expect(lastChart().options.chart.animations.enabled).toBe(false);
+  });
+
+  it("keeps resting markers on a dense series", () => {
+    // Markers are what show where observations actually sit; dropping them made
+    // a sparse series spread over months read as continuous data.
+    h.query.data = queryResult(pointsAt(1200));
+    render(<WidgetChart widget={baseWidget} globalDateRange={null} />);
+
+    expect(lastChart().options.markers.size).toBeGreaterThan(0);
+  });
+
+  it("still marks the hovered point on a dense chart", () => {
+    h.query.data = queryResult(pointsAt(1200));
+    render(<WidgetChart widget={baseWidget} globalDateRange={null} />);
+
+    expect(lastChart().options.markers.hover.size).toBeGreaterThan(0);
+  });
+
+  it("plots every point it was given even when the animation is dropped", () => {
+    h.query.data = queryResult(pointsAt(1200));
+    render(<WidgetChart widget={baseWidget} globalDateRange={null} />);
+
+    expect(lastChart().series[0].data).toHaveLength(1200);
+  });
+
+  it("charges the budget after empty buckets are dropped, not before", () => {
+    // 2,000 minute buckets, 20 of them observed: the chart plots 20 points and
+    // stays well inside the budget.
+    h.query.data = queryResult(pointsAt(2000, { everyNthHasValue: 100 }));
+    render(<WidgetChart widget={baseWidget} globalDateRange={null} />);
+
+    expect(lastChart().series[0].data).toHaveLength(20);
+    expect(lastChart().options.chart.animations.enabled).toBe(true);
+    expect(lastChart().options.markers.size).toBeGreaterThan(0);
+  });
+});
+
+describe("WidgetChart — table bucket pruning (TH-7757)", () => {
+  const bucketsSpanning = (count, valueAt) =>
+    Array.from({ length: count }, (_, i) => ({
+      timestamp: new Date(Date.UTC(2026, 6, 9) + i * 60_000).toISOString(),
+      value: valueAt(i),
+    }));
+
+  const tableWidget = {
+    ...baseWidget,
+    chart_config: { chart_type: "table" },
+  };
+
+  const bodyRowCount = () =>
+    document.querySelectorAll("tbody tr").length;
+
+  it("renders one row per bucket while the table is short enough to read", () => {
+    h.query.data = queryResult(bucketsSpanning(30, (i) => (i % 3 ? null : i)));
+    render(<WidgetChart widget={tableWidget} globalDateRange={null} />);
+
+    expect(bodyRowCount()).toBe(30);
+  });
+
+  it("drops empty buckets from a minute-granularity range", () => {
+    // 2,000 buckets, 20 observed: the reader gets the 20 that carry data.
+    h.query.data = queryResult(
+      bucketsSpanning(2000, (i) => (i % 100 === 0 ? i : null)),
+    );
+    render(<WidgetChart widget={tableWidget} globalDateRange={null} />);
+
+    expect(bodyRowCount()).toBe(20);
+  });
+
+  it("caps a dense range instead of rendering every bucket", () => {
+    h.query.data = queryResult(bucketsSpanning(2000, (i) => i));
+    render(<WidgetChart widget={tableWidget} globalDateRange={null} />);
+
+    expect(bodyRowCount()).toBe(TABLE_BUCKET_LIMIT);
+  });
+});
+
+describe("WidgetChart — line interpolation", () => {
+  it("smooths without monotoneCubic, which doubles the line back on itself", () => {
+    // monotoneCubic sizes each control handle from the neighbouring gaps, so a
+    // tight cluster next to a long empty stretch produced a handle ~174px past
+    // a 10px segment: the line ran forward, then visibly reversed. Measured on
+    // dev with hand-written data, so it is the interpolation, not the payload.
+    h.query.data = queryResult([
+      { timestamp: "2026-07-09T00:00:00Z", value: 10 },
+      { timestamp: "2026-07-09T01:00:00Z", value: 120 },
+      { timestamp: "2026-08-30T00:00:00Z", value: 10 },
+    ]);
+    render(<WidgetChart widget={baseWidget} globalDateRange={null} />);
+
+    expect(h.apex.mock.calls.at(-1)[0].options.stroke.curve).toBe("smooth");
   });
 });

--- a/frontend/src/sections/dashboards/__tests__/WidgetChart.test.jsx
+++ b/frontend/src/sections/dashboards/__tests__/WidgetChart.test.jsx
@@ -1639,7 +1639,9 @@ describe("WidgetChart — dense-series budget (TH-7757)", () => {
       enabled: true,
       speed: 400,
     });
+    // Sparse series get one resting marker per point, not the thinned array.
     expect(lastChart().options.markers.size).toBeGreaterThan(0);
+    expect(lastChart().options.markers.discrete).toHaveLength(0);
   });
 
   it("draws a dense chart in one static pass", () => {
@@ -1649,13 +1651,20 @@ describe("WidgetChart — dense-series budget (TH-7757)", () => {
     expect(lastChart().options.chart.animations.enabled).toBe(false);
   });
 
-  it("keeps resting markers on a dense series", () => {
-    // Markers are what show where observations actually sit; dropping them made
-    // a sparse series spread over months read as continuous data.
+  it("thins resting markers to a bounded set on a dense series", () => {
+    // A marker per point over thousands of points costs real render time for
+    // a signal a coarse, evenly spaced sampling already conveys. The uniform
+    // size is dropped in favour of `discrete` entries so only the sampled
+    // points get a dot.
     h.query.data = queryResult(pointsAt(1200));
     render(<WidgetChart widget={baseWidget} globalDateRange={null} />);
 
-    expect(lastChart().options.markers.size).toBeGreaterThan(0);
+    const { markers } = lastChart().options;
+    expect(markers.size).toBe(0);
+    expect(Array.isArray(markers.discrete)).toBe(true);
+    expect(markers.discrete.length).toBeGreaterThan(0);
+    expect(markers.discrete.length).toBeLessThanOrEqual(60);
+    expect(markers.discrete.length).toBeLessThan(1200);
   });
 
   it("still marks the hovered point on a dense chart", () => {
@@ -1696,8 +1705,7 @@ describe("WidgetChart — table bucket pruning (TH-7757)", () => {
     chart_config: { chart_type: "table" },
   };
 
-  const bodyRowCount = () =>
-    document.querySelectorAll("tbody tr").length;
+  const bodyRowCount = () => document.querySelectorAll("tbody tr").length;
 
   it("renders one row per bucket while the table is short enough to read", () => {
     h.query.data = queryResult(bucketsSpanning(30, (i) => (i % 3 ? null : i)));

--- a/frontend/src/sections/dashboards/__tests__/useClampedChartTooltips.test.jsx
+++ b/frontend/src/sections/dashboards/__tests__/useClampedChartTooltips.test.jsx
@@ -1,0 +1,75 @@
+import React, { useRef, useState } from "react";
+import { describe, it, expect } from "vitest";
+import { act, render, waitFor } from "src/utils/test-utils";
+import useClampedChartTooltips from "../hooks/useClampedChartTooltips";
+
+// Apex writes the tooltip's position straight onto the style attribute, so the
+// tests drive that attribute rather than a React prop.
+function Harness({ mountChartImmediately = true }) {
+  const containerRef = useRef(null);
+  const [chartMounted, setChartMounted] = useState(mountChartImmediately);
+  useClampedChartTooltips(containerRef);
+  return (
+    <div>
+      <button onClick={() => setChartMounted(true)}>render chart</button>
+      {chartMounted && (
+        <div ref={containerRef} data-testid="container">
+          <div className="apexcharts-tooltip" data-testid="tooltip" />
+        </div>
+      )}
+    </div>
+  );
+}
+
+const setTop = (el, top) => act(() => { el.style.top = top; });
+
+describe("useClampedChartTooltips", () => {
+  it("pulls a tooltip drawn above the canvas back to the top edge", async () => {
+    const { getByTestId } = render(<Harness />);
+    const tooltip = getByTestId("tooltip");
+
+    setTop(tooltip, "-84.86px");
+
+    await waitFor(() => expect(tooltip.style.top).toBe("0px"));
+  });
+
+  it("leaves a tooltip that already fits following the cursor", async () => {
+    const { getByTestId } = render(<Harness />);
+    const tooltip = getByTestId("tooltip");
+
+    setTop(tooltip, "120px");
+
+    // Give the observer a chance to fire before asserting it did nothing.
+    await new Promise((resolve) => setTimeout(resolve, 30));
+    expect(tooltip.style.top).toBe("120px");
+  });
+
+  it("clamps a chart that only mounts once its query resolves", async () => {
+    // The widget editor renders its chart inside a branch that is empty until
+    // data arrives, so the ref is null when the effect first runs. An observer
+    // attached to the ref at mount would watch nothing for the widget's life.
+    const { getByText, getByTestId } = render(
+      <Harness mountChartImmediately={false} />,
+    );
+
+    act(() => getByText("render chart").click());
+    const tooltip = getByTestId("tooltip");
+    setTop(tooltip, "-40px");
+
+    await waitFor(() => expect(tooltip.style.top).toBe("0px"));
+  });
+
+  it("ignores tooltips belonging to a different chart", async () => {
+    const { getByTestId } = render(<Harness />);
+    const stray = document.createElement("div");
+    stray.className = "apexcharts-tooltip";
+    stray.style.top = "-50px";
+    document.body.appendChild(stray);
+
+    setTop(getByTestId("tooltip"), "-10px");
+    await waitFor(() => expect(getByTestId("tooltip").style.top).toBe("0px"));
+
+    expect(stray.style.top).toBe("-50px");
+    stray.remove();
+  });
+});

--- a/frontend/src/sections/dashboards/__tests__/useClampedChartTooltips.test.jsx
+++ b/frontend/src/sections/dashboards/__tests__/useClampedChartTooltips.test.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React, { useRef, useState } from "react";
 import { describe, it, expect } from "vitest";
 import { act, render, waitFor } from "src/utils/test-utils";

--- a/frontend/src/sections/dashboards/__tests__/useClampedChartTooltips.test.jsx
+++ b/frontend/src/sections/dashboards/__tests__/useClampedChartTooltips.test.jsx
@@ -23,6 +23,29 @@ function Harness({ mountChartImmediately = true }) {
 
 const setTop = (el, top) => act(() => { el.style.top = top; });
 
+// A caller can end up handing the same ref object to genuinely different DOM
+// nodes across renders — e.g. a loading state and a loaded state that render
+// different element types at the same position, which React unmounts and
+// remounts rather than reusing. A `useEffect` keyed on the ref objects alone
+// would attach once and never notice the ref now points somewhere else.
+function RemountingHarness() {
+  const containerRef = useRef(null);
+  const [loaded, setLoaded] = useState(false);
+  useClampedChartTooltips(containerRef);
+  return (
+    <div>
+      <button onClick={() => setLoaded(true)}>load chart</button>
+      {loaded ? (
+        <section ref={containerRef} data-testid="container">
+          <div className="apexcharts-tooltip" data-testid="tooltip" />
+        </section>
+      ) : (
+        <article ref={containerRef} data-testid="spinner" />
+      )}
+    </div>
+  );
+}
+
 describe("useClampedChartTooltips", () => {
   it("pulls a tooltip drawn above the canvas back to the top edge", async () => {
     const { getByTestId } = render(<Harness />);
@@ -71,5 +94,15 @@ describe("useClampedChartTooltips", () => {
 
     expect(stray.style.top).toBe("-50px");
     stray.remove();
+  });
+
+  it("re-targets when containerRef is reattached to a new node (spinner → chart)", async () => {
+    const { getByText, getByTestId } = render(<RemountingHarness />);
+
+    act(() => getByText("load chart").click());
+    const tooltip = getByTestId("tooltip");
+    setTop(tooltip, "-30px");
+
+    await waitFor(() => expect(tooltip.style.top).toBe("0px"));
   });
 });

--- a/frontend/src/sections/dashboards/__tests__/widgetUtils.test.js
+++ b/frontend/src/sections/dashboards/__tests__/widgetUtils.test.js
@@ -11,11 +11,19 @@ import {
   getExactDashboardResult,
   getDashboardMetricSeriesState,
   getPlottedChartSeries,
+  getChartTimeWindow,
+  CHART_DENSE_POINT_BUDGET,
+  countPlottedPoints,
+  getTableBucketPlan,
+  describeTableBuckets,
+  TABLE_BUCKET_LIMIT,
+  isDenseChartSeries,
   getSeriesScalar,
   groupPieSeries,
   isAdditiveAggregation,
   getYAxisRangeWarning,
   getAutoYAxisBounds,
+  getSeriesExtent,
   getFittedYAxisBounds,
   getVisibleIndices,
   resolveAxisBounds,
@@ -25,7 +33,6 @@ import {
   resolveSavedSelection,
   resolveVisibleSeries,
   seriesHasDataPoints,
-  shouldConnectAcrossMissingBuckets,
   toAxisConfigPayload,
 } from "../widgetUtils";
 import { ALL_AGGREGATIONS } from "../constants";
@@ -100,33 +107,56 @@ describe("seriesHasDataPoints", () => {
 });
 
 describe("getPlottedChartSeries", () => {
-  it("connects both line and stacked-line area renderers across missing buckets", () => {
-    expect(shouldConnectAcrossMissingBuckets("line")).toBe(true);
-    expect(shouldConnectAcrossMissingBuckets("area")).toBe(true);
-    expect(shouldConnectAcrossMissingBuckets("bar")).toBe(false);
-  });
+  const source = () => [
+    {
+      name: "Latency (avg)",
+      data: [
+        { x: 1, y: 12 },
+        { x: 2, y: null },
+        { x: 3, y: 0 },
+        { x: 4, y: 18 },
+      ],
+    },
+  ];
 
-  it("connects the widget editor line preview across null buckets without changing zeroes or source data", () => {
-    const source = [
-      {
-        name: "Latency (avg)",
-        data: [
-          { x: 1, y: 12 },
-          { x: 2, y: null },
-          { x: 3, y: 0 },
-          { x: 4, y: 18 },
-        ],
-      },
-    ];
-
-    expect(getPlottedChartSeries(source, true)[0].data).toEqual([
+  it("drops undrawable buckets while keeping zeroes", () => {
+    expect(getPlottedChartSeries(source())[0].data).toEqual([
       { x: 1, y: 12 },
       { x: 3, y: 0 },
       { x: 4, y: 18 },
     ]);
-    expect(source[0].data).toHaveLength(4);
-    expect(source[0].data[1].y).toBeNull();
-    expect(getPlottedChartSeries(source, false)).toBe(source);
+  });
+
+  it("leaves the response untouched for the table, CSV and metric card", () => {
+    const original = source();
+    getPlottedChartSeries(original);
+    expect(original[0].data).toHaveLength(4);
+    expect(original[0].data[1].y).toBeNull();
+  });
+
+  it("drops them for every chart type, bars included", () => {
+    // A bar for an empty bucket has no height, but Apex still emits a node for
+    // it: a column widget over five minute-granularity days drew 7,201 paths
+    // for 36 observed values (TH-7757).
+    const buckets = [
+      {
+        name: "count",
+        data: Array.from({ length: 7201 }, (_, x) => ({
+          x,
+          y: x % 200 === 0 ? 1 : null,
+        })),
+      },
+    ];
+    expect(getPlottedChartSeries(buckets)[0].data).toHaveLength(37);
+  });
+
+  it("handles empty, malformed and missing input", () => {
+    expect(getPlottedChartSeries()).toEqual([]);
+    expect(getPlottedChartSeries([])).toEqual([]);
+    expect(getPlottedChartSeries(null)).toEqual([]);
+    expect(getPlottedChartSeries([{ name: "no data" }])).toEqual([
+      { name: "no data", data: [] },
+    ]);
   });
 });
 
@@ -1048,4 +1078,488 @@ describe("the saved widget and the editor preview share one axis plan", () => {
       expect(src).not.toContain("resolveAxisBounds(");
     },
   );
+});
+
+describe("dense-series budget (TH-7757)", () => {
+  const seriesOf = (...lengths) =>
+    lengths.map((length, index) => ({
+      name: `s${index}`,
+      data: Array.from({ length }, (_, i) => ({ x: i, y: i })),
+    }));
+
+  it("counts points across every series", () => {
+    expect(countPlottedPoints(seriesOf(3, 4))).toBe(7);
+  });
+
+  it("counts nothing for empty, malformed or missing input", () => {
+    expect(countPlottedPoints()).toBe(0);
+    expect(countPlottedPoints([])).toBe(0);
+    expect(countPlottedPoints(null)).toBe(0);
+    expect(countPlottedPoints([{ name: "no data" }, null])).toBe(0);
+  });
+
+  it("calls a series at the budget sparse and one past it dense", () => {
+    expect(isDenseChartSeries(seriesOf(CHART_DENSE_POINT_BUDGET))).toBe(false);
+    expect(isDenseChartSeries(seriesOf(CHART_DENSE_POINT_BUDGET + 1))).toBe(
+      true,
+    );
+  });
+
+  it("spends the budget across series, not per series", () => {
+    const half = Math.ceil(CHART_DENSE_POINT_BUDGET / 2);
+    expect(isDenseChartSeries(seriesOf(half, half + 1))).toBe(true);
+  });
+
+  it("calls an empty chart sparse", () => {
+    expect(isDenseChartSeries([])).toBe(false);
+  });
+
+  it("charges the budget for what is plotted, not what was returned", () => {
+    // A minute-granularity widget: thousands of buckets, a handful of values.
+    const sparse = [
+      {
+        name: "completeness",
+        data: Array.from({ length: 7201 }, (_, i) => ({
+          x: i,
+          y: i % 160 === 0 ? 1 : null,
+        })),
+      },
+    ];
+    expect(isDenseChartSeries(sparse)).toBe(true);
+    expect(isDenseChartSeries(getPlottedChartSeries(sparse))).toBe(false);
+  });
+});
+
+describe("table bucket plan (TH-7757)", () => {
+  const seriesOfValues = (values) => [
+    { name: "a", data: values.map((y, x) => ({ x, y })) },
+  ];
+  const long = (length, valueAt) => [
+    {
+      name: "a",
+      data: Array.from({ length }, (_, x) => ({ x, y: valueAt(x) })),
+    },
+  ];
+
+  it("renders every bucket of a table that already fits, empty ones included", () => {
+    const plan = getTableBucketPlan(seriesOfValues([12, null, 7]));
+    expect(plan.indices).toEqual([0, 1, 2]);
+    expect(plan.omitted).toBe(0);
+  });
+
+  it("drops empty buckets only once the table is too long to read", () => {
+    const plan = getTableBucketPlan(
+      long(12, (x) => (x % 4 === 0 ? 1 : null)),
+      {
+        limit: 5,
+      },
+    );
+    expect(plan.indices).toEqual([0, 4, 8]);
+    expect(plan).toMatchObject({ total: 12, shown: 3, omitted: 9 });
+  });
+
+  it("keeps a bucket that any one series reported", () => {
+    const plan = getTableBucketPlan(
+      [
+        {
+          name: "a",
+          data: Array.from({ length: 8 }, (_, x) => ({ x, y: null })),
+        },
+        {
+          name: "b",
+          data: Array.from({ length: 8 }, (_, x) => ({
+            x,
+            y: x === 5 ? 3 : null,
+          })),
+        },
+      ],
+      { limit: 4 },
+    );
+    expect(plan.indices).toEqual([5]);
+  });
+
+  it("treats zero as a reported value, not an empty bucket", () => {
+    const plan = getTableBucketPlan(
+      long(10, (x) => (x % 5 === 0 ? 0 : null)),
+      {
+        limit: 4,
+      },
+    );
+    expect(plan.indices).toEqual([0, 5]);
+  });
+
+  it("caps a dense series at the limit", () => {
+    const plan = getTableBucketPlan(long(1200, (x) => x));
+    expect(plan.shown).toBe(TABLE_BUCKET_LIMIT);
+    expect(plan.omitted).toBe(1200 - TABLE_BUCKET_LIMIT);
+  });
+
+  it("keeps the most recent buckets, not the oldest (review D5)", () => {
+    // Slicing from the front discarded the newest days: a 721-bucket hourly
+    // table showed Aug 3 to Aug 24 and silently dropped the last nine days.
+    const plan = getTableBucketPlan(long(1200, (x) => x));
+    expect(plan.indices.at(0)).toBe(1200 - TABLE_BUCKET_LIMIT);
+    expect(plan.indices.at(-1)).toBe(1199);
+    expect(plan.truncated).toBe(true);
+  });
+
+  it("does not claim truncation when it only dropped empty buckets", () => {
+    const plan = getTableBucketPlan(
+      long(900, (x) => (x % 100 === 0 ? 1 : null)),
+    );
+    expect(plan.shown).toBe(9);
+    expect(plan.truncated).toBe(false);
+  });
+
+  it("keeps a capped time axis when the whole long range is empty", () => {
+    const plan = getTableBucketPlan(
+      long(10, () => null),
+      { limit: 4 },
+    );
+    expect(plan.indices).toEqual([6, 7, 8, 9]);
+    expect(plan.omitted).toBe(6);
+  });
+
+  it("reports nothing for empty, malformed or missing input", () => {
+    for (const input of [undefined, [], null, [null], [{ name: "x" }]]) {
+      expect(getTableBucketPlan(input)).toMatchObject({
+        indices: [],
+        total: 0,
+        omitted: 0,
+      });
+    }
+  });
+
+  it("sizes a minute-granularity widget down to its observed buckets", () => {
+    const plan = getTableBucketPlan(
+      long(7201, (x) => (x % 160 === 0 ? 1 : null)),
+    );
+    expect(plan.total).toBe(7201);
+    expect(plan.shown).toBe(46);
+  });
+});
+
+describe("chart time window (TH-7757)", () => {
+  it("reads the window the backend actually queried", () => {
+    expect(
+      getChartTimeWindow({
+        time_range: {
+          start: "2026-08-23T00:00:00+00:00",
+          end: "2026-08-30T00:00:00+00:00",
+        },
+      }),
+    ).toEqual({
+      min: Date.parse("2026-08-23T00:00:00+00:00"),
+      max: Date.parse("2026-08-30T00:00:00+00:00"),
+    });
+  });
+
+  it("spans the whole window even when only a few buckets reported", () => {
+    // The point of the helper: the axis must not collapse onto the data.
+    const window = getChartTimeWindow({
+      time_range: {
+        start: "2026-08-23T00:00:00Z",
+        end: "2026-08-30T00:00:00Z",
+      },
+    });
+    const firstObserved = Date.parse("2026-08-24T06:26:00Z");
+    const lastObserved = Date.parse("2026-08-26T13:26:00Z");
+    expect(window.min).toBeLessThan(firstObserved);
+    expect(window.max).toBeGreaterThan(lastObserved);
+  });
+
+  it("defers to Apex rather than emit an unusable axis", () => {
+    for (const result of [
+      undefined,
+      null,
+      {},
+      { time_range: {} },
+      { time_range: { start: "not a date", end: "2026-08-30T00:00:00Z" } },
+      { time_range: { start: "2026-08-30T00:00:00Z", end: "not a date" } },
+      // An inverted window would render an axis running backwards.
+      {
+        time_range: {
+          start: "2026-08-30T00:00:00Z",
+          end: "2026-08-23T00:00:00Z",
+        },
+      },
+      // A zero-width window collapses the plot.
+      {
+        time_range: {
+          start: "2026-08-23T00:00:00Z",
+          end: "2026-08-23T00:00:00Z",
+        },
+      },
+    ]) {
+      expect(getChartTimeWindow(result)).toBeNull();
+    }
+  });
+});
+
+describe("getSeriesExtent — sparse and very long ranges (TH-7757)", () => {
+  const bucketsOf = (length, valueAt) => [
+    {
+      name: "a",
+      data: Array.from({ length }, (_, x) => ({ x, y: valueAt(x) })),
+    },
+  ];
+
+  it("ignores empty buckets instead of reading them as zero", () => {
+    // Number(null) is 0, which would anchor the floor at a value never drawn.
+    const series = bucketsOf(50, (x) => (x % 10 === 0 ? x + 5 : null));
+    expect(getSeriesExtent(series)).toEqual({ min: 5, max: 45 });
+  });
+
+  it("ignores them on the stacked path too", () => {
+    const series = [
+      {
+        name: "a",
+        data: [
+          { x: 0, y: 4 },
+          { x: 1, y: null },
+          { x: 2, y: 6 },
+        ],
+      },
+      {
+        name: "b",
+        data: [
+          { x: 0, y: 3 },
+          { x: 1, y: null },
+          { x: 2, y: null },
+        ],
+      },
+    ];
+    expect(getSeriesExtent(series, { stacked: true })).toEqual({
+      min: 6,
+      max: 7,
+    });
+  });
+
+  it("still reports a real zero", () => {
+    expect(getSeriesExtent(bucketsOf(4, (x) => (x === 0 ? 0 : 9)))).toEqual({
+      min: 0,
+      max: 9,
+    });
+  });
+
+  it("measures a quarter of minute buckets without overflowing the stack", () => {
+    // Spreading a collected array into Math.min is an argument list, and the
+    // engine gives up around 125k. A 90-day minute range carries ~132k.
+    const series = bucketsOf(132_481, (x) => x % 7);
+    expect(() => getSeriesExtent(series)).not.toThrow();
+    expect(getSeriesExtent(series)).toEqual({ min: 0, max: 6 });
+    expect(() => getSeriesExtent(series, { stacked: true })).not.toThrow();
+  });
+
+  it("needs two observations before it will report an extent", () => {
+    expect(
+      getSeriesExtent(bucketsOf(9000, (x) => (x === 3 ? 5 : null))),
+    ).toBeNull();
+    expect(getSeriesExtent([])).toBeNull();
+  });
+});
+
+describe("getPlottedChartSeries — stacked alignment (TH-7757 review D1)", () => {
+  // ApexCharts stacks by array index, so a stacked chart's series must stay the
+  // same length and index j must denote the same bucket in all of them.
+  const padded = () => [
+    {
+      name: "A",
+      data: [10, 10, null, null, null, 10].map((y, x) => ({ x, y })),
+    },
+    {
+      name: "B",
+      data: [null, null, null, null, null, 100].map((y, x) => ({ x, y })),
+    },
+  ];
+
+  it("keeps every series the same length when stacked", () => {
+    const out = getPlottedChartSeries(padded(), { stacked: true });
+    expect(out[0].data).toHaveLength(out[1].data.length);
+  });
+
+  it("keeps the same array index pointing at the same bucket", () => {
+    const out = getPlottedChartSeries(padded(), { stacked: true });
+    out[0].data.forEach((point, index) => {
+      expect(point.x).toBe(out[1].data[index].x);
+    });
+  });
+
+  it("still collapses buckets that no series reported", () => {
+    const out = getPlottedChartSeries(padded(), { stacked: true });
+    expect(out[0].data.map((p) => p.x)).toEqual([0, 1, 5]);
+  });
+
+  it("pads a series that did not report a kept bucket, rather than shifting it", () => {
+    const out = getPlottedChartSeries(padded(), { stacked: true });
+    expect(out[1].data).toEqual([
+      { x: 0, y: null },
+      { x: 1, y: null },
+      { x: 5, y: 100 },
+    ]);
+  });
+
+  it("lets unstacked series drop their own buckets so lines connect across gaps", () => {
+    const out = getPlottedChartSeries(padded());
+    expect(out[0].data).toHaveLength(3);
+    expect(out[1].data).toHaveLength(1);
+  });
+
+  it("collapses a sparse stacked range as hard as an unstacked one", () => {
+    const sparse = [
+      {
+        name: "a",
+        data: Array.from({ length: 7201 }, (_, x) => ({
+          x,
+          y: x % 200 === 0 ? 1 : null,
+        })),
+      },
+      {
+        name: "b",
+        data: Array.from({ length: 7201 }, (_, x) => ({
+          x,
+          y: x % 200 === 0 ? 2 : null,
+        })),
+      },
+    ];
+    expect(
+      getPlottedChartSeries(sparse, { stacked: true })[0].data,
+    ).toHaveLength(37);
+  });
+});
+
+describe("getChartTimeWindow — bucket alignment (TH-7757 review D2)", () => {
+  // The reported window is the instant the query resolved to, but buckets snap
+  // to the start of their period, so bucket 0 precedes it. Pinning the axis at
+  // the raw instant drew that bucket off-canvas.
+  const result = {
+    time_range: {
+      start: "2026-08-26T12:17:18.076Z",
+      end: "2026-09-02T12:17:18.076Z",
+    },
+    metrics: [
+      {
+        series: [
+          {
+            data: [
+              { timestamp: "2026-08-26T00:00:00Z", value: 1 },
+              { timestamp: "2026-09-02T00:00:00Z", value: 2 },
+            ],
+          },
+        ],
+      },
+    ],
+  };
+
+  it("floors the window at the first bucket, not the resolved instant", () => {
+    expect(getChartTimeWindow(result).min).toBe(
+      Date.parse("2026-08-26T00:00:00Z"),
+    );
+  });
+
+  it("never starts after the earliest point it has to draw", () => {
+    const { min } = getChartTimeWindow(result);
+    const firstPoint = Date.parse(
+      result.metrics[0].series[0].data[0].timestamp,
+    );
+    expect(min).toBeLessThanOrEqual(firstPoint);
+  });
+
+  it("keeps the reported end when no bucket runs past it", () => {
+    expect(getChartTimeWindow(result).max).toBe(
+      Date.parse("2026-09-02T12:17:18.076Z"),
+    );
+  });
+
+  it("extends the end if a bucket somehow runs past the window", () => {
+    const late = JSON.parse(JSON.stringify(result));
+    late.metrics[0].series[0].data.push({
+      timestamp: "2026-09-03T00:00:00Z",
+      value: 3,
+    });
+    expect(getChartTimeWindow(late).max).toBe(
+      Date.parse("2026-09-03T00:00:00Z"),
+    );
+  });
+
+  it("falls back to the reported window when there are no buckets", () => {
+    expect(
+      getChartTimeWindow({ time_range: result.time_range, metrics: [] }),
+    ).toEqual({
+      min: Date.parse("2026-08-26T12:17:18.076Z"),
+      max: Date.parse("2026-09-02T12:17:18.076Z"),
+    });
+  });
+});
+
+describe("describeTableBuckets (review D5)", () => {
+  it("says nothing when nothing was left out", () => {
+    expect(
+      describeTableBuckets({ shown: 30, total: 30, omitted: 0 }),
+    ).toBeNull();
+    expect(describeTableBuckets()).toBeNull();
+  });
+
+  it("names the end it kept when the cap was hit", () => {
+    expect(
+      describeTableBuckets({
+        shown: 500,
+        total: 721,
+        omitted: 221,
+        truncated: true,
+      }),
+    ).toBe("latest 500 of 721 buckets");
+  });
+
+  it("does not claim truncation when only empty buckets were dropped", () => {
+    expect(
+      describeTableBuckets({
+        shown: 46,
+        total: 7201,
+        omitted: 7155,
+        truncated: false,
+      }),
+    ).toBe("46 of 7,201 buckets");
+  });
+});
+
+describe("getSeriesScalar — unbounded ranges (review D4)", () => {
+  const points = (n, valueAt) =>
+    Array.from({ length: n }, (_, i) => ({ x: i, y: valueAt(i) }));
+
+  it("takes min and max over a quarter of minute buckets without crashing", () => {
+    // Spreading into Math.min is an argument list; ~132k values crashed the
+    // whole page through the metric card, not just the widget.
+    const dense = points(132_481, (i) => (i % 97) + 1);
+    expect(() => getSeriesScalar(dense, "min")).not.toThrow();
+    expect(getSeriesScalar(dense, "min")).toBe(1);
+    expect(getSeriesScalar(dense, "max")).toBe(97);
+  });
+
+  it("still handles small, negative and single-value series", () => {
+    expect(
+      getSeriesScalar(
+        points(5, (i) => i - 2),
+        "min",
+      ),
+    ).toBe(-2);
+    expect(
+      getSeriesScalar(
+        points(5, (i) => i - 2),
+        "max",
+      ),
+    ).toBe(2);
+    expect(getSeriesScalar([{ x: 0, y: 7 }], "min")).toBe(7);
+    expect(getSeriesScalar([{ x: 0, y: 7 }], "max")).toBe(7);
+  });
+
+  it("ignores empty buckets and reports nothing for an empty series", () => {
+    expect(
+      getSeriesScalar(
+        points(6, (i) => (i === 3 ? 9 : null)),
+        "min",
+      ),
+    ).toBe(9);
+    expect(getSeriesScalar([], "min")).toBeNull();
+  });
 });

--- a/frontend/src/sections/dashboards/__tests__/widgetUtils.test.js
+++ b/frontend/src/sections/dashboards/__tests__/widgetUtils.test.js
@@ -1393,9 +1393,27 @@ describe("getPlottedChartSeries — stacked alignment (TH-7757 review D1)", () =
   it("pads a series that did not report a kept bucket, rather than shifting it", () => {
     const out = getPlottedChartSeries(padded(), { stacked: true });
     expect(out[1].data).toEqual([
-      { x: 0, y: null },
-      { x: 1, y: null },
+      { x: 0, y: 0 },
+      { x: 1, y: 0 },
       { x: 5, y: 100 },
+    ]);
+  });
+
+  it("coerces a present null to 0 instead of feeding the smooth apex stacker a gap (TH-7757 review fix)", () => {
+    // stacked_line renders as a smooth apex area chart: a null pushed into the
+    // stack baseline makes the next series' point render above the grid top.
+    const series = [
+      { name: "A", data: [10, null, 10].map((y, x) => ({ x, y })) },
+      { name: "B", data: [5, 5, 5].map((y, x) => ({ x, y })) },
+    ];
+    const out = getPlottedChartSeries(series, { stacked: true });
+    out.forEach((item) => {
+      expect(item.data.some((point) => point.y === null)).toBe(false);
+    });
+    expect(out[0].data).toEqual([
+      { x: 0, y: 10 },
+      { x: 1, y: 0 },
+      { x: 2, y: 10 },
     ]);
   });
 

--- a/frontend/src/sections/dashboards/__tests__/widgetUtils.test.js
+++ b/frontend/src/sections/dashboards/__tests__/widgetUtils.test.js
@@ -24,7 +24,6 @@ import {
   isAdditiveAggregation,
   getYAxisRangeWarning,
   getAutoYAxisBounds,
-  getSeriesExtent,
   getFittedYAxisBounds,
   getVisibleIndices,
   resolveAxisBounds,

--- a/frontend/src/sections/dashboards/hooks/useClampedChartTooltips.js
+++ b/frontend/src/sections/dashboards/hooks/useClampedChartTooltips.js
@@ -1,0 +1,45 @@
+import { useEffect } from "react";
+
+/** Keeps an ApexCharts tooltip inside the container that clips it.
+ *
+ *  Apex places the tooltip entirely above the cursor — `cursorY - gridTop -
+ *  tooltipHeight` — and never clamps that at 0; it clamps x three ways and
+ *  clamps y only against the grid's bottom. Any point in the top
+ *  `tooltipHeight` px of the plot therefore gets a negative top and is drawn
+ *  above the canvas, where the surrounding `overflow: hidden` slices it. On a
+ *  widget card that is most of the plot: 134px of tooltip against a 230px grid.
+ *
+ *  The container cannot simply drop the overflow (the chart's ResizeObserver
+ *  then loses its height constraint and the canvas grows unbounded),
+ *  `tooltip.fixed` is ignored on the intersect path these charts use, and a
+ *  chart-level `mouseMove` hook loses the race — Apex rewrites the style after
+ *  it, even a frame later. Watching the attribute is what reliably catches the
+ *  write, whenever Apex makes it. Only a negative top is rewritten, so a
+ *  tooltip that already fits is left following the cursor.
+ *
+ *  The observer watches the document rather than `containerRef.current`,
+ *  because a chart that only renders once its query resolves leaves that ref
+ *  empty on mount — an observer attached then would watch nothing for the rest
+ *  of the widget's life. Containment is checked per mutation instead, once the
+ *  ref is populated, so the clamp stays scoped to this chart. Records are
+ *  filtered on the tooltip class first, which keeps the callback off the hot
+ *  path of unrelated style writes. */
+export default function useClampedChartTooltips(containerRef) {
+  useEffect(() => {
+    const observer = new MutationObserver((records) => {
+      for (const { target } of records) {
+        if (!target.classList?.contains("apexcharts-tooltip")) continue;
+        if (!containerRef.current?.contains(target)) continue;
+        const top = Number.parseFloat(target.style.top);
+        if (Number.isFinite(top) && top < 0) target.style.top = "0px";
+      }
+    });
+
+    observer.observe(document.body, {
+      attributes: true,
+      subtree: true,
+      attributeFilter: ["style"],
+    });
+    return () => observer.disconnect();
+  }, [containerRef]);
+}

--- a/frontend/src/sections/dashboards/hooks/useClampedChartTooltips.js
+++ b/frontend/src/sections/dashboards/hooks/useClampedChartTooltips.js
@@ -1,4 +1,4 @@
-import { useEffect } from "react";
+import { useEffect, useRef } from "react";
 
 /** Keeps an ApexCharts tooltip inside the container that clips it.
  *
@@ -17,29 +17,55 @@ import { useEffect } from "react";
  *  write, whenever Apex makes it. Only a negative top is rewritten, so a
  *  tooltip that already fits is left following the cursor.
  *
- *  The observer watches the document rather than `containerRef.current`,
- *  because a chart that only renders once its query resolves leaves that ref
- *  empty on mount — an observer attached then would watch nothing for the rest
- *  of the widget's life. Containment is checked per mutation instead, once the
- *  ref is populated, so the clamp stays scoped to this chart. Records are
- *  filtered on the tooltip class first, which keeps the callback off the hot
- *  path of unrelated style writes. */
-export default function useClampedChartTooltips(containerRef) {
-  useEffect(() => {
-    const observer = new MutationObserver((records) => {
-      for (const { target } of records) {
-        if (!target.classList?.contains("apexcharts-tooltip")) continue;
-        if (!containerRef.current?.contains(target)) continue;
-        const top = Number.parseFloat(target.style.top);
-        if (Number.isFinite(top) && top < 0) target.style.top = "0px";
-      }
-    });
+ *  The observer is scoped to `observeRootRef` (defaulting to `containerRef`
+ *  itself), not the document: on a dashboard with a dozen widgets, one
+ *  body-wide observer per chart is a dozen subtrees being watched for a style
+ *  write that only ever happens inside one chart. A chart that only renders
+ *  once its query resolves leaves `containerRef` empty on mount, so a caller
+ *  whose chart mounts late should pass a stable ancestor as `observeRootRef`
+ *  instead — one that is present from the first render. If the resolved root
+ *  is still null when the effect runs, this falls back to `document.body`
+ *  rather than observing nothing for the rest of the widget's life.
+ *  Containment against `containerRef.current` is still checked per mutation,
+ *  once that ref is populated, so the clamp stays scoped to this chart.
+ *  Records are filtered on the tooltip class first, which keeps the callback
+ *  off the hot path of unrelated style writes.
+ *
+ *  A widget typically swaps `ref={containerRef}` across several conditionally
+ *  rendered nodes over its life — a loading spinner, then the chart — so the
+ *  resolved root can point at a new, detached node after a later render than
+ *  the one the effect first ran on. Re-checking on every render (a cheap
+ *  identity comparison) and re-observing when the root changed keeps the
+ *  observer attached to whichever node is live, without recreating it. */
+export default function useClampedChartTooltips(containerRef, observeRootRef) {
+  const observerRef = useRef(null);
+  const observedRootRef = useRef(null);
 
-    observer.observe(document.body, {
-      attributes: true,
-      subtree: true,
-      attributeFilter: ["style"],
-    });
-    return () => observer.disconnect();
-  }, [containerRef]);
+  useEffect(() => {
+    if (!observerRef.current) {
+      observerRef.current = new MutationObserver((records) => {
+        for (const { target } of records) {
+          if (!target.classList?.contains("apexcharts-tooltip")) continue;
+          if (!containerRef.current?.contains(target)) continue;
+          const top = Number.parseFloat(target.style.top);
+          if (Number.isFinite(top) && top < 0) target.style.top = "0px";
+        }
+      });
+    }
+
+    const root = (observeRootRef || containerRef).current || document.body;
+    if (root !== observedRootRef.current) {
+      observerRef.current.disconnect();
+      observerRef.current.observe(root, {
+        attributes: true,
+        subtree: true,
+        attributeFilter: ["style"],
+      });
+      observedRootRef.current = root;
+    }
+  });
+
+  useEffect(() => {
+    return () => observerRef.current?.disconnect();
+  }, []);
 }

--- a/frontend/src/sections/dashboards/widgetUtils.js
+++ b/frontend/src/sections/dashboards/widgetUtils.js
@@ -63,20 +63,199 @@ export const getDashboardMetricSeriesState = (metrics = []) => {
 };
 
 /**
- * A missing aggregate bucket is not a zero. For line charts, omit null points
- * so Apex connects the neighbouring observed points without mutating the exact
- * response used by table and non-line renderers.
+ * A missing aggregate bucket is not a zero, and nothing is drawn for it. Apex
+ * still emits a node per point it is handed, so a minute-granularity range
+ * spends thousands of nodes on buckets that render nothing (TH-7757) — a column
+ * chart over five days drew 7,201 paths for 36 observed values.
+ *
+ * How they are dropped depends on stacking, and the difference is not cosmetic:
+ *
+ * - Unstacked, each series is positioned by its own point's x, so each may drop
+ *   its own empty buckets. A line then connects across the gap, which is the
+ *   behaviour line and area charts have always had.
+ * - Stacked, ApexCharts sums BY ARRAY INDEX, not by x. The backend pads every
+ *   series over one shared bucket list precisely so index j is the same instant
+ *   everywhere. Filtering per series destroys that: a series would land on the
+ *   baseline and cover its neighbour instead of resting on it, and the stacked
+ *   totals Apex derives would be wrong. So only buckets that no series reported
+ *   are dropped, which keeps every series the same length and still collapses
+ *   the sparse case.
+ *
+ * Either way the exact response is untouched for the table, the CSV export and
+ * the metric card, which all distinguish "no data" from zero.
  */
-export const getPlottedChartSeries = (series = [], isLineChart = false) =>
-  isLineChart
-    ? series.map((item) => ({
-        ...item,
-        data: (item?.data || []).filter((point) => point?.y != null),
-      }))
-    : series;
+export const getPlottedChartSeries = (
+  series = [],
+  { stacked = false } = {},
+) => {
+  const rows = Array.isArray(series) ? series : [];
 
-export const shouldConnectAcrossMissingBuckets = (apexType) =>
-  apexType === "line" || apexType === "area";
+  if (!stacked) {
+    return rows.map((item) => ({
+      ...item,
+      data: (item?.data || []).filter((point) => point?.y != null),
+    }));
+  }
+
+  const width = rows.reduce(
+    (widest, item) => Math.max(widest, item?.data?.length || 0),
+    0,
+  );
+  const kept = [];
+  for (let index = 0; index < width; index += 1) {
+    if (!rows.some((item) => item?.data?.[index]?.y != null)) continue;
+    // Carry the bucket's own x so a series missing this index can still be
+    // padded at the right instant rather than collapsing the row.
+    kept.push({
+      index,
+      x: rows.find((item) => item?.data?.[index])?.data?.[index]?.x,
+    });
+  }
+  return rows.map((item) => ({
+    ...item,
+    data: kept.map(({ index, x }) => item?.data?.[index] ?? { x, y: null }),
+  }));
+};
+
+/**
+ * Past this many plotted points, ApexCharts' draw-in animation stops paying for
+ * itself: it re-serialises the entire SVG path on every frame, so its cost
+ * scales with the point count rather than with the amount of real data. A
+ * minute-granularity widget spanning days carries thousands of buckets and
+ * blocks the main thread for seconds per frame (TH-7757). Past the budget the
+ * chart is drawn in a single static pass.
+ *
+ * Only the animation is gated. Resting markers were briefly gated here too and
+ * that was wrong: they cost ~72 nodes against the animation's tens of
+ * thousands, and on a sparse series spread over a long range they are the only
+ * thing showing where observations actually sit — without them the line reads
+ * as continuous data when it is really a few points joined across weeks.
+ */
+export const CHART_DENSE_POINT_BUDGET = 400;
+
+export const countPlottedPoints = (series = []) =>
+  (Array.isArray(series) ? series : []).reduce(
+    (total, item) => total + (item?.data?.length || 0),
+    0,
+  );
+
+export const isDenseChartSeries = (series = []) =>
+  countPlottedPoints(series) > CHART_DENSE_POINT_BUDGET;
+
+/**
+ * Empty buckets are dropped before plotting, so the points alone describe only
+ * the stretch that reported values — left to infer the axis from them, Apex
+ * collapses a week-long widget onto the three days that happen to have data
+ * (TH-7757). The response states the window the backend actually queried,
+ * independently of which buckets survived, so pin the axis to that instead: an
+ * empty stretch then reads as empty rather than vanishing.
+ *
+ * Returns null when the response omits or malforms the window, leaving Apex to
+ * fall back to its own inference rather than rendering an inverted axis.
+ */
+export const getChartTimeWindow = (result) => {
+  const start = Date.parse(result?.time_range?.start ?? "");
+  const end = Date.parse(result?.time_range?.end ?? "");
+  if (!Number.isFinite(start) || !Number.isFinite(end) || end <= start)
+    return null;
+
+  // The window is the instant the query resolved to, but buckets snap to the
+  // start of their period, so the first bucket precedes it by up to a full
+  // granularity step. Pinning the axis at the raw instant puts that bucket
+  // outside the grid, where it is drawn off-canvas and silently lost.
+  let first = null;
+  let last = null;
+  for (const metric of result?.metrics || []) {
+    for (const item of metric?.series || []) {
+      const data = item?.data || [];
+      if (!data.length) continue;
+      const head = Date.parse(data[0]?.timestamp ?? "");
+      const tail = Date.parse(data[data.length - 1]?.timestamp ?? "");
+      if (Number.isFinite(head) && (first === null || head < first))
+        first = head;
+      if (Number.isFinite(tail) && (last === null || tail > last)) last = tail;
+    }
+  }
+
+  return {
+    min: first === null ? start : Math.min(start, first),
+    max: last === null ? end : Math.max(end, last),
+  };
+};
+
+/**
+ * A widget's table renders one cell per bucket per series, and a
+ * minute-granularity widget spanning days carries thousands of buckets
+ * (TH-7757).
+ *
+ * A table that already fits renders every bucket, empty ones included: a gap in
+ * a short range is information the reader wants. Only once the range is too
+ * long to read at all do empty buckets get dropped, which leaves the observed
+ * buckets adjacent instead of stranded in a wall of dashes; whatever survives is
+ * then capped so a dense series cannot render an unbounded table either. CSV
+ * export builds from the full response and is deliberately left alone.
+ */
+export const TABLE_BUCKET_LIMIT = 500;
+
+/**
+ * How a table should describe what it left out, or null when it left out
+ * nothing. Shared so the three tables cannot drift apart in wording: a capped
+ * table says which end it kept, one that only dropped empty buckets does not
+ * claim to have truncated.
+ */
+export const describeTableBuckets = ({
+  shown,
+  total,
+  omitted,
+  truncated,
+} = {}) => {
+  if (!omitted || omitted <= 0) return null;
+  const kept = Number(shown || 0).toLocaleString();
+  const all = Number(total || 0).toLocaleString();
+  return truncated
+    ? `latest ${kept} of ${all} buckets`
+    : `${kept} of ${all} buckets`;
+};
+
+export const getTableBucketPlan = (
+  series = [],
+  { limit = TABLE_BUCKET_LIMIT } = {},
+) => {
+  const rows = (Array.isArray(series) ? series : []).filter(Boolean);
+  const total = rows.reduce(
+    (widest, item) => Math.max(widest, item?.data?.length || 0),
+    0,
+  );
+
+  const everyBucket = Array.from({ length: total }, (_, index) => index);
+  if (total <= limit) {
+    return {
+      indices: everyBucket,
+      total,
+      shown: total,
+      omitted: 0,
+      truncated: false,
+    };
+  }
+
+  const observed = everyBucket.filter((index) =>
+    rows.some((item) => item?.data?.[index]?.y != null),
+  );
+  // With nothing observed anywhere, keep a window of buckets so the table still
+  // shows a time axis instead of collapsing to a bare header row.
+  const candidates = observed.length > 0 ? observed : everyBucket;
+  // The tail, not the head: a dashboard reader wants the most recent buckets,
+  // and slicing from the front silently discarded the newest days.
+  const indices = candidates.slice(-limit);
+
+  return {
+    indices,
+    total,
+    shown: indices.length,
+    omitted: total - indices.length,
+    truncated: candidates.length > limit,
+  };
+};
 
 /**
  * Dashboard responses are all-or-nothing aggregates. A single sampled,
@@ -191,8 +370,11 @@ export const getSeriesScalar = (points = [], aggregation = "avg") => {
   if (ADDITIVE_AGGREGATIONS.has(aggregation)) {
     return values.reduce((a, b) => a + b, 0);
   }
-  if (aggregation === "min") return Math.min(...values);
-  if (aggregation === "max") return Math.max(...values);
+  // Folded rather than spread into Math.min/max: a spread is an argument list,
+  // and a minute-granularity quarter carries ~132k values, well past the
+  // engine's limit. Spreading here crashed the whole page (TH-7757).
+  if (aggregation === "min") return values.reduce((a, b) => (b < a ? b : a));
+  if (aggregation === "max") return values.reduce((a, b) => (b > a ? b : a));
   return values.reduce((a, b) => a + b, 0) / values.length;
 };
 
@@ -544,30 +726,52 @@ const niceCeil = (value) => {
  * nothing finite to measure. Stacked charts are read off the summed height.
  */
 export const getSeriesExtent = (series = [], { stacked = false } = {}) => {
-  const totals = [];
+  // `Number(null)` is 0, so reading a point's value arithmetically would let an
+  // empty bucket register as a real zero: it anchors the floor at 0 using data
+  // the chart never draws, and on a 90-day minute range it pads the sample from
+  // hundreds of observations to six figures.
+  const valueOf = (point) => {
+    const raw = typeof point === "number" ? point : point?.y;
+    if (raw == null) return null;
+    const value = Number(raw);
+    return Number.isFinite(value) ? value : null;
+  };
+
+  // Folded in one pass rather than collected and spread into `Math.min`:
+  // spreading is an argument list, and a minute-granularity quarter carries
+  // ~132k points, well past the engine's limit (TH-7757).
+  let min = Infinity;
+  let max = -Infinity;
+  let observed = 0;
+  const fold = (value) => {
+    if (value < min) min = value;
+    if (value > max) max = value;
+    observed += 1;
+  };
+
   if (stacked) {
     // The backend pads every bucket (null for gaps) so series are aligned and
     // equal-length — the same positional sum ApexCharts itself does.
     const byIndex = [];
-    for (const s of series) {
-      (s?.data || []).forEach((pt, i) => {
-        const value = Number(typeof pt === "number" ? pt : pt?.y);
-        if (!Number.isFinite(value)) return;
-        byIndex[i] = (byIndex[i] || 0) + value;
+    for (const item of series) {
+      (item?.data || []).forEach((point, index) => {
+        const value = valueOf(point);
+        if (value === null) return;
+        byIndex[index] = (byIndex[index] || 0) + value;
       });
     }
-    totals.push(...byIndex.filter((v) => Number.isFinite(v)));
+    // Sparse array: forEach visits only the buckets some series reported.
+    byIndex.forEach((total) => fold(total));
   } else {
-    for (const s of series) {
-      for (const pt of s?.data || []) {
-        const value = Number(typeof pt === "number" ? pt : pt?.y);
-        if (Number.isFinite(value)) totals.push(value);
+    for (const item of series) {
+      for (const point of item?.data || []) {
+        const value = valueOf(point);
+        if (value !== null) fold(value);
       }
     }
   }
 
-  if (totals.length < 2) return null;
-  return { min: Math.min(...totals), max: Math.max(...totals) };
+  return observed < 2 ? null : { min, max };
 };
 
 /**

--- a/frontend/src/sections/dashboards/widgetUtils.js
+++ b/frontend/src/sections/dashboards/widgetUtils.js
@@ -113,7 +113,14 @@ export const getPlottedChartSeries = (
   }
   return rows.map((item) => ({
     ...item,
-    data: kept.map(({ index, x }) => item?.data?.[index] ?? { x, y: null }),
+    data: kept.map(({ index, x }) => {
+      const point = item?.data?.[index];
+      const y = point?.y;
+      // Stacked rendering is a smooth apex area chart: a null pushed into the
+      // stack baseline makes the next series' point render above the grid
+      // top. Absent is 0 contribution to the stack, not a gap.
+      return { x: point ? point.x : x, y: Number.isFinite(y) ? y : 0 };
+    }),
   }));
 };
 


### PR DESCRIPTION
## What

A widget at minute granularity gets one bucket per minute regardless of how many carry a value: **7,201 for five days, 132,481 for ninety**. The frontend handed every one to ApexCharts and to the preview table, so cost tracked the bucket count rather than the data.

Reported as "the animation becomes choppy and then crashes". It is not the animation's fault so much as its size.

| | Before | After |
|---|---|---|
| One widget, 7,201 buckets, 46 values | 2,591 ms | **1,669 ms** |
| Three such widgets on a dashboard | 62,692 ms, load timed out | **184 ms** |
| Chart SVG nodes on that dashboard | 14,701 | **407** |
| Metric card, min over 132,481 buckets | crashed the whole page | renders |

Measured at 4x CPU throttle in headless Chromium against a local stack.

### The bug as reported

Recorded against the reporter's build, CPU throttled. A 400 ms draw-in animation takes about 7 s; the clip ends before it finishes.

https://github.com/user-attachments/assets/45a418bc-3172-40d3-a345-54afc6e16c79

### The dashboard that used to freeze

Three minute-granularity widgets, 10,081 buckets each. 62,692 ms of blocked main thread and a timed-out load before; 184 ms now.

![dashboard after](https://github.com/user-attachments/assets/c7f1ca9d-b80c-4da4-bcfc-830171e6c2a3)

### The first data point was drawn off-canvas

The window is the instant the query resolved to; buckets snap to their period. Pinning at the raw instant put bucket zero at `cx = -84`, outside the grid. Now it is at `cx = 0`. Before, then after:

![axis before](https://github.com/user-attachments/assets/0ef06535-39c6-4223-a4ef-25fed3071f33)

![axis after](https://github.com/user-attachments/assets/2972c241-d5fb-484b-ad6c-0d09c2b523d6)

### The line ran forward and doubled back

`monotoneCubic` on the left, `smooth` on the right. Look at the July spike. Measured on unmodified `dev` with hand-written data, so it is the interpolation and not the payload:

| curve | sideways bulges | worst overshoot |
|---|---|---|
| `monotoneCubic` | 2 | 174 px |
| `smooth` | 0 | none |

![curve before](https://github.com/user-attachments/assets/e1bb99a1-f31e-445a-91a9-03aaacb7d05b)

![curve after](https://github.com/user-attachments/assets/89701c5e-a61e-42c5-9626-ceacbd66d1c6)

### The table says what it left out

Previously the saved dashboard dropped rows silently and kept the *oldest* 500, so the most recent nine days vanished.

![table label](https://github.com/user-attachments/assets/c0e32e44-83aa-48a8-9735-66c16cce27e0)

### Stacked alignment

Not screenshotted because the bars are sub-pixel at this bucket count and a picture shows nothing useful. Measured instead, two series with different null patterns at a shared bucket:

| | series A | series B | result |
|---|---|---|---|
| Before | y 158–172 | y 34–**171** | B reaches the baseline and covers A |
| After | y 158–172 | y 21–**158** | B rests on A |

The column read 100 where the true total was 110.

## How

**Empty buckets are dropped before plotting.** Unstacked series each drop their own, so lines still connect across gaps. Stacked series cannot do that: ApexCharts sums **by array index**, and the backend pads every series over one shared bucket list, so filtering per series makes one series land on the baseline and cover its neighbour. Stacked charts therefore drop only buckets that no series reported, which keeps them index-aligned and still collapses the sparse case.

**The draw-in animation is dropped past 400 plotted points**, because it re-serialises the whole SVG path on every frame. Markers stay. They cost about 72 nodes against the animation's tens of thousands, and without them a sparse series spread over months reads as continuous data.

**Tables past 500 buckets drop empty ones, keep the most recent, and say so.** Slicing from the front discarded the newest days.

**`Math.min(...values)` is folded into a loop** in two places. A spread is an argument list and gives up around 125k, which is how a metric card took down the page.

**The x-axis is pinned to the queried window**, floored at the first bucket. The window is the instant the query resolved to while buckets snap to their period, so pinning at the raw instant drew the first point off-canvas.

## Two fixes riding along

Both are one line each in files this PR already touches. Happy to split them out if preferred.

- **The TH-7679 tooltip clamp now applies to the widget editor**, which never got it. Extracted to a hook so both renderers share it. It observes the document rather than a ref, because the editor's chart mounts only after its query resolves, so a ref-attached observer would watch nothing for the widget's life.
- **`curve: "smooth"` instead of `monotoneCubic`.** monotoneCubic sizes each control handle from the neighbouring gap widths, so a cluster beside a long gap got a handle ~174px past a 10px segment and the line visibly ran forward then doubled back. These two files were the only place in the app using it; ~34 other charts already use `smooth`.

## Testing

4,486 tests pass. This adds 44, including the cases that were missing entirely: stacked series staying index-aligned, the window never starting after the first point it must draw, and the 132,481-value fold that used to throw.

Verified in a real browser for every claim, before and after. Chart correctness lives in geometry, and unit tests that assert the options object pass regardless.

## Not in this PR

Three defects found while testing, each pre-existing and worth its own ticket:

- Count metrics are labelled with the underlying metric's unit, so a count of traces reads `latency (count) (ms)`.
- The dashboard date preset overrides a widget's range without re-checking granularity, so picking 3M forces a minute widget into six-figure bucket counts, a combination the editor refuses to let you build.
- Pinning the axis changes tick density, since ApexCharts ignores `tickAmount` once given explicit bounds. No data is affected; a 30-day hourly chart gets 4 date labels instead of 15.

## Note on the base

Targets `fix/th-7680-dynamic-y-axis-scaling` (#2406), not `dev`. The fold in `getSeriesExtent` and the axis-bounds paths only exist on that branch, so this cannot apply to `dev` until #2406 lands.



---

### Post-review verification (real browser)

Captured in a real Chromium against the running app after the review fixes + the base merge. Full frontend suite green (4518/4518).

**Dense series render without freezing — markers thinned, not tooltips.** A ~1,500-point/series widget: animations off, visible dots thinned to ~60 per series (the rest are `r=0`/invisible), `tooltip.enabled` unchanged. This is the finding #4 behaviour — spaced, not removed.

![dense widget — spaced markers](https://github.com/user-attachments/assets/cb59d079-fa94-4f92-a1dc-af1fd6c9817a)

**A live dashboard renders cleanly through the merged `widgetUtils`/`WidgetChart` code** — sparse series keep full markers, y-axis scaling (reconciled `getSeriesExtent`) intact, 0 runtime errors:

![live dashboard render](https://github.com/user-attachments/assets/d6db981b-dc65-47ee-bb6e-7dd59b90a014)