### PR TITLE
fix(install): detect Windows netstat listeners in port preflight

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -364,6 +364,12 @@ port_holder() {
   elif command -v ss >/dev/null 2>&1; then
     out=$(ss -ltn 2>/dev/null)
     [[ -n "$out" ]] && awk -v p=":$port\$" '$4 ~ p {print $0; exit}' <<<"$out"
+  elif command -v netstat >/dev/null 2>&1; then
+    # Windows fallback (MSYS2, Git Bash): neither lsof nor ss exists there.
+    # Match TCP listeners in LISTENING state on exactly $port; the trailing
+    # anchor keeps :3000 from matching :30000, and UDP lines never match.
+    out=$(netstat -ano 2>/dev/null | awk -v p="$port" '$1 == "TCP" && $4 == "LISTENING" && $2 ~ ":"p"$"')
+    [[ -n "$out" ]] && head -1 <<<"$out"
   fi
   set -eE
   return 0

--- a/bin/test_install_port_holder.sh
+++ b/bin/test_install_port_holder.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+# Regression tests for port_holder() in bin/install.
+# Covers the Windows netstat fallback (future-agi#2274, fixed by #2396):
+# with lsof/ss unavailable, TCP LISTENING ports must still be detected.
+set -uo pipefail
+cd "$(dirname "$0")/.."
+
+TMP=$(mktemp -d)
+trap 'rm -rf "$TMP"' EXIT
+
+# Extract port_holder() without running the installer.
+sed -n '/^port_holder() {$/,/^}$/p' bin/install >"$TMP/port_holder.sh"
+if [[ ! -s "$TMP/port_holder.sh" ]]; then
+  echo "FAIL: could not extract port_holder() from bin/install"
+  exit 1
+fi
+
+# Stub bin: a fake Windows-style netstat plus the tools port_holder needs.
+# lsof and ss are deliberately absent so the netstat branch is taken.
+STUB="$TMP/stubbin"
+mkdir -p "$STUB"
+ln -s "$(command -v awk)" "$STUB/awk"
+ln -s "$(command -v head)" "$STUB/head"
+ln -s "$(command -v bash)" "$STUB/bash"
+cat >"$STUB/netstat" <<'EOF'
+#!/usr/bin/env bash
+printf '%s\n' \
+  'Active Connections' \
+  '  Proto  Local Address          Foreign Address        State           PID' \
+  '  TCP    0.0.0.0:3000           0.0.0.0:0              LISTENING       44576' \
+  '  TCP    [::]:5432              [::]:0                 LISTENING       1234' \
+  '  TCP    0.0.0.0:30001          0.0.0.0:0              LISTENING       7777' \
+  '  UDP    0.0.0.0:4000           *:*                                    9999'
+EOF
+chmod +x "$STUB/netstat"
+
+run_holder() { # run_holder <port> -> stdout of port_holder, always exit 0
+  env -i PATH="$STUB" bash -c "source '$TMP/port_holder.sh'; port_holder '$1'"
+}
+
+PASS=0
+FAIL=0
+check() { # check <desc> <expected-substring-or-empty> <actual>
+  local desc="$1" expected="$2" actual="$3"
+  if [[ -z "$expected" && -z "$actual" ]]; then
+    PASS=$((PASS + 1)); echo "ok - $desc"
+  elif [[ -n "$expected" && "$actual" == *"$expected"* ]]; then
+    PASS=$((PASS + 1)); echo "ok - $desc"
+  else
+    FAIL=$((FAIL + 1)); echo "not ok - $desc"
+    echo "  expected to contain: [$expected]"
+    echo "  got: [$actual]"
+  fi
+}
+
+out=$(run_holder 3000)
+check "detects occupied TCP port 3000" "44576" "$out"
+
+out=$(run_holder 5432)
+check "detects IPv6 TCP listener" "1234" "$out"
+
+out=$(run_holder 3999)
+check "reports unoccupied port as free" "" "$out"
+
+out=$(run_holder 4000)
+check "ignores UDP-only port" "" "$out"
+
+out=$(run_holder 30001)
+check "matches exact port 30001" "7777" "$out"
+
+out=$(run_holder 3000)
+if [[ "$out" == *"7777"* ]]; then
+  FAIL=$((FAIL + 1)); echo "not ok - port 3000 must not match :30001"
+else
+  PASS=$((PASS + 1)); echo "ok - port 3000 must not match :30001"
+fi
+
+echo "---"
+echo "passed: $PASS, failed: $FAIL"
+[[ "$FAIL" -eq 0 ]]


### PR DESCRIPTION
## What does this PR do?

`port_holder()` in `bin/install` gains a Windows `netstat -ano` fallback, taken when neither `lsof` nor `ss` exists (MSYS2 / Git Bash). Previously the function returned empty there and the installer reported occupied ports as free, failing later in `docker compose up`.

## Changes

- Match TCP lines in `LISTENING` state on exactly the requested port (anchored: `:3000` never matches `:30001`); UDP ignored
- Existing Linux/macOS detection order (`lsof` → `ss` → `netstat`) preserved
- New `bin/test_install_port_holder.sh`: 6 regression cases against a stubbed Windows-style netstat

## Testing

- `bash -n bin/install`, `bash -n bin/test_install_port_holder.sh`
- `bin/test_install_port_holder.sh`: 6/6 pass (occupied v4/v6, free port, UDP-only, exact-port anchoring)
- Linux path re-verified unchanged (free port → empty, exit 0)

Fixes #2396, closes #2274