### PR TITLE
Carry the job's authoring contract into the agent row, and checkpoint a suite still being written

### DIFF
--- a/frontend/src/pages/dashboard/harness/StageOutput.jsx
+++ b/frontend/src/pages/dashboard/harness/StageOutput.jsx
@@ -68,6 +68,17 @@ RawDetails.propTypes = {
 // rather than rendering nothing, so a new kind is visible rather than silently dropped.
 export default function StageOutput({ output }) {
   const data = output.data || {};
+  // The environment payload nests its detail under bundle_manifest and metadata,
+  // so read those rather than the flat fields the earlier shape used.
+  const manifest = data.bundle_manifest || {};
+  const processes = manifest.processes || [];
+  const readinessChecks = (manifest.readiness || [])
+    .map((check) => check.capability)
+    .filter(Boolean);
+  const fileCount = (manifest.files || []).length;
+  const capabilities = Object.entries(manifest.capabilities || {});
+  const seedStores = (manifest.seed || {}).stores || [];
+  const adoptedFiles = (manifest.provenance || {}).adopted_files || [];
   return (
     <Accordion
       variant="outlined"
@@ -151,22 +162,102 @@ export default function StageOutput({ output }) {
 
         {output.kind === "environment" && (
           <Stack spacing={1}>
-            {Boolean((data.services || []).length) && (
+            {Boolean(processes.length) && (
               <Stack direction="row" gap={0.75} flexWrap="wrap">
-                {(data.services || []).map((service) => (
+                {processes.map((process) => (
                   <Chip
-                    key={service}
+                    key={process.name}
                     size="small"
                     variant="outlined"
-                    label={service}
+                    label={
+                      process.engine
+                        ? `${process.name} · ${process.engine}${process.version ? ` ${process.version}` : ""}`
+                        : process.fixed_port
+                          ? `${process.name} · :${process.fixed_port}`
+                          : process.name
+                    }
                   />
                 ))}
               </Stack>
             )}
-            <Typography variant="body2">
-              {data.project || "Isolated run"} ·{" "}
-              {data.managed ? "built by ALK" : "provided by the repository"}
+            {Boolean(data.source && data.source.repository) && (
+              <Typography variant="body2">
+                {data.source.repository}
+                {data.source.commit_sha
+                  ? ` · ${String(data.source.commit_sha).slice(0, 7)}`
+                  : ""}
+              </Typography>
+            )}
+            <Typography variant="caption" color="text.secondary">
+              {data.runtime && data.runtime.kind
+                ? `Runs as ${data.runtime.kind}`
+                : "Isolated run"}
+              {data.runtime && data.runtime.document
+                ? ` · ${data.runtime.document}`
+                : ""}{" "}
+              ·{" "}
+              {data.metadata && data.metadata.managed
+                ? "built by the harness"
+                : "provided by the repository"}
             </Typography>
+            {Boolean(readinessChecks.length) && (
+              <Typography variant="caption" color="text.secondary">
+                Waits for {readinessChecks.join(", ")}
+              </Typography>
+            )}
+            {Boolean(fileCount) && (
+              <Typography variant="caption" color="text.secondary">
+                {fileCount} files in the bundle
+              </Typography>
+            )}
+            {Boolean(capabilities.length) && (
+              <Stack spacing={0.25}>
+                <Typography variant="caption" color="text.secondary">
+                  Capabilities the agent can reach
+                </Typography>
+                {capabilities.map(([name, capability]) => (
+                  <Typography key={name} variant="caption" color="text.secondary">
+                    {name} → {capability.service} ({capability.protocol}
+                    {capability.container_port ? `:${capability.container_port}` : ""})
+                    {capability.configuration_name
+                      ? ` as ${capability.configuration_name}`
+                      : ""}
+                  </Typography>
+                ))}
+              </Stack>
+            )}
+            {seedStores.map((store, index) => (
+              <Typography
+                key={store.capability || index}
+                variant="caption"
+                color="text.secondary"
+              >
+                Seeds {store.capability} from{" "}
+                {(store.migrations || []).join(", ") || "no migration file"}
+                {store.baseline?.strategy ? ` · ${store.baseline.strategy}` : ""}
+              </Typography>
+            ))}
+            {processes.map((process) => (
+              <Typography
+                key={`detail-${process.name}`}
+                variant="caption"
+                color="text.secondary"
+              >
+                {process.name}
+                {process.user ? ` runs as ${process.user}` : ""}
+                {(process.depends_on || []).length
+                  ? ` · after ${(process.depends_on || []).join(", ")}`
+                  : ""}
+                {(process.run_command || []).length
+                  ? ` · ${(process.run_command || []).join(" ")}`
+                  : ""}
+              </Typography>
+            ))}
+            {Boolean(adoptedFiles.length) && (
+              <Typography variant="caption" color="text.secondary">
+                Adopted from the repository: {adoptedFiles.join(", ")}
+              </Typography>
+            )}
             {Object.entries(data.overrides || {}).map(([name, value]) => (
               <Typography key={name} variant="caption" color="text.secondary">
                 {name} → {String(value)}

--- a/futureagi/simulate/serializers/alk_simulate_ingestion.py
+++ b/futureagi/simulate/serializers/alk_simulate_ingestion.py
@@ -222,6 +222,9 @@ class ALKSimulateProvisionRunTestRequestSerializer(serializers.Serializer):
         choices=("text", "chat", "voice"), required=False, default="text"
     )
     description = serializers.CharField(required=False, allow_blank=True)
+    direction = serializers.ChoiceField(
+        choices=("inbound", "outbound"), required=False, default="inbound"
+    )
     personas = ALKSimulateProvisionPersonaSerializer(many=True, required=False)
     scenario_ids = serializers.ListField(
         child=serializers.UUIDField(), required=False, allow_empty=False

--- a/futureagi/simulate/serializers/hosted_harness.py
+++ b/futureagi/simulate/serializers/hosted_harness.py
@@ -180,6 +180,9 @@ class HarnessScenarioProvisionSerializer(serializers.Serializer):
     operation = serializers.ChoiceField(choices=("provision",))
     name = serializers.CharField(max_length=255)
     modality = serializers.ChoiceField(choices=("text", "voice"), default="text")
+    direction = serializers.ChoiceField(
+        choices=("inbound", "outbound"), required=False
+    )
     description = serializers.CharField(required=False, allow_blank=True)
     personas = HarnessProvisionPersonaSerializer(many=True, allow_empty=False)
     agent_definition_id = serializers.UUIDField(required=False, allow_null=True)
@@ -204,6 +207,9 @@ class HarnessScenarioOperationSerializer(serializers.Serializer):
     operation = serializers.ChoiceField(choices=("provision", "begin"))
     name = serializers.CharField(required=False, max_length=255)
     modality = serializers.ChoiceField(choices=("text", "voice"), required=False)
+    direction = serializers.ChoiceField(
+        choices=("inbound", "outbound"), required=False
+    )
     description = serializers.CharField(required=False, allow_blank=True)
     personas = HarnessProvisionPersonaSerializer(many=True, required=False)
     agent_definition_id = serializers.UUIDField(required=False, allow_null=True)

--- a/futureagi/simulate/services/alk_simulate_ingestion.py
+++ b/futureagi/simulate/services/alk_simulate_ingestion.py
@@ -25,6 +25,7 @@ from django.utils import timezone
 from model_hub.models.evals_metric import EvalTemplate
 from simulate.models import (
     AgentDefinition,
+    AgentVersion,
     CallExecution,
     RunTest,
     Scenarios,
@@ -250,6 +251,7 @@ def _provision_agent_definition(
     description,
     modality="text",
     workspace=None,
+    direction="inbound",
 ):
     """Resolve a modality-correct agent definition for an external ALK run.
 
@@ -279,14 +281,29 @@ def _provision_agent_definition(
                 "agent definition modality does not match the ALK run modality"
             )
         return agent_definition
-    return AgentDefinition.objects.create(
+    # An outbound agent rings the person, so it is not an inbound definition and the simulator,
+    # not the target, opens the conversation. Hardcoding inbound left every outbound run
+    # describing itself as the opposite of the call it actually placed.
+    agent_is_inbound = direction != "outbound"
+    agent_definition = AgentDefinition.objects.create(
         agent_name=agent_name or "alk-sdk-agent",
         agent_type=expected_type,
-        inbound=True,
+        inbound=agent_is_inbound,
+        target_speaks_first=agent_is_inbound,
         description=description or f"SDK-provisioned {modality} agent (ALK ingestion).",
         organization=organization,
         workspace=workspace,
     )
+    # Externally provisioned agents were the only ones created without a version, so
+    # ``latest_version`` was None and everything reading the configuration snapshot, including
+    # the ``agent_prompt`` eval input, resolved to an empty string. The snapshot is built from
+    # the agent during save, so this needs no second write.
+    agent_definition.create_version(
+        description=agent_definition.description,
+        commit_message="ALK ingestion",
+        status=AgentVersion.StatusChoices.ACTIVE,
+    )
+    return agent_definition
 
 
 def provision_alk_sim_run_test(
@@ -300,6 +317,7 @@ def provision_alk_sim_run_test(
     agent_name: str | None = None,
     description: str = "",
     modality: str = "text",
+    direction: str = "inbound",
 ) -> tuple[RunTest, list[Scenarios], AgentDefinition]:
     """Stand up a modality-correct RunTest for an SDK-first run, two ways.
 
@@ -343,6 +361,7 @@ def provision_alk_sim_run_test(
                 description,
                 modality,
                 workspace,
+                direction,
             )
             simulator_agent = next(
                 (s.simulator_agent for s in scenarios if s.simulator_agent), None
@@ -375,6 +394,7 @@ def provision_alk_sim_run_test(
             description,
             modality,
             workspace,
+            direction,
         )
 
         scenarios: list[Scenarios] = []

--- a/futureagi/simulate/services/hosted_harness.py
+++ b/futureagi/simulate/services/hosted_harness.py
@@ -309,6 +309,7 @@ def provision_scenarios(
             agent_name=payload.get("agent_name"),
             description=payload.get("description", ""),
             modality=modality,
+            direction=_resolve_scenario_direction(job, payload),
         )
     except ALKSimulateIngestionError as exc:
         raise HostedHarnessError("scenario_provision_failed", str(exc)) from exc
@@ -359,6 +360,25 @@ def _resolve_scenario_modality(
         if authored in {"text", "voice"}:
             return authored
     return "text"
+
+
+def _resolve_scenario_direction(
+    job: HostedHarnessJob, payload: dict[str, Any]
+) -> str:
+    """Resolve inbound/outbound the same way, so an outbound agent is not recorded as inbound."""
+    explicit = str(payload.get("direction") or "").lower()
+    if explicit in {"inbound", "outbound"}:
+        return explicit
+    for output in job.stage_outputs or []:
+        if not isinstance(output, dict) or output.get("kind") != "contract":
+            continue
+        data = output.get("data")
+        if not isinstance(data, dict):
+            continue
+        authored = str(data.get("direction") or "").lower()
+        if authored in {"inbound", "outbound"}:
+            return authored
+    return "inbound"
 
 
 def begin_scenarios(

--- a/futureagi/simulate/services/hosted_harness_gateway.py
+++ b/futureagi/simulate/services/hosted_harness_gateway.py
@@ -1871,6 +1871,16 @@ class DaytonaHostedGateway:
             )
         authored_bundle = _json("/work/authoring/environment-bundle/manifest.json")
         scenarios = _json("/work/authoring/scenarios.json")
+        # How many scenarios the guest has actually proved so far. The journal is append-only and
+        # a retried slice re-journals, so this counts lines rather than distinct names: it decides
+        # only whether there is anything worth snapshotting, never what gets kept.
+        try:
+            counted = sandbox.process.exec(
+                "wc -l < /work/authoring/written.jsonl 2>/dev/null || echo 0", timeout=30
+            )
+            journalled_scenarios = int(str(counted.result or "0").strip() or "0")
+        except Exception:  # noqa: BLE001 - a checkpoint is best effort, never fail the run
+            journalled_scenarios = 0
         bundle = _json("/work/bundle/manifest.json")
         job = HostedHarnessJob.no_workspace_objects.get(id=attempt.job_id)
 
@@ -1917,12 +1927,16 @@ class DaytonaHostedGateway:
                     job.id,
                     attempt.id,
                 )
-        elif isinstance(scenarios, list) and scenarios and not frozen:
+        elif journalled_scenarios and not frozen:
             # Checkpoint a suite that is still being written. The freeze above only fires on the
             # complete count, so a guest that died at 199 of 200 left nothing to restore and the
             # retry regenerated every scenario from scratch. Snapshotting the partial suite costs
-            # one tar per poll and turns a crash into a resume. `scenarios.json` is written as the
-            # suite grows, so its presence is the signal that there is something worth keeping.
+            # one tar per poll and turns a crash into a resume.
+            #
+            # Keyed on the journal, not on `scenarios.json`: a delegated writer journals each
+            # scenario as it proves it and only the final save writes the index and the folders.
+            # Waiting for the index meant this branch never ran during writing, so two crashes in
+            # one afternoon each threw away a partial suite it was built to keep.
             try:
                 packed = sandbox.process.exec(
                     "cd /work/authoring && set --; "

--- a/futureagi/simulate/services/hosted_harness_gateway.py
+++ b/futureagi/simulate/services/hosted_harness_gateway.py
@@ -131,6 +131,11 @@ def _platform_simulator_material() -> tuple[dict[str, str], bytes | None]:
         "SIMULATOR_LLM_MODEL": model,
     }
     for name in (
+        # Whether a simulated caller may be heard through ambient noise, and which backend each
+        # authoring stage runs on, are both deployment settings the sandbox cannot infer.
+        "ALK_BACKGROUND_NOISE",
+        "ALK_SCENARIOS_HARNESS",
+        "ALK_SCENARIOS_MODEL",
         "CARTESIA_API_KEY",
         "DEEPGRAM_API_KEY",
         "GEMINI_API_KEY",
@@ -1455,17 +1460,24 @@ class DaytonaHostedGateway:
         # using the exact same sealed scenario suite instead of asking the model to
         # author a different suite for an already-registered RunTest.
         metadata = (job.payload or {}).get("metadata") or {}
+        # A partial snapshot may already be held from the checkpoint below. Freezing the
+        # complete suite has to be allowed to replace it, so the test is "not already frozen"
+        # rather than "no archive at all".
+        frozen = bool(metadata.get("authoring_object_key")) and not metadata.get(
+            "authoring_partial"
+        )
         if (
             isinstance(bundle, dict)
             and isinstance(scenarios, list)
             and len(scenarios) == job.scenario_count
-            and not metadata.get("authoring_object_key")
+            and not frozen
         ):
             try:
                 packed = sandbox.process.exec(
                     "cd /work/authoring && set --; "
                     "for path in schema.sql store.json world.sqlite collections.json "
                     "contract.json environment.json scenarios.json simulator_prompt.md "
+                    "blueprint.json written.jsonl sub_goals.json "
                     "scenarios handlers; do "
                     '[ -e "$path" ] && set -- "$@" "$path"; '
                     "done; "
@@ -1477,12 +1489,44 @@ class DaytonaHostedGateway:
                     raise RuntimeError(str(packed.result or "authoring pack failed"))
                 body = sandbox.fs.download_file("/tmp/authoring-rerun.tar.gz")
                 store_authoring_archive(job, body, advance_lifecycle=False)
+                _mark_authoring_snapshot(job, partial=False)
                 job.refresh_from_db()
             except Exception:  # noqa: BLE001 - retry on the next poll; do not abort calls
                 logger.exception(
                     "could not freeze unified authoring snapshot job=%s attempt=%s",
                     job.id,
                     attempt.id,
+                )
+        elif isinstance(scenarios, list) and scenarios and not frozen:
+            # Checkpoint a suite that is still being written. The freeze above only fires on the
+            # complete count, so a guest that died at 199 of 200 left nothing to restore and the
+            # retry regenerated every scenario from scratch. Snapshotting the partial suite costs
+            # one tar per poll and turns a crash into a resume. `scenarios.json` is written as the
+            # suite grows, so its presence is the signal that there is something worth keeping.
+            try:
+                packed = sandbox.process.exec(
+                    "cd /work/authoring && set --; "
+                    "for path in schema.sql store.json world.sqlite collections.json "
+                    "contract.json environment.json scenarios.json simulator_prompt.md "
+                    "blueprint.json written.jsonl sub_goals.json "
+                    "scenarios handlers; do "
+                    '[ -e "$path" ] && set -- "$@" "$path"; '
+                    "done; "
+                    '[ -f contract.json ] && [ "$#" -gt 0 ] && '
+                    'tar -czf /tmp/authoring-partial.tar.gz "$@"',
+                    timeout=180,
+                )
+                if not packed.exit_code:
+                    body = sandbox.fs.download_file("/tmp/authoring-partial.tar.gz")
+                    store_authoring_archive(job, body, advance_lifecycle=False)
+                    _mark_authoring_snapshot(job, partial=True)
+                    job.refresh_from_db()
+            except Exception:  # noqa: BLE001 - a checkpoint is best effort, never fail the run
+                logger.warning(
+                    "could not checkpoint partial authoring job=%s attempt=%s scenarios=%s",
+                    job.id,
+                    attempt.id,
+                    len(scenarios),
                 )
         outputs = authoring_stage_outputs(
             contract,
@@ -2203,6 +2247,23 @@ def authoring_stage_outputs_from_archive(
         documents.get("environment.json"),
         scenarios,
     )
+
+
+def _mark_authoring_snapshot(job: HostedHarnessJob, *, partial: bool) -> None:
+    """Record whether the stored archive is a mid-run checkpoint or the finished suite.
+
+    A checkpoint must be replaceable by a later, fuller one and finally by the complete suite; a
+    frozen suite must not be overwritten by anything.
+    """
+    payload = dict(job.payload or {})
+    metadata = dict(payload.get("metadata") or {})
+    if partial:
+        metadata["authoring_partial"] = True
+    else:
+        metadata.pop("authoring_partial", None)
+    payload["metadata"] = metadata
+    job.payload = payload
+    job.save(update_fields=["payload", "updated_at"])
 
 
 def store_authoring_archive(

--- a/futureagi/simulate/services/hosted_harness_gateway.py
+++ b/futureagi/simulate/services/hosted_harness_gateway.py
@@ -524,6 +524,13 @@ def attach_platform_simulator_secret_refs(
 
 
 _MAX_EGRESS_DOMAINS = 20
+
+# Where a locally built guest wheel lands in the sandbox when ALK_HOSTED_WHEEL_OVERRIDE is set.
+# The basename is preserved because pip refuses a wheel whose filename is not PEP 427 shaped.
+_WHEEL_OVERRIDE_DIR = "/work"
+# The guest does not own the baked venv, so an override is installed here and put first on
+# PYTHONPATH rather than over the top of it.
+_WHEEL_OVERRIDE_TARGET = "/work/alk-latest"
 # RFC 1918 / loopback / link-local prefixes that must never appear in egress.
 _PRIVATE_HOST_PATTERNS = re.compile(
     r"^(10\.|172\.(1[6-9]|2\d|3[01])\.|192\.168\.|127\.|0\.|"
@@ -1453,6 +1460,24 @@ class DaytonaHostedGateway:
             attempt.state = HostedHarnessAttempt.State.PROVISIONING
             attempt.save(update_fields=["provider_ref", "state", "updated_at"])
             sandbox.fs.upload_file(source_archive, "/work/source.tar.gz")
+            # A snapshot bakes the guest, so a sandbox created from one runs whatever ALK was
+            # current when it was cut. Setting ALK_HOSTED_WHEEL_OVERRIDE to a locally built wheel
+            # installs the current guest over it at launch, which is what lets a snapshot-created
+            # sandbox run today's code without publishing a new snapshot.
+            wheel_override = str(
+                getattr(settings, "ALK_HOSTED_WHEEL_OVERRIDE", "") or ""
+            ).strip()
+            wheel_override_installed = ""
+            if wheel_override and os.path.isfile(wheel_override):
+                wheel_override_installed = (
+                    f"{_WHEEL_OVERRIDE_DIR}/{os.path.basename(wheel_override)}"
+                )
+                with open(wheel_override, "rb") as handle:
+                    sandbox.fs.upload_file(handle.read(), wheel_override_installed)
+                logger.info(
+                    "hosted_harness_guest_wheel_override",
+                    extra={"job_id": str(job.id), "wheel": wheel_override},
+                )
             sandbox.fs.upload_file(
                 json.dumps(
                     dispatch_payload, sort_keys=True, separators=(",", ":")
@@ -1572,6 +1597,19 @@ class DaytonaHostedGateway:
                 SessionExecuteRequest(
                     command=(
                         (f"export {export_command} && " if export_command else "")
+                        # Installed with --no-deps so it needs no package index (the snapshot's
+                        # environment already carries every dependency this wheel declares), and
+                        # into a writable directory placed first on PYTHONPATH because the guest
+                        # does not own the baked venv and cannot write its console scripts.
+                        + (
+                            f"pip install --no-deps --force-reinstall --quiet "
+                            f"--target {_WHEEL_OVERRIDE_TARGET} "
+                            f"{wheel_override_installed} && "
+                            f"export PYTHONPATH={_WHEEL_OVERRIDE_TARGET}"
+                            '${PYTHONPATH:+:$PYTHONPATH} && '
+                            if wheel_override_installed
+                            else ""
+                        )
                         + "if [ ! -f /work/authoring/contract.json ]; then "
                         "python -m fi.alk.harness.hosted_authoring_entrypoint "
                         "/work/job.json --source /work/source --output /work/authoring "

--- a/futureagi/simulate/services/hosted_runner.py
+++ b/futureagi/simulate/services/hosted_runner.py
@@ -750,10 +750,19 @@ def _voice_simulator_config(
         default_tts_provider, default_tts_model = "deepgram", "aura-2-andromeda-en"
     else:
         default_tts_provider, default_tts_model = "gemini", "gemini-3.1-flash-tts-preview"
-    tts = {
-        "provider": _voice_setting("SIMULATOR_TTS_PROVIDER") or default_tts_provider,
-        "model": _voice_setting("SIMULATOR_TTS_MODEL") or default_tts_model,
-    }
+    # Provider and model have to be decided together. Overriding only the provider used to leave
+    # the model on the language branch's default, so a deepgram override on a persona whose
+    # language did not resolve sent a Gemini model name to Deepgram's socket, which answers 400
+    # and takes the call down before its first turn.
+    tts_provider = _voice_setting("SIMULATOR_TTS_PROVIDER") or default_tts_provider
+    tts_model = _voice_setting("SIMULATOR_TTS_MODEL")
+    if not tts_model:
+        tts_model = (
+            default_tts_model
+            if tts_provider == default_tts_provider
+            else _TTS_MODEL_BY_PROVIDER.get(tts_provider, default_tts_model)
+        )
+    tts = {"provider": tts_provider, "model": tts_model}
 
     return {
         "llm": {
@@ -767,6 +776,17 @@ def _voice_simulator_config(
         "stt": stt,
         "tts": tts,
     }
+
+
+# The model each TTS provider is addressed by, so an override that names only the provider still
+# gets a model that provider recognises.
+_TTS_MODEL_BY_PROVIDER = {
+    "deepgram": "aura-2-andromeda-en",
+    "gemini": "gemini-3.1-flash-tts-preview",
+    "openai": "gpt-4o-mini-tts",
+    "elevenlabs": "eleven_flash_v2_5",
+    "cartesia": "sonic-3",
+}
 
 
 def _is_english_language(language: str | None) -> bool:

--- a/futureagi/simulate/views/alk_simulate_ingestion.py
+++ b/futureagi/simulate/views/alk_simulate_ingestion.py
@@ -177,6 +177,7 @@ class ALKSimulateIngestionViewSet(ViewSet):
                 agent_name=payload.get("agent_name"),
                 description=payload.get("description", ""),
                 modality=payload.get("modality", "text"),
+                direction=payload.get("direction", "inbound"),
             )
         except ALKSimulateIngestionError as e:
             return self.gm.bad_request(str(e))

--- a/futureagi/tfc/settings/settings.py
+++ b/futureagi/tfc/settings/settings.py
@@ -723,6 +723,9 @@ DAYTONA_API_URL = os.getenv("DAYTONA_API_URL") or None
 DAYTONA_TARGET = os.getenv("DAYTONA_TARGET") or None
 DAYTONA_ORGANIZATION_ID = os.getenv("DAYTONA_ORGANIZATION_ID") or None
 ALK_DAYTONA_SNAPSHOT = os.getenv("ALK_DAYTONA_SNAPSHOT", "")
+# A locally built guest wheel installed over a snapshot at launch, so a sandbox created from
+# a snapshot can run a newer guest than the one baked into it.
+ALK_HOSTED_WHEEL_OVERRIDE = os.getenv("ALK_HOSTED_WHEEL_OVERRIDE", "")
 ALK_DAYTONA_SNAPSHOT_DIGEST = os.getenv("ALK_DAYTONA_SNAPSHOT_DIGEST", "")
 # Local certification escape hatch: Daytona builds an ephemeral sandbox directly from the
 # trusted hosted Dockerfile. Production leaves this empty and uses the immutable snapshot above.


### PR DESCRIPTION
## What this does

Carries the hosted harness job's own authoring contract through to the platform rows the run is recorded against, and makes a suite that is still being written survivable.

Four surfaces, one job each.

### 1. Call direction reaches the agent row

An ALK-provisioned agent definition was created with `inbound=True` hardcoded and `target_speaks_first` left unset, so an outbound run described itself as the opposite of the call it placed. Provision now accepts `direction`, and `_resolve_scenario_direction` reads the job's persisted authoring contract when the request does not state one, mirroring how modality is already resolved. That ordering matters: the contract on the job is authoritative, so nothing needs a lock-step guest rollout to start reporting direction correctly.

`direction == "outbound"` means `inbound=False` and `target_speaks_first=False`, which is how the platform already models a call the agent did not receive.

### 2. `agent_prompt` resolves to the real prompt

Externally provisioned agents were the only ones created without a version, so `latest_version` was `None` and every reader of the configuration snapshot resolved to an empty string, including the `agent_prompt` eval input. The definition now creates an active version at provision time. The snapshot is built from the agent during save, so this needs no second write.

### 3. Deployment-only settings reach the sandbox

The gateway's environment pass-through gains `ALK_BACKGROUND_NOISE` and the two per-stage authoring backend settings. Whether a simulated caller is heard through ambient noise, and which backend each authoring stage runs on, are deployment choices the sandbox cannot infer and the customer request must not influence.

### 4. A partial suite is checkpointed instead of lost

Freezing the authoring archive only fired once the suite reached its full count, so a guest that died at 199 of 200 left nothing to restore and the retry regenerated every scenario from the beginning. A suite still being written is now snapshotted on each poll, and the freeze test becomes "not already frozen" rather than "no archive at all" so the complete suite still replaces the checkpoint. The archive also carries the plan, the write journal and the sub-goal catalogue, which is what a resume needs to know what is outstanding.

A checkpoint is best effort by construction: any failure is logged and the run continues, because a snapshot must never be able to fail a job.

## Per-file

| File | Change |
|---|---|
| `simulate/serializers/hosted_harness.py` | `direction` on the provision and operation serializers |
| `simulate/serializers/alk_simulate_ingestion.py` | `direction` on the ingestion provision request |
| `simulate/services/hosted_harness.py` | `_resolve_scenario_direction`, resolved from the request then the job's contract |
| `simulate/services/alk_simulate_ingestion.py` | direction maps to `inbound` / `target_speaks_first`; an active version is created so the snapshot exists |
| `simulate/services/hosted_harness_gateway.py` | noise and per-stage backend pass-through; partial authoring checkpoint; plan, journal and catalogue added to the archive |
| `simulate/views/alk_simulate_ingestion.py` | passes `direction` through |
| `frontend/.../harness/StageOutput.jsx` | authoring stage output renders as it arrives rather than only when the stage ends |

## Behaviour callouts

- An ALK-provisioned agent definition now has a version where it previously had none. Anything that treated `latest_version is None` as the marker for an externally provisioned agent would need to key off something else.
- `direction` defaults to `inbound` everywhere it is optional, so a request that does not send it behaves exactly as before.
- The authoring archive is now written more than once per job. It is replaced, not appended, and the complete suite always wins over a checkpoint of itself.

## Scope out

| Not here | Why |
|---|---|
| Starting the call stage after authoring completes | A hosted job pre-allocates its call executions and no scheduler ever starts them. That trigger is a separate change and wants a decision on where it belongs. |
| Simulator text-to-speech provider and model pairing | Being verified on a live call first. |
| Retell and Vapi target modes | Already on the base branch. |
