### PR TITLE
fix(agent-playground): display node execution duration in detail inspector (Fixes #2509)

### DIFF
--- a/frontend/src/sections/agent-playground/AgentBuilder/RunAgentPanel/NodeOutputDetail.jsx
+++ b/frontend/src/sections/agent-playground/AgentBuilder/RunAgentPanel/NodeOutputDetail.jsx
@@ -13,6 +13,8 @@ import { AgGridReact } from "ag-grid-react";
 import { useAgThemeWith } from "src/hooks/use-ag-theme";
 import { useGetNodeExecutionDetail } from "src/api/agent-playground/agent-playground";
 import CustomJsonViewer from "src/components/custom-json-viewer/CustomJsonViewer";
+import { formatDuration } from "src/utils/format-time";
+import SvgColor from "src/components/svg-color";
 
 const tryParseJson = (str) => {
   if (typeof str !== "string") return null;
@@ -239,6 +241,24 @@ export default function NodeOutputDetail({ executionId, nodeExecutionId }) {
   );
   const hasErrorMessage = !!errorMessage && outputs.length === 0;
   const isPairedMode = inputs.length > 0 && inputs.length === outputs.length;
+
+  const rawDuration =
+    nodeDetail?.duration_seconds ?? nodeDetail?.duration;
+  const isNodeFinished =
+    !isNodeRunning &&
+    nodeStatus !== "skipped" &&
+    nodeStatus !== "idle" &&
+    rawDuration != null &&
+    Number.isFinite(Number(rawDuration)) &&
+    Number(rawDuration) >= 0;
+
+  const formattedDuration = isNodeFinished
+    ? formatDuration(
+        Number(rawDuration) >= 1
+          ? Math.round(Number(rawDuration))
+          : Math.round(Number(rawDuration) * 10) / 10,
+      )
+    : null;
 
   // Map API response to AG Grid row data
   const rowData = useMemo(() => {
@@ -511,7 +531,7 @@ export default function NodeOutputDetail({ executionId, nodeExecutionId }) {
           mb: 2,
         }}
       >
-        <Box>
+        <Box sx={{ display: "flex", alignItems: "center", gap: 1 }}>
           <Typography
             typography="m3"
             fontWeight="fontWeightMedium"
@@ -519,6 +539,28 @@ export default function NodeOutputDetail({ executionId, nodeExecutionId }) {
           >
             Agent flow results
           </Typography>
+          {formattedDuration && (
+            <Box
+              data-testid="node-execution-duration"
+              sx={{
+                display: "inline-flex",
+                alignItems: "center",
+                gap: 0.5,
+              }}
+            >
+              <SvgColor
+                src="/assets/icons/navbar/ic_new_clock.svg"
+                sx={{ width: 14, height: 14, bgcolor: "text.disabled" }}
+              />
+              <Typography
+                typography="s2"
+                color="text.secondary"
+                fontWeight="fontWeightRegular"
+              >
+                {formattedDuration}
+              </Typography>
+            </Box>
+          )}
         </Box>
 
         <FormControlLabel

--- a/frontend/src/sections/agent-playground/AgentBuilder/RunAgentPanel/__tests__/NodeOutputDetail.test.jsx
+++ b/frontend/src/sections/agent-playground/AgentBuilder/RunAgentPanel/__tests__/NodeOutputDetail.test.jsx
@@ -1,0 +1,201 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import React from "react";
+import NodeOutputDetail from "../NodeOutputDetail";
+import { useGetNodeExecutionDetail } from "src/api/agent-playground/agent-playground";
+
+vi.mock("src/api/agent-playground/agent-playground", () => ({
+  useGetNodeExecutionDetail: vi.fn(),
+}));
+
+vi.mock("ag-grid-react", async () => {
+  const React = await import("react");
+  const MockAgGrid = React.forwardRef(function MockAgGrid(_props, _ref) {
+    return <div data-testid="ag-grid-mock" />;
+  });
+  return { AgGridReact: MockAgGrid };
+});
+
+vi.mock("src/hooks/use-ag-theme", () => ({
+  useAgThemeWith: () => ({}),
+}));
+
+vi.mock("src/components/custom-json-viewer/CustomJsonViewer", () => ({
+  default: () => null,
+}));
+
+vi.mock("src/components/svg-color", () => ({
+  default: ({ src, ...props }) => (
+    <span data-testid="svg-color" data-src={src} {...props} />
+  ),
+}));
+
+describe("NodeOutputDetail - Node execution duration", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    useGetNodeExecutionDetail.mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      isError: false,
+    });
+  });
+
+  it("renders 'Select a node to view details' when nodeExecutionId is missing", () => {
+    render(<NodeOutputDetail executionId="exec-1" nodeExecutionId={null} />);
+    expect(screen.getByText("Select a node to view details")).toBeInTheDocument();
+  });
+
+  it("displays formatted duration for a successfully completed node", () => {
+    useGetNodeExecutionDetail.mockReturnValue({
+      data: {
+        node_execution_id: "node-exec-1",
+        status: "success",
+        duration_seconds: 5.2,
+        inputs: [],
+        outputs: [],
+      },
+      isLoading: false,
+      isError: false,
+    });
+
+    render(
+      <NodeOutputDetail executionId="exec-1" nodeExecutionId="node-exec-1" />,
+    );
+
+    const durationElement = screen.getByTestId("node-execution-duration");
+    expect(durationElement).toBeInTheDocument();
+    expect(screen.getByText("5s")).toBeInTheDocument();
+  });
+
+  it("displays formatted minutes and seconds for longer executions", () => {
+    useGetNodeExecutionDetail.mockReturnValue({
+      data: {
+        node_execution_id: "node-exec-1",
+        status: "success",
+        duration_seconds: 75,
+        inputs: [],
+        outputs: [],
+      },
+      isLoading: false,
+      isError: false,
+    });
+
+    render(
+      <NodeOutputDetail executionId="exec-1" nodeExecutionId="node-exec-1" />,
+    );
+
+    expect(screen.getByTestId("node-execution-duration")).toBeInTheDocument();
+    expect(screen.getByText("1m 15s")).toBeInTheDocument();
+  });
+
+  it("displays formatted duration for a completed node that errored/failed", () => {
+    useGetNodeExecutionDetail.mockReturnValue({
+      data: {
+        node_execution_id: "node-exec-1",
+        status: "failed",
+        duration_seconds: 12,
+        error_message: "Process timed out",
+        inputs: [],
+        outputs: [],
+      },
+      isLoading: false,
+      isError: false,
+    });
+
+    render(
+      <NodeOutputDetail executionId="exec-1" nodeExecutionId="node-exec-1" />,
+    );
+
+    expect(screen.getByTestId("node-execution-duration")).toBeInTheDocument();
+    expect(screen.getByText("12s")).toBeInTheDocument();
+  });
+
+  it("guards against currently running nodes and does not show duration", () => {
+    useGetNodeExecutionDetail.mockReturnValue({
+      data: {
+        node_execution_id: "node-exec-1",
+        status: "running",
+        duration_seconds: 10,
+        inputs: [{ payload: "test input" }],
+        outputs: [],
+      },
+      isLoading: false,
+      isError: false,
+    });
+
+    render(
+      <NodeOutputDetail executionId="exec-1" nodeExecutionId="node-exec-1" />,
+    );
+
+    expect(
+      screen.queryByTestId("node-execution-duration"),
+    ).not.toBeInTheDocument();
+    expect(screen.queryByText("10s")).not.toBeInTheDocument();
+  });
+
+  it("guards against currently pending nodes and does not show duration", () => {
+    useGetNodeExecutionDetail.mockReturnValue({
+      data: {
+        node_execution_id: "node-exec-1",
+        status: "pending",
+        duration_seconds: 0,
+        inputs: [],
+        outputs: [],
+      },
+      isLoading: false,
+      isError: false,
+    });
+
+    render(
+      <NodeOutputDetail executionId="exec-1" nodeExecutionId="node-exec-1" />,
+    );
+
+    expect(
+      screen.queryByTestId("node-execution-duration"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("guards against skipped or unexecuted nodes", () => {
+    useGetNodeExecutionDetail.mockReturnValue({
+      data: {
+        node_execution_id: "node-exec-1",
+        status: "skipped",
+        duration_seconds: null,
+        inputs: [],
+        outputs: [],
+      },
+      isLoading: false,
+      isError: false,
+    });
+
+    render(
+      <NodeOutputDetail executionId="exec-1" nodeExecutionId="node-exec-1" />,
+    );
+
+    expect(
+      screen.queryByTestId("node-execution-duration"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("does not show duration if duration_seconds is null or undefined", () => {
+    useGetNodeExecutionDetail.mockReturnValue({
+      data: {
+        node_execution_id: "node-exec-1",
+        status: "success",
+        duration_seconds: null,
+        inputs: [],
+        outputs: [],
+      },
+      isLoading: false,
+      isError: false,
+    });
+
+    render(
+      <NodeOutputDetail executionId="exec-1" nodeExecutionId="node-exec-1" />,
+    );
+
+    expect(
+      screen.queryByTestId("node-execution-duration"),
+    ).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
﻿## Summary
Fixes #2509 by displaying node execution elapsed time/duration in the Agent Playground node detail inspector (`NodeOutputDetail`).

## Context & Changes
- In `frontend/src/sections/agent-playground/AgentBuilder/RunAgentPanel/NodeOutputDetail.jsx`:
  - Read `duration_seconds` (or `duration`) from the node detail payload returned by `useGetNodeExecutionDetail`.
  - Used existing `formatDuration` helper from `src/utils/format-time` to format the duration into human-readable text (e.g. `5s`, `1m 15s`).
  - Added guards against unexecuted, skipped, idle, and currently running/pending nodes to prevent displaying misleading durations.
  - Rendered the duration with a clock icon (`/assets/icons/navbar/ic_new_clock.svg`) next to "Agent flow results" in the header without moving or disrupting other header controls.
- In `frontend/src/sections/agent-playground/AgentBuilder/RunAgentPanel/__tests__/NodeOutputDetail.test.jsx`:
  - Added comprehensive unit test coverage verifying duration display for completed nodes, format conversion, and guarding against running, pending, skipped, and unexecuted nodes.

## Verification Evidence
- Unit Tests: `npx vitest run src/sections/agent-playground/AgentBuilder/RunAgentPanel/__tests__/NodeOutputDetail.test.jsx` (8/8 passed)
- Playground Test Suite: `npx vitest run src/sections/agent-playground` (604/604 passed)
- Linter: `npx eslint "src/sections/agent-playground/AgentBuilder/RunAgentPanel/**/*.{js,jsx}"` (0 errors, 0 warnings)
- Build: `npx vite build` (built cleanly in 1m 24s)
