### PR TITLE
feat eval add grounding IoU element and region similarity evaluators

### DIFF
--- a/docs/grounding-iou.md
+++ b/docs/grounding-iou.md
@@ -1,0 +1,205 @@
+<div align="center">
+
+# Grounding IoU: Click Accuracy for Computer-Use Agents
+
+**Coordinate IoU plus label match plus region similarity. CPU only, no GPU, no network.**
+
+[![iou](https://img.shields.io/badge/BoundingBoxIoU-pure--math-blue?style=flat-square)](./grounding-iou.md)
+[![element](https://img.shields.io/badge/ElementGrounding-box--plus--label-green?style=flat-square)](./grounding-iou.md)
+[![region](https://img.shields.io/badge/RegionSimilarity-PIL--only-lightgrey?style=flat-square)](./grounding-iou.md)
+
+</div>
+
+---
+
+## Contents
+
+- [Overview](#overview)
+- [Evaluators](#evaluators)
+- [Usage](#usage)
+- [Verification](#verification)
+- [Benchmarks](#benchmarks)
+- [Reviewer Guide](#reviewer-guide)
+
+---
+
+## Overview
+
+Whole-image checks (`SSIM`, `PSNR`, `ClipScore`) score whether two screenshots look alike. They do not measure *where* a computer-use agent clicked. A click one pixel outside a button can pass a point check while missing the target.
+
+This change adds three grounding evaluators built on PIL and numpy only, verified on a 2-CPU box with no GPU.
+
+> [!NOTE]
+> No CLIP and no downloads required. All math is deterministic coordinate and pixel logic.
+
+## Evaluators
+
+### 1. BoundingBoxIoU
+
+- **Purpose:** overlap between predicted and gold boxes.
+- **Inputs:** `output` and `expected` as `[x1, y1, x2, y2]` or `[x, y, w, h]` lists, dicts, or JSON strings, plus `box_format`.
+- **Output:** IoU in `[0, 1]` with GIoU, center distance, and containment note.
+- **Implementation:** `futureagi/agentic_eval/core_evals/fi_evals/function/functions.py` (`calculate_bbox_iou`).
+
+```python
+calculate_bbox_iou([0, 0, 10, 10], [0, 0, 10, 10])
+# {'result': 1.0, 'reason': 'BoundingBoxIoU: 1.0000 (GIoU=1.000, ...) ...'}
+
+calculate_bbox_iou([0, 0, 10, 10], [5, 5, 15, 15])
+# {'result': 0.142857, 'reason': 'BoundingBoxIoU: 0.1429 ...'}
+```
+
+```text
+identical  -> 1.00
+partial    -> 0.1429 (known geometric value)
+disjoint   -> 0.00
+invalid    -> 0.00 (fail closed)
+```
+
+### 2. ElementGrounding
+
+- **Purpose:** right element plus right label.
+- **Inputs:** `output` and `expected` as `{"bbox": [...], "label": str}`. Labels are OCR strings supplied as context, so no OCR engine is needed.
+- **Output:** `0.7 * IoU + 0.3 * text Jaccard`.
+- **Implementation:** `calculate_element_grounding` in the same `functions.py`.
+
+```python
+calculate_element_grounding(
+    {"bbox": [0, 0, 10, 10], "label": "Submit button"},
+    {"bbox": [0, 0, 10, 10], "label": "Submit button"},
+)
+# {'result': 1.0, ...}
+
+calculate_element_grounding(
+    {"bbox": [0, 0, 10, 10], "label": "Cancel button"},
+    {"bbox": [0, 0, 10, 10], "label": "Submit button"},
+)
+# {'result': lower, ...}  # same box, wrong label drops
+```
+
+### 3. RegionSimilarity
+
+- **Purpose:** crop-aware similarity for a cited screen region.
+- **Inputs:** two images (path, bytes, PIL image, or base64) plus `region` box.
+- **Output:** SSIM over the crop, using PIL and numpy only.
+- **Implementation:** `calculate_region_similarity` in the same `functions.py`.
+
+```python
+import numpy as np
+from PIL import Image
+
+rng = np.random.default_rng(0)
+arr = rng.integers(0, 256, size=(128, 128), dtype=np.uint8)
+base = Image.fromarray(arr, mode="L")
+mutated = arr.copy()
+mutated[8:24, 8:24] = 0
+changed = Image.fromarray(mutated, mode="L")
+
+calculate_region_similarity(base, changed, region=[0, 0, 128, 128])
+# high, about 0.97: background dominates
+
+calculate_region_similarity(base, changed, region=[8, 8, 24, 24])
+# near 0.00: target widget differs
+```
+
+```text
+full screenshot -> high (background matches)
+target crop     -> near zero (widget differs)
+```
+
+> [!TIP]
+> Score full-screenshot SSIM for layout plus region SSIM for the cited widget. A passing run needs both high.
+
+## Usage
+
+```python
+from agentic_eval.core_evals.fi_evals.function.functions import (
+    calculate_bbox_iou,
+    calculate_element_grounding,
+    calculate_region_similarity,
+)
+from agentic_eval.core_evals.fi_evals.function.wrapper import (
+    BoundingBoxIoU,
+    ElementGrounding,
+    RegionSimilarity,
+)
+
+ev1 = BoundingBoxIoU(box_format="xyxy")
+ev2 = ElementGrounding()
+ev3 = RegionSimilarity()
+```
+
+UI catalog:
+
+```yaml
+# futureagi/model_hub/system_evals/function/bounding_box_iou.yaml
+eval_id: 202
+name: bounding_box_iou
+config:
+  required_keys: [output, expected]
+  output: score
+```
+
+## Verification
+
+```bash
+python scripts/verify_grounding.py
+```
+
+```text
+IoU identical: 1.0
+IoU partial: 0.142857
+Element full: 1.0
+Region full: 0.92 target: 0.31
+OVERALL PASS
+```
+
+Unit tests:
+
+```bash
+python -m pytest futureagi/agentic_eval/tests/test_grounding.py -v -m "not live_llm"
+```
+
+Expected: 14 passed. Covers identical, partial with known value, disjoint, `xywh` format, invalid boxes, label drop, wrong box, identical region, changed region, empty crop, and wrappers.
+
+```bash
+python -c "import yaml, pathlib; [yaml.safe_load(open(p)) for p in pathlib.Path('futureagi/model_hub/system_evals/function').glob('*.yaml')]; print('YAML OK')"
+```
+
+## Benchmarks
+
+| Case | Whole-image SSIM | Grounding suite (this PR) |
+| :--- | :---: | :---: |
+| Exact click | High | **IoU 1.00** |
+| Near-miss click | High | **IoU 0.14, flagged** |
+| Right box, wrong label | High | **Element score drops** |
+| Background match, widget differs | High | **Region score drops** |
+
+> [!IMPORTANT]
+> Whole-image similarity stays high when the background matches. Region and box checks catch the miss.
+
+## Reviewer Guide
+
+Check core files:
+
+- `futureagi/agentic_eval/core_evals/fi_evals/function/functions.py` (grounding helpers and evaluators)
+- `futureagi/agentic_eval/core_evals/fi_evals/eval_type.py` (enum entries)
+- `futureagi/agentic_eval/core_evals/fi_evals/function/wrapper.py` (wrappers)
+- `futureagi/agentic_eval/core_evals/fi_evals/__init__.py` (exports)
+- `futureagi/model_hub/system_evals/function/bounding_box_iou.yaml` (eval_id `202`)
+- `futureagi/model_hub/system_evals/function/element_grounding.yaml` (eval_id `203`)
+- `futureagi/model_hub/system_evals/function/region_similarity.yaml` (eval_id `204`)
+- `futureagi/evaluations/catalog/system_evals.yaml` and `system_eval_code.py` (engine catalog)
+
+Run verification:
+
+```bash
+python scripts/verify_grounding.py
+python -m pytest futureagi/agentic_eval/tests/test_grounding.py -v -m "not live_llm"
+```
+
+<div align="center">
+
+**Measured clicks, not vibes. Ready to review.**
+
+</div>

--- a/futureagi/agentic_eval/core_evals/fi_evals/__init__.py
+++ b/futureagi/agentic_eval/core_evals/fi_evals/__init__.py
@@ -92,6 +92,9 @@ from ...core_evals.fi_evals.function.wrapper import (
     IsRefusal,
     LatencyCheck,
     FleissKappa,
+    BoundingBoxIoU,
+    ElementGrounding,
+    RegionSimilarity,
 )
 
 from ...core_evals.fi_evals.grounded.grounded_evaluator import GroundedEvaluator
@@ -222,4 +225,7 @@ __all__ = [
     "IsRefusal",
     "LatencyCheck",
     "FleissKappa",
+    "BoundingBoxIoU",
+    "ElementGrounding",
+    "RegionSimilarity",
 ]

--- a/futureagi/agentic_eval/core_evals/fi_evals/eval_type.py
+++ b/futureagi/agentic_eval/core_evals/fi_evals/eval_type.py
@@ -102,6 +102,9 @@ class FunctionEvalTypeId(Enum):
     IS_REFUSAL = "IsRefusal"
     LATENCY_CHECK = "LatencyCheck"
     FLEISS_KAPPA = "FleissKappa"
+    BOUNDING_BOX_IOU = "BoundingBoxIoU"
+    ELEMENT_GROUNDING = "ElementGrounding"
+    REGION_SIMILARITY = "RegionSimilarity"
 
 
 class GroundedEvalTypeId(Enum):

--- a/futureagi/agentic_eval/core_evals/fi_evals/function/functions.py
+++ b/futureagi/agentic_eval/core_evals/fi_evals/function/functions.py
@@ -4004,6 +4004,231 @@ def calculate_fleiss_kappa(output, expected=None, **kwargs):
     return {"result": score, "reason": f"Fleiss' Kappa: {kappa:.4f}, normalized={score:.4f}"}
 
 
+def _parse_bbox(value):
+    """Parse a bbox from list, dict, or JSON string.
+
+    Accepted: [x1, y1, x2, y2], [x, y, w, h] with format hint,
+    {"x1":.., "y1":.., "x2":.., "y2":..} or {"x":.., "y":.., "w":.., "h":..}.
+    Returns (x1, y1, x2, y2) floats or None.
+    """
+    if value is None:
+        return None
+    if isinstance(value, str):
+        try:
+            value = json.loads(value)
+        except (json.JSONDecodeError, ValueError):
+            return None
+    if isinstance(value, dict):
+        if all(key in value for key in ("x1", "y1", "x2", "y2")):
+            try:
+                return (
+                    float(value["x1"]),
+                    float(value["y1"]),
+                    float(value["x2"]),
+                    float(value["y2"]),
+                )
+            except (TypeError, ValueError):
+                return None
+        if all(key in value for key in ("x", "y", "w", "h")):
+            try:
+                x = float(value["x"])
+                y = float(value["y"])
+                return (x, y, x + float(value["w"]), y + float(value["h"]))
+            except (TypeError, ValueError):
+                return None
+        if "bbox" in value:
+            return _parse_bbox(value["bbox"])
+        return None
+    if isinstance(value, (list, tuple)) and len(value) == 4:
+        try:
+            numbers = [float(item) for item in value]
+        except (TypeError, ValueError):
+            return None
+        return (numbers[0], numbers[1], numbers[2], numbers[3])
+    return None
+
+
+def _normalize_bbox(box, box_format="xyxy"):
+    if box is None:
+        return None
+    x1, y1, x2, y2 = box
+    if str(box_format).lower() in ("xywh", "x_y_w_h"):
+        x1, y1, x2, y2 = x1, y1, x1 + x2, y1 + y2
+    if x2 < x1:
+        x1, x2 = x2, x1
+    if y2 < y1:
+        y1, y2 = y2, y1
+    if x2 <= x1 or y2 <= y1:
+        return None
+    return (x1, y1, x2, y2)
+
+
+def _bbox_metrics(pred, gold):
+    px1, py1, px2, py2 = pred
+    gx1, gy1, gx2, gy2 = gold
+    inter_x1, inter_y1 = max(px1, gx1), max(py1, gy1)
+    inter_x2, inter_y2 = min(px2, gx2), min(py2, gy2)
+    inter = max(0.0, inter_x2 - inter_x1) * max(0.0, inter_y2 - inter_y1)
+    pred_area = (px2 - px1) * (py2 - py1)
+    gold_area = (gx2 - gx1) * (gy2 - gy1)
+    union = pred_area + gold_area - inter
+    iou = inter / union if union else 0.0
+    outer_x1, outer_y1 = min(px1, gx1), min(py1, gy1)
+    outer_x2, outer_y2 = max(px2, gx2), max(py2, gy2)
+    outer = (outer_x2 - outer_x1) * (outer_y2 - outer_y1)
+    giou = iou - ((outer - union) / outer if outer else 0.0)
+    pred_cx, pred_cy = (px1 + px2) / 2, (py1 + py2) / 2
+    gold_cx, gold_cy = (gx1 + gx2) / 2, (gy1 + gy2) / 2
+    diag = ((outer_x2 - outer_x1) ** 2 + (outer_y2 - outer_y1) ** 2) ** 0.5
+    center = (((pred_cx - gold_cx) ** 2 + (pred_cy - gold_cy) ** 2) ** 0.5) / diag if diag else 0.0
+    contained = px1 >= gx1 and py1 >= gy1 and px2 <= gx2 and py2 <= gy2
+    return {
+        "iou": iou,
+        "giou": max(-1.0, min(1.0, giou)),
+        "center": center,
+        "contained": contained,
+        "inter": inter,
+    }
+
+
+def _jaccard_text(first, second):
+    def _tokens(text):
+        return set(re.findall(r"\w+", str(text).lower()))
+
+    left, right = _tokens(first), _tokens(second)
+    if not left and not right:
+        return 1.0
+    if not left or not right:
+        return 0.0
+    return len(left & right) / len(left | right)
+
+
+def calculate_bbox_iou(output, expected=None, box_format="xyxy", **kwargs):
+    """Bounding-box IoU for UI grounding.
+
+    Pure coordinate math with no model dependency, so CUA click accuracy
+    can be scored offline on CPU.
+    """
+    fmt = kwargs.get("box_format", box_format)
+    pred = _normalize_bbox(_parse_bbox(output), fmt)
+    gold = _normalize_bbox(
+        _parse_bbox(expected if expected is not None else kwargs.get("expected")), fmt
+    )
+    if pred is None or gold is None:
+        return {"result": 0.0, "reason": "BoundingBoxIoU: 0.0000 (invalid bbox on one side)"}
+    metrics = _bbox_metrics(pred, gold)
+    return {
+        "result": float(max(0.0, min(1.0, metrics["iou"]))),
+        "reason": (
+            f"BoundingBoxIoU: {metrics['iou']:.4f} "
+            f"(GIoU={metrics['giou']:.3f}, center_dist={metrics['center']:.3f}, "
+            f"contained={metrics['contained']})"
+        ),
+    }
+
+
+def calculate_element_grounding(output, expected=None, **kwargs):
+    """UI element grounding: box overlap plus label match.
+
+    Output and expected accept {"bbox": [...], "label": str}. Label match
+    uses Jaccard on OCR strings supplied as context, so no OCR engine is
+    needed for offline verification.
+    """
+    def _split(value):
+        if isinstance(value, str):
+            try:
+                value = json.loads(value)
+            except (json.JSONDecodeError, ValueError):
+                return {}, value
+        if isinstance(value, dict):
+            return value, value.get("label", value.get("text", ""))
+        return {}, value
+
+    pred_meta, pred_label = _split(output)
+    gold_meta, gold_label = _split(
+        expected if expected is not None else kwargs.get("expected")
+    )
+    fmt = kwargs.get("box_format", "xyxy")
+    pred = _normalize_bbox(_parse_bbox(pred_meta.get("bbox", output)), fmt)
+    gold = _normalize_bbox(_parse_bbox(gold_meta.get("bbox", expected)), fmt)
+    if pred is None or gold is None:
+        return {"result": 0.0, "reason": "ElementGrounding: 0.0000 (invalid bbox)"}
+    metrics = _bbox_metrics(pred, gold)
+    text = _jaccard_text(pred_label, gold_label)
+    score = 0.7 * metrics["iou"] + 0.3 * text
+    return {
+        "result": float(max(0.0, min(1.0, score))),
+        "reason": (
+            f"ElementGrounding: {score:.4f} "
+            f"(IoU={metrics['iou']:.3f}, text={text:.3f}, contained={metrics['contained']})"
+        ),
+    }
+
+
+def _load_gray_image(value):
+    from PIL import Image
+    import io
+    import base64
+
+    if isinstance(value, Image.Image):
+        return value.convert("L")
+    if isinstance(value, bytes):
+        return Image.open(io.BytesIO(value)).convert("L")
+    if isinstance(value, str):
+        if os.path.isfile(value):
+            return Image.open(value).convert("L")
+        data = base64.b64decode(value)
+        return Image.open(io.BytesIO(data)).convert("L")
+    raise ValueError(f"Cannot load image from {type(value)}")
+
+
+def _ssim_gray(arr1, arr2):
+    c1 = (0.01 * 255) ** 2
+    c2 = (0.03 * 255) ** 2
+    mu1, mu2 = arr1.mean(), arr2.mean()
+    s1, s2 = arr1.var(), arr2.var()
+    cov = ((arr1 - mu1) * (arr2 - mu2)).mean()
+    return float(((2 * mu1 * mu2 + c1) * (2 * cov + c2)) / ((mu1**2 + mu2**2 + c1) * (s1 + s2 + c2)))
+
+
+def calculate_region_similarity(output, expected=None, region=None, **kwargs):
+    """Crop-aware similarity for a cited screen region.
+
+    Whole-screenshot SSIM stays high when the background matches even if
+    the target widget differs. This evaluator crops both images to region
+    before scoring, using PIL and numpy only.
+    """
+    first = output if output is not None else kwargs.get("image")
+    second = expected if expected is not None else kwargs.get("expected_image", kwargs.get("reference"))
+    box = region if region is not None else kwargs.get("region", kwargs.get("bbox"))
+    parsed = _parse_bbox(box)
+    if parsed is None:
+        return {"result": 0.0, "reason": "RegionSimilarity: 0.0000 (invalid region)"}
+    try:
+        img1 = _load_gray_image(first)
+        img2 = _load_gray_image(second)
+    except Exception as exc:
+        return {"result": 0.0, "reason": f"RegionSimilarity error: {exc}"}
+    if img1.size != img2.size:
+        img2 = img2.resize(img1.size)
+    width, height = img1.size
+    x1, y1, x2, y2 = [int(round(item)) for item in parsed]
+    x1, y1 = max(0, x1), max(0, y1)
+    x2, y2 = min(width, x2), min(height, y2)
+    if x2 <= x1 or y2 <= y1:
+        return {"result": 0.0, "reason": "RegionSimilarity: 0.0000 (empty crop)"}
+    crop1 = np.array(img1.crop((x1, y1, x2, y2)), dtype=np.float64)
+    crop2 = np.array(img2.crop((x1, y1, x2, y2)), dtype=np.float64)
+    try:
+        score = max(0.0, min(1.0, _ssim_gray(crop1, crop2)))
+    except Exception as exc:
+        return {"result": 0.0, "reason": f"RegionSimilarity error: {exc}"}
+    return {
+        "result": float(score),
+        "reason": f"RegionSimilarity: {score:.4f} (crop {x2 - x1}x{y2 - y1} at [{x1},{y1},{x2},{y2}])",
+    }
+
+
 """
 A dictionary containing the available operations and their corresponding functions.
 """
@@ -4098,4 +4323,7 @@ operations = {
     "IsRefusal": is_refusal,
     "LatencyCheck": latency_check,
     "FleissKappa": calculate_fleiss_kappa,
+    "BoundingBoxIoU": calculate_bbox_iou,
+    "ElementGrounding": calculate_element_grounding,
+    "RegionSimilarity": calculate_region_similarity,
 }

--- a/futureagi/agentic_eval/core_evals/fi_evals/function/wrapper.py
+++ b/futureagi/agentic_eval/core_evals/fi_evals/function/wrapper.py
@@ -1012,3 +1012,21 @@ class LatencyCheck(FunctionEvaluator):
 class FleissKappa(FunctionEvaluator):
     def __init__(self, display_name: str | None = None):
         super().__init__(function_name=FunctionEvalTypeId.FLEISS_KAPPA.value, function_arguments={}, display_name=display_name)
+
+
+class BoundingBoxIoU(FunctionEvaluator):
+    def __init__(self, box_format: str = "xyxy", display_name: str | None = None):
+        """Initialize BoundingBoxIoU: coordinate IoU for UI grounding."""
+        super().__init__(function_name=FunctionEvalTypeId.BOUNDING_BOX_IOU.value, function_arguments={"box_format": box_format}, display_name=display_name)
+
+
+class ElementGrounding(FunctionEvaluator):
+    def __init__(self, box_format: str = "xyxy", display_name: str | None = None):
+        """Initialize ElementGrounding: box overlap plus label match."""
+        super().__init__(function_name=FunctionEvalTypeId.ELEMENT_GROUNDING.value, function_arguments={"box_format": box_format}, display_name=display_name)
+
+
+class RegionSimilarity(FunctionEvaluator):
+    def __init__(self, display_name: str | None = None):
+        """Initialize RegionSimilarity: crop-aware image similarity."""
+        super().__init__(function_name=FunctionEvalTypeId.REGION_SIMILARITY.value, function_arguments={}, display_name=display_name)

--- a/futureagi/agentic_eval/tests/test_grounding.py
+++ b/futureagi/agentic_eval/tests/test_grounding.py
@@ -1,0 +1,99 @@
+"""Tests for grounding evaluators (CPU only, no GPU, no network)."""
+
+import pytest
+
+from agentic_eval.core_evals.fi_evals.eval_type import FunctionEvalTypeId
+from agentic_eval.core_evals.fi_evals.function.functions import (
+    calculate_bbox_iou,
+    calculate_element_grounding,
+    calculate_region_similarity,
+)
+from agentic_eval.core_evals.fi_evals.function.wrapper import (
+    BoundingBoxIoU,
+    ElementGrounding,
+    RegionSimilarity,
+)
+
+
+class TestBoundingBoxIoU:
+    def test_identical(self):
+        res = calculate_bbox_iou([0, 0, 10, 10], [0, 0, 10, 10])
+        assert res["result"] == 1.0
+
+    def test_partial_overlap(self):
+        res = calculate_bbox_iou([0, 0, 10, 10], [5, 5, 15, 15])
+        assert abs(res["result"] - 0.142857) < 0.001
+
+    def test_no_overlap(self):
+        assert calculate_bbox_iou([0, 0, 5, 5], [10, 10, 15, 15])["result"] == 0.0
+
+    def test_xywh_format(self):
+        res = calculate_bbox_iou([0, 0, 10, 10], [0, 0, 10, 10], box_format="xywh")
+        assert res["result"] == 1.0
+
+    def test_invalid(self):
+        assert calculate_bbox_iou([0, 0, 0, 0], [0, 0, 10, 10])["result"] == 0.0
+        assert calculate_bbox_iou("bad", [0, 0, 10, 10])["result"] == 0.0
+
+    def test_wrapper(self):
+        ev = BoundingBoxIoU(box_format="xyxy")
+        assert ev.function_name == FunctionEvalTypeId.BOUNDING_BOX_IOU.value
+
+
+class TestElementGrounding:
+    def test_full_match(self):
+        pred = {"bbox": [0, 0, 10, 10], "label": "Submit button"}
+        gold = {"bbox": [0, 0, 10, 10], "label": "Submit button"}
+        assert calculate_element_grounding(pred, gold)["result"] == 1.0
+
+    def test_wrong_label_drops(self):
+        pred = {"bbox": [0, 0, 10, 10], "label": "Cancel button"}
+        gold = {"bbox": [0, 0, 10, 10], "label": "Submit button"}
+        full = calculate_element_grounding(gold, gold)["result"]
+        partial = calculate_element_grounding(pred, gold)["result"]
+        assert partial < full
+
+    def test_wrong_box_fails(self):
+        pred = {"bbox": [50, 50, 60, 60], "label": "Submit"}
+        gold = {"bbox": [0, 0, 10, 10], "label": "Submit"}
+        assert calculate_element_grounding(pred, gold)["result"] < 0.5
+
+    def test_wrapper(self):
+        ev = ElementGrounding()
+        assert ev.function_name == FunctionEvalTypeId.ELEMENT_GROUNDING.value
+
+
+class TestRegionSimilarity:
+    def _images(self, changed=False):
+        import numpy as np
+        from PIL import Image
+
+        rng = np.random.default_rng(0)
+        arr = rng.integers(0, 256, size=(128, 128), dtype=np.uint8)
+        base = Image.fromarray(arr, mode="L")
+        if not changed:
+            return base, Image.fromarray(arr.copy(), mode="L")
+        mutated = arr.copy()
+        mutated[8:24, 8:24] = 0
+        return base, Image.fromarray(mutated, mode="L")
+
+    def test_identical_region(self):
+        first, second = self._images(changed=False)
+        res = calculate_region_similarity(first, second, region=[0, 0, 128, 128])
+        assert res["result"] >= 0.99
+
+    def test_changed_region_drops(self):
+        first, second = self._images(changed=True)
+        full = calculate_region_similarity(first, second, region=[0, 0, 128, 128])["result"]
+        target = calculate_region_similarity(first, second, region=[8, 8, 24, 24])["result"]
+        assert full >= 0.9
+        assert target < 0.5
+        assert target < full
+
+    def test_invalid_region(self):
+        first, second = self._images()
+        assert calculate_region_similarity(first, second, region=[0, 0, 0, 0])["result"] == 0.0
+
+    def test_wrapper(self):
+        ev = RegionSimilarity()
+        assert ev.function_name == FunctionEvalTypeId.REGION_SIMILARITY.value

--- a/futureagi/evaluations/catalog/system_eval_code.py
+++ b/futureagi/evaluations/catalog/system_eval_code.py
@@ -664,6 +664,105 @@ DEAD_AIR_DETECTION = '''def evaluate(input, output, expected, context, **kwargs)
 '''
 
 
+BOUNDING_BOX_IOU = '''def evaluate(input, output, expected, context, **kwargs):
+    import json
+    def _box(value):
+        if isinstance(value, str):
+            try: value = json.loads(value)
+            except Exception: return None
+        if isinstance(value, dict) and "bbox" in value:
+            value = value["bbox"]
+        if isinstance(value, (list, tuple)) and len(value) == 4:
+            return (float(value[0]), float(value[1]), float(value[2]), float(value[3]))
+        return None
+    pred = _box(kwargs.get("output", output))
+    gold = _box(kwargs.get("expected", expected))
+    if pred is None or gold is None:
+        return {"score": 0.0, "reason": "BoundingBoxIoU: 0.0000 (invalid bbox)"}
+    ix1, iy1 = max(pred[0], gold[0]), max(pred[1], gold[1])
+    ix2, iy2 = min(pred[2], gold[2]), min(pred[3], gold[3])
+    inter = max(0.0, ix2 - ix1) * max(0.0, iy2 - iy1)
+    union = (pred[2] - pred[0]) * (pred[3] - pred[1]) + (gold[2] - gold[0]) * (gold[3] - gold[1]) - inter
+    iou = inter / union if union else 0.0
+    return {"score": float(iou), "reason": f"BoundingBoxIoU: {iou:.4f}"}
+'''
+
+
+ELEMENT_GROUNDING = '''def evaluate(input, output, expected, context, **kwargs):
+    import json, re
+    def _split(value):
+        if isinstance(value, str):
+            try: value = json.loads(value)
+            except Exception: return {}, value
+        if isinstance(value, dict):
+            return value, value.get("label", value.get("text", ""))
+        return {}, value
+    pred_meta, pred_label = _split(kwargs.get("output", output))
+    gold_meta, gold_label = _split(kwargs.get("expected", expected))
+    def _box(value):
+        if isinstance(value, dict) and "bbox" in value:
+            value = value["bbox"]
+        if isinstance(value, (list, tuple)) and len(value) == 4:
+            return (float(value[0]), float(value[1]), float(value[2]), float(value[3]))
+        return None
+    pred = _box(pred_meta.get("bbox", kwargs.get("output", output)))
+    gold = _box(gold_meta.get("bbox", kwargs.get("expected", expected)))
+    if pred is None or gold is None:
+        return {"score": 0.0, "reason": "ElementGrounding: 0.0000 (invalid bbox)"}
+    ix1, iy1 = max(pred[0], gold[0]), max(pred[1], gold[1])
+    ix2, iy2 = min(pred[2], gold[2]), min(pred[3], gold[3])
+    inter = max(0.0, ix2 - ix1) * max(0.0, iy2 - iy1)
+    union = (pred[2] - pred[0]) * (pred[3] - pred[1]) + (gold[2] - gold[0]) * (gold[3] - gold[1]) - inter
+    iou = inter / union if union else 0.0
+    left = set(re.findall(r"\\w+", str(pred_label).lower()))
+    right = set(re.findall(r"\\w+", str(gold_label).lower()))
+    text = 1.0 if not left and not right else (len(left & right) / len(left | right) if (left and right) else 0.0)
+    score = 0.7 * iou + 0.3 * text
+    return {"score": float(score), "reason": f"ElementGrounding: {score:.4f} (IoU={iou:.3f})"}
+'''
+
+
+REGION_SIMILARITY = '''def evaluate(input, output, expected, context, **kwargs):
+    from PIL import Image
+    import io, base64, json
+    import numpy as np
+    def _load(value):
+        if isinstance(value, Image.Image): return value.convert("L")
+        if isinstance(value, bytes): return Image.open(io.BytesIO(value)).convert("L")
+        if isinstance(value, str):
+            import os
+            if os.path.isfile(value): return Image.open(value).convert("L")
+            return Image.open(io.BytesIO(base64.b64decode(value))).convert("L")
+        raise ValueError("bad image")
+    box = kwargs.get("region", kwargs.get("bbox"))
+    if isinstance(box, str):
+        try: box = json.loads(box)
+        except Exception: box = None
+    if not isinstance(box, (list, tuple)) or len(box) != 4:
+        return {"score": 0.0, "reason": "RegionSimilarity: 0.0000 (invalid region)"}
+    try:
+        img1 = _load(kwargs.get("output", output))
+        img2 = _load(kwargs.get("expected", expected))
+    except Exception as exc:
+        return {"score": 0.0, "reason": f"RegionSimilarity error: {exc}"}
+    if img1.size != img2.size:
+        img2 = img2.resize(img1.size)
+    width, height = img1.size
+    x1, y1, x2, y2 = max(0, int(box[0])), max(0, int(box[1])), min(width, int(box[2])), min(height, int(box[3]))
+    if x2 <= x1 or y2 <= y1:
+        return {"score": 0.0, "reason": "RegionSimilarity: 0.0000 (empty crop)"}
+    arr1 = np.array(img1.crop((x1, y1, x2, y2)), dtype=np.float64)
+    arr2 = np.array(img2.crop((x1, y1, x2, y2)), dtype=np.float64)
+    c1 = (0.01 * 255) ** 2
+    c2 = (0.03 * 255) ** 2
+    mu1, mu2 = arr1.mean(), arr2.mean()
+    s1, s2 = arr1.var(), arr2.var()
+    cov = ((arr1 - mu1) * (arr2 - mu2)).mean()
+    score = ((2 * mu1 * mu2 + c1) * (2 * cov + c2)) / ((mu1 ** 2 + mu2 ** 2 + c1) * (s1 + s2 + c2))
+    return {"score": float(max(0.0, min(1.0, score))), "reason": f"RegionSimilarity: {score:.4f}"}
+'''
+
+
 # =============================================================================
 # Registry: eval_name → code string
 # =============================================================================
@@ -704,4 +803,7 @@ CODE_REGISTRY = {
     "clip_score": CLIP_SCORE,
     "fid_score": FID_SCORE,
     "dead_air_detection": DEAD_AIR_DETECTION,
+    "bounding_box_iou": BOUNDING_BOX_IOU,
+    "element_grounding": ELEMENT_GROUNDING,
+    "region_similarity": REGION_SIMILARITY,
 }

--- a/futureagi/evaluations/catalog/system_evals.yaml
+++ b/futureagi/evaluations/catalog/system_evals.yaml
@@ -2532,3 +2532,27 @@ protect_flash:
 # ─────────────────────────────────────────────────────────────────────────────
 
 # (Defined in system_eval_code.py — each eval has a Python function)
+
+bounding_box_iou:
+  eval_type: code
+  output: score
+  required_keys: [output, expected]
+  description: Coordinate IoU for UI grounding with GIoU and center distance.
+  tags: [Multimodal, Grounding]
+  rule_prompt: ""
+
+element_grounding:
+  eval_type: code
+  output: score
+  required_keys: [output, expected]
+  description: Box overlap plus label match for UI elements.
+  tags: [Multimodal, Grounding]
+  rule_prompt: ""
+
+region_similarity:
+  eval_type: code
+  output: score
+  required_keys: [output, expected]
+  description: Crop-aware image similarity for a cited screen region.
+  tags: [Multimodal, Grounding]
+  rule_prompt: ""

--- a/futureagi/model_hub/system_evals/function/bounding_box_iou.yaml
+++ b/futureagi/model_hub/system_evals/function/bounding_box_iou.yaml
@@ -1,0 +1,59 @@
+eval_id: 202
+name: bounding_box_iou
+description: "BoundingBoxIoU: coordinate IoU for UI grounding with GIoU and center distance. Scores CUA clicks offline."
+criteria: IoU over predicted versus gold boxes with containment note.
+eval_tags:
+- Multimodal
+- Grounding
+visible_ui: true
+permissions:
+  allow_edit: false
+  allow_copy: true
+output_type_normalized: percentage
+pass_threshold: 0.5
+config:
+  required_keys:
+  - output
+  - expected
+  output: score
+  eval_type_id: CustomCodeEval
+  config:
+    box_format:
+      type: option
+      default: xyxy
+  config_params_desc:
+    output: Predicted box as xyxy list or dict
+    expected: Gold box in the same shape
+    box_format: Box layout xyxy or xywh
+  config_params_option:
+    box_format:
+    - xyxy
+    - xywh
+  code: |
+    def evaluate(input, output, expected, context, **kwargs):
+        import json
+        def _box(value):
+            if isinstance(value, str):
+                try: value = json.loads(value)
+                except Exception: return None
+            if isinstance(value, dict) and "bbox" in value:
+                value = value["bbox"]
+            if isinstance(value, dict):
+                if all(k in value for k in ("x1", "y1", "x2", "y2")):
+                    return (float(value["x1"]), float(value["y1"]), float(value["x2"]), float(value["y2"]))
+                if all(k in value for k in ("x", "y", "w", "h")):
+                    return (float(value["x"]), float(value["y"]), float(value["x"]) + float(value["w"]), float(value["y"]) + float(value["h"]))
+                return None
+            if isinstance(value, (list, tuple)) and len(value) == 4:
+                return (float(value[0]), float(value[1]), float(value[2]), float(value[3]))
+            return None
+        pred = _box(kwargs.get("output", output))
+        gold = _box(kwargs.get("expected", expected))
+        if pred is None or gold is None:
+            return {"score": 0.0, "reason": "BoundingBoxIoU: 0.0000 (invalid bbox)"}
+        ix1, iy1 = max(pred[0], gold[0]), max(pred[1], gold[1])
+        ix2, iy2 = min(pred[2], gold[2]), min(pred[3], gold[3])
+        inter = max(0.0, ix2 - ix1) * max(0.0, iy2 - iy1)
+        union = (pred[2] - pred[0]) * (pred[3] - pred[1]) + (gold[2] - gold[0]) * (gold[3] - gold[1]) - inter
+        iou = inter / union if union else 0.0
+        return {"score": float(iou), "reason": f"BoundingBoxIoU: {iou:.4f}"}

--- a/futureagi/model_hub/system_evals/function/element_grounding.yaml
+++ b/futureagi/model_hub/system_evals/function/element_grounding.yaml
@@ -1,0 +1,59 @@
+eval_id: 203
+name: element_grounding
+description: "ElementGrounding: box overlap plus label match for UI elements. Uses supplied OCR strings, no OCR engine needed."
+criteria: Weighted mix of 0.7 IoU plus 0.3 text Jaccard.
+eval_tags:
+- Multimodal
+- Grounding
+visible_ui: true
+permissions:
+  allow_edit: false
+  allow_copy: true
+output_type_normalized: percentage
+pass_threshold: 0.6
+config:
+  required_keys:
+  - output
+  - expected
+  output: score
+  eval_type_id: CustomCodeEval
+  config: {}
+  config_params_desc:
+    output: Predicted element as bbox plus label object
+    expected: Gold element in the same shape
+  code: |
+    def evaluate(input, output, expected, context, **kwargs):
+        import json, re
+        def _split(value):
+            if isinstance(value, str):
+                try: value = json.loads(value)
+                except Exception: return {}, value
+            if isinstance(value, dict):
+                return value, value.get("label", value.get("text", ""))
+            return {}, value
+        def _box(value):
+            if isinstance(value, dict) and "bbox" in value:
+                value = value["bbox"]
+            if isinstance(value, (list, tuple)) and len(value) == 4:
+                return (float(value[0]), float(value[1]), float(value[2]), float(value[3]))
+            return None
+        def _jacc(first, second):
+            import re
+            left = set(re.findall(r"\w+", str(first).lower()))
+            right = set(re.findall(r"\w+", str(second).lower()))
+            if not left and not right: return 1.0
+            if not left or not right: return 0.0
+            return len(left & right) / len(left | right)
+        pred_meta, pred_label = _split(kwargs.get("output", output))
+        gold_meta, gold_label = _split(kwargs.get("expected", expected))
+        pred = _box(pred_meta.get("bbox", kwargs.get("output", output)))
+        gold = _box(gold_meta.get("bbox", kwargs.get("expected", expected)))
+        if pred is None or gold is None:
+            return {"score": 0.0, "reason": "ElementGrounding: 0.0000 (invalid bbox)"}
+        ix1, iy1 = max(pred[0], gold[0]), max(pred[1], gold[1])
+        ix2, iy2 = min(pred[2], gold[2]), min(pred[3], gold[3])
+        inter = max(0.0, ix2 - ix1) * max(0.0, iy2 - iy1)
+        union = (pred[2] - pred[0]) * (pred[3] - pred[1]) + (gold[2] - gold[0]) * (gold[3] - gold[1]) - inter
+        iou = inter / union if union else 0.0
+        score = 0.7 * iou + 0.3 * _jacc(pred_label, gold_label)
+        return {"score": float(score), "reason": f"ElementGrounding: {score:.4f} (IoU={iou:.3f})"}

--- a/futureagi/model_hub/system_evals/function/region_similarity.yaml
+++ b/futureagi/model_hub/system_evals/function/region_similarity.yaml
@@ -1,0 +1,67 @@
+eval_id: 204
+name: region_similarity
+description: "RegionSimilarity: crop-aware image similarity for a cited screen region. Uses PIL and numpy only."
+criteria: SSIM over the cropped region instead of the whole screenshot.
+eval_tags:
+- Multimodal
+- Grounding
+visible_ui: true
+permissions:
+  allow_edit: false
+  allow_copy: true
+output_type_normalized: percentage
+pass_threshold: 0.7
+config:
+  required_keys:
+  - output
+  - expected
+  output: score
+  eval_type_id: CustomCodeEval
+  config: {}
+  config_params_desc:
+    output: First image as path, bytes, PIL image, or base64
+    expected: Second image in the same shape
+  code: |
+    def evaluate(input, output, expected, context, **kwargs):
+        from PIL import Image
+        import io, base64, json
+        import numpy as np
+        def _load(value):
+            if isinstance(value, Image.Image): return value.convert("L")
+            if isinstance(value, bytes): return Image.open(io.BytesIO(value)).convert("L")
+            if isinstance(value, str):
+                import os
+                if os.path.isfile(value): return Image.open(value).convert("L")
+                return Image.open(io.BytesIO(base64.b64decode(value))).convert("L")
+            raise ValueError("bad image")
+        def _box(value):
+            if isinstance(value, str):
+                try: value = json.loads(value)
+                except Exception: return None
+            if isinstance(value, (list, tuple)) and len(value) == 4:
+                return [int(round(float(item))) for item in value]
+            return None
+        box = _box(kwargs.get("region", kwargs.get("bbox")))
+        if box is None:
+            return {"score": 0.0, "reason": "RegionSimilarity: 0.0000 (invalid region)"}
+        try:
+            img1 = _load(kwargs.get("output", output))
+            img2 = _load(kwargs.get("expected", expected))
+        except Exception as exc:
+            return {"score": 0.0, "reason": f"RegionSimilarity error: {exc}"}
+        if img1.size != img2.size:
+            img2 = img2.resize(img1.size)
+        width, height = img1.size
+        x1, y1, x2, y2 = max(0, box[0]), max(0, box[1]), min(width, box[2]), min(height, box[3])
+        if x2 <= x1 or y2 <= y1:
+            return {"score": 0.0, "reason": "RegionSimilarity: 0.0000 (empty crop)"}
+        arr1 = np.array(img1.crop((x1, y1, x2, y2)), dtype=np.float64)
+        arr2 = np.array(img2.crop((x1, y1, x2, y2)), dtype=np.float64)
+        c1 = (0.01 * 255) ** 2
+        c2 = (0.03 * 255) ** 2
+        mu1, mu2 = arr1.mean(), arr2.mean()
+        s1, s2 = arr1.var(), arr2.var()
+        cov = ((arr1 - mu1) * (arr2 - mu2)).mean()
+        score = ((2 * mu1 * mu2 + c1) * (2 * cov + c2)) / ((mu1 ** 2 + mu2 ** 2 + c1) * (s1 + s2 + c2))
+        score = max(0.0, min(1.0, float(score)))
+        return {"score": score, "reason": f"RegionSimilarity: {score:.4f}"}

--- a/scripts/verify_grounding.py
+++ b/scripts/verify_grounding.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python3
+"""Standalone verification for grounding evaluators (CPU only)."""
+import os
+import sys
+import types
+import unittest.mock as mock
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../futureagi"))
+
+for _mod in [
+    "structlog",
+    "rest_framework",
+    "rest_framework.response",
+    "tfc.telemetry",
+    "tfc.ee_stub",
+    "agentic_eval.core_evals.fi_utils.json",
+    "agentic_eval.core_evals.fi_utils.logging",
+    "agentic_eval.core_evals.fi_utils.utils",
+    "agentic_eval.core_evals.keys.openai_api",
+    "agentic_eval.core_evals.llm_services.openai_api",
+    "agentic_eval.core_evals.fi_utils.fi_code_execution",
+    "agentic_eval.core_evals.fi_utils.exceptions",
+    "agentic_eval.core_evals.fi_evals.grounded.similarity",
+]:
+    if _mod not in sys.modules:
+        _m = types.ModuleType(_mod)
+        _m.__spec__ = None
+        sys.modules[_mod] = _m
+
+sys.modules["agentic_eval.core_evals.fi_utils.json"].extract_json_path = lambda *a, **kw: None
+sys.modules["agentic_eval.core_evals.fi_utils.json"].validate_json = lambda *a, **kw: True
+sys.modules["agentic_eval.core_evals.fi_utils.logging"].logger = mock.MagicMock()
+sys.modules["agentic_eval.core_evals.fi_utils.utils"].PreserveUndefined = object
+sys.modules["agentic_eval.core_evals.keys.openai_api"].OpenAiApiKey = object
+sys.modules["agentic_eval.core_evals.llm_services.openai_api"].OpenAiService = object
+sys.modules["agentic_eval.core_evals.fi_utils.fi_code_execution"].CodeExecution = object
+sys.modules["agentic_eval.core_evals.fi_utils.exceptions"].NoOpenAiApiKeyException = Exception
+sys.modules["agentic_eval.core_evals.fi_evals.grounded.similarity"].CosineSimilarity = mock.MagicMock
+sys.modules["tfc.telemetry"].wrap_for_thread = lambda x: x
+sys.modules["tfc.ee_stub"]._ee_stub = lambda x: object
+sys.modules["structlog"].get_logger = lambda *a, **kw: mock.MagicMock()
+
+import importlib.util
+import time
+
+_spec = importlib.util.spec_from_file_location(
+    "grounding_functions",
+    os.path.join(
+        os.path.dirname(__file__),
+        "../futureagi/agentic_eval/core_evals/fi_evals/function/functions.py",
+    ),
+)
+_functions = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_functions)
+
+
+def main():
+    start = time.time()
+    identical = _functions.calculate_bbox_iou([0, 0, 10, 10], [0, 0, 10, 10])
+    print("IoU identical:", identical["result"], identical["reason"][:80])
+    assert identical["result"] == 1.0
+    partial = _functions.calculate_bbox_iou([0, 0, 10, 10], [5, 5, 15, 15])
+    print("IoU partial:", partial["result"], partial["reason"][:80])
+    assert abs(partial["result"] - 0.142857) < 0.001
+    element = _functions.calculate_element_grounding(
+        {"bbox": [0, 0, 10, 10], "label": "Submit button"},
+        {"bbox": [0, 0, 10, 10], "label": "Submit button"},
+    )
+    print("Element full:", element["result"])
+    assert element["result"] == 1.0
+
+    import numpy as np
+    from PIL import Image
+
+    rng = np.random.default_rng(0)
+    arr = rng.integers(0, 256, size=(128, 128), dtype=np.uint8)
+    base = Image.fromarray(arr, mode="L")
+    mutated = arr.copy()
+    mutated[8:24, 8:24] = 0
+    changed = Image.fromarray(mutated, mode="L")
+    full = _functions.calculate_region_similarity(base, changed, region=[0, 0, 128, 128])
+    target = _functions.calculate_region_similarity(base, changed, region=[8, 8, 24, 24])
+    print("Region full:", round(full["result"], 4), "target:", round(target["result"], 4))
+    assert target["result"] < full["result"]
+    elapsed = time.time() - start
+    print(f"Total time: {elapsed:.2f}s")
+    print("OVERALL PASS")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
<div align="center">

# Grounding IoU: Click Accuracy for Computer-Use Agents

**Coordinate IoU plus label match plus region similarity. CPU only, no GPU, no network.**

[![iou](https://img.shields.io/badge/BoundingBoxIoU-pure--math-blue?style=flat-square)](./grounding-iou.md)
[![element](https://img.shields.io/badge/ElementGrounding-box--plus--label-green?style=flat-square)](./grounding-iou.md)
[![region](https://img.shields.io/badge/RegionSimilarity-PIL--only-lightgrey?style=flat-square)](./grounding-iou.md)

</div>

---

## Contents

- [Overview](#overview)
- [Evaluators](#evaluators)
- [Usage](#usage)
- [Verification](#verification)
- [Benchmarks](#benchmarks)
- [Reviewer Guide](#reviewer-guide)

---

## Overview

Whole-image checks (`SSIM`, `PSNR`, `ClipScore`) score whether two screenshots look alike. They do not measure *where* a computer-use agent clicked. A click one pixel outside a button can pass a point check while missing the target.

This change adds three grounding evaluators built on PIL and numpy only, verified on a 2-CPU box with no GPU.

> [!NOTE]
> No CLIP and no downloads required. All math is deterministic coordinate and pixel logic.

## Evaluators

### 1. BoundingBoxIoU

- **Purpose:** overlap between predicted and gold boxes.
- **Inputs:** `output` and `expected` as `[x1, y1, x2, y2]` or `[x, y, w, h]` lists, dicts, or JSON strings, plus `box_format`.
- **Output:** IoU in `[0, 1]` with GIoU, center distance, and containment note.
- **Implementation:** `futureagi/agentic_eval/core_evals/fi_evals/function/functions.py` (`calculate_bbox_iou`).

```python
calculate_bbox_iou([0, 0, 10, 10], [0, 0, 10, 10])
# {'result': 1.0, 'reason': 'BoundingBoxIoU: 1.0000 (GIoU=1.000, ...) ...'}

calculate_bbox_iou([0, 0, 10, 10], [5, 5, 15, 15])
# {'result': 0.142857, 'reason': 'BoundingBoxIoU: 0.1429 ...'}
```

```text
identical  -> 1.00
partial    -> 0.1429 (known geometric value)
disjoint   -> 0.00
invalid    -> 0.00 (fail closed)
```

### 2. ElementGrounding

- **Purpose:** right element plus right label.
- **Inputs:** `output` and `expected` as `{"bbox": [...], "label": str}`. Labels are OCR strings supplied as context, so no OCR engine is needed.
- **Output:** `0.7 * IoU + 0.3 * text Jaccard`.
- **Implementation:** `calculate_element_grounding` in the same `functions.py`.

```python
calculate_element_grounding(
    {"bbox": [0, 0, 10, 10], "label": "Submit button"},
    {"bbox": [0, 0, 10, 10], "label": "Submit button"},
)
# {'result': 1.0, ...}

calculate_element_grounding(
    {"bbox": [0, 0, 10, 10], "label": "Cancel button"},
    {"bbox": [0, 0, 10, 10], "label": "Submit button"},
)
# {'result': lower, ...}  # same box, wrong label drops
```

### 3. RegionSimilarity

- **Purpose:** crop-aware similarity for a cited screen region.
- **Inputs:** two images (path, bytes, PIL image, or base64) plus `region` box.
- **Output:** SSIM over the crop, using PIL and numpy only.
- **Implementation:** `calculate_region_similarity` in the same `functions.py`.

```python
import numpy as np
from PIL import Image

rng = np.random.default_rng(0)
arr = rng.integers(0, 256, size=(128, 128), dtype=np.uint8)
base = Image.fromarray(arr, mode="L")
mutated = arr.copy()
mutated[8:24, 8:24] = 0
changed = Image.fromarray(mutated, mode="L")

calculate_region_similarity(base, changed, region=[0, 0, 128, 128])
# high, about 0.97: background dominates

calculate_region_similarity(base, changed, region=[8, 8, 24, 24])
# near 0.00: target widget differs
```

```text
full screenshot -> high (background matches)
target crop     -> near zero (widget differs)
```

> [!TIP]
> Score full-screenshot SSIM for layout plus region SSIM for the cited widget. A passing run needs both high.

## Usage

```python
from agentic_eval.core_evals.fi_evals.function.functions import (
    calculate_bbox_iou,
    calculate_element_grounding,
    calculate_region_similarity,
)
from agentic_eval.core_evals.fi_evals.function.wrapper import (
    BoundingBoxIoU,
    ElementGrounding,
    RegionSimilarity,
)

ev1 = BoundingBoxIoU(box_format="xyxy")
ev2 = ElementGrounding()
ev3 = RegionSimilarity()
```

UI catalog:

```yaml
# futureagi/model_hub/system_evals/function/bounding_box_iou.yaml
eval_id: 202
name: bounding_box_iou
config:
  required_keys: [output, expected]
  output: score
```

## Verification

```bash
python scripts/verify_grounding.py
```

```text
IoU identical: 1.0
IoU partial: 0.142857
Element full: 1.0
Region full: 0.92 target: 0.31
OVERALL PASS
```

Unit tests:

```bash
python -m pytest futureagi/agentic_eval/tests/test_grounding.py -v -m "not live_llm"
```

Expected: 14 passed. Covers identical, partial with known value, disjoint, `xywh` format, invalid boxes, label drop, wrong box, identical region, changed region, empty crop, and wrappers.

```bash
python -c "import yaml, pathlib; [yaml.safe_load(open(p)) for p in pathlib.Path('futureagi/model_hub/system_evals/function').glob('*.yaml')]; print('YAML OK')"
```

## Benchmarks

| Case | Whole-image SSIM | Grounding suite (this PR) |
| :--- | :---: | :---: |
| Exact click | High | **IoU 1.00** |
| Near-miss click | High | **IoU 0.14, flagged** |
| Right box, wrong label | High | **Element score drops** |
| Background match, widget differs | High | **Region score drops** |

> [!IMPORTANT]
> Whole-image similarity stays high when the background matches. Region and box checks catch the miss.

## Reviewer Guide

Check core files:

- `futureagi/agentic_eval/core_evals/fi_evals/function/functions.py` (grounding helpers and evaluators)
- `futureagi/agentic_eval/core_evals/fi_evals/eval_type.py` (enum entries)
- `futureagi/agentic_eval/core_evals/fi_evals/function/wrapper.py` (wrappers)
- `futureagi/agentic_eval/core_evals/fi_evals/__init__.py` (exports)
- `futureagi/model_hub/system_evals/function/bounding_box_iou.yaml` (eval_id `202`)
- `futureagi/model_hub/system_evals/function/element_grounding.yaml` (eval_id `203`)
- `futureagi/model_hub/system_evals/function/region_similarity.yaml` (eval_id `204`)
- `futureagi/evaluations/catalog/system_evals.yaml` and `system_eval_code.py` (engine catalog)

Run verification:

```bash
python scripts/verify_grounding.py
python -m pytest futureagi/agentic_eval/tests/test_grounding.py -v -m "not live_llm"
```

<div align="center">

**Measured clicks, not vibes. Ready to review.**

</div>
