### PR TITLE
fix(agentic_eval): compute Spearman rho over ranks instead of the d² shortcut

### DIFF
--- a/futureagi/agentic_eval/core_evals/fi_evals/function/functions.py
+++ b/futureagi/agentic_eval/core_evals/fi_evals/function/functions.py
@@ -3573,48 +3573,79 @@ def _parse_number_list(val):
     return [float(val)]
 
 
+def _pearson_r(x, y):
+    """Pearson's r for two equal-length sequences.
+
+    Returns None when either sequence is constant, because r is undefined there
+    (the denominator is zero). Callers decide how to report that.
+
+    Callers validate equal lengths before reaching here, so ``strict=True``
+    guards against future misuse.
+    """
+    n = len(x)
+    mx, my = sum(x) / n, sum(y) / n
+    ss_x = sum((xi - mx) ** 2 for xi in x)
+    ss_y = sum((yi - my) ** 2 for yi in y)
+    if ss_x == 0 or ss_y == 0:
+        return None
+    cov = sum((xi - mx) * (yi - my) for xi, yi in zip(x, y, strict=True))
+    return cov / (ss_x * ss_y) ** 0.5
+
+
 def calculate_pearson_correlation(output, expected, **kwargs):
     """Compute Pearson correlation coefficient between two sets of values."""
     x = _parse_number_list(output)
     y = _parse_number_list(expected)
     if len(x) != len(y) or len(x) < 2:
         return {"result": 0.0, "reason": f"Invalid input: {len(x)} vs {len(y)} values (need >=2)"}
-    n = len(x)
-    mx, my = sum(x) / n, sum(y) / n
-    ss_x = sum((xi - mx) ** 2 for xi in x)
-    ss_y = sum((yi - my) ** 2 for yi in y)
-    if ss_x == 0 or ss_y == 0:
+    r = _pearson_r(x, y)
+    if r is None:
         return {"result": 0.0, "reason": "Zero variance in one or both inputs"}
-    r = sum((xi - mx) * (yi - my) for xi, yi in zip(x, y)) / (ss_x * ss_y) ** 0.5
     score = (r + 1) / 2  # Normalize from [-1,1] to [0,1]
     return {"result": score, "reason": f"Pearson r={r:.4f}, normalized={score:.4f}"}
 
 
+def _midranks(vals):
+    """Rank ``vals`` ascending, assigning tied values the average of their ranks."""
+    n = len(vals)
+    indexed = sorted(enumerate(vals), key=lambda t: t[1])
+    ranks = [0.0] * n
+    i = 0
+    while i < n:
+        j = i
+        while j < n - 1 and indexed[j + 1][1] == indexed[i][1]:
+            j += 1
+        avg_rank = (i + j) / 2.0 + 1
+        for k in range(i, j + 1):
+            ranks[indexed[k][0]] = avg_rank
+        i = j + 1
+    return ranks
+
+
 def calculate_spearman_correlation(output, expected, **kwargs):
-    """Compute Spearman rank correlation coefficient."""
+    """Compute Spearman rank correlation coefficient.
+
+    Spearman's rho is Pearson's r computed over the ranks. The familiar
+    ``1 - 6*sum(d^2)/(n*(n^2-1))`` shortcut is an algebraic simplification that
+    holds only when both rank vectors are permutations of 1..n. Ties produce
+    midranks, which breaks that assumption, so the shortcut is not used here.
+    """
     x = _parse_number_list(output)
     y = _parse_number_list(expected)
     if len(x) != len(y) or len(x) < 2:
         return {"result": 0.0, "reason": f"Invalid input: {len(x)} vs {len(y)} values"}
-    n = len(x)
 
-    def _rank(vals):
-        indexed = sorted(enumerate(vals), key=lambda t: t[1])
-        ranks = [0.0] * n
-        i = 0
-        while i < n:
-            j = i
-            while j < n - 1 and indexed[j + 1][1] == indexed[i][1]:
-                j += 1
-            avg_rank = (i + j) / 2.0 + 1
-            for k in range(i, j + 1):
-                ranks[indexed[k][0]] = avg_rank
-            i = j + 1
-        return ranks
+    rx, ry = _midranks(x), _midranks(y)
+    rho = _pearson_r(rx, ry)
+    if rho is None:
+        # Every value in one input is identical, so its ranks are constant and
+        # rho is undefined. Report no correlation (0.5 once normalized) rather
+        # than the perfect 1.0 the d^2 shortcut produced for this input.
+        return {
+            "result": 0.5,
+            "reason": "Zero variance in one or both inputs; Spearman rho is undefined",
+        }
 
-    rx, ry = _rank(x), _rank(y)
-    d_sq = sum((rxi - ryi) ** 2 for rxi, ryi in zip(rx, ry))
-    rho = 1 - (6 * d_sq) / (n * (n ** 2 - 1))
     score = (rho + 1) / 2
     return {"result": score, "reason": f"Spearman rho={rho:.4f}, normalized={score:.4f}"}
 

--- a/futureagi/agentic_eval/core_evals/fi_evals/function/tests/test_spearman_correlation.py
+++ b/futureagi/agentic_eval/core_evals/fi_evals/function/tests/test_spearman_correlation.py
@@ -1,0 +1,168 @@
+"""Regression tests for Spearman rank correlation.
+
+Spearman's rho is Pearson's r over the ranks. The familiar
+``1 - 6*sum(d^2)/(n*(n^2-1))`` shortcut only holds when both rank vectors are
+permutations of 1..n, which ties break. The evaluator assigned midranks to ties
+and then applied the shortcut anyway, so any input containing a duplicate scored
+wrong, and a constant input scored a perfect 1.0.
+
+Expected rho values below were cross-checked against ``scipy.stats.spearmanr``.
+scipy is not imported here, so these tests add no dependency.
+"""
+
+import pytest
+
+from agentic_eval.core_evals.fi_evals.function.functions import (
+    calculate_pearson_correlation,
+    calculate_spearman_correlation,
+)
+
+
+def _rho(output, expected):
+    """Return rho, undoing the [-1, 1] -> [0, 1] normalisation applied to result."""
+    return calculate_spearman_correlation(output, expected)["result"] * 2 - 1
+
+
+class TestNoTies:
+    """The shortcut and the definition agree here; these must not regress."""
+
+    def test_perfect_positive(self):
+        assert _rho([1, 2, 3, 4], [1, 2, 3, 4]) == pytest.approx(1.0)
+
+    def test_perfect_negative(self):
+        assert _rho([1, 2, 3, 4], [4, 3, 2, 1]) == pytest.approx(-1.0)
+
+    def test_monotone_nonlinear_is_still_perfect(self):
+        # Spearman measures monotonicity, not linearity.
+        assert _rho([1, 2, 3, 4, 5], [1, 4, 9, 16, 25]) == pytest.approx(1.0)
+
+    def test_normalisation_maps_to_unit_interval(self):
+        assert calculate_spearman_correlation([1, 2, 3, 4], [4, 3, 2, 1])[
+            "result"
+        ] == pytest.approx(0.0)
+        assert calculate_spearman_correlation([1, 2, 3, 4], [1, 2, 3, 4])[
+            "result"
+        ] == pytest.approx(1.0)
+
+
+class TestTiedRanks:
+    """Every case here was wrong before: midranks + the d^2 shortcut."""
+
+    @pytest.mark.parametrize(
+        "x, y, expected_rho, shortcut_rho",
+        [
+            ([1, 1, 2, 3], [1, 2, 2, 3], 0.8333333333, 0.85),
+            ([1, 1, 1, 2], [1, 2, 3, 4], 0.7745966692, 0.80),
+            ([1, 1, 1, 1, 2], [5, 4, 3, 2, 1], -0.7071067812, -0.25),
+            ([1, 2, 2, 3], [1, 2, 3, 4], 0.9486832981, 0.95),
+        ],
+    )
+    def test_matches_definition_not_shortcut(self, x, y, expected_rho, shortcut_rho):
+        actual = _rho(x, y)
+        assert actual == pytest.approx(
+            expected_rho
+        ), f"rho for {x} vs {y} should be {expected_rho}, got {actual}"
+        # Guard against a silent revert to the shortcut.
+        assert actual != pytest.approx(shortcut_rho, abs=1e-6)
+
+    def test_heavy_ties_error_was_large(self):
+        # The worst case found: the shortcut reported -0.25 for data whose true
+        # rank correlation is -0.707 -- a 0.46 error in rho, 0.23 in the score.
+        x, y = [1, 1, 1, 1, 2], [5, 4, 3, 2, 1]
+        assert _rho(x, y) == pytest.approx(-0.7071067812)
+        assert calculate_spearman_correlation(x, y)["result"] == pytest.approx(
+            0.1464466094
+        )
+
+    def test_all_values_tied_on_one_side_only(self):
+        # x is constant -> its ranks are constant -> rho undefined.
+        result = calculate_spearman_correlation([2, 2, 2, 2], [1, 2, 3, 4])
+        assert result["result"] == pytest.approx(0.5)
+        assert "Zero variance" in result["reason"]
+
+    def test_ties_do_not_push_score_outside_unit_interval(self):
+        # With enough ties the shortcut could leave [-1, 1], and the normalised
+        # score with it.
+        for x, y in [
+            ([1, 1, 1, 1, 1, 2], [6, 5, 4, 3, 2, 1]),
+            ([1, 1, 2, 2, 3, 3], [3, 3, 2, 2, 1, 1]),
+            ([1, 1, 1, 2, 2, 2], [1, 2, 3, 4, 5, 6]),
+        ]:
+            score = calculate_spearman_correlation(x, y)["result"]
+            assert 0.0 <= score <= 1.0, f"{x} vs {y} scored {score}"
+
+
+class TestZeroVariance:
+    """A collapsed model must not score as a perfect correlation."""
+
+    def test_both_inputs_constant(self):
+        # Regression: d^2 was 0 for every pair, so the shortcut returned rho=1.0
+        # and a perfect score of 1.0 -- the exact failure this metric is run to
+        # detect, inverted into a pass.
+        result = calculate_spearman_correlation([3, 3, 3, 3], [3, 3, 3, 3])
+        assert result["result"] == pytest.approx(0.5)
+        assert result["result"] != pytest.approx(1.0)
+        assert "Zero variance" in result["reason"]
+
+    def test_predictions_collapsed_against_varied_truth(self):
+        # A model emitting the same value every row.
+        result = calculate_spearman_correlation([0.7] * 5, [1, 2, 3, 4, 5])
+        assert result["result"] == pytest.approx(0.5)
+
+    def test_reason_explains_why(self):
+        reason = calculate_spearman_correlation([1, 1, 1], [1, 1, 1])["reason"]
+        assert "undefined" in reason.lower()
+
+
+class TestInputHandling:
+    def test_json_string_inputs(self):
+        assert _rho("[1, 2, 3, 4]", "[1, 2, 3, 4]") == pytest.approx(1.0)
+
+    def test_comma_separated_string_inputs(self):
+        assert _rho("1, 1, 2, 3", "1, 2, 2, 3") == pytest.approx(0.8333333333)
+
+    def test_length_mismatch_returns_zero(self):
+        result = calculate_spearman_correlation([1, 2, 3], [1, 2])
+        assert result["result"] == 0.0
+        assert "3 vs 2" in result["reason"]
+
+    def test_single_pair_is_rejected(self):
+        # n < 2 also protects the old shortcut's n*(n^2-1) denominator.
+        assert calculate_spearman_correlation([1], [1])["result"] == 0.0
+
+    def test_empty_inputs_are_rejected(self):
+        assert calculate_spearman_correlation([], [])["result"] == 0.0
+
+    def test_order_of_arguments_is_symmetric(self):
+        x, y = [1, 1, 2, 3], [1, 2, 2, 3]
+        assert _rho(x, y) == pytest.approx(_rho(y, x))
+
+
+class TestPearsonUnchanged:
+    """`_pearson_r` was factored out of Pearson; its behaviour must not move."""
+
+    def test_perfect_positive(self):
+        assert calculate_pearson_correlation([1, 2, 3], [1, 2, 3])[
+            "result"
+        ] == pytest.approx(1.0)
+
+    def test_perfect_negative(self):
+        assert calculate_pearson_correlation([1, 2, 3], [3, 2, 1])[
+            "result"
+        ] == pytest.approx(0.0)
+
+    def test_known_value(self):
+        # scipy.stats.pearsonr([1,2,3,4], [2,4,5,9]).statistic == 0.9647638212
+        assert calculate_pearson_correlation([1, 2, 3, 4], [2, 4, 5, 9])[
+            "result"
+        ] == pytest.approx((0.9647638212 + 1) / 2)
+
+    def test_zero_variance_still_returns_zero(self):
+        # Deliberately left as-is. Note this differs from Spearman above and
+        # from the platform YAML, both of which report 0.5. See PR notes.
+        result = calculate_pearson_correlation([1, 1, 1], [1, 2, 3])
+        assert result["result"] == 0.0
+        assert "Zero variance" in result["reason"]
+
+    def test_length_mismatch_returns_zero(self):
+        assert calculate_pearson_correlation([1, 2], [1, 2, 3])["result"] == 0.0


### PR DESCRIPTION
## Summary

`calculate_spearman_correlation` assigned midranks to tied values and then computed rho with the `1 - 6*sum(d^2)/(n*(n^2-1))` shortcut. That shortcut is an algebraic simplification of Pearson's r over the ranks and holds only when both rank vectors are permutations of 1..n — midranks break that assumption, so the two halves of the function contradicted each other and **any input containing a duplicate scored wrong**. `[1,1,1,1,2]` vs `[5,4,3,2,1]` reported rho −0.25 where the true value is −0.707.

Constant input was worse: with every `d` zero, the shortcut returned a **perfect rho of 1.0** for data whose correlation is undefined, so a collapsed model emitting the same value every row scored as a flawless correlation — the exact failure this metric exists to catch, inverted into a pass.

This computes rho as Pearson's r over the midranks and reports no correlation for constant input, matching the fix accepted for the platform YAML in #1624 and cross-checked against `scipy.stats.spearmanr`.

**User-visible impact:** Spearman scores change for any input containing ties, which for Likert-scale judge ratings is most of them. The old values were wrong, so this is a correction — but it deserves a release-note line so it is not read as a model regression.

## Linked issues

Closes #2569
Linear:

Related: #1610 (audit listing this defect), #1624 (same fix for the platform YAML copy), #1890 / #1688 (SDK↔platform eval parity).

## Type of change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📖 Documentation only
- [ ] 🧹 Chore / refactor (no user-visible change)
- [ ] 🚀 Performance improvement
- [ ] 🧪 Test-only change

> No API or signature change, so not ticked as breaking — but the numeric output of one evaluator does change for tied input. Called out in §6.

## E2E coverage

E2E: exempt (backend-internal)

---

## 1) What changes were done

**A. Spearman computed from its definition (`functions.py`)**

- Replaced the d² shortcut with Pearson's r over the midranks, which is what the surrounding midranking code already assumed.
- The inner `_rank` closure is lifted to a module-level `_midranks` helper, unchanged in behaviour, with a docstring stating that ties get the average of their ranks.
- Added a docstring explaining why the shortcut is not used, so it is not "simplified" back in later.

**B. Zero variance no longer scores as a correlation**

- When either input is constant its ranks are constant and rho is undefined. The evaluator now returns `0.5` — no correlation on the normalised scale — with the reason `"Zero variance in one or both inputs; Spearman rho is undefined"`.
- Previously: both inputs constant returned a perfect `1.0`; a collapsed prediction against varied truth returned `0.75`.
- `0.5` matches `pearson_correlation.yaml` and the value adopted by #1624, so the SDK and platform agree.

**C. Shared `_pearson_r` helper**

- Pearson's r is factored out of `calculate_pearson_correlation` into `_pearson_r(x, y)`, which returns `None` when either sequence is constant and lets each caller decide how to report that.
- `calculate_pearson_correlation` keeps its behaviour **exactly**, including returning `0.0` for zero variance — verified by a differential run and pinned by tests.
- Both correlation evaluators now share one implementation of the formula, instead of the copy that let them drift apart.

---

## 2) Why the changes were done

- **Product/UX:** ties are not an edge case for this metric. Its natural inputs are LLM-judge ratings and human annotation scores on 1–5 or 1–10 Likert scales, where ties are the norm. And a constant-output model scoring a perfect 1.0 is the worst possible direction to fail in — it is a green light on the precise pathology the metric is deployed to detect.
- **Technical:** the fix is not a new algorithm, it is deleting a shortcut that was never valid in this function. The midranking code was already correct; only the final step contradicted it. Computing Pearson's r over those ranks is the definition of Spearman's rho.
- **Architecture:** the correlation formula existed twice in this file. Sharing `_pearson_r` removes the duplication that allows one copy to be fixed while the other silently rots — which is the same failure mode as the SDK/YAML split this PR is closing.
- **Parity:** #1624 fixes the platform YAML. Landing the identical semantics here keeps the two hand-synced implementations agreeing rather than adding a new divergence.

---

## 3) Tests written + scenarios each covers

**`agentic_eval/core_evals/fi_evals/function/tests/test_spearman_correlation.py`** — rank correlation with and without ties, zero variance, input handling, and a guard on Pearson

`TestNoTies` — cases where the shortcut and the definition agree; these must not regress

- `test_perfect_positive` — identical sequences give rho 1.0
- `test_perfect_negative` — reversed sequences give rho −1.0
- `test_monotone_nonlinear_is_still_perfect` — `[1,2,3,4,5]` vs `[1,4,9,16,25]`; Spearman measures monotonicity, not linearity
- `test_normalisation_maps_to_unit_interval` — rho −1 → 0.0 and rho 1 → 1.0

`TestTiedRanks` — every case here was wrong before

- `test_matches_definition_not_shortcut[...]` — 4 parametrised pairs; asserts the scipy value **and** asserts the result is not the old shortcut value, so a silent revert fails
- `test_heavy_ties_error_was_large` — the worst case found: −0.25 reported for data whose rho is −0.7071
- `test_all_values_tied_on_one_side_only` — one constant input is undefined, not a correlation
- `test_ties_do_not_push_score_outside_unit_interval` — three heavy-tie inputs stay within `[0, 1]`

`TestZeroVariance` — a collapsed model must not score as a perfect correlation

- `test_both_inputs_constant` — was 1.0, now 0.5
- `test_predictions_collapsed_against_varied_truth` — a model emitting one value every row
- `test_reason_explains_why` — the reason says rho is undefined

`TestInputHandling` — parsing and guards

- `test_json_string_inputs` — JSON-array strings
- `test_comma_separated_string_inputs` — comma-separated strings, with ties
- `test_length_mismatch_returns_zero` — reason names both lengths
- `test_single_pair_is_rejected` — `n < 2` also protected the old `n*(n^2-1)` denominator
- `test_empty_inputs_are_rejected` — empty lists
- `test_order_of_arguments_is_symmetric` — rho(x,y) == rho(y,x)

`TestPearsonUnchanged` — `_pearson_r` was extracted from Pearson; its behaviour must not move

- `test_perfect_positive` / `test_perfect_negative` — the endpoints
- `test_known_value` — matches `scipy.stats.pearsonr` to 10 dp
- `test_zero_variance_still_returns_zero` — pins Pearson's existing `0.0`, deliberately left alone (see §6)
- `test_length_mismatch_returns_zero` — the guard still fires

> Run result: **25 passed** across this suite. Lint (ruff) + format (black) + isort clean on both changed files; mypy clean.

**These are genuine regression tests:** run against `dev`'s `functions.py`, **10 of the 25 fail**. Against this branch all 25 pass.

**Collateral check:** a differential run of all **90 registered operations** on tie-free numeric input shows **0 differences** between `dev` and this branch. Comparing Spearman and Pearson directly across five fixtures, Pearson is identical in every case (1.0, 0.926401, 0.146447, 0.0, 0.982382) and Spearman moves only where it should:

| input | `dev` | this branch |
|---|---|---|
| `[1,1,2,3]` vs `[1,2,2,3]` | 0.925000 | 0.916667 |
| `[1,1,1,1,2]` vs `[5,4,3,2,1]` | 0.375000 | 0.146447 |
| `[3,3,3,3]` vs `[3,3,3,3]` | 1.000000 | 0.500000 |
| `[1,2,3,4]` vs `[1,2,3,4]` | 1.000000 | 1.000000 |

Expected values were cross-checked against `scipy.stats.spearmanr`, but the tests do not import scipy, so no dependency is added.

---

## 4) How to run / test

### Backend tests

~~~bash
cd futureagi

# Create venv with correct Python (one-time):
uv venv --python 3.11
source .venv/bin/activate
uv pip install -r requirements-test.txt

# This suite:
bin/test agentic_eval/core_evals/fi_evals/function/tests/test_spearman_correlation.py -v

# Single test by name:
bin/test agentic_eval/core_evals/fi_evals/function/tests/test_spearman_correlation.py -k "test_heavy_ties_error_was_large"

# Full suite:
bin/test
~~~

### Frontend tests (if applicable)

Not applicable — no frontend change.

### Contract verification (if API surface changed)

Not applicable — no API surface change. No signature, parameter or return-shape change; only the numeric value for tied and constant input.

### UI steps (manual)

Not applicable — backend-internal scoring change. To verify at the Python level:

~~~python
from agentic_eval.core_evals.fi_evals.function.functions import (
    calculate_spearman_correlation,
)

calculate_spearman_correlation([1, 1, 1, 1, 2], [5, 4, 3, 2, 1])
# before: {'result': 0.375, 'reason': 'Spearman rho=-0.2500, normalized=0.3750'}
# after:  {'result': 0.1464, 'reason': 'Spearman rho=-0.7071, normalized=0.1464'}

calculate_spearman_correlation([3, 3, 3, 3], [3, 3, 3, 3])
# before: {'result': 1.0, 'reason': 'Spearman rho=1.0000, normalized=1.0000'}
# after:  {'result': 0.5, 'reason': 'Zero variance in one or both inputs; Spearman rho is undefined'}
~~~

Cross-check against the reference implementation:

~~~python
from scipy.stats import spearmanr
spearmanr([1, 1, 1, 1, 2], [5, 4, 3, 2, 1]).statistic   # -0.7071067811865475
~~~

---

## 5) Screenshots / recordings

### Test output

~~~
$ pytest agentic_eval/core_evals/fi_evals/function/tests/test_spearman_correlation.py -q
.........................                                                [100%]
25 passed
~~~

### UI testing

Not applicable — no UI change.

---

## 6) Edge cases & considerations

- **Scores change for tied input.** Anyone with a baseline built on the old values will see them move. The old numbers were wrong; worth a release-note line.
- **Untied input is bit-for-bit unchanged.** Where both rank vectors are true permutations of 1..n, the shortcut and the definition agree exactly — confirmed by the 0-difference differential run.
- **Pearson's zero-variance value is deliberately left at `0.0`**, which now differs from Spearman's `0.5` in the same file and from `pearson_correlation.yaml`. On a normalised scale `0.0` means "perfectly anticorrelated", so it is arguably wrong too — but changing it is outside a Spearman fix. Pinned by `test_zero_variance_still_returns_zero` so the current behaviour is explicit; happy to align it here or in a follow-up if you prefer.
- **Only one side constant** — handled by the same branch, since one constant rank vector makes rho undefined regardless of the other.
- **`n < 2`** — still rejected up front, as before. This also protected the old `n*(n^2-1)` denominator from a divide-by-zero at `n = 1`.
- **Argument order** — rho is symmetric, and a test pins it.
- **`_pearson_r` uses `zip(..., strict=True)`.** Both callers validate equal lengths first, so this guards against future misuse rather than changing behaviour. Needs Python ≥ 3.10; `pyproject.toml` sets `requires-python = ">=3.11"`.
- **Floating point** — expected values are asserted with `pytest.approx`, not equality.

---

## 7) Pre-existing issues (NOT introduced by this PR)

- `functions.py` is **not black-clean on `dev`**. I deliberately did not run `black` across the file, since that would produce a large reformat diff unrelated to this fix. Only my added lines are black-formatted; the new test file is fully clean. Ruff findings in the file go from 73 on `dev` to 72.
- `_parse_number_list` raises an uncaught `ValueError` on non-numeric input, so `calculate_spearman_correlation("abc", "[1,2]")` propagates instead of returning the documented `{"result", "reason"}` dict. This affects Pearson, Spearman, R², RMSE and log-loss alike, so it belongs in its own change rather than here.
- The wider `agentic_eval` module has no test collection path from either documented entrypoint — see #1610. The new test file sits in `function/tests/`, next to the code it covers, matching where the module's other tests live.

---

## 8) Architectural / important decisions

- **Pearson-over-ranks rather than a tie-correction term on the shortcut:** there is a corrected-for-ties variant of the d² formula, but it is more code, easy to get subtly wrong, and still only an optimisation of the definition. Computing r over the ranks is what Spearman *is*.
- **`0.5` rather than `0.0` for undefined rho:** `0.5` is rho 0 on the normalised scale, i.e. "no correlation", which is the honest answer. It also matches `pearson_correlation.yaml` and #1624, keeping SDK and platform in agreement.
- **Shared `_pearson_r` rather than a second copy of the formula:** the duplication is precisely why these two functions had drifted, and it mirrors the SDK/YAML split this PR closes.
- **`_rank` lifted to module-level `_midranks`:** it was a closure recreated per call and untestable in isolation; behaviour is unchanged.

---

## Checklist

- [x] My code follows the [style guide](../CONTRIBUTING.md#code-style)
- [x] I've added tests that prove my fix is effective or that my feature works
- [ ] `bin/test` passes locally (backend) — see note below
- [ ] `yarn test:run` passes locally (frontend) — n/a, no frontend change
- [ ] `yarn contracts:check` passes if API surface changed — n/a, no API change
- [ ] I've updated the documentation where relevant — n/a
- [x] No hardcoded secrets, URLs, or PII
- [x] I've signed the [CLA](../CONTRIBUTING.md#contributor-license-agreement-cla)
- [x] PR title follows Conventional Commits
- [ ] Linear issue is linked and updated with status

> **On `bin/test`:** the 25 tests in this suite pass, but I could not run the full backend suite locally — it needs the Docker stack, and my host hits `RuntimeError: Model class accounts.models.audit_log.AuditLog doesn't declare an explicit app_label` outside it. Please run `bin/test` in CI, or point me at any failures and I'll fix them.