### PR TITLE
fix(observe): recover catalog runtime and preserve task filters

### DIFF
--- a/fi-collector/pkg/propertycatalog/producer_retirement.go
+++ b/fi-collector/pkg/propertycatalog/producer_retirement.go
@@ -218,15 +218,40 @@ func validateProducerRetirement(value ProducerStateRetirement) error {
 		return err
 	}
 	prefix := value.LifecycleMode + "_"
+	lifecycleMatches := true
 	for _, stream := range plan.Streams {
 		if !strings.HasPrefix(stream.SourceCutoff.Label, prefix) {
-			return errors.New("retirement lifecycle mode differs from its build plan")
+			lifecycleMatches = false
+			break
 		}
+	}
+	if !lifecycleMatches && !isPhysicalSnapshotRetirement(value, plan) {
+		return errors.New("retirement lifecycle mode differs from its build plan")
 	}
 	if value.RetirementSHA256 != producerRetirementSHA256(value) {
 		return errors.New("retirement digest does not match its fields")
 	}
 	return nil
+}
+
+func isPhysicalSnapshotRetirement(
+	value ProducerStateRetirement, plan buildPlanDocumentJSON,
+) bool {
+	// Physical snapshots are immutable initial builds whose opaque generation is
+	// shared by every stream. The revision-scoped label keeps this contract valid
+	// for any OSS deployment without weakening normal lifecycle-plan validation.
+	if value.LifecycleMode != "initial_backfill" || len(plan.Streams) != 10 {
+		return false
+	}
+	label := fmt.Sprintf("physical_snapshot_r%d", value.CatalogRevision)
+	generation := plan.Streams[0].SourceCutoff.Value
+	for _, stream := range plan.Streams {
+		if stream.SourceCutoff.Label != label ||
+			stream.SourceCutoff.Value != generation {
+			return false
+		}
+	}
+	return generation != 0
 }
 
 func (r *HotRuntime) compactProducerState(ctx context.Context, fences []RevisionFence) error {

--- a/fi-collector/pkg/propertycatalog/producer_retirement_test.go
+++ b/fi-collector/pkg/propertycatalog/producer_retirement_test.go
@@ -3,6 +3,7 @@ package propertycatalog
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
 	"os"
 	"path/filepath"
@@ -35,6 +36,46 @@ func writePythonRetirementFixture(t *testing.T, directory string) {
 	); err != nil {
 		t.Fatal(err)
 	}
+}
+
+func physicalSnapshotRetirementFixture(t *testing.T) ProducerStateRetirement {
+	t.Helper()
+	var document producerRetirementDocument
+	if err := json.Unmarshal(bytes.TrimSpace(pythonRetirementFixture(t)), &document); err != nil {
+		t.Fatal(err)
+	}
+	value := document.Retirements[0]
+	value.CatalogEpoch = 1
+	value.CatalogRevision = 3
+	value.ProjectionVersion = 3
+	value.LineageAnchorRevision = 3
+
+	var plan buildPlanDocumentJSON
+	if err := json.Unmarshal([]byte(value.BuildPlanJSON), &plan); err != nil {
+		t.Fatal(err)
+	}
+	plan.CatalogEpoch = value.CatalogEpoch
+	plan.CatalogRevision = value.CatalogRevision
+	plan.ProjectionVersion = value.ProjectionVersion
+	for index := range plan.Streams {
+		plan.Streams[index].SourceCutoff.Label = "physical_snapshot_r3"
+		plan.Streams[index].SourceCutoff.Value = 1788179167838495941
+	}
+	setRetirementPlan(t, &value, plan)
+	return value
+}
+
+func setRetirementPlan(
+	t *testing.T, value *ProducerStateRetirement, plan buildPlanDocumentJSON,
+) {
+	t.Helper()
+	raw, err := json.Marshal(plan)
+	if err != nil {
+		t.Fatal(err)
+	}
+	value.BuildPlanJSON = string(raw)
+	value.BuildLeaseSHA256 = testDigest(value.BuildPlanJSON)
+	value.RetirementSHA256 = producerRetirementSHA256(*value)
 }
 
 func retirementRevisionFence(revision uint64, status string) RevisionFence {
@@ -170,6 +211,67 @@ func TestProducerRetirementConsumesExactCanonicalPythonProof(t *testing.T) {
 			t.Fatalf("non-private proof error=%v", err)
 		}
 	})
+}
+
+func TestProducerRetirementAcceptsRevisionScopedPhysicalSnapshots(t *testing.T) {
+	exact := physicalSnapshotRetirementFixture(t)
+	if err := validateProducerRetirement(exact); err != nil {
+		t.Fatalf("exact physical snapshot retirement was rejected: %v", err)
+	}
+
+	t.Run("different deployment coordinates", func(t *testing.T) {
+		value := exact
+		var plan buildPlanDocumentJSON
+		if err := json.Unmarshal([]byte(value.BuildPlanJSON), &plan); err != nil {
+			t.Fatal(err)
+		}
+		value.CatalogEpoch = 7
+		value.CatalogRevision = 41
+		value.ProjectionVersion = 9
+		value.LineageAnchorRevision = value.CatalogRevision
+		plan.CatalogEpoch = value.CatalogEpoch
+		plan.CatalogRevision = value.CatalogRevision
+		plan.ProjectionVersion = value.ProjectionVersion
+		for index := range plan.Streams {
+			plan.Streams[index].SourceCutoff.Label = "physical_snapshot_r41"
+		}
+		setRetirementPlan(t, &value, plan)
+		if err := validateProducerRetirement(value); err != nil {
+			t.Fatalf("generic physical snapshot retirement was rejected: %v", err)
+		}
+	})
+
+	tests := map[string]func(*ProducerStateRetirement, *buildPlanDocumentJSON){
+		"revision label mismatch": func(value *ProducerStateRetirement, plan *buildPlanDocumentJSON) {
+			value.CatalogRevision = 4
+			value.LineageAnchorRevision = 4
+			plan.CatalogRevision = 4
+		},
+		"non-initial lifecycle": func(value *ProducerStateRetirement, _ *buildPlanDocumentJSON) {
+			value.LifecycleMode = "full_repair"
+		},
+		"mixed label": func(_ *ProducerStateRetirement, plan *buildPlanDocumentJSON) {
+			plan.Streams[0].SourceCutoff.Label = "initial_backfill_postgres_until_us"
+		},
+		"mixed generation": func(_ *ProducerStateRetirement, plan *buildPlanDocumentJSON) {
+			plan.Streams[0].SourceCutoff.Value++
+		},
+	}
+	for name, mutate := range tests {
+		t.Run(name, func(t *testing.T) {
+			value := exact
+			var plan buildPlanDocumentJSON
+			if err := json.Unmarshal([]byte(value.BuildPlanJSON), &plan); err != nil {
+				t.Fatal(err)
+			}
+			mutate(&value, &plan)
+			setRetirementPlan(t, &value, plan)
+			if err := validateProducerRetirement(value); err == nil ||
+				!strings.Contains(err.Error(), "lifecycle mode differs") {
+				t.Fatalf("unsafe physical snapshot retirement error=%v", err)
+			}
+		})
+	}
 }
 
 func TestNewRuntimeAllowsEmptyPreBootstrapVolumeWithoutFence(t *testing.T) {

--- a/frontend/src/sections/common/EvalsTasks/EditTaskDrawer/DetailsEdit.jsx
+++ b/frontend/src/sections/common/EvalsTasks/EditTaskDrawer/DetailsEdit.jsx
@@ -35,8 +35,6 @@ import {
 import Iconify from "src/components/iconify";
 import { enqueueSnackbar } from "notistack";
 import {
-  extractAttributeFilters,
-  getTaskFilterApiKey,
   getNewTaskFilters,
   NewTaskValidationSchema,
 } from "../NewTaskDrawer/validation";
@@ -264,28 +262,11 @@ const DetailsEdit = ({
   const onUpdateSubmit = (data, editType) => {
     // Flat chip list with col_type for the BE dispatcher; observation_type
     // (incl. node_type alias) still rides as a sibling key.
-    const attributeFilters = extractAttributeFilters(data?.filters);
-
-    // Task system filter aggregation. The task filter UI only exposes
-    // backend-supported system fields plus span attributes, so unsupported
-    // TraceFilterPanel fields cannot be saved and silently ignored.
-    const systemFilters = {};
-    (data.filters || []).forEach((f) => {
-      if (!f?.property || f.property === "attributes") return;
-      const apiKey = getTaskFilterApiKey(f.property);
-      const v = f?.filterConfig?.filterValue;
-      const values = Array.isArray(v)
-        ? v
-        : v !== undefined && v !== null && v !== ""
-          ? [v]
-          : [];
-      if (!values.length) return;
-      if (systemFilters[apiKey]) {
-        systemFilters[apiKey].push(...values);
-      } else {
-        systemFilters[apiKey] = [...values];
-      }
-    });
+    const { filters: systemFilters, attributeFilters } = getNewTaskFilters(
+      data,
+      data.project,
+      true,
+    );
 
     const transformedData = {
       evals: data.evalsDetails?.map((item) => item.id) || [],

--- a/frontend/src/sections/common/EvalsTasks/EditTaskDrawer/EditTaskDrawer.release-contract.test.jsx
+++ b/frontend/src/sections/common/EvalsTasks/EditTaskDrawer/EditTaskDrawer.release-contract.test.jsx
@@ -1,0 +1,164 @@
+// @vitest-environment jsdom
+import React from "react";
+import PropTypes from "prop-types";
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import DetailsEdit from "./DetailsEdit";
+import EditTaskDrawerV2 from "./EditTaskDrawerV2";
+import { formatTaskFilters } from "../common";
+
+const state = vi.hoisted(() => ({
+  patch: vi.fn(), get: vi.fn(), post: vi.fn(), rows: [], empty: [],
+  project: "10000000-0000-4000-8000-000000000001",
+  task: "20000000-0000-4000-8000-000000000001",
+  eval: "30000000-0000-4000-8000-000000000001",
+}));
+vi.mock("src/utils/axios", () => ({
+  default: { get: (...args) => state.get(...args), patch: (...args) => state.patch(...args), post: (...args) => state.post(...args) },
+  endpoints: { project: {
+    patchEvalTask: () => "/task/update", getEvalTaskConfig: () => "/task/configured",
+    listProjects: () => "/projects", createEvalTask: () => "/task/create",
+    createEvalTaskConfig: () => "/task/configure",
+  } },
+}));
+vi.mock("../common", async (importOriginal) => ({
+  formatTaskFilters: (await importOriginal()).formatTaskFilters,
+  FIELD_CATEGORY_TO_COL_TYPE: { attribute: "SPAN_ATTRIBUTE", system: "SYSTEM_METRIC", eval: "EVAL_METRIC", annotation: "ANNOTATION" },
+  ANNOTATION_COLUMN_IDS: new Set(["annotator", "my_annotations"]),
+  getDefaultTaskValues: () => ({
+    name: "Mounted task", project: state.project, rowType: "traces", runType: "continuous",
+    spansLimit: "10", samplingRate: 100, evalsDetails: [{ id: state.eval, name: "Quality" }],
+    startDate: "2026-09-01T00:00:00.000Z", endDate: "2026-09-02T00:00:00.000Z", filters: [],
+  }),
+  useGetTaskData: () => ({ data: { id: state.task, project_id: state.project }, isLoading: false, isError: false }),
+}));
+vi.mock("src/auth/hooks", () => ({ useAuthContext: () => ({ role: "admin" }) }));
+vi.mock("src/utils/rolePermissionMapping", () => ({
+  PERMISSIONS: { ADD_TASKS_ALERTS: "edit" }, RolePermission: { OBSERVABILITY: { edit: { admin: true } } },
+}));
+vi.mock("src/api/project/evals-task", () => ({ useGetProjectById: () => ({ data: { name: "Project" } }) }));
+vi.mock("src/hooks/use-debounce", () => ({ useDebounce: (value) => value }));
+vi.mock("notistack", async (importOriginal) => ({
+  ...(await importOriginal()),
+  enqueueSnackbar: vi.fn(),
+}));
+vi.mock("src/components/iconify", () => ({ default: () => null }));
+vi.mock("src/components/FormTextField/FormTextFieldV2", () => ({ default: () => null }));
+vi.mock("src/components/FormSelectField", () => ({ FormSelectField: () => null }));
+vi.mock("src/sections/develop-detail/AccordianElements", () => {
+  const Container = ({ children }) => <div>{children}</div>;
+  Container.propTypes = { children: PropTypes.node };
+  return { Accordion: Container, AccordionSummary: Container, AccordionDetails: Container };
+});
+vi.mock("src/components/ComplexFilter/FilterErrorBoundary", () => ({ default: ({ children }) => children }));
+vi.mock("../NewTaskDrawer/NewTaskFilterBox", async () => {
+  const { useWatch } = await import("react-hook-form");
+  const FixtureFilterBox = ({ setValue, control }) => {
+    const rows = useWatch({ control, name: "filters" });
+    return <button type="button" onClick={() => setValue("filters", structuredClone(state.rows))}>
+      Use fixture filters ({rows?.length || 0})
+    </button>;
+  };
+  FixtureFilterBox.propTypes = { setValue: PropTypes.func.isRequired, control: PropTypes.object.isRequired };
+  return { default: FixtureFilterBox };
+});
+vi.mock("../NewTaskDrawer/ScheduledRuns", () => ({ default: () => null }));
+vi.mock("../NewTaskDrawer/EvaluationSection", () => ({ default: () => null }));
+vi.mock("./TaskLogs", () => ({ default: () => null }));
+vi.mock("../TaskLogsView", () => ({ default: () => null }));
+vi.mock("src/components/show", () => ({ ShowComponent: ({ condition, children }) => condition ? children : null }));
+vi.mock("../../EvaluationDrawer/context/EvaluationContext", () => ({ useEvaluationContext: () => ({ visibleSection: "list" }) }));
+vi.mock("../../EvaluationDrawer/EvaluationDrawer", () => ({ default: ({ listComponent }) => listComponent }));
+vi.mock("src/sections/develop-detail/Common/ConfiguredEvaluationType/ConfiguredEvaluationType", () => ({ default: () => null }));
+vi.mock("src/sections/common/EvalPicker/serializeEvalConfig", () => ({ sanitizeEvalMapping: (value) => value }));
+vi.mock("src/sections/evals/store/useEvalStore", () => ({ resetEvalStore: vi.fn() }));
+vi.mock("src/sections/projects/LLMTracing/AttributeInventoryControls", () => ({ default: () => null }));
+vi.mock("src/sections/projects/LLMTracing/useCursorAttributeInventory", () => ({
+  attributeInventoryKey: (value) => value,
+  useCursorAttributeInventory: () => ({ filteredAttributes: state.empty, inventoryControlProps: {} }),
+}));
+vi.mock("../use_task_eval_attribute_inventory", () => ({
+  useTaskEvalAttributeInventory: () => ({ sourceColumns: state.empty, attributeFields: state.empty }),
+}));
+vi.mock("../../EvalPicker", () => ({ EvalPickerDrawer: () => null, serializeEvalConfig: (value) => value }));
+vi.mock("src/sections/evals/utils/evalMappingPath", () => ({ mappingChipLabel: (value) => value }));
+vi.mock("src/utils/errorUtils", () => ({ getSafeActionErrorMessage: (_error, fallback) => fallback }));
+
+const ID = "40000000-0000-4000-8000-000000000001";
+const row = (property, op, value, extra = {}) => ({
+  property, filterConfig: { filterType: "text", filterOp: op, filterValue: value }, ...extra,
+});
+const wire = (column_id, col_type, filter_op, filter_value, property_id, types) => ({
+  column_id, ...(property_id ? { property_id } : {}),
+  filter_config: { filter_type: "text", filter_op, filter_value, col_type,
+    ...(types ? { attribute_value_types: types } : {}) },
+});
+const attr = (field, type, op, value) => ({
+  property: "attributes", propertyId: field, apiColType: "SPAN_ATTRIBUTE",
+  filterConfig: { filterType: type, filterOp: op, filterValue: value },
+});
+const attrWire = (field, type, op, value) => ({
+  column_id: field, filter_config: { col_type: "SPAN_ATTRIBUTE", filter_type: type, filter_op: op, filter_value: value },
+});
+const cases = [
+  ["hydrated legacy span IDs", formatTaskFilters({ span_id: [ID] }), { span_id: [ID] }, []],
+  ["legacy positive IDs", [row("trace_id", "in", [ID]), row("session_id", "equals", ID)], { trace_id: [ID], session_id: [ID] }, []],
+  ["legacy span-kind and node-type aliases", [row("span_kind", "in", ["llm"]), row("node_type", "in", ["tool"])], { observation_type: ["llm", "tool"] }, []],
+  ["company_id membership AND clauses", [
+    attr("company_id", "text", "in", ["a", "b"]), attr("company_id", "text", "in", ["b", "c"]),
+  ], {}, [attrWire("company_id", "text", "in", ["a", "b"]), attrWire("company_id", "text", "in", ["b", "c"])]],
+  ["numeric range AND clauses", [
+    attr("quality", "number", "between", [0, 10]), attr("quality", "number", "between", [5, 20]),
+  ], {}, [attrWire("quality", "number", "between", [0, 10]), attrWire("quality", "number", "between", [5, 20])]],
+  ["negative string AND clauses", [
+    attr("company_id", "text", "not_contains", "alpha"), attr("company_id", "text", "not_contains", "beta"),
+  ], {}, [attrWire("company_id", "text", "not_contains", "alpha"), attrWire("company_id", "text", "not_contains", "beta")]],
+  ["canonical model and latency without invalid positive sibling keys", [
+    row("model", "not_in", ["bad-model"], { propertyId: "model", apiColType: "SYSTEM_METRIC" }),
+    { property: "latency", propertyId: "latency", apiColType: "SYSTEM_METRIC", filterConfig: { filterType: "number", filterOp: "between", filterValue: [10, 20] } },
+  ], {}, [
+    wire("model", "SYSTEM_METRIC", "not_in", ["bad-model"]),
+    { column_id: "latency", filter_config: { col_type: "SYSTEM_METRIC", filter_type: "number", filter_op: "between", filter_value: [10, 20] } },
+  ]],
+];
+let client;
+beforeEach(() => {
+  state.patch.mockReset().mockResolvedValue({ data: { result: { message: "Updated" } } });
+  state.post.mockReset().mockRejectedValue(new Error("Unexpected create request"));
+  state.get.mockReset().mockImplementation(async (url) => ({ data: { result:
+    url === "/task/configured" ? [{ id: state.eval, name: "Quality" }] : { projects: [] },
+  } }));
+  client = new QueryClient({ defaultOptions: { queries: { retry: false, staleTime: Infinity }, mutations: { retry: false } } });
+});
+afterEach(() => { cleanup(); client.clear(); });
+
+describe.each([
+  ["DetailsEdit", DetailsEdit, "filters", { isEdit: true, isView: true }],
+  ["EditTaskDrawerV2", EditTaskDrawerV2, "span_attributes_filters", {}],
+])("%s mounted submit payload", (_label, Component, nestedKey, props) => {
+  it.each(cases)("submits %s through Update Task and the real confirmation dialog", async (_case, rows, siblings, canonical) => {
+    state.rows = rows;
+    render(<QueryClientProvider client={client}>
+      <Component open selectedRow={{ id: state.task }} taskDetails={{ id: state.task }}
+        observeId={state.project} onClose={vi.fn()} refreshGrid={vi.fn()} {...props} />
+    </QueryClientProvider>);
+    fireEvent.click(await screen.findByRole("button", { name: "Use fixture filters (0)" }));
+    expect(await screen.findByRole("button", { name: "Use fixture filters (" + rows.length + ")" })).toBeTruthy();
+    fireEvent.click(screen.getByRole("button", { name: "Update Task" }));
+    fireEvent.click(await screen.findByText("Edit & Re-run Existing Evals"));
+    fireEvent.click(screen.getByRole("button", { name: "Run task" }));
+    await waitFor(() => expect(state.patch).toHaveBeenCalledTimes(1));
+    expect(state.patch).toHaveBeenCalledWith("/task/update", {
+      eval_task_id: state.task, evals: [state.eval], project_id: state.project,
+      name: "Mounted task", project: state.project, run_type: "continuous",
+      sampling_rate: 100, spans_limit: "10", edit_type: "edit_rerun",
+      filters: {
+        project_id: state.project,
+        date_range: ["2026-09-01T00:00:00.000Z", "2026-09-02T00:00:00.000Z"],
+        ...siblings, ...(canonical.length ? { [nestedKey]: canonical } : {}),
+      },
+    });
+    expect(state.post).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/sections/common/EvalsTasks/EditTaskDrawer/EditTaskDrawerV2.jsx
+++ b/frontend/src/sections/common/EvalsTasks/EditTaskDrawer/EditTaskDrawerV2.jsx
@@ -43,8 +43,6 @@ import axios, { endpoints } from "src/utils/axios";
 import { red } from "src/theme/palette";
 import { mappingChipLabel } from "src/sections/evals/utils/evalMappingPath";
 import {
-  extractAttributeFilters,
-  getTaskFilterApiKey,
   getNewTaskFilters,
   NewTaskValidationSchema,
 } from "../NewTaskDrawer/validation";
@@ -259,28 +257,11 @@ const EditTaskDrawerV2Content = ({
   const onUpdateSubmit = useCallback(
     (editType) => {
       const data = formValues;
-      const attributeFilters = extractAttributeFilters(data?.filters);
-
-      // Task system filter aggregation. Keep the update payload aligned with
-      // the backend-supported task filter contract instead of saving fields
-      // that the dispatcher would ignore.
-      const systemFilters = {};
-      (data.filters || []).forEach((f) => {
-        if (!f?.property || f.property === "attributes") return;
-        const apiKey = getTaskFilterApiKey(f.property);
-        const v = f?.filterConfig?.filterValue;
-        const values = Array.isArray(v)
-          ? v
-          : v !== undefined && v !== null && v !== ""
-            ? [v]
-            : [];
-        if (!values.length) return;
-        if (systemFilters[apiKey]) {
-          systemFilters[apiKey].push(...values);
-        } else {
-          systemFilters[apiKey] = [...values];
-        }
-      });
+      const { filters: systemFilters, attributeFilters } = getNewTaskFilters(
+        data,
+        data.project,
+        true,
+      );
 
       const transformedData = {
         evals: data.evalsDetails?.map((item) => item.id) || [],

--- a/frontend/src/sections/common/EvalsTasks/NewTaskDrawer/__tests__/validation.test.js
+++ b/frontend/src/sections/common/EvalsTasks/NewTaskDrawer/__tests__/validation.test.js
@@ -4,6 +4,42 @@ import { getNewTaskFilters, NewTaskValidationSchema } from "../validation";
 import { formatTaskFilters } from "../../common";
 
 describe("eval task filter payload contract", () => {
+  it("keeps a hydrated legacy span restriction on save", () => {
+    const rows = formatTaskFilters({ span_id: ["span-a", "span-b"] });
+    expect(getNewTaskFilters({ filters: rows }, "project", true)).toEqual({
+      filters: { project_id: "project", span_id: ["span-a", "span-b"] },
+      attributeFilters: [],
+    });
+  });
+
+  it.each(["SYSTEM_METRIC", "SPAN_ATTRIBUTE"])(
+    "does not turn a canonical %s span_id exclusion into a positive sibling",
+    (source) => {
+      const row = {
+        property: "span_id",
+        propertyId: "span_id",
+        apiColType: source,
+        filterConfig: {
+          filterType: "text",
+          filterOp: "not_in",
+          filterValue: ["span-a"],
+        },
+      };
+      expect(getNewTaskFilters({ filters: [row] }, "project", true)).toEqual({
+        filters: { project_id: "project" },
+        attributeFilters: [{
+          column_id: "span_id",
+          filter_config: {
+            col_type: source,
+            filter_type: "text",
+            filter_op: "not_in",
+            filter_value: ["span-a"],
+          },
+        }],
+      });
+    },
+  );
+
   it("hydrates property_id into registryId without replacing propertyId", () => {
     expect(
       formatTaskFilters({

--- a/frontend/src/sections/common/EvalsTasks/NewTaskDrawer/validation.js
+++ b/frontend/src/sections/common/EvalsTasks/NewTaskDrawer/validation.js
@@ -47,7 +47,18 @@ export const extractAttributeFilters = (filters) => {
 const extractSiblingFilters = (filters) => {
   const out = {};
   (filters || []).forEach((f) => {
-    const beKey = TOP_LEVEL_SIBLING_KEY_BY_PROPERTY[f?.property];
+    // Preserve old saved span links without retyping canonical or raw rows.
+    const beKey =
+      TOP_LEVEL_SIBLING_KEY_BY_PROPERTY[f?.property] ||
+      (f?.property === "span_id" &&
+      !f.propertyId &&
+      !f.apiColType &&
+      !f.filterConfig?.colType &&
+      !f.fieldCategory &&
+      !f.registryId &&
+      !f.property_id
+        ? "span_id"
+        : undefined);
     if (!beKey) return;
     const val = f?.filterConfig?.filterValue;
     const vals = Array.isArray(val)

--- a/frontend/src/sections/projects/LLMTracing/SpanGrid.jsx
+++ b/frontend/src/sections/projects/LLMTracing/SpanGrid.jsx
@@ -261,7 +261,7 @@ const SpanGrid = React.forwardRef(
         headerTextColor: theme.palette.text.primary,
         rowHoverColor: "rgba(120,87,252,0.04)",
       }),
-      [theme],
+      [theme.palette.text.primary, theme.typography.fontWeightMedium],
     );
     const agTheme = useAgThemeWith(gridThemeParams);
     const { observeId } = useParams();

--- a/frontend/src/sections/projects/LLMTracing/TraceGrid.jsx
+++ b/frontend/src/sections/projects/LLMTracing/TraceGrid.jsx
@@ -127,7 +127,7 @@ const TraceGrid = React.forwardRef(
         headerTextColor: theme.palette.text.primary,
         rowHoverColor: "rgba(120,87,252,0.04)",
       }),
-      [theme],
+      [theme.palette.text.primary],
     );
     const agTheme = useAgThemeWith(gridThemeParams);
     const [dateInterval] = useUrlState("dateInterval", "day");

--- a/frontend/src/sections/projects/__tests__/timeWindowPresets.test.js
+++ b/frontend/src/sections/projects/__tests__/timeWindowPresets.test.js
@@ -11,7 +11,8 @@ import {
 const freezeClock = () => {
   beforeEach(() => {
     vi.useFakeTimers({ shouldAdvanceTime: true });
-    vi.setSystemTime(new Date("2026-08-21T06:00:00Z"));
+    // Presets and labels use browser-local time, not a fixed UTC calendar day.
+    vi.setSystemTime(new Date(2026, 7, 21, 6));
   });
   afterEach(() => vi.useRealTimers());
 };

--- a/frontend/src/sections/tasks/components/TaskFilterBar.jsx
+++ b/frontend/src/sections/tasks/components/TaskFilterBar.jsx
@@ -260,15 +260,11 @@ export function convertNewToOld(newFilters, { rowType } = {}) {
 }
 
 // ── form filter → new panel format ──
-// One form row → one panel row. Only ops with a natural multi-value shape
-// (range, list, or string equals/not_equals just rewritten to in/not_in via
-// HYDRATE_STRING_OP) collapse same-(field, op) rows into one multi-value
-// panel row — grouping any other op (e.g. not_contains) would let the chip
-// + panel UI fold "exclude A AND exclude B" into a single "[A, B]" row.
+// Keep each AND clause separate; list values belong to their own row and
+// separate range clauses must never overwrite one another on edit-open.
 // eslint-disable-next-line react-refresh/only-export-components
 export function convertOldToNew(oldFilters, { rowType } = {}) {
   const isVoiceCalls = String(rowType || "").toLowerCase() === "voicecalls";
-  const groups = new Map();
   const result = [];
   (oldFilters || []).forEach((f) => {
     if (!f) return;
@@ -302,51 +298,22 @@ export function convertOldToNew(oldFilters, { rowType } = {}) {
       op = HYDRATE_STRING_OP[op];
     }
 
-    const isMultiValueOp =
-      RANGE_OPS.has(op) || LIST_OPS.has(op) || Boolean(hydrated);
-
-    let entry;
-    if (isMultiValueOp) {
-      const key = `${registryId || "legacy"}|${field}|${op}|${category}`;
-      entry = groups.get(key);
-      if (!entry) {
-        entry = {
-          field,
-          ...(registryId ? { registryId } : {}),
-          fieldLabel: voiceField?.label || f.fieldLabel || field,
-          fieldType,
-          fieldCategory: category,
-          apiColType:
-            voiceField?.apiColType ||
-            resolveApiColType(
-              f.apiColType || f?.filterConfig?.colType,
-              category,
-            ),
-          operator: op,
-          value: [],
-          valueTypes: [],
-        };
-        groups.set(key, entry);
-        result.push(entry);
-      }
-    } else {
-      entry = {
-        field,
-        ...(registryId ? { registryId } : {}),
-        fieldLabel: voiceField?.label || f.fieldLabel || field,
-        fieldType,
-        fieldCategory: category,
-        // Preserved so the panel re-renders the right chip on edit-open.
-        apiColType: resolveApiColType(
-          voiceField?.apiColType || f.apiColType || f?.filterConfig?.colType,
-          category,
-        ),
-        operator: op,
-        value: [],
-        valueTypes: [],
-      };
-      result.push(entry);
-    }
+    const entry = {
+      field,
+      ...(registryId ? { registryId } : {}),
+      fieldLabel: voiceField?.label || f.fieldLabel || field,
+      fieldType,
+      fieldCategory: category,
+      // Preserved so the panel re-renders the right chip on edit-open.
+      apiColType: resolveApiColType(
+        voiceField?.apiColType || f.apiColType || f?.filterConfig?.colType,
+        category,
+      ),
+      operator: op,
+      value: [],
+      valueTypes: [],
+    };
+    result.push(entry);
 
     if (NO_VALUE_OPS.has(op)) return;
 

--- a/frontend/src/sections/tasks/components/__tests__/TaskFilterBar.voiceCalls.test.js
+++ b/frontend/src/sections/tasks/components/__tests__/TaskFilterBar.voiceCalls.test.js
@@ -556,6 +556,105 @@ describe("TaskFilterBar voice-call filter contract", () => {
 });
 
 describe("TaskFilterBar structured and mixed filter contract", () => {
+  it.each(
+    ["traces", "spans", "sessions"].flatMap((rowType) => [
+      [
+        rowType,
+        "attribute",
+        "number",
+        "between",
+        [
+          [0, 10],
+          [5, 20],
+        ],
+      ],
+      [
+        rowType,
+        "eval",
+        "number",
+        "between",
+        [
+          [0, 0.7],
+          [0.5, 1],
+        ],
+      ],
+      [
+        rowType,
+        "annotation",
+        "categorical",
+        "in",
+        [
+          ["approved", "review"],
+          ["review", "rejected"],
+        ],
+      ],
+      [
+        rowType,
+        "attribute",
+        "string",
+        "in",
+        [
+          ["001", 1],
+          ["002", 2],
+        ],
+      ],
+    ]),
+  )(
+    "preserves separate AND clauses on %s %s %s %s panel reapply",
+    (rowType, category, type, operator, values) => {
+      const colType = {
+        attribute: "SPAN_ATTRIBUTE",
+        eval: "EVAL_METRIC",
+        annotation: "ANNOTATION",
+      }[category];
+      const registryId = `${category === "attribute" ? "custom_attribute" : category}:quality`;
+      const panelRows = values.map((value) => ({
+        field: "quality",
+        registryId,
+        fieldCategory: category,
+        fieldType: type,
+        apiColType: colType,
+        operator,
+        value,
+        ...(type === "string" ? { valueTypes: ["string", "number"] } : {}),
+      }));
+      panelRows.push({
+        field: "prompt",
+        fieldCategory: "attribute",
+        fieldType: "string",
+        apiColType: "SPAN_ATTRIBUTE",
+        operator: "contains",
+        value: "long prompt ".repeat(50),
+      });
+      const formRows = convertNewToOld(panelRows, { rowType });
+      const original = JSON.stringify(formRows);
+      const expected = buildApiFilterArray(formRows);
+      expect(
+        expected.slice(0, 2).map((filter) => filter.filter_config.filter_value),
+      ).toEqual(values);
+      const actual = buildApiFilterArray(
+        convertNewToOld(convertOldToNew(formRows, { rowType }), { rowType }),
+      );
+      const request = buildTaskPreviewListParams({
+        rowType,
+        projectId: "project-and-scope",
+        apiFilters: actual,
+      });
+      expect(JSON.parse(request.filters)).toEqual(expected);
+      expect(actual.slice(0, 2).map((filter) => filter.property_id)).toEqual([
+        registryId,
+        registryId,
+      ]);
+      expect(request).toMatchObject({
+        project_id: "project-and-scope",
+        cursor_mode: true,
+        page_number: 0,
+        page_size: 1,
+      });
+      expect(JSON.stringify(formRows)).toBe(original);
+    },
+  );
+
   const mixedPanelFilters = [
     {
       field: "final_status",

--- a/futureagi/tracer/services/clickhouse/v2/property_catalog/durable_lifecycle.py
+++ b/futureagi/tracer/services/clickhouse/v2/property_catalog/durable_lifecycle.py
@@ -2042,9 +2042,10 @@ def _decode_plan_scope(
     if len(by_role) != len(plan.streams):
         raise DurableLifecycleError("build plan contains duplicate lifecycle roles")
     if any(
-        value.source_cutoff_label == "physical_snapshot_r3" for value in plan.streams
+        value.source_cutoff_label.startswith("physical_snapshot_")
+        for value in plan.streams
     ):
-        # Decode-only compatibility with the completed r3 physical backfill.
+        # Physical snapshots are revision-scoped immutable initial builds.
         # OPEN/DRAINING recovery deliberately does not opt in: these are not
         # executable lifecycle plans. Active reads still require the fenced
         # reservation, matching activation manifest and ten clean checkpoints.
@@ -2052,11 +2053,10 @@ def _decode_plan_scope(
             raise DurableLifecycleError(
                 "physical snapshot cannot resume as a lifecycle run"
             )
+        expected_label = f"physical_snapshot_r{plan.catalog_revision}"
         if (
-            (plan.catalog_epoch, plan.catalog_revision, plan.projection_version)
-            != (1, 3, 3)
-            or {value.source_cutoff_label for value in plan.streams}
-            != {"physical_snapshot_r3"}
+            {value.source_cutoff_label for value in plan.streams}
+            != {expected_label}
             or len({value.source_version_fence for value in plan.streams}) != 1
         ):
             raise DurableLifecycleError("physical snapshot build plan contract changed")

--- a/futureagi/tracer/services/clickhouse/v2/property_catalog/projection.py
+++ b/futureagi/tracer/services/clickhouse/v2/property_catalog/projection.py
@@ -195,12 +195,24 @@ def resolve_binding_history(
     if len(binding_ids) != 1:
         raise ValueError("binding history contains multiple binding IDs")
 
-    max_version = max(event.source_version for event in eligible)
-    candidates = [event for event in eligible if event.source_version == max_version]
+    # Catalog revisions are qualified and activated as complete snapshots. A
+    # newer revision therefore supersedes an older revision before its
+    # source-local version is compared. This is also the ordering used by the
+    # production ClickHouse reader and permits a source-version domain change
+    # across revisions without allowing stale state within one revision.
+    max_version = max(
+        (event.catalog_revision, event.source_version) for event in eligible
+    )
+    candidates = [
+        event
+        for event in eligible
+        if (event.catalog_revision, event.source_version) == max_version
+    ]
     state_hashes = {event.state_sha256 for event in candidates}
     if len(state_hashes) != 1:
         raise DefinitionConflictError(
-            f"binding {eligible[0].binding_id} has conflicting source version {max_version}"
+            f"binding {eligible[0].binding_id} has conflicting source version "
+            f"{max_version[1]} at catalog revision {max_version[0]}"
         )
     current = max(candidates, key=_transport_order)
     return BindingHistoryResolution(

--- a/futureagi/tracer/services/clickhouse/v2/property_catalog/reconciler.py
+++ b/futureagi/tracer/services/clickhouse/v2/property_catalog/reconciler.py
@@ -712,7 +712,10 @@ def _project_records(
         record = records_by_entity.get(old.source_entity_id)
         if record is None or old.is_deleted or old.binding_id in by_binding:
             continue
-        if old.source_version >= request.source_version:
+        if (old.catalog_revision, old.source_version) >= (
+            request.context.catalog_revision,
+            request.source_version,
+        ):
             conflicts.add(old.binding_id)
             continue
         source_fingerprint = framed_sha256(
@@ -749,8 +752,13 @@ def _project_records(
         old = current_by_binding.get(binding_id)
         if old is None:
             continue
-        if old.source_version > request.source_version or (
-            old.source_version == request.source_version
+        old_version = (old.catalog_revision, old.source_version)
+        request_version = (
+            request.context.catalog_revision,
+            request.source_version,
+        )
+        if old_version > request_version or (
+            old_version == request_version
             and old.state_sha256 != row.state_sha256
         ):
             conflicts.add(binding_id)
@@ -779,7 +787,10 @@ def _repair_tombstones(
     for old in baseline:
         if old.is_deleted or old.binding_id in seen:
             continue
-        if old.source_version >= request.source_version:
+        if (old.catalog_revision, old.source_version) >= (
+            request.context.catalog_revision,
+            request.source_version,
+        ):
             conflicts += 1
             continue
         source_fingerprint = framed_sha256(

--- a/futureagi/tracer/tests/test_property_catalog_physical_snapshot_lifecycle.py
+++ b/futureagi/tracer/tests/test_property_catalog_physical_snapshot_lifecycle.py
@@ -273,12 +273,28 @@ def test_physical_snapshot_without_activation_is_not_resumable(status):
         )
 
 
-@pytest.mark.parametrize(
-    "field,value",
-    [("catalog_epoch", 2), ("catalog_revision", 4), ("projection_version", 1)],
-)
-def test_physical_snapshot_rejects_other_contracts(field, value):
-    plan = replace(_PhysicalSnapshot().plan, **{field: value})
+def test_physical_snapshot_contract_is_revision_scoped_not_deployment_scoped():
+    plan = _PhysicalSnapshot().plan
+    plan = replace(
+        plan,
+        catalog_epoch=2,
+        catalog_revision=4,
+        projection_version=7,
+        streams=tuple(
+            replace(stream, source_cutoff_label="physical_snapshot_r4")
+            for stream in plan.streams
+        ),
+    )
+
+    decoded = dl._decode_plan_scope(plan, allow_physical_snapshot=True)
+
+    assert decoded.mode is dl.LifecycleRunMode.INITIAL_BACKFILL
+    assert decoded.physical_snapshot
+    assert decoded.cutoffs.span_audit_generation == FENCE
+
+
+def test_physical_snapshot_rejects_revision_label_mismatch():
+    plan = replace(_PhysicalSnapshot().plan, catalog_revision=4)
     with pytest.raises(dl.DurableLifecycleError, match="contract changed"):
         dl._decode_plan_scope(plan, allow_physical_snapshot=True)
 

--- a/futureagi/tracer/tests/test_property_catalog_projection.py
+++ b/futureagi/tracer/tests/test_property_catalog_projection.py
@@ -150,7 +150,7 @@ def test_tombstone_restore_stale_duplicate_and_conflict_resolution() -> None:
     assert resolve_source_update(restore_v3, tombstone_v2).status is (
         VersionResolutionStatus.STALE
     )
-    duplicate = replace(restore_v3, catalog_revision=4, producer_sequence=9)
+    duplicate = replace(restore_v3, producer_sequence=9)
     duplicate_result = resolve_source_update(restore_v3, duplicate)
     assert duplicate_result.status is VersionResolutionStatus.DUPLICATE
     assert duplicate_result.current is duplicate
@@ -158,7 +158,7 @@ def test_tombstone_restore_stale_duplicate_and_conflict_resolution() -> None:
     conflict = _row(
         definition=_definition(details={"choices": ["free", "paid"]}),
         source_version=3,
-        revision=4,
+        revision=3,
         sequence=4,
     )
     assert resolve_source_update(restore_v3, conflict).status is (
@@ -171,6 +171,21 @@ def test_tombstone_restore_stale_duplicate_and_conflict_resolution() -> None:
     assert resolved.current is duplicate
     assert resolved.duplicate_count == 1
     assert resolved.stale_count == 2
+
+
+def test_new_catalog_revision_precedes_prior_source_version_domain() -> None:
+    physical_snapshot = _row(
+        source_version=1_787_459_205_903_148_937,
+        revision=3,
+        sequence=1,
+    )
+    lifecycle = _row(source_version=1_788_557_026_259_543, revision=4, sequence=2)
+
+    resolved = resolve_binding_history([physical_snapshot, lifecycle])
+
+    assert resolved.current is lifecycle
+    assert resolved.duplicate_count == 0
+    assert resolved.stale_count == 1
 
 
 def test_visibility_is_tenant_scoped_tombstone_safe_and_deduplicated() -> None:

--- a/futureagi/tracer/tests/test_property_catalog_reconciler.py
+++ b/futureagi/tracer/tests/test_property_catalog_reconciler.py
@@ -123,7 +123,9 @@ def test_incremental_visibility_change_tombstones_stale_binding_immediately() ->
         definition=definition,
         source_adapter=SourceAdapter.EVAL_CONFIG,
         source_entity_id="77777777-7777-4777-8777-777777777777",
-        source_version=1,
+        # The completed physical snapshot used a nanosecond generation while
+        # the following lifecycle revision uses a microsecond source fence.
+        source_version=1_787_459_205_903_148_937,
         source_fingerprint=_sha("v1"),
         producer_stream_id=STREAM,
         producer_sequence=1,
@@ -173,6 +175,63 @@ def test_incremental_visibility_change_tombstones_stale_binding_immediately() ->
         (PROJECT_A, True),
         (PROJECT_B, False),
     }
+
+
+def test_same_revision_newer_source_version_still_conflicts() -> None:
+    definition = _definition()
+    old = project_definition(
+        organization_id=ORG,
+        workspace_id=WORKSPACE,
+        catalog_epoch=1,
+        catalog_revision=2,
+        build_token=BUILD,
+        projection_version=1,
+        visibility=VisibilityBinding(VisibilityScope.PROJECT, PROJECT_A),
+        definition=definition,
+        source_adapter=SourceAdapter.EVAL_CONFIG,
+        source_entity_id="77777777-7777-4777-8777-777777777777",
+        source_version=3,
+        source_fingerprint=_sha("v3"),
+        producer_stream_id=STREAM,
+        producer_sequence=1,
+        emitted_at=NOW,
+    )
+    record = _make_source_record(
+        source_adapter=SourceAdapter.EVAL_CONFIG,
+        source_entity_id=old.source_entity_id,
+        source_updated_at=NOW,
+        definition=definition,
+        visibilities=(VisibilityBinding(VisibilityScope.PROJECT, PROJECT_B),),
+    )
+    snapshot = SourceSnapshot(
+        source_adapter=SourceAdapter.EVAL_CONFIG,
+        records=(record,),
+        next_cursor=None,
+        terminal=True,
+        source_count=1,
+        source_bytes=record.encoded_bytes,
+        source_digest=_sha("snapshot"),
+        page_count=1,
+    )
+    request = ReconcileRequest(
+        context=PostgresSnapshotContext(
+            organization_id=ORG,
+            workspace_id=WORKSPACE,
+            project_ids=(PROJECT,),
+            catalog_epoch=1,
+            catalog_revision=2,
+            projection_version=1,
+            snapshot_cutoff=NOW,
+        ),
+        build_token=BUILD,
+        producer_stream_id=STREAM,
+        emitted_at=NOW,
+        source_version=2,
+    )
+
+    _, conflicts = _project_records(snapshot=snapshot, current=(old,), request=request)
+
+    assert conflicts == 1
 
 
 class _EmptyCurrentBindings:


### PR DESCRIPTION
## Approved hotfix increment (2026-09-06)

Commit: `e9b1f9ee82e72565365fb868f810ef1b5a8a4356`

- Keep separate task-filter AND clauses intact when reopening/editing them, including numeric ranges, eval/annotation clauses, and typed multi-value inputs.
- Use the existing shared serializer in both task editors; preserve older saved top-level span IDs without retyping explicitly sourced filters.
- Stabilize trace/span grid theme memoization across equivalent theme-object rerenders.
- Six frontend runtime files (+42/-102 lines) and four regression-test files. No new API schema, dependencies, SQL, database, indexes, image tags, or deployment changes in this increment.

### Validation for the new increment

- 2,292 local tests passed across 191 selected suite files; 0 failed/pending.
- 118 overlapping targeted tests passed again with a separate frozen-yarn-lock dependency install; 0 failed/pending.
- Local production-mode frontend build passed with the frozen-lock install. Network was denied, so no Sentry artifacts were uploaded.
- The same 2,292 selected tests (191 suite files, 0 failed/pending) and production-mode frontend build were rerun successfully on **Node 22.18.0**, using the frozen-lock dependencies. Tracked source remained clean. Local component tests use an offline Iconify rendering stub; repository-native CI is a separate gate.
- The tested frontend source fingerprint was unchanged during validation: `8f609bc44eb1d0e818f836748cc00e3c86f604e318ad55be9d91bb6a461740a1`.
- Fresh frontend, backend, API-contract, and E2E CI is running on the pushed commit. The frontend API-contract check has passed. Check the live CI panel for final outcomes.
- The main-branch ruleset requires **one approving review**; none is present yet. Both CI and this review are release gates. No protections were bypassed.

### Release scope and outstanding qualification

This is a **partial correctness hotfix, not the production performance qualification**. It does not establish the sub-5-second list target, graph targets, or all 250+ attribute/operator/cross-type combinations over 7D/30D/12M. Remaining slow queries, backend source-name collisions, broader pagination/latest-state work, and cap-policy changes are excluded and preserved for follow-up.

The added increment requires a frontend image. The existing catalog-runtime portion below also changes backend and fi-collector; the whole PR is not frontend-only. No merge, deployment, production mutation, or backfill restart has been performed for this increment.

## Original catalog-runtime context

The RCA, validation, and deployment notes below are the original PR snapshot, not a fresh claim about current production pod/data state.

## Summary

- accept revision-scoped physical snapshot retirement proofs for any OSS catalog epoch and projection while preserving the signed lease, canonical stream inventory, lifecycle mode, revision-label, and generation checks
- align lifecycle binding resolution with the production ClickHouse reader ordering of catalog revision followed by source version
- allow a newer catalog revision to supersede an older revision whose source version came from a different numeric domain, while retaining same-revision stale and conflict protection

## Live RCA

- the consumer is healthy
- the sequencer currently exits because initial_backfill retirement proofs contain physical_snapshot_r3 labels
- the live retirement file contains 240 records; every record has ten streams with a consistent non-zero generation and the label matching revision 3
- the lifecycle sidecar also reports definition binding conflicts and expired incomplete revisions

## Validation

- go test ./... from fi-collector
- go build ./cmd/... from fi-collector
- 748 property-catalog and unified property-catalog Python tests passed
- Ruff passed for all modified Python files
- git diff --check passed

## Deployment order

1. Build and deploy the updated fi-collector and backend images.
2. Confirm the new image digests are running.
3. Enable repairExpiredIncomplete to replace revisions already left incomplete by the old runtime.
4. Require fi-property-catalog-sequencer-0 to remain 2/2 Ready and the consumer to remain healthy before touching the paused historical backfill.

No production data, Kubernetes resources, or backfill state were changed while preparing this PR.
