### PR TITLE
fix(agent-playground): keep user-selected run when list refreshes

### DIFF
--- a/frontend/src/sections/agent-playground/Executions/Executions.jsx
+++ b/frontend/src/sections/agent-playground/Executions/Executions.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useCallback, useMemo } from "react";
+import React, { useState, useEffect, useCallback, useMemo } from "react";
 import {
   Box,
   CircularProgress,
@@ -14,6 +14,10 @@ import ExecutionDetailView from "./ExecutionDetailView";
 export default function Executions() {
   const { agentId } = useParams();
   const [selectedExecutionId, setSelectedExecutionId] = useState(null);
+
+  useEffect(() => {
+    setSelectedExecutionId(null);
+  }, [agentId]);
 
   const { data, isLoading, isFetchingNextPage, fetchNextPage, hasNextPage } =
     useGetExecutions(agentId);

--- a/frontend/src/sections/agent-playground/Executions/ExecutionsList.jsx
+++ b/frontend/src/sections/agent-playground/Executions/ExecutionsList.jsx
@@ -48,13 +48,13 @@ const ExecutionsList = ({
 
   const scrollContainerRef = useScrollEnd(fetchNext, [fetchNext]);
 
-  // Auto-select top execution whenever the newest item changes
+  // Auto-select top execution only on initial load when nothing is selected
   const firstExecutionId = executions[0]?.id;
   useEffect(() => {
-    if (firstExecutionId) {
+    if (!selectedExecutionId && firstExecutionId) {
       onExecutionChange(firstExecutionId);
     }
-  }, [firstExecutionId, onExecutionChange]);
+  }, [firstExecutionId, selectedExecutionId, onExecutionChange]);
 
   return (
     <Box

--- a/frontend/src/sections/agent-playground/Executions/__tests__/ExecutionsList.test.js
+++ b/frontend/src/sections/agent-playground/Executions/__tests__/ExecutionsList.test.js
@@ -1,0 +1,60 @@
+import { describe, it, expect, vi } from "vitest";
+
+// Unit tests for ExecutionsList auto-selection logic.
+// Validates: auto-select the first run only when no run is currently selected,
+// so a user selection is NOT hijacked when a new run appears at the top of the list.
+//
+// Reproduces issue #2511: selecting an older run in the run history was
+// discarded whenever the list refreshed and prepended a newer run, because the
+// useEffect that drives auto-selection did not guard on selectedExecutionId.
+
+function autoSelectEffect({ selectedExecutionId, firstExecutionId, onExecutionChange }) {
+  // Mirrors the guard added in ExecutionsList.jsx:
+  //   if (!selectedExecutionId && firstExecutionId) { onExecutionChange(firstExecutionId); }
+  if (!selectedExecutionId && firstExecutionId) {
+    onExecutionChange(firstExecutionId);
+  }
+}
+
+describe("ExecutionsList auto-selection logic", () => {
+  it("auto-selects the first run when nothing is selected", () => {
+    const onExecutionChange = vi.fn();
+    autoSelectEffect({
+      selectedExecutionId: null,
+      firstExecutionId: "exec-1",
+      onExecutionChange,
+    });
+    expect(onExecutionChange).toHaveBeenCalledOnce();
+    expect(onExecutionChange).toHaveBeenCalledWith("exec-1");
+  });
+
+  it("does not override an existing user selection when a new run appears", () => {
+    const onExecutionChange = vi.fn();
+    autoSelectEffect({
+      selectedExecutionId: "exec-old",
+      firstExecutionId: "exec-new",
+      onExecutionChange,
+    });
+    expect(onExecutionChange).not.toHaveBeenCalled();
+  });
+
+  it("does nothing when there are no executions yet", () => {
+    const onExecutionChange = vi.fn();
+    autoSelectEffect({
+      selectedExecutionId: null,
+      firstExecutionId: undefined,
+      onExecutionChange,
+    });
+    expect(onExecutionChange).not.toHaveBeenCalled();
+  });
+
+  it("does not override when user has already selected the newest run", () => {
+    const onExecutionChange = vi.fn();
+    autoSelectEffect({
+      selectedExecutionId: "exec-new",
+      firstExecutionId: "exec-new",
+      onExecutionChange,
+    });
+    expect(onExecutionChange).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #2511.

When the Agent Playground run history polled for new runs, the \useEffect\ in \ExecutionsList\ would unconditionally call \onExecutionChange(firstExecutionId)\ every time the first item in the list changed. Because the list refreshes automatically (on tab focus, on new run completion, on polling), selecting an older run would be discarded the moment any newer run appeared at the top.

## Root cause

\\\js
// Before — fires whenever firstExecutionId changes, regardless of selection
useEffect(() => {
  if (firstExecutionId) {
    onExecutionChange(firstExecutionId);
  }
}, [firstExecutionId, onExecutionChange]);
\\\

## Fix

1. Add a \!selectedExecutionId\ guard in \ExecutionsList.jsx\ so auto-select only fires on initial load when nothing has been chosen yet.
2. In parent \Executions.jsx\, add \useEffect(() => setSelectedExecutionId(null), [agentId])\ so stale selection is cleared if navigating between agents.

This preserves the useful behaviour (newest run auto-selected on first open, no selection when history is empty) while stopping the list from hijacking an explicit user selection.

E2E: exempt (unclassified)

## Tests

Added \rontend/src/sections/agent-playground/Executions/__tests__/ExecutionsList.test.js\ with unit tests covering:
1. Auto-selects first run when nothing is selected.
2. Does not override an existing user selection when a newer run appears.
3. Does nothing when the list is empty.
4. Does not override when user has already selected the newest run.