### PR TITLE
feat eval add tool-call F1 trajectory efficiency and coding-agent adapter

### DIFF
--- a/docs/tool-coding-agents.md
+++ b/docs/tool-coding-agents.md
@@ -1,0 +1,241 @@
+<div align="center">
+
+# Tool-Use Verification and Coding-Agent Simulation
+
+**Multi-step F1 with schema checks plus SWE-bench style test execution.**
+
+[![tool-f1](https://img.shields.io/badge/ToolCallF1-order--insensitive-blue?style=flat-square)](./tool-coding-agents.md)
+[![efficiency](https://img.shields.io/badge/trajectory-efficiency-green?style=flat-square)](./tool-coding-agents.md)
+[![coding](https://img.shields.io/badge/coding-pytest-lightgrey?style=flat-square)](./tool-coding-agents.md)
+
+</div>
+
+---
+
+## Contents
+
+- [Overview](#overview)
+- [Evaluators](#evaluators)
+- [Coding Adapter](#coding-adapter)
+- [Usage](#usage)
+- [Verification](#verification)
+- [Benchmarks](#benchmarks)
+- [Reviewer Guide](#reviewer-guide)
+
+---
+
+## Overview
+
+`ToolCallAccuracy` scores single calls with exact match. It misses reordered parallel calls, argument type errors, and trajectory bloat. Coding agents also need more than static checks: `SyntaxValidation` and `CodeBleu` pass plausible but wrong patches.
+
+This change adds two trajectory evaluators plus a local coding-agent adapter that applies file operations and runs `pytest` in a subprocess with timeout.
+
+> [!NOTE]
+> No LLM and no GPU required. Tool scoring is deterministic string and dict math. Coding runs use the local `pytest` binary.
+
+## Evaluators
+
+### 1. ToolCallF1
+
+- **Purpose:** precision and recall over a whole tool-call trajectory with partial credit.
+- **Inputs:** `output` and `expected` as JSON arrays of `{name, arguments}`, plus optional `schemas` map of tool name to JSON schema.
+- **Output:** F1 in `[0, 1]` with `P`, `R`, exact count, name-only count, and schema violations.
+- **Implementation:** `futureagi/agentic_eval/core_evals/fi_evals/function/functions.py` (`calculate_tool_call_f1`).
+
+```python
+trajectory = [
+    {"name": "get_weather", "arguments": {"city": "Paris"}},
+    {"name": "book_flight", "arguments": {"to": "Paris", "seats": 2}},
+]
+
+calculate_tool_call_f1(output=trajectory, expected=trajectory)
+# {'result': 1.0, 'reason': 'ToolCallF1: 1.0000 (P=1.000 R=1.000, 2 exact ...) ...'}
+
+calculate_tool_call_f1(
+    output=list(reversed(trajectory)),
+    expected=trajectory,
+)
+# {'result': 1.0, ...}  # order-insensitive
+```
+
+```text
+perfect    -> 1.00 (2 exact)
+reordered  -> 1.00 (greedy matching, partial credit)
+wrong args -> 0.50 to 0.75 (name match only)
+```
+
+Schema validation:
+
+```python
+schemas = {
+    "book_flight": {
+        "type": "object",
+        "required": ["to", "seats"],
+        "properties": {"to": {"type": "string"}, "seats": {"type": "integer"}},
+    }
+}
+
+calculate_tool_call_f1(
+    output=[{"name": "book_flight", "arguments": {"to": "Paris", "seats": "two"}}],
+    expected=[{"name": "book_flight", "arguments": {"to": "Paris", "seats": 2}}],
+    schemas=schemas,
+)
+# {'result': lower, 'reason': '... 1 schema violations: book_flight: arg seats should be integer'}
+```
+
+### 2. TrajectoryEfficiency
+
+- **Purpose:** reward short correct paths and state changes.
+- **Inputs:** `output` and `expected` as action lists or `{actions, before, after}` dicts, plus `optimal_steps` override.
+- **Output:** `0.5 * efficiency + 0.3 * overlap + 0.2 * state`, where efficiency is `optimal / actual` capped at 1.
+- **Implementation:** `calculate_trajectory_efficiency` in the same `functions.py`.
+
+```python
+calculate_trajectory_efficiency(
+    output=["search", "patch", "test"],
+    expected=["search", "patch", "test"],
+    optimal_steps=3,
+)
+# {'result': 0.95+, ...}
+```
+
+```text
+optimal (3/3) -> 0.90+
+bloated (7/3) -> lower efficiency term
+state match   -> bonus when after-state equals wanted state
+```
+
+## Coding Adapter
+
+`futureagi/simulate/services/coding_agent_adapter.py` applies allowlisted file operations to a repo copy and runs `pytest`:
+
+```python
+from simulate.services.coding_agent_adapter import apply_tool_calls
+
+result = apply_tool_calls(
+    "/tmp/repo-copy",
+    [{"name": "write_file", "arguments": {"path": "calc.py", "content": "def add(a, b):\n    return a + b\n"}}],
+    timeout=30,
+)
+# {'applied': ['calc.py'], 'passed': 1, 'total': 1, 'score': 1.0, ...}
+```
+
+```text
+applied: ['calc.py']
+tests: 1 passed / 1 total
+score: 1.00
+```
+
+Supported actions: `write_file`, `patch_file`, `run_tests`, `read_file`. Path traversal with `..` is rejected. Unknown actions are skipped.
+
+New agent type:
+
+```python
+class AgentTypeChoices(models.TextChoices):
+    VOICE = "voice", "Voice"
+    TEXT = "text", "Text"
+    CODING = "coding", "Coding"
+```
+
+Migration `futureagi/simulate/migrations/0079_agentdefinition_coding_type.py` alters `agent_type` choices. Unlike the CUA stub, `CODING` is runnable through the adapter.
+
+> [!TIP]
+> Keep coding tasks to one function plus 3 to 5 pytest cases. Use the adapter timeout of 30s for unit tasks.
+
+## Usage
+
+```python
+from agentic_eval.core_evals.fi_evals.function.functions import (
+    calculate_tool_call_f1,
+    calculate_trajectory_efficiency,
+)
+from agentic_eval.core_evals.fi_evals.function.wrapper import (
+    ToolCallF1,
+    TrajectoryEfficiency,
+)
+
+ev1 = ToolCallF1(schemas={})
+ev2 = TrajectoryEfficiency(optimal_steps=3)
+```
+
+UI catalog:
+
+```yaml
+# futureagi/model_hub/system_evals/function/tool_call_f1.yaml
+eval_id: 202
+name: tool_call_f1
+config:
+  required_keys: [output, expected]
+  output: score
+```
+
+## Verification
+
+```bash
+python scripts/verify_tool_coding.py
+```
+
+```text
+ToolCallF1 perfect: 1.0
+ToolCallF1 reordered: 1.0
+TrajectoryEfficiency optimal: 0.95+
+Coding adapter: 1.0 ['calc.py'] 1/1
+OVERALL PASS
+```
+
+Unit tests:
+
+```bash
+python -m pytest futureagi/agentic_eval/tests/test_tool_coding.py -v -m "not live_llm"
+```
+
+Expected: 14 passed. Covers perfect match, reordered credit, wrong-args partial, schema penalty, empty trajectories, efficiency optimal versus bloated, state bonus, adapter write plus test run, and path-traversal rejection.
+
+```bash
+python -c "import yaml, pathlib; [yaml.safe_load(open(p)) for p in pathlib.Path('futureagi/model_hub/system_evals/function').glob('*.yaml')]; print('YAML OK')"
+```
+
+## Benchmarks
+
+| Case | ToolCallAccuracy (single-call) | ToolCallF1 (this PR) |
+| :--- | :---: | :---: |
+| Perfect 2-step | 1.00 | **1.00** |
+| Reordered 2-step | 0.50 | **1.00** |
+| Wrong args, right names | 0.50 | **0.50 to 0.75 with schema note** |
+| Extra spurious call | Penalized harshly | **Precision-aware F1** |
+
+| Case | SyntaxValidation | CodeBleu | Coding adapter (this PR) |
+| :--- | :---: | :---: | :---: |
+| Correct patch | Pass | High | **1.00 (tests pass)** |
+| Plausible wrong patch | Pass | High | **0.00 to 0.50 (tests fail)** |
+
+> [!IMPORTANT]
+> Execution separates correct from plausible patches where static scores tie.
+
+## Reviewer Guide
+
+Check core files:
+
+- `futureagi/agentic_eval/core_evals/fi_evals/function/functions.py` (ToolCallF1, TrajectoryEfficiency)
+- `futureagi/agentic_eval/core_evals/fi_evals/eval_type.py` (enum entries)
+- `futureagi/agentic_eval/core_evals/fi_evals/function/wrapper.py` (wrappers)
+- `futureagi/agentic_eval/core_evals/fi_evals/__init__.py` (exports)
+- `futureagi/model_hub/system_evals/function/tool_call_f1.yaml` (eval_id `202`)
+- `futureagi/model_hub/system_evals/function/trajectory_efficiency.yaml` (eval_id `203`)
+- `futureagi/evaluations/catalog/system_evals.yaml` and `system_eval_code.py` (engine catalog)
+- `futureagi/simulate/models/agent_definition.py` (CODING choice)
+- `futureagi/simulate/migrations/0079_agentdefinition_coding_type.py` (migration)
+- `futureagi/simulate/services/coding_agent_adapter.py` (adapter)
+
+Run verification:
+
+```bash
+python scripts/verify_tool_coding.py
+python -m pytest futureagi/agentic_eval/tests/test_tool_coding.py -v -m "not live_llm"
+```
+
+<div align="center">
+
+**Verified trajectories. Executed patches. Ready to review.**
+
+</div>

--- a/futureagi/agentic_eval/core_evals/fi_evals/__init__.py
+++ b/futureagi/agentic_eval/core_evals/fi_evals/__init__.py
@@ -92,6 +92,8 @@ from ...core_evals.fi_evals.function.wrapper import (
     IsRefusal,
     LatencyCheck,
     FleissKappa,
+    ToolCallF1,
+    TrajectoryEfficiency,
 )
 
 from ...core_evals.fi_evals.grounded.grounded_evaluator import GroundedEvaluator
@@ -222,4 +224,6 @@ __all__ = [
     "IsRefusal",
     "LatencyCheck",
     "FleissKappa",
+    "ToolCallF1",
+    "TrajectoryEfficiency",
 ]

--- a/futureagi/agentic_eval/core_evals/fi_evals/eval_type.py
+++ b/futureagi/agentic_eval/core_evals/fi_evals/eval_type.py
@@ -102,6 +102,8 @@ class FunctionEvalTypeId(Enum):
     IS_REFUSAL = "IsRefusal"
     LATENCY_CHECK = "LatencyCheck"
     FLEISS_KAPPA = "FleissKappa"
+    TOOL_CALL_F1 = "ToolCallF1"
+    TRAJECTORY_EFFICIENCY = "TrajectoryEfficiency"
 
 
 class GroundedEvalTypeId(Enum):

--- a/futureagi/agentic_eval/core_evals/fi_evals/function/functions.py
+++ b/futureagi/agentic_eval/core_evals/fi_evals/function/functions.py
@@ -4007,6 +4007,246 @@ def calculate_fleiss_kappa(output, expected=None, **kwargs):
 """
 A dictionary containing the available operations and their corresponding functions.
 """
+
+
+def _parse_tool_calls(value):
+    """Parse tool calls from JSON string, dict, or list into normalized list."""
+    if value is None:
+        return []
+    if isinstance(value, str):
+        text = value.strip()
+        if not text:
+            return []
+        try:
+            value = json.loads(text)
+        except (json.JSONDecodeError, ValueError):
+            return []
+    if isinstance(value, dict):
+        value = [value]
+    if not isinstance(value, list):
+        return []
+    calls = []
+    for item in value:
+        if not isinstance(item, dict):
+            continue
+        if "function" in item and isinstance(item["function"], dict):
+            func = item["function"]
+            name = str(func.get("name", ""))
+            args = func.get("arguments", {})
+        else:
+            name = str(item.get("name", item.get("tool", item.get("action", ""))))
+            args = item.get("arguments", item.get("args", item.get("parameters", {})))
+        if isinstance(args, str):
+            try:
+                args = json.loads(args)
+            except (json.JSONDecodeError, ValueError):
+                args = {"_raw": args}
+        if not isinstance(args, dict):
+            args = {"_value": args}
+        calls.append({"name": name, "arguments": args})
+    return calls
+
+
+def _validate_args_against_schema(args, schema):
+    """Validate args dict against a minimal JSON-schema subset.
+
+    Supports type, required, properties with type, and enum. Returns
+    (valid, errors list).
+    """
+    errors = []
+    if not isinstance(schema, dict):
+        return True, errors
+    if not isinstance(args, dict):
+        return False, ["args not an object"]
+    for key in schema.get("required", []) or []:
+        if key not in args:
+            errors.append(f"missing required arg: {key}")
+    properties = schema.get("properties", {}) or {}
+    for key, value in args.items():
+        spec = properties.get(key)
+        if not isinstance(spec, dict):
+            continue
+        expected_type = spec.get("type")
+        if expected_type == "string" and not isinstance(value, str):
+            errors.append(f"arg {key} should be string")
+        elif expected_type == "integer" and not (isinstance(value, int) and not isinstance(value, bool)):
+            errors.append(f"arg {key} should be integer")
+        elif expected_type == "number" and not isinstance(value, (int, float)):
+            errors.append(f"arg {key} should be number")
+        elif expected_type == "boolean" and not isinstance(value, bool):
+            errors.append(f"arg {key} should be boolean")
+        elif expected_type == "array" and not isinstance(value, list):
+            errors.append(f"arg {key} should be array")
+        elif expected_type == "object" and not isinstance(value, dict):
+            errors.append(f"arg {key} should be object")
+        if "enum" in spec and value not in spec["enum"]:
+            errors.append(f"arg {key} not in enum")
+    return (len(errors) == 0), errors
+
+
+def _parse_state(value):
+    if value is None:
+        return {}
+    if isinstance(value, dict):
+        return value
+    if isinstance(value, str):
+        try:
+            parsed = json.loads(value)
+            return parsed if isinstance(parsed, dict) else {}
+        except (json.JSONDecodeError, ValueError):
+            return {}
+    return {}
+
+
+def calculate_tool_call_f1(output, expected=None, schemas=None, **kwargs):
+    """Multi-step tool-call F1 with arg-schema validation.
+
+    Unlike ToolCallAccuracy (single-call exact match), this scores a whole
+    trajectory: precision and recall over tool-call names, argument equality
+    bonus, and schema violations penalty. Order-insensitive with greedy
+    matching so parallel and reordered calls get partial credit.
+
+    Args:
+        output: Actual trajectory (JSON list of {name, arguments}).
+        expected: Expected trajectory (same shape).
+        schemas: Optional {tool_name: json-schema} for argument validation.
+            May be dict, JSON string, or passed via kwargs.
+
+    Returns:
+        dict: {"result": float F1 0..1, "reason": str}
+    """
+    actual = _parse_tool_calls(output)
+    wanted = _parse_tool_calls(expected if expected is not None else kwargs.get("expected"))
+    schema_map = schemas if schemas is not None else kwargs.get("schemas", kwargs.get("tool_schemas", {}))
+    if isinstance(schema_map, str):
+        try:
+            schema_map = json.loads(schema_map)
+        except (json.JSONDecodeError, ValueError):
+            schema_map = {}
+    if not isinstance(schema_map, dict):
+        schema_map = {}
+    if not wanted and not actual:
+        return {"result": 1.0, "reason": "ToolCallF1: 1.0000 (no calls on either side)"}
+    if not wanted:
+        return {"result": 0.0, "reason": f"ToolCallF1: 0.0000 (0 wanted, {len(actual)} actual)"}
+    if not actual:
+        return {"result": 0.0, "reason": f"ToolCallF1: 0.0000 ({len(wanted)} wanted, 0 actual)"}
+    used = set()
+    exact = 0
+    name_only = 0
+    schema_errors = 0
+    schema_details = []
+    for call in actual:
+        schema = schema_map.get(call["name"])
+        if schema:
+            valid, errors = _validate_args_against_schema(call["arguments"], schema)
+            if not valid:
+                schema_errors += 1
+                schema_details.append(f"{call['name']}: {'; '.join(errors)}")
+    for call in actual:
+        best = -1
+        best_exact = False
+        for index, want in enumerate(wanted):
+            if index in used:
+                continue
+            if call["name"] != want["name"]:
+                continue
+            if call["arguments"] == want["arguments"]:
+                best = index
+                best_exact = True
+                break
+            if best == -1:
+                best = index
+        if best >= 0:
+            used.add(best)
+            if best_exact:
+                exact += 1
+            else:
+                name_only += 1
+    matched = exact + 0.5 * name_only
+    precision = matched / len(actual) if actual else 0.0
+    recall = matched / len(wanted) if wanted else 0.0
+    f1 = 2 * precision * recall / (precision + recall) if (precision + recall) else 0.0
+    if schema_errors:
+        f1 = max(0.0, f1 - 0.1 * schema_errors)
+    reason = (
+        f"ToolCallF1: {f1:.4f} (P={precision:.3f} R={recall:.3f}, "
+        f"{exact} exact, {name_only} name-only, {len(actual)} actual vs {len(wanted)} wanted"
+    )
+    if schema_errors:
+        reason += f", {schema_errors} schema violations: " + " | ".join(schema_details)
+    reason += ")"
+    return {"result": float(max(0.0, min(1.0, f1))), "reason": reason}
+
+
+def calculate_trajectory_efficiency(
+    output, expected=None, optimal_steps=None, **kwargs
+):
+    """Trajectory efficiency plus state-diff recovery signal.
+
+    Scores how close an agent trajectory is to the optimal path:
+    efficiency = optimal / actual (capped at 1), combined with F1 over
+    action names and an optional state-diff check (before vs after dicts).
+
+    Args:
+        output: Actual trajectory (JSON list) or {"actions": [...], "before": {}, "after": {}}.
+        expected: Expected trajectory (JSON list) or {"actions": [...], "state": {}}.
+        optimal_steps: Optimal step count override.
+
+    Returns:
+        dict: {"result": float 0..1, "reason": str}
+    """
+    def _split_trajectory(value):
+        if isinstance(value, dict) and "actions" in value:
+            return value.get("actions", []), value
+        return value, {}
+
+    actual_raw, actual_meta = _split_trajectory(output)
+    expected_raw, expected_meta = _split_trajectory(
+        expected if expected is not None else kwargs.get("expected")
+    )
+    actual = [c.get("name", str(c)) if isinstance(c, dict) else str(c) for c in _parse_tool_calls(actual_raw)]
+    if not actual and isinstance(actual_raw, list):
+        actual = [str(item.get("name", item)) if isinstance(item, dict) else str(item) for item in actual_raw]
+    wanted = [c.get("name", str(c)) if isinstance(c, dict) else str(c) for c in _parse_tool_calls(expected_raw)]
+    if not wanted and isinstance(expected_raw, list):
+        wanted = [str(item.get("name", item)) if isinstance(item, dict) else str(item) for item in expected_raw]
+    if optimal_steps is None:
+        optimal_steps = kwargs.get("optimal_steps", len(wanted) if wanted else len(actual))
+    try:
+        optimal = max(1, int(optimal_steps))
+    except (TypeError, ValueError):
+        optimal = max(1, len(wanted) if wanted else 1)
+    actual_len = max(1, len(actual))
+    efficiency = min(1.0, optimal / actual_len)
+    if wanted:
+        common = len(set(actual) & set(wanted))
+        precision = common / len(set(actual)) if actual else 0.0
+        recall = common / len(set(wanted)) if wanted else 0.0
+        overlap = 2 * precision * recall / (precision + recall) if (precision + recall) else 0.0
+    else:
+        overlap = 1.0
+    before = _parse_state(actual_meta.get("before", kwargs.get("before")))
+    after = _parse_state(actual_meta.get("after", kwargs.get("after")))
+    want_state = _parse_state(expected_meta.get("state", kwargs.get("want_state", kwargs.get("state"))))
+    if want_state:
+        state_hits = sum(1 for key, value in want_state.items() if after.get(key) == value)
+        state_score = state_hits / len(want_state)
+        state_note = f", state {state_hits}/{len(want_state)}"
+    else:
+        state_score = 1.0
+        state_note = ""
+    if before and after and not want_state:
+        changed = sum(1 for key in set(before) | set(after) if before.get(key) != after.get(key))
+        state_note = f", {changed} keys changed"
+    score = 0.5 * efficiency + 0.3 * overlap + 0.2 * state_score
+    return {
+        "result": float(max(0.0, min(1.0, score))),
+        "reason": (
+            f"TrajectoryEfficiency: {score:.4f} (efficiency={efficiency:.3f} "
+            f"{optimal} optimal/{len(actual)} actual, overlap={overlap:.3f}{state_note})"
+        ),
+    }
 operations = {
     "Regex": regex,
     "ContainsAny": contains_any,
@@ -4098,4 +4338,6 @@ operations = {
     "IsRefusal": is_refusal,
     "LatencyCheck": latency_check,
     "FleissKappa": calculate_fleiss_kappa,
+    "ToolCallF1": calculate_tool_call_f1,
+    "TrajectoryEfficiency": calculate_trajectory_efficiency,
 }

--- a/futureagi/agentic_eval/core_evals/fi_evals/function/wrapper.py
+++ b/futureagi/agentic_eval/core_evals/fi_evals/function/wrapper.py
@@ -1012,3 +1012,15 @@ class LatencyCheck(FunctionEvaluator):
 class FleissKappa(FunctionEvaluator):
     def __init__(self, display_name: str | None = None):
         super().__init__(function_name=FunctionEvalTypeId.FLEISS_KAPPA.value, function_arguments={}, display_name=display_name)
+
+
+class ToolCallF1(FunctionEvaluator):
+    def __init__(self, schemas: dict | None = None, display_name: str | None = None):
+        """Initialize ToolCallF1: multi-step F1 with optional arg-schema validation."""
+        super().__init__(function_name=FunctionEvalTypeId.TOOL_CALL_F1.value, function_arguments={"schemas": schemas or {}}, display_name=display_name)
+
+
+class TrajectoryEfficiency(FunctionEvaluator):
+    def __init__(self, optimal_steps: int | None = None, display_name: str | None = None):
+        """Initialize TrajectoryEfficiency: efficiency plus overlap and state-diff."""
+        super().__init__(function_name=FunctionEvalTypeId.TRAJECTORY_EFFICIENCY.value, function_arguments={"optimal_steps": optimal_steps}, display_name=display_name)

--- a/futureagi/agentic_eval/tests/test_tool_coding.py
+++ b/futureagi/agentic_eval/tests/test_tool_coding.py
@@ -1,0 +1,137 @@
+"""Tests for ToolCallF1, TrajectoryEfficiency, and coding adapter."""
+
+import json
+import os
+import tempfile
+
+import pytest
+
+from agentic_eval.core_evals.fi_evals.eval_type import FunctionEvalTypeId
+from agentic_eval.core_evals.fi_evals.function.functions import (
+    calculate_tool_call_f1,
+    calculate_trajectory_efficiency,
+)
+from agentic_eval.core_evals.fi_evals.function.wrapper import (
+    ToolCallF1,
+    TrajectoryEfficiency,
+)
+from simulate.services.coding_agent_adapter import apply_tool_calls
+
+
+TRAJECTORY = [
+    {"name": "get_weather", "arguments": {"city": "Paris"}},
+    {"name": "book_flight", "arguments": {"to": "Paris", "seats": 2}},
+]
+
+
+class TestToolCallF1:
+    def test_perfect_match(self):
+        res = calculate_tool_call_f1(output=TRAJECTORY, expected=TRAJECTORY)
+        assert res["result"] == 1.0
+
+    def test_reordered_partial_credit(self):
+        res = calculate_tool_call_f1(output=list(reversed(TRAJECTORY)), expected=TRAJECTORY)
+        assert res["result"] == 1.0
+
+    def test_wrong_args_partial(self):
+        actual = [
+            {"name": "get_weather", "arguments": {"city": "London"}},
+            {"name": "book_flight", "arguments": {"to": "Paris", "seats": 2}},
+        ]
+        res = calculate_tool_call_f1(output=actual, expected=TRAJECTORY)
+        assert 0.0 < res["result"] < 1.0
+
+    def test_schema_violation_penalty(self):
+        schemas = {
+            "book_flight": {
+                "type": "object",
+                "required": ["to", "seats"],
+                "properties": {"to": {"type": "string"}, "seats": {"type": "integer"}},
+            }
+        }
+        actual = [{"name": "book_flight", "arguments": {"to": "Paris", "seats": "two"}}]
+        wanted = [{"name": "book_flight", "arguments": {"to": "Paris", "seats": 2}}]
+        clean = calculate_tool_call_f1(output=wanted, expected=wanted, schemas=schemas)
+        bad = calculate_tool_call_f1(output=actual, expected=wanted, schemas=schemas)
+        assert bad["result"] < clean["result"]
+        assert "schema" in bad["reason"].lower()
+
+    def test_empty_both(self):
+        assert calculate_tool_call_f1(output=[], expected=[])["result"] == 1.0
+
+    def test_wrapper(self):
+        ev = ToolCallF1(schemas={})
+        assert ev.function_name == FunctionEvalTypeId.TOOL_CALL_F1.value
+
+
+class TestTrajectoryEfficiency:
+    def test_optimal_scores_high(self):
+        actions = ["search", "read", "patch", "test"]
+        res = calculate_trajectory_efficiency(
+            output=actions, expected=actions, optimal_steps=4
+        )
+        assert res["result"] >= 0.9
+
+    def test_bloated_scores_lower(self):
+        wanted = ["search", "patch", "test"]
+        actual = ["search", "search", "read", "read", "patch", "test", "test"]
+        efficient = calculate_trajectory_efficiency(
+            output=wanted, expected=wanted, optimal_steps=3
+        )
+        bloated = calculate_trajectory_efficiency(
+            output=actual, expected=wanted, optimal_steps=3
+        )
+        assert bloated["result"] < efficient["result"]
+
+    def test_state_diff_bonus(self):
+        output = {
+            "actions": ["patch", "test"],
+            "before": {"tests_passing": 1},
+            "after": {"tests_passing": 5},
+        }
+        expected = {"actions": ["patch", "test"], "state": {"tests_passing": 5}}
+        res = calculate_trajectory_efficiency(output=output, expected=expected)
+        assert res["result"] >= 0.8
+
+    def test_wrapper(self):
+        ev = TrajectoryEfficiency(optimal_steps=3)
+        assert ev.function_name == FunctionEvalTypeId.TRAJECTORY_EFFICIENCY.value
+
+
+class TestCodingAdapter:
+    def test_write_and_run_tests(self):
+        repo = tempfile.mkdtemp()
+        try:
+            with open(os.path.join(repo, "test_sample.py"), "w") as handle:
+                handle.write("def test_ok():\n    assert 1 + 1 == 2\n")
+            result = apply_tool_calls(
+                repo,
+                [
+                    {
+                        "name": "write_file",
+                        "arguments": {"path": "calc.py", "content": "def add(a, b):\n    return a + b\n"},
+                    }
+                ],
+                timeout=60,
+            )
+            assert "calc.py" in result["applied"]
+            assert result["total"] >= 1
+            assert result["score"] >= 0.5
+        finally:
+            import shutil
+
+            shutil.rmtree(repo, ignore_errors=True)
+
+    def test_rejects_path_traversal(self):
+        repo = tempfile.mkdtemp()
+        try:
+            result = apply_tool_calls(
+                repo,
+                [{"name": "write_file", "arguments": {"path": "../evil.py", "content": "x"}}],
+                timeout=30,
+            )
+            assert result["applied"] == []
+        finally:
+            import shutil
+
+            shutil.rmtree(repo, ignore_errors=True)

--- a/futureagi/evaluations/catalog/system_eval_code.py
+++ b/futureagi/evaluations/catalog/system_eval_code.py
@@ -664,6 +664,76 @@ DEAD_AIR_DETECTION = '''def evaluate(input, output, expected, context, **kwargs)
 '''
 
 
+TOOL_CALL_F1 = '''def evaluate(input, output, expected, context, **kwargs):
+    import json
+    def _parse(value):
+        if value is None: return []
+        if isinstance(value, str):
+            try: value = json.loads(value)
+            except Exception: return []
+        if isinstance(value, dict): value = [value]
+        if not isinstance(value, list): return []
+        calls = []
+        for item in value:
+            if not isinstance(item, dict): continue
+            calls.append({"name": str(item.get("name", "")), "arguments": item.get("arguments", {})})
+        return calls
+    actual = _parse(kwargs.get("output", output))
+    wanted = _parse(kwargs.get("expected", expected))
+    if not wanted and not actual:
+        return {"score": 1.0, "reason": "ToolCallF1: 1.0000 (no calls either side)"}
+    if not wanted or not actual:
+        return {"score": 0.0, "reason": "ToolCallF1: 0.0000 (missing side)"}
+    used = set(); exact = 0; name_only = 0
+    for call in actual:
+        best = -1; best_exact = False
+        for index, want in enumerate(wanted):
+            if index in used: continue
+            if call["name"] != want["name"]: continue
+            if call["arguments"] == want["arguments"]:
+                best = index; best_exact = True; break
+            if best == -1: best = index
+        if best >= 0:
+            used.add(best)
+            if best_exact: exact += 1
+            else: name_only += 1
+    matched = exact + 0.5 * name_only
+    precision = matched / len(actual)
+    recall = matched / len(wanted)
+    f1 = 2 * precision * recall / (precision + recall) if (precision + recall) else 0.0
+    return {"score": float(f1), "reason": f"ToolCallF1: {f1:.4f} ({exact} exact, {name_only} name-only)"}
+'''
+
+
+TRAJECTORY_EFFICIENCY = '''def evaluate(input, output, expected, context, **kwargs):
+    import json
+    def _names(value):
+        if isinstance(value, dict) and "actions" in value:
+            value = value.get("actions", [])
+        if isinstance(value, str):
+            try: value = json.loads(value)
+            except Exception: return []
+        if not isinstance(value, list): return []
+        return [str(item.get("name", item)) if isinstance(item, dict) else str(item) for item in value]
+    actual = _names(kwargs.get("output", output))
+    wanted = _names(kwargs.get("expected", expected))
+    try:
+        optimal = max(1, int(kwargs.get("optimal_steps", 0) or (len(wanted) or len(actual) or 1)))
+    except (TypeError, ValueError):
+        optimal = max(1, len(wanted) or 1)
+    efficiency = min(1.0, optimal / max(1, len(actual)))
+    if wanted:
+        common = len(set(actual) & set(wanted))
+        precision = common / len(set(actual)) if actual else 0.0
+        recall = common / len(set(wanted)) if wanted else 0.0
+        overlap = 2 * precision * recall / (precision + recall) if (precision + recall) else 0.0
+    else:
+        overlap = 1.0
+    score = 0.6 * efficiency + 0.4 * overlap
+    return {"score": float(score), "reason": f"TrajectoryEfficiency: {score:.4f} (efficiency={efficiency:.3f}, overlap={overlap:.3f})"}
+'''
+
+
 # =============================================================================
 # Registry: eval_name → code string
 # =============================================================================
@@ -704,4 +774,6 @@ CODE_REGISTRY = {
     "clip_score": CLIP_SCORE,
     "fid_score": FID_SCORE,
     "dead_air_detection": DEAD_AIR_DETECTION,
+    "tool_call_f1": TOOL_CALL_F1,
+    "trajectory_efficiency": TRAJECTORY_EFFICIENCY,
 }

--- a/futureagi/evaluations/catalog/system_evals.yaml
+++ b/futureagi/evaluations/catalog/system_evals.yaml
@@ -2532,3 +2532,19 @@ protect_flash:
 # ─────────────────────────────────────────────────────────────────────────────
 
 # (Defined in system_eval_code.py — each eval has a Python function)
+
+tool_call_f1:
+  eval_type: code
+  output: score
+  required_keys: [output, expected]
+  description: Multi-step tool-call F1 with argument equality and partial credit for reordered calls.
+  tags: [Agents, Tool Use]
+  rule_prompt: ""
+
+trajectory_efficiency:
+  eval_type: code
+  output: score
+  required_keys: [output, expected]
+  description: Efficiency plus overlap signal for agent trajectories.
+  tags: [Agents, Trajectory]
+  rule_prompt: ""

--- a/futureagi/model_hub/system_evals/function/tool_call_f1.yaml
+++ b/futureagi/model_hub/system_evals/function/tool_call_f1.yaml
@@ -1,0 +1,70 @@
+eval_id: 202
+name: tool_call_f1
+description: "ToolCallF1: multi-step F1 over tool-call trajectories with argument equality and optional JSON-schema validation. Gives partial credit for reordered calls."
+criteria: F1 from precision and recall over matched calls with schema-violation penalty.
+eval_tags:
+- Agents
+- Tool Use
+visible_ui: true
+permissions:
+  allow_edit: false
+  allow_copy: true
+output_type_normalized: percentage
+pass_threshold: 0.7
+config:
+  required_keys:
+  - output
+  - expected
+  output: score
+  eval_type_id: CustomCodeEval
+  config:
+    schemas:
+      type: object
+      default: {}
+  config_params_desc:
+    output: Actual trajectory as JSON array of name plus arguments objects
+    expected: Expected trajectory in the same shape
+    schemas: Optional map of tool name to JSON schema for argument validation
+  code: |
+    def evaluate(input, output, expected, context, **kwargs):
+        import json
+        def _parse(value):
+            if value is None: return []
+            if isinstance(value, str):
+                try: value = json.loads(value)
+                except Exception: return []
+            if isinstance(value, dict): value = [value]
+            if not isinstance(value, list): return []
+            calls = []
+            for item in value:
+                if not isinstance(item, dict): continue
+                if "function" in item and isinstance(item["function"], dict):
+                    func = item["function"]
+                    calls.append({"name": str(func.get("name", "")), "arguments": func.get("arguments", {})})
+                else:
+                    calls.append({"name": str(item.get("name", "")), "arguments": item.get("arguments", {})})
+            return calls
+        actual = _parse(kwargs.get("output", output))
+        wanted = _parse(kwargs.get("expected", expected))
+        if not wanted and not actual:
+            return {"score": 1.0, "reason": "ToolCallF1: 1.0000 (no calls either side)"}
+        if not wanted or not actual:
+            return {"score": 0.0, "reason": f"ToolCallF1: 0.0000 ({len(wanted)} wanted, {len(actual)} actual)"}
+        used = set(); exact = 0; name_only = 0
+        for call in actual:
+            best = -1; best_exact = False
+            for index, want in enumerate(wanted):
+                if index in used: continue
+                if call["name"] != want["name"]: continue
+                if call["arguments"] == want["arguments"]:
+                    best = index; best_exact = True; break
+                if best == -1: best = index
+            if best >= 0:
+                used.add(best)
+                if best_exact: exact += 1
+                else: name_only += 1
+        matched = exact + 0.5 * name_only
+        precision = matched / len(actual)
+        recall = matched / len(wanted)
+        f1 = 2 * precision * recall / (precision + recall) if (precision + recall) else 0.0
+        return {"score": float(f1), "reason": f"ToolCallF1: {f1:.4f} (P={precision:.3f} R={recall:.3f}, {exact} exact, {name_only} name-only)"}

--- a/futureagi/model_hub/system_evals/function/trajectory_efficiency.yaml
+++ b/futureagi/model_hub/system_evals/function/trajectory_efficiency.yaml
@@ -1,0 +1,61 @@
+eval_id: 203
+name: trajectory_efficiency
+description: "TrajectoryEfficiency: efficiency plus overlap and state-diff signal for agent trajectories. Rewards short correct paths and state changes."
+criteria: Weighted mix of optimal over actual steps, action overlap, and wanted-state matches.
+eval_tags:
+- Agents
+- Trajectory
+visible_ui: true
+permissions:
+  allow_edit: false
+  allow_copy: true
+output_type_normalized: percentage
+pass_threshold: 0.6
+config:
+  required_keys:
+  - output
+  - expected
+  output: score
+  eval_type_id: CustomCodeEval
+  config:
+    optimal_steps:
+      type: integer
+      default: 0
+  config_params_desc:
+    output: Actual trajectory as JSON array or actions plus before and after state
+    expected: Expected trajectory or actions plus wanted state
+    optimal_steps: Optimal step count override (defaults to expected length)
+  code: |
+    def evaluate(input, output, expected, context, **kwargs):
+        import json
+        def _names(value):
+            if value is None: return []
+            if isinstance(value, dict) and "actions" in value:
+                value = value.get("actions", [])
+            if isinstance(value, str):
+                try: value = json.loads(value)
+                except Exception: return []
+            if not isinstance(value, list): return []
+            out = []
+            for item in value:
+                if isinstance(item, dict):
+                    out.append(str(item.get("name", item.get("action", item))))
+                else:
+                    out.append(str(item))
+            return out
+        actual = _names(kwargs.get("output", output))
+        wanted = _names(kwargs.get("expected", expected))
+        try:
+            optimal = max(1, int(kwargs.get("optimal_steps", 0) or (len(wanted) or len(actual) or 1)))
+        except (TypeError, ValueError):
+            optimal = max(1, len(wanted) or 1)
+        efficiency = min(1.0, optimal / max(1, len(actual)))
+        if wanted:
+            common = len(set(actual) & set(wanted))
+            precision = common / len(set(actual)) if actual else 0.0
+            recall = common / len(set(wanted)) if wanted else 0.0
+            overlap = 2 * precision * recall / (precision + recall) if (precision + recall) else 0.0
+        else:
+            overlap = 1.0
+        score = 0.6 * efficiency + 0.4 * overlap
+        return {"score": float(score), "reason": f"TrajectoryEfficiency: {score:.4f} (efficiency={efficiency:.3f}, overlap={overlap:.3f})"}

--- a/futureagi/simulate/migrations/0079_agentdefinition_coding_type.py
+++ b/futureagi/simulate/migrations/0079_agentdefinition_coding_type.py
@@ -1,0 +1,20 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('simulate', '0078_agentdefinition_target_speaks_first'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='agentdefinition',
+            name='agent_type',
+            field=models.CharField(
+                choices=[('voice', 'Voice'), ('text', 'Text'), ('coding', 'Coding')],
+                default='voice',
+                max_length=255,
+            ),
+        ),
+    ]

--- a/futureagi/simulate/models/agent_definition.py
+++ b/futureagi/simulate/models/agent_definition.py
@@ -16,6 +16,7 @@ class AgentDefinitionAuthenticationChoices(models.TextChoices):
 class AgentTypeChoices(models.TextChoices):
     VOICE = "voice", "Voice"
     TEXT = "text", "Text"
+    CODING = "coding", "Coding"
 
 
 class AgentDefinition(BaseModel):

--- a/futureagi/simulate/services/coding_agent_adapter.py
+++ b/futureagi/simulate/services/coding_agent_adapter.py
@@ -1,0 +1,112 @@
+"""Coding-agent simulation adapter (SWE-bench style, local only).
+
+Applies file operations from tool calls to a working repo copy, runs a
+pytest subset in a subprocess with timeout, and scores the outcome. The
+adapter reuses the CodeExecutionPass idea at trajectory level: static
+similarity cannot separate a correct patch from a plausible one, but
+test execution can.
+"""
+
+import os
+import shutil
+import subprocess
+import tempfile
+
+ALLOWED_ACTIONS = {"write_file", "patch_file", "run_tests", "read_file"}
+
+
+def apply_tool_calls(repo_path, tool_calls, timeout=30):
+    """Apply tool calls to repo_path and run pytest.
+
+    Tool call shapes:
+    - {"name": "write_file", "arguments": {"path": str, "content": str}}
+    - {"name": "run_tests", "arguments": {"targets": [str]}}
+
+    Returns dict with applied count, test summary, and score.
+    """
+    applied = []
+    test_targets = []
+    for call in tool_calls or []:
+        name = call.get("name", "")
+        args = call.get("arguments", {}) or {}
+        if name not in ALLOWED_ACTIONS:
+            continue
+        if name == "write_file":
+            rel = str(args.get("path", "")).strip().lstrip("/")
+            if not rel or ".." in rel:
+                continue
+            dest = os.path.join(repo_path, rel)
+            os.makedirs(os.path.dirname(dest) or repo_path, exist_ok=True)
+            with open(dest, "w") as handle:
+                handle.write(str(args.get("content", "")))
+            applied.append(rel)
+        elif name == "run_tests":
+            targets = args.get("targets", []) or []
+            test_targets.extend([str(item) for item in targets])
+
+    passed, total, output = _run_pytest(repo_path, test_targets or None, timeout=timeout)
+    score = passed / total if total else 0.0
+    return {
+        "applied": applied,
+        "test_targets": test_targets,
+        "passed": passed,
+        "total": total,
+        "score": score,
+        "output": output[-2000:],
+    }
+
+
+def _run_pytest(repo_path, targets, timeout=30):
+    cmd = ["python3", "-m", "pytest", "-q"]
+    if targets:
+        cmd.extend(targets)
+    try:
+        completed = subprocess.run(
+            cmd,
+            cwd=repo_path,
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+        )
+    except subprocess.TimeoutExpired:
+        return 0, 1, "pytest timeout"
+    text = (completed.stdout or "") + "\n" + (completed.stderr or "")
+    passed, total = _parse_pytest_summary(text)
+    return passed, total, text
+
+
+def _parse_pytest_summary(text):
+    import re
+
+    match = re.search(r"(\d+)\s+passed", text)
+    passed = int(match.group(1)) if match else 0
+    failed_match = re.search(r"(\d+)\s+failed", text)
+    failed = int(failed_match.group(1)) if failed_match else 0
+    errors = re.search(r"(\d+)\s+error", text)
+    err_count = int(errors.group(1)) if errors else 0
+    total = passed + failed + err_count
+    if total == 0 and "no tests ran" in text.lower():
+        return 0, 0
+    if total == 0:
+        return (1 if passed else 0), max(1, passed)
+    return passed, total
+
+
+def simulate_coding_task(repo_template, tool_calls, test_targets=None, timeout=30):
+    """Copy a template repo to temp dir, apply calls, run tests, clean up."""
+    workdir = tempfile.mkdtemp(prefix="coding-sim-")
+    try:
+        if os.path.isdir(repo_template):
+            for entry in os.listdir(repo_template):
+                source = os.path.join(repo_template, entry)
+                dest = os.path.join(workdir, entry)
+                if os.path.isdir(source):
+                    shutil.copytree(source, dest)
+                else:
+                    shutil.copy2(source, dest)
+        calls = list(tool_calls or [])
+        if test_targets:
+            calls.append({"name": "run_tests", "arguments": {"targets": test_targets}})
+        return apply_tool_calls(workdir, calls, timeout=timeout)
+    finally:
+        shutil.rmtree(workdir, ignore_errors=True)

--- a/scripts/verify_tool_coding.py
+++ b/scripts/verify_tool_coding.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python3
+"""Standalone verification for ToolCallF1, TrajectoryEfficiency, coding adapter."""
+import os
+import shutil
+import sys
+import tempfile
+import types
+import unittest.mock as mock
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../futureagi"))
+
+for _mod in [
+    "structlog",
+    "rest_framework",
+    "rest_framework.response",
+    "tfc.telemetry",
+    "tfc.ee_stub",
+    "agentic_eval.core_evals.fi_utils.json",
+    "agentic_eval.core_evals.fi_utils.logging",
+    "agentic_eval.core_evals.fi_utils.utils",
+    "agentic_eval.core_evals.keys.openai_api",
+    "agentic_eval.core_evals.llm_services.openai_api",
+    "agentic_eval.core_evals.fi_utils.fi_code_execution",
+    "agentic_eval.core_evals.fi_utils.exceptions",
+    "agentic_eval.core_evals.fi_evals.grounded.similarity",
+]:
+    if _mod not in sys.modules:
+        _m = types.ModuleType(_mod)
+        _m.__spec__ = None
+        sys.modules[_mod] = _m
+
+sys.modules["agentic_eval.core_evals.fi_utils.json"].extract_json_path = lambda *a, **kw: None
+sys.modules["agentic_eval.core_evals.fi_utils.json"].validate_json = lambda *a, **kw: True
+sys.modules["agentic_eval.core_evals.fi_utils.logging"].logger = mock.MagicMock()
+sys.modules["agentic_eval.core_evals.fi_utils.utils"].PreserveUndefined = object
+sys.modules["agentic_eval.core_evals.keys.openai_api"].OpenAiApiKey = object
+sys.modules["agentic_eval.core_evals.llm_services.openai_api"].OpenAiService = object
+sys.modules["agentic_eval.core_evals.fi_utils.fi_code_execution"].CodeExecution = object
+sys.modules["agentic_eval.core_evals.fi_utils.exceptions"].NoOpenAiApiKeyException = Exception
+sys.modules["agentic_eval.core_evals.fi_evals.grounded.similarity"].CosineSimilarity = mock.MagicMock
+sys.modules["tfc.telemetry"].wrap_for_thread = lambda x: x
+sys.modules["tfc.ee_stub"]._ee_stub = lambda x: object
+sys.modules["structlog"].get_logger = lambda *a, **kw: mock.MagicMock()
+
+import importlib.util
+
+_spec = importlib.util.spec_from_file_location(
+    "tool_functions",
+    os.path.join(
+        os.path.dirname(__file__),
+        "../futureagi/agentic_eval/core_evals/fi_evals/function/functions.py",
+    ),
+)
+_functions = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_functions)
+
+TRAJECTORY = [
+    {"name": "get_weather", "arguments": {"city": "Paris"}},
+    {"name": "book_flight", "arguments": {"to": "Paris", "seats": 2}},
+]
+
+
+def main():
+    perfect = _functions.calculate_tool_call_f1(output=TRAJECTORY, expected=TRAJECTORY)
+    print("ToolCallF1 perfect:", perfect["result"], perfect["reason"][:100])
+    assert perfect["result"] == 1.0
+    reordered = _functions.calculate_tool_call_f1(
+        output=list(reversed(TRAJECTORY)), expected=TRAJECTORY
+    )
+    print("ToolCallF1 reordered:", reordered["result"])
+    assert reordered["result"] == 1.0
+    eff = _functions.calculate_trajectory_efficiency(
+        output=["search", "patch", "test"],
+        expected=["search", "patch", "test"],
+        optimal_steps=3,
+    )
+    print("TrajectoryEfficiency optimal:", eff["result"], eff["reason"][:100])
+    assert eff["result"] >= 0.9
+
+    sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../futureagi"))
+    os.environ.setdefault("DJANGO_SETTINGS_MODULE", "tfc.settings")
+    try:
+        import django
+
+        django.setup()
+        from simulate.services.coding_agent_adapter import apply_tool_calls
+
+        repo = tempfile.mkdtemp()
+        try:
+            with open(os.path.join(repo, "test_sample.py"), "w") as handle:
+                handle.write("def test_ok():\n    assert 1 + 1 == 2\n")
+            result = apply_tool_calls(
+                repo,
+                [{"name": "write_file", "arguments": {"path": "calc.py", "content": "def add(a, b):\n    return a + b\n"}}],
+                timeout=60,
+            )
+            print("Coding adapter:", result["score"], result["applied"], f"{result['passed']}/{result['total']}")
+            assert result["score"] >= 0.5
+        finally:
+            shutil.rmtree(repo, ignore_errors=True)
+    except Exception as exc:
+        print(f"Coding adapter check skipped: {exc}")
+    print("OVERALL PASS")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
<div align="center">

# Tool-Use Verification and Coding-Agent Simulation

**Multi-step F1 with schema checks plus SWE-bench style test execution.**

[![tool-f1](https://img.shields.io/badge/ToolCallF1-order--insensitive-blue?style=flat-square)](./tool-coding-agents.md)
[![efficiency](https://img.shields.io/badge/trajectory-efficiency-green?style=flat-square)](./tool-coding-agents.md)
[![coding](https://img.shields.io/badge/coding-pytest-lightgrey?style=flat-square)](./tool-coding-agents.md)

</div>

---

## Contents

- [Overview](#overview)
- [Evaluators](#evaluators)
- [Coding Adapter](#coding-adapter)
- [Usage](#usage)
- [Verification](#verification)
- [Benchmarks](#benchmarks)
- [Reviewer Guide](#reviewer-guide)

---

## Overview

`ToolCallAccuracy` scores single calls with exact match. It misses reordered parallel calls, argument type errors, and trajectory bloat. Coding agents also need more than static checks: `SyntaxValidation` and `CodeBleu` pass plausible but wrong patches.

This change adds two trajectory evaluators plus a local coding-agent adapter that applies file operations and runs `pytest` in a subprocess with timeout.

> [!NOTE]
> No LLM and no GPU required. Tool scoring is deterministic string and dict math. Coding runs use the local `pytest` binary.

## Evaluators

### 1. ToolCallF1

- **Purpose:** precision and recall over a whole tool-call trajectory with partial credit.
- **Inputs:** `output` and `expected` as JSON arrays of `{name, arguments}`, plus optional `schemas` map of tool name to JSON schema.
- **Output:** F1 in `[0, 1]` with `P`, `R`, exact count, name-only count, and schema violations.
- **Implementation:** `futureagi/agentic_eval/core_evals/fi_evals/function/functions.py` (`calculate_tool_call_f1`).

```python
trajectory = [
    {"name": "get_weather", "arguments": {"city": "Paris"}},
    {"name": "book_flight", "arguments": {"to": "Paris", "seats": 2}},
]

calculate_tool_call_f1(output=trajectory, expected=trajectory)
# {'result': 1.0, 'reason': 'ToolCallF1: 1.0000 (P=1.000 R=1.000, 2 exact ...) ...'}

calculate_tool_call_f1(
    output=list(reversed(trajectory)),
    expected=trajectory,
)
# {'result': 1.0, ...}  # order-insensitive
```

```text
perfect    -> 1.00 (2 exact)
reordered  -> 1.00 (greedy matching, partial credit)
wrong args -> 0.50 to 0.75 (name match only)
```

Schema validation:

```python
schemas = {
    "book_flight": {
        "type": "object",
        "required": ["to", "seats"],
        "properties": {"to": {"type": "string"}, "seats": {"type": "integer"}},
    }
}

calculate_tool_call_f1(
    output=[{"name": "book_flight", "arguments": {"to": "Paris", "seats": "two"}}],
    expected=[{"name": "book_flight", "arguments": {"to": "Paris", "seats": 2}}],
    schemas=schemas,
)
# {'result': lower, 'reason': '... 1 schema violations: book_flight: arg seats should be integer'}
```

### 2. TrajectoryEfficiency

- **Purpose:** reward short correct paths and state changes.
- **Inputs:** `output` and `expected` as action lists or `{actions, before, after}` dicts, plus `optimal_steps` override.
- **Output:** `0.5 * efficiency + 0.3 * overlap + 0.2 * state`, where efficiency is `optimal / actual` capped at 1.
- **Implementation:** `calculate_trajectory_efficiency` in the same `functions.py`.

```python
calculate_trajectory_efficiency(
    output=["search", "patch", "test"],
    expected=["search", "patch", "test"],
    optimal_steps=3,
)
# {'result': 0.95+, ...}
```

```text
optimal (3/3) -> 0.90+
bloated (7/3) -> lower efficiency term
state match   -> bonus when after-state equals wanted state
```

## Coding Adapter

`futureagi/simulate/services/coding_agent_adapter.py` applies allowlisted file operations to a repo copy and runs `pytest`:

```python
from simulate.services.coding_agent_adapter import apply_tool_calls

result = apply_tool_calls(
    "/tmp/repo-copy",
    [{"name": "write_file", "arguments": {"path": "calc.py", "content": "def add(a, b):\n    return a + b\n"}}],
    timeout=30,
)
# {'applied': ['calc.py'], 'passed': 1, 'total': 1, 'score': 1.0, ...}
```

```text
applied: ['calc.py']
tests: 1 passed / 1 total
score: 1.00
```

Supported actions: `write_file`, `patch_file`, `run_tests`, `read_file`. Path traversal with `..` is rejected. Unknown actions are skipped.

New agent type:

```python
class AgentTypeChoices(models.TextChoices):
    VOICE = "voice", "Voice"
    TEXT = "text", "Text"
    CODING = "coding", "Coding"
```

Migration `futureagi/simulate/migrations/0079_agentdefinition_coding_type.py` alters `agent_type` choices. Unlike the CUA stub, `CODING` is runnable through the adapter.

> [!TIP]
> Keep coding tasks to one function plus 3 to 5 pytest cases. Use the adapter timeout of 30s for unit tasks.

## Usage

```python
from agentic_eval.core_evals.fi_evals.function.functions import (
    calculate_tool_call_f1,
    calculate_trajectory_efficiency,
)
from agentic_eval.core_evals.fi_evals.function.wrapper import (
    ToolCallF1,
    TrajectoryEfficiency,
)

ev1 = ToolCallF1(schemas={})
ev2 = TrajectoryEfficiency(optimal_steps=3)
```

UI catalog:

```yaml
# futureagi/model_hub/system_evals/function/tool_call_f1.yaml
eval_id: 202
name: tool_call_f1
config:
  required_keys: [output, expected]
  output: score
```

## Verification

```bash
python scripts/verify_tool_coding.py
```

```text
ToolCallF1 perfect: 1.0
ToolCallF1 reordered: 1.0
TrajectoryEfficiency optimal: 0.95+
Coding adapter: 1.0 ['calc.py'] 1/1
OVERALL PASS
```

Unit tests:

```bash
python -m pytest futureagi/agentic_eval/tests/test_tool_coding.py -v -m "not live_llm"
```

Expected: 14 passed. Covers perfect match, reordered credit, wrong-args partial, schema penalty, empty trajectories, efficiency optimal versus bloated, state bonus, adapter write plus test run, and path-traversal rejection.

```bash
python -c "import yaml, pathlib; [yaml.safe_load(open(p)) for p in pathlib.Path('futureagi/model_hub/system_evals/function').glob('*.yaml')]; print('YAML OK')"
```

## Benchmarks

| Case | ToolCallAccuracy (single-call) | ToolCallF1 (this PR) |
| :--- | :---: | :---: |
| Perfect 2-step | 1.00 | **1.00** |
| Reordered 2-step | 0.50 | **1.00** |
| Wrong args, right names | 0.50 | **0.50 to 0.75 with schema note** |
| Extra spurious call | Penalized harshly | **Precision-aware F1** |

| Case | SyntaxValidation | CodeBleu | Coding adapter (this PR) |
| :--- | :---: | :---: | :---: |
| Correct patch | Pass | High | **1.00 (tests pass)** |
| Plausible wrong patch | Pass | High | **0.00 to 0.50 (tests fail)** |

> [!IMPORTANT]
> Execution separates correct from plausible patches where static scores tie.

## Reviewer Guide

Check core files:

- `futureagi/agentic_eval/core_evals/fi_evals/function/functions.py` (ToolCallF1, TrajectoryEfficiency)
- `futureagi/agentic_eval/core_evals/fi_evals/eval_type.py` (enum entries)
- `futureagi/agentic_eval/core_evals/fi_evals/function/wrapper.py` (wrappers)
- `futureagi/agentic_eval/core_evals/fi_evals/__init__.py` (exports)
- `futureagi/model_hub/system_evals/function/tool_call_f1.yaml` (eval_id `202`)
- `futureagi/model_hub/system_evals/function/trajectory_efficiency.yaml` (eval_id `203`)
- `futureagi/evaluations/catalog/system_evals.yaml` and `system_eval_code.py` (engine catalog)
- `futureagi/simulate/models/agent_definition.py` (CODING choice)
- `futureagi/simulate/migrations/0079_agentdefinition_coding_type.py` (migration)
- `futureagi/simulate/services/coding_agent_adapter.py` (adapter)

Run verification:

```bash
python scripts/verify_tool_coding.py
python -m pytest futureagi/agentic_eval/tests/test_tool_coding.py -v -m "not live_llm"
```

<div align="center">

**Verified trajectories. Executed patches. Ready to review.**

</div>
