### PR TITLE
fix(agentic_eval): resolve positive class by convention in precision/F-beta

### DIFF
--- a/futureagi/agentic_eval/core_evals/fi_evals/function/functions.py
+++ b/futureagi/agentic_eval/core_evals/fi_evals/function/functions.py
@@ -3069,7 +3069,116 @@ def calculate_accuracy(output, expected, **kwargs):
     return {"result": accuracy, "reason": f"Accuracy: {accuracy:.4f} ({correct}/{len(labels)} correct)"}
 
 
-def calculate_precision_score(output, expected, positive_label=None, **kwargs):
+# Conventional binary label pairs, mapped to the member that means "positive".
+# Used to resolve the positive class when the caller does not name one. Picking
+# the positive class alphabetically is wrong for every pair listed here, so a
+# label set that matches one of these is resolved by convention instead.
+_POSITIVE_LABEL_CONVENTIONS = (
+    (frozenset({"yes", "no"}), "yes"),
+    (frozenset({"true", "false"}), "true"),
+    (frozenset({"1", "0"}), "1"),
+    (frozenset({"positive", "negative"}), "positive"),
+    (frozenset({"pass", "fail"}), "pass"),
+    (frozenset({"spam", "ham"}), "spam"),
+    (frozenset({"relevant", "irrelevant"}), "relevant"),
+    (frozenset({"correct", "incorrect"}), "correct"),
+    (frozenset({"valid", "invalid"}), "valid"),
+)
+
+_VALID_AVERAGES = ("binary", "macro", "micro", "weighted")
+
+
+def _parse_label_list(val):
+    """Normalize a label input into a lowercased list of string labels."""
+    if val is None:
+        return []
+    if isinstance(val, list):
+        return [str(v).lower() for v in val]
+    if isinstance(val, str):
+        try:
+            parsed = json.loads(val)
+            if isinstance(parsed, list):
+                return [str(v).lower() for v in parsed]
+        except (json.JSONDecodeError, ValueError):
+            pass
+        return [val.strip().lower()]
+    return [str(val).lower()]
+
+
+def _resolve_conventional_positive_label(classes):
+    """Return the conventional positive label for a binary class set, else None.
+
+    Only exact two-class matches against ``_POSITIVE_LABEL_CONVENTIONS`` resolve;
+    anything else returns None so the caller can fall back to averaging rather
+    than guessing a class.
+    """
+    class_set = frozenset(classes)
+    if len(class_set) != 2:
+        return None
+    for pair, positive in _POSITIVE_LABEL_CONVENTIONS:
+        if class_set == pair:
+            return positive
+    return None
+
+
+def _binary_counts(preds, labels, pos):
+    """Return (tp, fp, fn) for ``pos`` treated as the positive class.
+
+    Callers validate that ``preds`` and ``labels`` are the same length before
+    reaching here, so ``strict=True`` guards against future misuse.
+    """
+    tp = fp = fn = 0
+    for pred, label in zip(preds, labels, strict=True):
+        if pred == pos:
+            if label == pos:
+                tp += 1
+            else:
+                fp += 1
+        elif label == pos:
+            fn += 1
+    return tp, fp, fn
+
+
+def _resolve_averaging(preds, labels, positive_label):
+    """Decide how to reduce per-class scores to a single number.
+
+    Returns ``(pos, average)``. When ``pos`` is not None the caller scores that
+    single class one-vs-rest; otherwise it averages using ``average``.
+
+    Resolution order:
+      1. An explicitly supplied ``positive_label`` (including falsy ones such as
+         ``0`` or ``"0"``) wins.
+      2. A two-class problem matching a known convention resolves to that
+         convention's positive member.
+      3. Everything else macro-averages, which is independent of label ordering.
+    """
+    if positive_label is not None:
+        return str(positive_label).lower(), "binary"
+
+    classes = set(labels) | set(preds)
+    conventional = _resolve_conventional_positive_label(classes)
+    if conventional is not None:
+        return conventional, "binary"
+
+    return None, "macro"
+
+
+def _average_per_class(per_class, labels, average):
+    """Reduce ``{class: score}`` to a scalar using the requested averaging."""
+    if not per_class:
+        return 0.0
+    if average == "weighted":
+        supports = {cls: labels.count(cls) for cls in per_class}
+        total = sum(supports.values())
+        if total == 0:
+            return 0.0
+        return sum(per_class[cls] * supports[cls] for cls in per_class) / total
+    return sum(per_class.values()) / len(per_class)
+
+
+def calculate_precision_score(
+    output, expected, positive_label=None, average=None, **kwargs
+):
     """
     Compute precision for binary/multiclass classification.
     Precision = TP / (TP + FP).
@@ -3077,46 +3186,96 @@ def calculate_precision_score(output, expected, positive_label=None, **kwargs):
     Args:
         output: Predicted label(s).
         expected: Expected label(s).
-        positive_label: The label considered as positive (default: auto-detect).
+        positive_label: The label to treat as positive. When omitted, a known
+            binary convention (yes/no, true/false, 1/0, spam/ham, ...) is used
+            if the labels match one; otherwise precision is macro-averaged over
+            every class.
+        average: Explicit averaging strategy — one of "binary", "macro",
+            "micro", "weighted". "binary" requires ``positive_label`` or a
+            resolvable convention. Defaults to automatic resolution.
 
     Returns:
         dict: {"result": float (0-1), "reason": str}
     """
-    def _parse(val):
-        if val is None:
-            return []
-        if isinstance(val, list):
-            return [str(v).lower() for v in val]
-        if isinstance(val, str):
-            try:
-                parsed = json.loads(val)
-                if isinstance(parsed, list):
-                    return [str(v).lower() for v in parsed]
-            except (json.JSONDecodeError, ValueError):
-                pass
-            return [val.strip().lower()]
-        return [str(val).lower()]
-
-    preds = _parse(output)
-    labels = _parse(expected)
+    preds = _parse_label_list(output)
+    labels = _parse_label_list(expected)
 
     if len(preds) != len(labels) or not labels:
-        return {"result": 0.0, "reason": f"Invalid input: {len(preds)} preds vs {len(labels)} labels"}
+        return {
+            "result": 0.0,
+            "reason": f"Invalid input: {len(preds)} preds vs {len(labels)} labels",
+        }
 
-    if positive_label is not None:
-        pos = str(positive_label).lower()
-    else:
-        unique = set(labels)
-        pos = sorted(unique)[0] if unique else ""
+    if average is not None and average not in _VALID_AVERAGES:
+        return {
+            "result": 0.0,
+            "reason": (
+                f"Invalid average '{average}'; expected one of "
+                f"{', '.join(_VALID_AVERAGES)}"
+            ),
+        }
 
-    tp = sum(1 for p, l in zip(preds, labels) if p == pos and l == pos)
-    fp = sum(1 for p, l in zip(preds, labels) if p == pos and l != pos)
+    pos, resolved_average = _resolve_averaging(preds, labels, positive_label)
+    if average is not None:
+        resolved_average = average
+        if average != "binary":
+            pos = None
+        elif pos is None:
+            return {
+                "result": 0.0,
+                "reason": (
+                    "average='binary' requires positive_label, or labels that "
+                    "match a known binary convention"
+                ),
+            }
 
-    if tp + fp == 0:
-        return {"result": 0.0, "reason": f"Precision: 0.0 (no positive predictions for label '{pos}')"}
+    if resolved_average == "binary":
+        tp, fp, _ = _binary_counts(preds, labels, pos)
+        if tp + fp == 0:
+            return {
+                "result": 0.0,
+                "reason": (
+                    f"Precision: 0.0 (no predictions for positive label '{pos}')"
+                ),
+            }
+        precision = tp / (tp + fp)
+        return {
+            "result": precision,
+            "reason": (
+                f"Precision: {precision:.4f} (TP={tp}, FP={fp}, positive='{pos}')"
+            ),
+        }
 
-    precision = tp / (tp + fp)
-    return {"result": precision, "reason": f"Precision: {precision:.4f} (TP={tp}, FP={fp}, positive='{pos}')"}
+    classes = sorted(set(labels) | set(preds))
+
+    if resolved_average == "micro":
+        tp_total = sum(_binary_counts(preds, labels, c)[0] for c in classes)
+        fp_total = sum(_binary_counts(preds, labels, c)[1] for c in classes)
+        if tp_total + fp_total == 0:
+            return {"result": 0.0, "reason": "Precision: 0.0 (no predictions)"}
+        precision = tp_total / (tp_total + fp_total)
+        return {
+            "result": precision,
+            "reason": (
+                f"Precision (micro): {precision:.4f} "
+                f"(TP={tp_total}, FP={fp_total}, {len(classes)} classes)"
+            ),
+        }
+
+    per_class = {}
+    for cls in classes:
+        tp, fp, _ = _binary_counts(preds, labels, cls)
+        per_class[cls] = tp / (tp + fp) if tp + fp > 0 else 0.0
+
+    precision = _average_per_class(per_class, labels, resolved_average)
+    breakdown = ", ".join(f"{c}={per_class[c]:.4f}" for c in classes)
+    return {
+        "result": precision,
+        "reason": (
+            f"Precision ({resolved_average}): {precision:.4f} "
+            f"over {len(classes)} classes [{breakdown}]"
+        ),
+    }
 
 
 def calculate_cohen_kappa(output, expected, **kwargs):
@@ -3689,36 +3848,129 @@ def calculate_balanced_accuracy(output, expected, **kwargs):
     return {"result": ba, "reason": f"Balanced Accuracy: {ba:.4f} (avg recall across {len(classes)} classes)"}
 
 
-def calculate_f_beta_score(output, expected, beta=1.0, positive_label=None, **kwargs):
-    """Compute F-beta score with configurable beta."""
-    def _parse(val):
-        if isinstance(val, list):
-            return [str(v).lower() for v in val]
-        if isinstance(val, str):
-            try:
-                parsed = json.loads(val)
-                if isinstance(parsed, list):
-                    return [str(v).lower() for v in parsed]
-            except (json.JSONDecodeError, ValueError):
-                pass
-            return [val.strip().lower()]
-        return [str(val).lower()]
-    preds = _parse(output)
-    labels = _parse(expected)
-    if len(preds) != len(labels) or not labels:
-        return {"result": 0.0, "reason": "Invalid input"}
-    beta = float(beta)
-    pos = str(positive_label).lower() if positive_label else sorted(set(labels))[0]
-    tp = sum(1 for p, l in zip(preds, labels) if p == pos and l == pos)
-    fp = sum(1 for p, l in zip(preds, labels) if p == pos and l != pos)
-    fn = sum(1 for p, l in zip(preds, labels) if p != pos and l == pos)
-    precision = tp / (tp + fp) if (tp + fp) > 0 else 0.0
-    recall = tp / (tp + fn) if (tp + fn) > 0 else 0.0
+def _f_beta(precision, recall, b2):
+    """Combine precision and recall into an F-beta score."""
     if precision + recall == 0:
-        return {"result": 0.0, "reason": f"F{beta}: 0.0 (no TP)"}
-    b2 = beta ** 2
-    fb = (1 + b2) * precision * recall / (b2 * precision + recall)
-    return {"result": fb, "reason": f"F{beta}: {fb:.4f} (P={precision:.4f}, R={recall:.4f})"}
+        return 0.0
+    return (1 + b2) * precision * recall / (b2 * precision + recall)
+
+
+def calculate_f_beta_score(
+    output, expected, beta=1.0, positive_label=None, average=None, **kwargs
+):
+    """Compute F-beta score with configurable beta.
+
+    Args:
+        output: Predicted label(s).
+        expected: Expected label(s).
+        beta: Weight of recall relative to precision.
+        positive_label: The label to treat as positive. When omitted, a known
+            binary convention (yes/no, true/false, 1/0, spam/ham, ...) is used
+            if the labels match one; otherwise the score is macro-averaged over
+            every class.
+        average: Explicit averaging strategy — one of "binary", "macro",
+            "micro", "weighted". "binary" requires ``positive_label`` or a
+            resolvable convention. Defaults to automatic resolution.
+
+    Returns:
+        dict: {"result": float (0-1), "reason": str}
+    """
+    preds = _parse_label_list(output)
+    labels = _parse_label_list(expected)
+    if len(preds) != len(labels) or not labels:
+        return {
+            "result": 0.0,
+            "reason": f"Invalid input: {len(preds)} preds vs {len(labels)} labels",
+        }
+
+    try:
+        beta = float(beta)
+    except (TypeError, ValueError):
+        return {"result": 0.0, "reason": f"Invalid beta: {beta!r}"}
+    if beta < 0:
+        return {"result": 0.0, "reason": f"beta must be non-negative, got {beta}"}
+
+    if average is not None and average not in _VALID_AVERAGES:
+        return {
+            "result": 0.0,
+            "reason": (
+                f"Invalid average '{average}'; expected one of "
+                f"{', '.join(_VALID_AVERAGES)}"
+            ),
+        }
+
+    pos, resolved_average = _resolve_averaging(preds, labels, positive_label)
+    if average is not None:
+        resolved_average = average
+        if average != "binary":
+            pos = None
+        elif pos is None:
+            return {
+                "result": 0.0,
+                "reason": (
+                    "average='binary' requires positive_label, or labels that "
+                    "match a known binary convention"
+                ),
+            }
+
+    b2 = beta**2
+
+    if resolved_average == "binary":
+        tp, fp, fn = _binary_counts(preds, labels, pos)
+        precision = tp / (tp + fp) if (tp + fp) > 0 else 0.0
+        recall = tp / (tp + fn) if (tp + fn) > 0 else 0.0
+        fb = _f_beta(precision, recall, b2)
+        if fb == 0.0:
+            return {
+                "result": 0.0,
+                "reason": f"F{beta}: 0.0 (no true positives for '{pos}')",
+            }
+        return {
+            "result": fb,
+            "reason": (
+                f"F{beta}: {fb:.4f} (P={precision:.4f}, R={recall:.4f}, "
+                f"positive='{pos}')"
+            ),
+        }
+
+    classes = sorted(set(labels) | set(preds))
+
+    if resolved_average == "micro":
+        tp_total = fp_total = fn_total = 0
+        for cls in classes:
+            tp, fp, fn = _binary_counts(preds, labels, cls)
+            tp_total += tp
+            fp_total += fp
+            fn_total += fn
+        precision = (
+            tp_total / (tp_total + fp_total) if (tp_total + fp_total) > 0 else 0.0
+        )
+        recall = tp_total / (tp_total + fn_total) if (tp_total + fn_total) > 0 else 0.0
+        fb = _f_beta(precision, recall, b2)
+        return {
+            "result": fb,
+            "reason": (
+                f"F{beta} (micro): {fb:.4f} (P={precision:.4f}, R={recall:.4f}, "
+                f"{len(classes)} classes)"
+            ),
+        }
+
+    per_class = {}
+    for cls in classes:
+        tp, fp, fn = _binary_counts(preds, labels, cls)
+        precision = tp / (tp + fp) if (tp + fp) > 0 else 0.0
+        recall = tp / (tp + fn) if (tp + fn) > 0 else 0.0
+        per_class[cls] = _f_beta(precision, recall, b2)
+
+    fb = _average_per_class(per_class, labels, resolved_average)
+    breakdown = ", ".join(f"{c}={per_class[c]:.4f}" for c in classes)
+    return {
+        "result": fb,
+        "reason": (
+            f"F{beta} ({resolved_average}): {fb:.4f} "
+            f"over {len(classes)} classes [{breakdown}]"
+        ),
+    }
 
 
 def calculate_log_loss(output, expected, **kwargs):

--- a/futureagi/agentic_eval/core_evals/fi_evals/function/tests/test_precision_fbeta_positive_label.py
+++ b/futureagi/agentic_eval/core_evals/fi_evals/function/tests/test_precision_fbeta_positive_label.py
@@ -1,0 +1,264 @@
+"""Regression tests for positive-class resolution in precision / F-beta.
+
+Both evaluators used to auto-select the positive class alphabetically, which
+resolves to the *negative* member of every common binary convention (no, false,
+0, negative, fail, ham). These tests pin the corrected behaviour.
+"""
+
+import pytest
+
+from agentic_eval.core_evals.fi_evals.function.functions import (
+    calculate_f_beta_score,
+    calculate_precision_score,
+)
+
+# A spam classifier over 10 samples: 2 truly spam, 3 predicted spam, 2 correct.
+# Precision for "spam" is 2/3; precision for "ham" is 7/7 = 1.0.
+SPAM_LABELS = ["spam", "spam", "ham", "ham", "ham", "ham", "ham", "ham", "ham", "ham"]
+SPAM_PREDS = ["spam", "spam", "spam", "ham", "ham", "ham", "ham", "ham", "ham", "ham"]
+
+
+class TestConventionalPositiveLabel:
+    """Auto-detection must resolve to the positive member of a known pair."""
+
+    def test_spam_ham_does_not_score_the_negative_class(self):
+        # Regression: previously returned 1.0, the precision of "ham".
+        result = calculate_precision_score(SPAM_PREDS, SPAM_LABELS)
+        assert result["result"] == pytest.approx(2 / 3)
+        assert "spam" in result["reason"]
+
+    def test_auto_matches_explicit_positive_label(self):
+        auto = calculate_precision_score(SPAM_PREDS, SPAM_LABELS)
+        explicit = calculate_precision_score(
+            SPAM_PREDS, SPAM_LABELS, positive_label="spam"
+        )
+        assert auto["result"] == pytest.approx(explicit["result"])
+
+    @pytest.mark.parametrize(
+        "positive,negative",
+        [
+            ("yes", "no"),
+            ("true", "false"),
+            ("1", "0"),
+            ("positive", "negative"),
+            ("pass", "fail"),
+            ("spam", "ham"),
+            ("relevant", "irrelevant"),
+            ("correct", "incorrect"),
+            ("valid", "invalid"),
+        ],
+    )
+    def test_every_convention_resolves_to_the_positive_member(self, positive, negative):
+        labels = [positive, positive, negative, negative]
+        preds = [positive, positive, positive, negative]
+
+        # For the positive class: TP=2, FP=1, FN=0 -> P=2/3, R=1.0, F1=0.8.
+        # For the negative class: TP=1, FP=0, FN=1 -> P=1.0, R=0.5, F1=2/3.
+        # The old alphabetical auto-detection picked the negative class in every
+        # one of these pairs, so these two assertions pin the correct choice.
+        precision = calculate_precision_score(preds, labels)
+        assert precision["result"] == pytest.approx(
+            2 / 3
+        ), f"precision scored the wrong class for {positive}/{negative}"
+        assert f"positive='{positive}'" in precision["reason"]
+
+        f_beta = calculate_f_beta_score(preds, labels)
+        assert f_beta["result"] == pytest.approx(
+            0.8
+        ), f"f_beta scored the wrong class for {positive}/{negative}"
+        assert f"positive='{positive}'" in f_beta["reason"]
+
+    def test_convention_is_case_insensitive(self):
+        labels = ["Yes", "Yes", "No", "No"]
+        preds = ["Yes", "Yes", "Yes", "No"]
+        assert calculate_precision_score(preds, labels)["result"] == pytest.approx(
+            2 / 3
+        )
+
+    def test_convention_resolves_from_union_of_labels_and_predictions(self):
+        # "no" never appears in ground truth but is predicted; the pair is still
+        # recognised, so precision is scored for "yes" (2 of 3 correct).
+        labels = ["yes", "yes", "yes"]
+        preds = ["yes", "yes", "no"]
+        result = calculate_precision_score(preds, labels)
+        assert result["result"] == pytest.approx(1.0)
+        assert "positive='yes'" in result["reason"]
+
+
+class TestExplicitPositiveLabel:
+    def test_explicit_label_overrides_convention(self):
+        result = calculate_precision_score(
+            SPAM_PREDS, SPAM_LABELS, positive_label="ham"
+        )
+        assert result["result"] == pytest.approx(1.0)
+
+    def test_falsy_integer_zero_is_honoured_by_precision(self):
+        labels = ["0", "0", "1", "1"]
+        preds = ["0", "0", "0", "1"]
+        # positive_label=0 is falsy; it must not be discarded.
+        result = calculate_precision_score(preds, labels, positive_label=0)
+        assert result["result"] == pytest.approx(2 / 3)
+        assert "positive='0'" in result["reason"]
+
+    def test_falsy_integer_zero_is_honoured_by_f_beta(self):
+        # Regression: `if positive_label` dropped an explicit 0 and fell back to
+        # auto-detection, which scored class "1" instead.
+        labels = ["0", "0", "1", "1"]
+        preds = ["0", "0", "0", "1"]
+        result = calculate_f_beta_score(preds, labels, positive_label=0)
+        # P = 2/3, R = 1.0 -> F1 = 0.8
+        assert result["result"] == pytest.approx(0.8)
+        assert "positive='0'" in result["reason"]
+
+    def test_falsy_string_zero_is_honoured(self):
+        labels = ["0", "0", "1", "1"]
+        preds = ["0", "0", "0", "1"]
+        assert calculate_f_beta_score(preds, labels, positive_label="0")[
+            "result"
+        ] == pytest.approx(0.8)
+
+    def test_unknown_positive_label_yields_zero_not_a_crash(self):
+        result = calculate_precision_score(
+            SPAM_PREDS, SPAM_LABELS, positive_label="phishing"
+        )
+        assert result["result"] == 0.0
+        assert "no predictions" in result["reason"]
+
+
+class TestAveragingFallback:
+    """Label sets with no known convention must average, not guess a class."""
+
+    def test_non_conventional_binary_macro_averages(self):
+        labels = ["cat", "cat", "dog", "dog"]
+        preds = ["cat", "cat", "dog", "cat"]
+        # cat: 3 predicted, 2 correct -> 2/3 ; dog: 1 predicted, 1 correct -> 1.0
+        result = calculate_precision_score(preds, labels)
+        assert result["result"] == pytest.approx((2 / 3 + 1.0) / 2)
+        assert "macro" in result["reason"]
+
+    def test_multiclass_macro_is_label_order_independent(self):
+        labels = ["alpha", "beta", "gamma", "alpha", "beta", "gamma"]
+        preds = ["alpha", "beta", "alpha", "alpha", "gamma", "gamma"]
+        baseline = calculate_precision_score(preds, labels)["result"]
+
+        # Renaming the classes must not change the score. Under the old
+        # alphabetical auto-detection it did.
+        rename = {"alpha": "zeta", "beta": "alpha", "gamma": "beta"}
+        renamed = calculate_precision_score(
+            [rename[p] for p in preds], [rename[label] for label in labels]
+        )["result"]
+        assert renamed == pytest.approx(baseline)
+
+    def test_f_beta_multiclass_macro_averages(self):
+        labels = ["a", "b", "c", "a"]
+        preds = ["a", "b", "c", "b"]
+        # a: P=1.0 R=0.5 F1=2/3 ; b: P=0.5 R=1.0 F1=2/3 ; c: P=1.0 R=1.0 F1=1.0
+        result = calculate_f_beta_score(preds, labels)
+        assert result["result"] == pytest.approx((2 / 3 + 2 / 3 + 1.0) / 3)
+        assert "macro" in result["reason"]
+
+
+class TestExplicitAveraging:
+    LABELS = ["a", "b", "c", "a"]
+    PREDS = ["a", "b", "c", "b"]
+
+    def test_micro_precision_equals_accuracy_for_single_label(self):
+        result = calculate_precision_score(self.PREDS, self.LABELS, average="micro")
+        assert result["result"] == pytest.approx(0.75)
+        assert "micro" in result["reason"]
+
+    def test_weighted_precision_uses_support(self):
+        # supports: a=2, b=1, c=1 ; per-class precision a=1.0, b=0.5, c=1.0
+        expected = (1.0 * 2 + 0.5 * 1 + 1.0 * 1) / 4
+        result = calculate_precision_score(self.PREDS, self.LABELS, average="weighted")
+        assert result["result"] == pytest.approx(expected)
+        assert "weighted" in result["reason"]
+
+    def test_binary_average_without_resolvable_label_is_rejected(self):
+        result = calculate_precision_score(self.PREDS, self.LABELS, average="binary")
+        assert result["result"] == 0.0
+        assert "requires positive_label" in result["reason"]
+
+    def test_binary_average_with_explicit_label_is_accepted(self):
+        result = calculate_precision_score(
+            self.PREDS, self.LABELS, average="binary", positive_label="a"
+        )
+        assert result["result"] == pytest.approx(1.0)
+
+    def test_explicit_average_overrides_convention(self):
+        # Labels match the spam/ham convention, but macro was asked for.
+        result = calculate_precision_score(SPAM_PREDS, SPAM_LABELS, average="macro")
+        assert result["result"] == pytest.approx((1.0 + 2 / 3) / 2)
+        assert "macro" in result["reason"]
+
+    @pytest.mark.parametrize(
+        "scorer", [calculate_precision_score, calculate_f_beta_score]
+    )
+    def test_invalid_average_is_reported(self, scorer):
+        result = scorer(SPAM_PREDS, SPAM_LABELS, average="nonsense")
+        assert result["result"] == 0.0
+        assert "Invalid average" in result["reason"]
+
+
+class TestInputHandling:
+    def test_json_string_inputs_are_parsed(self):
+        result = calculate_precision_score(
+            '["spam", "ham"]', '["spam", "spam"]', positive_label="spam"
+        )
+        assert result["result"] == pytest.approx(1.0)
+
+    def test_length_mismatch_reports_both_lengths(self):
+        result = calculate_precision_score(["yes"], ["yes", "no"])
+        assert result["result"] == 0.0
+        assert "1 preds vs 2 labels" in result["reason"]
+
+    @pytest.mark.parametrize(
+        "scorer", [calculate_precision_score, calculate_f_beta_score]
+    )
+    def test_none_input_is_handled_without_crashing(self, scorer):
+        # f_beta's parser previously lacked a None branch and coerced it to the
+        # literal label "none".
+        result = scorer(None, None)
+        assert result["result"] == 0.0
+
+    def test_empty_inputs_return_zero(self):
+        assert calculate_precision_score([], [])["result"] == 0.0
+
+    def test_beta_weights_recall(self):
+        labels = ["yes", "yes", "yes", "no"]
+        preds = ["yes", "no", "no", "no"]
+        # P = 1.0, R = 1/3
+        f1 = calculate_f_beta_score(preds, labels, beta=1.0)["result"]
+        f2 = calculate_f_beta_score(preds, labels, beta=2.0)["result"]
+        assert f1 == pytest.approx(0.5)
+        # Higher beta weights recall more, and recall is the weaker half here.
+        assert f2 < f1
+
+    def test_beta_zero_reduces_to_precision(self):
+        labels = ["yes", "yes", "yes", "no"]
+        preds = ["yes", "no", "no", "no"]
+        assert calculate_f_beta_score(preds, labels, beta=0.0)[
+            "result"
+        ] == pytest.approx(1.0)
+
+    def test_negative_beta_is_rejected(self):
+        result = calculate_f_beta_score(SPAM_PREDS, SPAM_LABELS, beta=-1.0)
+        assert result["result"] == 0.0
+        assert "non-negative" in result["reason"]
+
+    def test_non_numeric_beta_is_rejected(self):
+        result = calculate_f_beta_score(SPAM_PREDS, SPAM_LABELS, beta="wide")
+        assert result["result"] == 0.0
+        assert "Invalid beta" in result["reason"]
+
+
+class TestScoreRange:
+    @pytest.mark.parametrize(
+        "scorer", [calculate_precision_score, calculate_f_beta_score]
+    )
+    @pytest.mark.parametrize("average", [None, "macro", "micro", "weighted"])
+    def test_result_stays_within_unit_interval(self, scorer, average):
+        labels = ["a", "b", "c", "a", "b", "c", "a"]
+        preds = ["a", "c", "c", "b", "b", "a", "a"]
+        result = scorer(preds, labels, average=average)
+        assert 0.0 <= result["result"] <= 1.0

--- a/futureagi/agentic_eval/core_evals/fi_evals/function/tests/test_precision_fbeta_positive_label.py
+++ b/futureagi/agentic_eval/core_evals/fi_evals/function/tests/test_precision_fbeta_positive_label.py
@@ -102,13 +102,37 @@ class TestExplicitPositiveLabel:
 
     def test_falsy_integer_zero_is_honoured_by_f_beta(self):
         # Regression: `if positive_label` dropped an explicit 0 and fell back to
-        # auto-detection, which scored class "1" instead.
+        # auto-detection. With labels {0, 1} the old code happened to land on
+        # "0" anyway, so the defect only shows once another class sorts ahead of
+        # it -- see test_falsy_zero_with_a_lower_sorting_class below.
         labels = ["0", "0", "1", "1"]
         preds = ["0", "0", "0", "1"]
         result = calculate_f_beta_score(preds, labels, positive_label=0)
         # P = 2/3, R = 1.0 -> F1 = 0.8
         assert result["result"] == pytest.approx(0.8)
         assert "positive='0'" in result["reason"]
+
+    @pytest.mark.parametrize(
+        "scorer, expected",
+        [(calculate_precision_score, 1.0), (calculate_f_beta_score, 2 / 3)],
+    )
+    def test_falsy_zero_with_a_lower_sorting_class(self, scorer, expected):
+        # Sentiment labels -1 / 0 / 1, scoring the neutral class 0. "-1" sorts
+        # ahead of "0", so the old truthiness gate discarded positive_label=0
+        # and silently scored "-1" instead, reporting a perfect 1.0 for F1.
+        labels = ["0", "0", "1", "-1", "1"]
+        preds = ["0", "1", "1", "-1", "1"]
+        result = scorer(preds, labels, positive_label=0)
+        assert result["result"] == pytest.approx(expected)
+        assert "positive='0'" in result["reason"]
+
+    def test_int_and_str_positive_label_agree(self):
+        # Passing 0 and "0" must not produce different scores.
+        labels = ["0", "0", "1", "-1", "1"]
+        preds = ["0", "1", "1", "-1", "1"]
+        as_int = calculate_f_beta_score(preds, labels, positive_label=0)["result"]
+        as_str = calculate_f_beta_score(preds, labels, positive_label="0")["result"]
+        assert as_int == pytest.approx(as_str)
 
     def test_falsy_string_zero_is_honoured(self):
         labels = ["0", "0", "1", "1"]

--- a/futureagi/agentic_eval/core_evals/fi_evals/function/wrapper.py
+++ b/futureagi/agentic_eval/core_evals/fi_evals/function/wrapper.py
@@ -824,11 +824,19 @@ class Accuracy(FunctionEvaluator):
 
 
 class PrecisionScore(FunctionEvaluator):
-    def __init__(self, positive_label: str | None = None, display_name: str | None = None):
-        """Initialize the PrecisionScore evaluator. Classification precision."""
+    def __init__(self, positive_label: str | None = None, display_name: str | None = None, *, average: str | None = None):
+        """Initialize the PrecisionScore evaluator. Classification precision.
+
+        Args:
+            positive_label: Label to treat as positive. When omitted, a known
+                binary convention is used if the labels match one, otherwise
+                precision is macro-averaged over every class.
+            average: Explicit averaging strategy — "binary", "macro", "micro"
+                or "weighted".
+        """
         super().__init__(
             function_name=FunctionEvalTypeId.PRECISION_SCORE.value,
-            function_arguments={"positive_label": positive_label},
+            function_arguments={"positive_label": positive_label, "average": average},
             display_name=display_name,
         )
 
@@ -940,8 +948,18 @@ class BalancedAccuracy(FunctionEvaluator):
 
 
 class FBetaScore(FunctionEvaluator):
-    def __init__(self, beta: float = 1.0, positive_label: str | None = None, display_name: str | None = None):
-        super().__init__(function_name=FunctionEvalTypeId.F_BETA_SCORE.value, function_arguments={"beta": beta, "positive_label": positive_label}, display_name=display_name)
+    def __init__(self, beta: float = 1.0, positive_label: str | None = None, display_name: str | None = None, *, average: str | None = None):
+        """Initialize the FBetaScore evaluator.
+
+        Args:
+            beta: Weight of recall relative to precision.
+            positive_label: Label to treat as positive. When omitted, a known
+                binary convention is used if the labels match one, otherwise
+                the score is macro-averaged over every class.
+            average: Explicit averaging strategy — "binary", "macro", "micro"
+                or "weighted".
+        """
+        super().__init__(function_name=FunctionEvalTypeId.F_BETA_SCORE.value, function_arguments={"beta": beta, "positive_label": positive_label, "average": average}, display_name=display_name)
 
 
 class LogLoss(FunctionEvaluator):


### PR DESCRIPTION
## Summary

`PrecisionScore` and `FBetaScore` chose the positive class alphabetically when the caller did not name one, and `sorted(...)[0]` is the **negative** member in eight of the nine binary conventions people actually use (`no`, `false`, `0`, `negative`, `fail`, `ham`, `irrelevant`, `invalid`). A spam classifier with a false positive scored precision **1.00** instead of 0.667 and F1 **0.93** instead of 0.80 — silently, because the class actually used appeared only in the prose `reason` field while the wrong number went to the metric store.

This resolves the positive class from a known-convention table, falls back to macro-averaging when no convention matches (so the score no longer depends on label ordering), and adds an explicit `average` parameter. It also fixes a second defect where `FBetaScore` gated on `if positive_label`, silently discarding an explicitly supplied `positive_label=0`.

**User-visible impact:** binary precision and F-beta scores will change for anyone who relied on the default. The old numbers described the wrong class, so this is a correction rather than a regression — but it is worth a release-note line so it is not misread as a model regression.

## Linked issues

Closes #2567
Linear:

## Type of change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📖 Documentation only
- [ ] 🧹 Chore / refactor (no user-visible change)
- [ ] 🚀 Performance improvement
- [ ] 🧪 Test-only change

> Not ticked as breaking because no API or signature breaks — but the numeric output of two evaluators does change. Called out in §6.

## E2E coverage

E2E: exempt (backend-internal)

---

## 1) What changes were done

**A. Positive-class resolution (`functions.py`)**

- Added `_POSITIVE_LABEL_CONVENTIONS`, a table of binary label pairs mapped to the member that means "positive": `yes/no`, `true/false`, `1/0`, `positive/negative`, `pass/fail`, `spam/ham`, `relevant/irrelevant`, `correct/incorrect`, `valid/invalid`.
- `_resolve_conventional_positive_label` matches only exact two-class sets and returns `None` otherwise, so nothing is guessed.
- `_resolve_averaging` applies the order: explicit `positive_label` → known convention → macro-average.
- The user now sees the resolved class and averaging mode in `reason`, e.g. `Precision: 0.6667 (TP=2, FP=1, positive='spam')`.

**B. Averaging support**

- New `average` parameter on `calculate_precision_score` and `calculate_f_beta_score`: `binary`, `macro`, `micro`, `weighted`.
- Multiclass previously did unaveraged one-vs-rest against one arbitrary class. With no `positive_label` it now macro-averages, which is label-order independent.
- `average="binary"` without a resolvable positive label returns an explanatory result instead of silently picking one.
- An unrecognised `average` returns a result naming the valid options.

**C. Falsy `positive_label`**

- `calculate_f_beta_score` now uses `is not None` instead of truthiness, so `positive_label=0` is honoured and agrees with `positive_label="0"`.

**D. Input handling and validation**

- The two duplicated `_parse` closures are replaced by one `_parse_label_list`. The `calculate_f_beta_score` copy had no `None` branch and turned `None` into the literal label `"none"`; the dedupe fixes that.
- `beta` that is negative or non-numeric now returns the documented `{"result", "reason"}` dict. `beta="wide"` previously raised an uncaught `ValueError`.
- Length-mismatch messages now report both lengths in both functions.

**E. Evaluator wrappers (`wrapper.py`)**

- `PrecisionScore` and `FBetaScore` accept `average` and pass it through in `function_arguments`.
- `average` is **keyword-only**, so the existing positional parameter order (`positive_label, display_name` / `beta, positive_label, display_name`) is byte-identical to `dev` and existing positional calls are unaffected.
- Added docstrings to both, describing the resolution order.

---

## 2) Why the changes were done

- **Product/UX:** an evaluation platform's deterministic metrics are the layer users trust most, precisely because they look like they cannot be wrong. A precision of 1.00 on a model that produced a false positive is the worst kind of failure — it clears a CI gate that exists to catch exactly that.
- **Technical:** alphabetical selection is not a heuristic, it is an accident of string ordering. Two options are defensible: recognise the conventions people actually use, or average over all classes. This does both — convention first because it matches intent, macro-average as the fallback because it is the only label-order-independent answer when intent is unknown.
- **Architecture:** the positive-class and per-class-count logic is factored into small shared helpers (`_parse_label_list`, `_binary_counts`, `_resolve_averaging`, `_average_per_class`, `_f_beta`) rather than duplicated across the two functions, which is how the original defect came to differ between them in the first place.
- **Compatibility:** `average` is keyword-only specifically so a user calling `PrecisionScore("spam", "My precision")` positionally is unaffected.

---

## 3) Tests written + scenarios each covers

**`agentic_eval/core_evals/fi_evals/function/tests/test_precision_fbeta_positive_label.py`** — positive-class resolution, averaging, falsy labels, input handling and score range

`TestConventionalPositiveLabel` — auto-detection resolves to the positive member

- `test_spam_ham_does_not_score_the_negative_class` — the headline regression: previously 1.0 (`ham`), now 0.667 (`spam`)
- `test_auto_matches_explicit_positive_label` — auto-detection agrees with `positive_label="spam"`
- `test_every_convention_resolves_to_the_positive_member[...]` — 9 parametrised pairs; asserts precision 2/3 and F1 0.8 for the positive class, where scoring the negative class would give 1.0 and 2/3
- `test_convention_is_case_insensitive` — `Yes`/`No` resolves the same as `yes`/`no`
- `test_convention_resolves_from_union_of_labels_and_predictions` — a class present only in predictions still forms the pair

`TestExplicitPositiveLabel` — an explicit label always wins

- `test_explicit_label_overrides_convention` — `positive_label="ham"` scores `ham`
- `test_falsy_integer_zero_is_honoured_by_precision` — `positive_label=0` not discarded
- `test_falsy_integer_zero_is_honoured_by_f_beta` — same for F-beta
- `test_falsy_zero_with_a_lower_sorting_class[...]` — 2 params; sentiment `-1/0/1` where `"-1"` sorts ahead of `"0"`. This is the case that actually isolates the truthiness bug: old code returned F1 1.0 having scored `-1`
- `test_int_and_str_positive_label_agree` — `0` and `"0"` give the same score
- `test_falsy_string_zero_is_honoured` — the string form is unaffected
- `test_unknown_positive_label_yields_zero_not_a_crash` — a label present in neither list returns 0.0 with an explanatory reason

`TestAveragingFallback` — no convention match means averaging, not guessing

- `test_non_conventional_binary_macro_averages` — `cat`/`dog` macro-averages
- `test_multiclass_macro_is_label_order_independent` — renaming classes does not change the score; under the old code it did
- `test_f_beta_multiclass_macro_averages` — per-class F1 averaged over 3 classes

`TestExplicitAveraging` — the `average` parameter

- `test_micro_precision_equals_accuracy_for_single_label` — micro precision equals accuracy for single-label multiclass
- `test_weighted_precision_uses_support` — weighting by per-class support
- `test_binary_average_without_resolvable_label_is_rejected` — explanatory result, not a silent pick
- `test_binary_average_with_explicit_label_is_accepted` — `average="binary"` plus a label works
- `test_explicit_average_overrides_convention` — `average="macro"` beats a matching convention
- `test_invalid_average_is_reported[...]` — 2 params; unknown `average` names the valid options

`TestInputHandling` — parsing and validation

- `test_json_string_inputs_are_parsed` — JSON-array string inputs
- `test_length_mismatch_reports_both_lengths` — the reason names both lengths
- `test_none_input_is_handled_without_crashing[...]` — 2 params; F-beta previously coerced `None` to the label `"none"`
- `test_empty_inputs_return_zero` — empty lists
- `test_beta_weights_recall` — higher beta weights recall
- `test_beta_zero_reduces_to_precision` — `beta=0` is precision
- `test_negative_beta_is_rejected` — explanatory result
- `test_non_numeric_beta_is_rejected` — previously an uncaught `ValueError`

`TestScoreRange` — the documented contract

- `test_result_stays_within_unit_interval[...]` — 8 params (2 scorers × 4 averaging modes); asserts `0.0 <= result <= 1.0`

> Run result: **48 passed** across this suite. Lint (ruff) + format (black) + isort clean on all three changed files; ruff findings in `functions.py` drop from 73 on `dev` to 63.

**These are genuine regression tests:** run against `dev`'s `functions.py`, **30 of the 48 fail**. Against this branch, all 48 pass.

**Collateral check:** a differential run of all **90 registered operations** on identical inputs, `dev` vs this branch, shows exactly **one** changed output — `PrecisionScore` 1.0 → 0.667. `FBetaScore` matched only because that probe fixture was coincidentally symmetric; on the spam fixture it moves 0.933 → 0.800.

---

## 4) How to run / test

### Backend tests

~~~bash
cd futureagi

# Create venv with correct Python (one-time):
uv venv --python 3.11
source .venv/bin/activate
uv pip install -r requirements-test.txt

# This suite:
bin/test agentic_eval/core_evals/fi_evals/function/tests/test_precision_fbeta_positive_label.py -v

# Single test by name:
bin/test agentic_eval/core_evals/fi_evals/function/tests/test_precision_fbeta_positive_label.py -k "test_spam_ham_does_not_score_the_negative_class"

# Full suite:
bin/test
~~~

### Frontend tests (if applicable)

Not applicable — no frontend change.

### Contract verification (if API surface changed)

Not applicable — no API surface change. `average` is a new keyword-only argument with a `None` default on two evaluator wrappers; `function_arguments` stored before this change deserialise unchanged.

### UI steps (manual)

Not applicable — backend-internal scoring change with no UI surface of its own. The corrected values appear wherever these two evaluators are already charted. To verify at the Python level:

~~~python
from agentic_eval.core_evals.fi_evals.function.functions import (
    calculate_precision_score,
    calculate_f_beta_score,
)

labels = ["spam", "spam", "ham", "ham", "ham", "ham", "ham", "ham", "ham", "ham"]
preds  = ["spam", "spam", "spam", "ham", "ham", "ham", "ham", "ham", "ham", "ham"]

calculate_precision_score(preds, labels)
# before: {'result': 1.0,    'reason': "Precision: 1.0000 (TP=7, FP=0, positive='ham')"}
# after:  {'result': 0.6667, 'reason': "Precision: 0.6667 (TP=2, FP=1, positive='spam')"}

calculate_f_beta_score(preds, labels)
# before: {'result': 0.9333, 'reason': 'F1.0: 0.9333 (P=1.0000, R=0.8750)'}
# after:  {'result': 0.8,    'reason': "F1.0: 0.8000 (P=0.6667, R=1.0000, positive='spam')"}
~~~

---

## 5) Screenshots / recordings

### Test output

~~~
$ pytest agentic_eval/core_evals/fi_evals/function/tests/test_precision_fbeta_positive_label.py -q
................................................                         [100%]
48 passed
~~~

### UI testing

Not applicable — no UI change.

---

## 6) Edge cases & considerations

- **Existing scores change:** anyone relying on the default `positive_label` will see binary precision/F-beta move. The old value described the wrong class. Worth a release-note line.
- **`correct`/`incorrect` was never affected:** it happens to sort to the positive member. It is in the convention table anyway, so the behaviour is explicit rather than accidental.
- **Positional compatibility:** `average` is keyword-only, so `PrecisionScore("spam", "My name")` and `FBetaScore(2.0, "spam", "My name")` behave exactly as on `dev`.
- **Stored configs:** `function_arguments` persisted before this change have no `average` key; it defaults to `None` and resolution is unchanged for them.
- **Unknown `positive_label`** (present in neither predictions nor labels): returns 0.0 with a reason naming the label, rather than raising.
- **Convention matching uses labels ∪ predictions**, so a pair is still recognised when one member appears only in predictions. A third class breaks the pair and falls through to macro-averaging, which is the safe direction.
- **Case-insensitive throughout:** inputs are lowercased before matching, so `Yes`/`No` and `yes`/`no` behave identically.
- **`_binary_counts` uses `zip(..., strict=True)`:** callers validate equal lengths first, so this guards against future misuse rather than changing behaviour. Requires Python ≥ 3.10; `pyproject.toml` sets `requires-python = ">=3.11"`.
- **Empty / `None` / mismatched-length inputs:** return 0.0 with an explanatory reason, matching the existing convention in this module.

---

## 7) Pre-existing issues (NOT introduced by this PR)

- `functions.py` and `wrapper.py` are **not black-clean on `dev`**. I deliberately did not run `black` across either file, since that would produce a thousand-line reformat diff unrelated to this fix. Only my added lines are black-formatted; the new test file is fully clean.
- The wider `agentic_eval` module has no test collection path from either documented entrypoint — see #1610, which documents this. The new test file sits in `function/tests/` next to the code it covers, matching where the module's other tests live.

---

## 8) Architectural / important decisions

- **Convention table before macro-average, rather than macro-average alone:** macro-averaging every binary case would be correct but surprising — a user scoring `yes`/`no` wants precision for `yes`, not the mean of both classes. The table covers that intent; macro-average handles everything else.
- **Macro rather than alphabetical-with-a-warning as the fallback:** a warning in `reason` is effectively what the current code already does, and it did not help — nothing downstream reads `reason`. The fallback needed to be correct on its own.
- **`average` keyword-only:** these are public SDK classes with no in-repo callers, so external positional calls were the compatibility risk; keyword-only removes it entirely.
- **Helpers factored out rather than fixed twice:** the two functions had drifted (one used `is not None`, the other truthiness; one handled `None` input, the other did not). Shared helpers stop that recurring.

---

## Checklist

- [x] My code follows the [style guide](../CONTRIBUTING.md#code-style)
- [x] I've added tests that prove my fix is effective or that my feature works
- [ ] `bin/test` passes locally (backend) — see note below
- [ ] `yarn test:run` passes locally (frontend) — n/a, no frontend change
- [ ] `yarn contracts:check` passes if API surface changed — n/a, no API change
- [ ] I've updated the documentation where relevant — n/a
- [x] No hardcoded secrets, URLs, or PII
- [x] I've signed the [CLA](../CONTRIBUTING.md#contributor-license-agreement-cla)
- [x] PR title follows Conventional Commits
- [ ] Linear issue is linked and updated with status

> **On `bin/test`:** the 48 tests in this suite pass, but I could not run the full backend suite locally — it needs the Docker stack, and my host hits `RuntimeError: Model class accounts.models.audit_log.AuditLog doesn't declare an explicit app_label` outside it. Please run `bin/test` in CI, or point me at any failures and I'll fix them.