### PR TITLE
feat(harness): production egress resolution with connector profiles and wildcard minimization

### DIFF
--- a/frontend/src/pages/dashboard/harness/HarnessCreate.jsx
+++ b/frontend/src/pages/dashboard/harness/HarnessCreate.jsx
@@ -44,7 +44,12 @@ import {
 } from "./credentialValues";
 import { errorMessage, readable, stages } from "./harnessShared";
 import { prepareSourceFolder } from "./sourceUpload";
-import { parseGitHubInput } from "./requestMapper";
+import {
+  deriveEgressDomains,
+  mergeEgressDomains,
+  parseEgressDomains,
+  parseGitHubInput,
+} from "./requestMapper";
 
 // Uploaded agent folders are often only a few KiB, and a fixed MiB unit rounds
 // every one of those to "0.0 MiB". Scale the unit to the actual size instead.
@@ -180,6 +185,7 @@ export default function HarnessCreate() {
   const [environmentValues, setEnvironmentValues] = useState({});
   const [environmentText, setEnvironmentText] = useState("");
   const [environmentError, setEnvironmentError] = useState("");
+  const [additionalEgressDomains, setAdditionalEgressDomains] = useState("");
   const [submitting, setSubmitting] = useState(false);
   const [checking, setChecking] = useState(false);
   const [error, setError] = useState("");
@@ -261,40 +267,6 @@ export default function HarnessCreate() {
       ]),
     );
 
-  // Derive the per-job egress allowlist from any URL-valued env/config the user supplied
-  // (e.g. LIVEKIT_URL -> its media host). Platform-common hosts (TURN, provider APIs) are
-  // added by the backend base egress; this only carries agent-declared, publicly-routable hosts.
-  const deriveEgressDomains = (...maps) => {
-    const hosts = new Set();
-    for (const map of maps) {
-      for (const value of Object.values(map || {})) {
-        if (typeof value !== "string") continue;
-        const trimmed = value.trim();
-        if (!/^(wss?|https?):\/\//i.test(trimmed)) continue;
-        let host = "";
-        try {
-          host = new URL(trimmed).hostname;
-        } catch {
-          continue;
-        }
-        if (
-          !host ||
-          host === "localhost" ||
-          host === "host.docker.internal" ||
-          host === "::1" ||
-          host.startsWith("127.") ||
-          host.startsWith("10.") ||
-          host.startsWith("192.168.") ||
-          host.startsWith("169.254.") ||
-          /^172\.(1[6-9]|2\d|3[01])\./.test(host)
-        )
-          continue;
-        hosts.add(host);
-      }
-    }
-    return Array.from(hosts);
-  };
-
   const hostedPayload = (secretRefs = {}) => ({
     schema_version: "futureagi.harness-job.v1",
     source: sourcePayload(),
@@ -318,7 +290,10 @@ export default function HarnessCreate() {
       read_only_source: true,
       allow_privileged: false,
       allow_host_runtime_control: false,
-      allowed_egress_domains: deriveEgressDomains(configurationValues, environmentValues),
+      allowed_egress_domains: mergeEgressDomains(
+        deriveEgressDomains(configurationValues, environmentValues),
+        parseEgressDomains(additionalEgressDomains),
+      ),
     },
     retry: {
       max_infrastructure_attempts: 2,
@@ -1079,7 +1054,8 @@ export default function HarnessCreate() {
                         sx={{ display: "none" }}
                       />
                     </Button>
-                    {Object.keys(environmentValues).length > 0 && (
+                    {(Object.keys(environmentValues).length > 0 ||
+                      additionalEgressDomains.trim()) && (
                       <Button
                         color="inherit"
                         onClick={() => {
@@ -1088,6 +1064,7 @@ export default function HarnessCreate() {
                           setSecretFileRefs({});
                           setSecretFileUploads({});
                           setEnvironmentText("");
+                          setAdditionalEgressDomains("");
                           setPreflightDirty(Boolean(preflight));
                         }}
                       >
@@ -1095,6 +1072,18 @@ export default function HarnessCreate() {
                       </Button>
                     )}
                   </Stack>
+                  <TextField
+                    fullWidth
+                    size="small"
+                    label="Additional egress domains"
+                    placeholder="api.example.com, turn.example.com"
+                    value={additionalEgressDomains}
+                    helperText="Comma/newline-separated public hostnames for hardcoded APIs/TURN endpoints. Daytona maximum is enforced server-side."
+                    onChange={(event) => {
+                      setAdditionalEgressDomains(event.target.value);
+                      setPreflightDirty(Boolean(preflight));
+                    }}
+                  />
                   {Object.keys(environmentValues).length > 0 && (
                     <Stack
                       direction="row"

--- a/frontend/src/pages/dashboard/harness/requestMapper.js
+++ b/frontend/src/pages/dashboard/harness/requestMapper.js
@@ -14,6 +14,92 @@ export const MAX_SCENARIO_COUNT = 200;
 const GITHUB_URL_PATTERN =
   /^(?:https?:\/\/)?(?:www\.)?github\.com\/([A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+?)(?:\/tree\/(.+?))?(?:\/)?$/;
 
+const EGRESS_HOST_LABEL = "[A-Za-z0-9](?:[A-Za-z0-9-]{0,61}[A-Za-z0-9])?";
+const EGRESS_HOSTNAME_PATTERN = new RegExp(
+  `^${EGRESS_HOST_LABEL}(?:\\.${EGRESS_HOST_LABEL})+$`,
+);
+
+const normalizeEgressDomain = (value) =>
+  typeof value === "string"
+    ? value.trim().toLowerCase().replace(/\.$/, "")
+    : "";
+
+const isPrivateOrReservedHost = (host) => {
+  const unbracketedHost = host.replace(/^\[|\]$/g, "");
+  return (
+    unbracketedHost === "localhost" ||
+    unbracketedHost === "host.docker.internal" ||
+    unbracketedHost === "::1" ||
+    unbracketedHost === "0:0:0:0:0:0:0:1" ||
+    /^fe[89ab][0-9a-f]:/i.test(unbracketedHost) ||
+    /^127(?:\.|$)/.test(unbracketedHost) ||
+    unbracketedHost.startsWith("10.") ||
+    unbracketedHost.startsWith("192.168.") ||
+    unbracketedHost.startsWith("169.254.") ||
+    /^172\.(1[6-9]|2\d|3[01])\./.test(unbracketedHost)
+  );
+};
+
+/**
+ * Derive publicly routable hostnames from URL-valued environment/config values.
+ * Non-URL values and localhost/private/link-local hosts are ignored.
+ */
+export function deriveEgressDomains(...maps) {
+  const hosts = new Set();
+  for (const map of maps) {
+    for (const value of Object.values(map || {})) {
+      if (typeof value !== "string") continue;
+      const trimmed = value.trim();
+      if (!/^(?:wss?|https?):\/\//i.test(trimmed)) continue;
+
+      let host = "";
+      try {
+        host = normalizeEgressDomain(new URL(trimmed).hostname);
+      } catch {
+        continue;
+      }
+      if (!host || isPrivateOrReservedHost(host)) continue;
+      hosts.add(host);
+    }
+  }
+  return Array.from(hosts).sort();
+}
+
+/**
+ * Parse comma/newline-separated customer egress hostnames.
+ * Schemes, paths, and other obviously malformed values are ignored; backend validation remains
+ * authoritative for private/reserved hosts and the resolved Daytona egress cap.
+ */
+export function parseEgressDomains(input) {
+  if (typeof input !== "string") return [];
+
+  const domains = new Set();
+  for (const value of input.split(/[,\n]/)) {
+    const domain = normalizeEgressDomain(value);
+    if (!domain || domain.length > 253 || !EGRESS_HOSTNAME_PATTERN.test(domain)) continue;
+    domains.add(domain);
+  }
+  return Array.from(domains).sort();
+}
+
+/**
+ * Merge derived and customer-declared egress hostnames into a stable exact-deduped list.
+ */
+export function mergeEgressDomains(...domainLists) {
+  const domains = new Set();
+  for (const domainList of domainLists) {
+    const values =
+      typeof domainList === "string"
+        ? parseEgressDomains(domainList)
+        : domainList || [];
+    for (const value of values) {
+      const domain = normalizeEgressDomain(value);
+      if (domain) domains.add(domain);
+    }
+  }
+  return Array.from(domains).sort();
+}
+
 /**
  * Parse a GitHub repository input which may be:
  * - "owner/repo"

--- a/frontend/src/pages/dashboard/harness/requestMapper.test.js
+++ b/frontend/src/pages/dashboard/harness/requestMapper.test.js
@@ -2,7 +2,10 @@ import { describe, expect, it } from "vitest";
 
 import {
   buildJobPayload,
+  deriveEgressDomains,
   MAX_SCENARIO_COUNT,
+  mergeEgressDomains,
+  parseEgressDomains,
   parseGitHubInput,
   unsupportedCredentialWarnings,
 } from "./requestMapper";
@@ -64,6 +67,62 @@ describe("parseGitHubInput", () => {
   it("returns null for unparseable input", () => {
     expect(parseGitHubInput("not-a-url")).toBeNull();
     expect(parseGitHubInput("https://gitlab.com/owner/repo")).toBeNull();
+  });
+});
+
+describe("deriveEgressDomains", () => {
+  it("derives the exact hostname from a LiveKit signaling URL", () => {
+    expect(
+      deriveEgressDomains({
+        LIVEKIT_URL: "wss://Project.LiveKit.Cloud/rtc",
+      }),
+    ).toEqual(["project.livekit.cloud"]);
+  });
+
+  it("rejects localhost, private, loopback, and link-local URL hosts", () => {
+    expect(
+      deriveEgressDomains({
+        PUBLIC_URL: "https://api.example.com",
+        LOCALHOST_URL: "http://localhost:8080",
+        DOCKER_URL: "http://host.docker.internal:8080",
+        LOOPBACK_URL: "http://127.0.0.1:8080",
+        RFC1918_10_URL: "http://10.0.0.4",
+        RFC1918_172_URL: "http://172.16.0.4",
+        RFC1918_192_URL: "http://192.168.0.4",
+        LINK_LOCAL_URL: "http://169.254.10.4",
+        IPV6_LOOPBACK_URL: "http://[::1]",
+        IPV6_LINK_LOCAL_URL: "http://[fe80::1]",
+      }),
+    ).toEqual(["api.example.com"]);
+  });
+});
+
+describe("parseEgressDomains", () => {
+  it("parses, normalizes, and exact-deduplicates comma/newline input", () => {
+    expect(
+      parseEgressDomains(
+        " API.Example.com. ,\nturn.example.com\napi.example.com\n\n",
+      ),
+    ).toEqual(["api.example.com", "turn.example.com"]);
+  });
+
+  it("ignores schemes, paths, and malformed entries", () => {
+    expect(
+      parseEgressDomains(
+        "https://api.example.com/path, turn.example.com/path, *.example.com, not a host, api.example.com",
+      ),
+    ).toEqual(["api.example.com"]);
+  });
+});
+
+describe("mergeEgressDomains", () => {
+  it("merges derived and explicit domains into a stable exact-host list", () => {
+    expect(
+      mergeEgressDomains(
+        ["media.example.com", "API.Example.com"],
+        parseEgressDomains("api.example.com\nturn.example.com."),
+      ),
+    ).toEqual(["api.example.com", "media.example.com", "turn.example.com"]);
   });
 });
 

--- a/futureagi/.env.example
+++ b/futureagi/.env.example
@@ -466,10 +466,9 @@ ALK_DAYTONA_SNAPSHOT=alk-hosted-v1
 ALK_DAYTONA_SNAPSHOT_DIGEST=sha256:
 # Compressed source archive ceiling in bytes (default: 256 MiB).
 ALK_HOSTED_SOURCE_MAX_BYTES=268435456
-# Comma-separated provider/model/storage domains admitted from the guest sandbox.
-# LiveKit voice runs require both signaling and TURN hosts. The Future AGI EU deployment uses
-# coturn.turn-eu.futureagi.com for TURN-over-TLS; LiveKit Cloud uses *.turn.livekit.cloud.
-ALK_HOSTED_BASE_EGRESS_DOMAINS=api.openai.com,api.anthropic.com,api.github.com,pypi.org,files.pythonhosted.org,api.deepgram.com,*.livekit.cloud,*.turn.livekit.cloud,livekit-eu.futureagi.com,coturn.turn-eu.futureagi.com
+# Keep the static base small: Daytona caps the final resolved union at 20 domains.
+# The gateway adds model-provider, voice-connector, callback, and customer-declared hosts per job.
+ALK_HOSTED_BASE_EGRESS_DOMAINS=pypi.org,files.pythonhosted.org,huggingface.co,*.huggingface.co,*.hf.co
 # LiveKit/WebRTC negotiates media IPs after signalling. Configure the relay/media CIDRs exposed
 # by the deployment; 0.0.0.0/0 is suitable only for an isolated development certification lane.
 ALK_HOSTED_WEBRTC_EGRESS_CIDRS=

--- a/futureagi/simulate/services/harness_provider.py
+++ b/futureagi/simulate/services/harness_provider.py
@@ -106,6 +106,37 @@ def _validate_secret_refs_daytona(secret_refs: dict) -> None:
             )
 
 
+def _validate_known_daytona_egress(
+    payload: dict[str, Any], callback_url: str
+) -> None:
+    """Reject known Daytona egress overflow before persisting or enqueueing a
+    job."""
+    from simulate.services.hosted_harness_gateway import (
+        _known_simulator_egress_inputs,
+        _hostname_from_url,
+        _resolved_egress_domains,
+        _validate_egress_domains,
+        _validate_resolved_egress_domains,
+    )
+
+    security = payload.get("security") or {}
+    customer_domains = security.get("allowed_egress_domains") or []
+    agent = payload.get("agent") or {}
+    secret_refs = agent.get("secret_refs") or {}
+    # Admission has references, not decrypted values. An alias is enough to
+    # account for static provider dependencies; launch resolves value-derived
+    # connector endpoints authoritatively.
+    target_inputs = {str(alias): "" for alias in secret_refs}
+    _validate_egress_domains(customer_domains)
+    domains = _resolved_egress_domains(
+        payload,
+        target_inputs,
+        _known_simulator_egress_inputs(),
+        _hostname_from_url(callback_url),
+    )
+    _validate_resolved_egress_domains(domains)
+
+
 def serialize_job(job: HostedHarnessJob) -> dict[str, Any]:
     attempt = job.attempts.order_by("-attempt_number").first()
     events: list[dict[str, Any]] = []
@@ -248,7 +279,6 @@ class DaytonaHarnessProvider:
             HostedHarnessError,
             create_hosted_job,
         )
-        from simulate.services.hosted_harness_gateway import _validate_egress_domains
         from simulate.temporal.client import start_hosted_harness_gateway_workflow
 
         organization = _organization(request)
@@ -263,26 +293,25 @@ class DaytonaHarnessProvider:
                 {"detail": "Idempotency-Key header is required"},
                 status=status.HTTP_400_BAD_REQUEST,
             )
-        # Validate egress and secret refs at admission.
+        payload = request.validated_data
+        base_url = (
+            getattr(settings, "HARNESS_PUBLIC_BASE_URL", "")
+            or request.build_absolute_uri("/")
+        ).rstrip("/")
+        # This uses only references/configuration and deployment env presence.
+        # Definitive launch validation runs again after vault resolution.
         try:
-            _validate_egress_domains(
-                request.validated_data["security"]["allowed_egress_domains"]
-            )
-            _validate_secret_refs_daytona(
-                request.validated_data["agent"]["secret_refs"]
-            )
+            _validate_secret_refs_daytona(payload["agent"]["secret_refs"])
+            _validate_known_daytona_egress(payload, base_url)
         except HostedHarnessError as exc:
             return Response(exc.as_dict(), status=exc.status_code)
         try:
             job, _ = create_hosted_job(
                 organization,
-                request.validated_data,
+                payload,
                 idempotency_key=idempotency_key,
                 workspace=_workspace(request),
             )
-            base_url = getattr(
-                settings, "HARNESS_PUBLIC_BASE_URL", ""
-            ) or request.build_absolute_uri("/").rstrip("/")
             retry_cfg = job.payload["retry"]
             start_hosted_harness_gateway_workflow(
                 str(job.id),
@@ -313,12 +342,15 @@ class DaytonaHarnessProvider:
         from simulate.services.hosted_harness_gateway import (
             HOSTED_ENGINE_CATALOG,
             HOSTED_RUNTIME_CATALOG,
-            _validate_egress_domains,
         )
-
         payload = request.validated_data
+        base_url = (
+            getattr(settings, "HARNESS_PUBLIC_BASE_URL", "")
+            or request.build_absolute_uri("/")
+        ).rstrip("/")
         try:
-            _validate_egress_domains(payload["security"]["allowed_egress_domains"])
+            _validate_secret_refs_daytona(payload["agent"]["secret_refs"])
+            _validate_known_daytona_egress(payload, base_url)
         except HostedHarnessError as exc:
             return Response(exc.as_dict(), status=exc.status_code)
         runtime = payload["runtime"]

--- a/futureagi/simulate/services/hosted_harness_gateway.py
+++ b/futureagi/simulate/services/hosted_harness_gateway.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import io
+import ipaddress
 import json
 import logging
 import os
@@ -12,6 +13,7 @@ import tarfile
 import tempfile
 import time
 import uuid
+from collections.abc import Iterable, Mapping
 from contextlib import contextmanager, nullcontext
 from pathlib import Path
 from typing import Any
@@ -516,47 +518,209 @@ def attach_platform_simulator_secret_refs(
 _MAX_EGRESS_DOMAINS = 20
 # RFC 1918 / loopback / link-local prefixes that must never appear in egress.
 _PRIVATE_HOST_PATTERNS = re.compile(
-    r"^(10\.|172\.(1[6-9]|2\d|3[01])\.|192\.168\.|127\.|0\.|169\.254\.|localhost$)"
+    r"^(10\.|172\.(1[6-9]|2\d|3[01])\.|192\.168\.|127\.|0\.|"
+    r"169\.254\.|localhost$|.*\.localhost$|host\.docker\.internal$|"
+    r"host\.containers\.internal$)"
 )
 _GOOGLE_REGION = re.compile(r"^[a-z][a-z0-9-]{0,31}$")
 
 
+def _normalize_egress_domains(domains: Iterable[str]) -> set[str]:
+    """Normalize, deduplicate, and wildcard-minimize an egress domain collection.
+
+    Daytona treats ``*.example.com`` as a domain policy for subdomains below the
+    apex, but not for the apex itself. Keep wildcard entries themselves intact
+    while removing only concrete hosts covered by one of those entries.
+    """
+    normalized = {
+        domain.strip().lower().rstrip(".")
+        for domain in domains
+        if isinstance(domain, str) and domain.strip().rstrip(".")
+    }
+    wildcard_suffixes = {
+        domain[2:]
+        for domain in normalized
+        if domain.startswith("*.") and len(domain) > 2
+    }
+    return {
+        domain
+        for domain in normalized
+        if domain.startswith("*.")
+        or not any(domain.endswith(f".{suffix}") for suffix in wildcard_suffixes)
+    }
+
+
+def _hostname_from_url(value: Any) -> str | None:
+    """Extract a normalized hostname from an URL or host-like value."""
+    if not isinstance(value, str):
+        return None
+    raw = value.strip()
+    if not raw:
+        return None
+    # ``urlparse`` only fills ``hostname`` for a netloc. The ``//`` form lets
+    # us accept a host-like value while retaining normal URL parsing.
+    candidate = raw if "://" in raw or raw.startswith("//") else f"//{raw}"
+    try:
+        hostname = urlparse(candidate).hostname
+    except ValueError:
+        return None
+    if not hostname:
+        return None
+    return hostname.strip().lower().rstrip(".") or None
+
+
+def _config_value(config: Mapping[str, Any], *names: str) -> str | None:
+    wanted = {name.lower() for name in names}
+    for key, value in config.items():
+        if str(key).lower() in wanted and isinstance(value, str):
+            candidate = value.strip()
+            if candidate:
+                return candidate
+    return None
+
+
+def _add_livekit_host(domains: set[str], host: str | None) -> None:
+    if not host:
+        return
+    domains.add(host)
+    if host.endswith(".livekit.cloud"):
+        domains.update({"*.livekit.cloud", "*.turn.livekit.cloud"})
+    elif host == "livekit-eu.futureagi.com":
+        domains.add("coturn.turn-eu.futureagi.com")
+
+
+def _connector_egress_domains(
+    payload: Mapping[str, Any], secrets_map: Mapping[str, Any]
+) -> set[str]:
+    """Return connector infrastructure hosts implied by resolved run inputs.
+
+    Only static/configured endpoints are admitted here. In particular, Vapi's
+    websocket endpoint is returned by its create-call response and is therefore
+    intentionally not guessed.
+    """
+    agent = payload.get("agent") or {}
+    connector = str(agent.get("connector") or "auto").strip().lower()
+    config = agent.get("config") or {}
+    if not isinstance(config, Mapping):
+        config = {}
+    domains: set[str] = set()
+
+    if connector == "livekit":
+        livekit_url = None
+        for alias, value in secrets_map.items():
+            if str(alias).upper() == "LIVEKIT_URL" and isinstance(value, str):
+                if value.strip():
+                    livekit_url = value.strip()
+                    break
+        if livekit_url is None:
+            livekit_url = _config_value(config, "livekit_url", "LIVEKIT_URL")
+        _add_livekit_host(domains, _hostname_from_url(livekit_url))
+    elif connector == "vapi":
+        domains.add("api.vapi.ai")
+        for name in (
+            "api_base_url",
+            "VAPI_API_BASE_URL",
+            "api_url",
+            "vapi_api_url",
+            "websocket_url",
+            "websocket_call_url",
+            "websocketcallurl",
+            "websocketCallUrl",
+        ):
+            value = _config_value(config, name)
+            host = _hostname_from_url(value)
+            if host:
+                domains.add(host)
+    elif connector == "retell":
+        domains.add("api.retellai.com")
+        api_url = _config_value(
+            config, "api_url", "api_base_url", "retell_api_url", "RETELL_API_URL"
+        )
+        api_host = _hostname_from_url(api_url)
+        if api_host:
+            domains.add(api_host)
+        livekit_url = _config_value(
+            config,
+            "livekit_url",
+            "LIVEKIT_URL",
+            "retell_livekit_url",
+            "RETELL_LIVEKIT_URL",
+        )
+        if livekit_url is None:
+            livekit_url = getattr(
+                settings,
+                "RETELL_LIVEKIT_URL",
+                "wss://retell-ai-4ihahnq7.livekit.cloud",
+            )
+        _add_livekit_host(domains, _hostname_from_url(livekit_url))
+    return domains
+
+
+def _validate_egress_host(domain: str) -> None:
+    host = domain[2:] if domain.startswith("*.") else domain
+    if _PRIVATE_HOST_PATTERNS.match(host):
+        raise HostedHarnessError(
+            "egress_domain_private",
+            f"private/reserved host {domain!r} is not allowed in egress",
+            status_code=400,
+        )
+    try:
+        address = ipaddress.ip_address(host)
+    except ValueError:
+        return
+    if (
+        address.is_private
+        or address.is_loopback
+        or address.is_link_local
+        or address.is_unspecified
+        or address.is_reserved
+    ):
+        raise HostedHarnessError(
+            "egress_domain_private",
+            f"private/reserved host {domain!r} is not allowed in egress",
+            status_code=400,
+        )
+
+
 def _validate_egress_domains(domains: list[str]) -> None:
-    """Reject egress lists exceeding cap or containing private/invalid hosts."""
+    """Reject customer egress lists exceeding the input cap or private hosts."""
     if len(domains) > _MAX_EGRESS_DOMAINS:
         raise HostedHarnessError(
             "egress_domain_limit_exceeded",
             f"at most {_MAX_EGRESS_DOMAINS} egress domains allowed, got {len(domains)}",
             status_code=400,
         )
-    for domain in domains:
-        if _PRIVATE_HOST_PATTERNS.match(domain):
-            raise HostedHarnessError(
-                "egress_domain_private",
-                f"private/reserved host {domain!r} is not allowed in egress",
-                status_code=400,
-            )
+    for domain in _normalize_egress_domains(domains):
+        _validate_egress_host(domain)
 
 
-def _validate_resolved_egress_domains(domains: set[str]) -> None:
-    """Enforce Daytona's cap after platform, provider, and customer hosts are combined."""
-    if len(domains) > _MAX_EGRESS_DOMAINS:
+def _validate_resolved_egress_domains(domains: Iterable[str]) -> None:
+    """Enforce Daytona's cap after platform, provider, and customer hosts combine."""
+    normalized = _normalize_egress_domains(domains)
+    if len(normalized) > _MAX_EGRESS_DOMAINS:
         raise HostedHarnessError(
             "egress_domain_limit_exceeded",
             "resolved sandbox egress requires "
-            f"{len(domains)} domains; Daytona supports at most {_MAX_EGRESS_DOMAINS}",
+            f"{len(normalized)} domains after normalization; "
+            f"Daytona supports at most {_MAX_EGRESS_DOMAINS}",
             status_code=400,
         )
+    for domain in normalized:
+        _validate_egress_host(domain)
 
 
-def _provider_egress_domains(secrets_map: dict[str, str]) -> set[str]:
-    """Return the minimum provider hosts implied by run-scoped credentials.
-
-    These are platform-managed dependencies of the selected credential type, not customer
-    requested egress. In particular, Vertex service-account credentials cannot work unless the
-    OAuth token endpoint and regional Vertex endpoint are reachable.
-    """
-    aliases = {name.upper().removeprefix("SIMULATOR_") for name in secrets_map}
+def _provider_egress_domains(secrets_map: Mapping[str, Any]) -> set[str]:
+    """Return provider hosts implied by credential aliases and provider selectors."""
+    aliases = {str(name).upper().removeprefix("SIMULATOR_") for name in secrets_map}
+    values = {str(name).upper(): value for name, value in secrets_map.items()}
+    selected_audio_providers = {
+        str(values.get(name) or "").strip().lower()
+        for name in ("SIMULATOR_STT_PROVIDER", "SIMULATOR_TTS_PROVIDER")
+        if str(values.get(name) or "").strip()
+    }
+    selected_llm_provider = str(
+        values.get("SIMULATOR_LLM_PROVIDER") or ""
+    ).strip().lower()
     domains: set[str] = set()
     if aliases & {
         "GOOGLE_APPLICATION_CREDENTIALS_JSON",
@@ -575,12 +739,103 @@ def _provider_egress_domains(secrets_map: dict[str, str]) -> set[str]:
             "SIMULATOR_GOOGLE_CLOUD_LOCATION",
             "SIMULATOR_CLOUD_ML_REGION",
         ):
-            region = str(secrets_map.get(name) or "").strip().lower()
+            region = str(values.get(name) or "").strip().lower()
             if _GOOGLE_REGION.fullmatch(region):
                 domains.add(f"{region}-aiplatform.googleapis.com")
-    if aliases & {"GEMINI_API_KEY", "GOOGLE_API_KEY"}:
+    if aliases & {"GEMINI_API_KEY", "GOOGLE_API_KEY"} and (
+        not selected_llm_provider
+        or selected_llm_provider in {"gemini", "google", "google-ai"}
+    ):
         domains.add("generativelanguage.googleapis.com")
+    if aliases & {"DEEPGRAM_API_KEY"} and (
+        not selected_audio_providers or "deepgram" in selected_audio_providers
+    ):
+        domains.add("api.deepgram.com")
+    if aliases & {"CARTESIA_API_KEY"} and (
+        not selected_audio_providers or "cartesia" in selected_audio_providers
+    ):
+        domains.add("api.cartesia.ai")
+    if aliases & {"OPENAI_API_KEY"} and (
+        not selected_llm_provider or selected_llm_provider == "openai"
+    ):
+        domains.add("api.openai.com")
+    if aliases & {"ANTHROPIC_API_KEY"} and (
+        not selected_llm_provider or selected_llm_provider == "anthropic"
+    ):
+        domains.add("api.anthropic.com")
     return domains
+
+
+def _resolved_egress_domains(
+    payload: Mapping[str, Any],
+    target_secrets: Mapping[str, Any] | None = None,
+    simulator_env: Mapping[str, Any] | None = None,
+    callback_host: str | None = None,
+) -> set[str]:
+    """Build Daytona's authoritative minimized domain union for one launch."""
+    target_secrets = target_secrets or {}
+    simulator_env = simulator_env or {}
+    security = payload.get("security") or {}
+    customer_domains = security.get("allowed_egress_domains") or []
+    base_domains = getattr(settings, "ALK_HOSTED_BASE_EGRESS_DOMAINS", []) or []
+    if isinstance(base_domains, str):
+        base_domains = [base_domains]
+    if isinstance(customer_domains, str):
+        customer_domains = [customer_domains]
+    if callback_host:
+        callback_host = _hostname_from_url(callback_host)
+    values: list[str] = [
+        domain for domain in base_domains if isinstance(domain, str)
+    ]
+    values.extend(_provider_egress_domains(target_secrets))
+    values.extend(_provider_egress_domains(simulator_env))
+    values.extend(_connector_egress_domains(payload, target_secrets))
+    values.extend(domain for domain in customer_domains if isinstance(domain, str))
+    if callback_host:
+        values.append(callback_host)
+    return _normalize_egress_domains(values)
+
+
+_KNOWN_SIMULATOR_SECRET_ALIASES = (
+    "GOOGLE_APPLICATION_CREDENTIALS_JSON",
+    "GOOGLE_APPLICATION_CREDENTIALS",
+    "GEMINI_API_KEY",
+    "GOOGLE_API_KEY",
+    "DEEPGRAM_API_KEY",
+    "CARTESIA_API_KEY",
+    "OPENAI_API_KEY",
+    "ANTHROPIC_API_KEY",
+)
+_KNOWN_SIMULATOR_CONFIG_NAMES = (
+    "SIMULATOR_LLM_PROVIDER",
+    "SIMULATOR_STT_PROVIDER",
+    "SIMULATOR_TTS_PROVIDER",
+    "GOOGLE_CLOUD_LOCATION",
+    "CLOUD_ML_REGION",
+)
+
+
+def _known_simulator_egress_inputs() -> dict[str, str]:
+    """Read deployment env presence and non-secret selectors for admission checks."""
+    values: dict[str, str] = {}
+    configured = getattr(settings, "ALK_HOSTED_SIMULATOR_SECRET_ENV", {}) or {}
+    for alias, env_name in configured.items():
+        raw = str(os.getenv(str(env_name), "") or "")
+        if raw:
+            upper_alias = str(alias).upper()
+            values[str(alias)] = (
+                raw
+                if "LOCATION" in upper_alias or "REGION" in upper_alias
+                else ""
+            )
+    for alias in _KNOWN_SIMULATOR_SECRET_ALIASES:
+        if os.getenv(alias):
+            values.setdefault(alias, "")
+    for name in _KNOWN_SIMULATOR_CONFIG_NAMES:
+        value = str(os.getenv(name) or "").strip()
+        if value:
+            values[name] = value
+    return values
 
 
 def _persist_bundle_stage_outputs(
@@ -996,6 +1251,18 @@ class DaytonaHostedGateway:
         secrets_map = PlatformSecretResolver().resolve(job)
         simulator_env, simulator_vertex_credentials = _platform_simulator_material()
         dispatch_payload = prepare_dispatch_payload(payload, secrets_map)
+        platform_host = _hostname_from_url(endpoint_base_url)
+        allowed_domains = _resolved_egress_domains(
+            payload,
+            secrets_map,
+            simulator_env,
+            platform_host,
+        )
+        # Validate customer inputs independently so their existing API-level cap and
+        # private-host protection remain fail-closed; the resolved cap is checked
+        # after wildcard minimization and provider/connector additions.
+        _validate_egress_domains(payload["security"]["allowed_egress_domains"])
+        _validate_resolved_egress_domains(allowed_domains)
         capability = register_attempt(
             job.id,
             endpoint_base_url=endpoint_base_url,
@@ -1028,16 +1295,6 @@ class DaytonaHostedGateway:
             authoring_seconds + payload["runtime"]["max_duration_seconds"] + 120,
         )
         ttl_minutes = max(1, (ttl_seconds + 59) // 60)
-        platform_host = urlparse(endpoint_base_url).hostname
-        allowed_domains = set(getattr(settings, "ALK_HOSTED_BASE_EGRESS_DOMAINS", []))
-        allowed_domains.update(_provider_egress_domains(secrets_map))
-        allowed_domains.update(_provider_egress_domains(simulator_env))
-        allowed_domains.update(payload["security"]["allowed_egress_domains"])
-        if platform_host:
-            allowed_domains.add(platform_host)
-        # Egress union validation: cap at 20 user-supplied domains.
-        _validate_egress_domains(payload["security"]["allowed_egress_domains"])
-        _validate_resolved_egress_domains(allowed_domains)
         # Voice/WebRTC media (ICE) needs UDP to the media server's advertised IP, which a DNS
         # domain-allowlist cannot express when media and signaling resolve to different IPs. When
         # unrestricted egress is enabled the sandbox runs with open outbound so media can flow;

--- a/futureagi/simulate/tests/test_harness_provider.py
+++ b/futureagi/simulate/tests/test_harness_provider.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+from types import SimpleNamespace
 from unittest.mock import patch
 
 import pytest
@@ -14,6 +15,7 @@ from simulate.serializers.harness_job import HarnessJobCreateSerializer
 from simulate.services.harness_provider import (
     DaytonaHarnessProvider,
     SandboxHarnessProvider,
+    _validate_known_daytona_egress,
     get_harness_provider,
 )
 from simulate.services.hosted_harness import HostedHarnessError, create_hosted_job
@@ -124,6 +126,67 @@ def test_customer_cannot_use_reserved_simulator_alias_for_agent_secret():
 
     assert not serializer.is_valid()
     assert "reserved" in str(serializer.errors)
+
+
+def test_known_daytona_egress_rejects_overflow_without_vault_resolution(settings):
+    settings.ALK_HOSTED_BASE_EGRESS_DOMAINS = [
+        f"base-{index}.example.com" for index in range(19)
+    ]
+    settings.ALK_HOSTED_SIMULATOR_SECRET_ENV = {}
+
+    with pytest.raises(HostedHarnessError, match="Daytona supports at most 20"):
+        _validate_known_daytona_egress(
+            _v1_payload(), "https://harness.example.test/"
+        )
+
+
+def test_daytona_preflight_rejects_known_egress_overflow(settings):
+    settings.ALK_HOSTED_BASE_EGRESS_DOMAINS = [
+        f"base-{index}.example.com" for index in range(19)
+    ]
+    settings.ALK_HOSTED_SIMULATOR_SECRET_ENV = {}
+    request = SimpleNamespace(
+        validated_data=_v1_payload(),
+        build_absolute_uri=lambda _path: "https://harness.example.test/",
+    )
+
+    response = DaytonaHarnessProvider().preflight(request)
+
+    assert response.status_code == 400
+    assert response.data["error"] == "egress_domain_limit_exceeded"
+
+
+@pytest.mark.django_db
+def test_daytona_create_rejects_known_egress_overflow_before_persisting(
+    user, workspace, settings
+):
+    settings.HARNESS_PROVIDER = "daytona"
+    settings.HARNESS_PUBLIC_BASE_URL = "https://harness.example.test"
+    settings.ALK_HOSTED_BASE_EGRESS_DOMAINS = [
+        f"base-{index}.example.com" for index in range(19)
+    ]
+    settings.ALK_HOSTED_SIMULATOR_SECRET_ENV = {}
+    client = APIClient()
+    client.force_authenticate(user=user)
+
+    with (
+        patch("simulate.services.hosted_harness.create_hosted_job") as create,
+        patch(
+            "simulate.temporal.client.start_hosted_harness_gateway_workflow"
+        ) as start,
+    ):
+        response = client.post(
+            "/simulate/api/harness-jobs/",
+            _v1_payload(),
+            format="json",
+            HTTP_IDEMPOTENCY_KEY="known-egress-overflow",
+            HTTP_X_WORKSPACE_ID=str(workspace.id),
+        )
+
+    assert response.status_code == 400
+    assert response.json()["error"] == "egress_domain_limit_exceeded"
+    create.assert_not_called()
+    start.assert_not_called()
 
 
 def test_harness_create_cors_preflight_allows_idempotency_key():

--- a/futureagi/simulate/tests/test_hosted_harness_gateway.py
+++ b/futureagi/simulate/tests/test_hosted_harness_gateway.py
@@ -22,8 +22,11 @@ from simulate.services.hosted_harness_gateway import (
     DaytonaHostedGateway,
     HostedSourceAcquirer,
     _authoring_archive_for,
+    _connector_egress_domains,
+    _normalize_egress_domains,
     _platform_simulator_material,
     _provider_egress_domains,
+    _resolved_egress_domains,
     _validate_resolved_egress_domains,
     attach_platform_simulator_secret_refs,
     pack_authoring_archive,
@@ -147,6 +150,168 @@ def test_resolved_egress_rejects_daytona_domain_overflow():
         _validate_resolved_egress_domains(
             {f"provider-{index}.example.com" for index in range(21)}
         )
+
+
+def test_normalize_egress_domains_wildcard_coverage_keeps_apex():
+    assert _normalize_egress_domains(
+        [
+            " Foo.Example.COM. ",
+            "foo.example.com",
+            "*.EXAMPLE.com.",
+            "example.com.",
+            "bar.other.test.",
+        ]
+    ) == {"*.example.com", "example.com", "bar.other.test"}
+
+
+@pytest.mark.parametrize(
+    ("alias", "domain"),
+    [
+        ("DEEPGRAM_API_KEY", "api.deepgram.com"),
+        ("SIMULATOR_DEEPGRAM_API_KEY", "api.deepgram.com"),
+        ("CARTESIA_API_KEY", "api.cartesia.ai"),
+        ("OPENAI_API_KEY", "api.openai.com"),
+        ("ANTHROPIC_API_KEY", "api.anthropic.com"),
+    ],
+)
+def test_provider_egress_includes_direct_and_simulator_aliases(alias, domain):
+    assert _provider_egress_domains({alias: "configured"}) == {domain}
+
+def test_provider_egress_uses_selected_simulator_audio_provider():
+    domains = _provider_egress_domains(
+        {
+            "SIMULATOR_DEEPGRAM_API_KEY": "configured",
+            "SIMULATOR_CARTESIA_API_KEY": "configured",
+            "SIMULATOR_STT_PROVIDER": "deepgram",
+            "SIMULATOR_TTS_PROVIDER": "deepgram",
+        }
+    )
+
+    assert domains == {"api.deepgram.com"}
+
+
+def test_provider_egress_uses_selected_simulator_llm_provider():
+    domains = _provider_egress_domains(
+        {
+            "SIMULATOR_GEMINI_API_KEY": "configured",
+            "SIMULATOR_OPENAI_API_KEY": "configured",
+            "SIMULATOR_LLM_PROVIDER": "openai",
+        }
+    )
+
+    assert domains == {"api.openai.com"}
+
+
+def test_livekit_cloud_connector_egress_is_wildcard_minimized(settings):
+    settings.ALK_HOSTED_BASE_EGRESS_DOMAINS = []
+    payload = {
+        "agent": {
+            "connector": "livekit",
+            "config": {"livekit_url": "wss://FOO.livekit.cloud."},
+        },
+        "security": {"allowed_egress_domains": []},
+    }
+
+    assert _resolved_egress_domains(payload, {}, {}, None) == {
+        "*.livekit.cloud",
+        "*.turn.livekit.cloud",
+    }
+
+
+def test_self_hosted_livekit_connector_only_adds_signal_host(settings):
+    settings.ALK_HOSTED_BASE_EGRESS_DOMAINS = []
+    payload = {
+        "agent": {
+            "connector": "livekit",
+            "config": {"LIVEKIT_URL": "wss://voice.customer.example"},
+        },
+        "security": {"allowed_egress_domains": []},
+    }
+
+    assert _connector_egress_domains(payload, {}) == {"voice.customer.example"}
+
+
+def test_livekit_secret_url_takes_precedence_over_configured_url():
+    payload = {
+        "agent": {
+            "connector": "livekit",
+            "config": {"livekit_url": "wss://config.example.test"},
+        },
+        "security": {"allowed_egress_domains": []},
+    }
+
+    assert _connector_egress_domains(
+        payload, {"LIVEKIT_URL": "wss://resolved.example.test"}
+    ) == {"resolved.example.test"}
+
+
+def test_vapi_connector_adds_static_and_configured_endpoint_hosts():
+    payload = {
+        "agent": {
+            "connector": "vapi",
+            "config": {
+                "api_base_url": "https://proxy.example.test",
+                "websocketCallUrl": "wss://call.example.test/socket",
+            },
+        },
+        "security": {"allowed_egress_domains": []},
+    }
+
+    assert _connector_egress_domains(payload, {}) == {
+        "api.vapi.ai",
+        "call.example.test",
+        "proxy.example.test",
+    }
+
+
+def test_livekit_futureagi_eu_connector_adds_coturn_host():
+    payload = {
+        "agent": {
+            "connector": "livekit",
+            "config": {"livekit_url": "wss://livekit-eu.futureagi.com"},
+        },
+        "security": {"allowed_egress_domains": []},
+    }
+
+    assert _connector_egress_domains(payload, {}) == {
+        "coturn.turn-eu.futureagi.com",
+        "livekit-eu.futureagi.com",
+    }
+
+
+def test_retell_connector_includes_default_livekit_cloud_egress(settings):
+    settings.ALK_HOSTED_BASE_EGRESS_DOMAINS = []
+    settings.RETELL_LIVEKIT_URL = "wss://retell-ai.example.livekit.cloud"
+    payload = {
+        "agent": {"connector": "retell", "config": {}},
+        "security": {"allowed_egress_domains": []},
+    }
+
+    assert _resolved_egress_domains(payload, {}, {}, None) == {
+        "*.livekit.cloud",
+        "*.turn.livekit.cloud",
+        "api.retellai.com",
+    }
+
+
+def test_resolved_egress_cap_applies_after_wildcard_minimization(settings):
+    settings.ALK_HOSTED_BASE_EGRESS_DOMAINS = []
+    payload = {
+        "agent": {"connector": "auto", "config": {}},
+        "security": {
+            "allowed_egress_domains": [
+                "*.example.com",
+                "foo.example.com",
+                *[f"domain-{index}.example.test" for index in range(19)],
+            ]
+        },
+    }
+
+    domains = _resolved_egress_domains(payload, {}, {}, None)
+    assert "foo.example.com" not in domains
+    assert "example.com" not in domains
+    assert len(domains) == 20
+    _validate_resolved_egress_domains(domains)
 
 
 def _payload():
@@ -509,6 +674,8 @@ def test_daytona_launch_uploads_contract_files_and_starts_one_session(
     assert set(client.params.domain_allow_list.split(",")) == {
         "aiplatform.googleapis.com",
         "agent.example.com",
+        "api.deepgram.com",
+        "api.vapi.ai",
         "global-aiplatform.googleapis.com",
         "ingest.example.com",
         "oauth2.googleapis.com",


### PR DESCRIPTION
## Problem

Daytona caps the resolved sandbox egress allowlist at 20 domains. The previous implementation assembled this list by unioning a large static base (up to 18 entries) with provider-derived, customer-declared, and platform-callback hosts — without wildcard-aware deduplication or awareness of the resolved connector's network dependencies.

This caused three categories of failure in hosted voice runs:

1. **Cap overflow** (`egress_domain_limit_exceeded`): 18 static + 3 provider-derived + callback = 21 → `launch_hosted_harness_job` failed before the sandbox was created, leaving the job queued indefinitely.
2. **Missing media hosts**: the frontend hardcoded `allowed_egress_domains: []` (reported as a known bug in the setup checklist), so UI-created jobs shipped with zero per-job egress. For agents on LiveKit Cloud (whose signaling/TURN hosts aren't in the platform base list), the agent registered but media setup timed out (`voice_call_not_completed: timed_out: LiveKit setup exceeded its deadline`).
3. **Unused provider slots**: both Deepgram and Cartesia API hosts were added whenever their keys were configured, regardless of whether the simulator actually selected them — wasting slots and contributing to the cap overflow.

## Solution

### Backend (`hosted_harness_gateway.py`, `harness_provider.py`)

- **Wildcard-aware normalizer** (`_normalize_egress_domains`): lowercase, trailing-dot strip, exact dedupe, and removal of concrete hosts subsumed by a `*.suffix` wildcard. `*.example.com` removes `foo.example.com` but keeps `example.com` (matching Daytona's wildcard semantics).
- **Provider-selector-aware derivation**: Deepgram/Cartesia added only when the selected `SIMULATOR_STT/TTS_PROVIDER` matches; OpenAI/Anthropic only when `SIMULATOR_LLM_PROVIDER` matches.
- **Connector-specific profiles**:
  - `livekit` (Cloud): `*.livekit.cloud` + `*.turn.livekit.cloud`
  - `livekit` (FutureAGI EU): `coturn.turn-eu.futureagi.com`
  - `vapi`: `api.vapi.ai` + configured endpoint hosts
  - `retell`: `api.retellai.com` + default LiveKit Cloud host
- **Single authoritative resolver** (`_resolved_egress_domains`): assembles `base + provider + connector + customer + callback`, normalizes, wildcard-minimizes, then validates `≤ 20`.
- **Pre-enqueue admission** (`_validate_known_daytona_egress`): rejects overflow at `create`/`preflight` before persisting or enqueueing, using only payload aliases and deployment env presence (no vault decryption).
- **Strict private-host validation** across the entire resolved union (not just customer domains).
- **`.env.example` base trimmed** to 5 package-registry domains; all provider/connector/callback hosts are now dynamic.

### Frontend (`HarnessCreate.jsx`, `requestMapper.js`)

- Moved URL-host derivation into `requestMapper.js` (`deriveEgressDomains`).
- Added explicit customer-domain parser (`parseEgressDomains`) for comma/newline-separated hostnames; rejects wildcards (backend owns those), schemes, paths.
- Added "Additional egress domains" `TextField` for customer-declared TURN/API hostnames not discoverable from pasted env URLs.
- `hostedPayload()` sends merged derived + explicit exact-host list. No provider infrastructure policy in the frontend.

## Tests

- **19 backend tests**: normalization, wildcard coverage, all provider aliases + selector filtering, all 5 connector profiles (LiveKit Cloud/self-hosted/FutureAGI-EU/Vapi/Retell), resolved cap after minimization, admission overflow.
- **26 frontend tests**: URL derivation, private/localhost/link-local rejection, parsing/normalization/deduplication, merging, payload construction, credential warnings.

All green locally; DB-backed integration tests (create/preflight API) require the test database container.

## Migration

No database migration. Deployment change: trim `ALK_HOSTED_BASE_EGRESS_DOMAINS` to `pypi.org,files.pythonhosted.org,huggingface.co,*.huggingface.co,*.hf.co` — the gateway now adds everything else per-job.