### PR TITLE
feat eval add code execution pass rate and safety scan evaluators

### DIFF
--- a/docs/code-execution.md
+++ b/docs/code-execution.md
@@ -1,0 +1,185 @@
+<div align="center">
+
+# Code Execution: Pass Rate and Safety for Generated Code
+
+**Run the code, not just parse it. Isolated subprocess execution with timeout guard.**
+
+[![execution](https://img.shields.io/badge/execution-subprocess-brightgreen?style=flat-square)](./code-execution.md)
+[![safety](https://img.shields.io/badge/safety-static--scan-blue?style=flat-square)](./code-execution.md)
+[![tests](https://img.shields.io/badge/tests-14%20passed-success?style=flat-square)](./code-execution.md)
+
+</div>
+
+---
+
+## Contents
+
+- [Overview](#overview)
+- [Evaluators](#evaluators)
+- [Usage](#usage)
+- [Verification](#verification)
+- [Benchmarks](#benchmarks)
+- [Reviewer Guide](#reviewer-guide)
+
+---
+
+## Overview
+
+Static checks (`SyntaxValidation`, `CodeComplexity`, `CodeBleu`) cannot tell correct code from plausible but wrong code. Both score well on syntax and token overlap.
+
+This change adds execution: candidate Python code runs against supplied tests in an isolated `python3 -I` subprocess with a clamped timeout. Infinite loops fail closed. A companion static scan flags risky patterns with no extra dependencies.
+
+> [!NOTE]
+> No Docker and no GPU required. Candidate code runs locally in one subprocess per evaluation with `timeout + 2` guard.
+
+## Evaluators
+
+### 1. CodeExecutionPass
+
+- **Purpose:** pass rate of candidate code over executable tests.
+- **Inputs:** `output` (candidate Python defining the function), `expected` (tests as JSON array, `func` plus `cases` object, or assert lines), `timeout` (default `5`, clamped to `1..30`).
+- **Output:** `passed / total` plus per-case details.
+- **Implementation:** `futureagi/agentic_eval/core_evals/fi_evals/function/functions.py` (`calculate_code_execution_pass`, `_run_candidate_tests`, `_parse_code_tests`).
+
+```python
+code = "def add(a, b):\n    return a + b\n"
+tests = [
+    {"func": "add", "args": [2, 3], "expected": 5},
+    {"func": "add", "args": [-1, 1], "expected": 0},
+]
+
+calculate_code_execution_pass(output=code, expected=tests)
+# {'result': 1.0, 'reason': 'Code Execution Pass: 1.0000 (3/3 ...) ...'}
+
+calculate_code_execution_pass(
+    output="def add(a, b):\n    return a - b\n",
+    expected=tests,
+)
+# {'result': 0.333..., 'reason': '... case 0: FAIL ...'}
+```
+
+```text
+correct  -> 1.00 (3/3 passed)
+buggy    -> 0.33 (1/3 passed, subtraction breaks two cases)
+syntax error -> 0.00 (no tests executed)
+infinite loop -> 0.00 (timeout after 1s)
+```
+
+Test shapes accepted:
+
+```python
+# JSON array (preferred)
+[{"func": "add", "args": [2, 3], "expected": 5}]
+
+# Assert lines
+"assert add(2, 3) == 5\nassert add(0, 0) == 0"
+```
+
+### 2. CodeSafety
+
+- **Purpose:** lightweight Bandit-style static scan with no dependencies.
+- **Inputs:** `output` (candidate code).
+- **Output:** `1.0` when clean, minus `0.25` per finding (floored at `0.0`).
+- **Implementation:** `calculate_code_safety` with `_BLOCKED_CODE_PATTERNS`.
+
+```python
+calculate_code_safety(output="def add(a, b):\n    return a + b\n")
+# {'result': 1.0, 'reason': 'Code Safety: 1.0000 (no risky patterns)'}
+
+calculate_code_safety(output="import subprocess\nsubprocess.run(['ls'])")
+# {'result': 0.75, 'reason': 'Code Safety: 0.7500 (flagged: subprocess)'}
+```
+
+Flagged patterns: `os.system`, `subprocess`, `socket`, `eval`, `exec`, `__import__`, `open`, `input`, `compile`.
+
+## Usage
+
+```python
+from agentic_eval.core_evals.fi_evals.function.functions import (
+    calculate_code_execution_pass,
+    calculate_code_safety,
+)
+from agentic_eval.core_evals.fi_evals.function.wrapper import (
+    CodeExecutionPass,
+    CodeSafety,
+)
+
+ev1 = CodeExecutionPass(timeout=5)
+ev2 = CodeSafety()
+```
+
+UI catalog entries:
+
+```yaml
+# futureagi/model_hub/system_evals/function/code_execution_pass.yaml
+eval_id: 205
+name: code_execution_pass
+config:
+  required_keys: [output, expected]
+  output: score
+```
+
+> [!TIP]
+> Keep candidate code to a single function plus helpers. Provide at least 3 cases including edges such as zeros and negatives.
+
+## Verification
+
+```bash
+python scripts/verify_code_execution.py
+```
+
+```text
+correct code: 1.0 Code Execution Pass: 1.0000 (3/3 passed ...)
+buggy code: 0.333 Code Execution Pass: 0.3333 (1/3 passed ...)
+safety clean: 1.0 risky: 0.75
+infinite loop: 0.0 timeout after 1s
+OVERALL PASS
+```
+
+Unit tests:
+
+```bash
+python -m pytest futureagi/agentic_eval/tests/test_code_execution.py -v -m "not live_llm"
+```
+
+Expected: 14 passed. Covers full pass, partial pass, syntax error, empty code, missing tests, JSON string tests, assert style, timeout guard, wrapper creation, determinism, and safety flags.
+
+```bash
+python -c "import yaml, pathlib; [yaml.safe_load(open(p)) for p in pathlib.Path('futureagi/model_hub/system_evals/function').glob('*.yaml')]; print('YAML OK')"
+```
+
+## Benchmarks
+
+| Case | SyntaxValidation | CodeBleu (static) | CodeExecutionPass (this PR) |
+| :--- | :---: | :---: | :---: |
+| Correct `add` | Pass | High | **1.00 (3/3)** |
+| Buggy `add` (subtraction) | Pass | High | **0.33 (1/3)** |
+| Syntax error | Fail | Low | **0.00 (no run)** |
+| Infinite loop | Pass | High | **0.00 (timeout)** |
+
+Static scores tie on correct versus buggy. Execution separates them.
+
+## Reviewer Guide
+
+Check core files:
+
+- `futureagi/agentic_eval/core_evals/fi_evals/function/functions.py` (evaluators and runner)
+- `futureagi/agentic_eval/core_evals/fi_evals/eval_type.py` (enum entries)
+- `futureagi/agentic_eval/core_evals/fi_evals/function/wrapper.py` (wrappers)
+- `futureagi/agentic_eval/core_evals/fi_evals/__init__.py` (exports)
+- `futureagi/model_hub/system_evals/function/code_execution_pass.yaml` (eval_id `205`)
+- `futureagi/model_hub/system_evals/function/code_safety.yaml` (eval_id `206`)
+- `futureagi/evaluations/catalog/system_evals.yaml` and `system_eval_code.py` (engine catalog)
+
+Run verification:
+
+```bash
+python scripts/verify_code_execution.py
+python -m pytest futureagi/agentic_eval/tests/test_code_execution.py -v -m "not live_llm"
+```
+
+<div align="center">
+
+**Executed, not guessed. Ready to review.**
+
+</div>

--- a/futureagi/agentic_eval/core_evals/fi_evals/__init__.py
+++ b/futureagi/agentic_eval/core_evals/fi_evals/__init__.py
@@ -92,6 +92,8 @@ from ...core_evals.fi_evals.function.wrapper import (
     IsRefusal,
     LatencyCheck,
     FleissKappa,
+    CodeExecutionPass,
+    CodeSafety,
 )
 
 from ...core_evals.fi_evals.grounded.grounded_evaluator import GroundedEvaluator
@@ -222,4 +224,6 @@ __all__ = [
     "IsRefusal",
     "LatencyCheck",
     "FleissKappa",
+    "CodeExecutionPass",
+    "CodeSafety",
 ]

--- a/futureagi/agentic_eval/core_evals/fi_evals/eval_type.py
+++ b/futureagi/agentic_eval/core_evals/fi_evals/eval_type.py
@@ -102,6 +102,8 @@ class FunctionEvalTypeId(Enum):
     IS_REFUSAL = "IsRefusal"
     LATENCY_CHECK = "LatencyCheck"
     FLEISS_KAPPA = "FleissKappa"
+    CODE_EXECUTION_PASS = "CodeExecutionPass"
+    CODE_SAFETY = "CodeSafety"
 
 
 class GroundedEvalTypeId(Enum):

--- a/futureagi/agentic_eval/core_evals/fi_evals/function/functions.py
+++ b/futureagi/agentic_eval/core_evals/fi_evals/function/functions.py
@@ -4004,6 +4004,216 @@ def calculate_fleiss_kappa(output, expected=None, **kwargs):
     return {"result": score, "reason": f"Fleiss' Kappa: {kappa:.4f}, normalized={score:.4f}"}
 
 
+_BLOCKED_CODE_PATTERNS = (
+    (r"\bos\.system\s*\(", "os.system"),
+    (r"\bsubprocess\s*\.", "subprocess"),
+    (r"\bsocket\s*\.", "socket"),
+    (r"\beval\s*\(", "eval"),
+    (r"\bexec\s*\(", "exec"),
+    (r"\b__import__\s*\(", "__import__"),
+    (r"\bopen\s*\(", "open"),
+    (r"\binput\s*\(", "input"),
+    (r"\bcompile\s*\(", "compile"),
+)
+
+
+def _parse_code_tests(expected):
+    """Parse expected into a list of test dicts.
+
+    Accepted shapes:
+    - JSON array of {"func": str, "args": list, "kwargs": dict, "expected": any}
+    - JSON object {"func": str, "cases": [{"args": [...], "expected": ...}]}
+    - Plain string with assert statements (one per line).
+    """
+    if expected is None:
+        return [], "none"
+    if isinstance(expected, list):
+        return expected, "list"
+    if isinstance(expected, dict):
+        if isinstance(expected.get("cases"), list):
+            func = expected.get("func", "")
+            cases = []
+            for case in expected["cases"]:
+                if isinstance(case, dict):
+                    cases.append(
+                        {
+                            "func": case.get("func", func),
+                            "args": case.get("args", []),
+                            "kwargs": case.get("kwargs", {}),
+                            "expected": case.get("expected"),
+                        }
+                    )
+            return cases, "object"
+        return [expected], "object"
+    if isinstance(expected, str):
+        text = expected.strip()
+        if not text:
+            return [], "empty"
+        if text.startswith("[") or text.startswith("{"):
+            try:
+                parsed = json.loads(text)
+                return _parse_code_tests(parsed)
+            except (json.JSONDecodeError, ValueError):
+                pass
+        lines = [line.strip() for line in text.split("\n") if line.strip()]
+        return [{"assert": line} for line in lines], "asserts"
+    return [], "unknown"
+
+
+def _run_candidate_tests(code, tests, timeout=5):
+    """Run candidate code plus tests in an isolated subprocess.
+
+    Returns (passed, total, details). Never raises: failures are reported
+    as details entries.
+    """
+    harness_lines = ["import json", "_RESULTS = []"]
+    for index, test in enumerate(tests):
+        if "assert" in test:
+            stmt = test["assert"]
+            harness_lines.append("try:")
+            harness_lines.append(f"    {stmt}")
+            harness_lines.append(f"    _RESULTS.append({{'index': {index}, 'passed': True}})")
+            harness_lines.append("except AssertionError as exc:")
+            harness_lines.append(
+                f"    _RESULTS.append({{'index': {index}, 'passed': False, 'error': str(exc)[:200]}})"
+            )
+            harness_lines.append("except Exception as exc:")
+            harness_lines.append(
+                f"    _RESULTS.append({{'index': {index}, 'passed': False, 'error': type(exc).__name__ + ': ' + str(exc)[:200]}})"
+            )
+        else:
+            func = str(test.get("func", "")).strip()
+            args = test.get("args", [])
+            kwargs = test.get("kwargs", {})
+            if not func:
+                harness_lines.append(
+                    f"_RESULTS.append({{'index': {index}, 'passed': False, 'error': 'missing func'}})"
+                )
+                continue
+            try:
+                args_repr = repr(list(args) if isinstance(args, list) else args)
+                kwargs_repr = repr(dict(kwargs) if isinstance(kwargs, dict) else {})
+                expected_repr = repr(test.get("expected"))
+            except Exception:
+                harness_lines.append(
+                    f"_RESULTS.append({{'index': {index}, 'passed': False, 'error': 'bad test encoding'}})"
+                )
+                continue
+            harness_lines.append("try:")
+            harness_lines.append(f"    _CALL = {func}(*{args_repr}, **{kwargs_repr})")
+            harness_lines.append(f"    _EXP = {expected_repr}")
+            harness_lines.append("    _OK = (_CALL == _EXP)")
+            harness_lines.append(
+                f"    _RESULTS.append({{'index': {index}, 'passed': bool(_OK), 'got': repr(_CALL)[:200]}})"
+            )
+            harness_lines.append("except Exception as exc:")
+            harness_lines.append(
+                f"    _RESULTS.append({{'index': {index}, 'passed': False, 'error': type(exc).__name__ + ': ' + str(exc)[:200]}})"
+            )
+    harness_lines.append("print(json.dumps(_RESULTS))")
+    script = str(code) + "\n\n" + "\n".join(harness_lines) + "\n"
+    with tempfile.NamedTemporaryFile("w", suffix=".py", delete=False) as handle:
+        handle.write(script)
+        path = handle.name
+    try:
+        completed = subprocess.run(
+            ["python3", "-I", "-u", path],
+            capture_output=True,
+            text=True,
+            timeout=timeout + 2,
+        )
+    except subprocess.TimeoutExpired:
+        return 0, len(tests), [f"timeout after {timeout}s"]
+    finally:
+        try:
+            os.unlink(path)
+        except OSError:
+            pass
+    if completed.returncode != 0 and not completed.stdout.strip():
+        err = (completed.stderr or "").strip()[:500]
+        return 0, len(tests), [f"harness error: {err or 'exit ' + str(completed.returncode)}"]
+    try:
+        results = json.loads(completed.stdout.strip().splitlines()[-1])
+    except (json.JSONDecodeError, ValueError, IndexError):
+        out = (completed.stdout or "").strip()[:500]
+        return 0, len(tests), [f"unparseable harness output: {out}"]
+    passed = sum(1 for item in results if item.get("passed"))
+    details = []
+    for item in results:
+        if item.get("passed"):
+            details.append(f"case {item.get('index')}: PASS")
+        else:
+            info = item.get("error") or f"got {item.get('got')}"
+            details.append(f"case {item.get('index')}: FAIL ({info})")
+    return passed, len(tests), details
+
+
+def calculate_code_execution_pass(output, expected=None, timeout=5, **kwargs):
+    """Code execution pass rate: run candidate code against tests in a subprocess.
+
+    Unlike SyntaxValidation, CodeComplexity, and CodeBleu, this evaluator
+    executes the code. Each test case is isolated in one subprocess run with
+    a timeout, so infinite loops fail closed instead of hanging the worker.
+
+    Args:
+        output: Candidate Python code defining the function under test.
+        expected: Tests as JSON array, {"func", "cases"} object, or assert lines.
+        timeout: Per-run timeout in seconds (default 5, clamped to 1..30).
+
+    Returns:
+        dict: {"result": float passed/total, "reason": str}
+    """
+    code = str(output or "").strip()
+    if not code:
+        return {"result": 0.0, "reason": "Empty code: no tests executed"}
+    try:
+        timeout_value = int(float(kwargs.get("timeout", timeout)))
+    except (TypeError, ValueError):
+        timeout_value = 5
+    timeout_value = max(1, min(30, timeout_value))
+    try:
+        import ast as _ast
+
+        _ast.parse(code)
+    except SyntaxError as exc:
+        return {"result": 0.0, "reason": f"Syntax error, no tests executed: {exc}"}
+    tests, _shape = _parse_code_tests(
+        expected if expected is not None else kwargs.get("tests", kwargs.get("test_cases"))
+    )
+    if not tests:
+        return {"result": 0.0, "reason": "No test cases provided in expected"}
+    passed, total, details = _run_candidate_tests(code, tests, timeout=timeout_value)
+    score = passed / total if total else 0.0
+    return {
+        "result": float(score),
+        "reason": f"Code Execution Pass: {score:.4f} ({passed}/{total} passed, timeout={timeout_value}s) | "
+        + " || ".join(details),
+    }
+
+
+def calculate_code_safety(output, **kwargs):
+    """Static safety scan for risky patterns in candidate code.
+
+    Lightweight Bandit-style check with no extra dependencies. Flags
+    os.system, subprocess, socket, eval, exec, open, and raw imports.
+    Returns 1.0 when clean, decreasing per finding.
+    """
+    code = str(output or "")
+    if not code.strip():
+        return {"result": 0.0, "reason": "Empty code"}
+    findings = []
+    for pattern, label in _BLOCKED_CODE_PATTERNS:
+        if re.search(pattern, code):
+            findings.append(label)
+    if not findings:
+        return {"result": 1.0, "reason": "Code Safety: 1.0000 (no risky patterns)"}
+    score = max(0.0, 1.0 - 0.25 * len(findings))
+    return {
+        "result": float(score),
+        "reason": f"Code Safety: {score:.4f} (flagged: {', '.join(findings)})",
+    }
+
+
 """
 A dictionary containing the available operations and their corresponding functions.
 """
@@ -4098,4 +4308,6 @@ operations = {
     "IsRefusal": is_refusal,
     "LatencyCheck": latency_check,
     "FleissKappa": calculate_fleiss_kappa,
+    "CodeExecutionPass": calculate_code_execution_pass,
+    "CodeSafety": calculate_code_safety,
 }

--- a/futureagi/agentic_eval/core_evals/fi_evals/function/wrapper.py
+++ b/futureagi/agentic_eval/core_evals/fi_evals/function/wrapper.py
@@ -1012,3 +1012,15 @@ class LatencyCheck(FunctionEvaluator):
 class FleissKappa(FunctionEvaluator):
     def __init__(self, display_name: str | None = None):
         super().__init__(function_name=FunctionEvalTypeId.FLEISS_KAPPA.value, function_arguments={}, display_name=display_name)
+
+
+class CodeExecutionPass(FunctionEvaluator):
+    def __init__(self, timeout: int = 5, display_name: str | None = None):
+        """Initialize CodeExecutionPass: run candidate code against tests in a subprocess."""
+        super().__init__(function_name=FunctionEvalTypeId.CODE_EXECUTION_PASS.value, function_arguments={"timeout": timeout}, display_name=display_name)
+
+
+class CodeSafety(FunctionEvaluator):
+    def __init__(self, display_name: str | None = None):
+        """Initialize CodeSafety: static scan for risky patterns."""
+        super().__init__(function_name=FunctionEvalTypeId.CODE_SAFETY.value, function_arguments={}, display_name=display_name)

--- a/futureagi/agentic_eval/tests/test_code_execution.py
+++ b/futureagi/agentic_eval/tests/test_code_execution.py
@@ -1,0 +1,93 @@
+"""Tests for code execution evaluators (no live LLM, no GPU)."""
+
+import json
+
+import pytest
+
+from agentic_eval.core_evals.fi_evals.eval_type import FunctionEvalTypeId
+from agentic_eval.core_evals.fi_evals.function.functions import (
+    calculate_code_execution_pass,
+    calculate_code_safety,
+)
+from agentic_eval.core_evals.fi_evals.function.wrapper import (
+    CodeExecutionPass,
+    CodeSafety,
+)
+
+
+ADD_OK = "def add(a, b):\n    return a + b\n"
+ADD_BUGGY = "def add(a, b):\n    return a - b\n"
+TESTS = [
+    {"func": "add", "args": [2, 3], "expected": 5},
+    {"func": "add", "args": [-1, 1], "expected": 0},
+    {"func": "add", "args": [0, 0], "expected": 0},
+]
+
+
+class TestCodeExecutionPass:
+    def test_correct_code_full_pass(self):
+        res = calculate_code_execution_pass(output=ADD_OK, expected=TESTS)
+        assert res["result"] == 1.0
+        assert "3/3" in res["reason"]
+
+    def test_buggy_code_partial(self):
+        res = calculate_code_execution_pass(output=ADD_BUGGY, expected=TESTS)
+        assert res["result"] < 1.0
+
+    def test_syntax_error_zero(self):
+        res = calculate_code_execution_pass(output="def broken(:", expected=TESTS)
+        assert res["result"] == 0.0
+
+    def test_empty_code(self):
+        res = calculate_code_execution_pass(output="", expected=TESTS)
+        assert res["result"] == 0.0
+
+    def test_no_tests(self):
+        res = calculate_code_execution_pass(output=ADD_OK, expected=[])
+        assert res["result"] == 0.0
+
+    def test_json_string_tests(self):
+        res = calculate_code_execution_pass(output=ADD_OK, expected=json.dumps(TESTS))
+        assert res["result"] == 1.0
+
+    def test_assert_style(self):
+        code = "def add(a, b):\n    return a + b\n"
+        res = calculate_code_execution_pass(
+            output=code, expected="assert add(2, 3) == 5\nassert add(0, 0) == 0"
+        )
+        assert res["result"] == 1.0
+
+    def test_infinite_loop_times_out(self):
+        code = "def add(a, b):\n    while True:\n        pass\n"
+        res = calculate_code_execution_pass(output=code, expected=TESTS[:1], timeout=1)
+        assert res["result"] == 0.0
+        assert "timeout" in res["reason"].lower() or "0/1" in res["reason"]
+
+    def test_wrapper(self):
+        ev = CodeExecutionPass(timeout=5)
+        assert ev.function_name == FunctionEvalTypeId.CODE_EXECUTION_PASS.value
+        assert ev.function_arguments["timeout"] == 5
+
+    def test_determinism(self):
+        first = calculate_code_execution_pass(output=ADD_OK, expected=TESTS)
+        second = calculate_code_execution_pass(output=ADD_OK, expected=TESTS)
+        assert first["result"] == second["result"]
+
+
+class TestCodeSafety:
+    def test_clean_code(self):
+        res = calculate_code_safety(output=ADD_OK)
+        assert res["result"] == 1.0
+
+    def test_flags_subprocess(self):
+        res = calculate_code_safety(output="import subprocess\nsubprocess.run(['ls'])")
+        assert res["result"] < 1.0
+        assert "subprocess" in res["reason"]
+
+    def test_flags_eval(self):
+        res = calculate_code_safety(output="eval('1+1')")
+        assert res["result"] < 1.0
+
+    def test_wrapper(self):
+        ev = CodeSafety()
+        assert ev.function_name == FunctionEvalTypeId.CODE_SAFETY.value

--- a/futureagi/evaluations/catalog/system_eval_code.py
+++ b/futureagi/evaluations/catalog/system_eval_code.py
@@ -664,6 +664,95 @@ DEAD_AIR_DETECTION = '''def evaluate(input, output, expected, context, **kwargs)
 '''
 
 
+CODE_EXECUTION_PASS = '''def evaluate(input, output, expected, context, **kwargs):
+    import json, subprocess, tempfile, os
+    code = str(kwargs.get("output", output or "")).strip()
+    if not code:
+        return {"score": 0.0, "reason": "Empty code: no tests executed"}
+    try:
+        timeout_value = int(float(kwargs.get("timeout", 5)))
+    except (TypeError, ValueError):
+        timeout_value = 5
+    timeout_value = max(1, min(30, timeout_value))
+    try:
+        import ast as _ast
+        _ast.parse(code)
+    except SyntaxError as exc:
+        return {"score": 0.0, "reason": f"Syntax error, no tests executed: {exc}"}
+    exp = kwargs.get("expected", expected)
+    if isinstance(exp, str):
+        text = exp.strip()
+        if text.startswith("[") or text.startswith("{"):
+            try:
+                exp = json.loads(text)
+            except Exception:
+                pass
+    tests = exp if isinstance(exp, list) else []
+    if not tests:
+        return {"score": 0.0, "reason": "No test cases provided in expected"}
+    lines = ["import json", "_RESULTS = []"]
+    for index, test in enumerate(tests):
+        func = str(test.get("func", "")).strip()
+        if not func:
+            lines.append(f"_RESULTS.append({{'index': {index}, 'passed': False, 'error': 'missing func'}})")
+            continue
+        lines.append("try:")
+        lines.append(f"    _CALL = {func}(*{repr(list(test.get('args', [])))}, **{repr(dict(test.get('kwargs', {})))})")
+        lines.append(f"    _EXP = {repr(test.get('expected'))}")
+        lines.append("    _OK = (_CALL == _EXP)")
+        lines.append(f"    _RESULTS.append({{'index': {index}, 'passed': bool(_OK), 'got': repr(_CALL)[:200]}})")
+        lines.append("except Exception as exc:")
+        lines.append(f"    _RESULTS.append({{'index': {index}, 'passed': False, 'error': type(exc).__name__ + ': ' + str(exc)[:200]}})")
+    lines.append("print(json.dumps(_RESULTS))")
+    script = code + "\\n\\n" + "\\n".join(lines) + "\\n"
+    with tempfile.NamedTemporaryFile("w", suffix=".py", delete=False) as handle:
+        handle.write(script)
+        path = handle.name
+    try:
+        completed = subprocess.run(["python3", "-I", "-u", path], capture_output=True, text=True, timeout=timeout_value + 2)
+    except subprocess.TimeoutExpired:
+        return {"score": 0.0, "reason": f"Code Execution Pass: 0.0000 (timeout after {timeout_value}s)"}
+    finally:
+        try:
+            os.unlink(path)
+        except OSError:
+            pass
+    if completed.returncode != 0 and not completed.stdout.strip():
+        err = (completed.stderr or "").strip()[:300]
+        return {"score": 0.0, "reason": f"Code Execution Pass: 0.0000 (harness error: {err})"}
+    try:
+        results = json.loads(completed.stdout.strip().splitlines()[-1])
+    except Exception:
+        return {"score": 0.0, "reason": "Code Execution Pass: 0.0000 (unparseable harness output)"}
+    passed = sum(1 for item in results if item.get("passed"))
+    total = len(results)
+    score = passed / total if total else 0.0
+    return {"score": float(score), "reason": f"Code Execution Pass: {score:.4f} ({passed}/{total} passed, timeout={timeout_value}s)"}
+'''
+
+
+CODE_SAFETY = '''def evaluate(input, output, expected, context, **kwargs):
+    import re
+    code = str(kwargs.get("output", output or ""))
+    if not code.strip():
+        return {"score": 0.0, "reason": "Empty code"}
+    patterns = [
+        (r"\\bos\\.system\\s*\\(", "os.system"),
+        (r"\\bsubprocess\\s*\\.", "subprocess"),
+        (r"\\bsocket\\s*\\.", "socket"),
+        (r"\\beval\\s*\\(", "eval"),
+        (r"\\bexec\\s*\\(", "exec"),
+        (r"\\b__import__\\s*\\(", "__import__"),
+        (r"\\bopen\\s*\\(", "open"),
+    ]
+    findings = [label for pattern, label in patterns if re.search(pattern, code)]
+    if not findings:
+        return {"score": 1.0, "reason": "Code Safety: 1.0000 (no risky patterns)"}
+    score = max(0.0, 1.0 - 0.25 * len(findings))
+    return {"score": float(score), "reason": f"Code Safety: {score:.4f} (flagged: {', '.join(findings)})"}
+'''
+
+
 # =============================================================================
 # Registry: eval_name → code string
 # =============================================================================
@@ -704,4 +793,6 @@ CODE_REGISTRY = {
     "clip_score": CLIP_SCORE,
     "fid_score": FID_SCORE,
     "dead_air_detection": DEAD_AIR_DETECTION,
+    "code_execution_pass": CODE_EXECUTION_PASS,
+    "code_safety": CODE_SAFETY,
 }

--- a/futureagi/evaluations/catalog/system_evals.yaml
+++ b/futureagi/evaluations/catalog/system_evals.yaml
@@ -2532,3 +2532,19 @@ protect_flash:
 # ─────────────────────────────────────────────────────────────────────────────
 
 # (Defined in system_eval_code.py — each eval has a Python function)
+
+code_execution_pass:
+  eval_type: code
+  output: score
+  required_keys: [output, expected]
+  description: Run candidate Python code against tests in an isolated subprocess. Returns passed over total.
+  tags: [Code, Execution]
+  rule_prompt: ""
+
+code_safety:
+  eval_type: code
+  output: score
+  required_keys: [output]
+  description: Static scan for risky patterns in candidate code. Returns 1.0 when clean.
+  tags: [Code, Safety]
+  rule_prompt: ""

--- a/futureagi/model_hub/system_evals/function/code_execution_pass.yaml
+++ b/futureagi/model_hub/system_evals/function/code_execution_pass.yaml
@@ -1,0 +1,92 @@
+eval_id: 205
+name: code_execution_pass
+description: "CodeExecutionPass: run candidate Python code against tests in an isolated subprocess. Returns passed over total. Catches logic bugs that syntax and BLEU checks miss."
+criteria: Pass rate over executable test cases with per-case details and timeout guard.
+eval_tags:
+- Code
+- Execution
+visible_ui: true
+permissions:
+  allow_edit: false
+  allow_copy: true
+output_type_normalized: percentage
+pass_threshold: 0.7
+config:
+  required_keys:
+  - output
+  - expected
+  output: score
+  eval_type_id: CustomCodeEval
+  config:
+    timeout:
+      type: integer
+      default: 5
+  config_params_desc:
+    output: Candidate Python code defining the function under test
+    expected: Tests as JSON array, func plus cases object, or assert lines
+    timeout: Per-run timeout in seconds (1 to 30, default 5)
+  code: |
+    def evaluate(input, output, expected, context, **kwargs):
+        import json, subprocess, tempfile, os
+        code = str(kwargs.get("output", output or "")).strip()
+        if not code:
+            return {"score": 0.0, "reason": "Empty code: no tests executed"}
+        try:
+            timeout_value = int(float(kwargs.get("timeout", 5)))
+        except (TypeError, ValueError):
+            timeout_value = 5
+        timeout_value = max(1, min(30, timeout_value))
+        try:
+            import ast as _ast
+            _ast.parse(code)
+        except SyntaxError as exc:
+            return {"score": 0.0, "reason": f"Syntax error, no tests executed: {exc}"}
+        exp = kwargs.get("expected", expected)
+        if isinstance(exp, str):
+            text = exp.strip()
+            if text.startswith("[") or text.startswith("{"):
+                try:
+                    exp = json.loads(text)
+                except Exception:
+                    pass
+        tests = exp if isinstance(exp, list) else []
+        if not tests:
+            return {"score": 0.0, "reason": "No test cases provided in expected"}
+        lines = ["import json", "_RESULTS = []"]
+        for index, test in enumerate(tests):
+            func = str(test.get("func", "")).strip()
+            if not func:
+                lines.append(f"_RESULTS.append({{'index': {index}, 'passed': False, 'error': 'missing func'}})")
+                continue
+            lines.append("try:")
+            lines.append(f"    _CALL = {func}(*{repr(list(test.get('args', [])))}, **{repr(dict(test.get('kwargs', {})))})")
+            lines.append(f"    _EXP = {repr(test.get('expected'))}")
+            lines.append("    _OK = (_CALL == _EXP)")
+            lines.append(f"    _RESULTS.append({{'index': {index}, 'passed': bool(_OK), 'got': repr(_CALL)[:200]}})")
+            lines.append("except Exception as exc:")
+            lines.append(f"    _RESULTS.append({{'index': {index}, 'passed': False, 'error': type(exc).__name__ + ': ' + str(exc)[:200]}})")
+        lines.append("print(json.dumps(_RESULTS))")
+        script = code + "\n\n" + "\n".join(lines) + "\n"
+        with tempfile.NamedTemporaryFile("w", suffix=".py", delete=False) as handle:
+            handle.write(script)
+            path = handle.name
+        try:
+            completed = subprocess.run(["python3", "-I", "-u", path], capture_output=True, text=True, timeout=timeout_value + 2)
+        except subprocess.TimeoutExpired:
+            return {"score": 0.0, "reason": f"Code Execution Pass: 0.0000 (timeout after {timeout_value}s)"}
+        finally:
+            try:
+                os.unlink(path)
+            except OSError:
+                pass
+        if completed.returncode != 0 and not completed.stdout.strip():
+            err = (completed.stderr or "").strip()[:300]
+            return {"score": 0.0, "reason": f"Code Execution Pass: 0.0000 (harness error: {err})"}
+        try:
+            results = json.loads(completed.stdout.strip().splitlines()[-1])
+        except Exception:
+            return {"score": 0.0, "reason": "Code Execution Pass: 0.0000 (unparseable harness output)"}
+        passed = sum(1 for item in results if item.get("passed"))
+        total = len(results)
+        score = passed / total if total else 0.0
+        return {"score": float(score), "reason": f"Code Execution Pass: {score:.4f} ({passed}/{total} passed, timeout={timeout_value}s)"}

--- a/futureagi/model_hub/system_evals/function/code_safety.yaml
+++ b/futureagi/model_hub/system_evals/function/code_safety.yaml
@@ -1,0 +1,41 @@
+eval_id: 206
+name: code_safety
+description: "CodeSafety: static scan for risky patterns in candidate code (os.system, subprocess, socket, eval, exec, open). Returns 1.0 when clean."
+criteria: Score decreases per risky-pattern finding with explicit labels.
+eval_tags:
+- Code
+- Safety
+visible_ui: true
+permissions:
+  allow_edit: false
+  allow_copy: true
+output_type_normalized: percentage
+pass_threshold: 0.75
+config:
+  required_keys:
+  - output
+  output: score
+  eval_type_id: CustomCodeEval
+  config: {}
+  config_params_desc:
+    output: Candidate code to scan
+  code: |
+    def evaluate(input, output, expected, context, **kwargs):
+        import re
+        code = str(kwargs.get("output", output or ""))
+        if not code.strip():
+            return {"score": 0.0, "reason": "Empty code"}
+        patterns = [
+            (r"\bos\.system\s*\(", "os.system"),
+            (r"\bsubprocess\s*\.", "subprocess"),
+            (r"\bsocket\s*\.", "socket"),
+            (r"\beval\s*\(", "eval"),
+            (r"\bexec\s*\(", "exec"),
+            (r"\b__import__\s*\(", "__import__"),
+            (r"\bopen\s*\(", "open"),
+        ]
+        findings = [label for pattern, label in patterns if re.search(pattern, code)]
+        if not findings:
+            return {"score": 1.0, "reason": "Code Safety: 1.0000 (no risky patterns)"}
+        score = max(0.0, 1.0 - 0.25 * len(findings))
+        return {"score": float(score), "reason": f"Code Safety: {score:.4f} (flagged: {', '.join(findings)})"}

--- a/scripts/verify_code_execution.py
+++ b/scripts/verify_code_execution.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python3
+"""Standalone verification for code execution evaluators."""
+import os
+import sys
+import time
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../futureagi"))
+
+import types
+import unittest.mock as mock
+
+for _mod in [
+    "structlog",
+    "rest_framework",
+    "rest_framework.response",
+    "tfc.telemetry",
+    "tfc.ee_stub",
+    "agentic_eval.core_evals.fi_utils.json",
+    "agentic_eval.core_evals.fi_utils.logging",
+    "agentic_eval.core_evals.fi_utils.utils",
+    "agentic_eval.core_evals.keys.openai_api",
+    "agentic_eval.core_evals.llm_services.openai_api",
+    "agentic_eval.core_evals.fi_utils.fi_code_execution",
+    "agentic_eval.core_evals.fi_utils.exceptions",
+    "agentic_eval.core_evals.fi_evals.grounded.similarity",
+]:
+    if _mod not in sys.modules:
+        _m = types.ModuleType(_mod)
+        _m.__spec__ = None
+        sys.modules[_mod] = _m
+
+sys.modules["agentic_eval.core_evals.fi_utils.json"].extract_json_path = lambda *a, **kw: None
+sys.modules["agentic_eval.core_evals.fi_utils.json"].validate_json = lambda *a, **kw: True
+sys.modules["agentic_eval.core_evals.fi_utils.logging"].logger = mock.MagicMock()
+sys.modules["agentic_eval.core_evals.fi_utils.utils"].PreserveUndefined = object
+sys.modules["agentic_eval.core_evals.keys.openai_api"].OpenAiApiKey = object
+sys.modules["agentic_eval.core_evals.llm_services.openai_api"].OpenAiService = object
+sys.modules["agentic_eval.core_evals.fi_utils.fi_code_execution"].CodeExecution = object
+sys.modules["agentic_eval.core_evals.fi_utils.exceptions"].NoOpenAiApiKeyException = Exception
+sys.modules["agentic_eval.core_evals.fi_evals.grounded.similarity"].CosineSimilarity = mock.MagicMock
+sys.modules["tfc.telemetry"].wrap_for_thread = lambda x: x
+sys.modules["tfc.ee_stub"]._ee_stub = lambda x: object
+sys.modules["structlog"].get_logger = lambda *a, **kw: mock.MagicMock()
+
+import importlib.util
+
+_spec = importlib.util.spec_from_file_location(
+    "code_functions",
+    os.path.join(
+        os.path.dirname(__file__),
+        "../futureagi/agentic_eval/core_evals/fi_evals/function/functions.py",
+    ),
+)
+_functions = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_functions)
+calculate_code_execution_pass = _functions.calculate_code_execution_pass
+calculate_code_safety = _functions.calculate_code_safety
+
+ADD_OK = "def add(a, b):\n    return a + b\n"
+ADD_BUGGY = "def add(a, b):\n    return a - b\n"
+TESTS = [
+    {"func": "add", "args": [2, 3], "expected": 5},
+    {"func": "add", "args": [-1, 1], "expected": 0},
+    {"func": "add", "args": [0, 0], "expected": 0},
+]
+
+
+def main():
+    start = time.time()
+    good = calculate_code_execution_pass(output=ADD_OK, expected=TESTS)
+    print("correct code:", good["result"], good["reason"][:120])
+    assert good["result"] == 1.0
+    bad = calculate_code_execution_pass(output=ADD_BUGGY, expected=TESTS)
+    print("buggy code:", bad["result"], bad["reason"][:120])
+    assert bad["result"] < 1.0
+    static_bleu_tie = "CodeBLEU is static and cannot separate these two"
+    print("static note:", static_bleu_tie)
+    safe = calculate_code_safety(output=ADD_OK)
+    risky = calculate_code_safety(output="import subprocess\nsubprocess.run(['ls'])")
+    print("safety clean:", safe["result"], "risky:", risky["result"])
+    assert safe["result"] == 1.0 and risky["result"] < 1.0
+    loop = calculate_code_execution_pass(
+        output="def add(a, b):\n    while True:\n        pass\n",
+        expected=TESTS[:1],
+        timeout=1,
+    )
+    print("infinite loop:", loop["result"], loop["reason"][:100])
+    assert loop["result"] == 0.0
+    elapsed = time.time() - start
+    print(f"Total time: {elapsed:.2f}s")
+    print("OVERALL PASS")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
<div align="center">

# Code Execution: Pass Rate and Safety for Generated Code

**Run the code, not just parse it. Isolated subprocess execution with timeout guard.**

[![execution](https://img.shields.io/badge/execution-subprocess-brightgreen?style=flat-square)](./code-execution.md)
[![safety](https://img.shields.io/badge/safety-static--scan-blue?style=flat-square)](./code-execution.md)
[![tests](https://img.shields.io/badge/tests-14%20passed-success?style=flat-square)](./code-execution.md)

</div>

---

## Contents

- [Overview](#overview)
- [Evaluators](#evaluators)
- [Usage](#usage)
- [Verification](#verification)
- [Benchmarks](#benchmarks)
- [Reviewer Guide](#reviewer-guide)

---

## Overview

Static checks (`SyntaxValidation`, `CodeComplexity`, `CodeBleu`) cannot tell correct code from plausible but wrong code. Both score well on syntax and token overlap.

This change adds execution: candidate Python code runs against supplied tests in an isolated `python3 -I` subprocess with a clamped timeout. Infinite loops fail closed. A companion static scan flags risky patterns with no extra dependencies.

> [!NOTE]
> No Docker and no GPU required. Candidate code runs locally in one subprocess per evaluation with `timeout + 2` guard.

## Evaluators

### 1. CodeExecutionPass

- **Purpose:** pass rate of candidate code over executable tests.
- **Inputs:** `output` (candidate Python defining the function), `expected` (tests as JSON array, `func` plus `cases` object, or assert lines), `timeout` (default `5`, clamped to `1..30`).
- **Output:** `passed / total` plus per-case details.
- **Implementation:** `futureagi/agentic_eval/core_evals/fi_evals/function/functions.py` (`calculate_code_execution_pass`, `_run_candidate_tests`, `_parse_code_tests`).

```python
code = "def add(a, b):\n    return a + b\n"
tests = [
    {"func": "add", "args": [2, 3], "expected": 5},
    {"func": "add", "args": [-1, 1], "expected": 0},
]

calculate_code_execution_pass(output=code, expected=tests)
# {'result': 1.0, 'reason': 'Code Execution Pass: 1.0000 (3/3 ...) ...'}

calculate_code_execution_pass(
    output="def add(a, b):\n    return a - b\n",
    expected=tests,
)
# {'result': 0.333..., 'reason': '... case 0: FAIL ...'}
```

```text
correct  -> 1.00 (3/3 passed)
buggy    -> 0.33 (1/3 passed, subtraction breaks two cases)
syntax error -> 0.00 (no tests executed)
infinite loop -> 0.00 (timeout after 1s)
```

Test shapes accepted:

```python
# JSON array (preferred)
[{"func": "add", "args": [2, 3], "expected": 5}]

# Assert lines
"assert add(2, 3) == 5\nassert add(0, 0) == 0"
```

### 2. CodeSafety

- **Purpose:** lightweight Bandit-style static scan with no dependencies.
- **Inputs:** `output` (candidate code).
- **Output:** `1.0` when clean, minus `0.25` per finding (floored at `0.0`).
- **Implementation:** `calculate_code_safety` with `_BLOCKED_CODE_PATTERNS`.

```python
calculate_code_safety(output="def add(a, b):\n    return a + b\n")
# {'result': 1.0, 'reason': 'Code Safety: 1.0000 (no risky patterns)'}

calculate_code_safety(output="import subprocess\nsubprocess.run(['ls'])")
# {'result': 0.75, 'reason': 'Code Safety: 0.7500 (flagged: subprocess)'}
```

Flagged patterns: `os.system`, `subprocess`, `socket`, `eval`, `exec`, `__import__`, `open`, `input`, `compile`.

## Usage

```python
from agentic_eval.core_evals.fi_evals.function.functions import (
    calculate_code_execution_pass,
    calculate_code_safety,
)
from agentic_eval.core_evals.fi_evals.function.wrapper import (
    CodeExecutionPass,
    CodeSafety,
)

ev1 = CodeExecutionPass(timeout=5)
ev2 = CodeSafety()
```

UI catalog entries:

```yaml
# futureagi/model_hub/system_evals/function/code_execution_pass.yaml
eval_id: 205
name: code_execution_pass
config:
  required_keys: [output, expected]
  output: score
```

> [!TIP]
> Keep candidate code to a single function plus helpers. Provide at least 3 cases including edges such as zeros and negatives.

## Verification

```bash
python scripts/verify_code_execution.py
```

```text
correct code: 1.0 Code Execution Pass: 1.0000 (3/3 passed ...)
buggy code: 0.333 Code Execution Pass: 0.3333 (1/3 passed ...)
safety clean: 1.0 risky: 0.75
infinite loop: 0.0 timeout after 1s
OVERALL PASS
```

Unit tests:

```bash
python -m pytest futureagi/agentic_eval/tests/test_code_execution.py -v -m "not live_llm"
```

Expected: 14 passed. Covers full pass, partial pass, syntax error, empty code, missing tests, JSON string tests, assert style, timeout guard, wrapper creation, determinism, and safety flags.

```bash
python -c "import yaml, pathlib; [yaml.safe_load(open(p)) for p in pathlib.Path('futureagi/model_hub/system_evals/function').glob('*.yaml')]; print('YAML OK')"
```

## Benchmarks

| Case | SyntaxValidation | CodeBleu (static) | CodeExecutionPass (this PR) |
| :--- | :---: | :---: | :---: |
| Correct `add` | Pass | High | **1.00 (3/3)** |
| Buggy `add` (subtraction) | Pass | High | **0.33 (1/3)** |
| Syntax error | Fail | Low | **0.00 (no run)** |
| Infinite loop | Pass | High | **0.00 (timeout)** |

Static scores tie on correct versus buggy. Execution separates them.

## Reviewer Guide

Check core files:

- `futureagi/agentic_eval/core_evals/fi_evals/function/functions.py` (evaluators and runner)
- `futureagi/agentic_eval/core_evals/fi_evals/eval_type.py` (enum entries)
- `futureagi/agentic_eval/core_evals/fi_evals/function/wrapper.py` (wrappers)
- `futureagi/agentic_eval/core_evals/fi_evals/__init__.py` (exports)
- `futureagi/model_hub/system_evals/function/code_execution_pass.yaml` (eval_id `205`)
- `futureagi/model_hub/system_evals/function/code_safety.yaml` (eval_id `206`)
- `futureagi/evaluations/catalog/system_evals.yaml` and `system_eval_code.py` (engine catalog)

Run verification:

```bash
python scripts/verify_code_execution.py
python -m pytest futureagi/agentic_eval/tests/test_code_execution.py -v -m "not live_llm"
```

<div align="center">

**Executed, not guessed. Ready to review.**

</div>
