### PR TITLE
fix(observe): parse metric chart timestamps as UTC instants

### DIFF
--- a/frontend/src/sections/projects/ChartsView/ChartsView.jsx
+++ b/frontend/src/sections/projects/ChartsView/ChartsView.jsx
@@ -28,7 +28,7 @@ import ChartsGenerator from "./ChartsGenerator";
 import ChartsDateTimeRangePicker from "./ChartsDateTimeRangePicker";
 import EvaluationCharts from "./EvaluationCharts";
 import { useChartsViewContext } from "./ChartsViewProvider/ChartsViewContext";
-import { normalizeTimestamp } from "./ChartsViewProvider/common";
+import { parseTimestampToMs } from "./ChartsViewProvider/timestampUtils";
 import SvgColor from "src/components/svg-color";
 import Iconify from "src/components/iconify";
 import TraceFilterPanel from "../LLMTracing/TraceFilterPanel";
@@ -329,7 +329,7 @@ const ChartsView = () => {
                   name: "Latency",
                   data:
                     systemMetrics?.latency?.map((item) => ({
-                      x: normalizeTimestamp(item?.timestamp),
+                      x: parseTimestampToMs(item?.timestamp),
                       y: item?.latency,
                     })) || [],
                 },
@@ -346,7 +346,7 @@ const ChartsView = () => {
                   name: "Tokens",
                   data:
                     systemMetrics?.tokens?.map((item) => ({
-                      x: normalizeTimestamp(item?.timestamp),
+                      x: parseTimestampToMs(item?.timestamp),
                       y: item?.tokens,
                     })) || [],
                 },
@@ -363,7 +363,7 @@ const ChartsView = () => {
                   name: "Traffic",
                   data:
                     systemMetrics?.traffic?.map((item) => ({
-                      x: normalizeTimestamp(item?.timestamp),
+                      x: parseTimestampToMs(item?.timestamp),
                       y: item?.traffic,
                     })) || [],
                 },
@@ -380,7 +380,7 @@ const ChartsView = () => {
                   name: "Cost",
                   data:
                     systemMetrics?.cost?.map((item) => ({
-                      x: normalizeTimestamp(item?.timestamp),
+                      x: parseTimestampToMs(item?.timestamp),
                       y: item?.cost,
                     })) || [],
                 },

--- a/frontend/src/sections/projects/ChartsView/ChartsViewProvider/common.js
+++ b/frontend/src/sections/projects/ChartsView/ChartsViewProvider/common.js
@@ -5,10 +5,3 @@ export const convertToISO = (dateArray) => {
     return d.toISOString();
   });
 };
-
-export const normalizeTimestamp = (timestamp) => {
-  if (!timestamp) return timestamp;
-
-  // Remove common timezone patterns: +00:00, -05:00, Z, etc.
-  return timestamp.replace(/([+-]\d{2}:\d{2}|Z)$/, "");
-};

--- a/frontend/src/sections/projects/ChartsView/ChartsViewProvider/timestampUtils.js
+++ b/frontend/src/sections/projects/ChartsView/ChartsViewProvider/timestampUtils.js
@@ -1,0 +1,23 @@
+import { isValid, parseISO } from "date-fns";
+
+/**
+ * Parse a chart timestamp into epoch milliseconds for plotting.
+ *
+ * Backend timestamps arrive as ISO-8601 strings with an explicit UTC
+ * offset (e.g. "2024-01-01T14:30:00+00:00"). Stripping the offset and
+ * feeding the bare string to `new Date()` makes it parse as local time,
+ * which shifts every point on the chart for non-UTC viewers. Parsing
+ * with `parseISO` preserves the offset so the value is a correct UTC
+ * instant; ApexCharts then renders it in the viewer's local timezone.
+ *
+ * Mirrors `parseTimestampToMs` in the LLMTracing GraphSection
+ * (see https://github.com/future-agi/future-agi/pull/1329).
+ *
+ * @param {string|number|Date|null|undefined} ts
+ * @returns {number|null} epoch ms, or null if the value is missing/invalid
+ */
+export function parseTimestampToMs(ts) {
+  if (ts == null) return null;
+  const date = typeof ts === "string" ? parseISO(ts) : new Date(ts);
+  return isValid(date) ? date.getTime() : null;
+}

--- a/frontend/src/sections/projects/ChartsView/ChartsViewProvider/timestampUtils.test.js
+++ b/frontend/src/sections/projects/ChartsView/ChartsViewProvider/timestampUtils.test.js
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+
+import { parseTimestampToMs } from "./timestampUtils";
+
+describe("parseTimestampToMs", () => {
+  it("preserves the offset so an offset-suffixed string parses to the exact epoch ms", () => {
+    expect(parseTimestampToMs("2024-01-01T14:30:00+05:30")).toBe(
+      new Date("2024-01-01T09:00:00Z").getTime(),
+    );
+  });
+
+  it("parses Z-suffixed timestamps as UTC", () => {
+    expect(parseTimestampToMs("2024-01-01T14:30:00Z")).toBe(
+      Date.parse("2024-01-01T14:30:00Z"),
+    );
+  });
+
+  it("parses negative offsets correctly", () => {
+    expect(parseTimestampToMs("2024-01-01T14:30:00-08:00")).toBe(
+      Date.parse("2024-01-01T22:30:00Z"),
+    );
+  });
+
+  it("still returns a finite number for timestamps with no offset", () => {
+    const result = parseTimestampToMs("2024-01-01T14:30:00");
+    expect(typeof result).toBe("number");
+    expect(Number.isFinite(result)).toBe(true);
+  });
+
+  it("returns null for missing values", () => {
+    expect(parseTimestampToMs(null)).toBeNull();
+    expect(parseTimestampToMs(undefined)).toBeNull();
+  });
+
+  it("returns null for invalid strings", () => {
+    expect(parseTimestampToMs("not-a-date")).toBeNull();
+  });
+
+  it("passes through epoch-ms numbers and Date objects", () => {
+    const ms = Date.parse("2024-01-01T09:00:00Z");
+    expect(parseTimestampToMs(ms)).toBe(ms);
+    expect(parseTimestampToMs(new Date(ms))).toBe(ms);
+  });
+});

--- a/frontend/src/sections/projects/ChartsView/ChartsWithFetch.jsx
+++ b/frontend/src/sections/projects/ChartsView/ChartsWithFetch.jsx
@@ -7,7 +7,7 @@ import { transformEvaluationPayload } from "./common";
 import { Box, Button, Skeleton, Typography } from "@mui/material";
 import { useChartsViewContext } from "./ChartsViewProvider/ChartsViewContext";
 import { getStorage } from "src/hooks/use-local-storage";
-import { normalizeTimestamp } from "./ChartsViewProvider/common";
+import { parseTimestampToMs } from "./ChartsViewProvider/timestampUtils";
 import {
   AGGREGATION_PREPARING_MESSAGE,
   awaitAggregationRequestWithDeadline,
@@ -91,7 +91,7 @@ export default function ChartWithFetch({ evaluation, observeId, inView }) {
       series: result.map((seriesObj) => ({
         name: seriesObj?.name,
         data: (seriesObj?.data ?? []).map((item) => ({
-          x: normalizeTimestamp(item.timestamp),
+          x: parseTimestampToMs(item.timestamp),
           y: item?.value,
         })),
       })),


### PR DESCRIPTION
## Summary

The latency, tokens, traffic and cost charts on a project — and the evaluation charts on the same screen — stripped the timezone suffix off every timestamp before plotting. The bare string that remained was parsed as local time, shifting every point by the viewer's UTC offset. This PR replaces the strip with a proper parse that preserves the offset, so points render at the correct local time, and adds regression tests.

## Linked issues

Closes #2510
Linear:

## Type of change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📖 Documentation only
- [ ] 🧹 Chore / refactor (no user-visible change)
- [ ] 🚀 Performance improvement
- [ ] 🧪 Test-only change

## E2E coverage

E2E: exempt (harness-gap no browser-timezone control — the bug only manifests for non-UTC viewers, so a UTC browser run cannot distinguish fixed from broken)

---

## 1) What changes were done

**A. New `parseTimestampToMs` helper — `ChartsViewProvider/timestampUtils.js`**

- Parses a chart timestamp into epoch milliseconds with date-fns `parseISO`, preserving the offset; returns `null` for missing/invalid values.
- Mirrors the helper added for the tracing graphs in PR #1329; the two can be folded into one shared helper once that lands.

**B. Metric and evaluation charts now use the parse**

- `ChartsView.jsx` — the four metric series (latency, tokens, traffic, cost) map `x` through `parseTimestampToMs`.
- `ChartsWithFetch.jsx` — the evaluation chart series does the same.
- Removed the old `normalizeTimestamp` strip from `ChartsViewProvider/common.js` (no remaining callers).

**C. User-visible effects**

- Points draw at the correct local hour for non-UTC viewers on all five charts.
- Chart tooltips also show the correct local time now — `new Date(xValue)` in `ChartsGenerator.jsx` had the same bug with the naive strings.

## 2) Why the changes were done

- **Product/UX:** a spike at 15:30 IST was drawn at 10:00 — the charts silently mis-stated when things happened, and nothing on screen suggested it.
- **Technical:** epoch ms is timezone-safe end to end; ApexCharts `xaxis: { type: "datetime" }` renders ms in the viewer's timezone.
- **Architecture:** mirrors the tracing-side fix (#1329) so the two copies can be folded into a shared helper later, as issue #2510 suggests.

---

## 3) Tests written + scenarios each covers

**`frontend/src/sections/projects/ChartsView/ChartsViewProvider/timestampUtils.test.js`** — what `parseTimestampToMs` returns for every timestamp shape

- `preserves the offset so an offset-suffixed string parses to the exact epoch ms` — `+05:30` string lands on the correct UTC instant
- `parses Z-suffixed timestamps as UTC` — `Z` strings parse to the exact epoch ms
- `parses negative offsets correctly` — `-08:00` strings land on the correct instant
- `still returns a finite number for timestamps with no offset` — no-offset points are handled, not dropped or thrown
- `returns null for missing values` — `null`/`undefined` in, `null` out
- `returns null for invalid strings` — garbage never becomes a plotted point
- `passes through epoch-ms numbers and Date objects` — non-string inputs are untouched

> Run result: **7 passed** in this suite. Full frontend suite `yarn test:run`: **448 files / 4425 tests passed**. ESLint clean on all changed files (two pre-existing warnings in an untouched file, `ChartsDateTimeRangePicker.jsx`).

---

## 4) How to run / test

### Frontend tests

```bash
cd frontend
yarn install
yarn test:run src/sections/projects/ChartsView/ChartsViewProvider/timestampUtils.test.js
# full suite:
yarn test:run
```

### UI steps (manual)

1. Start the stack and log in at **http://localhost:3000** (or 3031 in dev).
2. Open a project → Charts view.
3. Send traffic at a known time, then hover the chart points: the tooltip should show that time in the viewer's local timezone (e.g. for a UTC timestamp of 10:00, an IST viewer sees 15:30).

---

## 5) Screenshots / recordings

### Test output

```
 ✓ src/sections/projects/ChartsView/ChartsViewProvider/timestampUtils.test.js (7 tests) 4ms
 Test Files  1 passed (1)
      Tests  7 passed (7)
```

### UI testing

Local stack verification in progress — screenshot to be attached once the self-hosted stack finishes booting.

---

## 6) Edge cases & considerations

- Missing (`null`/`undefined`) timestamps → `x: null`, the chart skips the point (previously `x: undefined`).
- Timestamps with no offset → parsed as local time by `parseISO`, consistent with PR #1329; the backend sends explicit offsets, so this path is defensive.
- Invalid strings → `null` instead of a garbage plotted point.
- Epoch-ms numbers and `Date` objects pass through unchanged.

---

## 7) Pre-existing issues (NOT introduced by this PR)

*None.*

---

## 8) Architectural / important decisions

- **Return epoch ms rather than a reformatted string:** ApexCharts' datetime axis consumes ms natively; any string format would need a second parse at render time and another timezone decision there.
- **Helper lives in `ChartsViewProvider/`, not imported across sections:** there are no cross-section imports of this kind today; issue #2510 explicitly proposes folding into a shared helper once #1329 lands.

---

## Checklist

- [x] My code follows the [style guide](../CONTRIBUTING.md#code-style)
- [x] I've added tests that prove my fix is effective or that my feature works
- [ ] `bin/test` passes locally (backend) — no backend changes
- [x] `yarn test:run` passes locally (frontend)
- [ ] `yarn contracts:check` passes if API surface changed — no API surface change
- [x] I've updated the documentation where relevant — no docs needed
- [x] No hardcoded secrets, URLs, or PII
- [ ] I've signed the [CLA](../CONTRIBUTING.md#contributor-license-agreement-cla) — will sign when the bot prompts
- [x] PR title follows Conventional Commits
- [ ] Linear issue is linked and updated with status — no Linear access
