### PR TITLE
fix(ai-tools): read eval failure text from error_message when eval_explanation is empty

### DIFF
--- a/futureagi/ai_tools/tests/test_tracing_tools.py
+++ b/futureagi/ai_tools/tests/test_tracing_tools.py
@@ -319,3 +319,81 @@ class TestDeleteProjectTool:
         )
 
         assert result.is_error
+
+
+class TestGetEvalTaskLogsTool:
+    ENGINE_FAILURE = (
+        "Error during evaluation: No input received for any of "
+        "'input', 'output'. Please check your inputs."
+    )
+    INLINE_FAILURE = "Response contradicts the provided context."
+
+    def _errored_entry(self, tool_context, project, **fields):
+        import uuid as _uuid
+
+        from tracer.models.observation_span import (
+            EvalEntryStatus,
+            ObservationSpan,
+        )
+        from tracer.tests.eval_task_factories import make_config, make_row
+        from tracer.tests.eval_task_factories import make_task, make_template
+
+        trace = make_trace(tool_context, project=project)
+        span = ObservationSpan.objects.create(
+            id=f"span-{_uuid.uuid4().hex[:8]}",
+            project=project,
+            trace=trace,
+            name="llm-call",
+            observation_type="llm",
+        )
+        template = make_template(
+            organization=tool_context.organization,
+            workspace=tool_context.workspace,
+        )
+        config = make_config(project=project, template=template, name="Eval")
+        task = make_task(project=project)
+        make_row(
+            span=span,
+            cfg=config,
+            task=task,
+            status=EvalEntryStatus.ERRORED,
+            error=True,
+            **fields,
+        )
+        return task
+
+    def test_engine_failure_text_reaches_the_caller(self, tool_context, project):
+        task = self._errored_entry(
+            tool_context,
+            project,
+            eval_explanation="",
+            error_message=self.ENGINE_FAILURE,
+        )
+
+        result = run_tool(
+            "get_eval_task_logs", {"eval_task_id": str(task.id)}, tool_context
+        )
+
+        assert not result.is_error
+        assert result.data["errors_count"] == 1
+        assert result.data["errors_message"] == [self.ENGINE_FAILURE]
+        assert "### Error Messages" in result.content
+        assert self.ENGINE_FAILURE in result.content
+
+    def test_inline_eval_reason_is_not_displaced_by_a_null_error_message(
+        self, tool_context, project
+    ):
+        task = self._errored_entry(
+            tool_context,
+            project,
+            eval_explanation=self.INLINE_FAILURE,
+            error_message=None,
+        )
+
+        result = run_tool(
+            "get_eval_task_logs", {"eval_task_id": str(task.id)}, tool_context
+        )
+
+        assert not result.is_error
+        assert result.data["errors_message"] == [self.INLINE_FAILURE]
+        assert self.INLINE_FAILURE in result.content

--- a/futureagi/ai_tools/tools/tracing/get_eval_task_logs.py
+++ b/futureagi/ai_tools/tools/tracing/get_eval_task_logs.py
@@ -32,7 +32,8 @@ class GetEvalTaskLogsTool(BaseTool):
     def execute(self, params: GetEvalTaskLogsInput, context: ToolContext) -> ToolResult:
 
         from django.contrib.postgres.aggregates import ArrayAgg
-        from django.db.models import Count, Q
+        from django.db.models import Count, Q, TextField, Value
+        from django.db.models.functions import Coalesce, NullIf
 
         from tracer.models.eval_task import EvalTask
         from tracer.models.observation_span import EvalLogger
@@ -53,7 +54,17 @@ class GetEvalTaskLogsTool(BaseTool):
                 "id", filter=Q(error=False, skipped_reason__isnull=True)
             ),
             skipped_count=Count("id", filter=Q(skipped_reason__isnull=False)),
-            errors_message=ArrayAgg("eval_explanation", filter=Q(error=True)),
+            # Engine failures write the text to error_message and leave
+            # eval_explanation empty; inline evals do the reverse.
+            errors_message=ArrayAgg(
+                Coalesce(
+                    NullIf("eval_explanation", Value("")),
+                    "error_message",
+                    Value("", output_field=TextField()),
+                    output_field=TextField(),
+                ),
+                filter=Q(error=True),
+            ),
         )
 
         total_count = (


### PR DESCRIPTION
## Problem / Summary

The `get_eval_task_logs` agent tool aggregates eval failure text out of a single column:

```python
errors_message=ArrayAgg("eval_explanation", filter=Q(error=True))
```

The eval engine does not write its failure text there. On the engine failure paths it writes to
`error_message` and leaves `eval_explanation` empty; `eval_explanation` is populated by inline
evals, which set it from `evaluation.reason` (`tracer/utils/inline_evals.py`). So every engine
failure aggregates as an empty string, the `if e` filter on line 82 drops it as falsy, and the
tool omits the entire "Error Messages" section. The agent is told how many evals failed and never
told why, while the row underneath carries the exact diagnosis.

Measured against the tool as it stands on `dev`, with one errored entry whose `error_message` is
`Error during evaluation: No input received for any of 'input', 'output'. Please check your inputs.`
and whose `eval_explanation` is empty:

```
## Eval Task Logs: Eval task
**Total Processed:** 1
**Successful:** 0
**Errors:** 1

result.data["errors_message"] == ['']
(no "### Error Messages" section is emitted at all)
```

The HTTP endpoint this tool mirrors, `tracer/views/eval_task.py::get_eval_task_logs`, already reads
both columns. That landed in `0689b98ae` ("fix(eval-tasks): bound usage reads and preserve details",
2026-08-12) and was re-verified correct on `dev` while scoping this change, so the dashboard error
log is not affected and is not touched here. This PR closes the same gap on the surface the agent
reads.

## Fix / Changes

`futureagi/ai_tools/tools/tracing/get_eval_task_logs.py`, one aggregate expression:

- Aggregate over `Coalesce(NullIf("eval_explanation", ""), "error_message", "")` instead of
  `eval_explanation` alone. This is the same expression shape the view already uses, so both
  surfaces now resolve failure text identically and cannot drift apart again silently.
- The `NullIf` on the empty string is what makes this a fallback rather than a column swap. An
  inline eval that wrote its reason to `eval_explanation` and left `error_message` NULL keeps
  working exactly as before. A blind swap to `error_message` would have broken that case, which is
  why the second test below exists.
- `output_field=TextField()` is required on the literal and on the `Coalesce` for the same reason
  the view needs it: mixing a TextField source with a CharField literal otherwise raises
  "Expression contains mixed types: TextField, CharField".

No schema change, no migration, no response-shape change. `errors_message` stays a list of strings
and `data`/`content` keep the same keys.

## Verification / Test plan

Two behavioral tests on the real tool call path (`registry.get("get_eval_task_logs").run(...)`,
against real rows in Postgres), added as `TestGetEvalTaskLogsTool` in
`futureagi/ai_tools/tests/test_tracing_tools.py`. The tool had zero test coverage before this.

RED, with the fix reverted and the tests in place:

```
$ pytest ai_tools/tests/test_tracing_tools.py --reuse-db -q
collected 28 items

ai_tools/tests/test_tracing_tools.py ..........................F.        [100%]

=================================== FAILURES ===================================
_____ TestGetEvalTaskLogsTool.test_engine_failure_text_reaches_the_caller ______
ai_tools/tests/test_tracing_tools.py:379: in test_engine_failure_text_reaches_the_caller
    assert result.data["errors_message"] == [self.ENGINE_FAILURE]
E   assert [''] == ['Error durin...your inputs.']
E
E     At index 0 diff: '' != "Error during evaluation: No input received for any of 'input', 'output'. Please check your inputs."
========================= 1 failed, 27 passed in 5.04s =========================
```

GREEN, with the fix applied, run together with the adjacent suites the blast-radius search turned up:

```
$ pytest ai_tools/tests/test_tracing_tools.py ai_tools/tests/test_workflows_eval_tracing.py \
         tracer/tests/test_eval_task.py --reuse-db -q
collected 95 items

ai_tools/tests/test_tracing_tools.py ............................        [ 29%]
ai_tools/tests/test_workflows_eval_tracing.py ...                        [ 32%]
tracer/tests/test_eval_task.py ......................................... [ 75%]
.......................                                                  [100%]

======================== 95 passed in 86.39s (0:01:26) =========================
```

Note that `test_inline_eval_reason_is_not_displaced_by_a_null_error_message` passes in both runs by
design. It is not there to prove this fix; it is the guard that fails if someone later "simplifies"
the coalesce into a straight swap to `error_message`.

## Screenshots

N/A backend. Tool output before and after, same fixture row:

```
before:  **Errors:** 1     errors_message == ['']
                           (no "### Error Messages" section)

after:   **Errors:** 1     errors_message == ["Error during evaluation: No input received
                           for any of 'input', 'output'. Please check your inputs."]

                           ### Error Messages

                           - Error during evaluation: No input received for any of
                             'input', 'output'. Please check your inputs.
```


## Out of scope

- `tracer/views/eval_task.py` is deliberately untouched. It was fixed in `0689b98ae` and verified
  correct on `dev` before this branch was cut, so there is nothing to change there.
- `TaskLogs.jsx` still reads `data?.errors_message` from the HTTP endpoint, which stopped returning
  that key when it moved to `error_groups`. That is a dead render branch, pre-existing and
  unrelated to this aggregate. Separate ticket.
- This tool counts failures with `error=True` while the view counts `status=ERRORED`. The two can
  disagree for a row written before the status lifecycle landed. Reconciling them is a behaviour
  change to the counts, not to the error text, so it is left alone here.
- The tool does not apply the prefix and span-id normalization the view does, so its ten unique
  strings are raw. Worth doing, but it changes what the agent reads and belongs in its own change.
