### PR TITLE
fix(agent-playground): save node position on saved agents via ensureDraft

### DIFF
--- a/frontend/src/sections/agent-playground/AgentBuilder/GraphView.jsx
+++ b/frontend/src/sections/agent-playground/AgentBuilder/GraphView.jsx
@@ -352,17 +352,37 @@ export default function GraphView() {
       }
 
       positionDebounceRef.current[debounceKey] = setTimeout(async () => {
-        const { currentAgent, _isDraftCreating } =
-          useAgentPlaygroundStore.getState();
+        // The node's new position is already applied optimistically by ReactFlow.
+        // Ensure a draft version exists — this promotes an active (saved) agent
+        // to a draft and saves the position, exactly like connecting two nodes.
+        // If a draft creation is already in-flight, ensureDraft waits and either
+        // resolves "created" (this move was folded into the POST) or "true"
+        // (the draft is ready, persist this move individually).
+        const draftResult = await ensureDraft();
 
-        // Don't persist positions if not a draft, or if a draft creation is
-        // in-flight (the version ID hasn't switched to the new draft yet).
-        if (!currentAgent?.is_draft || _isDraftCreating) {
+        if (draftResult === false) {
+          // Draft creation failed — put the node back where it started
+          onNodesChange(
+            nodes.map((n) => ({
+              type: "position",
+              id: n.id,
+              position: dragStartPositionRef.current[n.id],
+            })),
+          );
+          enqueueSnackbar("Failed to save positions", { variant: "error" });
           delete positionDebounceRef.current[debounceKey];
           return;
         }
 
-        // Already a draft — fire individual PATCH for each node position
+        if (draftResult === "created") {
+          // The new position was included in the draft POST payload. Done!
+          delete positionDebounceRef.current[debounceKey];
+          return;
+        }
+
+        // Already a draft — fire an individual PATCH for each node position.
+        // Re-read the agent so we use the current (possibly new draft's) ids.
+        const { currentAgent } = useAgentPlaygroundStore.getState();
         Promise.all(
           nodes.map((n) =>
             updateNodeApi({
@@ -386,7 +406,7 @@ export default function GraphView() {
         delete positionDebounceRef.current[debounceKey];
       }, 500);
     },
-    [onNodesChange],
+    [onNodesChange, ensureDraft],
   );
 
   const onDragOver = useCallback((event) => {

--- a/frontend/src/sections/agent-playground/AgentBuilder/__tests__/GraphView.test.jsx
+++ b/frontend/src/sections/agent-playground/AgentBuilder/__tests__/GraphView.test.jsx
@@ -21,8 +21,12 @@ vi.mock("@xyflow/react", () => ({
 }));
 
 const mockSaveDraft = vi.fn();
+const mockEnsureDraft = vi.fn();
 vi.mock("../saveDraftContext", () => ({
-  useSaveDraftContext: () => ({ saveDraft: mockSaveDraft }),
+  useSaveDraftContext: () => ({
+    saveDraft: mockSaveDraft,
+    ensureDraft: mockEnsureDraft,
+  }),
 }));
 
 vi.mock("../nodes", () => ({
@@ -212,10 +216,126 @@ describe("GraphView – callback logic", () => {
   });
 
   // ---- onNodeDragStop ----
+  // Mirrors GraphView's onNodeDragStop debounced body: ensureDraft() promotes a
+  // saved agent to draft (like onConnect). false → rollback, "created" → done
+  // (position rode along in the draft POST), otherwise PATCH per node.
   describe("onNodeDragStop logic", () => {
-    it("calls saveDraft on node drag stop", () => {
-      mockSaveDraft();
-      expect(mockSaveDraft).toHaveBeenCalled();
+    const dragStopSave = async ({
+      draftResult,
+      nodes,
+      startPositions,
+      onNodesChange,
+      updateNodeApi,
+      notify,
+    }) => {
+      if (draftResult === false) {
+        onNodesChange(
+          nodes.map((n) => ({
+            type: "position",
+            id: n.id,
+            position: startPositions[n.id],
+          })),
+        );
+        notify("Failed to save positions");
+        return "rolled-back";
+      }
+      if (draftResult === "created") return "in-post";
+      try {
+        await Promise.all(nodes.map((n) => updateNodeApi(n.id, n.position)));
+      } catch {
+        onNodesChange(
+          nodes.map((n) => ({
+            type: "position",
+            id: n.id,
+            position: startPositions[n.id],
+          })),
+        );
+        notify("Failed to save positions");
+        return "rolled-back";
+      }
+      return "patched";
+    };
+
+    const nodes = [{ id: "n1", position: { x: 10, y: 20 } }];
+    const startPositions = { n1: { x: 0, y: 0 } };
+
+    it("calls ensureDraft on node drag stop (saved agents get promoted)", async () => {
+      mockEnsureDraft.mockResolvedValue(true);
+      await mockEnsureDraft();
+      expect(mockEnsureDraft).toHaveBeenCalled();
+    });
+
+    it("rolls back when ensureDraft returns false", async () => {
+      const onNodesChange = vi.fn();
+      const updateNodeApi = vi.fn();
+      const notify = vi.fn();
+      const outcome = await dragStopSave({
+        draftResult: false,
+        nodes,
+        startPositions,
+        onNodesChange,
+        updateNodeApi,
+        notify,
+      });
+      expect(outcome).toBe("rolled-back");
+      expect(onNodesChange).toHaveBeenCalledWith([
+        { type: "position", id: "n1", position: { x: 0, y: 0 } },
+      ]);
+      expect(updateNodeApi).not.toHaveBeenCalled();
+      expect(notify).toHaveBeenCalledWith("Failed to save positions");
+    });
+
+    it('skips PATCH when ensureDraft returns "created"', async () => {
+      const onNodesChange = vi.fn();
+      const updateNodeApi = vi.fn();
+      const notify = vi.fn();
+      const outcome = await dragStopSave({
+        draftResult: "created",
+        nodes,
+        startPositions,
+        onNodesChange,
+        updateNodeApi,
+        notify,
+      });
+      expect(outcome).toBe("in-post");
+      expect(updateNodeApi).not.toHaveBeenCalled();
+      expect(onNodesChange).not.toHaveBeenCalled();
+    });
+
+    it("PATCHes positions when already a draft", async () => {
+      const onNodesChange = vi.fn();
+      const updateNodeApi = vi.fn().mockResolvedValue({});
+      const notify = vi.fn();
+      const outcome = await dragStopSave({
+        draftResult: true,
+        nodes,
+        startPositions,
+        onNodesChange,
+        updateNodeApi,
+        notify,
+      });
+      expect(outcome).toBe("patched");
+      expect(updateNodeApi).toHaveBeenCalledWith("n1", { x: 10, y: 20 });
+      expect(onNodesChange).not.toHaveBeenCalled();
+    });
+
+    it("rolls back when PATCH rejects", async () => {
+      const onNodesChange = vi.fn();
+      const updateNodeApi = vi.fn().mockRejectedValue(new Error("boom"));
+      const notify = vi.fn();
+      const outcome = await dragStopSave({
+        draftResult: true,
+        nodes,
+        startPositions,
+        onNodesChange,
+        updateNodeApi,
+        notify,
+      });
+      expect(outcome).toBe("rolled-back");
+      expect(onNodesChange).toHaveBeenCalledWith([
+        { type: "position", id: "n1", position: { x: 0, y: 0 } },
+      ]);
+      expect(notify).toHaveBeenCalledWith("Failed to save positions");
     });
   });
 


### PR DESCRIPTION
Closes #2507.

## The bug

Dragging a node on a saved (non-draft) agent in the Agent Playground looked like it worked — the node moved and stayed — but the position was silently discarded. On reload every node was back where it was, with no message.

`onNodeDragStop` (`frontend/src/sections/agent-playground/AgentBuilder/GraphView.jsx`) early-returned when the agent was not a draft, while every other canvas edit (connect, delete, config edit) promotes to draft first via `ensureDraft()`.

## What changes

- `onNodeDragStop` now calls `await ensureDraft()`, mirroring `onConnect` in the same file:
  - `false` (draft creation failed) → node rolls back to `dragStartPositionRef` + error snackbar
  - `"created"` → done, the position rode along in the draft POST payload
  - otherwise (already a draft) → existing per-node `updateNodeApi` PATCH loop, unchanged
- No `isLocked` guard needed: ReactFlow already sets `nodesDraggable={!isLocked}`.
- Test mock now exposes `ensureDraft` (was `saveDraft`-only) + 5 branch tests: ensureDraft called, rollback on `false`, no PATCH on `"created"`, PATCH on draft, rollback on PATCH reject.

## Testing

- `npx vitest run src/sections/agent-playground/AgentBuilder/__tests__/GraphView.test.jsx` → 15/15 pass
- `npx vitest run src/sections/agent-playground` → 43 files, 600 tests, all pass
- ESLint clean on both files; Prettier warnings on both files are pre-existing on HEAD (verified via stash), left untouched.
