### PR TITLE
fix(frontend): distinguish skipped playground nodes from never-run

### DIFF
--- a/frontend/src/components/AgentGraph/AgentGraph.jsx
+++ b/frontend/src/components/AgentGraph/AgentGraph.jsx
@@ -13,6 +13,7 @@ import ExecutionNode from "./ExecutionNode";
 import StartEndNode from "./StartEndNode";
 import SubgraphGroupNode from "./SubgraphGroupNode";
 import { buildExecutionGraph } from "./layoutUtils";
+import { isSkippedExecutionStatus } from "./nodeUtils";
 import "./agent-graph-animations.css";
 
 const nodeTypes = {
@@ -39,6 +40,7 @@ function AgentGraphInner({ executionData, onNodeClick, selectedNodeId }) {
   const handleNodeClick = useCallback(
     (event, node) => {
       if (!node.data?.nodeExecution) return;
+      if (isSkippedExecutionStatus(node.data.nodeExecution.status)) return;
       onNodeClick?.(event, node);
     },
     [onNodeClick],

--- a/frontend/src/components/AgentGraph/ExecutionNode.jsx
+++ b/frontend/src/components/AgentGraph/ExecutionNode.jsx
@@ -1,5 +1,5 @@
 import React, { memo } from "react";
-import { Box, Stack, Typography, useTheme } from "@mui/material";
+import { Box, Stack, Tooltip, Typography, useTheme } from "@mui/material";
 import PropTypes from "prop-types";
 import SvgColor from "src/components/svg-color";
 import { NODE_TYPE_CONFIG } from "src/sections/agent-playground/utils/constants";
@@ -7,6 +7,7 @@ import { EXECUTION_STATUS } from "src/sections/agent-playground/utils/workflowEx
 import {
   getStatusBorderColor,
   getStatusBackgroundColor,
+  isSkippedExecutionStatus,
   PortHandles,
 } from "./nodeUtils";
 import "./agent-graph-animations.css";
@@ -22,6 +23,8 @@ const ExecutionNode = ({ data }) => {
   const { label, frontendNodeType, selected, nodeExecution, ports = [] } = data;
   const nodeStatus = nodeExecution?.status;
   const isPending = !nodeExecution;
+  const isSkipped = isSkippedExecutionStatus(nodeStatus);
+  const isDimmed = isPending || isSkipped;
   const isRunning = nodeStatus?.toLowerCase() === EXECUTION_STATUS.RUNNING;
 
   const config =
@@ -41,8 +44,11 @@ const ExecutionNode = ({ data }) => {
   const inputPorts = ports.filter((p) => p.direction === "input");
   const outputPorts = ports.filter((p) => p.direction === "output");
 
-  return (
-    <Box sx={{ position: "relative", opacity: isPending ? 0.4 : 1 }}>
+  const node = (
+    <Box
+      sx={{ position: "relative", opacity: isDimmed ? 0.4 : 1 }}
+      aria-label={isSkipped ? "Skipped" : undefined}
+    >
       <PortHandles ports={inputPorts} type="input" borderColor={borderColor} />
 
       {/* Node body */}
@@ -50,7 +56,7 @@ const ExecutionNode = ({ data }) => {
         sx={{
           minWidth: 200,
           borderRadius: 0.5,
-          borderStyle: isRunning ? "none" : "solid",
+          borderStyle: isRunning ? "none" : isSkipped ? "dashed" : "solid",
           borderWidth: isRunning ? 0 : "1px",
           borderColor,
           backgroundColor,
@@ -59,7 +65,7 @@ const ExecutionNode = ({ data }) => {
           px: isRunning ? "13px" : 1.5,
           display: "flex",
           alignItems: "center",
-          cursor: isPending ? "default" : "pointer",
+          cursor: isDimmed ? "default" : "pointer",
           overflow: "visible",
           ...(selected && {
             borderColor: "primary.main",
@@ -132,6 +138,26 @@ const ExecutionNode = ({ data }) => {
           >
             {label}
           </Typography>
+          {isSkipped && (
+            <Box
+              component="span"
+              sx={{
+                ml: "auto",
+                px: 0.5,
+                py: 0.15,
+                borderRadius: 0.5,
+                bgcolor: "error.main",
+                color: "#fff",
+                fontSize: 9,
+                fontWeight: 700,
+                letterSpacing: "0.04em",
+                lineHeight: 1.4,
+                flexShrink: 0,
+              }}
+            >
+              SKIPPED
+            </Box>
+          )}
         </Stack>
       </Box>
 
@@ -141,6 +167,14 @@ const ExecutionNode = ({ data }) => {
         borderColor={borderColor}
       />
     </Box>
+  );
+
+  if (!isSkipped) return node;
+
+  return (
+    <Tooltip title="Skipped" placement="top">
+      {node}
+    </Tooltip>
   );
 };
 

--- a/frontend/src/components/AgentGraph/__tests__/ExecutionNode.test.jsx
+++ b/frontend/src/components/AgentGraph/__tests__/ExecutionNode.test.jsx
@@ -32,6 +32,10 @@ const theme = createTheme({
     red: {
       50: "#ffebee",
       500: "#f44336",
+      700: "#d32f2f",
+    },
+    error: {
+      main: "#f44336",
     },
   },
 });
@@ -117,5 +121,25 @@ describe("ExecutionNode", () => {
   it("renders correctly with selected state", () => {
     renderNode({ selected: true, nodeExecution: { status: "success" } });
     expect(screen.getByText("Test Node")).toBeInTheDocument();
+  });
+
+  it("dims a skipped node like a never-run node and marks it SKIPPED", () => {
+    renderNode({
+      nodeExecution: { status: "skipped" },
+    });
+    const skipped = screen.getByLabelText("Skipped");
+    expect(skipped).toHaveStyle({ opacity: "0.4" });
+    expect(screen.getByText("SKIPPED")).toBeInTheDocument();
+  });
+
+  it("does not render the skipped mark on a never-run node", () => {
+    renderNode();
+    expect(screen.queryByText("SKIPPED")).not.toBeInTheDocument();
+    expect(screen.queryByLabelText("Skipped")).not.toBeInTheDocument();
+  });
+
+  it("exposes a Skipped hover title", async () => {
+    renderNode({ nodeExecution: { status: "skipped" } });
+    expect(screen.getByLabelText("Skipped")).toBeInTheDocument();
   });
 });

--- a/frontend/src/components/AgentGraph/__tests__/nodeUtils.test.js
+++ b/frontend/src/components/AgentGraph/__tests__/nodeUtils.test.js
@@ -1,0 +1,149 @@
+import { describe, it, expect } from "vitest";
+import { createTheme } from "@mui/material/styles";
+import { alpha } from "@mui/material";
+import { START_ID, END_ID } from "../layoutUtils";
+import {
+  getStatusBorderColor,
+  getStatusBackgroundColor,
+  isSkippedExecutionStatus,
+  isSelectableExecutionNode,
+} from "../nodeUtils";
+
+const defaultColor = { light: "#e0e0e0", dark: "#9e9e9e" };
+
+const lightTheme = createTheme({
+  palette: {
+    mode: "light",
+    green: { 50: "#e8f5e9", 500: "#4caf50" },
+    red: { 50: "#ffebee", 500: "#f44336", 700: "#d32f2f" },
+  },
+});
+
+const darkTheme = createTheme({
+  palette: {
+    mode: "dark",
+    green: { 50: "#e8f5e9", 500: "#4caf50" },
+    red: { 50: "#ffebee", 500: "#f44336", 700: "#d32f2f" },
+  },
+});
+
+describe("getStatusBorderColor", () => {
+  it("returns green for success and running", () => {
+    expect(
+      getStatusBorderColor("success", lightTheme, false, defaultColor),
+    ).toBe(lightTheme.palette.green[500]);
+    expect(
+      getStatusBorderColor("running", lightTheme, false, defaultColor),
+    ).toBe(lightTheme.palette.green[500]);
+  });
+
+  it("returns red for failed and error", () => {
+    expect(
+      getStatusBorderColor("failed", lightTheme, false, defaultColor),
+    ).toBe(lightTheme.palette.red[500]);
+    expect(getStatusBorderColor("error", lightTheme, false, defaultColor)).toBe(
+      lightTheme.palette.red[500],
+    );
+  });
+
+  it("returns red for skipped instead of the no-result default", () => {
+    expect(
+      getStatusBorderColor("skipped", lightTheme, false, defaultColor),
+    ).toBe(lightTheme.palette.red[500]);
+    expect(
+      getStatusBorderColor("SKIPPED", lightTheme, false, defaultColor),
+    ).toBe(lightTheme.palette.red[500]);
+    expect(getStatusBorderColor("skipped", darkTheme, true, defaultColor)).toBe(
+      darkTheme.palette.red[500],
+    );
+  });
+
+  it("returns the default grey when there is no result", () => {
+    expect(
+      getStatusBorderColor(undefined, lightTheme, false, defaultColor),
+    ).toBe(defaultColor.light);
+    expect(getStatusBorderColor(null, darkTheme, true, defaultColor)).toBe(
+      defaultColor.dark,
+    );
+  });
+});
+
+describe("getStatusBackgroundColor", () => {
+  it("returns a green tint for success", () => {
+    expect(getStatusBackgroundColor("success", lightTheme, false)).toBe(
+      lightTheme.palette.green[50],
+    );
+  });
+
+  it("returns a red tint for failed", () => {
+    expect(getStatusBackgroundColor("failed", lightTheme, false)).toBe(
+      lightTheme.palette.red[50],
+    );
+  });
+
+  it("returns a skipped red tint instead of the no-result default", () => {
+    expect(getStatusBackgroundColor("skipped", lightTheme, false)).toBe(
+      alpha(lightTheme.palette.red[500], 0.08),
+    );
+    expect(getStatusBackgroundColor("skipped", darkTheme, true)).toBe(
+      alpha(darkTheme.palette.red[500], 0.16),
+    );
+    expect(getStatusBackgroundColor(undefined, lightTheme, false)).toBeNull();
+  });
+});
+
+describe("isSkippedExecutionStatus", () => {
+  it("matches skipped case-insensitively", () => {
+    expect(isSkippedExecutionStatus("skipped")).toBe(true);
+    expect(isSkippedExecutionStatus("SKIPPED")).toBe(true);
+    expect(isSkippedExecutionStatus("success")).toBe(false);
+    expect(isSkippedExecutionStatus(undefined)).toBe(false);
+  });
+});
+
+describe("isSelectableExecutionNode", () => {
+  it("rejects start and end markers", () => {
+    expect(isSelectableExecutionNode({ id: START_ID })).toBe(false);
+    expect(isSelectableExecutionNode({ id: END_ID })).toBe(false);
+  });
+
+  it("rejects skipped nodes so they cannot open the empty panel", () => {
+    expect(
+      isSelectableExecutionNode({
+        id: "n1",
+        data: { nodeExecution: { status: "skipped" } },
+      }),
+    ).toBe(false);
+    expect(
+      isSelectableExecutionNode({
+        id: "n1",
+        node_execution: { status: "SKIPPED" },
+      }),
+    ).toBe(false);
+  });
+
+  it("allows success, failed, and running nodes", () => {
+    expect(
+      isSelectableExecutionNode({
+        id: "n1",
+        data: { nodeExecution: { status: "success" } },
+      }),
+    ).toBe(true);
+    expect(
+      isSelectableExecutionNode({
+        id: "n1",
+        data: { nodeExecution: { status: "failed" } },
+      }),
+    ).toBe(true);
+    expect(
+      isSelectableExecutionNode({
+        id: "n1",
+        data: { nodeExecution: { status: "running" } },
+      }),
+    ).toBe(true);
+  });
+
+  it("allows a never-run node at the click-helper layer (canvas still ignores it)", () => {
+    expect(isSelectableExecutionNode({ id: "n1", data: {} })).toBe(true);
+  });
+});

--- a/frontend/src/components/AgentGraph/nodeUtils.jsx
+++ b/frontend/src/components/AgentGraph/nodeUtils.jsx
@@ -3,6 +3,7 @@ import { Handle, Position } from "@xyflow/react";
 import { alpha, Typography } from "@mui/material";
 import PropTypes from "prop-types";
 import { EXECUTION_STATUS } from "src/sections/agent-playground/utils/workflowExecution";
+import { START_ID, END_ID } from "./layoutUtils";
 
 // eslint-disable-next-line react-refresh/only-export-components
 export const handleBaseStyle = {
@@ -28,6 +29,8 @@ export const getStatusBorderColor = (status, theme, isDark, defaultColor) => {
     case EXECUTION_STATUS.FAILED:
     case EXECUTION_STATUS.ERROR:
       return theme.palette.red[500];
+    case EXECUTION_STATUS.SKIPPED:
+      return theme.palette.red[500];
     default:
       return isDark ? defaultColor.dark : defaultColor.light;
   }
@@ -46,9 +49,31 @@ export const getStatusBackgroundColor = (status, theme, isDark) => {
       return isDark
         ? alpha(theme.palette.red[700], 0.3)
         : theme.palette.red[50];
+    case EXECUTION_STATUS.SKIPPED:
+      return isDark
+        ? alpha(theme.palette.red[500], 0.16)
+        : alpha(theme.palette.red[500], 0.08);
     default:
       return null;
   }
+};
+
+// eslint-disable-next-line react-refresh/only-export-components
+export const isSkippedExecutionStatus = (status) =>
+  status?.toLowerCase() === EXECUTION_STATUS.SKIPPED;
+
+/**
+ * Run-canvas nodes that should not open the detail panel.
+ * Start/end markers and skipped nodes are inert.
+ */
+// eslint-disable-next-line react-refresh/only-export-components
+export const isSelectableExecutionNode = (node) => {
+  if (!node || node.id === START_ID || node.id === END_ID) return false;
+  const status =
+    node.data?.nodeExecution?.status ||
+    node.nodeExecution?.status ||
+    node.node_execution?.status;
+  return !isSkippedExecutionStatus(status);
 };
 
 const PORT_LABEL_OFFSET = 14;

--- a/frontend/src/sections/agent-playground/AgentBuilder/RunAgentPanel/RunAgentPanel.jsx
+++ b/frontend/src/sections/agent-playground/AgentBuilder/RunAgentPanel/RunAgentPanel.jsx
@@ -2,7 +2,10 @@ import { Box } from "@mui/material";
 import React, { useCallback, useRef, useState, useEffect } from "react";
 import PropTypes from "prop-types";
 import { AgentGraph } from "src/components/AgentGraph";
-import { START_ID, END_ID } from "src/components/AgentGraph/layoutUtils";
+import {
+  isSelectableExecutionNode,
+  isSkippedExecutionStatus,
+} from "src/components/AgentGraph/nodeUtils";
 import useResolvedExecution from "../../hooks/useResolvedExecution";
 import { useWorkflowRunStoreShallow } from "../../store";
 import NodeOutputDetail from "./NodeOutputDetail";
@@ -34,9 +37,10 @@ export default function RunAgentPanel({
   useEffect(() => {
     if (!executionData?.nodes?.length || selectedNodeId) return;
 
-    const executedNodes = executionData.nodes.filter(
-      (n) => n.nodeExecution || n.node_execution,
-    );
+    const executedNodes = executionData.nodes.filter((n) => {
+      const exec = n.nodeExecution || n.node_execution;
+      return exec && !isSkippedExecutionStatus(exec.status);
+    });
     if (executedNodes.length === 0) return;
 
     if (isRunning) {
@@ -46,9 +50,10 @@ export default function RunAgentPanel({
       // On completion, select the last executed node
       const lastNode = executedNodes[executedNodes.length - 1];
       if (lastNode.subGraph?.nodes?.length) {
-        const executedInner = lastNode.subGraph.nodes.filter(
-          (n) => n.nodeExecution || n.node_execution,
-        );
+        const executedInner = lastNode.subGraph.nodes.filter((n) => {
+          const exec = n.nodeExecution || n.node_execution;
+          return exec && !isSkippedExecutionStatus(exec.status);
+        });
         if (executedInner.length > 0) {
           const lastInner = executedInner[executedInner.length - 1];
           setSelectedNodeId(`${lastNode.id}__${lastInner.id}`);
@@ -107,7 +112,7 @@ export default function RunAgentPanel({
   };
 
   const handleGraphNodeClick = useCallback((_event, node) => {
-    if (node.id === START_ID || node.id === END_ID) return;
+    if (!isSelectableExecutionNode(node)) return;
     setSelectedNodeId(node.id);
   }, []);
 

--- a/frontend/src/sections/agent-playground/Executions/ExecutionDetailView.jsx
+++ b/frontend/src/sections/agent-playground/Executions/ExecutionDetailView.jsx
@@ -3,7 +3,10 @@ import { Box, CircularProgress, Typography } from "@mui/material";
 import PropTypes from "prop-types";
 import { useQueryClient } from "@tanstack/react-query";
 import { AgentGraph } from "src/components/AgentGraph";
-import { START_ID, END_ID } from "src/components/AgentGraph/layoutUtils";
+import {
+  isSelectableExecutionNode,
+  isSkippedExecutionStatus,
+} from "src/components/AgentGraph/nodeUtils";
 import NodeOutputDetail from "../AgentBuilder/RunAgentPanel/NodeOutputDetail";
 import ResizablePanels from "src/components/resizablePanels/ResizablePanels";
 import { useGetExecutionDetail } from "src/api/agent-playground/agent-playground";
@@ -83,7 +86,10 @@ export default function ExecutionDetailView({ graphId, executionId }) {
       return;
     }
     // Find last node that has a node_execution (skip pending nodes)
-    const executedNodes = executionData.nodes.filter((n) => n.node_execution);
+    const executedNodes = executionData.nodes.filter(
+      (n) =>
+        n.node_execution && !isSkippedExecutionStatus(n.node_execution.status),
+    );
     if (executedNodes.length === 0) {
       setSelectedNodeId(null);
       return;
@@ -92,7 +98,9 @@ export default function ExecutionDetailView({ graphId, executionId }) {
     const lastNodeSubGraph = lastNode.sub_graph;
     if (lastNodeSubGraph?.nodes?.length) {
       const executedInner = lastNodeSubGraph.nodes.filter(
-        (n) => n.node_execution,
+        (n) =>
+          n.node_execution &&
+          !isSkippedExecutionStatus(n.node_execution.status),
       );
       if (executedInner.length > 0) {
         const lastInner = executedInner[executedInner.length - 1];
@@ -107,7 +115,7 @@ export default function ExecutionDetailView({ graphId, executionId }) {
     useResolvedExecution({ selectedNodeId, executionData, executionId });
 
   const handleGraphNodeClick = useCallback((_event, node) => {
-    if (node.id === START_ID || node.id === END_ID) return;
+    if (!isSelectableExecutionNode(node)) return;
     setSelectedNodeId(node.id);
   }, []);
 

--- a/frontend/src/sections/agent-playground/Executions/ExecutionsList.jsx
+++ b/frontend/src/sections/agent-playground/Executions/ExecutionsList.jsx
@@ -11,6 +11,7 @@ const STATUS_COLORS = {
   [EXECUTION_STATUS.PENDING]: "warning.main",
   [EXECUTION_STATUS.ERROR]: "error.main",
   [EXECUTION_STATUS.FAILED]: "error.main",
+  [EXECUTION_STATUS.SKIPPED]: "error.main",
 };
 
 const STATUS_LABELS = {
@@ -19,6 +20,7 @@ const STATUS_LABELS = {
   [EXECUTION_STATUS.PENDING]: "Pending",
   [EXECUTION_STATUS.ERROR]: "Error",
   [EXECUTION_STATUS.FAILED]: "Failed",
+  [EXECUTION_STATUS.SKIPPED]: "Skipped",
 };
 
 const ExecutionSkeleton = () => (
@@ -146,3 +148,5 @@ ExecutionsList.propTypes = {
 };
 
 export default ExecutionsList;
+
+export { STATUS_LABELS, STATUS_COLORS };

--- a/frontend/src/sections/agent-playground/Executions/__tests__/ExecutionsList.test.jsx
+++ b/frontend/src/sections/agent-playground/Executions/__tests__/ExecutionsList.test.jsx
@@ -1,0 +1,55 @@
+import React from "react";
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { ThemeProvider, createTheme } from "@mui/material/styles";
+import ExecutionsList, { STATUS_LABELS } from "../ExecutionsList";
+import { EXECUTION_STATUS } from "../../utils/workflowExecution";
+
+vi.mock("src/hooks/use-scroll-end", () => ({
+  useScrollEnd: () => ({ current: null }),
+}));
+
+const theme = createTheme();
+
+const renderList = (executions) =>
+  render(
+    <ThemeProvider theme={theme}>
+      <ExecutionsList
+        executions={executions}
+        selectedExecutionId={executions[0]?.id}
+        onExecutionChange={vi.fn()}
+      />
+    </ThemeProvider>,
+  );
+
+describe("ExecutionsList status labels", () => {
+  it("writes skipped the same way as the other outcomes", () => {
+    expect(STATUS_LABELS[EXECUTION_STATUS.SKIPPED]).toBe("Skipped");
+    expect(STATUS_LABELS[EXECUTION_STATUS.SUCCESS]).toBe("Success");
+    expect(STATUS_LABELS[EXECUTION_STATUS.FAILED]).toBe("Failed");
+    expect(STATUS_LABELS[EXECUTION_STATUS.RUNNING]).toBe("Running");
+  });
+
+  it("renders Skipped in the history list instead of raw lowercase status", () => {
+    renderList([
+      {
+        id: "ex-1",
+        status: "skipped",
+        startedAt: "2026-09-03T10:00:00.000Z",
+      },
+    ]);
+    expect(screen.getByText("Skipped")).toBeInTheDocument();
+    expect(screen.queryByText("skipped")).not.toBeInTheDocument();
+  });
+
+  it("still renders Success for a successful run", () => {
+    renderList([
+      {
+        id: "ex-2",
+        status: "success",
+        startedAt: "2026-09-03T10:00:00.000Z",
+      },
+    ]);
+    expect(screen.getByText("Success")).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- Skipped Agent Playground nodes no longer share the never-ran canvas colour, opacity, or empty panel.
- Canvas: dimmed + inert, dashed error border, SKIPPED mark (tracing skipped-path treatment), hover says Skipped.
- Click and auto-select ignore skipped nodes so the empty inspector does not open.
- Run history writes "Skipped" the same way as Success / Failed / Running.

## Test plan
- [ ] Agents → open agent → build tab. Run a workflow with a condition that takes one branch.
- [ ] Untaken-branch node is dimmed, shows SKIPPED, hover says Skipped, click does not open the panel.
- [ ] A node that never ran stays dim grey with no SKIPPED mark.
- [ ] Success / running / failed nodes look and behave as today.
- [ ] Run history list shows "Skipped" (not "skipped").

Fixes #2504.