### PR TITLE
fix: preserve selected agent execution

### DIFF
--- a/frontend/src/sections/agent-playground/Executions/ExecutionsList.jsx
+++ b/frontend/src/sections/agent-playground/Executions/ExecutionsList.jsx
@@ -48,13 +48,14 @@ const ExecutionsList = ({
 
   const scrollContainerRef = useScrollEnd(fetchNext, [fetchNext]);
 
-  // Auto-select top execution whenever the newest item changes
+  // Select the newest execution only when the history first opens. Once a
+  // user has chosen an execution, refreshing the list must not replace it.
   const firstExecutionId = executions[0]?.id;
   useEffect(() => {
-    if (firstExecutionId) {
+    if (firstExecutionId && !selectedExecutionId) {
       onExecutionChange(firstExecutionId);
     }
-  }, [firstExecutionId, onExecutionChange]);
+  }, [firstExecutionId, onExecutionChange, selectedExecutionId]);
 
   return (
     <Box

--- a/frontend/src/sections/agent-playground/Executions/__tests__/ExecutionsList.test.jsx
+++ b/frontend/src/sections/agent-playground/Executions/__tests__/ExecutionsList.test.jsx
@@ -1,0 +1,69 @@
+import React from "react";
+import { describe, expect, it, vi } from "vitest";
+import { fireEvent, render, screen } from "src/utils/test-utils";
+import ExecutionsList from "../ExecutionsList";
+
+vi.mock("src/hooks/use-scroll-end", () => ({
+  useScrollEnd: () => vi.fn(),
+}));
+
+const execution = (id, startedAt) => ({
+  id,
+  startedAt,
+  status: "success",
+});
+
+const baseProps = {
+  isFetchingNextPage: false,
+  fetchNextPage: vi.fn(),
+  hasNextPage: false,
+};
+
+describe("ExecutionsList", () => {
+  it("selects the newest execution when there is no current selection", () => {
+    const onExecutionChange = vi.fn();
+
+    render(
+      <ExecutionsList
+        {...baseProps}
+        executions={[execution("newest", "2026-09-04T10:00:00Z")]}
+        selectedExecutionId={null}
+        onExecutionChange={onExecutionChange}
+      />,
+    );
+
+    expect(onExecutionChange).toHaveBeenCalledExactlyOnceWith("newest");
+  });
+
+  it("keeps a user-selected execution when a newer execution refreshes the list", () => {
+    const onExecutionChange = vi.fn();
+    const older = execution("older", "2026-09-03T10:00:00Z");
+    const selected = execution("selected", "2026-09-03T11:00:00Z");
+    const { rerender } = render(
+      <ExecutionsList
+        {...baseProps}
+        executions={[selected, older]}
+        selectedExecutionId="selected"
+        onExecutionChange={onExecutionChange}
+      />,
+    );
+
+    fireEvent.click(screen.getByText("Sep 03, 2026, 3:00 PM"));
+    expect(onExecutionChange).toHaveBeenCalledExactlyOnceWith("older");
+
+    rerender(
+      <ExecutionsList
+        {...baseProps}
+        executions={[
+          execution("newest", "2026-09-04T10:00:00Z"),
+          selected,
+          older,
+        ]}
+        selectedExecutionId="older"
+        onExecutionChange={onExecutionChange}
+      />,
+    );
+
+    expect(onExecutionChange).toHaveBeenCalledExactlyOnceWith("older");
+  });
+});


### PR DESCRIPTION
Summary
Preserves a user-selected agent execution when the history refreshes, while keeping automatic newest-execution selection on initial load.

Validation
Focused Vitest regression test passed. ESLint passed for both changed files.

Addresses issue 2511.