### PR TITLE
fix(tracer): match eval alert choice verdicts stored in output_str (TH-7788)

### DIFF
--- a/futureagi/tracer/services/clickhouse/query_builders/eval_metrics.py
+++ b/futureagi/tracer/services/clickhouse/query_builders/eval_metrics.py
@@ -23,6 +23,9 @@ from typing import Any
 
 from tracer.services.clickhouse.eval_logger_table import eval_logger_source
 from tracer.services.clickhouse.query_builders.base import BaseQueryBuilder
+from tracer.services.clickhouse.query_builders.expressions import (
+    eval_choice_match_expr,
+)
 
 # Eval output type constants (mirrors EvalOutputType from Django models)
 SCORE = "SCORE"
@@ -334,17 +337,14 @@ class EvalMetricsQueryBuilder(BaseQueryBuilder):
             # No choices defined -- return a simple count query
             return self._build_score_raw()
 
-        # Build per-choice columns. ClickHouse stores output_str_list as a JSON
-        # string, so parse it before calling has(); output_str is kept as the
-        # single-choice fallback for older rows/imports.
+        # Build per-choice columns; the match predicate is shared with the
+        # alert builder so charts and alerts agree on the same rows.
         choice_cols: list[str] = []
-        choice_array_expr = "JSONExtract(output_str_list, 'Array(String)')"
         for i, choice in enumerate(self.choices):
             param_name = f"choice_{i}"
             self.params[param_name] = choice
             choice_cols.append(
-                f"countIf(has({choice_array_expr}, %({param_name})s) "
-                f"OR output_str = %({param_name})s) * 100.0 "
+                f"countIf({eval_choice_match_expr(param_name)}) * 100.0 "
                 f"/ greatest(count(), 1) AS `choice_{i}`"
             )
 

--- a/futureagi/tracer/services/clickhouse/query_builders/expressions.py
+++ b/futureagi/tracer/services/clickhouse/query_builders/expressions.py
@@ -33,3 +33,20 @@ def annotation_numeric_value_expr(
         f"JSONExtractFloat({prefix}value, 'rating'), "
         f"JSONExtractFloat({prefix}value, 'value'))"
     )
+
+
+def eval_choice_match_expr(param_name: str) -> str:
+    """Return a predicate matching a CHOICES-eval verdict to ``%(param_name)s``.
+
+    A verdict can land in any of three places depending on the writer path
+    (TH-7788): the ``output_str_list`` JSON list, a bare ``output_str`` string,
+    or the ``choice`` key of a JSON object stored in ``output_str``.
+    ``JSONExtractString`` yields ``''`` on non-JSON text, so free-text rows
+    never false-match.
+    """
+    p = f"%({param_name})s"
+    return (
+        f"(has(JSONExtract(output_str_list, 'Array(String)'), {p}) "
+        f"OR output_str = {p} "
+        f"OR JSONExtractString(output_str, 'choice') = {p})"
+    )

--- a/futureagi/tracer/services/clickhouse/query_builders/monitor_metrics.py
+++ b/futureagi/tracer/services/clickhouse/query_builders/monitor_metrics.py
@@ -35,6 +35,9 @@ from tracer.services.clickhouse.eval_logger_table import (
     eval_logger_version_column,
 )
 from tracer.services.clickhouse.query_builders.base import BaseQueryBuilder, _parse_dt
+from tracer.services.clickhouse.query_builders.expressions import (
+    eval_choice_match_expr,
+)
 from tracer.services.clickhouse.query_builders.filters import ClickHouseFilterBuilder
 from tracer.services.clickhouse.v2.id_remap_sql import (
     remap_left_join,
@@ -125,8 +128,8 @@ class MonitorMetricsQueryBuilder(BaseQueryBuilder):
 
     @staticmethod
     def _eval_choice_match_expr(param_name: str = "choice_val") -> str:
-        """Choice membership in the JSON list (PG parity: list containment only)."""
-        return f"has(JSONExtract(output_str_list, 'Array(String)'), %({param_name})s)"
+        """Choice verdict match shared with the charts builder (TH-7788)."""
+        return eval_choice_match_expr(param_name)
 
     def _translate_filters(self) -> None:
         """Translate raw monitor filter JSON into CH WHERE clause fragments."""

--- a/futureagi/tracer/services/clickhouse/query_builders/monitor_metrics.py
+++ b/futureagi/tracer/services/clickhouse/query_builders/monitor_metrics.py
@@ -66,6 +66,8 @@ _EVAL_SPAN_BUCKET_EXPR = (
 _EVAL_NON_VALUE_STATUSES = ", ".join(
     f"'{s.value}'" for s in EvalEntryStatus if s is not EvalEntryStatus.COMPLETED
 )
+
+
 def _pruned_window(start_param: str, end_param: str) -> str:
     """Half-open exact start_time window ``[start, end)`` + padded created_at guard.
 
@@ -684,7 +686,8 @@ class MonitorMetricsQueryBuilder(BaseQueryBuilder):
         ):
             obs_type = (
                 "tool"
-                if metric_type == MonitorMetricTypeChoices.ERROR_RATES_FOR_FUNCTION_CALLING
+                if metric_type
+                == MonitorMetricTypeChoices.ERROR_RATES_FOR_FUNCTION_CALLING
                 else "llm"
             )
             params["obs_type_ts"] = obs_type
@@ -833,9 +836,7 @@ class MonitorMetricsQueryBuilder(BaseQueryBuilder):
         version_column = eval_logger_version_column(eval_table)
         span_cols = "id, start_time" if include_span_start_time else "id"
         span_projection = (
-            ", sp.start_time AS span_start_time"
-            if include_span_start_time
-            else ""
+            ", sp.start_time AS span_start_time" if include_span_start_time else ""
         )
         return f"""
             (

--- a/futureagi/tracer/tests/test_clickhouse.py
+++ b/futureagi/tracer/tests/test_clickhouse.py
@@ -6453,7 +6453,8 @@ class TestEvalMetricsQueryBuilderExtended:
         query, params = builder.build()
         assert "countIf" in query
         assert "has(JSONExtract(output_str_list, 'Array(String)')" in query
-        assert "OR output_str =" in query
+        assert "OR output_str = %(choice_0)s" in query
+        assert "OR JSONExtractString(output_str, 'choice') = %(choice_0)s" in query
         assert "choice_0" in params
         assert "choice_1" in params
         assert "choice_2" in params
@@ -9032,12 +9033,14 @@ class TestMonitorMetricsQueryBuilder:
         query, params = builder.build_metric_value_query(
             "evaluation_metrics", datetime(2024, 1, 1), datetime(2024, 1, 31)
         )
-        # List-containment only: choice evals write output_str_list exclusively.
+        # TH-7788: the verdict may live in the list, a bare output_str, or the
+        # JSON ``choice`` key — all three must match.
         assert (
             "has(JSONExtract(output_str_list, 'Array(String)'), %(choice_val)s)"
             in query
         )
-        assert "OR output_str =" not in query
+        assert "OR output_str = %(choice_val)s" in query
+        assert "OR JSONExtractString(output_str, 'choice') = %(choice_val)s" in query
         assert params["choice_val"] == "Good"
 
     def test_evaluation_metrics_no_config_returns_null(self):

--- a/futureagi/tracer/tests/test_clickhouse.py
+++ b/futureagi/tracer/tests/test_clickhouse.py
@@ -612,9 +612,9 @@ class TestClickHouseSchema:
         assert names.index("span_metrics_hourly_mv") < names.index(
             "span_metrics_hourly"
         ), "MV must drop before its source table"
-        assert names.index("spans_mv") < names.index("tracer_observation_span"), (
-            "spans_mv must drop before tracer_observation_span"
-        )
+        assert names.index("spans_mv") < names.index(
+            "tracer_observation_span"
+        ), "spans_mv must drop before tracer_observation_span"
         # Idempotency: every drop wraps IF EXISTS so reruns are no-ops.
         for _, sql in drops:
             assert "IF EXISTS" in sql, f"drop must be idempotent: {sql}"
@@ -7696,17 +7696,17 @@ class TestVoiceCallListPhase1bMigration:
                 )
             ],
         )
-        assert "project_id = %(project_id)s" in query, (
-            "Phase 1b must scope by project_id so the primary key can prune."
-        )
+        assert (
+            "project_id = %(project_id)s" in query
+        ), "Phase 1b must scope by project_id so the primary key can prune."
         assert "trace_id IN %(content_trace_ids)s" in query
         assert "toDate(start_time) IN %(content_root_dates)s" in query
         assert "toUnixTimestamp64Micro(start_time)" in query
         assert params["content_root_identities"][0][3] % 1_000_000 == 123456
         # attrs_string Map strip.
-        assert "mapFilter" in query and "call_logs" in query, (
-            "Phase 1b must exclude `call_logs` from attrs_string at read time."
-        )
+        assert (
+            "mapFilter" in query and "call_logs" in query
+        ), "Phase 1b must exclude `call_logs` from attrs_string at read time."
         # attributes_extra JSON-overflow strip (backfill cohort).
         assert "JSONExtractKeysAndValuesRaw" in query, (
             "Phase 1b must also strip `call_logs` from attributes_extra so the "
@@ -8130,9 +8130,9 @@ class TestVoiceCallListQueryBuilderComprehensive:
         # Each phone number is still recognised as a simulator call in Python.
         for phone in VAPI_PHONE_NUMBERS:
             span_attrs = {"raw_log": {"customer": {"number": phone}}}
-            assert VoiceCallListQueryBuilder.is_simulator_call(span_attrs, "vapi"), (
-                f"Missing phone number: {phone}"
-            )
+            assert VoiceCallListQueryBuilder.is_simulator_call(
+                span_attrs, "vapi"
+            ), f"Missing phone number: {phone}"
 
     def test_simulation_filter_uses_json_extract(self):
         """Simulation filtering is now Python-side against parsed raw_log.

--- a/futureagi/tracer/tests/test_monitor_evaluator.py
+++ b/futureagi/tracer/tests/test_monitor_evaluator.py
@@ -114,8 +114,9 @@ def _patch_ch(results: List[Any]) -> mock._patch:
 
 @pytest.fixture(autouse=True)
 def _mute_notifications():
-    with mock.patch.object(monitor_mod, "_send_alert_email"), mock.patch.object(
-        monitor_mod, "_send_slack_notification"
+    with (
+        mock.patch.object(monitor_mod, "_send_alert_email"),
+        mock.patch.object(monitor_mod, "_send_slack_notification"),
     ):
         yield
 
@@ -308,9 +309,7 @@ def test_graph_static_formats_ch_series(user_alert_monitor) -> None:
     instance.execute_ch_query.return_value = _ch_result(
         [{"timestamp": ts, "value": 3}, {"timestamp": ts, "value": None}]
     )
-    with mock.patch.object(
-        graphs_mod, "AnalyticsQueryService", return_value=instance
-    ):
+    with mock.patch.object(graphs_mod, "AnalyticsQueryService", return_value=instance):
         data = graphs_mod.get_static_metric_graph_data(user_alert_monitor)
     assert data == [
         {"timestamp": ts.isoformat(), "value": 3},
@@ -338,9 +337,7 @@ def test_percentage_graph_alert_bars_use_evaluator_band(user_alert_monitor) -> N
         _ch_result([{"timestamp": ts, "value": 1000.0}]),
         _ch_result([{"mean": 100.0, "stddev": 10.0}]),  # per-row band
     ]
-    with mock.patch.object(
-        graphs_mod, "AnalyticsQueryService", return_value=instance
-    ):
+    with mock.patch.object(graphs_mod, "AnalyticsQueryService", return_value=instance):
         out = graphs_mod.get_percentage_change_metric_graph_data(user_alert_monitor)
 
     # A second CH query (the evaluator's historical stats) was issued.

--- a/futureagi/tracer/tests/test_monitor_evaluator.py
+++ b/futureagi/tracer/tests/test_monitor_evaluator.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 
 from datetime import timedelta
 from types import SimpleNamespace
-from typing import Any, List, Optional
+from typing import Any, List
 from unittest import mock
 
 import pytest
@@ -31,9 +31,11 @@ from tracer.utils.monitor import (
 pytestmark = pytest.mark.django_db
 
 
-def _fake_eval_config(output_value: Optional[str]) -> SimpleNamespace:
+def _fake_eval_config(
+    output_value: str | None, choices: list | None = None
+) -> SimpleNamespace:
     return SimpleNamespace(
-        eval_template=SimpleNamespace(config={"output": output_value})
+        eval_template=SimpleNamespace(config={"output": output_value}, choices=choices)
     )
 
 
@@ -55,6 +57,41 @@ def test_eval_output_type_normalized_to_builder_key(
     ):
         builder = build_monitor_ch_builder(user_alert_monitor)
     assert builder.eval_output_type == expected
+
+
+@pytest.mark.parametrize(
+    "stored,choices,threshold_value,expected",
+    [
+        # TH-7788: score template with choice labels + a selected label -> CHOICES
+        ("score", ["Complete", "Partial", "Incomplete"], "Incomplete", "CHOICES"),
+        # no label selected -> plain score average
+        ("score", ["Complete", "Partial", "Incomplete"], None, "SCORE"),
+        # selected value is not one of the template's labels -> plain score
+        ("score", ["Complete", "Partial"], "Bogus", "SCORE"),
+        # score template without labels -> unchanged
+        ("score", None, "Incomplete", "SCORE"),
+        # Pass/Fail uses threshold_metric_value for Passed/Failed -> untouched
+        ("Pass/Fail", ["Passed", "Failed"], "Passed", "PASS_FAIL"),
+    ],
+)
+def test_score_template_with_selected_choice_label_evaluates_as_choices(
+    user_alert_monitor,
+    stored: str,
+    choices: list | None,
+    threshold_value: str | None,
+    expected: str,
+) -> None:
+    user_alert_monitor.metric_type = "evaluation_metrics"
+    user_alert_monitor.metric = "22222222-2222-2222-2222-222222222222"
+    user_alert_monitor.threshold_metric_value = threshold_value
+    with mock.patch.object(
+        monitor_mod.CustomEvalConfig.objects,
+        "get",
+        return_value=_fake_eval_config(stored, choices),
+    ):
+        builder = build_monitor_ch_builder(user_alert_monitor)
+    assert builder.eval_output_type == expected
+    assert builder.threshold_metric_value == threshold_value
 
 
 def test_missing_eval_config_raises_config_error_at_builder(

--- a/futureagi/tracer/tests/test_monitor_metrics_eval_path.py
+++ b/futureagi/tracer/tests/test_monitor_metrics_eval_path.py
@@ -262,3 +262,26 @@ def test_choices_time_series_shape() -> None:
     assert "has(JSONExtract(output_str_list, 'Array(String)'), %(choice_val)s)" in sql
     assert params["choice_val"] == "Good"
     assert "GROUP BY timestamp" in sql
+
+
+def test_choices_match_shared_by_all_three_queries() -> None:
+    # TH-7788: value, historical stats and time series must all read the
+    # verdict from output_str_list, bare output_str, or the JSON choice key.
+    b = MonitorMetricsQueryBuilder(
+        project_id=PROJECT_ID,
+        eval_config_id=EVAL_CONFIG_ID,
+        eval_output_type="CHOICES",
+        threshold_metric_value="Complete",
+    )
+    mt = MonitorMetricTypeChoices.EVALUATION_METRICS
+    for sql, params in (
+        b.build_metric_value_query(mt, START, END),
+        b.build_historical_stats_query(mt, START, END),
+        b.build_time_series_query(mt, START, END, 3600),
+    ):
+        assert (
+            "has(JSONExtract(output_str_list, 'Array(String)'), %(choice_val)s)" in sql
+        )
+        assert "OR output_str = %(choice_val)s" in sql
+        assert "OR JSONExtractString(output_str, 'choice') = %(choice_val)s" in sql
+        assert params["choice_val"] == "Complete"

--- a/futureagi/tracer/tests/test_monitor_metrics_eval_path.py
+++ b/futureagi/tracer/tests/test_monitor_metrics_eval_path.py
@@ -62,9 +62,15 @@ def _eval_sqls(
 ) -> list[str]:
     b = _builder(cls, filters=filters)
     return [
-        b.build_metric_value_query(MonitorMetricTypeChoices.EVALUATION_METRICS, START, END)[0],
-        b.build_historical_stats_query(MonitorMetricTypeChoices.EVALUATION_METRICS, START, END)[0],
-        b.build_time_series_query(MonitorMetricTypeChoices.EVALUATION_METRICS, START, END, 3600)[0],
+        b.build_metric_value_query(
+            MonitorMetricTypeChoices.EVALUATION_METRICS, START, END
+        )[0],
+        b.build_historical_stats_query(
+            MonitorMetricTypeChoices.EVALUATION_METRICS, START, END
+        )[0],
+        b.build_time_series_query(
+            MonitorMetricTypeChoices.EVALUATION_METRICS, START, END, 3600
+        )[0],
     ]
 
 
@@ -76,9 +82,7 @@ def test_eval_legacy_table_default_predicate() -> None:
             assert "ORDER BY eval_scan._peerdb_version DESC" in sql
             assert "LIMIT 1 BY eval_scan.id" in sql
             assert "latest_eval._peerdb_is_deleted = 0" in sql
-            assert (
-                "(latest_eval.deleted = 0 OR latest_eval.deleted IS NULL)" in sql
-            )
+            assert "(latest_eval.deleted = 0 OR latest_eval.deleted IS NULL)" in sql
             assert sql.index("LIMIT 1 BY eval_scan.id") < sql.index(
                 "latest_eval._peerdb_is_deleted = 0"
             )
@@ -152,7 +156,10 @@ def test_v1_eval_filter_emits_legacy_span_attr_token() -> None:
     b = _builder(filters=ATTR_FILTER)
     assert b._filter_clause, "attr filter should compile to a clause"
     assert (
-        "span_attr" in b.build_metric_value_query(MonitorMetricTypeChoices.EVALUATION_METRICS, START, END)[0]
+        "span_attr"
+        in b.build_metric_value_query(
+            MonitorMetricTypeChoices.EVALUATION_METRICS, START, END
+        )[0]
     )
 
 
@@ -178,12 +185,14 @@ def test_eval_empty_window_yields_null_for_all_output_types() -> None:
         )
         assert (
             "ifNotFinite("
-            in b.build_metric_value_query(MonitorMetricTypeChoices.EVALUATION_METRICS, START, END)[0]
+            in b.build_metric_value_query(
+                MonitorMetricTypeChoices.EVALUATION_METRICS, START, END
+            )[0]
         )
         assert (
-            b.build_historical_stats_query(MonitorMetricTypeChoices.EVALUATION_METRICS, START, END)[0].count(
-                "ifNotFinite("
-            )
+            b.build_historical_stats_query(
+                MonitorMetricTypeChoices.EVALUATION_METRICS, START, END
+            )[0].count("ifNotFinite(")
             >= 2
         )
 
@@ -196,7 +205,9 @@ def test_all_eval_output_types_build(output_type: str) -> None:
         eval_output_type=output_type,
         threshold_metric_value="Passed" if output_type != "SCORE" else None,
     )
-    sql, _ = b.build_metric_value_query(MonitorMetricTypeChoices.EVALUATION_METRICS, START, END)
+    sql, _ = b.build_metric_value_query(
+        MonitorMetricTypeChoices.EVALUATION_METRICS, START, END
+    )
     assert "FROM " in sql and "custom_eval_config_id" in sql
 
 
@@ -209,9 +220,15 @@ def test_choices_without_threshold_value_returns_null() -> None:
         eval_output_type="CHOICES",
         threshold_metric_value=None,
     )
-    value_sql, _ = b.build_metric_value_query(MonitorMetricTypeChoices.EVALUATION_METRICS, START, END)
-    stats_sql, _ = b.build_historical_stats_query(MonitorMetricTypeChoices.EVALUATION_METRICS, START, END)
-    ts_sql, _ = b.build_time_series_query(MonitorMetricTypeChoices.EVALUATION_METRICS, START, END, 3600)
+    value_sql, _ = b.build_metric_value_query(
+        MonitorMetricTypeChoices.EVALUATION_METRICS, START, END
+    )
+    stats_sql, _ = b.build_historical_stats_query(
+        MonitorMetricTypeChoices.EVALUATION_METRICS, START, END
+    )
+    ts_sql, _ = b.build_time_series_query(
+        MonitorMetricTypeChoices.EVALUATION_METRICS, START, END, 3600
+    )
     assert "NULL" in value_sql and "output_str_list" not in value_sql
     assert "NULL" in stats_sql and "output_str_list" not in stats_sql
     assert "output_str_list" not in ts_sql
@@ -224,7 +241,9 @@ def test_pass_fail_time_series_shape() -> None:
         eval_output_type="PASS_FAIL",
         threshold_metric_value="Passed",
     )
-    sql, params = b.build_time_series_query(MonitorMetricTypeChoices.EVALUATION_METRICS, START, END, 3600)
+    sql, params = b.build_time_series_query(
+        MonitorMetricTypeChoices.EVALUATION_METRICS, START, END, 3600
+    )
     assert "output_bool = %(output_bool_val)s" in sql
     assert params["output_bool_val"] == 1
     assert "GROUP BY timestamp" in sql
@@ -237,7 +256,9 @@ def test_choices_time_series_shape() -> None:
         eval_output_type="CHOICES",
         threshold_metric_value="Good",
     )
-    sql, params = b.build_time_series_query(MonitorMetricTypeChoices.EVALUATION_METRICS, START, END, 3600)
+    sql, params = b.build_time_series_query(
+        MonitorMetricTypeChoices.EVALUATION_METRICS, START, END, 3600
+    )
     assert "has(JSONExtract(output_str_list, 'Array(String)'), %(choice_val)s)" in sql
     assert params["choice_val"] == "Good"
     assert "GROUP BY timestamp" in sql

--- a/futureagi/tracer/tests/test_monitor_metrics_integration.py
+++ b/futureagi/tracer/tests/test_monitor_metrics_integration.py
@@ -32,9 +32,20 @@ WINDOW_START = NOW - timedelta(minutes=30)
 WINDOW_END = NOW + timedelta(minutes=1)
 
 _SPAN_COLS = [
-    "id", "trace_id", "project_id", "name", "observation_type", "status",
-    "start_time", "created_at", "total_tokens", "latency_ms", "is_deleted",
-    "trace_session_id", "provider", "attrs_string",
+    "id",
+    "trace_id",
+    "project_id",
+    "name",
+    "observation_type",
+    "status",
+    "start_time",
+    "created_at",
+    "total_tokens",
+    "latency_ms",
+    "is_deleted",
+    "trace_session_id",
+    "provider",
+    "attrs_string",
 ]
 
 
@@ -50,10 +61,20 @@ def project_id() -> str:
 
 def _span(project_id: str, **kw: Any) -> Dict[str, Any]:
     row = dict(
-        id=str(uuid.uuid4()), trace_id=str(uuid.uuid4()), project_id=project_id,
-        name="s", observation_type="llm", status="OK", start_time=NOW,
-        created_at=NOW, total_tokens=0, latency_ms=0, is_deleted=0,
-        trace_session_id=None, provider="", attrs_string={},
+        id=str(uuid.uuid4()),
+        trace_id=str(uuid.uuid4()),
+        project_id=project_id,
+        name="s",
+        observation_type="llm",
+        status="OK",
+        start_time=NOW,
+        created_at=NOW,
+        total_tokens=0,
+        latency_ms=0,
+        is_deleted=0,
+        trace_session_id=None,
+        provider="",
+        attrs_string={},
     )
     row.update(kw)
     return row
@@ -74,8 +95,13 @@ def _seed_evals(ch, config_id: str, evals: List[Dict[str, Any]]) -> None:
     # v2 has ``is_deleted`` — both DEFAULT to not-deleted, so neither is
     # seeded (keeps the insert valid on a fresh CH for either shape).
     cols = [
-        "id", "custom_eval_config_id", "observation_span_id", "output_float",
-        "output_bool", "output_str_list", "created_at",
+        "id",
+        "custom_eval_config_id",
+        "observation_span_id",
+        "output_float",
+        "output_bool",
+        "output_str_list",
+        "created_at",
     ]
     rows = []
     for ev in evals:
@@ -95,8 +121,13 @@ def _seed_evals(ch, config_id: str, evals: List[Dict[str, Any]]) -> None:
 
 def _monitor(project_id: str, metric_type: str, **kw: Any) -> SimpleNamespace:
     base = dict(
-        id=uuid.uuid4(), metric_type=metric_type, project_id=project_id,
-        filters=None, metric=None, threshold_metric_value=None, alert_frequency=60,
+        id=uuid.uuid4(),
+        metric_type=metric_type,
+        project_id=project_id,
+        filters=None,
+        metric=None,
+        threshold_metric_value=None,
+        alert_frequency=60,
     )
     base.update(kw)
     return SimpleNamespace(**base)
@@ -153,16 +184,25 @@ def test_error_rates_for_function_calling(ch, project_id):
     # tool spans: 1 error of 4 -> 0.25; llm span ignored.
     _seed_spans(
         ch,
-        [_span(project_id, observation_type="tool", status=s) for s in ["ERROR", "OK", "OK", "OK"]]
+        [
+            _span(project_id, observation_type="tool", status=s)
+            for s in ["ERROR", "OK", "OK", "OK"]
+        ]
         + [_span(project_id, observation_type="llm", status="ERROR")],
     )
-    assert _value(project_id, MonitorMetricTypeChoices.ERROR_RATES_FOR_FUNCTION_CALLING) == 0.25
+    assert (
+        _value(project_id, MonitorMetricTypeChoices.ERROR_RATES_FOR_FUNCTION_CALLING)
+        == 0.25
+    )
 
 
 def test_llm_api_failure_rates(ch, project_id):
     _seed_spans(
         ch,
-        [_span(project_id, observation_type="llm", status=s) for s in ["ERROR", "ERROR", "ERROR", "OK", "OK"]],
+        [
+            _span(project_id, observation_type="llm", status=s)
+            for s in ["ERROR", "ERROR", "ERROR", "OK", "OK"]
+        ],
     )
     assert _value(project_id, MonitorMetricTypeChoices.LLM_API_FAILURE_RATES) == 0.6
 
@@ -177,7 +217,9 @@ def test_service_provider_error_free_rate(ch, project_id):
             _span(project_id, provider="p2", status="OK"),
         ],
     )
-    assert _value(project_id, MonitorMetricTypeChoices.SERVICE_PROVIDER_ERROR_RATES) == 0.5
+    assert (
+        _value(project_id, MonitorMetricTypeChoices.SERVICE_PROVIDER_ERROR_RATES) == 0.5
+    )
 
 
 def test_error_free_session_rates(ch, project_id):
@@ -227,7 +269,14 @@ def test_entity_scoping_filter_is_ignored(ch, project_id):
         [_span(project_id, trace_session_id=s1, status="ERROR") for _ in range(2)]
         + [_span(project_id, trace_session_id=s2, status="ERROR") for _ in range(5)],
     )
-    assert _value(project_id, MonitorMetricTypeChoices.COUNT_OF_ERRORS, filters={"session_id": [s1]}) == 7
+    assert (
+        _value(
+            project_id,
+            MonitorMetricTypeChoices.COUNT_OF_ERRORS,
+            filters={"session_id": [s1]},
+        )
+        == 7
+    )
 
 
 def test_observation_type_filter(ch, project_id):
@@ -236,7 +285,11 @@ def test_observation_type_filter(ch, project_id):
         [_span(project_id, observation_type="tool", status="ERROR") for _ in range(2)]
         + [_span(project_id, observation_type="llm", status="ERROR") for _ in range(4)],
     )
-    val = _value(project_id, MonitorMetricTypeChoices.COUNT_OF_ERRORS, filters={"observation_type": ["tool"]})
+    val = _value(
+        project_id,
+        MonitorMetricTypeChoices.COUNT_OF_ERRORS,
+        filters={"observation_type": ["tool"]},
+    )
     assert val == 2
 
 
@@ -247,21 +300,33 @@ def test_historical_stats_count_of_errors(ch, project_id):
     # Two hourly buckets: 4 errors then 2 errors -> mean 3, sample stddev sqrt(2).
     b1 = NOW - timedelta(hours=2)
     b2 = NOW - timedelta(hours=1)
-    rows = [_span(project_id, status="ERROR", start_time=b1, created_at=b1) for _ in range(4)]
-    rows += [_span(project_id, status="ERROR", start_time=b2, created_at=b2) for _ in range(2)]
+    rows = [
+        _span(project_id, status="ERROR", start_time=b1, created_at=b1)
+        for _ in range(4)
+    ]
+    rows += [
+        _span(project_id, status="ERROR", start_time=b2, created_at=b2)
+        for _ in range(2)
+    ]
     _seed_spans(ch, rows)
-    m = _monitor(project_id, MonitorMetricTypeChoices.COUNT_OF_ERRORS, alert_frequency=60)
+    m = _monitor(
+        project_id, MonitorMetricTypeChoices.COUNT_OF_ERRORS, alert_frequency=60
+    )
     mean, stddev = _get_historical_stats(m, NOW - timedelta(hours=3), NOW)
     assert mean == pytest.approx(3.0)
-    assert stddev == pytest.approx(2.0 ** 0.5, rel=1e-6)
+    assert stddev == pytest.approx(2.0**0.5, rel=1e-6)
 
 
 # --- Evaluation metrics (eval-logger table) -----------------------------------
 
 
 def _eval_value(
-    project_id, cfg, output_type, threshold_metric_value=None,
-    start=None, end=None,
+    project_id,
+    cfg,
+    output_type,
+    threshold_metric_value=None,
+    start=None,
+    end=None,
 ):
     from tracer.services.clickhouse.query_service import AnalyticsQueryService
 
@@ -272,18 +337,20 @@ def _eval_value(
         threshold_metric_value=threshold_metric_value,
     )
     query, params = builder.build_metric_value_query(
-        MonitorMetricTypeChoices.EVALUATION_METRICS, start or WINDOW_START, end or WINDOW_END
+        MonitorMetricTypeChoices.EVALUATION_METRICS,
+        start or WINDOW_START,
+        end or WINDOW_END,
     )
-    return AnalyticsQueryService().execute_ch_query(
-        query, params, timeout_ms=10000
-    ).data[0]["value"]
+    return (
+        AnalyticsQueryService()
+        .execute_ch_query(query, params, timeout_ms=10000)
+        .data[0]["value"]
+    )
 
 
 # prod uses the legacy `tracer_eval_logger`; test settings default to `_v2`. The
 # two use different not-deleted predicates, so assert the value on BOTH.
-@pytest.mark.parametrize(
-    "eval_table", ["tracer_eval_logger", "tracer_eval_logger_v2"]
-)
+@pytest.mark.parametrize("eval_table", ["tracer_eval_logger", "tracer_eval_logger_v2"])
 def test_evaluation_metrics_score_avg(ch, project_id, eval_table):
     from django.test import override_settings
 
@@ -302,9 +369,7 @@ def test_evaluation_metrics_score_avg(ch, project_id, eval_table):
         assert _eval_value(project_id, cfg, "SCORE") == pytest.approx(0.5)
 
 
-@pytest.mark.parametrize(
-    "eval_table", ["tracer_eval_logger", "tracer_eval_logger_v2"]
-)
+@pytest.mark.parametrize("eval_table", ["tracer_eval_logger", "tracer_eval_logger_v2"])
 def test_evaluation_metrics_pass_fail_rate(ch, project_id, eval_table):
     from django.test import override_settings
 
@@ -327,9 +392,7 @@ def test_evaluation_metrics_pass_fail_rate(ch, project_id, eval_table):
         ) == pytest.approx(2 / 3)
 
 
-@pytest.mark.parametrize(
-    "eval_table", ["tracer_eval_logger", "tracer_eval_logger_v2"]
-)
+@pytest.mark.parametrize("eval_table", ["tracer_eval_logger", "tracer_eval_logger_v2"])
 def test_evaluation_metrics_choices_rate(ch, project_id, eval_table):
     from django.test import override_settings
 
@@ -378,7 +441,7 @@ def test_historical_stats_token_usage(ch, project_id):
     m = _monitor(project_id, MonitorMetricTypeChoices.TOKEN_USAGE, alert_frequency=60)
     mean, stddev = _get_historical_stats(m, NOW - timedelta(hours=3), NOW)
     assert mean == pytest.approx(20.0)  # buckets [10, 30]
-    assert stddev == pytest.approx(200.0 ** 0.5, rel=1e-6)  # sample stddev
+    assert stddev == pytest.approx(200.0**0.5, rel=1e-6)  # sample stddev
 
 
 # --- End-to-end: real monitor row -> real alert log ---------------------------
@@ -453,10 +516,17 @@ def test_graph_percentage_change_marks_current_bucket_critical(ch, observe_proje
         + [_span(pid, status="ERROR") for _ in range(10)],
     )
     monitor = SimpleNamespace(
-        id=uuid.uuid4(), metric_type="count_of_errors", project_id=pid, filters=None,
-        metric=None, threshold_metric_value=None, alert_frequency=60,
-        auto_threshold_time_window=60 * 24 * 7, threshold_type="percentage_change",
-        threshold_operator="greater_than", critical_threshold_value=0,
+        id=uuid.uuid4(),
+        metric_type="count_of_errors",
+        project_id=pid,
+        filters=None,
+        metric=None,
+        threshold_metric_value=None,
+        alert_frequency=60,
+        auto_threshold_time_window=60 * 24 * 7,
+        threshold_type="percentage_change",
+        threshold_operator="greater_than",
+        critical_threshold_value=0,
         warning_threshold_value=None,
     )
     out = get_percentage_change_metric_graph_data(monitor)
@@ -494,7 +564,9 @@ def test_end_to_end_no_data_no_alert(ch, observe_project):
 def _run_query(query, params):
     from tracer.services.clickhouse.query_service import AnalyticsQueryService
 
-    return AnalyticsQueryService().execute_ch_query(query, params, timeout_ms=10000).data
+    return (
+        AnalyticsQueryService().execute_ch_query(query, params, timeout_ms=10000).data
+    )
 
 
 def test_half_open_window_excludes_end_boundary(ch, project_id):
@@ -519,8 +591,14 @@ def test_time_series_bucket_values(ch, project_id):
     # Two hourly buckets with 4 and 2 errors -> per-bucket values [4, 2].
     b1 = NOW - timedelta(hours=2)
     b2 = NOW - timedelta(hours=1)
-    rows = [_span(project_id, status="ERROR", start_time=b1, created_at=b1) for _ in range(4)]
-    rows += [_span(project_id, status="ERROR", start_time=b2, created_at=b2) for _ in range(2)]
+    rows = [
+        _span(project_id, status="ERROR", start_time=b1, created_at=b1)
+        for _ in range(4)
+    ]
+    rows += [
+        _span(project_id, status="ERROR", start_time=b2, created_at=b2)
+        for _ in range(2)
+    ]
     _seed_spans(ch, rows)
     b = MonitorMetricsQueryBuilderV2(project_id=project_id)
     query, params = b.build_time_series_query(
@@ -595,7 +673,9 @@ def test_attr_filter_is_span_scoped_and_windowed(ch, project_id):
     rows = [
         # attr + ERROR, in window -> the only counted span
         _span(
-            project_id, trace_id=t1, status="ERROR",
+            project_id,
+            trace_id=t1,
+            status="ERROR",
             attrs_string={"llm.model_name": "gpt-4o"},
         ),
         # attr but OK -> not counted
@@ -605,7 +685,8 @@ def test_attr_filter_is_span_scoped_and_windowed(ch, project_id):
         _span(project_id, trace_id=t1, status="ERROR"),
         # attr + ERROR but outside the window -> not counted
         _span(
-            project_id, status="ERROR",
+            project_id,
+            status="ERROR",
             attrs_string={"llm.model_name": "gpt-4o"},
             start_time=NOW - timedelta(days=3),
             created_at=NOW - timedelta(days=3),
@@ -633,7 +714,9 @@ def test_attr_filter_is_span_scoped_and_windowed(ch, project_id):
     query, params = builder.build_metric_value_query(
         MonitorMetricTypeChoices.COUNT_OF_ERRORS, WINDOW_START, WINDOW_END
     )
-    value = AnalyticsQueryService().execute_ch_query(
-        query, params, timeout_ms=10000
-    ).data[0]["value"]
+    value = (
+        AnalyticsQueryService()
+        .execute_ch_query(query, params, timeout_ms=10000)
+        .data[0]["value"]
+    )
     assert value == 1  # only the in-window ERROR span carrying the attr

--- a/futureagi/tracer/tests/test_monitor_metrics_integration.py
+++ b/futureagi/tracer/tests/test_monitor_metrics_integration.py
@@ -100,6 +100,7 @@ def _seed_evals(ch, config_id: str, evals: List[Dict[str, Any]]) -> None:
         "observation_span_id",
         "output_float",
         "output_bool",
+        "output_str",
         "output_str_list",
         "created_at",
     ]
@@ -112,6 +113,7 @@ def _seed_evals(ch, config_id: str, evals: List[Dict[str, Any]]) -> None:
                 "observation_span_id": ev["span_id"],
                 "output_float": ev.get("output_float"),
                 "output_bool": ev.get("output_bool"),
+                "output_str": ev.get("output_str"),
                 "output_str_list": ev.get("output_str_list", "[]"),
                 "created_at": ev.get("created_at", NOW),
             }
@@ -413,6 +415,49 @@ def test_evaluation_metrics_choices_rate(ch, project_id, eval_table):
         assert _eval_value(
             project_id, cfg, "CHOICES", threshold_metric_value="good"
         ) == pytest.approx(2 / 3)
+
+
+@pytest.mark.parametrize("eval_table", ["tracer_eval_logger", "tracer_eval_logger_v2"])
+def test_evaluation_metrics_choices_reads_verdict_from_output_str(
+    ch, project_id, eval_table
+):
+    """TH-7788: rows with an empty output_str_list must still count when the
+    verdict is in output_str (bare, or as the ``choice`` key of a JSON object).
+    The JSON shape is exactly what the reporting customer's rows look like."""
+    from django.test import override_settings
+
+    with override_settings(CH25_EVAL_LOGGER_TABLE=eval_table):
+        cfg = str(uuid.uuid4())
+        spans = [_span(project_id) for _ in range(5)]
+        _seed_spans(ch, spans)
+        _seed_evals(
+            ch,
+            cfg,
+            [
+                # legacy list shape
+                {"span_id": spans[0]["id"], "output_str_list": '["Complete"]'},
+                # bare string, empty list
+                {"span_id": spans[1]["id"], "output_str": "Complete"},
+                # JSON object, empty list (customer shape)
+                {
+                    "span_id": spans[2]["id"],
+                    "output_str": '{"score": 1.0, "choice": "Complete"}',
+                },
+                # JSON object with a different verdict
+                {
+                    "span_id": spans[3]["id"],
+                    "output_str": '{"score": 0.0, "choice": "Incomplete"}',
+                },
+                # free text that merely mentions the word must not match
+                {"span_id": spans[4]["id"], "output_str": "Not Complete at all"},
+            ],
+        )
+        assert _eval_value(
+            project_id, cfg, "CHOICES", threshold_metric_value="Complete"
+        ) == pytest.approx(3 / 5)
+        assert _eval_value(
+            project_id, cfg, "CHOICES", threshold_metric_value="Incomplete"
+        ) == pytest.approx(1 / 5)
 
 
 # --- Trailing-window (daily) --------------------------------------------------

--- a/futureagi/tracer/tests/test_monitor_metrics_parity.py
+++ b/futureagi/tracer/tests/test_monitor_metrics_parity.py
@@ -83,7 +83,9 @@ def test_time_aggregated_historical_agg_per_metric() -> None:
 
 
 def test_time_aggregated_historical_defaults_to_hour() -> None:
-    sql, _ = _builder().build_historical_stats_query(MonitorMetricTypeChoices.COUNT_OF_ERRORS, START, END)
+    sql, _ = _builder().build_historical_stats_query(
+        MonitorMetricTypeChoices.COUNT_OF_ERRORS, START, END
+    )
     assert "toStartOfHour(start_time) AS bucket_ts" in sql
 
 
@@ -110,7 +112,11 @@ def test_eval_stats_use_population_stddev() -> None:
 
 @pytest.mark.parametrize(
     "metric_type",
-    [MonitorMetricTypeChoices.TOKEN_USAGE, MonitorMetricTypeChoices.DAILY_TOKENS_SPENT, MonitorMetricTypeChoices.MONTHLY_TOKENS_SPENT],
+    [
+        MonitorMetricTypeChoices.TOKEN_USAGE,
+        MonitorMetricTypeChoices.DAILY_TOKENS_SPENT,
+        MonitorMetricTypeChoices.MONTHLY_TOKENS_SPENT,
+    ],
 )
 def test_token_value_null_on_empty_window(metric_type: str) -> None:
     sql, _ = _builder().build_metric_value_query(metric_type, START, END)

--- a/futureagi/tracer/tests/test_monitor_metrics_parity.py
+++ b/futureagi/tracer/tests/test_monitor_metrics_parity.py
@@ -143,15 +143,17 @@ def test_provider_guard_excludes_empty_string_only() -> None:
         assert "provider IS NOT NULL" not in sql
 
 
-# --- Eval CHOICES list containment only (PG parity) ---------------------------
+# --- Eval CHOICES verdict match (list, bare string, JSON choice key) -----------
 
 
-def test_eval_choices_no_output_str_fallback() -> None:
+def test_eval_choices_matches_all_verdict_shapes() -> None:
+    # TH-7788: rows whose verdict lives only in output_str must count.
     sql, _ = _builder(eval_output_type="CHOICES").build_metric_value_query(
         MonitorMetricTypeChoices.EVALUATION_METRICS, START, END
     )
     assert "has(JSONExtract(output_str_list, 'Array(String)'), %(choice_val)s)" in sql
-    assert "OR output_str" not in sql
+    assert "OR output_str = %(choice_val)s" in sql
+    assert "OR JSONExtractString(output_str, 'choice') = %(choice_val)s" in sql
 
 
 # --- Evaluator routing: CH serves these metrics, PG is never touched ----------

--- a/futureagi/tracer/utils/monitor.py
+++ b/futureagi/tracer/utils/monitor.py
@@ -65,6 +65,19 @@ def build_monitor_ch_builder(monitor: UserAlertMonitor) -> "MonitorMetricsQueryB
         eval_output_type = _EVAL_OUTPUT_TYPE_MAP.get(raw_output)
         if eval_output_type is None:
             raise MonitorConfigError(f"Eval config {monitor.metric} has no output type")
+        # TH-7788: a score-typed template can still carry choice labels (via
+        # choice_scores), and the alert form offers those labels. When the
+        # monitor was configured against one of them, evaluate it as a
+        # CHOICES metric; otherwise the selected label is silently ignored
+        # and the average score is compared to the threshold instead.
+        template_choices = getattr(custom_eval_config.eval_template, "choices", None)
+        if (
+            eval_output_type == "SCORE"
+            and monitor.threshold_metric_value
+            and isinstance(template_choices, list)
+            and monitor.threshold_metric_value in template_choices
+        ):
+            eval_output_type = "CHOICES"
         eval_config_id = str(monitor.metric)
 
     # v1↔v2 dispatch — flips with CH25_QUERY_TYPES_V2_PRIMARY=MONITOR_METRICS


### PR DESCRIPTION
## Summary

`evaluation_metrics` alerts configured against a choice label (e.g. "Incomplete") on an eval whose template is stored as `output=score` but carries choice labels via `choice_scores` never evaluated that label. The evaluator resolved the metric type from the stored template type alone, ran the SCORE branch, ignored the selected label, and compared the average score to the threshold. Separately, the CHOICES matcher only read `output_str_list`, which the writer leaves empty for exactly these templates (the verdict is in `output_str` as `{"score": 1.0, "choice": "Complete"}`), so even a CHOICES-typed alert would have computed 0 for such rows. This PR makes both readers find the verdict where the writer put it, and evaluates a label-selected alert as CHOICES.

User-facing impact: an alert like "Incomplete > threshold" on such an eval now computes the real percentage of Incomplete verdicts. The eval Charts tab agrees with the alert on the same rows.

## Linked issues

Closes TH-7788
Linear: https://linear.app/future-agi/issue/TH-7788/eval-alerts-never-fire-choice-matcher-reads-only-output-str-list-which

## Type of change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📖 Documentation only
- [ ] 🧹 Chore / refactor (no user-visible change)
- [ ] 🚀 Performance improvement
- [ ] 🧪 Test-only change

## E2E coverage

E2E: exempt (backend-internal)

---

## 1) What changes were done

**A. Shared CHOICES verdict matcher (alerts + charts)**

- New `eval_choice_match_expr(param_name)` in `tracer/services/clickhouse/query_builders/expressions.py`. It matches a choice against any of the three places the writer can put a verdict: `has(JSONExtract(output_str_list, 'Array(String)'), %(p)s)`, `output_str = %(p)s`, or `JSONExtractString(output_str, 'choice') = %(p)s`. `JSONExtractString` yields `''` on non-JSON text, so free-text rows never false-match.
- `MonitorMetricsQueryBuilder._eval_choice_match_expr` now delegates to it, so the value, historical-stats and time-series queries all pick it up. `MonitorMetricsQueryBuilderV2` inherits it.
- `EvalMetricsQueryBuilder` (Charts tab) uses the same helper. Its previous fallback compared the whole `output_str` to the choice, which cannot match a JSON object, so charts also read 0 for these rows.
- No API, serializer, model or frontend change.

**B. Evaluator resolves label-selected alerts as CHOICES**

- `tracer/utils/monitor.py::build_monitor_ch_builder`: when the stored template type is `score`, the monitor has a `threshold_metric_value`, and that value is one of the template's `choices`, the metric is evaluated as `CHOICES`. Pass/Fail (which uses `threshold_metric_value` for Passed/Failed), label-less score templates, and a stale value not in the label list are unchanged.
- This is the single resolution point shared by the evaluator, graph and preview paths.

**C. Mechanical**

- Two `style:` commits black-format the touched builder/test files (they were not black-clean on `main`) so the two `fix:` commits stay readable.

---

## 2) Why the changes were done

- **Product/UX:** Whatfix (`analytics-ai-prod-us`) has a live "Incomplete > 1.0" alert on `synthesis-quality-completeness`. It never evaluated "Incomplete" at all. Any customer with a score-typed template that carries choice labels is in the same state.
- **Technical:** the writer (`_dual_write_eval_value`, 22 May 2026) deliberately gates `output_str_list` on the stored type being `choices`. A `score` template with `choice_scores` still yields a `{"score", "choice"}` dict from `evaluations/engine/formatting.py`, which the score branch serialises into `output_str` + `output_float` with no list. The readers must therefore look in `output_str` too. One shared expression keeps alerts and charts in agreement.
- **Architecture:** the SQL predicate lives in the existing shared `expressions.py` module rather than being duplicated in two builders; the type override lives in the one place that already resolves the eval type for every monitor consumer.

### RCA (verified against US prod, read-only)

- All 5 affected eval configs in US prod are stored `output=score` / `output_type_normalized=percentage` and carry a `choices` label list (4 of 5 also have `choice_scores`): `synthesis-quality-completeness` (Whatfix), `scoringcustomllm-as-a-judge`, `who_conditions_online_test`, `geo-layer1-eval` (x2).
- The Whatfix monitor (created 2026-08-28) has `threshold_metric_value=Incomplete`, `greater_than`, static, critical `1.0`. With the stored type `score`, the evaluator ran the SCORE branch, so the ticket's "CHOICES alert reads 0" framing was not what was executing; the average score was being compared instead.
- `tracer_eval_logger` (dedup via FINAL, active rows): 1,035,113 total. Rows with an empty list and a JSON `choice` key in `output_str`: **704** across those 5 configs, all with `output_float` populated (so only choice matching was broken for them). Whatfix: 25 rows, all 2026-09-01. The ticket's "62 rows, output_float null" does not match prod.
- Rows with `output_float` null and a numeric/JSON score only in `output_str`: **0**. The SCORE branch therefore keeps reading `output_float`.
- Writer gating is unchanged since 22 May (`5d2d1018d`); the list-only alert matcher dates from 14 May (`e8aa70c6e`) and was pinned by a parity test on 20 Aug (`767bc7956`). No later change caused this; it is a template-shape the writer and readers disagreed on.

---

## 3) Tests written + scenarios each covers

**`tracer/tests/test_monitor_evaluator.py`** — evaluator resolves the eval metric type for the CH builder

- `test_score_template_with_selected_choice_label_evaluates_as_choices[score-…-Incomplete-CHOICES]` — score template + labels + selected label → CHOICES
- `…[score-…-None-SCORE]` — labels present but nothing selected → SCORE
- `…[score-…-Bogus-SCORE]` — selected value not in the label list → SCORE
- `…[score-None-Incomplete-SCORE]` — no labels on the template → SCORE
- `…[Pass/Fail-…-Passed-PASS_FAIL]` — Pass/Fail keeps using `threshold_metric_value` for Passed/Failed

**`tracer/tests/test_monitor_metrics_integration.py`** — real ClickHouse, both eval-logger table layouts

- `test_evaluation_metrics_choices_reads_verdict_from_output_str[tracer_eval_logger]` / `[…_v2]` — seeds legacy list row, bare-string row, JSON `{"score","choice"}` rows (the customer shape), and a free-text "Not Complete at all" row; asserts Complete = 3/5 and Incomplete = 1/5, so free text does not false-match
- `test_evaluation_metrics_choices_rate` (existing, seed helper now also writes `output_str`) — legacy list-only rows still count

**`tracer/tests/test_monitor_metrics_eval_path.py`**

- `test_choices_match_shared_by_all_three_queries` — value, historical stats and time-series queries all carry the three-way match with a single `choice_val` param
- `test_choices_time_series_shape` (existing) — unchanged assertion still holds

**`tracer/tests/test_monitor_metrics_parity.py`**

- `test_eval_choices_matches_all_verdict_shapes` — replaces `test_eval_choices_no_output_str_fallback`, which pinned the list-only behaviour

**`tracer/tests/test_clickhouse.py`**

- `TestEvalMetricsQueryBuilderExtended::test_choices_query_with_choices` — charts builder emits the JSON `choice` fallback per choice param
- `TestMonitorMetricsQueryBuilder::test_evaluation_metrics_choices_query` — flipped from asserting no `output_str` fallback to asserting all three matches

> Run result: **798 passed, 0 failed** across `test_monitor_evaluator.py`, `test_monitor_metrics_integration.py`, `test_monitor_metrics_parity.py`, `test_monitor_metrics_eval_path.py`, `test_clickhouse.py`, `test_monitor.py`, `test_monitor_metrics_execution_smoke.py`, `test_eval_dual_write.py`, `test_backfill_eval_logger_dual_format.py` (Docker Postgres + ClickHouse). black clean on touched files; the only ruff findings on the touched files are pre-existing lines.

---

## 4) How to run / test

### Backend tests

```bash
cd futureagi
NO_STARTUP_DB_MUTATIONS=false bin/test \
  tracer/tests/test_monitor_evaluator.py \
  tracer/tests/test_monitor_metrics_integration.py \
  tracer/tests/test_monitor_metrics_parity.py \
  tracer/tests/test_monitor_metrics_eval_path.py \
  tracer/tests/test_clickhouse.py
```

### UI steps (manual)

1. Start the stack and log in at **http://localhost:3031**.
2. Create an eval template with output type **Percentage** and labelled choice scores (e.g. Complete 1.0 / Partial 0.5 / Incomplete 0.2). Run it on a few traces so rows land in `tracer_eval_logger` with `output_str = {"score": …, "choice": …}` and an empty `output_str_list`.
3. Alerts → New alert → metric type Evaluation metrics → pick that eval → the choice dropdown appears; pick **Incomplete**, set a static threshold.
4. Verify the alert preview graph / value shows the real percentage of Incomplete verdicts (previously it showed the average score, or 0 for a choices-typed template with these rows). The eval's Charts tab shows the same distribution.

---

## 5) Screenshots / recordings

### Test output

```
tracer/tests/test_monitor_evaluator.py::test_score_template_with_selected_choice_label_evaluates_as_choices[score-choices0-Incomplete-CHOICES] PASSED
tracer/tests/test_monitor_evaluator.py::test_score_template_with_selected_choice_label_evaluates_as_choices[score-choices1-None-SCORE] PASSED
tracer/tests/test_monitor_evaluator.py::test_score_template_with_selected_choice_label_evaluates_as_choices[score-choices2-Bogus-SCORE] PASSED
tracer/tests/test_monitor_evaluator.py::test_score_template_with_selected_choice_label_evaluates_as_choices[score-None-Incomplete-SCORE] PASSED
tracer/tests/test_monitor_evaluator.py::test_score_template_with_selected_choice_label_evaluates_as_choices[Pass/Fail-choices4-Passed-PASS_FAIL] PASSED
tracer/tests/test_monitor_metrics_integration.py::test_evaluation_metrics_choices_reads_verdict_from_output_str[tracer_eval_logger] PASSED
tracer/tests/test_monitor_metrics_integration.py::test_evaluation_metrics_choices_reads_verdict_from_output_str[tracer_eval_logger_v2] PASSED
tracer/tests/test_monitor_metrics_parity.py::test_eval_choices_matches_all_verdict_shapes PASSED
tracer/tests/test_monitor_metrics_eval_path.py::test_choices_match_shared_by_all_three_queries PASSED
tracer/tests/test_clickhouse.py::TestEvalMetricsQueryBuilderExtended::test_choices_query_with_choices PASSED
tracer/tests/test_clickhouse.py::TestMonitorMetricsQueryBuilder::test_evaluation_metrics_choices_query PASSED
============================= 798 passed in 23.03s =============================
```

### UI testing

Local stack on this branch (backend from this branch on :8001, Vite on :3032). Seeded a **score**-typed template `synthesis-quality-completeness (TH-7788 demo)` with labels Complete/Partial/Incomplete + `choice_scores`, and 48 eval rows shaped exactly like the customer's (`output_str = {"score": …, "choice": …}`, `output_str_list = []`, 8 of 48 = Incomplete).

The recording: Alerts → New Alert → project → Evaluation Metrics → pick the eval → the **Choice** picker appears → select **Incomplete** → the preview graph immediately computes the Incomplete rate per bucket (spikes where the Incomplete rows land, 0 elsewhere) instead of the flat average score → set critical 0.1 / warning 0.05 → Create Alert → alert detail page shows the same series.

<img width="1568" height="759" alt="th7788_choice_alert_flow" src="https://github.com/user-attachments/assets/a417e462-40a1-4bb0-9c29-4031f4b763fc" />

Evaluator proof on the same local alert (`build_monitor_ch_builder` + the builder's value query over the seeded 5h window):

```
MONITOR 35bd8d4c-… | threshold_metric_value= Incomplete | stored template output= score | resolved eval_output_type= CHOICES
VALUE_LAST_5H [(0.16666666666666666,)]   # 8 Incomplete / 48 rows
```

Before this branch the same monitor resolved to SCORE and returned the average score (`avg(output_float)` ≈ 0.85), ignoring the selected label.

---

## 6) Edge cases & considerations

- **Free text containing a label word** (`"Not Complete at all"`): exact-equality on `output_str` and on the JSON `choice` key, never substring; covered by the integration test.
- **NULL `output_str`**: `NULL = x` is NULL; `has(...) OR NULL` is true when the list matches and NULL otherwise, which `CASE WHEN` / `countIf` treat as no match.
- **Rows with both list and JSON**: OR semantics, a row counts once.
- **Pass/Fail alerts**: `threshold_metric_value` carries Passed/Failed there; the override is restricted to stored type `score`.
- **Stale selected label** no longer in the template's `choices`: falls back to the SCORE branch instead of silently matching nothing.
- **Error rows** (`output_str = 'ERROR'`, ~250k in US prod): unaffected, they are filtered by the existing status/error predicates.
- **Blast radius on deploy**: monitors that were silently comparing an average score will start computing a real label percentage. Whatfix's "Incomplete > 1.0" will likely fire immediately; CS should be told before rollout.

---

## 7) Pre-existing issues (NOT introduced by this PR)

- 101 US-prod `tracer_eval_logger` rows hold the literal string `"None"` in `output_str` (writer `str(value)` fallback on an empty eval result).
- The pre-commit `mypy` hook calls `make mypy`, which has no target in `futureagi/Makefile`, so it is a no-op on every commit.
- The ticket's second part (should the writer populate `output_str_list` for score-plus-labels templates, and backfill the 704 rows) is a writer design decision and is intentionally not in this PR.

---

## 8) Architectural / important decisions

- **Read-side fix over writer change:** the writer gating is a documented design choice with tests; changing it needs a backfill and a product decision. Making both readers tolerant of all three storage shapes fixes every affected alert and chart now and stays correct if the writer is changed later.
- **One shared predicate:** alerts and charts previously used two different matchers and disagreed. A single helper in `expressions.py` is the only way to keep them in agreement.
- **Override keyed on the selected label, not on label presence:** requiring `threshold_metric_value in template.choices` means a score template with labels but no selection still alerts on the average score, and a stale value cannot flip an alert into a branch that matches nothing.
- **SCORE branch left on `output_float`:** prod has zero rows where a score exists only in `output_str`; adding a JSON fallback there would be speculative.

---

## Checklist

- [x] My code follows the style guide
- [x] I've added tests that prove my fix is effective or that my feature works
- [x] `bin/test` passes locally (backend)
- [ ] `yarn test:run` passes locally (frontend) — n/a, no frontend change
- [ ] `yarn contracts:check` passes if API surface changed — n/a, no API change
- [ ] I've updated the documentation where relevant — n/a
- [x] No hardcoded secrets, URLs, or PII
- [x] I've signed the CLA
- [x] PR title follows Conventional Commits
- [x] Linear issue is linked and updated with status

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018sBBvGsyVwpDigTkpphB6Q
