### PR TITLE
test(e2e): prompt workbench flows for /dashboard/workbench/all

### DIFF
--- a/e2e/FLOWS.md
+++ b/e2e/FLOWS.md
@@ -201,7 +201,7 @@
 ### PROMPT-E2E-005 — renaming and deleting a prompt from its row
 
 **Goal:** A user renames a prompt from its row and deletes one they no longer want, and the list reflects both  
-**Spec:** `flows/prompts/rename-and-delete.spec.ts:24`  
+**Spec:** `flows/prompts/rename-and-delete.spec.ts:23`  
 **Tags:** —
 
 **User steps:**
@@ -209,14 +209,14 @@
 1. seed two prompts
 2. open All Prompts
 3. rename the first from its row menu
-4. try to give the second that same name and be refused
+4. rename the second to that same name in the dialog and read the refusal
 5. delete the second from its row menu
 6. read the list
 
 **Backend state verified:**
 
 - save-name persists the new name on the PG row
-- save-name refuses a name already used by another template in the org, and the second prompt's name is unchanged
+- renaming to a name already used in the org is refused with a 400, the dialog surfaces the error and stays open, and the second prompt's name is unchanged in PG
 - bulk-delete soft-deletes: the PG row survives with deleted=true
 - the list endpoint no longer returns the deleted prompt but still returns the renamed one
 - the list shows the renamed row and no row for the deleted prompt

--- a/e2e/FLOWS.md
+++ b/e2e/FLOWS.md
@@ -107,3 +107,116 @@
 
 - the metrics catalog scoped to each project returns that project's eval template and not its sibling's
 - the frontend requests the catalog with project_ids set to the project being viewed
+
+## prompts
+
+### PROMPT-E2E-001 — a prompt created from the workbench appears in All Prompts
+
+**Goal:** A user creates a new prompt from the workbench and finds it in the All Prompts list  
+**Spec:** `flows/prompts/create-prompt.spec.ts:21`  
+**Tags:** —
+
+**User steps:**
+
+1. open All Prompts
+2. click Create prompt
+3. choose "Start from scratch"
+4. land on the editor for the new draft
+5. return to All Prompts
+6. read the new row
+
+**Backend state verified:**
+
+- create-draft persists a PromptTemplate in PG model_hub_prompttemplate, scoped to the actor org, deleted=false
+- the backend names an unnamed draft Untitled-<n>, the next free number in the org
+- the All Prompts list endpoint returns that prompt with type PROMPT
+- the list renders exactly one row linking to the new prompt id
+
+### PROMPT-E2E-002 — a prompt filed into a folder shows up under that folder
+
+**Goal:** A user files a prompt into a folder they created, and the folder shows that prompt rather than the whole library  
+**Spec:** `flows/prompts/folder-organisation.spec.ts:27`  
+**Tags:** —
+
+**User steps:**
+
+1. seed a prompt by API
+2. create a folder from the sidebar
+3. return to All Prompts
+4. open the prompt's row menu and move it into the folder
+5. open the folder from the sidebar
+6. read its rows
+
+**Backend state verified:**
+
+- the folder is a PG model_hub_prompt_folder row, org-scoped, parent_folder null, deleted=false
+- Move sets prompt_folder_id on the prompt row to that folder
+- the list endpoint scoped by prompt_folder returns exactly the moved prompt
+- All Prompts renders the folder as its own row alongside prompts
+- the folder view renders exactly the moved prompt
+
+### PROMPT-E2E-003 — search from All Prompts finds a prompt inside a folder
+
+**Goal:** A user searching from All Prompts finds a prompt even though it lives inside a folder, and sees which folder that is  
+**Spec:** `flows/prompts/search.spec.ts:24`  
+**Tags:** —
+
+**User steps:**
+
+1. seed a folder, a prompt inside it and a loose prompt sharing one minted token
+2. seed a decoy prompt that does not carry the token
+3. open All Prompts
+4. type the token into the search field
+5. read the rows once the debounce settles
+
+**Backend state verified:**
+
+- the list endpoint with name=<token> returns both prompts and the folder, and not the decoy
+- the in-folder prompt is returned from All Prompts without prompt_folder being sent — search is not folder-scoped
+- the rendered row set equals exactly the three seeded items
+- the sort and breadcrumb bar is hidden while a search is active
+- the in-folder prompt row names the folder it lives in
+
+### PROMPT-E2E-004 — sorting and paging the prompt list keeps it complete
+
+**Goal:** A user sorting and paging the prompt list gets a stable ordering with no row lost or repeated  
+**Spec:** `flows/prompts/sort-and-paging.spec.ts:28`  
+**Tags:** —
+
+**User steps:**
+
+1. seed a folder and eleven prompts whose names sort unambiguously
+2. open All Prompts
+3. widen the page size and sort by Name descending
+4. toggle the same sort to ascending
+5. return to ten per page and step from page 1 to page 2
+
+**Backend state verified:**
+
+- the list endpoint returns the seeded prompts in the requested sort_by/sort_order, both directions
+- the UI's rendered order of the seeded prompts matches the API's for the same query
+- paging the same query never repeats a row and covers every seeded prompt
+- the "No.of prompts" count is the prompt count and excludes the folder rows the same response carries
+
+### PROMPT-E2E-005 — renaming and deleting a prompt from its row
+
+**Goal:** A user renames a prompt from its row and deletes one they no longer want, and the list reflects both  
+**Spec:** `flows/prompts/rename-and-delete.spec.ts:24`  
+**Tags:** —
+
+**User steps:**
+
+1. seed two prompts
+2. open All Prompts
+3. rename the first from its row menu
+4. try to give the second that same name and be refused
+5. delete the second from its row menu
+6. read the list
+
+**Backend state verified:**
+
+- save-name persists the new name on the PG row
+- save-name refuses a name already used by another template in the org, and the second prompt's name is unchanged
+- bulk-delete soft-deletes: the PG row survives with deleted=true
+- the list endpoint no longer returns the deleted prompt but still returns the renamed one
+- the list shows the renamed row and no row for the deleted prompt

--- a/e2e/flows/prompts/create-prompt.spec.ts
+++ b/e2e/flows/prompts/create-prompt.spec.ts
@@ -1,0 +1,109 @@
+import { test, expect } from '../../lib/fixtures';
+import { flowAnnotation } from '../../lib/flow-meta';
+
+// Pinned from frontend/src/utils/axios.js (endpoints.develop.runPrompt):
+//   createPromptDraft -> /model-hub/prompt-templates/create-draft/
+//   promptExecutions  -> /model-hub/prompt-executions/
+const CREATE_DRAFT_PATH = '/model-hub/prompt-templates/create-draft/';
+const LIST_PATH = '/model-hub/prompt-executions/';
+// Browser-side waits. The local stack slows several-fold when specs run in
+// parallel, so the 10s expect default is not a first-paint budget; sized like
+// the observe flows' own constant.
+const UI_READY = 60_000;
+
+// The list endpoint is DRF-paginated ({count,total_pages,results}), not the
+// {result:{table}} envelope probe.apiList hard-codes — so the API lane here
+// goes through actor.api directly. Pinned from FolderListView.jsx:70-74.
+interface PromptRow { id: string; name: string; type: string }
+interface ListPage { count: number; total_pages: number; results: PromptRow[] }
+interface DraftEnvelope { result: { root_template: string; name: string } }
+
+test('PROMPT-E2E-001: a prompt created from the workbench appears in All Prompts', {
+  tag: ['@flow'],
+  annotation: flowAnnotation({
+    id: 'PROMPT-E2E-001', area: 'prompts',
+    userGoal: 'A user creates a new prompt from the workbench and finds it in the All Prompts list',
+    steps: ['open All Prompts',
+            'click Create prompt',
+            'choose "Start from scratch"',
+            'land on the editor for the new draft',
+            'return to All Prompts',
+            'read the new row'],
+    backendChecks: [
+      'create-draft persists a PromptTemplate in PG model_hub_prompttemplate, scoped to the actor org, deleted=false',
+      'the backend names an unnamed draft Untitled-<n>, the next free number in the org',
+      'the All Prompts list endpoint returns that prompt with type PROMPT',
+      'the list renders exactly one row linking to the new prompt id',
+    ],
+  }),
+}, async ({ page, actor, probe }, testInfo) => {
+  // Navigation plus 4 x UI_READY already passes the config's 120s default;
+  // the remainder is headroom so a slow run fails on the assertion that ran
+  // out rather than on the outer timeout.
+  test.setTimeout(240_000);
+
+  const created = await test.step('UI: create a prompt from scratch', async () => {
+    await page.goto('/dashboard/workbench/all', { waitUntil: 'domcontentloaded' });
+    // An empty org renders a second "Create prompt" in the empty layout
+    // (FolderListView.jsx:156-165) beside the header's own; both open the same
+    // dialog, and the header's is first in the DOM.
+    const createPrompt = page.getByRole('button', { name: 'Create prompt' }).first();
+    await expect(createPrompt).toBeEnabled({ timeout: UI_READY });
+
+    const drafted = page.waitForResponse(
+      (r) => r.url().includes(CREATE_DRAFT_PATH) && r.ok(), { timeout: UI_READY });
+    await createPrompt.click();
+    // CreateNewPrompt.jsx:182-201 renders each option as a clickable Stack;
+    // the click bubbles from the option's title to that handler.
+    await page.getByText('Start from scratch', { exact: true }).click();
+    const body = (await (await drafted).json()) as DraftEnvelope;
+
+    // CreateNewPrompt.jsx:99-104 navigates to the editor for the new draft.
+    await expect(page).toHaveURL(
+      `/dashboard/workbench/create/${body.result.root_template}`, { timeout: UI_READY });
+    return body.result;
+  });
+
+  await testInfo.attach('created-prompt', {
+    body: JSON.stringify(created), contentType: 'application/json',
+  });
+
+  await test.step('storage: the draft is an org-scoped, undeleted PG row named Untitled-<n>', async () => {
+    const rows = await probe.pg<{ name: string; deleted: boolean; prompt_folder_id: string | null }>(
+      'SELECT name, deleted, prompt_folder_id FROM model_hub_prompttemplate WHERE id = $1 AND organization_id = $2',
+      [created.root_template, actor.organizationId]);
+    expect(rows).toHaveLength(1);
+    expect(rows[0].deleted).toBe(false);
+    // Nothing was filed into a folder, so the draft is loose in All Prompts.
+    expect(rows[0].prompt_folder_id).toBeNull();
+    // The UI sends name:"" (workbench/constant.js:22), so the backend assigns
+    // the next free Untitled-N in the org (views/prompt_template.py:1231-1252).
+    expect(rows[0].name).toMatch(/^Untitled-\d+$/);
+    expect(rows[0].name).toBe(created.name);
+  });
+
+  await test.step('API: the All Prompts list returns the new prompt', async () => {
+    // The params FolderListView.jsx:47-64 sends for the "all" folder.
+    const listed = await actor.api.get<ListPage>(LIST_PATH, {
+      send_all: 'true', page: 1, page_size: 50, name: created.name,
+      sort_by: 'updated_at', sort_order: 'desc',
+    });
+    const mine = listed.results.filter((r) => r.id === created.root_template);
+    expect(mine).toHaveLength(1);
+    expect(mine[0].name).toBe(created.name);
+    expect(mine[0].type).toBe('PROMPT');
+  });
+
+  await test.step('UI: All Prompts shows exactly one row for the new prompt', async () => {
+    await page.goto('/dashboard/workbench/all', { waitUntil: 'domcontentloaded' });
+    // PromptItem.jsx:55-58 links a prompt row to the editor; that href is
+    // unique to the list, where a folder row's href collides with the sidebar.
+    const row = page.locator('[data-testid="prompt-list"] > div').filter({
+      has: page.locator(`a[href="/dashboard/workbench/create/${created.root_template}"]`),
+    });
+    await expect(row).toHaveCount(1, { timeout: UI_READY });
+    // Exact text, not containment: the row also carries "Created by …" and a
+    // timestamp, so scope to the element whose whole text is the name.
+    await expect(row.getByText(created.name, { exact: true })).toHaveCount(1);
+  });
+});

--- a/e2e/flows/prompts/folder-organisation.spec.ts
+++ b/e2e/flows/prompts/folder-organisation.spec.ts
@@ -1,0 +1,154 @@
+import { test, expect } from '../../lib/fixtures';
+import { flowAnnotation } from '../../lib/flow-meta';
+
+// Pinned from frontend/src/utils/axios.js (endpoints.develop.runPrompt):
+//   createPromptDraft -> /model-hub/prompt-templates/create-draft/
+//   promptFolder      -> /model-hub/prompt-folders/
+//   movePrompt        -> /model-hub/prompt-templates/{id}/save-prompt-folder/
+//   promptExecutions  -> /model-hub/prompt-executions/
+const CREATE_DRAFT_PATH = '/model-hub/prompt-templates/create-draft/';
+const FOLDERS_PATH = '/model-hub/prompt-folders/';
+const MOVE_PATH = (id: string) => `/model-hub/prompt-templates/${id}/save-prompt-folder/`;
+const LIST_PATH = '/model-hub/prompt-executions/';
+const UI_READY = 60_000;
+
+// The empty two-message config the Create prompt dialog posts, pinned from
+// frontend/src/sections/workbench/constant.js:1-29 (DefaultMessages).
+const DEFAULT_MESSAGES = [
+  { role: 'system', content: [{ type: 'text', text: '' }] },
+  { role: 'user', content: [{ type: 'text', text: '' }] },
+];
+
+interface PromptRow { id: string; name: string; type: string; prompt_folder: string | null }
+interface ListPage { count: number; total_pages: number; results: PromptRow[] }
+interface DraftEnvelope { result: { root_template: string; name: string } }
+interface FolderEnvelope { result: { id: string; name: string } }
+
+test('PROMPT-E2E-002: a prompt filed into a folder shows up under that folder', {
+  tag: ['@flow'],
+  annotation: flowAnnotation({
+    id: 'PROMPT-E2E-002', area: 'prompts',
+    userGoal: 'A user files a prompt into a folder they created, and the folder shows that prompt rather than the whole library',
+    steps: ['seed a prompt by API',
+            'create a folder from the sidebar',
+            'return to All Prompts',
+            "open the prompt's row menu and move it into the folder",
+            'open the folder from the sidebar',
+            'read its rows'],
+    backendChecks: [
+      'the folder is a PG model_hub_prompt_folder row, org-scoped, parent_folder null, deleted=false',
+      'Move sets prompt_folder_id on the prompt row to that folder',
+      'the list endpoint scoped by prompt_folder returns exactly the moved prompt',
+      'All Prompts renders the folder as its own row alongside prompts',
+      'the folder view renders exactly the moved prompt',
+    ],
+  }),
+}, async ({ page, actor, probe }, testInfo) => {
+  // Two navigations plus 5 browser waits pass the 120s default.
+  test.setTimeout(240_000);
+
+  const suffix = `${testInfo.workerIndex}-${Date.now().toString(36)}`;
+  const promptName = `e2e-prompt2-file-${suffix}`;
+  const folderName = `e2e-prompt2-folder-${suffix}`;
+
+  // create-draft uses a supplied name verbatim and only falls back to
+  // Untitled-N when it is empty (views/prompt_template.py:1199,1231).
+  const seeded = (await actor.api.post<DraftEnvelope>(CREATE_DRAFT_PATH, {
+    name: promptName, prompt_config: [{ messages: DEFAULT_MESSAGES }],
+  })).result;
+  await testInfo.attach('seeded-prompt', {
+    body: JSON.stringify(seeded), contentType: 'application/json',
+  });
+
+  const folderId = await test.step('UI: create a folder from the sidebar', async () => {
+    await page.goto('/dashboard/workbench/all', { waitUntil: 'domcontentloaded' });
+    const created = page.waitForResponse(
+      (r) => r.url().includes(FOLDERS_PATH) && r.request().method() === 'POST' && r.ok(),
+      { timeout: UI_READY });
+    // FileSystem.jsx:236 renders the sidebar's add-folder control.
+    await page.getByRole('button', { name: 'New Folder' }).click();
+    const dialog = page.getByRole('dialog');
+    await dialog.getByLabel('Name').fill(folderName);
+    // Scoped and exact: "Create prompt" is on the page behind the dialog, and
+    // Playwright's name match is a substring by default.
+    await dialog.getByRole('button', { name: 'Create', exact: true }).click();
+    const body = (await (await created).json()) as FolderEnvelope;
+    // AddFolder.jsx:34-36 navigates into the folder it just made.
+    await expect(page).toHaveURL(`/dashboard/workbench/${body.result.id}`, { timeout: UI_READY });
+    return body.result.id;
+  });
+
+  await testInfo.attach('created-folder', {
+    body: JSON.stringify({ folderId, folderName }), contentType: 'application/json',
+  });
+
+  await test.step('storage: the folder is an org-scoped root folder', async () => {
+    const rows = await probe.pg<{ name: string; parent_folder_id: string | null; deleted: boolean }>(
+      'SELECT name, parent_folder_id, deleted FROM model_hub_prompt_folder WHERE id = $1 AND organization_id = $2',
+      [folderId, actor.organizationId]);
+    expect(rows).toHaveLength(1);
+    expect(rows[0].name).toBe(folderName);
+    expect(rows[0].parent_folder_id).toBeNull();
+    expect(rows[0].deleted).toBe(false);
+  });
+
+  await test.step('UI: move the prompt into the folder from its row menu', async () => {
+    await page.goto('/dashboard/workbench/all', { waitUntil: 'domcontentloaded' });
+    const row = page.locator('[data-testid="prompt-list"] > div').filter({
+      has: page.locator(`a[href="/dashboard/workbench/create/${seeded.root_template}"]`),
+    });
+    await expect(row).toHaveCount(1, { timeout: UI_READY });
+
+    const moved = page.waitForResponse(
+      (r) => r.url().includes(MOVE_PATH(seeded.root_template)) && r.ok(), { timeout: UI_READY });
+    // PromptItem.jsx:288-308: the ellipsis is the row's only button.
+    await row.getByRole('button').click();
+    await page.getByRole('menuitem', { name: 'Move' }).click();
+    // MoveItem.jsx:101-106 renders a FormSearchSelectFieldState whose popover
+    // is a MUI MenuList, so each folder is a menuitem.
+    const dialog = page.getByRole('dialog');
+    await dialog.getByLabel('Select folder').click();
+    await page.getByRole('menuitem', { name: folderName }).click();
+    await dialog.getByRole('button', { name: 'Move', exact: true }).click();
+    await moved;
+  });
+
+  await test.step('storage: the prompt now points at the folder', async () => {
+    const rows = await probe.pg<{ prompt_folder_id: string | null }>(
+      'SELECT prompt_folder_id FROM model_hub_prompttemplate WHERE id = $1 AND organization_id = $2',
+      [seeded.root_template, actor.organizationId]);
+    expect(rows).toHaveLength(1);
+    expect(rows[0].prompt_folder_id).toBe(folderId);
+  });
+
+  await test.step('API: the folder-scoped list holds exactly the moved prompt', async () => {
+    // The params FolderListView.jsx:57-63 sends for a named folder — note it
+    // does NOT send send_all, so this is the folder-scoped queryset.
+    const listed = await actor.api.get<ListPage>(LIST_PATH, {
+      prompt_folder: folderId, page: 1, page_size: 50, ordering: '-updated_at',
+    });
+    expect(listed.results.map((r) => r.id)).toEqual([seeded.root_template]);
+  });
+
+  await test.step('UI: All Prompts lists the folder alongside prompts', async () => {
+    await page.goto('/dashboard/workbench/all', { waitUntil: 'domcontentloaded' });
+    // A folder row's href is the same shape the sidebar and breadcrumb use;
+    // the list testid is what separates the three.
+    const folderRow = page.locator('[data-testid="prompt-list"] > div').filter({
+      has: page.locator(`a[href="/dashboard/workbench/${folderId}"]`),
+    });
+    await expect(folderRow).toHaveCount(1, { timeout: UI_READY });
+    await expect(folderRow.getByText(folderName, { exact: true })).toHaveCount(1);
+  });
+
+  await test.step('UI: the folder view shows exactly the moved prompt', async () => {
+    await page.goto(`/dashboard/workbench/${folderId}`, { waitUntil: 'domcontentloaded' });
+    const rowLinks = page.locator('[data-testid="prompt-list"] a');
+    // Exact set, not containment: this is what proves the folder scopes the
+    // list rather than merely including the prompt somewhere.
+    await expect
+      .poll(async () => rowLinks.evaluateAll((els) => els.map((e) => e.getAttribute('href'))),
+        { timeout: UI_READY })
+      .toEqual([`/dashboard/workbench/create/${seeded.root_template}`]);
+  });
+});

--- a/e2e/flows/prompts/rename-and-delete.spec.ts
+++ b/e2e/flows/prompts/rename-and-delete.spec.ts
@@ -1,0 +1,140 @@
+import { test, expect } from '../../lib/fixtures';
+import { flowAnnotation } from '../../lib/flow-meta';
+import { ApiError } from '../../lib/api-client';
+
+// Pinned from frontend/src/utils/axios.js (endpoints.develop.runPrompt):
+//   getNameChange     -> /model-hub/prompt-templates/{id}/save-name/
+//   promptMultiDelete -> /model-hub/prompt-templates/bulk-delete/
+const CREATE_DRAFT_PATH = '/model-hub/prompt-templates/create-draft/';
+const SAVE_NAME_PATH = (id: string) => `/model-hub/prompt-templates/${id}/save-name/`;
+const BULK_DELETE_PATH = '/model-hub/prompt-templates/bulk-delete/';
+const LIST_PATH = '/model-hub/prompt-executions/';
+const UI_READY = 60_000;
+
+// frontend/src/sections/workbench/constant.js:1-29 (DefaultMessages).
+const DEFAULT_MESSAGES = [
+  { role: 'system', content: [{ type: 'text', text: '' }] },
+  { role: 'user', content: [{ type: 'text', text: '' }] },
+];
+
+interface PromptRow { id: string; name: string; type: string }
+interface ListPage { count: number; total_pages: number; results: PromptRow[] }
+interface DraftEnvelope { result: { root_template: string; name: string } }
+
+test('PROMPT-E2E-005: renaming and deleting a prompt from its row', {
+  tag: ['@flow'],
+  annotation: flowAnnotation({
+    id: 'PROMPT-E2E-005', area: 'prompts',
+    userGoal: 'A user renames a prompt from its row and deletes one they no longer want, and the list reflects both',
+    steps: ['seed two prompts',
+            'open All Prompts',
+            'rename the first from its row menu',
+            'try to give the second that same name and be refused',
+            'delete the second from its row menu',
+            'read the list'],
+    backendChecks: [
+      'save-name persists the new name on the PG row',
+      "save-name refuses a name already used by another template in the org, and the second prompt's name is unchanged",
+      'bulk-delete soft-deletes: the PG row survives with deleted=true',
+      'the list endpoint no longer returns the deleted prompt but still returns the renamed one',
+      'the list shows the renamed row and no row for the deleted prompt',
+    ],
+  }),
+}, async ({ page, actor, probe }, testInfo) => {
+  test.setTimeout(240_000);
+
+  const suffix = `${testInfo.workerIndex}-${Date.now().toString(36)}`;
+  const seedName = `e2e-prompt5-seed-${suffix}`;
+  const keeper = `e2e-prompt5-keep-${suffix}`;
+  const doomed = `e2e-prompt5-gone-${suffix}`;
+
+  const draft = async (name: string) =>
+    (await actor.api.post<DraftEnvelope>(CREATE_DRAFT_PATH, {
+      name, prompt_config: [{ messages: DEFAULT_MESSAGES }],
+    })).result;
+
+  const first = await draft(`${seedName}-a`);
+  const second = await draft(doomed);
+  await testInfo.attach('seeded', {
+    body: JSON.stringify({ first, second }), contentType: 'application/json',
+  });
+
+  const rowFor = (id: string) => page.locator('[data-testid="prompt-list"] > div').filter({
+    has: page.locator(`a[href="/dashboard/workbench/create/${id}"]`),
+  });
+
+  await test.step('UI: rename the first prompt from its row menu', async () => {
+    await page.goto('/dashboard/workbench/all', { waitUntil: 'domcontentloaded' });
+    const row = rowFor(first.root_template);
+    await expect(row).toHaveCount(1, { timeout: UI_READY });
+
+    const renamed = page.waitForResponse(
+      (r) => r.url().includes(SAVE_NAME_PATH(first.root_template)) && r.ok(),
+      { timeout: UI_READY });
+    await row.getByRole('button').click();
+    await page.getByRole('menuitem', { name: 'Rename' }).click();
+    // RenameItem.jsx:95-100 prefills the field with the current name.
+    await page.getByRole('dialog').getByLabel('Name').fill(keeper);
+    // ModalWrapper's default actionBtnTitle is "Save" (ModalWrapper.jsx:30).
+    await page.getByRole('dialog').getByRole('button', { name: 'Save' }).click();
+    await renamed;
+  });
+
+  await test.step('storage: the rename reached Postgres', async () => {
+    const rows = await probe.pg<{ name: string }>(
+      'SELECT name FROM model_hub_prompttemplate WHERE id = $1 AND organization_id = $2',
+      [first.root_template, actor.organizationId]);
+    expect(rows).toHaveLength(1);
+    expect(rows[0].name).toBe(keeper);
+  });
+
+  await test.step('API: a name already taken in the org is refused', async () => {
+    // views/prompt_template.py:3931-3942 rejects a duplicate with a 400 before
+    // touching the row; ApiClient turns any >=400 into ApiError.
+    const clash = actor.api.post(SAVE_NAME_PATH(second.root_template), { name: keeper });
+    await expect(clash).rejects.toThrow(ApiError);
+    await expect(clash).rejects.toMatchObject({ status: 400 });
+
+    const rows = await probe.pg<{ name: string }>(
+      'SELECT name FROM model_hub_prompttemplate WHERE id = $1',
+      [second.root_template]);
+    expect(rows[0].name).toBe(doomed);
+  });
+
+  await test.step('UI: delete the second prompt from its row menu', async () => {
+    await page.goto('/dashboard/workbench/all', { waitUntil: 'domcontentloaded' });
+    const row = rowFor(second.root_template);
+    await expect(row).toHaveCount(1, { timeout: UI_READY });
+
+    const deleted = page.waitForResponse(
+      (r) => r.url().includes(BULK_DELETE_PATH) && r.ok(), { timeout: UI_READY });
+    await row.getByRole('button').click();
+    await page.getByRole('menuitem', { name: 'Delete' }).click();
+    await page.getByRole('dialog').getByRole('button', { name: 'Delete' }).click();
+    await deleted;
+
+    await expect(rowFor(second.root_template)).toHaveCount(0, { timeout: UI_READY });
+    await expect(rowFor(first.root_template)).toHaveCount(1);
+    await expect(rowFor(first.root_template).getByText(keeper, { exact: true }))
+      .toHaveCount(1);
+  });
+
+  await test.step('storage: the delete is soft — the row survives, flagged', async () => {
+    const rows = await probe.pg<{ deleted: boolean; name: string }>(
+      'SELECT deleted, name FROM model_hub_prompttemplate WHERE id = $1',
+      [second.root_template]);
+    expect(rows).toHaveLength(1);
+    expect(rows[0].deleted).toBe(true);
+  });
+
+  await test.step('API: the list drops the deleted prompt and keeps the renamed one', async () => {
+    const listed = await actor.api.get<ListPage>(LIST_PATH, {
+      send_all: 'true', page: 1, page_size: 200,
+      sort_by: 'updated_at', sort_order: 'desc',
+    });
+    const ids = listed.results.map((r) => r.id);
+    expect(ids).toContain(first.root_template);
+    expect(ids).not.toContain(second.root_template);
+    expect(listed.results.find((r) => r.id === first.root_template)?.name).toBe(keeper);
+  });
+});

--- a/e2e/flows/prompts/rename-and-delete.spec.ts
+++ b/e2e/flows/prompts/rename-and-delete.spec.ts
@@ -1,6 +1,5 @@
 import { test, expect } from '../../lib/fixtures';
 import { flowAnnotation } from '../../lib/flow-meta';
-import { ApiError } from '../../lib/api-client';
 
 // Pinned from frontend/src/utils/axios.js (endpoints.develop.runPrompt):
 //   getNameChange     -> /model-hub/prompt-templates/{id}/save-name/
@@ -29,12 +28,12 @@ test('PROMPT-E2E-005: renaming and deleting a prompt from its row', {
     steps: ['seed two prompts',
             'open All Prompts',
             'rename the first from its row menu',
-            'try to give the second that same name and be refused',
+            'rename the second to that same name in the dialog and read the refusal',
             'delete the second from its row menu',
             'read the list'],
     backendChecks: [
       'save-name persists the new name on the PG row',
-      "save-name refuses a name already used by another template in the org, and the second prompt's name is unchanged",
+      "renaming to a name already used in the org is refused with a 400, the dialog surfaces the error and stays open, and the second prompt's name is unchanged in PG",
       'bulk-delete soft-deletes: the PG row survives with deleted=true',
       'the list endpoint no longer returns the deleted prompt but still returns the renamed one',
       'the list shows the renamed row and no row for the deleted prompt',
@@ -88,12 +87,29 @@ test('PROMPT-E2E-005: renaming and deleting a prompt from its row', {
     expect(rows[0].name).toBe(keeper);
   });
 
-  await test.step('API: a name already taken in the org is refused', async () => {
-    // views/prompt_template.py:3931-3942 rejects a duplicate with a 400 before
-    // touching the row; ApiClient turns any >=400 into ApiError.
-    const clash = actor.api.post(SAVE_NAME_PATH(second.root_template), { name: keeper });
-    await expect(clash).rejects.toThrow(ApiError);
-    await expect(clash).rejects.toMatchObject({ status: 400 });
+  await test.step('UI: renaming the second to the taken name is refused in the dialog', async () => {
+    const row = rowFor(second.root_template);
+    await expect(row).toHaveCount(1, { timeout: UI_READY });
+
+    // views/prompt_template.py:3931-3942 rejects the duplicate with a 400
+    // before touching the row.
+    const refused = page.waitForResponse(
+      (r) => r.url().includes(SAVE_NAME_PATH(second.root_template)) && r.status() === 400,
+      { timeout: UI_READY });
+    await row.getByRole('button').click();
+    await page.getByRole('menuitem', { name: 'Rename' }).click();
+    await page.getByRole('dialog').getByLabel('Name').fill(keeper);
+    await page.getByRole('dialog').getByRole('button', { name: 'Save' }).click();
+    await refused;
+
+    // App.jsx:75-94 (MutationCache onError) surfaces the backend message as an
+    // error snackbar; the text is error_codes.py TEMPLATE_ALREADY_EXIST.
+    await expect(page.getByText('A template with this name already exists.'))
+      .toBeVisible({ timeout: UI_READY });
+    // RenameItem.jsx closes the dialog only onSuccess, so the refusal leaves it
+    // open with the rejected name still in the field.
+    await expect(page.getByRole('dialog').getByLabel('Name')).toHaveValue(keeper);
+    await page.keyboard.press('Escape');
 
     const rows = await probe.pg<{ name: string }>(
       'SELECT name FROM model_hub_prompttemplate WHERE id = $1',

--- a/e2e/flows/prompts/search.spec.ts
+++ b/e2e/flows/prompts/search.spec.ts
@@ -1,0 +1,124 @@
+import { test, expect } from '../../lib/fixtures';
+import { flowAnnotation } from '../../lib/flow-meta';
+
+// Pinned from frontend/src/utils/axios.js (endpoints.develop.runPrompt).
+const CREATE_DRAFT_PATH = '/model-hub/prompt-templates/create-draft/';
+const FOLDERS_PATH = '/model-hub/prompt-folders/';
+const LIST_PATH = '/model-hub/prompt-executions/';
+const UI_READY = 60_000;
+
+// frontend/src/sections/workbench/constant.js:1-29 (DefaultMessages).
+const DEFAULT_MESSAGES = [
+  { role: 'system', content: [{ type: 'text', text: '' }] },
+  { role: 'user', content: [{ type: 'text', text: '' }] },
+];
+
+interface PromptRow {
+  id: string; name: string; type: string;
+  prompt_folder: string | null; prompt_folder_name: string | null;
+}
+interface ListPage { count: number; total_pages: number; results: PromptRow[] }
+interface DraftEnvelope { result: { root_template: string; name: string } }
+interface FolderEnvelope { result: { id: string; name: string } }
+
+test('PROMPT-E2E-003: search from All Prompts finds a prompt inside a folder', {
+  tag: ['@flow'],
+  annotation: flowAnnotation({
+    id: 'PROMPT-E2E-003', area: 'prompts',
+    userGoal: 'A user searching from All Prompts finds a prompt even though it lives inside a folder, and sees which folder that is',
+    steps: ['seed a folder, a prompt inside it and a loose prompt sharing one minted token',
+            'seed a decoy prompt that does not carry the token',
+            'open All Prompts',
+            'type the token into the search field',
+            'read the rows once the debounce settles'],
+    backendChecks: [
+      'the list endpoint with name=<token> returns both prompts and the folder, and not the decoy',
+      'the in-folder prompt is returned from All Prompts without prompt_folder being sent — search is not folder-scoped',
+      'the rendered row set equals exactly the three seeded items',
+      'the sort and breadcrumb bar is hidden while a search is active',
+      'the in-folder prompt row names the folder it lives in',
+    ],
+  }),
+}, async ({ page, actor }, testInfo) => {
+  test.setTimeout(240_000);
+
+  const suffix = `${testInfo.workerIndex}-${Date.now().toString(36)}`;
+  const token = `e2e-prompt3-${suffix}`;
+  const folderName = `${token}-folder`;
+  const insideName = `${token}-inside`;
+  const looseName = `${token}-loose`;
+  // Deliberately does not contain `token`, so it must never be returned.
+  const decoyName = `e2e-prompt3-decoy-${suffix}`;
+
+  const folder = (await actor.api.post<FolderEnvelope>(FOLDERS_PATH, { name: folderName })).result;
+  const draft = async (name: string, promptFolder?: string) =>
+    (await actor.api.post<DraftEnvelope>(CREATE_DRAFT_PATH, {
+      name, prompt_config: [{ messages: DEFAULT_MESSAGES }],
+      ...(promptFolder ? { prompt_folder: promptFolder } : {}),
+    })).result;
+
+  const inside = await draft(insideName, folder.id);
+  const loose = await draft(looseName);
+  const decoy = await draft(decoyName);
+
+  await testInfo.attach('seeded', {
+    body: JSON.stringify({ folder, inside, loose, decoy, token }),
+    contentType: 'application/json',
+  });
+
+  await test.step('API: the token matches both prompts and the folder, and not the decoy', async () => {
+    const listed = await actor.api.get<ListPage>(LIST_PATH, {
+      send_all: 'true', page: 1, page_size: 50, name: token,
+      sort_by: 'updated_at', sort_order: 'desc',
+    });
+    expect([...listed.results.map((r) => r.id)].sort())
+      .toEqual([folder.id, inside.root_template, loose.root_template].sort());
+    expect(listed.results.map((r) => r.id)).not.toContain(decoy.root_template);
+
+    // No prompt_folder param was sent, yet the in-folder prompt came back:
+    // the search crosses folders rather than being scoped to All Prompts.
+    const insideRow = listed.results.find((r) => r.id === inside.root_template);
+    expect(insideRow?.prompt_folder).toBe(folder.id);
+    expect(insideRow?.prompt_folder_name).toBe(folderName);
+  });
+
+  await test.step('UI: searching the token narrows the list to exactly the three seeded items', async () => {
+    await page.goto('/dashboard/workbench/all', { waitUntil: 'domcontentloaded' });
+    const searched = page.waitForResponse(
+      (r) => r.url().includes(LIST_PATH) && r.url().includes(token) && r.ok(),
+      { timeout: UI_READY });
+    // FolderView.jsx:89-94 — placeholder is "Search in prompts" off /all.
+    await page.getByPlaceholder('Search in prompts').fill(token);
+    await searched;
+
+    const rowLinks = page.locator('[data-testid="prompt-list"] a');
+    // Exact set: containment would pass with the decoy leaking in.
+    await expect
+      .poll(async () => (await rowLinks.evaluateAll(
+        (els) => els.map((e) => e.getAttribute('href')))).sort(), { timeout: UI_READY })
+      .toEqual([
+        `/dashboard/workbench/${folder.id}`,
+        `/dashboard/workbench/create/${inside.root_template}`,
+        `/dashboard/workbench/create/${loose.root_template}`,
+      ].sort());
+  });
+
+  await test.step('UI: the sort bar gives way to per-row locations while searching', async () => {
+    // FolderView.jsx:141 drops the ActionBar entirely once a search is active.
+    await expect(page.getByRole('button', { name: 'Sort' })).toHaveCount(0, { timeout: UI_READY });
+
+    const insideRow = page.locator('[data-testid="prompt-list"] > div').filter({
+      has: page.locator(`a[href="/dashboard/workbench/create/${inside.root_template}"]`),
+    });
+    // PromptItem.jsx:157-180 renders "All Prompts › <folder>" per result row.
+    await expect(insideRow.getByText('All Prompts', { exact: true })).toHaveCount(1);
+    await expect(insideRow.getByText(folderName, { exact: true })).toHaveCount(1);
+
+    // The loose prompt has no folder, so it gets the root crumb and nothing more.
+    const looseRow = page.locator('[data-testid="prompt-list"] > div').filter({
+      has: page.locator(`a[href="/dashboard/workbench/create/${loose.root_template}"]`),
+    });
+    await expect(looseRow.getByText('All Prompts', { exact: true })).toHaveCount(1);
+    await expect(looseRow.getByText(folderName, { exact: true })).toHaveCount(0);
+  });
+});

--- a/e2e/flows/prompts/sort-and-paging.spec.ts
+++ b/e2e/flows/prompts/sort-and-paging.spec.ts
@@ -1,0 +1,188 @@
+import { test, expect } from '../../lib/fixtures';
+import { flowAnnotation } from '../../lib/flow-meta';
+
+// Pinned from frontend/src/utils/axios.js (endpoints.develop.runPrompt).
+const CREATE_DRAFT_PATH = '/model-hub/prompt-templates/create-draft/';
+const FOLDERS_PATH = '/model-hub/prompt-folders/';
+const LIST_PATH = '/model-hub/prompt-executions/';
+const UI_READY = 60_000;
+// FolderListView.jsx:31 — the list opens at 10 per page, and the Result-per-page
+// select offers 10/20/30/40/50 (lines 277-281).
+const DEFAULT_PAGE_SIZE = 10;
+const WIDE_PAGE_SIZE = 50;
+// Enough seeded prompts that a second page exists whatever else the shared
+// worker org already holds.
+const SEEDED = 11;
+
+// frontend/src/sections/workbench/constant.js:1-29 (DefaultMessages).
+const DEFAULT_MESSAGES = [
+  { role: 'system', content: [{ type: 'text', text: '' }] },
+  { role: 'user', content: [{ type: 'text', text: '' }] },
+];
+
+interface PromptRow { id: string; name: string; type: string }
+interface ListPage { count: number; total_pages: number; results: PromptRow[] }
+interface DraftEnvelope { result: { root_template: string; name: string } }
+interface FolderEnvelope { result: { id: string; name: string } }
+
+test('PROMPT-E2E-004: sorting and paging the prompt list keeps it complete', {
+  tag: ['@flow'],
+  annotation: flowAnnotation({
+    id: 'PROMPT-E2E-004', area: 'prompts',
+    userGoal: 'A user sorting and paging the prompt list gets a stable ordering with no row lost or repeated',
+    steps: ['seed a folder and eleven prompts whose names sort unambiguously',
+            'open All Prompts',
+            'widen the page size and sort by Name descending',
+            'toggle the same sort to ascending',
+            'return to ten per page and step from page 1 to page 2'],
+    backendChecks: [
+      'the list endpoint returns the seeded prompts in the requested sort_by/sort_order, both directions',
+      "the UI's rendered order of the seeded prompts matches the API's for the same query",
+      'paging the same query never repeats a row and covers every seeded prompt',
+      'the "No.of prompts" count is the prompt count and excludes the folder rows the same response carries',
+    ],
+  }),
+}, async ({ page, actor }, testInfo) => {
+  test.setTimeout(300_000);
+
+  const suffix = `${testInfo.workerIndex}-${Date.now().toString(36)}`;
+  const token = `e2e-prompt4-${suffix}`;
+  // Zero-padded so the backend's case-insensitive string sort
+  // (views/prompt_template.py:4262-4268) orders them unambiguously.
+  const names = Array.from({ length: SEEDED }, (_, i) =>
+    `${token}-${String(i + 1).padStart(2, '0')}`);
+
+  const folder = (await actor.api.post<FolderEnvelope>(FOLDERS_PATH, {
+    name: `${token}-folder`,
+  })).result;
+  const seeded: { name: string; id: string }[] = [];
+  for (const name of names) {
+    const r = (await actor.api.post<DraftEnvelope>(CREATE_DRAFT_PATH, {
+      name, prompt_config: [{ messages: DEFAULT_MESSAGES }],
+    })).result;
+    seeded.push({ name, id: r.root_template });
+  }
+  await testInfo.attach('seeded', {
+    body: JSON.stringify({ folder, seeded }), contentType: 'application/json',
+  });
+
+  const ascHrefs = seeded.map((s) => `/dashboard/workbench/create/${s.id}`);
+  const descHrefs = [...ascHrefs].reverse();
+  const mine = new Set(ascHrefs);
+
+  // The rendered hrefs, narrowed to the rows this spec seeded — the worker org
+  // is shared, so absolute position means nothing and only relative order does.
+  const renderedOrder = async () =>
+    (await page.locator('[data-testid="prompt-list"] a')
+      .evaluateAll((els) => els.map((e) => e.getAttribute('href') ?? '')))
+      .filter((h) => mine.has(h));
+
+  const listPage = (params: Record<string, string | number>) =>
+    actor.api.get<ListPage>(LIST_PATH, {
+      send_all: 'true', sort_by: 'name', ...params,
+    });
+
+  await test.step('API: the endpoint honours both sort directions', async () => {
+    const desc = await listPage({ page: 1, page_size: 200, sort_order: 'desc' });
+    const asc = await listPage({ page: 1, page_size: 200, sort_order: 'asc' });
+    const onlyMine = (p: ListPage) =>
+      p.results.filter((r) => mine.has(`/dashboard/workbench/create/${r.id}`)).map((r) => r.name);
+    expect(onlyMine(desc)).toEqual([...names].reverse());
+    expect(onlyMine(asc)).toEqual(names);
+  });
+
+  await test.step('UI: the rendered order follows the chosen sort, both ways', async () => {
+    await page.goto('/dashboard/workbench/all', { waitUntil: 'domcontentloaded' });
+    await expect(page.getByRole('button', { name: 'Sort' })).toBeVisible({ timeout: UI_READY });
+
+    // Widen the page so all eleven seeded rows are on the page being read.
+    const widened = page.waitForResponse(
+      (r) => r.url().includes(LIST_PATH) && r.url().includes(`page_size=${WIDE_PAGE_SIZE}`) && r.ok(),
+      { timeout: UI_READY });
+    await page.locator('#page-size-select').click();
+    await page.getByRole('option', { name: String(WIDE_PAGE_SIZE), exact: true }).click();
+    await widened;
+
+    // ActionBar.jsx:57-68: the first pick of a new field lands on desc, and a
+    // second pick of the same field toggles to asc. The menu stays open in
+    // between (its auto-close is commented out), so both clicks are one visit.
+    const sortedDesc = page.waitForResponse(
+      (r) => r.url().includes(LIST_PATH) && r.url().includes('sort_by=name')
+        && r.url().includes('sort_order=desc') && r.ok(), { timeout: UI_READY });
+    await page.getByRole('button', { name: 'Sort' }).click();
+    await page.getByRole('menuitem', { name: 'Name' }).click();
+    await sortedDesc;
+
+    // The menu overlays the list but does not detach it, and renderedOrder
+    // reads hrefs out of the DOM, so both directions are read from one visit.
+    await expect.poll(renderedOrder, { timeout: UI_READY }).toEqual(descHrefs);
+
+    const sortedAsc = page.waitForResponse(
+      (r) => r.url().includes(LIST_PATH) && r.url().includes('sort_by=name')
+        && r.url().includes('sort_order=asc') && r.ok(), { timeout: UI_READY });
+    await page.getByRole('menuitem', { name: 'Name' }).click();
+    await sortedAsc;
+    await expect.poll(renderedOrder, { timeout: UI_READY }).toEqual(ascHrefs);
+
+    await page.keyboard.press('Escape');
+    // The menu's closing backdrop would otherwise swallow the next click.
+    await expect(page.getByRole('menuitem', { name: 'Name' }))
+      .toHaveCount(0, { timeout: UI_READY });
+  });
+
+  await test.step('UI: page 1 and page 2 are disjoint', async () => {
+    const narrowed = page.waitForResponse(
+      (r) => r.url().includes(LIST_PATH) && r.url().includes(`page_size=${DEFAULT_PAGE_SIZE}`) && r.ok(),
+      { timeout: UI_READY });
+    await page.locator('#page-size-select').click();
+    await page.getByRole('option', { name: String(DEFAULT_PAGE_SIZE), exact: true }).click();
+    await narrowed;
+
+    const allHrefs = () => page.locator('[data-testid="prompt-list"] a')
+      .evaluateAll((els) => els.map((e) => e.getAttribute('href') ?? ''));
+    await expect.poll(async () => (await allHrefs()).length, { timeout: UI_READY })
+      .toBe(DEFAULT_PAGE_SIZE);
+    const first = await allHrefs();
+
+    const paged = page.waitForResponse(
+      (r) => r.url().includes(LIST_PATH) && r.url().includes('page=2') && r.ok(),
+      { timeout: UI_READY });
+    await page.getByRole('button', { name: 'Go to page 2' }).click();
+    await paged;
+    await expect.poll(async () => (await allHrefs()).some((h) => h !== '' && !first.includes(h)),
+      { timeout: UI_READY }).toBe(true);
+    const second = await allHrefs();
+    expect(second.filter((h) => first.includes(h))).toEqual([]);
+  });
+
+  await test.step('API: paging covers every seeded prompt exactly once', async () => {
+    const seen: string[] = [];
+    let folderRows = 0;
+    let promptRows = 0;
+    const firstPage = await listPage({ page: 1, page_size: DEFAULT_PAGE_SIZE, sort_order: 'asc' });
+    for (let p = 1; p <= firstPage.total_pages; p += 1) {
+      const body = p === 1
+        ? firstPage
+        : await listPage({ page: p, page_size: DEFAULT_PAGE_SIZE, sort_order: 'asc' });
+      for (const row of body.results) {
+        seen.push(row.id);
+        if (row.type === 'FOLDER') folderRows += 1;
+        if (row.type === 'PROMPT') promptRows += 1;
+      }
+    }
+    // No row repeated across pages, and every seeded prompt turned up.
+    expect(new Set(seen).size).toBe(seen.length);
+    for (const s of seeded) expect(seen).toContain(s.id);
+    expect(seen).toContain(folder.id);
+
+    // The count the "No.of prompts" line renders is the prompt count, even
+    // though the same pages carry folder rows too
+    // (views/prompt_template.py:4166-4175).
+    expect(folderRows).toBeGreaterThan(0);
+    expect(firstPage.count).toBe(promptRows);
+    // FolderListView.jsx:184 renders it with no space after "No.of".
+    await page.goto('/dashboard/workbench/all', { waitUntil: 'domcontentloaded' });
+    await expect(page.getByText(`No.of prompts: ${firstPage.count}`))
+      .toBeVisible({ timeout: UI_READY });
+  });
+});

--- a/frontend/src/sections/workbench-v2/components/FolderListView.jsx
+++ b/frontend/src/sections/workbench-v2/components/FolderListView.jsx
@@ -199,6 +199,7 @@ export default function FolderListView({ sortConfig }) {
       >
         {/* Scrollable content */}
         <Stack
+          data-testid="prompt-list"
           direction="column"
           sx={{
             flex: 1,

--- a/frontend/src/sections/workbench-v2/components/PromptItem.jsx
+++ b/frontend/src/sections/workbench-v2/components/PromptItem.jsx
@@ -163,7 +163,7 @@ export default function PromptItem({
           >
             All Prompts
           </Typography>
-          <ShowComponent condition={extraData?.prompt_folderName}>
+          <ShowComponent condition={extraData?.prompt_folder_name}>
             <SvgColor
               sx={{ height: 16, width: 16, color: "text.primary" }}
               src="/assets/icons/custom/lucide--chevron-right.svg"
@@ -173,7 +173,7 @@ export default function PromptItem({
               fontWeight={"fontWeightMedium"}
               color={"text.primary"}
             >
-              {extraData?.prompt_folderName}
+              {extraData?.prompt_folder_name}
             </Typography>
           </ShowComponent>
         </Stack>


### PR DESCRIPTION
Five end-to-end flows over the prompt workbench page at `/dashboard/workbench/all` — the first flows in the `prompts` area — plus the two frontend changes they depend on.

`E2E: new PROMPT-E2E-001, PROMPT-E2E-002, PROMPT-E2E-003, PROMPT-E2E-004, PROMPT-E2E-005`

## Status at a glance

**All five flows pass and all 23 backend checks are proven able to fail.**

| id | Flow | Passes | Checks proven able to fail |
| --- | --- | --- | --- |
| PROMPT-E2E-001 | create a prompt | ✅ 2.1s | ✅ 4 / 4 |
| PROMPT-E2E-002 | file a prompt into a folder | ✅ 4.4s | ✅ 5 / 5 |
| PROMPT-E2E-003 | search across folders | ✅ 1.5s | ✅ 5 / 5 |
| PROMPT-E2E-004 | sort and page the list | ✅ 4.9s | ✅ 4 / 4 |
| PROMPT-E2E-005 | rename and delete a row | ✅ 2.3s | ✅ 5 / 5 |

Green together at the default parallelism too: `5 passed (13.1s)`. `yarn typecheck` clean, `yarn catalog:check` reports `FLOWS.md is current`, and the harness self-tests were green against the same stack immediately before the run (`5 passed`), so a failure would have been the flow's and not the stack's.

## What each flow claims

| id | Goal |
| --- | --- |
| PROMPT-E2E-001 | A user creates a new prompt from the workbench and finds it in the All Prompts list |
| PROMPT-E2E-002 | A user files a prompt into a folder they created, and the folder shows that prompt rather than the whole library |
| PROMPT-E2E-003 | A user searching from All Prompts finds a prompt even though it lives inside a folder, and sees which folder that is |
| PROMPT-E2E-004 | A user sorting and paging the prompt list gets a stable ordering with no row lost or repeated |
| PROMPT-E2E-005 | A user renames a prompt from its row and deletes one they no longer want, and the list reflects both |

## How the checks were proven

Each of the 23 was perturbed on the input side and the failure read, so none of them is decoration. The informative ones:

- `4.4` — the "No.of prompts" count is the prompt count and excludes the folder rows the same response carries. Asserting `promptRows + folderRows` failed `Expected: 12, Received: 11`.
- `4.3` — paging never repeats a row. Making every page fetch page 1 failed `Expected: 20, Received: 10`.
- `2.2` — Move sets `prompt_folder_id`. Failed quoting the real stored uuid against a one-character mutation.
- `3.5` — the in-folder row names its folder, the assertion the `PromptItem.jsx` fix below enables. A wrong folder name fails with `toHaveCount received 0`.
- `2.5` and `3.3` — the exact-set assertions. Adding one expected href fails, which is what proves the list was scoped rather than merely containing the right row.
- `5.1` — the rename reaches Postgres. Filling the dialog with `<name>-BROKEN` while the probe still expects `<name>` fails `Expected: "e2e-prompt5-keep-…" Received: "e2e-prompt5-keep-…-BROKEN"` — the probe reads the stored row, not the dialog.
- `5.2` — a taken name is refused, now driven through the Rename dialog itself: type the taken name, Save, and assert the error snackbar ("A template with this name already exists."), the dialog left open with the rejected name, and the unchanged PG row. Filling a free name instead fails `TimeoutError: page.waitForResponse: Timeout 60000ms exceeded` waiting for the 400 — the exact red this flow shows if the duplicate guard breaks.
- `5.3` — the delete is soft. Pointing the probe at the kept row's id fails `Expected: true, Received: false` on `deleted` — the flag is read from the real row.
- `5.4` — the list scopes out the deleted prompt. Asserting `not.toContain` on the kept id fails quoting the received array `["265b79cf-…"]`, which also shows the deleted id genuinely absent from the same response.
- `5.5` — the row renders the new name. Anchoring the text assertion on the pre-rename name fails `toHaveCount Expected: 1, Received: 0` while the row locator itself still matches — the name cell, not the row, is what's asserted.

## Two frontend changes ship with them

**`PromptItem.jsx` — a user-facing fix, not a test hook.** The component read `extraData?.prompt_folderName`; `PromptExecutionSerializer` emits `prompt_folder_name` (`futureagi/model_hub/serializers/prompt_template.py:260`). The `ShowComponent` guard therefore never opened, so searching from All Prompts showed a prompt that lives inside a folder with a greyed-out "All Prompts" crumb and no folder name after it. PROMPT-E2E-003 covers it.

**`FolderListView.jsx` — `data-testid="prompt-list"`.** A folder row in the list links to `/dashboard/workbench/<id>`, the same href shape the sidebar tree and the breadcrumb use, and no role, label or text separates the three. Without a scope there is no way to assert "the list holds exactly these rows", which is the assertion that fails when the prompts-and-folders merge breaks.

## What is pending

- **PROMPT-E2E-005's five proofs ran attached to the dev stack, not the e2e one.** By proof time the dev backend had reclaimed port 8100, so the perturbation runs used the branch-built nginx frontend on `:3101` against the dev backend and dev Postgres (`E2E_PG_URL` overridden). Fallibility of the assertions is environment-independent; the green verdicts in the table above are from the e2e-stack runs.

- **Not a standard `bin/e2e up` managed run.** Building the frontend into the stack OOM-killed the backend (Colima has 10 GiB; the dev stack, the e2e stack and a Vite production build do not fit together). The flows ran against a frontend container built from this branch on `:3101`, attached to the managed stack's API, Postgres and ClickHouse — so the real nginx artifact and the runtime `window.__FUTURE_AGI_CONFIG__` injection were exercised, but not by `bin/e2e up` itself. CI builds the frontend from source, so both frontend changes are exercised there.
- **Rebase onto current `dev`.** The branch was cut at `63f51e965`; `dev` has since moved to `f97a6d1b1` (TH-7797).

## Review findings still open

From a review of this branch, carried here rather than silently fixed:

- `create-prompt.spec.ts:34` — the annotation promises "the next free number in the org" but the spec only asserts `/^Untitled-\d+$/`. `FLOWS.md` is the public contract, so either assert the number or drop the clause.
- ~~`rename-and-delete.spec.ts:32` — "try to give the second that same name and be refused" is listed as a user step but is performed with `actor.api.post`, not through the Rename dialog.~~ **Resolved:** the refusal is now driven through the Rename dialog and asserts the user-visible outcome (error snackbar, dialog stays open, row unchanged).
- `sort-and-paging.spec.ts:106-123` — clicking "Name" twice in one menu visit works only because ActionBar's auto-close timer is commented out (`ActionBar.jsx:71-79`). Whoever uncomments that dead block breaks this flow.
- `sort-and-paging.spec.ts:118,125` — the exact-order assertion needs all 11 seeded rows on one page and 50 is the largest page size the UI offers. The worker org is shared and never cleaned, so a sixth prompts spec would push it past 50 and fail for a reason unrelated to sorting.
- `PromptItem.jsx:288` — an adjacent bug of the same class as the one fixed here: the row menu is gated on `extraData?.isSample`, but the serializer emits `is_sample`, so sample prompts get a live Rename/Move/Delete menu. Out of scope for this PR; worth its own ticket.


