### PR TITLE
fix(catalog): bind consumer to the configured production database

### DIFF
--- a/fi-collector/cmd/fi-property-catalog-consumer/main.go
+++ b/fi-collector/cmd/fi-property-catalog-consumer/main.go
@@ -28,6 +28,7 @@ const (
 	envDevAck       = "FI_PROPERTY_CATALOG_DEV_ACK"
 	envProdAck      = "FI_PROPERTY_CATALOG_PROD_ACK"
 
+	envProductionDatabase = "FI_PROPERTY_CATALOG_PRODUCTION_DATABASE"
 	envClickHouseURL      = "FI_PROPERTY_CATALOG_CH_URL"
 	envClickHouseDatabase = "FI_PROPERTY_CATALOG_CH_DATABASE"
 	envClickHouseUsername = "FI_PROPERTY_CATALOG_CH_USERNAME"
@@ -214,6 +215,10 @@ func loadConfig(args []string, lookup lookupEnvFunc) (commandConfig, error) {
 	if err != nil {
 		return commandConfig{}, err
 	}
+	productionDatabase, err := optionalProductionDatabase(lookup)
+	if err != nil {
+		return commandConfig{}, err
+	}
 
 	write, err := clickHouseConfig(
 		lookup,
@@ -222,6 +227,7 @@ func loadConfig(args []string, lookup lookupEnvFunc) (commandConfig, error) {
 		envClickHouseUsername,
 		envClickHousePassword,
 		environment,
+		productionDatabase,
 		deliveryTimeout,
 	)
 	if err != nil {
@@ -258,6 +264,7 @@ func loadConfig(args []string, lookup lookupEnvFunc) (commandConfig, error) {
 		envLedgerUsername,
 		envLedgerPassword,
 		environment,
+		productionDatabase,
 		deliveryTimeout,
 	)
 	if err != nil {
@@ -303,7 +310,7 @@ func loadConfig(args []string, lookup lookupEnvFunc) (commandConfig, error) {
 func clickHouseConfig(
 	lookup lookupEnvFunc,
 	urlName, databaseName, usernameName, passwordName string,
-	environment string,
+	environment, productionDatabase string,
 	requestTimeout time.Duration,
 ) (propertycatalog.ClickHouseSinkConfig, error) {
 	urlValue, err := requireEnv(lookup, urlName, false)
@@ -324,7 +331,7 @@ func clickHouseConfig(
 	}
 	cfg := propertycatalog.ClickHouseSinkConfig{
 		URL: urlValue, Database: database, Username: username, Password: password,
-		Environment: environment, RequestTimeout: requestTimeout,
+		Environment: environment, ProductionDatabase: productionDatabase, RequestTimeout: requestTimeout,
 	}
 	// Constructor validation is local-only and binds the isolated database
 	// prefix to the exact environment before a ledger read or Kafka client.
@@ -332,6 +339,17 @@ func clickHouseConfig(
 		return propertycatalog.ClickHouseSinkConfig{}, fmt.Errorf("%s: %w", databaseName, err)
 	}
 	return cfg, nil
+}
+
+// optionalProductionDatabase mirrors the backend's
+// PROPERTY_CATALOG_PRODUCTION_DATABASE contract: unset keeps the default
+// production catalog name, while a present value must be the exact isolated
+// database the deployment binds every reader and writer to.
+func optionalProductionDatabase(lookup lookupEnvFunc) (string, error) {
+	if _, present := lookup(envProductionDatabase); !present {
+		return "", nil
+	}
+	return requireEnv(lookup, envProductionDatabase, false)
 }
 
 func validatedEnvironment(lookup lookupEnvFunc) (string, error) {

--- a/fi-collector/cmd/fi-property-catalog-consumer/main_test.go
+++ b/fi-collector/cmd/fi-property-catalog-consumer/main_test.go
@@ -151,6 +151,51 @@ func TestProductionConsumerRequiresExactGateMatchingDatabaseAndLedgerSeed(t *tes
 	}
 }
 
+func TestProductionConsumerBindsToConfiguredProductionDatabase(t *testing.T) {
+	const isolated = "th7247_catalog_prod_20260823a"
+	isolatedEnvironment := func() map[string]string {
+		values := productionEnvironment()
+		values[envProductionDatabase] = isolated
+		values[envClickHouseDatabase] = isolated
+		values[envLedgerDatabase] = isolated
+		return values
+	}
+	cfg, err := loadConfig([]string{"--seed-from-delivery-ledger"}, mapLookup(isolatedEnvironment()))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.write.Database != isolated || cfg.write.ProductionDatabase != isolated ||
+		cfg.ledger.Database != isolated || cfg.ledger.ProductionDatabase != isolated {
+		t.Fatalf("production config=%+v", cfg)
+	}
+
+	for name, mutate := range map[string]func(map[string]string){
+		"default name once an isolated catalog is configured": func(values map[string]string) {
+			values[envClickHouseDatabase] = "property_catalog"
+			values[envLedgerDatabase] = "property_catalog"
+		},
+		"isolated name without configuring it": func(values map[string]string) {
+			delete(values, envProductionDatabase)
+		},
+		"surrounding whitespace": func(values map[string]string) {
+			values[envProductionDatabase] = " " + isolated
+		},
+		"empty": func(values map[string]string) {
+			values[envProductionDatabase] = ""
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			values := isolatedEnvironment()
+			mutate(values)
+			if _, err := loadConfig(
+				[]string{"--seed-from-delivery-ledger"}, mapLookup(values),
+			); err == nil {
+				t.Fatal("unsafe production configuration was accepted")
+			}
+		})
+	}
+}
+
 func TestDeliveryTimeoutSupportsOnlyBoundedEnvironmentOverrides(t *testing.T) {
 	values := validEnvironment()
 	values[envDeliveryWall] = "3s"

--- a/fi-collector/pkg/propertycatalog/clickhouse_sink.go
+++ b/fi-collector/pkg/propertycatalog/clickhouse_sink.go
@@ -47,13 +47,17 @@ var deliveryColumns = []string{
 }
 
 type ClickHouseSinkConfig struct {
-	URL            string
-	Database       string
-	Environment    string
-	Username       string
-	Password       string
-	RequestTimeout time.Duration
-	RoundTripper   http.RoundTripper
+	URL         string
+	Database    string
+	Environment string
+	// ProductionDatabase is the exact isolated catalog database this
+	// deployment binds every reader and writer to. Empty keeps the
+	// property_catalog default so existing installations are unchanged.
+	ProductionDatabase string
+	Username           string
+	Password           string
+	RequestTimeout     time.Duration
+	RoundTripper       http.RoundTripper
 }
 
 // ClickHouseSink is closed over the two new catalog data tables and their
@@ -74,7 +78,7 @@ func NewClickHouseSink(cfg ClickHouseSinkConfig) (*ClickHouseSink, error) {
 		(parsed.Path != "" && parsed.Path != "/") {
 		return nil, errors.New("propertycatalog: ClickHouse URL must be a bare http(s) origin")
 	}
-	if !safeClickHouseDatabase(cfg.Environment, cfg.Database) {
+	if !safeClickHouseDatabase(cfg.Environment, cfg.Database, cfg.ProductionDatabase) {
 		return nil, errors.New(
 			"propertycatalog: ClickHouse database must match the exact environment-specific isolated catalog name",
 		)
@@ -182,26 +186,36 @@ func (s *ClickHouseSink) insert(ctx context.Context, table string, columns []str
 	return nil
 }
 
-func safeClickHouseDatabase(environment, value string) bool {
+func safeClickHouseDatabase(environment, value, productionDatabase string) bool {
+	if productionDatabase == "" {
+		productionDatabase = prodCatalogDatabaseName
+	}
+	if !safeCatalogDatabaseIdentifier(productionDatabase) {
+		return false
+	}
 	switch environment {
 	case DevelopmentEnvironment:
-		if len(value) == 0 || len(value) > 128 || value == prodCatalogDatabaseName {
-			return false
-		}
-		if _, reserved := reservedCatalogDatabases[value]; reserved {
-			return false
-		}
-		for index, char := range value {
-			if char > 127 || (!(char >= 'a' && char <= 'z') &&
-				!(char >= '0' && char <= '9') && char != '_') ||
-				(index == 0 && !(char >= 'a' && char <= 'z')) {
-				return false
-			}
-		}
-		return true
+		return value != productionDatabase && safeCatalogDatabaseIdentifier(value)
 	case ProductionEnvironment:
-		return value == prodCatalogDatabaseName
+		return value == productionDatabase
 	default:
 		return false
 	}
+}
+
+func safeCatalogDatabaseIdentifier(value string) bool {
+	if len(value) == 0 || len(value) > 128 {
+		return false
+	}
+	if _, reserved := reservedCatalogDatabases[value]; reserved {
+		return false
+	}
+	for index, char := range value {
+		if char > 127 || (!(char >= 'a' && char <= 'z') &&
+			!(char >= '0' && char <= '9') && char != '_') ||
+			(index == 0 && !(char >= 'a' && char <= 'z')) {
+			return false
+		}
+	}
+	return true
 }

--- a/fi-collector/pkg/propertycatalog/clickhouse_sink_test.go
+++ b/fi-collector/pkg/propertycatalog/clickhouse_sink_test.go
@@ -128,3 +128,28 @@ func TestClickHouseSinkAcceptsOnlyStableProductionCatalogName(t *testing.T) {
 		t.Fatal(err)
 	}
 }
+
+func TestClickHouseSinkBindsProductionToConfiguredCatalogDatabase(t *testing.T) {
+	const isolated = "th7247_catalog_prod_20260823a"
+	if _, err := NewClickHouseSink(ClickHouseSinkConfig{
+		URL: "https://clickhouse:8443", Database: isolated, ProductionDatabase: isolated,
+		Environment: ProductionEnvironment, Username: "property_writer",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	for _, cfg := range []ClickHouseSinkConfig{
+		// The default name is no longer the production catalog once one is configured.
+		{URL: "https://clickhouse:8443", Database: "property_catalog", ProductionDatabase: isolated, Environment: ProductionEnvironment, Username: "writer"},
+		{URL: "https://clickhouse:8443", Database: isolated, Environment: ProductionEnvironment, Username: "writer"},
+		// The configured production identity must itself be a safe isolated name.
+		{URL: "https://clickhouse:8443", Database: "futureagi", ProductionDatabase: "futureagi", Environment: ProductionEnvironment, Username: "writer"},
+		{URL: "https://clickhouse:8443", Database: "Bad-Name", ProductionDatabase: "Bad-Name", Environment: ProductionEnvironment, Username: "writer"},
+		{URL: "https://clickhouse:8443", Database: "catalog;DROP", ProductionDatabase: "catalog;DROP", Environment: ProductionEnvironment, Username: "writer"},
+		// Development may never write into the configured production catalog.
+		{URL: "http://clickhouse:8123", Database: isolated, ProductionDatabase: isolated, Environment: DevelopmentEnvironment, Username: "writer"},
+	} {
+		if _, err := NewClickHouseSink(cfg); err == nil {
+			t.Fatalf("unsafe sink config accepted: %+v", cfg)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

The `fi-property-catalog-consumer` binary hardcodes `property_catalog` as the only ClickHouse database it will accept in `production` mode, while the backend made the production catalog identity configurable via `PROPERTY_CATALOG_PRODUCTION_DATABASE` (`0dae71a0a`). US prod binds every reader/writer to the isolated `th7247_catalog_prod_20260823a`, so the consumer crash-looped at startup during the rev 89 live-activation attempt (`ClickHouse database must match the exact environment-specific isolated catalog name`) and Helm `--atomic` rolled back to rev 88. This teaches the consumer the same contract: read `FI_PROPERTY_CATALOG_PRODUCTION_DATABASE`, validate it with the identifier rules the development gate already enforces, default to `property_catalog` when unset.

## Linked issues

Linear: TH-7247
Twin of #2531 (same commit against `dev`). This one targets `main` because prod fi-collector images are built from `main`, and the isolated-catalog activation is blocked on this binary.
Chart side: future-agi/deployment#313 (adds the env var; inert until this image ships)

## Type of change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## E2E coverage

E2E: exempt (not-in-stack — fi-collector production-mode startup gate; the compose/e2e stack runs the consumer in `development` mode, which is unchanged)

---

## 1) What changes were done

**A. `pkg/propertycatalog/clickhouse_sink.go` — configurable production identity**

- `ClickHouseSinkConfig` gains `ProductionDatabase`. Empty keeps the `property_catalog` default.
- `safeClickHouseDatabase` now takes the configured production name. Production accepts exactly that name; development accepts any safe identifier *except* that name. The configured name itself must pass the same identifier rules (lowercase `[a-z][a-z0-9_]*`, ≤128 bytes, not `default`/`futureagi`/`information_schema`/`system`).
- The identifier rules move out of the development branch into `safeCatalogDatabaseIdentifier` so both checks share them.

**B. `cmd/fi-property-catalog-consumer/main.go` — env wiring**

- New optional env `FI_PROPERTY_CATALOG_PRODUCTION_DATABASE`. When present it must be non-empty with no surrounding whitespace (same `requireEnv` rules as every other consumer variable).
- Passed into both the catalog write config and the delivery-ledger config so the existing "ledger DB must equal write DB" check still holds.

Nothing changes for deployments that don't set the variable.

---

## 2) Why the changes were done

- **Technical:** the DB name is an infrastructure contract (the isolated catalog already holds the 684M-row backfill and all per-role grants). The Python side reads it from env for exactly that reason; the Go consumer was never updated, so no chart/values change could make the shipped image start.
- **Why not switch the pod to `development` mode:** the dev gate rejects the prod acknowledgement, changes the Kafka client id, and defeats every production safety check in the pipeline. Running prod ingestion under a dev identity is not an option.
- **Architecture:** mirrors `futureagi/tracer/services/clickhouse/v2/property_catalog/database.py` one-to-one (same env-with-default pattern, same validation) so reader and writer cannot silently diverge again. The `FI_` prefix follows the consumer's existing env naming; the chart maps the backend's `PROPERTY_CATALOG_PRODUCTION_DATABASE` and this variable from the single `propertyCatalog.database` value.

---

## 3) Tests written + scenarios each covers

**`pkg/propertycatalog/clickhouse_sink_test.go`**

- `TestClickHouseSinkBindsProductionToConfiguredCatalogDatabase` — production accepts the configured isolated name; rejects `property_catalog` once an isolated name is configured; rejects the isolated name when nothing is configured; rejects unsafe configured names (`futureagi`, `Bad-Name`, `catalog;DROP`); development rejects the configured production name.
- Existing `TestClickHouseSinkAcceptsOnlyStableProductionCatalogName` and `TestClickHouseSinkRejectsUnsafeDestinationAndRowShapeBeforeIO` still pass unchanged — proves the unset-variable default is byte-for-byte the old behaviour.

**`cmd/fi-property-catalog-consumer/main_test.go`**

- `TestProductionConsumerBindsToConfiguredProductionDatabase` — full `loadConfig` in production mode with `FI_PROPERTY_CATALOG_PRODUCTION_DATABASE=th7247_catalog_prod_20260823a` succeeds and threads the value into both write and ledger configs; sub-cases reject `property_catalog` once an isolated name is configured, the isolated name without the variable, surrounding whitespace, and an empty value.
- Existing `TestProductionConsumerRequiresExactGateMatchingDatabaseAndLedgerSeed` unchanged.

> Run result: `ok pkg/propertycatalog`, `ok cmd/fi-property-catalog-consumer`, `ok cmd/fi-property-catalog-sequencer`, `ok cmd/fi-collector`. `gofmt -l` and `go vet` clean.

---

## 4) How to run / test

```bash
cd fi-collector
gofmt -l pkg/propertycatalog cmd/fi-property-catalog-consumer
go vet ./pkg/propertycatalog/ ./cmd/fi-property-catalog-consumer/
go test ./pkg/propertycatalog/ ./cmd/fi-property-catalog-consumer/ ./cmd/fi-property-catalog-sequencer/ ./cmd/fi-collector/
```

Manual (prod-shaped) check once the image is built:

```bash
FI_PROPERTY_CATALOG_CONSUMER_MODE=kafka \
FI_PROPERTY_CATALOG_ENVIRONMENT=production \
FI_PROPERTY_CATALOG_PROD_ACK=UNIFIED_PROPERTY_CATALOG_V1_PRODUCTION \
FI_PROPERTY_CATALOG_PRODUCTION_DATABASE=th7247_catalog_prod_20260823a \
FI_PROPERTY_CATALOG_CH_DATABASE=th7247_catalog_prod_20260823a \
FI_PROPERTY_CATALOG_LEDGER_CH_DATABASE=th7247_catalog_prod_20260823a \
... /usr/local/bin/fi-property-catalog-consumer --seed-from-delivery-ledger
# must get past config validation (previously failed before any I/O)
```

---

## 5) Screenshots / recordings

### Test output

```
$ go test ./pkg/propertycatalog/ ./cmd/fi-property-catalog-consumer/ ./cmd/fi-property-catalog-sequencer/ ./cmd/fi-collector/
ok  	github.com/future-agi/future-agi/fi-collector/pkg/propertycatalog	1.738s
ok  	github.com/future-agi/future-agi/fi-collector/cmd/fi-property-catalog-consumer	1.131s
ok  	github.com/future-agi/future-agi/fi-collector/cmd/fi-property-catalog-sequencer	(cached)
ok  	github.com/future-agi/future-agi/fi-collector/cmd/fi-collector	0.753s
```

Before the fix, the new tests fail to compile (`undefined: envProductionDatabase`, `cfg.write.ProductionDatabase undefined`) — verified red before green.

Prod evidence (rev 89, 2026-09-03 13:14:58 UTC):
```
fi-property-catalog-consumer: FI_PROPERTY_CATALOG_CH_DATABASE: propertycatalog: ClickHouse database must match the exact environment-specific isolated catalog name
```

---

## 6) Edge cases & considerations

- Variable unset → identical to today (`property_catalog` only in production).
- Variable set to `property_catalog` explicitly → same as unset.
- Variable set to a reserved/unsafe name → sink construction fails in production **and** development (a bad production identity must never be silently accepted as "just a dev name").
- Development mode with an isolated production name configured → that name is rejected as a dev target, exactly like `property_catalog` was.
- Ledger and write configs receive the same value, so the existing "ledger must match write destination" check is unaffected.

---

## 8) Architectural / important decisions

- **Env-with-default, not a new required variable:** matches the Python contract and keeps every existing installation (OSS compose, dev renderers) unchanged.
- **Validate the configured name, not just the target:** a typo in the production identity should fail closed at startup rather than let production mode accept an arbitrary string.

---

## Checklist

- [x] My code follows the style guide
- [x] I've added tests that prove my fix is effective
- [x] Go tests pass locally (`go test`, `go vet`, `gofmt`)
- [x] No hardcoded secrets, URLs, or PII
- [x] PR title follows Conventional Commits
- [x] Linear issue is linked
