### PR TITLE
fix(charts): plot metric points at the true instant, not viewer-local time

### DIFF
--- a/frontend/src/sections/projects/ChartsView/ChartsViewProvider/common.js
+++ b/frontend/src/sections/projects/ChartsView/ChartsViewProvider/common.js
@@ -8,7 +8,14 @@ export const convertToISO = (dateArray) => {
 
 export const normalizeTimestamp = (timestamp) => {
   if (!timestamp) return timestamp;
+  if (typeof timestamp === "number") return timestamp;
 
-  // Remove common timezone patterns: +00:00, -05:00, Z, etc.
-  return timestamp.replace(/([+-]\d{2}:\d{2}|Z)$/, "");
+  // Parse the timestamp with its offset intact and return epoch
+  // milliseconds. Stripping the offset suffix used to leave a bare
+  // local-time string, so every point was plotted shifted by the
+  // viewer's distance from UTC. Offset-less strings still parse as
+  // local time and pass through unchanged in value.
+  const parsed = new Date(timestamp);
+  if (Number.isNaN(parsed.getTime())) return timestamp;
+  return parsed.getTime();
 };


### PR DESCRIPTION
## What does this PR do?

Metric-chart points (latency, tokens, traffic, cost) and the evaluation charts sharing the helper are now drawn at the time they happened, in the viewer timezone — instead of shifted by the viewer offset from UTC.

## Why?

`normalizeTimestamp` stripped the offset suffix (`+00:00`, `Z`, …) off backend timestamps. The bare remainder parses as local time, so e.g. a viewer in IST saw every point 5.5h early. Shape right, clock position wrong, nothing on screen hinting at it.

## Changes

- `normalizeTimestamp` parses with the offset intact and returns epoch ms (unambiguous for the datetime axis and tooltips)
- Offset-less and unparseable inputs pass through as before
- Covers the 4 system-metric charts (`ChartsView.jsx`) and eval charts (`ChartsWithFetch.jsx`) alike; tracing graphs are a separate issue with a fix already in review and untouched here

Fixes #2510