### PR TITLE
fix(agent-playground): show errors with partial node output

### DIFF
--- a/frontend/src/sections/agent-playground/AgentBuilder/RunAgentPanel/NodeOutputDetail.jsx
+++ b/frontend/src/sections/agent-playground/AgentBuilder/RunAgentPanel/NodeOutputDetail.jsx
@@ -238,6 +238,7 @@ export default function NodeOutputDetail({ executionId, nodeExecutionId }) {
     [nodeDetail?.outputs],
   );
   const hasErrorMessage = !!errorMessage && outputs.length === 0;
+  const hasPartialError = !!errorMessage && outputs.length > 0;
   const isPairedMode = inputs.length > 0 && inputs.length === outputs.length;
 
   // Map API response to AG Grid row data
@@ -536,6 +537,17 @@ export default function NodeOutputDetail({ executionId, nodeExecutionId }) {
           }
         />
       </Box>
+
+      {hasPartialError && (
+        <Typography
+          role="alert"
+          typography="s2"
+          color="error.main"
+          sx={{ mb: 2, whiteSpace: "pre-wrap", wordBreak: "break-word" }}
+        >
+          {errorMessage}
+        </Typography>
+      )}
 
       {/* AG Grid Table */}
       <Box sx={{ flex: 1, minHeight: 0, overflow: "auto" }}>

--- a/frontend/src/sections/agent-playground/AgentBuilder/RunAgentPanel/NodeOutputDetail.jsx
+++ b/frontend/src/sections/agent-playground/AgentBuilder/RunAgentPanel/NodeOutputDetail.jsx
@@ -237,8 +237,10 @@ export default function NodeOutputDetail({ executionId, nodeExecutionId }) {
     () => nodeDetail?.outputs || [],
     [nodeDetail?.outputs],
   );
-  const hasErrorMessage = !!errorMessage && outputs.length === 0;
-  const hasPartialError = !!errorMessage && outputs.length > 0;
+  const isNodeFailed = nodeStatus === "failed" || nodeStatus === "error";
+  const hasErrorMessage =
+    isNodeFailed && !!errorMessage && outputs.length === 0;
+  const hasPartialError = isNodeFailed && !!errorMessage && outputs.length > 0;
   const isPairedMode = inputs.length > 0 && inputs.length === outputs.length;
 
   // Map API response to AG Grid row data

--- a/frontend/src/sections/agent-playground/AgentBuilder/RunAgentPanel/__tests__/NodeOutputDetail.test.jsx
+++ b/frontend/src/sections/agent-playground/AgentBuilder/RunAgentPanel/__tests__/NodeOutputDetail.test.jsx
@@ -1,0 +1,97 @@
+/* eslint-disable react/prop-types */
+import React from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import NodeOutputDetail from "../NodeOutputDetail";
+
+let mockNodeDetail;
+
+vi.mock("src/api/agent-playground/agent-playground", () => ({
+  useGetNodeExecutionDetail: () => ({
+    data: mockNodeDetail,
+    isLoading: false,
+    isError: false,
+  }),
+}));
+
+vi.mock("src/hooks/use-ag-theme", () => ({
+  useAgThemeWith: () => ({}),
+}));
+
+vi.mock("ag-grid-react", async () => {
+  const ReactModule = await import("react");
+  return {
+    AgGridReact: ReactModule.forwardRef(function MockAgGridReact(
+      { rowData },
+      _ref,
+    ) {
+      return (
+        <pre data-testid="node-output-grid">{JSON.stringify(rowData)}</pre>
+      );
+    }),
+  };
+});
+
+describe("NodeOutputDetail", () => {
+  beforeEach(() => {
+    mockNodeDetail = {
+      status: "failed",
+      node_execution_id: "node-execution-1",
+      inputs: [],
+      outputs: [],
+      error_message: null,
+    };
+  });
+
+  it("shows a failure alongside partial node output", () => {
+    mockNodeDetail.outputs = [{ payload: "partial result" }];
+    mockNodeDetail.error_message = "Provider connection failed";
+
+    render(
+      <NodeOutputDetail
+        executionId="execution-1"
+        nodeExecutionId="node-execution-1"
+      />,
+    );
+
+    expect(screen.getByRole("alert")).toHaveTextContent(
+      "Provider connection failed",
+    );
+    expect(screen.getByTestId("node-output-grid")).toHaveTextContent(
+      "partial result",
+    );
+  });
+
+  it("keeps the existing no-output error presentation", () => {
+    mockNodeDetail.error_message = "Node failed before producing output";
+
+    render(
+      <NodeOutputDetail
+        executionId="execution-1"
+        nodeExecutionId="node-execution-1"
+      />,
+    );
+
+    expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+    expect(screen.getByTestId("node-output-grid")).toHaveTextContent(
+      "Node failed before producing output",
+    );
+  });
+
+  it("does not show an error for a successful node", () => {
+    mockNodeDetail.status = "success";
+    mockNodeDetail.outputs = [{ payload: "complete result" }];
+
+    render(
+      <NodeOutputDetail
+        executionId="execution-1"
+        nodeExecutionId="node-execution-1"
+      />,
+    );
+
+    expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+    expect(screen.getByTestId("node-output-grid")).toHaveTextContent(
+      "complete result",
+    );
+  });
+});

--- a/frontend/src/sections/agent-playground/AgentBuilder/RunAgentPanel/__tests__/NodeOutputDetail.test.jsx
+++ b/frontend/src/sections/agent-playground/AgentBuilder/RunAgentPanel/__tests__/NodeOutputDetail.test.jsx
@@ -81,6 +81,7 @@ describe("NodeOutputDetail", () => {
   it("does not show an error for a successful node", () => {
     mockNodeDetail.status = "success";
     mockNodeDetail.outputs = [{ payload: "complete result" }];
+    mockNodeDetail.error_message = "Stale failure from an earlier attempt";
 
     render(
       <NodeOutputDetail


### PR DESCRIPTION
## Summary

Failed Agent Playground nodes now keep their partial output visible while also showing the backend error that stopped the node. Nodes that fail before producing output and successful nodes retain their existing presentation.

## Linked issues

Closes #2503
Linear: N/A

## Type of change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## E2E coverage

E2E: exempt (frontend-only node-detail presentation covered by a focused component regression test)

## 1) What changes were done

**A. Partial failure visibility**

- render the existing node error as an accessible alert when outputs are also present
- keep the output grid unchanged so partial results remain inspectable
- preserve the existing error-in-grid behavior when no output exists

**B. Regression coverage**

- cover a failed node with partial output and an error
- cover a failed node with no output
- cover a successful node with output

## 2) Why the changes were done

- **Product/UX:** a failed node should explain why it stopped without hiding useful partial work
- **Technical:** the backend already supplies both values, so the fix stays in the presentation layer and does not change API contracts

## 3) Tests written + scenarios each covers

**`NodeOutputDetail.test.jsx`** — node result presentation

- partial output plus failure shows both values
- failure without output keeps the existing presentation
- successful output does not show an error alert

> Run result: 3 targeted tests passed. The full frontend suite passed 4410/4410 tests across 448 files. Repository lint completed with 0 errors and 427 existing warnings, and the production build passed.

## 4) How to run / test

```bash
cd frontend
yarn test:run src/sections/agent-playground/AgentBuilder/RunAgentPanel/__tests__/NodeOutputDetail.test.jsx
yarn check-all
yarn build
```

## 5) Screenshots / recordings

Not captured because reproducing the live node-execution state requires the full backend stack. The component regression drives the exact response shapes for all three relevant states.

## 6) Edge cases & considerations

- empty-output failures remain rendered through the existing grid error path
- successful nodes do not gain additional UI
- long error messages retain wrapping and do not overflow the detail panel

## 8) Architectural / important decisions

- **Presentation-only fix:** no API or store changes are needed because both partial outputs and the error are already returned.

## Checklist

- [x] My code follows the style guide
- [x] I have added tests that prove the fix
- [x] `yarn test:run` passes locally
- [x] API contracts are unchanged
- [x] No hardcoded secrets, URLs, or PII
- [x] CLA pending first-contribution check
- [x] PR title follows Conventional Commits
- [x] Linear issue is not applicable

AI assistance was used during implementation. I reviewed the final diff and ran the verification listed above.