### PR TITLE
feat(error-feed): add source identifier (Scanner/Eval) to Error Feed rows [TH-7813]

### DIFF
--- a/frontend/src/pages/dashboard/error-feed/components/ErrorFeedFilters.jsx
+++ b/frontend/src/pages/dashboard/error-feed/components/ErrorFeedFilters.jsx
@@ -37,6 +37,12 @@ const SEVERITY_OPTIONS = [
   { value: "low", label: "Low" },
 ];
 
+const SOURCE_OPTIONS = [
+  { value: "", label: "All Sources" },
+  { value: "scanner", label: "Scanner" },
+  { value: "eval", label: "Eval" },
+];
+
 const TIME_RANGE_OPTIONS = [
   { value: "1", label: "Last 24 hours" },
   { value: "7", label: "Last 7 days" },
@@ -233,6 +239,8 @@ export default function ErrorFeedFilters({ selected, onClearSelection }) {
     setSelectedStatus,
     selectedSeverity,
     setSelectedSeverity,
+    selectedSource,
+    setSelectedSource,
     selectedFixLayer,
     setSelectedFixLayer,
     timeRange,
@@ -246,12 +254,17 @@ export default function ErrorFeedFilters({ selected, onClearSelection }) {
   );
 
   const hasActiveFilters =
-    selectedProject || selectedStatus || selectedSeverity || selectedFixLayer;
+    selectedProject ||
+    selectedStatus ||
+    selectedSeverity ||
+    selectedSource ||
+    selectedFixLayer;
 
   const clearAllFilters = () => {
     setSelectedProject("");
     setSelectedStatus("");
     setSelectedSeverity("");
+    setSelectedSource("");
     setSelectedFixLayer("");
     setSearchQuery("");
   };
@@ -341,6 +354,12 @@ export default function ErrorFeedFilters({ selected, onClearSelection }) {
             onChange={setSelectedFixLayer}
             options={FIX_LAYER_OPTIONS}
             minWidth={140}
+          />
+          <CompactSelect
+            value={selectedSource}
+            onChange={setSelectedSource}
+            options={SOURCE_OPTIONS}
+            minWidth={120}
           />
 
           {hasActiveFilters && (

--- a/frontend/src/pages/dashboard/error-feed/components/ErrorFeedTable.jsx
+++ b/frontend/src/pages/dashboard/error-feed/components/ErrorFeedTable.jsx
@@ -49,19 +49,30 @@ const humanizeTime = (iso) => {
 function ErrorTypeTag({ type, isDark }) {
   const shortType = type
     .replace(/Error$/, "")
-    .replace(/([A-Z])/g, " $1")
+    // Only split camelCase boundaries (lowercase→uppercase). The old
+    // `/([A-Z])/g` inserted a space before every capital, which is a no-op
+    // on already-spaced strings like "Tool Selection Errors" (HTML collapses
+    // the doubled space) but visibly breaks acronyms with no existing space,
+    // e.g. "KB Groundedness" -> "K B Groundedness".
+    .replace(/([a-z])([A-Z])/g, "$1 $2")
     .trim();
   return (
     <Chip
-      label={shortType}
       size="small"
+      icon={
+        <Iconify icon="mdi:bug-outline" width={11} sx={{ ml: "4px", mr: 0 }} />
+      }
+      label={shortType}
       sx={{
         height: 18,
         borderRadius: "3px",
         fontSize: "10px",
-        fontWeight: 500,
+        fontWeight: "fontWeightMedium",
         bgcolor: isDark ? "rgba(255,255,255,0.07)" : "rgba(0,0,0,0.06)",
         color: isDark ? "#a1a1aa" : "#605C70",
+        "& .MuiChip-icon": {
+          color: isDark ? "#a1a1aa" : "#605C70",
+        },
         "& .MuiChip-label": { px: "5px" },
         maxWidth: 140,
         overflow: "hidden",
@@ -72,6 +83,42 @@ function ErrorTypeTag({ type, isDark }) {
 
 ErrorTypeTag.propTypes = {
   type: PropTypes.string,
+  isDark: PropTypes.bool,
+};
+
+// Tells the row apart at a glance: a cluster is either Future AGI's built-in
+// scanner or one of the customer's own eval tasks. One icon for both states
+// — the label carries the difference. Mirrors the backend's own source
+// values (ClusterSource.SCANNER / .EVAL) rather than a separate display name.
+function SourceTag({ source, isDark }) {
+  const label = source === "eval" ? "Eval" : "Scanner";
+  return (
+    <Chip
+      size="small"
+      icon={
+        <Iconify icon="mdi:tag-outline" width={11} sx={{ ml: "4px", mr: 0 }} />
+      }
+      label={label}
+      sx={{
+        height: 18,
+        borderRadius: "3px",
+        fontSize: "10px",
+        fontWeight: "fontWeightMedium",
+        bgcolor: isDark ? "rgba(255,255,255,0.07)" : "rgba(0,0,0,0.06)",
+        color: isDark ? "#a1a1aa" : "#605C70",
+        "& .MuiChip-icon": {
+          color: isDark ? "#a1a1aa" : "#605C70",
+        },
+        "& .MuiChip-label": { px: "5px" },
+        maxWidth: 140,
+        overflow: "hidden",
+      }}
+    />
+  );
+}
+
+SourceTag.propTypes = {
+  source: PropTypes.string,
   isDark: PropTypes.bool,
 };
 
@@ -446,6 +493,7 @@ export default function ErrorFeedTable({ selected, onSelect, onSelectAll }) {
                           </Typography>
                         </Tooltip>
                         <Stack direction="row" alignItems="center" gap={0.75}>
+                          <SourceTag source={row.source} isDark={isDark} />
                           <ErrorTypeTag type={row.error.type} isDark={isDark} />
                           {row.eval_score != null && (
                             <Typography


### PR DESCRIPTION
## Summary

Hotfix cherry-pick of #2530 (already merged to `dev`) onto `main` — same change, no backend/contract diff, clean cherry-pick with zero conflicts.

- New source chip on every row: `Scanner` or `Eval`, matching the backend's own `ClusterSource` values directly
- Both the source chip and the existing error-type chip carry a small leading icon (`mdi:tag-outline` / `mdi:bug-outline`) — same grey styling as before, no new color
- New Source filter dropdown in the filter bar (last position, after Fix Layer)
- Fixes `ErrorTypeTag`'s label regex, which mangled acronyms in category/eval names (e.g. `KB Groundedness` → `K B Groundedness`)

See #2530 for full context, screenshots, and verification.

## Verification

- Lint/prettier clean on both changed files
- Cherry-picked diff is byte-identical to the merged PR's net change (2 files, 71 insertions / 4 deletions) — confirmed via `git diff up/main --stat`