### PR TITLE
fix(playground): keep user-selected run on history refresh

### DIFF
--- a/frontend/src/sections/agent-playground/Executions/ExecutionsList.jsx
+++ b/frontend/src/sections/agent-playground/Executions/ExecutionsList.jsx
@@ -48,13 +48,16 @@ const ExecutionsList = ({
 
   const scrollContainerRef = useScrollEnd(fetchNext, [fetchNext]);
 
-  // Auto-select top execution whenever the newest item changes
+  // Auto-select the newest execution only until the user picks one.
+  // A user-selected run must survive list refreshes (e.g. a new arrival
+  // or returning to the tab); with nothing chosen the newest is still
+  // selected automatically on first open.
   const firstExecutionId = executions[0]?.id;
   useEffect(() => {
-    if (firstExecutionId) {
+    if (firstExecutionId && selectedExecutionId == null) {
       onExecutionChange(firstExecutionId);
     }
-  }, [firstExecutionId, onExecutionChange]);
+  }, [firstExecutionId, selectedExecutionId, onExecutionChange]);
 
   return (
     <Box


### PR DESCRIPTION
## What does this PR do?

A run the user selected in the Agent Playground execution history now stays selected when the list refreshes (new arrival, tab refocus). The newest run is still auto-selected on first open while nothing is chosen.

## Why?

`ExecutionsList` ran `onExecutionChange(firstExecutionId)` whenever the first item changed, unconditionally dragging the user to the newest run.

## Changes

- Auto-select effect now only fires while `selectedExecutionId == null`
- No-selection and first-open behaviour unchanged

Fixes #2511