### PR TITLE
feat(playground): show save changelog and definition diff (#2506)

### DIFF
--- a/frontend/src/sections/agent-playground/components/SaveAgentChangelogTab.jsx
+++ b/frontend/src/sections/agent-playground/components/SaveAgentChangelogTab.jsx
@@ -1,0 +1,140 @@
+import React from "react";
+import PropTypes from "prop-types";
+import { Box, Chip, Stack, Typography } from "@mui/material";
+import SvgColor from "src/components/svg-color";
+import { fToNow } from "src/utils/format-time";
+import { NODE_TYPE_CONFIG, NODE_TYPES } from "../utils/constants";
+import { CHANGE_STATUS, CHANGE_STATUS_LABEL } from "../utils/saveAgentDiff";
+
+const STATUS_SX = {
+  [CHANGE_STATUS.CREATED]: {
+    color: "success.dark",
+    bgcolor: "success.lighter",
+  },
+  [CHANGE_STATUS.UPDATED]: {
+    color: "info.dark",
+    bgcolor: "info.lighter",
+  },
+  [CHANGE_STATUS.DELETED]: {
+    color: "error.dark",
+    bgcolor: "error.lighter",
+  },
+  [CHANGE_STATUS.REROUTED]: {
+    color: "primary.dark",
+    bgcolor: "primary.lighter",
+  },
+  [CHANGE_STATUS.UNCHANGED]: {
+    color: "text.secondary",
+    bgcolor: "action.hover",
+  },
+};
+
+function nodeIconSrc(type) {
+  if (type === NODE_TYPES.AGENT || type === "subgraph") {
+    return NODE_TYPE_CONFIG[NODE_TYPES.AGENT].iconSrc;
+  }
+  return NODE_TYPE_CONFIG[NODE_TYPES.LLM_PROMPT].iconSrc;
+}
+
+export default function SaveAgentChangelogTab({ entries = [] }) {
+  if (entries.length === 0) {
+    return (
+      <Typography
+        variant="body2"
+        color="text.secondary"
+        data-testid="save-changelog-empty"
+      >
+        Nothing to compare yet. This save will create the first version.
+      </Typography>
+    );
+  }
+
+  return (
+    <Stack
+      spacing={1.5}
+      data-testid="save-changelog-list"
+      sx={{ maxHeight: 320, overflowY: "auto", pr: 0.5 }}
+    >
+      {entries.map((entry) => {
+        const statusSx =
+          STATUS_SX[entry.status] || STATUS_SX[CHANGE_STATUS.UNCHANGED];
+        const timeLabel = entry.occurredAt ? fToNow(entry.occurredAt) : "";
+        return (
+          <Stack
+            key={`${entry.status}-${entry.id || entry.name}`}
+            direction="row"
+            spacing={1.5}
+            alignItems="flex-start"
+            data-testid={`save-changelog-row-${entry.name}`}
+            data-status={entry.status}
+          >
+            <Box
+              sx={{
+                width: 32,
+                height: 32,
+                borderRadius: 1,
+                bgcolor: "action.hover",
+                display: "flex",
+                alignItems: "center",
+                justifyContent: "center",
+                flexShrink: 0,
+              }}
+            >
+              <SvgColor
+                src={nodeIconSrc(entry.type)}
+                sx={{ width: 18, height: 18 }}
+              />
+            </Box>
+            <Box sx={{ flex: 1, minWidth: 0 }}>
+              <Stack
+                direction="row"
+                spacing={1}
+                alignItems="center"
+                flexWrap="wrap"
+              >
+                <Typography variant="subtitle2" noWrap>
+                  {entry.name}
+                </Typography>
+                <Chip
+                  size="small"
+                  label={CHANGE_STATUS_LABEL[entry.status] || entry.status}
+                  data-testid={`save-changelog-badge-${entry.name}`}
+                  sx={{
+                    height: 20,
+                    fontSize: 11,
+                    fontWeight: 600,
+                    ...statusSx,
+                    "& .MuiChip-label": { px: 0.75 },
+                  }}
+                />
+                {timeLabel ? (
+                  <Typography variant="caption" color="text.secondary">
+                    {timeLabel}
+                  </Typography>
+                ) : null}
+              </Stack>
+              {entry.description ? (
+                <Typography variant="caption" color="text.secondary">
+                  {entry.description}
+                </Typography>
+              ) : null}
+            </Box>
+          </Stack>
+        );
+      })}
+    </Stack>
+  );
+}
+
+SaveAgentChangelogTab.propTypes = {
+  entries: PropTypes.arrayOf(
+    PropTypes.shape({
+      id: PropTypes.string,
+      name: PropTypes.string.isRequired,
+      type: PropTypes.string,
+      status: PropTypes.string.isRequired,
+      description: PropTypes.string,
+      occurredAt: PropTypes.string,
+    }),
+  ),
+};

--- a/frontend/src/sections/agent-playground/components/SaveAgentCodeTab.jsx
+++ b/frontend/src/sections/agent-playground/components/SaveAgentCodeTab.jsx
@@ -1,0 +1,268 @@
+import React, { useCallback } from "react";
+import PropTypes from "prop-types";
+import { Box, IconButton, Stack, Typography } from "@mui/material";
+import Iconify from "src/components/iconify";
+import { enqueueSnackbar } from "notistack";
+
+const LINE_BG = {
+  added: "rgba(34, 154, 22, 0.12)",
+  removed: "rgba(183, 33, 54, 0.12)",
+  unchanged: "transparent",
+  filler: "transparent",
+};
+
+function DiffPane({ title, lines, testId }) {
+  return (
+    <Box
+      data-testid={testId}
+      sx={{
+        flex: 1,
+        minWidth: 0,
+        border: "1px solid",
+        borderColor: "divider",
+        borderRadius: 1,
+        overflow: "hidden",
+        display: "flex",
+        flexDirection: "column",
+      }}
+    >
+      <Typography
+        variant="caption"
+        sx={{
+          px: 1.5,
+          py: 0.75,
+          bgcolor: "action.hover",
+          borderBottom: "1px solid",
+          borderColor: "divider",
+          fontWeight: 600,
+        }}
+      >
+        {title}
+      </Typography>
+      <Box
+        component="pre"
+        sx={{
+          m: 0,
+          p: 0,
+          flex: 1,
+          overflow: "auto",
+          fontFamily: "ui-monospace, SFMono-Regular, Menlo, monospace",
+          fontSize: 11,
+          lineHeight: 1.6,
+          maxHeight: 260,
+        }}
+      >
+        {(lines || []).map((line, index) => (
+          <Box
+            // aligned rows: index is stable across left/right
+            // eslint-disable-next-line react/no-array-index-key
+            key={`${line.lineNumber ?? "g"}-${index}`}
+            sx={{
+              display: "flex",
+              bgcolor: LINE_BG[line.type] || "transparent",
+              px: 1,
+            }}
+          >
+            <Box
+              component="span"
+              sx={{
+                width: 32,
+                flexShrink: 0,
+                color: "text.disabled",
+                textAlign: "right",
+                pr: 1,
+                userSelect: "none",
+              }}
+            >
+              {line.lineNumber ?? ""}
+            </Box>
+            <Box component="span" sx={{ whiteSpace: "pre" }}>
+              {line.text || " "}
+            </Box>
+          </Box>
+        ))}
+      </Box>
+    </Box>
+  );
+}
+
+DiffPane.propTypes = {
+  title: PropTypes.string.isRequired,
+  lines: PropTypes.arrayOf(
+    PropTypes.shape({
+      text: PropTypes.string,
+      type: PropTypes.string,
+      lineNumber: PropTypes.number,
+    }),
+  ),
+  testId: PropTypes.string,
+};
+
+export default function SaveAgentCodeTab({
+  fileName,
+  currentJson = "",
+  aligned = { left: [], right: [] },
+  totals = { added: 0, removed: 0 },
+  perNode = [],
+  hasBaseline = false,
+}) {
+  const handleCopy = useCallback(async () => {
+    try {
+      await navigator.clipboard.writeText(currentJson);
+      enqueueSnackbar("Definition copied", { variant: "success" });
+    } catch (error) {
+      enqueueSnackbar("Could not copy definition", { variant: "error" });
+    }
+  }, [currentJson]);
+
+  const handleDownload = useCallback(() => {
+    const blob = new Blob([currentJson], { type: "application/json" });
+    const url = URL.createObjectURL(blob);
+    const link = document.createElement("a");
+    link.href = url;
+    link.download = fileName || "untitled-agent.json";
+    document.body.appendChild(link);
+    link.click();
+    link.remove();
+    URL.revokeObjectURL(url);
+  }, [currentJson, fileName]);
+
+  return (
+    <Stack spacing={1.5} data-testid="save-code-tab">
+      <Stack direction="row" alignItems="center" spacing={0.5}>
+        <Typography
+          variant="body2"
+          fontWeight={600}
+          data-testid="save-code-filename"
+        >
+          {fileName}
+        </Typography>
+        <IconButton
+          size="small"
+          aria-label="Copy definition"
+          onClick={handleCopy}
+          data-testid="save-code-copy"
+        >
+          <Iconify icon="solar:copy-bold" width={16} />
+        </IconButton>
+        <IconButton
+          size="small"
+          aria-label="Download definition"
+          onClick={handleDownload}
+          data-testid="save-code-download"
+        >
+          <Iconify icon="solar:download-minimalistic-bold" width={16} />
+        </IconButton>
+      </Stack>
+
+      {!hasBaseline ? (
+        <Typography
+          variant="body2"
+          color="text.secondary"
+          data-testid="save-code-empty"
+        >
+          Nothing to compare yet. The current draft is shown on the right.
+        </Typography>
+      ) : null}
+
+      <Stack direction="row" spacing={1} alignItems="stretch">
+        <DiffPane
+          title="Original definition"
+          lines={aligned.left}
+          testId="save-code-original"
+        />
+        <DiffPane
+          title="Modified"
+          lines={aligned.right}
+          testId="save-code-modified"
+        />
+        <Stack
+          spacing={1}
+          sx={{ width: 160, flexShrink: 0 }}
+          data-testid="save-code-summary"
+        >
+          <Box
+            sx={{
+              p: 1.25,
+              borderRadius: 1,
+              bgcolor: "rgba(34, 154, 22, 0.12)",
+              color: "success.dark",
+            }}
+          >
+            <Typography variant="subtitle2" data-testid="save-code-added-total">
+              +{totals.added} lines
+            </Typography>
+          </Box>
+          <Box
+            sx={{
+              p: 1.25,
+              borderRadius: 1,
+              bgcolor: "rgba(183, 33, 54, 0.12)",
+              color: "error.dark",
+            }}
+          >
+            <Typography
+              variant="subtitle2"
+              data-testid="save-code-removed-total"
+            >
+              -{totals.removed} lines
+            </Typography>
+          </Box>
+          <Stack spacing={0.75} sx={{ maxHeight: 180, overflowY: "auto" }}>
+            {perNode.map((node) => (
+              <Stack
+                key={node.name}
+                direction="row"
+                justifyContent="space-between"
+                data-testid={`save-code-node-stats-${node.name}`}
+              >
+                <Typography variant="caption" noWrap sx={{ maxWidth: 90 }}>
+                  {node.name}
+                </Typography>
+                <Typography variant="caption">
+                  {node.added ? (
+                    <Box component="span" sx={{ color: "success.dark" }}>
+                      +{node.added}
+                    </Box>
+                  ) : null}
+                  {node.added && node.removed ? " " : null}
+                  {node.removed ? (
+                    <Box component="span" sx={{ color: "error.dark" }}>
+                      -{node.removed}
+                    </Box>
+                  ) : null}
+                  {!node.added && !node.removed ? (
+                    <Box component="span" sx={{ color: "text.disabled" }}>
+                      0
+                    </Box>
+                  ) : null}
+                </Typography>
+              </Stack>
+            ))}
+          </Stack>
+        </Stack>
+      </Stack>
+    </Stack>
+  );
+}
+
+SaveAgentCodeTab.propTypes = {
+  fileName: PropTypes.string,
+  currentJson: PropTypes.string,
+  aligned: PropTypes.shape({
+    left: PropTypes.array,
+    right: PropTypes.array,
+  }),
+  totals: PropTypes.shape({
+    added: PropTypes.number,
+    removed: PropTypes.number,
+  }),
+  perNode: PropTypes.arrayOf(
+    PropTypes.shape({
+      name: PropTypes.string.isRequired,
+      added: PropTypes.number,
+      removed: PropTypes.number,
+    }),
+  ),
+  hasBaseline: PropTypes.bool,
+};

--- a/frontend/src/sections/agent-playground/components/SaveAgentDialog.jsx
+++ b/frontend/src/sections/agent-playground/components/SaveAgentDialog.jsx
@@ -1,19 +1,33 @@
-import React, { useEffect } from "react";
+import React, { useEffect, useMemo, useState } from "react";
 import ModalWrapper from "../../../components/ModalWrapper/ModalWrapper";
 import { useAgentPlaygroundStoreShallow } from "../store";
 import { z } from "zod";
 import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import FormTextFieldV2 from "src/components/FormTextField/FormTextFieldV2";
-import { Stack } from "@mui/material";
+import { Box, CircularProgress, Stack, Tab, Tabs } from "@mui/material";
+import Iconify from "src/components/iconify";
 import { useQueryClient } from "@tanstack/react-query";
-import { useSaveDraftVersion } from "src/api/agent-playground/agent-playground";
+import {
+  useSaveDraftVersion,
+  useGetGraphVersions,
+  useGetVersionDetail,
+} from "src/api/agent-playground/agent-playground";
 import { enqueueSnackbar } from "notistack";
 import { buildVersionPayload } from "../utils/versionPayloadUtils";
 import { VERSION_STATUS } from "../utils/constants";
 import { validateGraphForSave } from "../utils/workflowValidation";
 import useWorkflowExecution from "../hooks/useWorkflowExecution";
 import useCanEditAgent from "../hooks/useCanEditAgent";
+import SaveAgentChangelogTab from "./SaveAgentChangelogTab";
+import SaveAgentCodeTab from "./SaveAgentCodeTab";
+import {
+  buildAgentDefinitionFileName,
+  classifySaveChanges,
+  flattenGraphVersions,
+  pickBaselineVersion,
+  toGraphSnapshot,
+} from "../utils/saveAgentDiff";
 
 const formSchema = z.object({
   versionName: z.string().min(1, "Version name is required"),
@@ -48,6 +62,7 @@ export default function SaveAgentDialog() {
   }));
   const { runWorkflow } = useWorkflowExecution();
   const { canEditAgent } = useCanEditAgent();
+  const [activeTab, setActiveTab] = useState("changelog");
   const form = useForm({
     resolver: zodResolver(formSchema),
     defaultValues: {
@@ -71,7 +86,61 @@ export default function SaveAgentDialog() {
     });
   }, [currentAgent, reset]);
 
+  useEffect(() => {
+    if (openSaveAgentDialog) {
+      setActiveTab("changelog");
+    }
+  }, [openSaveAgentDialog]);
+
   const queryClient = useQueryClient();
+
+  const { data: versionsData, isLoading: isVersionsLoading } =
+    useGetGraphVersions(currentAgent?.id, {
+      enabled: openSaveAgentDialog && !!currentAgent?.id,
+    });
+
+  const versions = useMemo(
+    () => flattenGraphVersions(versionsData),
+    [versionsData],
+  );
+
+  const baseline = useMemo(
+    () => pickBaselineVersion(versions, currentAgent),
+    [versions, currentAgent],
+  );
+
+  const { data: baselineDetail, isLoading: isBaselineLoading } =
+    useGetVersionDetail(currentAgent?.id, baseline?.id, {
+      enabled: openSaveAgentDialog && !!currentAgent?.id && !!baseline?.id,
+    });
+
+  const currentVersionMeta = useMemo(
+    () => versions.find((version) => version.id === currentAgent?.version_id),
+    [versions, currentAgent?.version_id],
+  );
+
+  const saveDiff = useMemo(() => {
+    const currentSnapshot = toGraphSnapshot(buildVersionPayload(nodes, edges));
+    const previousSnapshot = baselineDetail
+      ? toGraphSnapshot(baselineDetail)
+      : { nodes: [], connections: [] };
+    return classifySaveChanges({
+      previousSnapshot,
+      currentSnapshot,
+      occurredAt: {
+        previous: baseline?.updated_at || baseline?.created_at || null,
+        current:
+          currentVersionMeta?.updated_at ||
+          currentVersionMeta?.created_at ||
+          null,
+      },
+    });
+  }, [nodes, edges, baselineDetail, baseline, currentVersionMeta]);
+
+  const fileName = buildAgentDefinitionFileName(currentAgent?.name);
+  const isDiffLoading =
+    openSaveAgentDialog &&
+    (isVersionsLoading || (!!baseline?.id && isBaselineLoading));
 
   const { mutate: saveAgent, isPending: isSavingAgent } = useSaveDraftVersion({
     onSuccess: (data) => {
@@ -168,6 +237,10 @@ export default function SaveAgentDialog() {
     });
   };
 
+  const agentTitle = currentAgent?.name
+    ? `Save ${currentAgent.name} agent`
+    : "Save Agent";
+
   return (
     <ModalWrapper
       open={openSaveAgentDialog}
@@ -175,9 +248,9 @@ export default function SaveAgentDialog() {
         setPendingRunAfterSave(false);
         setOpenSaveAgentDialog(false);
       }}
-      title="Save Agent"
-      subTitle="Save the agent with commit"
-      actionBtnTitle={pendingRunAfterSave ? "Save & Run" : "Save"}
+      title={agentTitle}
+      subTitle="Review the details below, and save the agent."
+      actionBtnTitle={pendingRunAfterSave ? "Save & Run" : "Save agent"}
       actionBtnProps={{
         size: "small",
         onClick: handleSaveAgent,
@@ -193,6 +266,7 @@ export default function SaveAgentDialog() {
       }}
       isValid={isValid}
       isLoading={isSavingAgent}
+      modalWidth="920px"
     >
       <form noValidate onSubmit={handleSubmit(handleSaveAgent)}>
         <Stack direction="column" gap={2}>
@@ -206,13 +280,60 @@ export default function SaveAgentDialog() {
             disabled
           />
           <FormTextFieldV2
-            label="Commit Message"
+            label="Commit message"
             fieldName="commitMessage"
             control={control}
             size="small"
             fullWidth
             disabled={isSavingAgent}
           />
+          <Tabs
+            value={activeTab}
+            onChange={(_event, value) => setActiveTab(value)}
+            textColor="primary"
+            data-testid="save-agent-diff-tabs"
+            sx={{ minHeight: 36, borderBottom: 1, borderColor: "divider" }}
+          >
+            <Tab
+              value="changelog"
+              label="Changelog"
+              icon={<Iconify icon="solar:document-text-bold" width={16} />}
+              iconPosition="start"
+              data-testid="save-agent-tab-changelog"
+              sx={{ minHeight: 36, textTransform: "none" }}
+            />
+            <Tab
+              value="code"
+              label="Code"
+              icon={<Iconify icon="solar:code-bold" width={16} />}
+              iconPosition="start"
+              data-testid="save-agent-tab-code"
+              sx={{ minHeight: 36, textTransform: "none" }}
+            />
+          </Tabs>
+          <Box sx={{ minHeight: 220 }}>
+            {isDiffLoading ? (
+              <Stack
+                alignItems="center"
+                justifyContent="center"
+                sx={{ py: 6 }}
+                data-testid="save-agent-diff-loading"
+              >
+                <CircularProgress size={24} />
+              </Stack>
+            ) : activeTab === "changelog" ? (
+              <SaveAgentChangelogTab entries={saveDiff.entries} />
+            ) : (
+              <SaveAgentCodeTab
+                fileName={fileName}
+                currentJson={saveDiff.currentJson}
+                aligned={saveDiff.aligned}
+                totals={saveDiff.totals}
+                perNode={saveDiff.perNode}
+                hasBaseline={saveDiff.hasBaseline}
+              />
+            )}
+          </Box>
         </Stack>
         {/* Hidden submit button to enable Enter key submission */}
         <button type="submit" style={{ display: "none" }} />

--- a/frontend/src/sections/agent-playground/components/SaveAgentDialog.jsx
+++ b/frontend/src/sections/agent-playground/components/SaveAgentDialog.jsx
@@ -26,7 +26,7 @@ import {
   classifySaveChanges,
   flattenGraphVersions,
   pickBaselineVersion,
-  toGraphSnapshot,
+  toComparableSnapshot,
 } from "../utils/saveAgentDiff";
 
 const formSchema = z.object({
@@ -120,9 +120,9 @@ export default function SaveAgentDialog() {
   );
 
   const saveDiff = useMemo(() => {
-    const currentSnapshot = toGraphSnapshot(buildVersionPayload(nodes, edges));
+    const currentSnapshot = toComparableSnapshot({ nodes, edges });
     const previousSnapshot = baselineDetail
-      ? toGraphSnapshot(baselineDetail)
+      ? toComparableSnapshot(baselineDetail)
       : { nodes: [], connections: [] };
     return classifySaveChanges({
       previousSnapshot,

--- a/frontend/src/sections/agent-playground/components/__tests__/SaveAgentDialog.test.jsx
+++ b/frontend/src/sections/agent-playground/components/__tests__/SaveAgentDialog.test.jsx
@@ -1,0 +1,331 @@
+/* eslint-disable react/prop-types */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { ThemeProvider, createTheme } from "@mui/material/styles";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import SaveAgentDialog from "../SaveAgentDialog";
+import { useAgentPlaygroundStore } from "../../store";
+import { NODE_TYPES } from "../../utils/constants";
+
+const mockSaveAgent = vi.fn();
+let mockVersionsData = null;
+let mockBaselineDetail = null;
+let mockVersionsLoading = false;
+let mockBaselineLoading = false;
+
+vi.mock("src/api/agent-playground/agent-playground", () => ({
+  useSaveDraftVersion: (options = {}) => ({
+    mutate: (vars) => {
+      mockSaveAgent(vars);
+      options.onSuccess?.({
+        data: {
+          result: {
+            id: "v-saved",
+            version_number: 2,
+            nodes: [],
+            node_connections: [],
+          },
+        },
+      });
+    },
+    isPending: false,
+  }),
+  useGetGraphVersions: () => ({
+    data: mockVersionsData,
+    isLoading: mockVersionsLoading,
+  }),
+  useGetVersionDetail: () => ({
+    data: mockBaselineDetail,
+    isLoading: mockBaselineLoading,
+  }),
+}));
+
+vi.mock("../../hooks/useCanEditAgent", () => ({
+  default: () => ({ canEditAgent: true, isReadOnly: false }),
+}));
+
+const mockRunWorkflow = vi.fn();
+vi.mock("../../hooks/useWorkflowExecution", () => ({
+  default: () => ({ runWorkflow: mockRunWorkflow }),
+}));
+
+vi.mock("../../utils/workflowValidation", () => ({
+  validateGraphForSave: vi.fn(() => ({
+    valid: true,
+    invalidNodeIds: [],
+    hasCycle: false,
+    errors: [],
+  })),
+}));
+
+vi.mock("notistack", () => ({
+  enqueueSnackbar: vi.fn(),
+}));
+
+vi.mock("src/components/svg-color", () => ({
+  default: () => <span data-testid="svg-icon" />,
+}));
+
+vi.mock("src/components/iconify", () => ({
+  default: (props) => (
+    <span data-testid="iconify-icon" data-icon={props.icon} />
+  ),
+}));
+
+vi.mock("src/components/FormTextField/FormTextFieldV2", () => ({
+  default: ({ label, fieldName, disabled }) => (
+    <label>
+      {label}
+      <input aria-label={label} name={fieldName} disabled={disabled} />
+    </label>
+  ),
+}));
+
+const theme = createTheme();
+
+function renderDialog() {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={client}>
+      <ThemeProvider theme={theme}>
+        <SaveAgentDialog />
+      </ThemeProvider>
+    </QueryClientProvider>,
+  );
+}
+
+function seedAgent({ isDraft = true } = {}) {
+  useAgentPlaygroundStore.setState({
+    openSaveAgentDialog: true,
+    currentAgent: {
+      id: "graph-1",
+      name: "Untitled_1",
+      version_id: "draft-1",
+      version_name: "Version 2",
+      is_draft: isDraft,
+    },
+    nodes: [
+      {
+        id: "n-prompt",
+        type: NODE_TYPES.LLM_PROMPT,
+        position: { x: 0, y: 0 },
+        data: {
+          label: "Prompt node",
+          node_template_id: "tpl-prompt",
+          config: {
+            modelConfig: {
+              model: "gpt-4",
+              modelDetail: {
+                modelName: "GPT-4",
+                logoUrl: "",
+                providers: "openai",
+                isAvailable: true,
+              },
+              responseFormat: "text",
+              toolChoice: "auto",
+              tools: [],
+            },
+            messages: [
+              {
+                id: "msg-0",
+                role: "system",
+                content: [{ type: "text", text: "new instructions" }],
+              },
+            ],
+          },
+        },
+      },
+      {
+        id: "n-research",
+        type: NODE_TYPES.AGENT,
+        position: { x: 400, y: 0 },
+        data: {
+          label: "Research Agent",
+          ref_graph_version_id: "ref-1",
+          config: { payload: { inputMappings: [] } },
+          ports: [],
+        },
+      },
+    ],
+    edges: [{ id: "e1", source: "n-prompt", target: "n-research" }],
+  });
+}
+
+describe("SaveAgentDialog changelog", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    useAgentPlaygroundStore.getState().reset();
+    mockSaveAgent.mockClear();
+    mockVersionsLoading = false;
+    mockBaselineLoading = false;
+    mockVersionsData = {
+      pages: [
+        {
+          data: {
+            result: {
+              versions: [
+                {
+                  id: "draft-1",
+                  status: "draft",
+                  created_at: "2026-09-04T00:00:00Z",
+                },
+                {
+                  id: "active-1",
+                  status: "active",
+                  created_at: "2026-09-03T00:00:00Z",
+                },
+              ],
+            },
+          },
+        },
+      ],
+    };
+    mockBaselineDetail = {
+      id: "active-1",
+      nodes: [
+        {
+          id: "old-prompt",
+          name: "Prompt node",
+          type: "atomic",
+          prompt_template: {
+            model: "gpt-4",
+            messages: [{ role: "system", content: "old instructions" }],
+          },
+        },
+        {
+          id: "old-research",
+          name: "Research Agent",
+          type: "subgraph",
+          ref_graph_version_id: "ref-1",
+        },
+        {
+          id: "old-output",
+          name: "Output node",
+          type: "atomic",
+          prompt_template: { model: "gpt-4", messages: [] },
+        },
+      ],
+      node_connections: [
+        { source_node_id: "old-prompt", target_node_id: "old-research" },
+      ],
+    };
+    seedAgent();
+  });
+
+  it("shows changelog and code tabs under the commit field", () => {
+    renderDialog();
+    expect(screen.getByTestId("save-agent-diff-tabs")).toBeInTheDocument();
+    expect(screen.getByTestId("save-agent-tab-changelog")).toBeInTheDocument();
+    expect(screen.getByTestId("save-agent-tab-code")).toBeInTheDocument();
+    expect(screen.getByLabelText("Commit message")).toBeInTheDocument();
+  });
+
+  it("lists created, updated, deleted, and unchanged nodes", () => {
+    renderDialog();
+    expect(
+      screen.getByTestId("save-changelog-badge-Prompt node"),
+    ).toHaveTextContent("Updated");
+    expect(
+      screen.getByTestId("save-changelog-badge-Research Agent"),
+    ).toHaveTextContent("No changes");
+    expect(
+      screen.getByTestId("save-changelog-badge-Output node"),
+    ).toHaveTextContent("Deleted");
+  });
+
+  it("keeps unchanged nodes visible", () => {
+    renderDialog();
+    expect(
+      screen.getByTestId("save-changelog-row-Research Agent"),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByTestId("save-changelog-badge-Research Agent"),
+    ).toHaveTextContent("No changes");
+  });
+
+  it("switches to the code tab with copy, download, and line totals", () => {
+    renderDialog();
+    fireEvent.click(screen.getByTestId("save-agent-tab-code"));
+    expect(screen.getByTestId("save-code-tab")).toBeInTheDocument();
+    expect(screen.getByTestId("save-code-filename")).toHaveTextContent(
+      "untitled-1-agent.json",
+    );
+    expect(screen.getByTestId("save-code-copy")).toBeInTheDocument();
+    expect(screen.getByTestId("save-code-download")).toBeInTheDocument();
+    expect(screen.getByTestId("save-code-added-total").textContent).toMatch(
+      /^\+\d+ lines$/,
+    );
+    expect(screen.getByTestId("save-code-removed-total").textContent).toMatch(
+      /^-\d+ lines$/,
+    );
+    expect(screen.getByTestId("save-code-original")).toBeInTheDocument();
+    expect(screen.getByTestId("save-code-modified")).toBeInTheDocument();
+  });
+
+  it("does not break when there is no previous version", () => {
+    mockVersionsData = {
+      pages: [
+        {
+          data: {
+            result: {
+              versions: [{ id: "draft-1", status: "draft" }],
+            },
+          },
+        },
+      ],
+    };
+    mockBaselineDetail = null;
+    renderDialog();
+    expect(screen.getByTestId("save-changelog-list")).toBeInTheDocument();
+    expect(
+      screen.getByTestId("save-changelog-badge-Prompt node"),
+    ).toHaveTextContent("Created");
+    fireEvent.click(screen.getByTestId("save-agent-tab-code"));
+    expect(screen.getByTestId("save-code-empty")).toBeInTheDocument();
+  });
+
+  it("saves a draft with the same payload shape as before", async () => {
+    renderDialog();
+    fireEvent.submit(document.querySelector("form"));
+    await waitFor(() => expect(mockSaveAgent).toHaveBeenCalled());
+    expect(mockSaveAgent.mock.calls[0][0]).toEqual({
+      graphId: "graph-1",
+      versionId: "draft-1",
+      payload: { status: "active" },
+    });
+  });
+
+  it("copies the current definition JSON", async () => {
+    const writeText = vi.fn().mockResolvedValue();
+    Object.assign(navigator, { clipboard: { writeText } });
+    renderDialog();
+    fireEvent.click(screen.getByTestId("save-agent-tab-code"));
+    fireEvent.click(screen.getByTestId("save-code-copy"));
+    await waitFor(() => expect(writeText).toHaveBeenCalled());
+    expect(writeText.mock.calls[0][0]).toContain("Prompt node");
+  });
+
+  it("downloads the current definition JSON", () => {
+    const createObjectURL = vi.fn(() => "blob:mock");
+    const revokeObjectURL = vi.fn();
+    globalThis.URL.createObjectURL = createObjectURL;
+    globalThis.URL.revokeObjectURL = revokeObjectURL;
+    const click = vi.fn();
+    const originalCreate = document.createElement.bind(document);
+    vi.spyOn(document, "createElement").mockImplementation((tag) => {
+      const el = originalCreate(tag);
+      if (tag === "a") {
+        el.click = click;
+      }
+      return el;
+    });
+
+    renderDialog();
+    fireEvent.click(screen.getByTestId("save-agent-tab-code"));
+    fireEvent.click(screen.getByTestId("save-code-download"));
+    expect(createObjectURL).toHaveBeenCalled();
+    expect(click).toHaveBeenCalled();
+  });
+});

--- a/frontend/src/sections/agent-playground/utils/__tests__/saveAgentDiff.test.js
+++ b/frontend/src/sections/agent-playground/utils/__tests__/saveAgentDiff.test.js
@@ -1,0 +1,234 @@
+import { describe, it, expect } from "vitest";
+import {
+  CHANGE_STATUS,
+  buildAgentDefinitionFileName,
+  buildDefinitionDocument,
+  classifySaveChanges,
+  countLineChanges,
+  definitionToJson,
+  flattenGraphVersions,
+  pairNodesByName,
+  pickBaselineVersion,
+} from "../saveAgentDiff";
+import { VERSION_STATUS } from "../constants";
+
+function node(id, name, extra = {}) {
+  return {
+    id,
+    name,
+    type: extra.type || "atomic",
+    prompt_template: extra.prompt_template || {
+      model: "gpt-4",
+      messages: [{ role: "system", content: extra.prompt || "hello" }],
+    },
+  };
+}
+
+function snapshot(nodes, connections = []) {
+  return { nodes, connections };
+}
+
+describe("pairNodesByName", () => {
+  it("pairs remapped UUIDs by name", () => {
+    const { pairs, created, deleted } = pairNodesByName(
+      [node("old-1", "Prompt node")],
+      [node("new-99", "Prompt node")],
+    );
+    expect(pairs).toHaveLength(1);
+    expect(pairs[0].previous.id).toBe("old-1");
+    expect(pairs[0].current.id).toBe("new-99");
+    expect(created).toHaveLength(0);
+    expect(deleted).toHaveLength(0);
+  });
+});
+
+describe("classifySaveChanges", () => {
+  it("marks created, updated, deleted, rerouted, and unchanged", () => {
+    const previous = snapshot(
+      [
+        node("a", "Prompt node", { prompt: "old instructions" }),
+        node("b", "Research Agent"),
+        node("c", "Conditional node"),
+        node("d", "Output node"),
+        node("idle", "Idle node"),
+      ],
+      [
+        { source_node_id: "a", target_node_id: "b" },
+        { source_node_id: "b", target_node_id: "d" },
+      ],
+    );
+    const current = snapshot(
+      [
+        node("a2", "Prompt node", { prompt: "new instructions" }),
+        node("b2", "Research Agent"),
+        node("d2", "Output node"),
+        node("e", "Custom code"),
+        node("idle2", "Idle node"),
+      ],
+      [
+        { source_node_id: "a2", target_node_id: "e" },
+        { source_node_id: "e", target_node_id: "d2" },
+      ],
+    );
+
+    const result = classifySaveChanges({
+      previousSnapshot: previous,
+      currentSnapshot: current,
+    });
+    const byName = Object.fromEntries(
+      result.entries.map((entry) => [entry.name, entry]),
+    );
+
+    expect(byName["Prompt node"].status).toBe(CHANGE_STATUS.UPDATED);
+    expect(byName["Prompt node"].description).toMatch(/prompt/i);
+    expect(byName["Research Agent"].status).toBe(CHANGE_STATUS.REROUTED);
+    expect(byName["Conditional node"].status).toBe(CHANGE_STATUS.DELETED);
+    expect(byName["Custom code"].status).toBe(CHANGE_STATUS.CREATED);
+    expect(byName["Output node"].status).toBe(CHANGE_STATUS.REROUTED);
+    expect(byName["Idle node"].status).toBe(CHANGE_STATUS.UNCHANGED);
+    expect(result.entries.map((entry) => entry.name)).toContain("Idle node");
+  });
+
+  it("treats first save with no previous version as all created", () => {
+    const result = classifySaveChanges({
+      previousSnapshot: snapshot([]),
+      currentSnapshot: snapshot([node("n1", "Prompt node")]),
+    });
+    expect(result.hasBaseline).toBe(false);
+    expect(result.entries).toHaveLength(1);
+    expect(result.entries[0].status).toBe(CHANGE_STATUS.CREATED);
+    expect(result.previousJson).toBeTruthy();
+    expect(result.currentJson).toContain("Prompt node");
+  });
+
+  it("does not throw when both sides are empty", () => {
+    expect(() =>
+      classifySaveChanges({
+        previousSnapshot: snapshot([]),
+        currentSnapshot: snapshot([]),
+      }),
+    ).not.toThrow();
+  });
+
+  it("ignores position-only moves", () => {
+    const previous = snapshot([
+      {
+        id: "a",
+        name: "Prompt node",
+        type: "atomic",
+        position: { x: 0, y: 0 },
+      },
+    ]);
+    const current = snapshot([
+      {
+        id: "b",
+        name: "Prompt node",
+        type: "atomic",
+        position: { x: 400, y: 20 },
+      },
+    ]);
+    const result = classifySaveChanges({
+      previousSnapshot: previous,
+      currentSnapshot: current,
+    });
+    expect(result.entries[0].status).toBe(CHANGE_STATUS.UNCHANGED);
+  });
+
+  it("computes line totals and per-node breakdown", () => {
+    const previous = snapshot([node("a", "Prompt node", { prompt: "old" })]);
+    const current = snapshot([
+      node("a2", "Prompt node", { prompt: "brand new prompt text" }),
+      node("b", "Research Agent"),
+    ]);
+    const result = classifySaveChanges({
+      previousSnapshot: previous,
+      currentSnapshot: current,
+    });
+    expect(result.totals.added).toBeGreaterThan(0);
+    const research = result.perNode.find(
+      (row) => row.name === "Research Agent",
+    );
+    expect(research.added).toBeGreaterThan(0);
+    expect(research.removed).toBe(0);
+  });
+});
+
+describe("pickBaselineVersion", () => {
+  const versions = [
+    { id: "draft-1", status: VERSION_STATUS.DRAFT, created_at: "2026-09-04" },
+    { id: "active-1", status: VERSION_STATUS.ACTIVE, created_at: "2026-09-03" },
+    { id: "old-1", status: VERSION_STATUS.INACTIVE, created_at: "2026-09-01" },
+  ];
+
+  it("uses the latest non-draft when the current version is a draft", () => {
+    const baseline = pickBaselineVersion(versions, {
+      version_id: "draft-1",
+      is_draft: true,
+    });
+    expect(baseline.id).toBe("active-1");
+  });
+
+  it("uses the current version when it is already saved", () => {
+    const baseline = pickBaselineVersion(versions, {
+      version_id: "active-1",
+      is_draft: false,
+    });
+    expect(baseline.id).toBe("active-1");
+  });
+
+  it("returns null for a first-ever draft", () => {
+    const baseline = pickBaselineVersion(
+      [{ id: "draft-1", status: VERSION_STATUS.DRAFT }],
+      { version_id: "draft-1", is_draft: true },
+    );
+    expect(baseline).toBeNull();
+  });
+});
+
+describe("flattenGraphVersions", () => {
+  it("flattens infinite-query pages", () => {
+    const flat = flattenGraphVersions({
+      pages: [
+        { data: { result: { versions: [{ id: "v1" }] } } },
+        { data: { result: { versions: [{ id: "v2" }] } } },
+      ],
+    });
+    expect(flat.map((v) => v.id)).toEqual(["v1", "v2"]);
+  });
+});
+
+describe("definition document", () => {
+  it("uses names instead of remapped ids in connections", () => {
+    const doc = buildDefinitionDocument(
+      snapshot(
+        [node("uuid-1", "Prompt node"), node("uuid-2", "Research Agent")],
+        [{ source_node_id: "uuid-1", target_node_id: "uuid-2" }],
+      ),
+    );
+    expect(doc.connections).toEqual([
+      { from: "Prompt node", to: "Research Agent" },
+    ]);
+    expect(definitionToJson(doc)).toContain("Prompt node");
+    expect(definitionToJson(doc)).not.toContain("uuid-1");
+  });
+});
+
+describe("buildAgentDefinitionFileName", () => {
+  it("slugifies the agent name", () => {
+    expect(buildAgentDefinitionFileName("Untitled_1")).toBe(
+      "untitled-1-agent.json",
+    );
+  });
+
+  it("falls back to untitled", () => {
+    expect(buildAgentDefinitionFileName("")).toBe("untitled-agent.json");
+  });
+});
+
+describe("countLineChanges", () => {
+  it("counts added and removed lines", () => {
+    const { added, removed } = countLineChanges("a\nb\n", "a\nc\n");
+    expect(added).toBe(1);
+    expect(removed).toBe(1);
+  });
+});

--- a/frontend/src/sections/agent-playground/utils/__tests__/saveAgentDiff.test.js
+++ b/frontend/src/sections/agent-playground/utils/__tests__/saveAgentDiff.test.js
@@ -10,7 +10,8 @@ import {
   pairNodesByName,
   pickBaselineVersion,
 } from "../saveAgentDiff";
-import { VERSION_STATUS } from "../constants";
+import { buildVersionPayload } from "../versionPayloadUtils";
+import { NODE_TYPES, VERSION_STATUS } from "../constants";
 
 function node(id, name, extra = {}) {
   return {
@@ -131,6 +132,79 @@ describe("classifySaveChanges", () => {
       previousSnapshot: previous,
       currentSnapshot: current,
     });
+    expect(result.entries[0].status).toBe(CHANGE_STATUS.UNCHANGED);
+  });
+
+  it("treats an unedited prompt node as unchanged across GET vs payload shapes", () => {
+    const previous = snapshot(
+      [
+        {
+          id: "old-prompt",
+          name: "Prompt node",
+          type: "atomic",
+          node_template_id: "tpl-prompt",
+          prompt_template: {
+            model: "gpt-4",
+            messages: [
+              { role: "system", content: "You are a helpful assistant" },
+            ],
+            template_format: "f-string",
+            variable_names: [],
+            metadata: {},
+            is_draft: false,
+            template_version: 1,
+            response_schema: null,
+            response_format: "text",
+          },
+        },
+      ],
+      [],
+    );
+    const currentPayload = buildVersionPayload(
+      [
+        {
+          id: "new-prompt",
+          type: NODE_TYPES.LLM_PROMPT,
+          position: { x: 0, y: 0 },
+          data: {
+            label: "Prompt node",
+            node_template_id: "tpl-prompt",
+            config: {
+              modelConfig: {
+                model: "gpt-4",
+                modelDetail: {
+                  modelName: "GPT-4",
+                  logoUrl: "",
+                  providers: "openai",
+                  isAvailable: true,
+                },
+                responseFormat: "text",
+                toolChoice: "auto",
+                tools: [],
+              },
+              messages: [
+                {
+                  id: "msg-0",
+                  role: "system",
+                  content: [
+                    { type: "text", text: "You are a helpful assistant" },
+                  ],
+                },
+              ],
+            },
+          },
+        },
+      ],
+      [],
+    );
+    const result = classifySaveChanges({
+      previousSnapshot: previous,
+      currentSnapshot: {
+        nodes: currentPayload.nodes,
+        connections: currentPayload.node_connections,
+      },
+    });
+    expect(result.entries).toHaveLength(1);
     expect(result.entries[0].status).toBe(CHANGE_STATUS.UNCHANGED);
   });
 

--- a/frontend/src/sections/agent-playground/utils/saveAgentDiff.js
+++ b/frontend/src/sections/agent-playground/utils/saveAgentDiff.js
@@ -1,0 +1,499 @@
+import { diffLines } from "diff";
+import { VERSION_STATUS } from "./constants";
+
+export const CHANGE_STATUS = {
+  CREATED: "created",
+  UPDATED: "updated",
+  DELETED: "deleted",
+  REROUTED: "rerouted",
+  UNCHANGED: "unchanged",
+};
+
+export const CHANGE_STATUS_LABEL = {
+  [CHANGE_STATUS.CREATED]: "Created",
+  [CHANGE_STATUS.UPDATED]: "Updated",
+  [CHANGE_STATUS.DELETED]: "Deleted",
+  [CHANGE_STATUS.REROUTED]: "Rerouting",
+  [CHANGE_STATUS.UNCHANGED]: "No changes",
+};
+
+function sortKeys(value) {
+  if (Array.isArray(value)) return value.map(sortKeys);
+  if (value && typeof value === "object") {
+    return Object.keys(value)
+      .sort()
+      .reduce((acc, key) => {
+        if (value[key] === undefined) return acc;
+        acc[key] = sortKeys(value[key]);
+        return acc;
+      }, {});
+  }
+  return value;
+}
+
+function stableStringify(value) {
+  return `${JSON.stringify(sortKeys(value), null, 2)}\n`;
+}
+
+function splitDiffLines(text) {
+  if (!text) return [];
+  const lines = text.split("\n");
+  if (lines[lines.length - 1] === "") lines.pop();
+  return lines;
+}
+
+function nodeName(node) {
+  return node?.name || node?.id || "Untitled node";
+}
+
+function sourceId(connection) {
+  return connection?.source_node_id || connection?.sourceNodeId;
+}
+
+function targetId(connection) {
+  return connection?.target_node_id || connection?.targetNodeId;
+}
+
+/**
+ * Strip identity/layout so a remapped draft can be compared with the last save.
+ */
+export function canonicalNodeBody(node = {}) {
+  const body = {
+    name: nodeName(node),
+    type: node.type || null,
+  };
+  const templateId = node.node_template_id ?? node.nodeTemplateId;
+  if (templateId != null) body.node_template_id = templateId;
+  const prompt = node.prompt_template || node.promptTemplate;
+  if (prompt) body.prompt_template = prompt;
+  if (Array.isArray(node.ports) && node.ports.length > 0) {
+    body.ports = node.ports;
+  }
+  const refVersion = node.ref_graph_version_id ?? node.refGraphVersionId;
+  if (refVersion) body.ref_graph_version_id = refVersion;
+  const mappings = node.input_mappings || node.inputMappings;
+  if (Array.isArray(mappings) && mappings.length > 0) {
+    body.input_mappings = mappings;
+  }
+  if (node.config && Object.keys(node.config).length > 0) {
+    body.config = node.config;
+  }
+  return body;
+}
+
+export function toGraphSnapshot(source = {}) {
+  return {
+    nodes: source.nodes || [],
+    connections: source.node_connections || source.nodeConnections || [],
+  };
+}
+
+function idToNameMap(nodes = []) {
+  return new Map(nodes.map((node) => [node.id, nodeName(node)]));
+}
+
+function namedConnections(snapshot) {
+  const names = idToNameMap(snapshot.nodes);
+  return (snapshot.connections || []).map((connection) => {
+    const fromId = sourceId(connection);
+    const toId = targetId(connection);
+    return {
+      from: names.get(fromId) || fromId,
+      to: names.get(toId) || toId,
+    };
+  });
+}
+
+function incidentConnectionSet(snapshot, name) {
+  return new Set(
+    namedConnections(snapshot)
+      .filter(
+        (connection) => connection.from === name || connection.to === name,
+      )
+      .map((connection) => `${connection.from}\0${connection.to}`),
+  );
+}
+
+function setsEqual(left, right) {
+  if (left.size !== right.size) return false;
+  for (const value of left) {
+    if (!right.has(value)) return false;
+  }
+  return true;
+}
+
+/**
+ * Pair previous/current nodes by name. Draft creation remaps UUIDs, so id is not stable.
+ * Duplicate names are paired in order of appearance.
+ */
+export function pairNodesByName(previousNodes = [], currentNodes = []) {
+  const previousByName = new Map();
+  previousNodes.forEach((node) => {
+    const name = nodeName(node);
+    if (!previousByName.has(name)) previousByName.set(name, []);
+    previousByName.get(name).push(node);
+  });
+
+  const used = new Map();
+  const pairs = [];
+  const created = [];
+
+  currentNodes.forEach((current) => {
+    const name = nodeName(current);
+    const index = used.get(name) || 0;
+    const previousList = previousByName.get(name) || [];
+    const previous = previousList[index];
+    used.set(name, index + 1);
+    if (previous) {
+      pairs.push({ previous, current });
+    } else {
+      created.push(current);
+    }
+  });
+
+  const deleted = [];
+  previousByName.forEach((list, name) => {
+    const start = used.get(name) || 0;
+    for (let i = start; i < list.length; i += 1) {
+      deleted.push(list[i]);
+    }
+  });
+
+  return { pairs, created, deleted };
+}
+
+function describeUpdated(previousBody, currentBody) {
+  const prevPrompt = JSON.stringify(
+    sortKeys(previousBody.prompt_template || null),
+  );
+  const nextPrompt = JSON.stringify(
+    sortKeys(currentBody.prompt_template || null),
+  );
+  if (prevPrompt !== nextPrompt) {
+    const prevMessages = JSON.stringify(
+      sortKeys(previousBody.prompt_template?.messages || []),
+    );
+    const nextMessages = JSON.stringify(
+      sortKeys(currentBody.prompt_template?.messages || []),
+    );
+    if (prevMessages !== nextMessages) {
+      return "Prompt instructions changed";
+    }
+    const prevModel = previousBody.prompt_template?.model;
+    const nextModel = currentBody.prompt_template?.model;
+    if (prevModel !== nextModel) {
+      return "Model changed";
+    }
+    return "Model settings changed";
+  }
+  if (previousBody.type !== currentBody.type) {
+    return "Node type changed";
+  }
+  if (
+    JSON.stringify(sortKeys(previousBody.ports || [])) !==
+    JSON.stringify(sortKeys(currentBody.ports || []))
+  ) {
+    return "Ports changed";
+  }
+  if (previousBody.ref_graph_version_id !== currentBody.ref_graph_version_id) {
+    return "Referenced agent version changed";
+  }
+  return "Node configuration changed";
+}
+
+export function describeChange(status, previousBody, currentBody) {
+  switch (status) {
+    case CHANGE_STATUS.CREATED:
+      return "Node added";
+    case CHANGE_STATUS.DELETED:
+      return "Node removed";
+    case CHANGE_STATUS.REROUTED:
+      return "Connections changed";
+    case CHANGE_STATUS.UNCHANGED:
+      return "No changes";
+    case CHANGE_STATUS.UPDATED:
+      return describeUpdated(previousBody, currentBody);
+    default:
+      return "Node configuration changed";
+  }
+}
+
+export function countLineChanges(original, current) {
+  const parts = diffLines(original || "", current || "");
+  let added = 0;
+  let removed = 0;
+  parts.forEach((part) => {
+    const lines = splitDiffLines(part.value);
+    if (part.added) added += lines.length;
+    else if (part.removed) removed += lines.length;
+  });
+  return { added, removed };
+}
+
+export function computeAlignedLineDiff(original, current) {
+  const parts = diffLines(original || "", current || "");
+  const left = [];
+  const right = [];
+  let leftLine = 0;
+  let rightLine = 0;
+
+  const pushSplit = (text, side) => {
+    splitDiffLines(text).forEach((line) => {
+      if (side === "both") {
+        leftLine += 1;
+        rightLine += 1;
+        left.push({ text: line, type: "unchanged", lineNumber: leftLine });
+        right.push({ text: line, type: "unchanged", lineNumber: rightLine });
+      } else if (side === "left") {
+        leftLine += 1;
+        left.push({ text: line, type: "removed", lineNumber: leftLine });
+        right.push({ text: "", type: "filler", lineNumber: null });
+      } else {
+        rightLine += 1;
+        left.push({ text: "", type: "filler", lineNumber: null });
+        right.push({ text: line, type: "added", lineNumber: rightLine });
+      }
+    });
+  };
+
+  for (let i = 0; i < parts.length; i += 1) {
+    const part = parts[i];
+    if (part.removed && parts[i + 1]?.added) {
+      const removedLines = splitDiffLines(part.value);
+      const addedLines = splitDiffLines(parts[i + 1].value);
+      const max = Math.max(removedLines.length, addedLines.length);
+      for (let j = 0; j < max; j += 1) {
+        if (j < removedLines.length) {
+          leftLine += 1;
+          left.push({
+            text: removedLines[j],
+            type: "removed",
+            lineNumber: leftLine,
+          });
+        } else {
+          left.push({ text: "", type: "filler", lineNumber: null });
+        }
+        if (j < addedLines.length) {
+          rightLine += 1;
+          right.push({
+            text: addedLines[j],
+            type: "added",
+            lineNumber: rightLine,
+          });
+        } else {
+          right.push({ text: "", type: "filler", lineNumber: null });
+        }
+      }
+      i += 1;
+    } else if (part.added) {
+      pushSplit(part.value, "right");
+    } else if (part.removed) {
+      pushSplit(part.value, "left");
+    } else {
+      pushSplit(part.value, "both");
+    }
+  }
+
+  return { left, right };
+}
+
+export function buildDefinitionDocument(
+  snapshot = { nodes: [], connections: [] },
+) {
+  const nodes = (snapshot.nodes || [])
+    .map((node) => canonicalNodeBody(node))
+    .sort((a, b) => a.name.localeCompare(b.name));
+  const connections = namedConnections(snapshot)
+    .map((connection) => ({ from: connection.from, to: connection.to }))
+    .sort((a, b) => `${a.from}:${a.to}`.localeCompare(`${b.from}:${b.to}`));
+  return { nodes, connections };
+}
+
+export function definitionToJson(document) {
+  return stableStringify(document);
+}
+
+function nodeDocument(snapshot, node) {
+  const name = nodeName(node);
+  return {
+    node: canonicalNodeBody(node),
+    connections: namedConnections(snapshot)
+      .filter(
+        (connection) => connection.from === name || connection.to === name,
+      )
+      .sort((a, b) => `${a.from}:${a.to}`.localeCompare(`${b.from}:${b.to}`)),
+  };
+}
+
+const STATUS_ORDER = {
+  [CHANGE_STATUS.CREATED]: 0,
+  [CHANGE_STATUS.UPDATED]: 1,
+  [CHANGE_STATUS.REROUTED]: 2,
+  [CHANGE_STATUS.DELETED]: 3,
+  [CHANGE_STATUS.UNCHANGED]: 4,
+};
+
+/**
+ * Latest published version that is not the current draft.
+ * Active/inactive versions count as saved. Drafts do not.
+ */
+export function pickBaselineVersion(versions = [], currentAgent = null) {
+  const list = Array.isArray(versions) ? versions : [];
+  const currentId = currentAgent?.version_id;
+  const isDraft = currentAgent?.is_draft ?? true;
+
+  if (!isDraft && currentId) {
+    return (
+      list.find((version) => version.id === currentId) || { id: currentId }
+    );
+  }
+
+  return (
+    list.find(
+      (version) =>
+        version.id !== currentId && version.status !== VERSION_STATUS.DRAFT,
+    ) || null
+  );
+}
+
+export function flattenGraphVersions(versionsData) {
+  return (versionsData?.pages ?? []).flatMap(
+    (page) => page.data?.result?.versions ?? [],
+  );
+}
+
+export function buildAgentDefinitionFileName(agentName) {
+  const raw = (agentName || "untitled").trim() || "untitled";
+  const slug = raw
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+  return `${slug || "untitled"}-agent.json`;
+}
+
+/**
+ * Classify every node (including unchanged) and compute definition + line diffs.
+ */
+export function classifySaveChanges({
+  previousSnapshot = { nodes: [], connections: [] },
+  currentSnapshot = { nodes: [], connections: [] },
+  occurredAt = {},
+} = {}) {
+  const previous = {
+    nodes: previousSnapshot.nodes || [],
+    connections: previousSnapshot.connections || [],
+  };
+  const current = {
+    nodes: currentSnapshot.nodes || [],
+    connections: currentSnapshot.connections || [],
+  };
+
+  const { pairs, created, deleted } = pairNodesByName(
+    previous.nodes,
+    current.nodes,
+  );
+  const entries = [];
+
+  created.forEach((node) => {
+    const body = canonicalNodeBody(node);
+    entries.push({
+      id: node.id,
+      name: nodeName(node),
+      type: node.type || null,
+      status: CHANGE_STATUS.CREATED,
+      description: describeChange(CHANGE_STATUS.CREATED),
+      occurredAt: occurredAt.current || null,
+      previousBody: null,
+      currentBody: body,
+    });
+  });
+
+  pairs.forEach(({ previous: prevNode, current: nextNode }) => {
+    const previousBody = canonicalNodeBody(prevNode);
+    const currentBody = canonicalNodeBody(nextNode);
+    const bodyChanged =
+      JSON.stringify(sortKeys(previousBody)) !==
+      JSON.stringify(sortKeys(currentBody));
+    const routesChanged = !setsEqual(
+      incidentConnectionSet(previous, nodeName(prevNode)),
+      incidentConnectionSet(current, nodeName(nextNode)),
+    );
+
+    let status = CHANGE_STATUS.UNCHANGED;
+    if (bodyChanged) status = CHANGE_STATUS.UPDATED;
+    else if (routesChanged) status = CHANGE_STATUS.REROUTED;
+
+    entries.push({
+      id: nextNode.id,
+      name: nodeName(nextNode),
+      type: nextNode.type || currentBody.type,
+      status,
+      description: describeChange(status, previousBody, currentBody),
+      occurredAt:
+        status === CHANGE_STATUS.UNCHANGED
+          ? occurredAt.previous || null
+          : occurredAt.current || occurredAt.previous || null,
+      previousBody,
+      currentBody,
+    });
+  });
+
+  deleted.forEach((node) => {
+    const body = canonicalNodeBody(node);
+    entries.push({
+      id: node.id,
+      name: nodeName(node),
+      type: node.type || null,
+      status: CHANGE_STATUS.DELETED,
+      description: describeChange(CHANGE_STATUS.DELETED),
+      occurredAt: occurredAt.previous || null,
+      previousBody: body,
+      currentBody: null,
+    });
+  });
+
+  entries.sort((a, b) => {
+    const rank = STATUS_ORDER[a.status] - STATUS_ORDER[b.status];
+    if (rank !== 0) return rank;
+    return a.name.localeCompare(b.name);
+  });
+
+  const previousDoc = buildDefinitionDocument(previous);
+  const currentDoc = buildDefinitionDocument(current);
+  const previousJson = definitionToJson(previousDoc);
+  const currentJson = definitionToJson(currentDoc);
+  const totals = countLineChanges(previousJson, currentJson);
+  const aligned = computeAlignedLineDiff(previousJson, currentJson);
+
+  const perNode = entries.map((entry) => {
+    const prevNode =
+      previous.nodes.find((node) => nodeName(node) === entry.name) || null;
+    const nextNode =
+      current.nodes.find((node) => nodeName(node) === entry.name) || null;
+    const prevJson = prevNode
+      ? definitionToJson(nodeDocument(previous, prevNode))
+      : "";
+    const nextJson = nextNode
+      ? definitionToJson(nodeDocument(current, nextNode))
+      : "";
+    const lines = countLineChanges(prevJson, nextJson);
+    return {
+      name: entry.name,
+      status: entry.status,
+      added: lines.added,
+      removed: lines.removed,
+    };
+  });
+
+  return {
+    entries,
+    previousDocument: previousDoc,
+    currentDocument: currentDoc,
+    previousJson,
+    currentJson,
+    totals,
+    aligned,
+    perNode,
+    hasBaseline: previous.nodes.length > 0 || previous.connections.length > 0,
+  };
+}

--- a/frontend/src/sections/agent-playground/utils/saveAgentDiff.js
+++ b/frontend/src/sections/agent-playground/utils/saveAgentDiff.js
@@ -1,5 +1,9 @@
 import { diffLines } from "diff";
 import { VERSION_STATUS } from "./constants";
+import {
+  buildVersionPayload,
+  parseVersionResponse,
+} from "./versionPayloadUtils";
 
 export const CHANGE_STATUS = {
   CREATED: "created",
@@ -54,6 +58,55 @@ function targetId(connection) {
   return connection?.target_node_id || connection?.targetNodeId;
 }
 
+function normalizeMessageContent(content) {
+  if (typeof content === "string") {
+    return [{ type: "text", text: content }];
+  }
+  if (Array.isArray(content)) {
+    return content.map((part) => {
+      if (typeof part === "string") {
+        return { type: "text", text: part };
+      }
+      return {
+        type: part?.type || "text",
+        text: part?.text || "",
+      };
+    });
+  }
+  if (content == null) return [{ type: "text", text: "" }];
+  return [{ type: "text", text: String(content) }];
+}
+
+/**
+ * Drop GET-serializer-only fields and flatten message content so a NodeRead
+ * prompt_template can be compared with buildVersionPayload output.
+ */
+export function canonicalPromptTemplate(prompt) {
+  if (!prompt) return null;
+  return {
+    model: prompt.model || null,
+    messages: (prompt.messages || []).map((message) => ({
+      role: message.role,
+      content: normalizeMessageContent(message.content),
+    })),
+    response_format: prompt.response_format || prompt.responseFormat || "text",
+    temperature: prompt.temperature ?? null,
+    max_tokens: prompt.max_tokens ?? null,
+    top_p: prompt.top_p ?? null,
+    tools: prompt.tools || [],
+    tool_choice: prompt.tool_choice || prompt.toolChoice || "",
+  };
+}
+
+function canonicalPorts(ports = []) {
+  return ports.map((port) => ({
+    key: port.key,
+    display_name: port.display_name || port.displayName,
+    direction: port.direction,
+    data_schema: port.data_schema || port.dataSchema || {},
+  }));
+}
+
 /**
  * Strip identity/layout so a remapped draft can be compared with the last save.
  */
@@ -65,9 +118,9 @@ export function canonicalNodeBody(node = {}) {
   const templateId = node.node_template_id ?? node.nodeTemplateId;
   if (templateId != null) body.node_template_id = templateId;
   const prompt = node.prompt_template || node.promptTemplate;
-  if (prompt) body.prompt_template = prompt;
+  if (prompt) body.prompt_template = canonicalPromptTemplate(prompt);
   if (Array.isArray(node.ports) && node.ports.length > 0) {
-    body.ports = node.ports;
+    body.ports = canonicalPorts(node.ports);
   }
   const refVersion = node.ref_graph_version_id ?? node.refGraphVersionId;
   if (refVersion) body.ref_graph_version_id = refVersion;
@@ -75,17 +128,43 @@ export function canonicalNodeBody(node = {}) {
   if (Array.isArray(mappings) && mappings.length > 0) {
     body.input_mappings = mappings;
   }
-  if (node.config && Object.keys(node.config).length > 0) {
-    body.config = node.config;
-  }
   return body;
 }
 
 export function toGraphSnapshot(source = {}) {
   return {
     nodes: source.nodes || [],
-    connections: source.node_connections || source.nodeConnections || [],
+    connections:
+      source.node_connections ||
+      source.nodeConnections ||
+      source.connections ||
+      [],
   };
+}
+
+/**
+ * Put GET version-detail, store canvas, and payload snapshots on the same
+ * buildVersionPayload shape before comparing.
+ */
+export function toComparableSnapshot(source = {}) {
+  const nodes = source.nodes || [];
+  const edges = source.edges || [];
+  const connections =
+    source.connections ||
+    source.node_connections ||
+    source.nodeConnections ||
+    [];
+  if (!nodes.length && !edges.length && !connections.length) {
+    return { nodes: [], connections: [] };
+  }
+  if (nodes.some((node) => node?.data != null) || edges.length > 0) {
+    return toGraphSnapshot(buildVersionPayload(nodes, edges));
+  }
+  const parsed = parseVersionResponse({
+    nodes,
+    node_connections: connections,
+  });
+  return toGraphSnapshot(buildVersionPayload(parsed.nodes, parsed.edges));
 }
 
 function idToNameMap(nodes = []) {
@@ -379,14 +458,8 @@ export function classifySaveChanges({
   currentSnapshot = { nodes: [], connections: [] },
   occurredAt = {},
 } = {}) {
-  const previous = {
-    nodes: previousSnapshot.nodes || [],
-    connections: previousSnapshot.connections || [],
-  };
-  const current = {
-    nodes: currentSnapshot.nodes || [],
-    connections: currentSnapshot.connections || [],
-  };
+  const previous = toComparableSnapshot(previousSnapshot);
+  const current = toComparableSnapshot(currentSnapshot);
 
   const { pairs, created, deleted } = pairNodesByName(
     previous.nodes,


### PR DESCRIPTION
## Summary
- The Save Agent dialog now shows Changelog and Code tabs under the commit message, so you can see what changed since the last save before writing that message.
- Changelog lists created, updated, deleted, and rerouted nodes, and keeps unchanged nodes visible instead of dropping them.
- Unedited prompt/LLM nodes compare last-saved GET detail against the current payload on a shared canonical shape, so they stay **unchanged** instead of looking updated.
- Code is a side-by-side definition diff (last saved on the left, current draft on the right) with copy/download and per-node +/- line counts.
- A first-ever save with nothing to compare still opens. Saving itself is unchanged (same draft-promote vs full payload split).

Fixes #2506.

## Test plan
- [ ] Open a previously saved agent, edit a node’s instructions, add a node, delete another, reroute a connection, press Save.
- [ ] Changelog shows Updated / Created / Deleted / Rerouting, and unchanged nodes as No changes — including prompt/LLM nodes you did not touch.
- [ ] Switch to Code: left is the last save, right is the current draft; totals and per-node stats look right; copy and download work.
- [ ] Brand-new agent that has never been saved: dialog still opens, no crash, Save still works.
- [ ] Save still promotes the draft / writes the version the same way as before.
- [x] `frontend` vitest: `saveAgentDiff.test.js` + `SaveAgentDialog.test.jsx` — 23 passed