### PR TITLE
fix: eval span CH point-read drops FINAL for LIMIT 1 BY dedup

### DIFF
--- a/futureagi/tracer/services/clickhouse/cluster_rca_spans.py
+++ b/futureagi/tracer/services/clickhouse/cluster_rca_spans.py
@@ -149,7 +149,7 @@ def spans_for_trace(project_id: str, trace_id: str) -> list[dict[str, Any]]:
 
 def read_span(project_id: str, span_id: str) -> dict[str, Any] | None:
     """One span by id, or None if absent / CH unavailable. Delegates to the
-    canonical CHSpanReader (v2, FINAL-deduped, project-scoped)."""
+    canonical CHSpanReader (v2, version-deduped, project-scoped)."""
     if not span_id:
         return None
     try:

--- a/futureagi/tracer/services/clickhouse/v2/span_reader.py
+++ b/futureagi/tracer/services/clickhouse/v2/span_reader.py
@@ -22,7 +22,7 @@ Design goals:
     authoritative store; the read path is meant to be pure).
   • Single small query per call (no N+1 joins). The CH schema denormalizes
     trace_session_id / org_id / project_version_id onto each span row, so
-    most eval reads need exactly one row from `spans FINAL`.
+    most eval reads need exactly one row from `spans`.
 
 CRITICAL non-goal: write back. Eval results (EvalLogger rows) still go to
 PG until that's also migrated to CH (separate task). This reader is
@@ -491,7 +491,8 @@ def _row_to_chspan(row: tuple) -> CHSpan:
 
 
 class CHSpanReader:
-    """Read-only span fetcher backed by ClickHouse `spans FINAL`.
+    """Read-only span fetcher over the ClickHouse `spans` ReplacingMergeTree
+    (resolved via FINAL or, per read, the non-FINAL `_dedup_sql` LIMIT 1 BY).
 
     Thread-safe. Holds a clickhouse-connect HTTP client; safe to share between
     threads but each `query` call holds the connection briefly. For concurrent
@@ -602,23 +603,20 @@ class CHSpanReader:
 
         ``project_id`` (optional) scopes to one tenant; omit for prior behavior.
 
-        ``id`` is below the primary-key prefix, so a bare ``id =`` read prunes
-        only via the ``idx_id`` bloom — which CH 25.3 disables under FINAL by
-        default. Without it a point-read does a full in-order merge over every
-        part and the fat ``attributes_extra`` granule buffers blow the memory
-        limit on a wide (voice) span. Re-enable skip indexes; ``id`` is stable
-        across a row's ReplacingMergeTree versions, so the bloom is safe."""
-        # No is_deleted predicate — see _FINAL_SKIP_INDEX_SETTINGS.
+        Non-FINAL: a FINAL point-read merge-reads every active part covering
+        the project's key range, so its cost tracks the partition's part count,
+        not the one target row — ~90 unmerged parts turned this lookup into a
+        multi-GiB code-241 OOM. ``_dedup_sql`` resolves the ReplacingMergeTree
+        via ``LIMIT 1 BY`` instead; without FINAL the ``idx_id`` bloom skip
+        index prunes unaided."""
         where = ["id = %(span_id)s"]
         params: dict[str, Any] = {"span_id": span_id}
         if project_id:
             where.append("project_id = %(pid)s")
             params["pid"] = str(project_id)
         rows = self._client.query(
-            f"SELECT {_SELECT_SQL} FROM spans FINAL "
-            f"WHERE {' AND '.join(where)} LIMIT 1",
+            _dedup_sql(" AND ".join(where), "LIMIT 1", include_heavy=True),
             parameters=params,
-            settings=_FINAL_SKIP_INDEX_SETTINGS,
         ).result_rows
         if not rows:
             return None

--- a/futureagi/tracer/tests/test_span_reader_limit_by_dedup.py
+++ b/futureagi/tracer/tests/test_span_reader_limit_by_dedup.py
@@ -1,4 +1,5 @@
-"""``dedup_via_limit_by`` must reproduce ``spans FINAL`` exactly (TH-7226).
+"""The LIMIT 1 BY dedup (``dedup_via_limit_by`` opt-ins, and always-on for
+``get()``) must reproduce ``spans FINAL`` exactly (TH-7226).
 
 Three rules, each silent when broken: is_deleted filtered AFTER the dedup (else
 deleted rows resurrect), the full sorting key as the dedup key, and every column
@@ -44,7 +45,7 @@ def _reader_with(client) -> CHSpanReader:
 
 
 def _dedup_reads():
-    """(label, callable) for each annotation-path read that opts in."""
+    """(label, callable) for each read resolved via LIMIT 1 BY."""
     return [
         (
             "roots_by_trace_ids",
@@ -58,6 +59,9 @@ def _dedup_reads():
                 ["s1", "s2"], include_heavy=True, dedup_via_limit_by=True
             ),
         ),
+        # Always non-FINAL: a FINAL point-read's cost tracks the partition's
+        # part count, not the one target row (see CHSpanReader.get).
+        ("get", lambda r: r.get("s1", project_id="p1")),
     ]
 
 
@@ -121,6 +125,28 @@ def test_every_column_is_named_for_the_outer_projection(label, call):
         assert name in projection, f"{label}: {name} missing from the projection"
     # No bare '' stubs: the lean select's unnamed stubs cannot be projected.
     assert ", ''," not in projection
+
+
+def test_get_is_single_row_and_scoped():
+    """get() keeps its point-read contract: one row, id + tenant predicates."""
+    client = _RecordingClient()
+    _reader_with(client).get("s1", project_id="p1")
+    assert client.sql.rstrip().endswith("LIMIT 1")
+    assert "id = %(span_id)s" in client.sql
+    assert "project_id = %(pid)s" in client.sql
+    # Heavy columns stay real — eval mapping reads attributes_extra.
+    assert "'' AS attributes_extra" not in client.sql
+
+
+def test_get_unscoped_stays_non_final():
+    """get(span_id) without a tenant: one predicate, still the dedup shape."""
+    client = _RecordingClient()
+    _reader_with(client).get("s1")
+    assert "FINAL" not in client.sql
+    assert "id = %(span_id)s" in client.sql
+    assert "project_id = %(pid)s" not in client.sql
+    assert "WHERE id = %(span_id)s ORDER BY" in client.sql  # no dangling AND
+    assert client.sql.rstrip().endswith("LIMIT 1")
 
 
 # ── the constant vs the live table ─────────────────────────────────────────────

--- a/futureagi/tracer/tests/test_span_reader_point_read_oom.py
+++ b/futureagi/tracer/tests/test_span_reader_point_read_oom.py
@@ -17,6 +17,9 @@ unpruned merge: the skip-index setting is on, and the ``is_deleted = 0``
 predicate (which, alongside the setting, arms the ``is_deleted`` minmax-index
 resurrection bug — the 2-arg ReplacingMergeTree drops deleted rows under FINAL
 anyway) is off. A revert of either fails here rather than as a prod OOM.
+
+``get()`` left FINAL entirely (even with the bloom, FINAL's merge cost tracks
+part count) and is pinned in ``test_span_reader_limit_by_dedup.py``.
 """
 
 from tracer.services.clickhouse.v2.span_reader import CHSpanReader
@@ -56,12 +59,6 @@ def _assert_final_oom_safe(client, key_predicate):
     assert "is_deleted = 0" not in client.sql
     # still prunes on the stable bloom-indexed column
     assert key_predicate in client.sql
-
-
-def test_get_is_final_oom_safe():
-    client = _RecordingClient()
-    _reader_with(client).get("span-1")
-    _assert_final_oom_safe(client, "id = %(span_id)s")
 
 
 def test_list_by_trace_is_final_oom_safe():


### PR DESCRIPTION
## Summary

`CHSpanReader.get()` did a single-span point read with `spans FINAL`. A FINAL read merges every active part covering the queried key range, so its cost tracks the partition's **part count**, not the one target row. On a fragmented partition (~90 unmerged parts) the eval single-span read merged every part and hit ClickHouse **code 241 (memory limit exceeded)** — and because the forced-ClickHouse eval path coerces a read *error* into a miss, it surfaced to users as the wrong message **"Observation span not found"**. This drops `FINAL` from `get()` and resolves the ReplacingMergeTree via the existing, tested non-FINAL dedup instead.

## Linked issues

Closes #
Linear: Fixed TH-7675

## Type of change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] 🚀 Performance improvement

## E2E coverage

E2E: covered-by EVAL-E2E-001 — the eval-task flow loads each span via `CHSpanReader.get()`, exercising this read end-to-end.

---

## 1) What changes were done

**A. `CHSpanReader.get()` no longer uses `FINAL`**

- Replaced `SELECT … FROM spans FINAL WHERE id=… LIMIT 1` (+ `use_skip_indexes_if_final`) with the existing `_dedup_sql()` helper: `ORDER BY _version DESC LIMIT 1 BY <full sorting key>` in a subquery, with `is_deleted = 0` filtered on the outer query and an outer `LIMIT 1`.
- `include_heavy=True` is kept (eval mapping needs `attributes_extra`). Column shape/order is identical, so `_row_to_chspan` decodes unchanged.
- No API/model/storage changes; this is an internal query-shape fix on one read.

**B. Docs / tests**

- Corrected the module + class docstrings that still described the reader as `spans FINAL`, and `cluster_rca_spans.read_span`'s "FINAL-deduped" wording.

---

## 2) Why the changes were done

- **Reliability:** eliminates the part-count-proportional memory blow-up on the single-span eval read (the code-241 OOM) and the mislabelled "Observation span not found" it produced.
- **Technical:** reuses the same `_dedup_sql` `LIMIT 1 BY` pattern already in production behind `dedup_via_limit_by=True` on `list_by_ids`/`roots_by_trace_ids` (TH-7226). Without `FINAL` the `idx_id` bloom prunes straight to the target row; benchmarks on that pattern show ~123 ms / 67 MiB vs ~2.4 s / 3.4 GiB under FINAL.
- **Scope:** the retryability half of TH-7675 (CH read errors → Temporal retry instead of a permanent errored row) already landed as `EvalTelemetryReadError`; this PR is the root-cause read-shape fix.

---

## 3) Tests written + scenarios each covers

**`test_span_reader_limit_by_dedup.py`** — the `LIMIT 1 BY` dedup reproduces `spans FINAL` exactly; now parametrized over `get()` too.

- `get` entry in the parametrized suite — `get()` SQL is non-FINAL, carries `LIMIT 1 BY` with the full sorting key, and filters `is_deleted = 0` outside the dedup subquery.
- `test_get_is_single_row_and_scoped` — `get(id, project_id)` keeps its point-read contract (`LIMIT 1`, both predicates, heavy columns real).
- `test_get_unscoped_stays_non_final` — `get(id)` without a tenant builds a single-predicate WHERE (no dangling `AND`), still non-FINAL.
- `test_limit_by_matches_final_including_deleted_rows` — proves against a real ReplacingMergeTree that the dedup equals FINAL for newest-wins and deletions.

**`test_span_reader_point_read_oom.py`** — point reads stay OOM-safe; the obsolete FINAL pin for `get()` removed (moved to the dedup suite).

> Run result: **32 passed** across these suites locally (ruff/black clean).

---

## 4) How to run / test

```bash
cd futureagi
bin/test tracer/tests/test_span_reader_limit_by_dedup.py tracer/tests/test_span_reader_point_read_oom.py -v
```

Also validated end-to-end on a local stack: 5 historical eval tasks (deterministic Levenshtein/ROUGE) over real spans with `EVAL_SPAN_READ_SOURCE=clickhouse` — the new non-FINAL point read executed 64× in `system.query_log` with zero read errors and zero "Observation span not found".

---

## 6) Edge cases & considerations

- **Deleted rows:** `is_deleted = 0` stays on the outer query — filtering inside the dedup would resurrect a row whose newest version is deleted. Pinned by the real-ReplacingMergeTree test.
- **Version ties:** `_version` is a per-row nanosecond timestamp, so ties between distinct versions don't occur in practice; behaviour matches the already-shipped annotation dedup path.
- **Unscoped `get(id)`:** single-predicate WHERE verified (no dangling `AND`).

---

## 7) Pre-existing issues (NOT introduced by this PR)

- Trace/session-level eval reads (`list_by_trace`, heavy `list_by_ids`, `list_by_session`) still use `FINAL` and remain exposed to the same part-count cost — tracked for the platform-wide FINAL retirement (TH-7226), out of scope here.

## 8) Architectural / important decisions

- **Reuse `_dedup_sql` rather than a new mechanism:** it's the established, tested end-state for retiring `spans FINAL`; `get()` joins `list_by_ids`/`roots_by_trace_ids` on the same pattern.
- **`get()` switches unconditionally (no opt-in flag):** a point read never benefits from FINAL, so there's no caller that wants the old shape.
