### PR TITLE
fix(catalog): continue lifecycle from completed physical snapshots

### DIFF
--- a/futureagi/tracer/services/clickhouse/v2/property_catalog/durable_lifecycle.py
+++ b/futureagi/tracer/services/clickhouse/v2/property_catalog/durable_lifecycle.py
@@ -379,10 +379,11 @@ class PriorActiveEvidence:
             raise ValueError("zero-depth lineage anchor is not the active revision")
         if not isinstance(self.build_plan, RevisionBuildPlan):
             raise TypeError("build_plan must be a RevisionBuildPlan")
-        if CatalogLifecycleMode(_decode_plan_scope(self.build_plan).mode.value) is not (
-            self.lifecycle_mode
-        ):
+        decoded = _decode_plan_scope(self.build_plan, allow_physical_snapshot=True)
+        if CatalogLifecycleMode(decoded.mode.value) is not self.lifecycle_mode:
             raise ValueError("active lifecycle mode differs from its build plan")
+        if decoded.physical_snapshot and self.lineage_anchor.active_revisions_since:
+            raise ValueError("physical snapshot must be its own lineage anchor")
         if not isinstance(self.streams, tuple) or any(
             not isinstance(value, ActiveStreamEvidence) for value in self.streams
         ):
@@ -1041,7 +1042,9 @@ class DurableWorkspaceCatalogLifecycle:
         # or widens the already-admitted half-open plan.
         _ = configured_bounds
         if active is not None:
-            prior_cutoffs = _decode_plan_scope(active.build_plan).cutoffs
+            prior_cutoffs = _decode_plan_scope(
+                active.build_plan, allow_physical_snapshot=True
+            ).cutoffs
             if decoded.cutoffs.snapshot_upper <= prior_cutoffs.snapshot_upper:
                 raise DurableLifecycleError(
                     "open scheduled build does not advance the active upper cutoff"
@@ -1112,7 +1115,9 @@ class DurableWorkspaceCatalogLifecycle:
                 raise DurableLifecycleError(
                     f"{mode} requires prior active checkpoint evidence"
                 )
-            active_scope = _decode_plan_scope(active.build_plan)
+            active_scope = _decode_plan_scope(
+                active.build_plan, allow_physical_snapshot=True
+            )
             span_since = (
                 active_scope.cutoffs.span_window.until
                 if mode is LifecycleRunMode.INCREMENTAL
@@ -1154,7 +1159,9 @@ class DurableWorkspaceCatalogLifecycle:
                 "scheduled source upper cutoff was not freshly frozen in UTC"
             )
         if active is not None:
-            previous = _decode_plan_scope(active.build_plan).cutoffs
+            previous = _decode_plan_scope(
+                active.build_plan, allow_physical_snapshot=True
+            ).cutoffs
             if cutoffs.snapshot_upper <= previous.snapshot_upper:
                 raise DurableLifecycleError(
                     "scheduled source upper cutoff did not strictly advance"
@@ -1221,6 +1228,7 @@ class _DecodedPlanScope:
     mode: LifecycleRunMode
     cutoffs: FrozenLifecycleCutoffs
     prior_active_revision: int | None
+    physical_snapshot: bool = False
 
 
 @dataclass(frozen=True, slots=True)
@@ -1349,7 +1357,9 @@ class ClickHouseLifecycleStateReader:
             raise DurableLifecycleError("active revision has no persisted reservation")
         if reservation.lease.projection_version != active.projection_version:
             raise DurableLifecycleError("active reservation projection changed")
-        decoded_plan = _decode_plan_scope(reservation.lease.build_plan)
+        decoded_plan = _decode_plan_scope(
+            reservation.lease.build_plan, allow_physical_snapshot=True
+        )
         if CatalogLifecycleMode(decoded_plan.mode.value) is not active.lifecycle_mode:
             raise DurableLifecycleError("active reservation changed its lifecycle mode")
         manifest_streams = _manifest_streams(active.source_manifest_json)
@@ -1399,6 +1409,7 @@ class ClickHouseLifecycleStateReader:
                     watermark=_persisted_active_watermark(
                         checkpoint,
                         snapshot_cutoff=decoded_plan.cutoffs.snapshot_upper,
+                        physical_snapshot=decoded_plan.physical_snapshot,
                     ),
                     checkpoint_state_sha256=checkpoint.checkpoint.state_sha256,
                 )
@@ -1845,6 +1856,16 @@ def _lower_watermarks(
     result = {value.role_key: value.watermark for value in active.streams}
     if set(result) != _EXPECTED_ROLE_INVENTORY:
         raise DurableLifecycleError("active lower-watermark inventory is incomplete")
+    if _decode_plan_scope(
+        active.build_plan, allow_physical_snapshot=True
+    ).physical_snapshot:
+        # Physical snapshots prove catalog contents, not PostgreSQL keyset
+        # positions. Refresh definitions within the next frozen source budget;
+        # never interpret their opaque generation as a timestamp/cursor.
+        for key in result:
+            if key[1] is ManifestStreamRole.DEFINITIONS:
+                result[key] = ""
+        return result
     for adapter in _RELATIONAL_ADAPTERS:
         if not result[(adapter, ManifestStreamRole.DEFINITIONS)]:
             raise DurableLifecycleError(
@@ -1857,16 +1878,25 @@ def _persisted_active_watermark(
     checkpoint: CheckpointWrite,
     *,
     snapshot_cutoff: datetime,
+    physical_snapshot: bool = False,
 ) -> str:
-    """Normalize only a provably empty legacy relational checkpoint.
+    """Validate physical snapshot markers or normalize empty legacy cursors.
 
     Older reconciler builds could activate a terminal relational stream with
     an empty watermark when its frozen snapshot contained zero rows.  The
     immutable build plan retains the exact snapshot cutoff, so that one legacy
     shape can be recovered without mutating persisted control-plane evidence.
     Every other blank relational watermark remains corruption and fails closed.
+    Physical generation markers are retained verbatim as evidence; only the
+    next run's definition lower bounds are reset by ``_lower_watermarks``.
     """
 
+    if physical_snapshot:
+        if checkpoint.watermark != str(checkpoint.source_version_fence):
+            raise DurableLifecycleError(
+                "physical snapshot checkpoint watermark changed"
+            )
+        return checkpoint.watermark
     if checkpoint.watermark:
         return checkpoint.watermark
     value = checkpoint.checkpoint
@@ -2002,13 +2032,50 @@ def _planned_streams(
     )
 
 
-def _decode_plan_scope(plan: RevisionBuildPlan) -> _DecodedPlanScope:
+def _decode_plan_scope(
+    plan: RevisionBuildPlan, *, allow_physical_snapshot: bool = False
+) -> _DecodedPlanScope:
     if not isinstance(plan, RevisionBuildPlan):
         raise TypeError("plan must be a RevisionBuildPlan")
     by_role = {(value.source_adapter, value.role): value for value in plan.streams}
     _require_exact_role_inventory(tuple(by_role), label="build plan")
     if len(by_role) != len(plan.streams):
         raise DurableLifecycleError("build plan contains duplicate lifecycle roles")
+    if any(
+        value.source_cutoff_label == "physical_snapshot_r3" for value in plan.streams
+    ):
+        # Decode-only compatibility with the completed r3 physical backfill.
+        # OPEN/DRAINING recovery deliberately does not opt in: these are not
+        # executable lifecycle plans. Active reads still require the fenced
+        # reservation, matching activation manifest and ten clean checkpoints.
+        if not allow_physical_snapshot:
+            raise DurableLifecycleError(
+                "physical snapshot cannot resume as a lifecycle run"
+            )
+        if (
+            (plan.catalog_epoch, plan.catalog_revision, plan.projection_version)
+            != (1, 3, 3)
+            or {value.source_cutoff_label for value in plan.streams}
+            != {"physical_snapshot_r3"}
+            or len({value.source_version_fence for value in plan.streams}) != 1
+        ):
+            raise DurableLifecycleError("physical snapshot build plan contract changed")
+        # The generation fence is opaque (not UTC microseconds). The signed
+        # source_scope is the authoritative half-open backfill time window.
+        window = SourceWindow(
+            _micros_to_datetime(plan.source_scope.span_since_us),
+            _micros_to_datetime(plan.source_scope.span_until_us),
+        )
+        return _DecodedPlanScope(
+            LifecycleRunMode.INITIAL_BACKFILL,
+            FrozenLifecycleCutoffs(
+                snapshot_upper=window.until,
+                span_window=window,
+                span_audit_generation=plan.streams[0].source_version_fence,
+            ),
+            None,
+            physical_snapshot=True,
+        )
     prefixes = {
         value.source_cutoff_label[: -len(suffix)]
         for value in plan.streams

--- a/futureagi/tracer/tests/test_property_catalog_physical_snapshot_lifecycle.py
+++ b/futureagi/tracer/tests/test_property_catalog_physical_snapshot_lifecycle.py
@@ -1,0 +1,354 @@
+"""Completed physical backfills are history, never executable resume plans."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import replace
+from datetime import timedelta
+from types import SimpleNamespace
+from uuid import NAMESPACE_URL, uuid5
+
+import pytest
+
+from tracer.services.clickhouse.v2.property_catalog import durable_lifecycle as dl
+from tracer.services.clickhouse.v2.property_catalog.activation import (
+    BuildPlanSourceScope,
+    BuildPlanStream,
+    ManifestStreamRole,
+    RevisionBuildPlan,
+    RevisionLease,
+)
+from tracer.services.clickhouse.v2.property_catalog.codec import (
+    canonical_json,
+    canonical_json_sha256,
+)
+from tracer.services.clickhouse.v2.property_catalog.projection import (
+    PostgresSnapshotContext,
+)
+from tracer.services.clickhouse.v2.property_catalog.qualification import (
+    CheckpointStatus,
+)
+from tracer.services.clickhouse.v2.property_catalog.reconciler import (
+    ReconcileRequest,
+    _source_cursor,
+)
+from tracer.tests.test_property_catalog_durable_lifecycle import (
+    INITIAL_SINCE,
+    INITIAL_UNTIL,
+    SHA_A,
+    TOKEN_A,
+    TOKEN_B,
+    _bounds,
+    _Clock,
+    _complete_checkpoints,
+    _Freezer,
+    _jsonstrings_activation_row,
+    _lifecycle,
+    _scope,
+    _State,
+)
+
+# A production-shaped opaque generation, intentionally too large for a UTC
+# microsecond timestamp. It must survive unchanged in persisted evidence.
+FENCE = 1788179167838495941
+
+
+class _PhysicalSnapshot:
+    catalog_database = "property_catalog_dev_unit"
+
+    def __init__(self):
+        self.scope = replace(_scope(), catalog_epoch=1, projection_version=3)
+        self.plan = RevisionBuildPlan(
+            organization_id=self.scope.organization_id,
+            workspace_id=self.scope.workspace_id,
+            catalog_epoch=1,
+            catalog_revision=3,
+            projection_version=3,
+            build_token=TOKEN_A,
+            source_scope=BuildPlanSourceScope(
+                project_ids=self.scope.project_ids,
+                span_since_us=dl._datetime_to_micros(INITIAL_SINCE),
+                span_until_us=dl._datetime_to_micros(INITIAL_UNTIL),
+            ),
+            streams=tuple(
+                BuildPlanStream(
+                    source_adapter=adapter,
+                    role=role,
+                    producer_stream_id=str(uuid5(NAMESPACE_URL, f"{adapter}/{role}")),
+                    source_cutoff_label="physical_snapshot_r3",
+                    source_version_fence=FENCE,
+                )
+                for adapter, role in sorted(dl._EXPECTED_ROLE_INVENTORY)
+            ),
+        )
+        self.lease = RevisionLease(
+            organization_id=self.scope.organization_id,
+            workspace_id=self.scope.workspace_id,
+            catalog_epoch=1,
+            catalog_revision=3,
+            projection_version=3,
+            build_token=TOKEN_A,
+            build_plan_json=self.plan.canonical_json,
+            build_lease_sha256=self.plan.sha256,
+            issued_at=INITIAL_UNTIL,
+            expires_at=INITIAL_UNTIL + timedelta(days=7),
+        )
+        self.reservation = {
+            "organization_id": self.scope.organization_id,
+            "workspace_id": self.scope.workspace_id,
+            "catalog_epoch": 1,
+            "catalog_revision": 3,
+            "build_token": TOKEN_A,
+            "projection_version": 3,
+            "producer_stream_id": TOKEN_A,
+            "envelope_version": 0,
+            "build_plan_json": self.plan.canonical_json,
+            "build_lease_sha256": self.plan.sha256,
+            "status": "fenced",
+            "started_at": self.lease.issued_at,
+            "drain_deadline": self.lease.expires_at,
+            "fenced_at": INITIAL_UNTIL,
+            "_version": 1,
+        }
+        manifest = canonical_json(
+            {
+                "lifecycle_mode": "initial_backfill",
+                "lineage_anchor_revision": 3,
+                "streams": [
+                    {
+                        "source_adapter": s.source_adapter,
+                        "role": s.role,
+                        "producer_stream_id": s.producer_stream_id,
+                        "source_version_fence": s.source_version_fence,
+                    }
+                    for s in self.plan.streams
+                ],
+            }
+        )
+        self.activation = dict(
+            _jsonstrings_activation_row(),
+            catalog_epoch=1,
+            catalog_revision=3,
+            projection_version=3,
+            lineage_anchor_revision=3,
+            activation_sequence=1,
+            source_manifest_json=manifest,
+            source_manifest_sha256=canonical_json_sha256(manifest),
+            qualified_at=INITIAL_UNTIL,
+            updated_at=INITIAL_UNTIL,
+        )
+        self.checkpoints = {
+            value.checkpoint.key: replace(value, watermark=str(FENCE))
+            for value in _complete_checkpoints(
+                SimpleNamespace(scope=self.scope, lease=self.lease)
+            )
+        }
+        self.queries = []
+
+    def query(self, sql, params, *, timeout_ms):
+        assert sql.startswith(("SELECT", "WITH"))
+        assert params["workspace_id"] == self.scope.workspace_id
+        assert timeout_ms <= 8500
+        self.queries.append(sql)
+        if "property_catalog_activations" in sql:
+            return (self.activation,)
+        assert "property_catalog_source_streams" in sql
+        return (self.reservation,)
+
+    def load_checkpoint_write(self, **params):
+        assert params["catalog_revision"] == 3
+        assert params["build_token"] == TOKEN_A
+        return self.checkpoints.get(
+            (params["source_adapter"], params["producer_stream_id"])
+        )
+
+    def reader(self):
+        return dl.ClickHouseLifecycleStateReader(
+            self, database=self.catalog_database, checkpoint_store=self
+        )
+
+
+def test_physical_snapshot_active_read_keeps_plan_and_checkpoint_hashes():
+    stored = _PhysicalSnapshot()
+    before = (
+        dict(stored.reservation),
+        dict(stored.activation),
+        dict(stored.checkpoints),
+    )
+
+    active = stored.reader().load_latest_active(stored.scope)
+
+    assert active.build_plan.canonical_json == stored.plan.canonical_json
+    assert active.build_plan.sha256 == stored.lease.build_lease_sha256
+    assert len(active.streams) == 10
+    assert {s.watermark for s in active.streams} == {str(FENCE)}
+    assert (stored.reservation, stored.activation, stored.checkpoints) == before
+    decoded = dl._decode_plan_scope(active.build_plan, allow_physical_snapshot=True)
+    assert decoded.cutoffs.span_window == dl.SourceWindow(INITIAL_SINCE, INITIAL_UNTIL)
+    assert decoded.cutoffs.span_audit_generation == FENCE
+    assert len(stored.queries) == 2
+
+
+@pytest.mark.parametrize(
+    "mode", [dl.LifecycleRunMode.INCREMENTAL, dl.LifecycleRunMode.FULL_REPAIR]
+)
+def test_next_run_uses_standard_plan_same_projection_and_safe_definition_watermarks(
+    mode,
+):
+    stored = _PhysicalSnapshot()
+    active = stored.reader().load_latest_active(stored.scope)
+    state = _State(active=active)
+    clock = _Clock(INITIAL_UNTIL + timedelta(minutes=15))
+    lifecycle = _lifecycle(
+        state=state, clock=clock, freezer=_Freezer(clock), tokens=[TOKEN_B]
+    )
+
+    prepared = lifecycle.prepare(
+        scope=stored.scope, mode=mode, configured_bounds=_bounds()
+    )
+
+    assert prepared.lease.catalog_revision == 4
+    assert prepared.lease.projection_version == 3
+    assert prepared.prior_active is active
+    assert dl._decode_plan_scope(prepared.lease.build_plan).mode is mode
+    assert prepared.cutoffs.span_window.since == (
+        INITIAL_UNTIL if mode is dl.LifecycleRunMode.INCREMENTAL else INITIAL_SINCE
+    )
+    assert all(
+        s.lower_watermark == ""
+        for s in prepared.streams
+        if s.role is ManifestStreamRole.DEFINITIONS
+    )
+    assert all(
+        s.source_cutoff_label != "physical_snapshot_r3"
+        for s in prepared.lease.build_plan.streams
+    )
+    assert active.build_plan.sha256 == stored.plan.sha256
+    context = PostgresSnapshotContext(
+        organization_id=stored.scope.organization_id,
+        workspace_id=stored.scope.workspace_id,
+        project_ids=stored.scope.project_ids,
+        catalog_epoch=stored.scope.catalog_epoch,
+        catalog_revision=prepared.lease.catalog_revision,
+        projection_version=prepared.lease.projection_version,
+        snapshot_cutoff=prepared.cutoffs.snapshot_upper,
+    )
+    # Exercise the downstream request/cursor contract for every definition
+    # adapter, not only the lifecycle's string-valued StreamStart container.
+    for stream in prepared.lease.build_plan.streams:
+        if stream.role is ManifestStreamRole.DEFINITIONS:
+            request = ReconcileRequest(
+                context=context,
+                build_token=prepared.lease.build_token,
+                producer_stream_id=stream.producer_stream_id,
+                emitted_at=clock.current,
+                mode=mode.reconcile_mode,
+                source_version=stream.source_version_fence,
+                lower_watermark=prepared.stream(
+                    stream.source_adapter, stream.role
+                ).lower_watermark,
+            )
+            assert _source_cursor(request) == ""
+    # Crash recovery uses the *new* executable plan, retaining the same token.
+    resumed = lifecycle.prepare(
+        scope=stored.scope, mode=mode, configured_bounds=_bounds()
+    )
+    assert resumed.lease == prepared.lease
+    assert resumed.resumed
+
+
+@pytest.mark.parametrize("status", list(dl.ReservationStatus))
+def test_physical_snapshot_without_activation_is_not_resumable(status):
+    stored = _PhysicalSnapshot()
+    state = _State(reservation=dl.PersistedReservation(stored.lease, status))
+    clock = _Clock(INITIAL_UNTIL + timedelta(minutes=15))
+    lifecycle = _lifecycle(
+        state=state, clock=clock, freezer=_Freezer(clock), tokens=[TOKEN_B]
+    )
+    with pytest.raises(dl.DurableLifecycleError, match="cannot resume"):
+        lifecycle.prepare(
+            scope=stored.scope,
+            mode=dl.LifecycleRunMode.AUTO,
+            configured_bounds=_bounds(),
+        )
+
+
+@pytest.mark.parametrize(
+    "field,value",
+    [("catalog_epoch", 2), ("catalog_revision", 4), ("projection_version", 1)],
+)
+def test_physical_snapshot_rejects_other_contracts(field, value):
+    plan = replace(_PhysicalSnapshot().plan, **{field: value})
+    with pytest.raises(dl.DurableLifecycleError, match="contract changed"):
+        dl._decode_plan_scope(plan, allow_physical_snapshot=True)
+
+
+@pytest.mark.parametrize("change", ["label", "fence", "inventory"])
+def test_physical_snapshot_rejects_mixed_or_missing_streams(change):
+    plan = _PhysicalSnapshot().plan
+    streams = list(plan.streams)
+    if change == "inventory":
+        streams.pop()
+    elif change == "label":
+        streams[0] = replace(
+            streams[0], source_cutoff_label="initial_backfill_postgres_until_us"
+        )
+    else:
+        streams[0] = replace(streams[0], source_version_fence=FENCE + 1)
+    with pytest.raises((dl.DurableLifecycleError, ValueError)):
+        plan = replace(plan, streams=tuple(streams))
+        dl._decode_plan_scope(plan, allow_physical_snapshot=True)
+
+
+@pytest.mark.parametrize(
+    "change",
+    ["missing", "running", "poison", "conflict", "gap", "projection", "watermark"],
+)
+def test_active_physical_snapshot_still_requires_ten_safe_checkpoints(change):
+    stored = _PhysicalSnapshot()
+    key = next(iter(stored.checkpoints))
+    value = stored.checkpoints[key]
+    if change == "missing":
+        del stored.checkpoints[key]
+    elif change == "watermark":
+        stored.checkpoints[key] = replace(value, watermark="unproven-cursor")
+    else:
+        kwargs = {
+            "running": {"status": CheckpointStatus.RUNNING, "terminal": False},
+            "poison": {"poison_count": 1},
+            "conflict": {"conflict_count": 1},
+            "gap": {"gap_count": 1},
+            "projection": {"projection_version": 1},
+        }[change]
+        stored.checkpoints[key] = replace(
+            value,
+            checkpoint=replace(value.checkpoint, **kwargs),
+            gap_reasons=("gap",) if change == "gap" else (),
+        )
+    with pytest.raises(dl.DurableLifecycleError):
+        stored.reader().load_latest_active(stored.scope)
+
+
+@pytest.mark.parametrize(
+    "change", ["open", "plan_hash", "manifest_hash", "manifest_stream", "projection"]
+)
+def test_active_physical_snapshot_rejects_invalid_reservation_or_activation(change):
+    stored = _PhysicalSnapshot()
+    if change == "open":
+        stored.reservation["status"] = "open"
+    elif change == "plan_hash":
+        stored.reservation["build_lease_sha256"] = SHA_A
+    elif change == "manifest_hash":
+        stored.activation["source_manifest_sha256"] = SHA_A
+    elif change == "projection":
+        stored.activation["projection_version"] = 1
+    else:
+        manifest = json.loads(stored.activation["source_manifest_json"])
+        manifest["streams"][0]["source_version_fence"] += 1
+        payload = canonical_json(manifest)
+        stored.activation.update(
+            source_manifest_json=payload,
+            source_manifest_sha256=canonical_json_sha256(payload),
+        )
+    with pytest.raises((dl.DurableLifecycleError, ValueError)):
+        stored.reader().load_latest_active(stored.scope)


### PR DESCRIPTION
## Summary

Allow the durable catalog lifecycle to read an already activated, completed `physical_snapshot_r3` backfill as prior history. Its opaque generation fence is not a UTC timestamp or a PostgreSQL keyset cursor. The next normal lifecycle revision keeps projection `3`, uses the signed source window and refreshes definition cursors without rewriting existing plans, checkpoints or hashes.

This is a narrowly scoped compatibility fix, not a deployment, data migration or automatic activation of the remaining backfill.

## Linked issues

- TH-7247; follow-up to https://github.com/future-agi/future-agi/pull/2541
- Deployment follow-up: https://github.com/future-agi/deployment/pull/315 (requires a new backend/EE image containing this commit)

## Type of change

- [x] Bug fix
- [x] Regression coverage

## E2E coverage

E2E: exempt (backend-internal)

Local reader/lifecycle/cursor regression tests are included. Live Observe/dashboard property-name and value checks remain a release requirement; no production E2E success is claimed here.

## 1) What changes were done

- Add decode-only compatibility for the exact completed snapshot contract: epoch `1`, revision `3`, projection `3`, all ten expected roles, uniform `physical_snapshot_r3` labels and one consistent source fence.
- Read the snapshot's half-open time window from its immutable `source_scope`, not by treating the generation fence as microseconds.
- Require the existing fenced reservation, matching activation manifest and complete, clean checkpoints. Preserve physical snapshot watermarks verbatim and require them to match the generation fence.
- Clear only the next run's definition lower bounds so opaque generation markers are not passed to keyset-cursor decoders. Persisted evidence is unchanged.
- Continue using ordinary executable plans for new incremental/full-repair runs and crash recovery. An unactivated physical snapshot cannot resume as an executable lifecycle plan.

Only `durable_lifecycle.py` and its new focused test file change. No collector ingestion, SQL projection, schema, UI or deployment files are included.

## 2) Why the changes were done

The completed physical-backfill plan uses a different cutoff representation from ordinary lifecycle plans. Treating it as an ordinary plan prevents the lifecycle controller from continuing; treating its generation as a time/cursor would be incorrect. Compatibility is restricted to completed prior history instead of weakening normal reservation, tenant, projection or checkpoint validation.

## 3) Tests written and scenarios covered

`futureagi/tracer/tests/test_property_catalog_physical_snapshot_lifecycle.py`:

- `test_physical_snapshot_active_read_keeps_plan_and_checkpoint_hashes`: loads the complete active history, preserves stored evidence and reads the signed window correctly.
- `test_next_run_uses_standard_plan_same_projection_and_safe_definition_watermarks`: incremental and full-repair preparation, all seven definition cursor adapters, retained projection and recovery of the new ordinary plan.
- `test_physical_snapshot_without_activation_is_not_resumable`: rejects attempts to execute unactivated physical-snapshot reservations.
- `test_physical_snapshot_rejects_other_contracts`: rejects other epochs, revisions and projections.
- `test_physical_snapshot_rejects_mixed_or_missing_streams`: rejects changed labels, inconsistent fences and missing roles.
- `test_active_physical_snapshot_still_requires_ten_safe_checkpoints`: rejects missing/running/poisoned/conflicting/gapped checkpoints, wrong projections and invalid watermarks.
- `test_active_physical_snapshot_rejects_invalid_reservation_or_activation`: rejects open reservations, invalid plan/manifest hashes, changed stream fences and activation projection mismatches.

Run result: **112 passed** across the new suite plus durable lifecycle, reconciler, projection, activation-control and dev-runtime-resume suites. Ruff check, Ruff format check and `git diff --check` pass. This is focused local validation; the full backend suite and deployment E2E have not been run for this PR.

## 4) How to run / test

From the repository root, with the project's Python/test dependencies installed:

```bash
PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 PYTHONPATH=futureagi python - <<'PY'
from django.conf import settings
from tfc.settings.runtime_setting_specs import RUNTIME_NUMERIC_SETTING_SPECS
settings.configure(
    SECRET_KEY="local-only-test",
    **{key: spec.default for key, spec in RUNTIME_NUMERIC_SETTING_SPECS.items()},
)
import pytest
raise SystemExit(pytest.main([
    "--noconftest", "--rootdir=.", "--confcutdir=futureagi/tracer/tests",
    "-p", "no:cacheprovider", "-c", "/dev/null", "-q",
    "futureagi/tracer/tests/test_property_catalog_physical_snapshot_lifecycle.py",
    "futureagi/tracer/tests/test_property_catalog_durable_lifecycle.py",
    "futureagi/tracer/tests/test_property_catalog_reconciler.py",
    "futureagi/tracer/tests/test_property_catalog_projection.py",
    "futureagi/tracer/tests/test_property_catalog_activation_control.py",
    "futureagi/tracer/tests/test_property_catalog_dev_runtime_resume.py",
]))
PY
```

This isolated invocation avoids starting production-configured services or running database setup hooks. No HTTP/OpenAPI contract changed.

## 5) Screenshots / recordings

Not applicable to this backend-only patch. Live rollout/UI verification is still pending.

## 6) Edge cases and considerations

- A valid completed snapshot is its own zero-depth lineage anchor.
- No unknown format, missing checkpoint or incomplete reservation is accepted by this compatibility path.
- Normal lifecycle plans retain their existing decode/recovery behavior.
- Projection version describes the format; it does not have to equal each newly allocated catalog revision.

## 7) Operational prerequisites outside this PR

- Build backend/CE and EE images from this commit; update both backend and lifecycle-controller immutable image pins. The current `v1.34.2` backend pin does not contain this decoder change.
- Align collector, sequencer and lifecycle runtime env to projection `3`, epoch `1`, with the intended isolated catalog database and all-workspace admission. Preserve revision fencing and qualification checks.
- Reconcile ownership before enabling the normal lifecycle: the external revision-4 backfill must not compete with the runtime for the same revision.
- Requalify the repaired definitions with actual counts and hashes under an unused publication revision. This decoder does not retroactively add later repair rows to the original signed snapshot evidence or publish pending backfill coverage.
- The local operator revision/projection alignment is a separate reviewed patch, not included here. Existing receipts must not be rewritten or uncertain writes retried.
- Complete the coordinated runtime drain/fence handover and verify actual running image/env, healthy processing cycles, and property names/values in Observe and dashboards before declaring production success.

## 8) Architectural decision

Use an explicit opt-in decoder for completed physical history. Do not mutate immutable backfill evidence, infer a timestamp from an opaque generation, or permit physical-snapshot reservations to execute as ordinary resumable builds.

## Checklist

- [x] Focused regression tests pass (112 tests)
- [x] Ruff lint and format checks pass
- [x] Only the intended two Core files are included
- [x] Conventional Commit title
- [ ] Full backend suite / remote CI completed
- [ ] New image digests published and deployment pins updated
- [ ] Backfill publication/ownership prerequisites verified
- [ ] Dev and production rollout/UI verification completed
