### PR TITLE
fix(agentic_eval): compute true multiclass MCC in MatthewsCorrelation

### DIFF
--- a/futureagi/agentic_eval/core_evals/fi_evals/function/functions.py
+++ b/futureagi/agentic_eval/core_evals/fi_evals/function/functions.py
@@ -3230,10 +3230,21 @@ def calculate_matthews_correlation(output, expected, **kwargs):
         else:
             mcc = (tp * tn - fp * fn) / denom
     else:
-        # Multiclass MCC (using confusion matrix)
-        n = len(labels)
-        correct = sum(1 for p, l in zip(preds, labels) if p == l)
-        mcc = (correct / n - 1 / len(categories)) / (1 - 1 / len(categories)) if len(categories) > 1 else 0.0
+        # Multiclass MCC via the confusion-matrix formulation (Gorodkin's R_K),
+        # equivalent to sklearn.metrics.matthews_corrcoef:
+        #   MCC = (c*s - sum_k p_k*t_k)
+        #         / sqrt((s^2 - sum_k p_k^2) * (s^2 - sum_k t_k^2))
+        # where s = number of samples, c = correct predictions, and t_k / p_k
+        # are the true / predicted counts of class k.
+        s = len(labels)
+        c = sum(1 for p, l in zip(preds, labels) if p == l)
+        t_counts = {cat: labels.count(cat) for cat in categories}
+        p_counts = {cat: preds.count(cat) for cat in categories}
+        sum_pt = sum(p_counts[cat] * t_counts[cat] for cat in categories)
+        sum_p2 = sum(v * v for v in p_counts.values())
+        sum_t2 = sum(v * v for v in t_counts.values())
+        denom = ((s * s - sum_p2) * (s * s - sum_t2)) ** 0.5
+        mcc = 0.0 if denom == 0 else (c * s - sum_pt) / denom
 
     # Normalize from [-1, 1] to [0, 1]
     score = (mcc + 1) / 2

--- a/futureagi/agentic_eval/core_evals/fi_evals/function/tests/test_matthews_correlation.py
+++ b/futureagi/agentic_eval/core_evals/fi_evals/function/tests/test_matthews_correlation.py
@@ -1,0 +1,74 @@
+"""Regression tests for ``calculate_matthews_correlation``.
+
+The multiclass branch previously computed a chance-corrected accuracy
+``(accuracy - 1/k) / (1 - 1/k)`` under a uniform class prior, which is not the
+Matthews Correlation Coefficient. It now uses the confusion-matrix formulation
+(Gorodkin's R_K), matching ``sklearn.metrics.matthews_corrcoef``.
+"""
+
+import unittest
+
+from agentic_eval.core_evals.fi_evals.function.functions import (
+    calculate_matthews_correlation,
+)
+
+
+class MatthewsCorrelationMulticlassTests(unittest.TestCase):
+    def test_constant_predictor_scores_chance_not_high(self):
+        # Always predict the majority class on imbalanced 3-class data. A
+        # constant predictor has zero correlation with the labels; true MCC is
+        # 0.0 (normalized 0.5). The old proxy returned 0.85 here.
+        preds = ["A"] * 10
+        labels = ["A"] * 8 + ["B"] + ["C"]
+        result = calculate_matthews_correlation(preds, labels)["result"]
+        self.assertAlmostEqual(result, 0.5, places=6)
+
+    def test_realistic_multiclass_matches_true_mcc(self):
+        # True multiclass MCC = 0.7078 (normalized 0.8539); the old proxy
+        # returned 0.7000 (normalized 0.8500).
+        preds = ["A", "B", "B", "B", "C", "A", "A", "B", "C", "A"]
+        labels = ["A", "A", "B", "B", "C", "C", "A", "B", "C", "A"]
+        result = calculate_matthews_correlation(preds, labels)["result"]
+        self.assertAlmostEqual(result, 0.8538880365655817, places=6)
+
+    def test_anticorrelated_predictions_are_negative(self):
+        # Systematically shifted labels -> negative correlation. The [0, 1]
+        # normalization of a negative MCC must fall below 0.5.
+        preds = ["B", "C", "A", "B", "C", "A"]
+        labels = ["A", "B", "C", "A", "B", "C"]
+        result = calculate_matthews_correlation(preds, labels)["result"]
+        self.assertAlmostEqual(result, 0.25, places=6)  # MCC = -0.5
+
+    def test_perfect_multiclass_is_one(self):
+        preds = ["A", "B", "C", "A"]
+        labels = ["A", "B", "C", "A"]
+        result = calculate_matthews_correlation(preds, labels)["result"]
+        self.assertAlmostEqual(result, 1.0, places=6)
+
+
+class MatthewsCorrelationBinaryTests(unittest.TestCase):
+    def test_binary_no_correlation(self):
+        preds = ["A", "A", "B", "B"]
+        labels = ["A", "B", "A", "B"]
+        result = calculate_matthews_correlation(preds, labels)["result"]
+        self.assertAlmostEqual(result, 0.5, places=6)  # MCC = 0.0
+
+    def test_binary_perfect(self):
+        preds = ["A", "B", "A", "B"]
+        labels = ["A", "B", "A", "B"]
+        result = calculate_matthews_correlation(preds, labels)["result"]
+        self.assertAlmostEqual(result, 1.0, places=6)
+
+
+class MatthewsCorrelationInputTests(unittest.TestCase):
+    def test_length_mismatch_returns_zero(self):
+        result = calculate_matthews_correlation(["A"], ["A", "B"])
+        self.assertEqual(result["result"], 0.0)
+
+    def test_empty_returns_zero(self):
+        result = calculate_matthews_correlation([], [])
+        self.assertEqual(result["result"], 0.0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

`calculate_matthews_correlation` (`MatthewsCorrelation`) returned a value that is not the Matthews Correlation Coefficient for inputs with more than two classes. The multiclass branch computed `(accuracy - 1/k) / (1 - 1/k)` — a chance-corrected accuracy under a uniform class prior (effectively a uniform-prior Cohen's kappa), not MCC — which contradicted the docstring ("balanced metric even for imbalanced classes"). This replaces that branch with the confusion-matrix MCC (Gorodkin's R_K), so the eval reports the correct value on multiclass data.

## Linked issues

Closes #2564 
Linear:

## Type of change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📖 Documentation only
- [ ] 🧹 Chore / refactor (no user-visible change)
- [ ] 🚀 Performance improvement
- [ ] 🧪 Test-only change

## E2E coverage

E2E: exempt (backend-internal)

---

## 1) What changes were done

**A. Correct multiclass MCC computation**

- Replaced the multiclass branch of `calculate_matthews_correlation` in `agentic_eval/core_evals/fi_evals/function/functions.py` with the confusion-matrix formulation (Gorodkin's R_K): `MCC = (c·s − Σ_k p_k·t_k) / sqrt((s² − Σ_k p_k²)(s² − Σ_k t_k²))`.
- No API/serializer change.
- No model/storage change.

**B. No change to the binary path**

- The `k = 2` branch was already correct and is left untouched; the new code only runs for 3+ classes.

**C. Architecture / layering**

- Implemented in pure Python (no new dependency), consistent with the other self-contained metrics in this module. Numerically equivalent to `sklearn.metrics.matthews_corrcoef`.

---

## 2) Why the changes were done

- **Product/UX:** users evaluating multiclass classifiers with the `MatthewsCorrelation` eval were getting a silently wrong score — a constant "always predict the majority class" classifier scored 0.85 on imbalanced 3-class data where true MCC is 0.0 (chance). The metric now behaves as documented.
- **Technical:** the old formula is a uniform-prior chance-corrected accuracy, not MCC. It could not reach the full `[-1, 1]` range and returned nearly the same values as the neighbouring `CohenKappa` eval on multiclass input. The confusion-matrix formula is the standard definition and matches sklearn.
- **Architecture:** kept the fix dependency-free to avoid a hard `scikit-learn` import in the eval hot path while staying numerically equivalent.

---

## 3) Tests written + scenarios each covers

**`agentic_eval/core_evals/fi_evals/function/tests/test_matthews_correlation.py`** — unit coverage for `calculate_matthews_correlation`

- `test_constant_predictor_scores_chance_not_high` — always-majority predictor on imbalanced 3-class data → 0.5 (the headline regression; previously 0.85)
- `test_realistic_multiclass_matches_true_mcc` — realistic 3-class case → 0.8539 (true MCC 0.7078; old proxy gave 0.7000)
- `test_anticorrelated_predictions_are_negative` — shifted labels → 0.25 (MCC −0.5), proving negatives are reachable
- `test_perfect_multiclass_is_one` — perfect agreement → 1.0
- `test_binary_no_correlation` — binary chance case → 0.5 (MCC 0.0)
- `test_binary_perfect` — binary perfect case → 1.0 (parity with existing branch)
- `test_length_mismatch_returns_zero` — mismatched input lengths → 0.0
- `test_empty_returns_zero` — empty input → 0.0

> Run result: all 8 cases verified against the edited function. `make check-all` / `bin/test` still to be run in a full backend env (see below).

---

## 4) How to run / test

### Backend tests

```bash
cd futureagi

# Create venv with correct Python (one-time):
uv venv --python 3.11
source .venv/bin/activate
uv pip install -r requirements-test.txt

# This suite:
bin/test agentic_eval/core_evals/fi_evals/function/tests/test_matthews_correlation.py -v

# Single test by name:
bin/test agentic_eval/core_evals/fi_evals/function/tests/test_matthews_correlation.py -k "constant_predictor"
```

### Frontend tests

N/A — backend-only change.

### Contract verification

N/A — no API surface changed.

### UI steps (manual)

N/A — no UI change.

---

## 5) Screenshots / recordings

N/A — backend-internal change; behaviour is covered by the unit tests in section 3.

---

## 6) Edge cases & considerations

- **Constant / single-value predictions** (`Σ p_k² = s²`): the denominator is 0; MCC is defined as 0.0 there, matching sklearn.
- **`k = 2`:** handled by the unchanged binary branch; the new code path only runs for 3+ classes.
- **Anticorrelated predictions:** now correctly produce a negative MCC (normalized below 0.5), which the old proxy could not fully represent.
- **Non-list / JSON-string inputs:** parsed by the existing `_parse` helper; unchanged.
- **Normalization:** the `[-1, 1] → [0, 1]` scoring normalization is preserved.

---

## 7) Pre-existing issues (NOT introduced by this PR)

None.

---

## 8) Architectural / important decisions

- **Pure-Python formula over a `sklearn` call:** keeps the module self-contained (consistent with the other metrics in this file) and avoids a hard `scikit-learn` import in the eval hot path, while remaining numerically equivalent to `sklearn.metrics.matthews_corrcoef`.

---

## Checklist

- [x] My code follows the [style guide](../CONTRIBUTING.md#code-style)
- [x] I've added tests that prove my fix is effective or that my feature works
- [ ] `bin/test` passes locally (backend)
- [ ] `yarn test:run` passes locally (frontend)
- [ ] `yarn contracts:check` passes if API surface changed
- [ ] I've updated the documentation where relevant
- [x] No hardcoded secrets, URLs, or PII
- [x] I've signed the [CLA](../CONTRIBUTING.md#contributor-license-agreement-cla)
- [x] PR title follows Conventional Commits
- [ ] Linear issue is linked and updated with status