### PR TITLE
fix(model_hub): raise on unsupported filter ops and escape LIKE wildc…

### DIFF
--- a/futureagi/model_hub/tests/test_build_sql_filters.py
+++ b/futureagi/model_hub/tests/test_build_sql_filters.py
@@ -1,0 +1,164 @@
+"""Regression tests for ``build_sql_filters``.
+
+Covers two defects in ``model_hub.utils.SQL_queries.build_sql_filters``:
+
+  * Filter operations that matched no branch used to be silently dropped, so
+    the caller ran an unfiltered query that looked filtered. They now raise.
+  * Text ILIKE operations interpolated the raw value into the pattern, so a
+    literal ``%`` or ``_`` acted as a wildcard. They are now escaped and the
+    clause carries an explicit ``ESCAPE`` character.
+
+The function is pure (no DB access); these tests exercise the SQL fragment and
+parameters it returns.
+"""
+
+import unittest
+
+from model_hub.utils.SQL_queries import build_sql_filters
+
+
+def _text_filter(op, value):
+    return [
+        {
+            "column_id": "name",
+            "filter_config": {
+                "filter_op": op,
+                "filter_value": value,
+                "filter_type": "text",
+            },
+        }
+    ]
+
+
+class BuildSqlFiltersTextTests(unittest.TestCase):
+    def test_contains_escapes_wildcards_and_sets_escape_clause(self):
+        sql, params = build_sql_filters(
+            _text_filter("contains", "100%_off"), {"name": "eu.user_id"}
+        )
+        self.assertEqual(sql, " AND eu.user_id ILIKE %s ESCAPE '\\'")
+        # % and _ are escaped so they match literally, wrapped for "contains".
+        self.assertEqual(params, ["%100\\%\\_off%"])
+
+    def test_equals_is_exact_not_wildcard(self):
+        sql, params = build_sql_filters(
+            _text_filter("equals", "100%"), {"name": "eu.user_id"}
+        )
+        self.assertEqual(sql, " AND eu.user_id ILIKE %s ESCAPE '\\'")
+        self.assertEqual(params, ["100\\%"])
+
+    def test_starts_with_and_ends_with(self):
+        _, start_params = build_sql_filters(
+            _text_filter("starts_with", "a_b"), {"name": "eu.user_id"}
+        )
+        self.assertEqual(start_params, ["a\\_b%"])
+        _, end_params = build_sql_filters(
+            _text_filter("ends_with", "a_b"), {"name": "eu.user_id"}
+        )
+        self.assertEqual(end_params, ["%a\\_b"])
+
+    def test_in_builds_placeholders(self):
+        sql, params = build_sql_filters(
+            _text_filter("in", ["a", "b", "c"]), {"name": "eu.user_id"}
+        )
+        self.assertEqual(sql, " AND eu.user_id IN (%s, %s, %s)")
+        self.assertEqual(params, ["a", "b", "c"])
+
+
+class BuildSqlFiltersUnsupportedOpTests(unittest.TestCase):
+    def test_text_op_with_default_number_type_raises(self):
+        # A text op sent without filter_type defaults to "number" and used to be
+        # silently dropped, returning an unfiltered result set.
+        filters = [
+            {
+                "column_id": "name",
+                "filter_config": {"filter_op": "contains", "filter_value": "abc"},
+            }
+        ]
+        with self.assertRaises(ValueError):
+            build_sql_filters(filters, {"name": "eu.user_id"})
+
+    def test_unhandled_text_op_raises(self):
+        with self.assertRaises(ValueError):
+            build_sql_filters(
+                _text_filter("is_null", ""), {"name": "eu.user_id"}
+            )
+
+    def test_unhandled_number_op_raises(self):
+        filters = [
+            {
+                "column_id": "score",
+                "filter_config": {
+                    "filter_op": "is_null",
+                    "filter_value": 1,
+                    "filter_type": "number",
+                },
+            }
+        ]
+        with self.assertRaises(ValueError):
+            build_sql_filters(filters, {"score": "os.score"})
+
+    def test_unknown_data_type_raises(self):
+        filters = [
+            {
+                "column_id": "name",
+                "filter_config": {
+                    "filter_op": "equals",
+                    "filter_value": "x",
+                    "filter_type": "boolean",
+                },
+            }
+        ]
+        with self.assertRaises(ValueError):
+            build_sql_filters(filters, {"name": "eu.user_id"})
+
+    def test_unknown_column_still_raises(self):
+        with self.assertRaises(Exception):
+            build_sql_filters(
+                _text_filter("contains", "x"), {"other": "eu.user_id"}
+            )
+
+
+class BuildSqlFiltersMiscTests(unittest.TestCase):
+    def test_number_equals(self):
+        filters = [
+            {
+                "column_id": "score",
+                "filter_config": {
+                    "filter_op": "equals",
+                    "filter_value": 5,
+                    "filter_type": "number",
+                },
+            }
+        ]
+        sql, params = build_sql_filters(filters, {"score": "os.score"})
+        self.assertEqual(sql, " AND os.score = %s")
+        self.assertEqual(params, [5])
+
+    def test_created_at_is_skipped(self):
+        filters = [
+            {
+                "column_id": "created_at",
+                "filter_config": {"filter_op": "equals", "filter_value": "x"},
+            }
+        ]
+        self.assertEqual(build_sql_filters(filters, {}), ("", []))
+
+    def test_empty_and_default_args(self):
+        self.assertEqual(build_sql_filters(), ("", []))
+        self.assertEqual(build_sql_filters([], {}), ("", []))
+
+    def test_mutable_default_not_shared_between_calls(self):
+        # Guards against the previous mutable default-argument signature.
+        first_sql, first_params = build_sql_filters(
+            _text_filter("contains", "a"), {"name": "eu.user_id"}
+        )
+        second_sql, second_params = build_sql_filters(
+            _text_filter("contains", "b"), {"name": "eu.user_id"}
+        )
+        self.assertEqual(first_params, ["%a%"])
+        self.assertEqual(second_params, ["%b%"])
+        self.assertEqual(first_sql, second_sql)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/futureagi/model_hub/utils/SQL_queries.py
+++ b/futureagi/model_hub/utils/SQL_queries.py
@@ -81,7 +81,20 @@ MODEL_COST_CALCULATION_SQL = """
 """
 
 
-def build_sql_filters(filters=[], column_map={}):
+def _escape_like_wildcards(value):
+    """Escape ILIKE/LIKE metacharacters so they match literally.
+
+    Filter values are always bound as parameters (never interpolated into the
+    SQL text), so this is not about SQL injection -- it prevents a literal
+    ``%`` or ``_`` inside a user's value from being treated as a wildcard.
+    Callers pair the escaped value with ``ESCAPE '\\'`` on the clause.
+    """
+    return str(value).replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
+
+
+def build_sql_filters(filters=None, column_map=None):
+    filters = filters if filters is not None else []
+    column_map = column_map if column_map is not None else {}
     filter_clauses = []
     params = []
     for f in filters:
@@ -97,23 +110,23 @@ def build_sql_filters(filters=[], column_map={}):
 
         if data_type == "text":
             if op == "contains":
-                filter_clauses.append(f"{col} ILIKE %s")
-                params.append(f"%{values}%")
+                filter_clauses.append(f"{col} ILIKE %s ESCAPE '\\'")
+                params.append(f"%{_escape_like_wildcards(values)}%")
             elif op == "not_contains":
-                filter_clauses.append(f"{col} NOT ILIKE %s")
-                params.append(f"%{values}%")
+                filter_clauses.append(f"{col} NOT ILIKE %s ESCAPE '\\'")
+                params.append(f"%{_escape_like_wildcards(values)}%")
             elif op == "equals":
-                filter_clauses.append(f"{col} ILIKE %s")
-                params.append(values)
+                filter_clauses.append(f"{col} ILIKE %s ESCAPE '\\'")
+                params.append(_escape_like_wildcards(values))
             elif op == "not_equals":
-                filter_clauses.append(f"{col} NOT ILIKE %s")
-                params.append(values)
+                filter_clauses.append(f"{col} NOT ILIKE %s ESCAPE '\\'")
+                params.append(_escape_like_wildcards(values))
             elif op == "starts_with":
-                filter_clauses.append(f"{col} ILIKE %s")
-                params.append(f"{values}%")
+                filter_clauses.append(f"{col} ILIKE %s ESCAPE '\\'")
+                params.append(f"{_escape_like_wildcards(values)}%")
             elif op == "ends_with":
-                filter_clauses.append(f"{col} ILIKE %s")
-                params.append(f"%{values}")
+                filter_clauses.append(f"{col} ILIKE %s ESCAPE '\\'")
+                params.append(f"%{_escape_like_wildcards(values)}")
             elif op == "in":
                 placeholders = ", ".join(["%s"] * len(values))
                 filter_clauses.append(f"{col} IN ({placeholders})")
@@ -122,6 +135,10 @@ def build_sql_filters(filters=[], column_map={}):
                 placeholders = ", ".join(["%s"] * len(values))
                 filter_clauses.append(f"{col} NOT IN ({placeholders})")
                 params.extend(values)
+            else:
+                raise ValueError(
+                    f"Unsupported filter operation '{op}' for text column '{col}'"
+                )
 
         elif data_type == "number":
             if op == "between":
@@ -148,6 +165,10 @@ def build_sql_filters(filters=[], column_map={}):
             elif op == "less_than_or_equal":
                 filter_clauses.append(f"{col} <= %s")
                 params.append(values)
+            else:
+                raise ValueError(
+                    f"Unsupported filter operation '{op}' for number column '{col}'"
+                )
 
         elif data_type == "datetime":
             if isinstance(values, list) and len(values) > 1:
@@ -155,6 +176,11 @@ def build_sql_filters(filters=[], column_map={}):
             sql, dt_params = build_datetime_filter_sql(values, op, col)
             filter_clauses.append(sql)
             params.extend(dt_params)
+
+        else:
+            raise ValueError(
+                f"Unsupported filter type '{data_type}' for column '{col}'"
+            )
 
     sql_query = ""
     if filter_clauses:


### PR DESCRIPTION
## Summary

`build_sql_filters` translated filters with `if/elif` chains that had no terminating `else`, so any operation matching no branch was silently dropped — the caller then ran an unfiltered query that looked filtered, with no error. It also interpolated raw values into ILIKE patterns, so a literal `%`/`_` acted as a wildcard. This makes unsupported ops fail loudly and escapes text wildcards so they match literally.

## Linked issues

Closes #2560
Linear:

## Type of change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📖 Documentation only
- [ ] 🧹 Chore / refactor (no user-visible change)
- [ ] 🚀 Performance improvement
- [ ] 🧪 Test-only change

## E2E coverage

E2E: exempt (backend-internal)

---

## 1) What changes were done

**A. Fail loud on unsupported filter operations / types**
- Added an `else` to the `text`, `number`, and data-type dispatch that raises `ValueError` for an unsupported op or `filter_type`, mirroring the existing `Invalid Column for filter` behaviour instead of returning wrong rows.

**B. Escape ILIKE wildcards**
- Added `_escape_like_wildcards()` and paired every text ILIKE clause with `ESCAPE '\'`, so a literal `%` or `_` in a value matches literally. Values remain bound parameters — this is a correctness fix, not an injection fix.

**C. Signature hygiene**
- Replaced the mutable default arguments (`filters=[], column_map={}`) with `None`.

## 2) Why the changes were done

- **Technical:** silently dropping a filter returns an unfiltered result set that looks filtered — worse than an error because nothing signals the miss. Raising matches the function's own unknown-column handling.
- **Correctness:** unescaped LIKE metacharacters silently broaden matches (`100%`, `user_id`).

## 3) Tests written + scenarios each covers

**`model_hub/tests/test_build_sql_filters.py`** — unit coverage for the filter builder

- `test_contains_escapes_wildcards_and_sets_escape_clause` — `%`/`_` escaped, `ESCAPE` clause present
- `test_equals_is_exact_not_wildcard` — text equals no longer wildcards on `%`
- `test_starts_with_and_ends_with` — anchored patterns escape wildcards
- `test_in_builds_placeholders` — `IN (...)` placeholder generation
- `test_text_op_with_default_number_type_raises` — the silent-drop regression (text op, default number type)
- `test_unhandled_text_op_raises` / `test_unhandled_number_op_raises` — `is_null`/unknown ops raise
- `test_unknown_data_type_raises` — unknown `filter_type` raises
- `test_unknown_column_still_raises` — existing behaviour preserved
- `test_number_equals`, `test_created_at_is_skipped`, `test_empty_and_default_args`, `test_mutable_default_not_shared_between_calls`

## 4) How to run / test

```bash
cd futureagi
bin/test model_hub/tests/test_build_sql_filters.py -v
```

## 6) Edge cases & considerations

- **Behaviour change:** unsupported ops now raise `ValueError` instead of returning unfiltered results. The only in-repo caller (`SQLQueryHandler.get_spans_by_end_users`) has no live callers, so there is no runtime impact in-tree; callers that relied on the silent no-op would now surface the bad filter.
- Non-string values in text ops are coerced via `str()` before escaping.

## Checklist

- [x] My code follows the [style guide](../CONTRIBUTING.md#code-style)
- [x] I've added tests that prove my fix is effective or that my feature works
- [x] `bin/test` passes locally (backend) 
- [ ] `yarn test:run` passes locally (frontend) — N/A, no frontend change
- [ ] `yarn contracts:check` passes if API surface changed — N/A, no API surface change
- [x] No hardcoded secrets, URLs, or PII
- [x] I've signed the CLA
- [x] PR title follows Conventional Commits
- [ ] Linear issue is linked and updated with status