### PR TITLE
feat(dataset): rerun dependent dynamic columns [agent]

### DIFF
--- a/e2e/FLOWS.md
+++ b/e2e/FLOWS.md
@@ -52,6 +52,27 @@
 - POST /accounts/token/ returns 200 with a token pair
 - the UI login persists a new active AuthToken row in PG for the user
 
+## datasets
+
+### DATA-E2E-001 — editing a dynamic column reruns selected dependents in order
+
+**Goal:** A dataset editor keeps derived columns current after changing an upstream dynamic column  
+**Spec:** `flows/datasets/rerun-dependent-columns.spec.ts:55`  
+**Tags:** —
+
+**User steps:**
+
+1. seed a dataset with a three-level classification dependency chain
+2. open the source classification column configuration
+3. update the source column
+4. review the direct and transitive dependents in the confirmation dialog
+5. rerun the selected dependent columns
+
+**Backend state verified:**
+
+- the browser posts dependent reruns in topological order with the stored operation type
+- the source and both selected dependent columns reach Completed
+
 ## evals
 
 ### EVAL-E2E-001 — eval task runs over ingested spans via the mock LLM

--- a/e2e/flows/datasets/rerun-dependent-columns.spec.ts
+++ b/e2e/flows/datasets/rerun-dependent-columns.spec.ts
@@ -1,0 +1,255 @@
+import { test, expect } from "../../lib/fixtures";
+import { flowAnnotation } from "../../lib/flow-meta";
+import { POLL } from "../../lib/state-probe";
+
+// Pinned from ManualDatasetCreateRequestSerializer and
+// ManuallyCreateDatasetView in futureagi/model_hub/views/develop_dataset.py.
+const CREATE_DATASET_PATH = "/model-hub/develops/create-dataset-manually/";
+// Pinned from DatasetUpdateCellValueRequestSerializer.
+const updateCellPath = (datasetId: string) =>
+  `/model-hub/develops/${datasetId}/update_cell_value/`;
+// Pinned from ClassifyColumnRequestSerializer and ClassifyColumnView.
+const classifyColumnPath = (datasetId: string) =>
+  `/model-hub/datasets/${datasetId}/classify-column/`;
+// Pinned from frontend/src/utils/axios.js `getDatasetDetail`.
+const datasetTablePath = (datasetId: string) =>
+  `/model-hub/develops/${datasetId}/get-dataset-table/`;
+// Pinned from frontend/src/utils/axios.js `updateDynamicColumn`.
+const RERUN_PATH = /\/model-hub\/columns\/([^/]+)\/rerun-operation\/$/;
+const UI_READY = 60_000;
+const RERUN_CHAIN_READY = 240_000;
+
+interface DatasetTableColumn {
+  id: string;
+  name: string;
+  origin_type: string | null;
+  status: string | null;
+}
+
+interface DatasetTableRow {
+  row_id: string;
+}
+
+interface DatasetTableEnvelope {
+  status: boolean;
+  result: {
+    column_config: DatasetTableColumn[];
+    table: DatasetTableRow[];
+  };
+}
+
+interface CreatedDatasetEnvelope {
+  status: boolean;
+  result: {
+    dataset_id: string;
+  };
+}
+
+interface CreatedColumnEnvelope {
+  status: boolean;
+  result: {
+    new_column_id: string;
+  };
+}
+
+test(
+  "DATA-E2E-001: editing a dynamic column reruns selected dependents in order",
+  {
+    tag: ["@flow"],
+    annotation: flowAnnotation({
+      id: "DATA-E2E-001",
+      area: "datasets",
+      userGoal:
+        "A dataset editor keeps derived columns current after changing an upstream dynamic column",
+      steps: [
+        "seed a dataset with a three-level classification dependency chain",
+        "open the source classification column configuration",
+        "update the source column",
+        "review the direct and transitive dependents in the confirmation dialog",
+        "rerun the selected dependent columns",
+      ],
+      backendChecks: [
+        "the browser posts dependent reruns in topological order with the stored operation type",
+        "the source and both selected dependent columns reach Completed",
+      ],
+    }),
+  },
+  async ({ page, actor }, testInfo) => {
+    // Three seed jobs (3 x ASYNC_JOB) + the source/dependent chain
+    // (RERUN_CHAIN_READY) + five UI/API waits (5 x 60s) = 720s.
+    test.setTimeout(720_000);
+
+    const suffix = `${testInfo.workerIndex}-${Date.now().toString(36)}`;
+    const datasetName = `e2e-data1-${suffix}`;
+    const sourceName = `e2e-source-${suffix}`;
+    const directName = `e2e-direct-${suffix}`;
+    const transitiveName = `e2e-transitive-${suffix}`;
+
+    const createdDataset = await actor.api.post<CreatedDatasetEnvelope>(
+      CREATE_DATASET_PATH,
+      {
+        dataset_name: datasetName,
+        number_of_rows: 1,
+        number_of_columns: 1,
+      },
+    );
+    const datasetId = createdDataset.result.dataset_id;
+
+    const readDataset = () =>
+      actor.api.get<DatasetTableEnvelope>(datasetTablePath(datasetId), {
+        current_page_index: 0,
+        filters: "[]",
+        sort: "[]",
+        page_size: 30,
+      });
+
+    const initialDataset = await readDataset();
+    const staticColumnId = initialDataset.result.column_config[0].id;
+    const rowId = initialDataset.result.table[0].row_id;
+
+    await actor.api.post(updateCellPath(datasetId), {
+      row_id: rowId,
+      column_id: staticColumnId,
+      new_value: `seed-${suffix}`,
+    });
+
+    const waitForCompleted = async (columnId: string) => {
+      await expect
+        .poll(async () => {
+          const dataset = await readDataset();
+          return dataset.result.column_config.find(
+            (column) => column.id === columnId,
+          )?.status;
+        }, POLL.ASYNC_JOB)
+        .toBe("Completed");
+    };
+
+    const createClassification = async (
+      columnId: string,
+      newColumnName: string,
+    ) => {
+      const created = await actor.api.post<CreatedColumnEnvelope>(
+        classifyColumnPath(datasetId),
+        {
+          column_id: columnId,
+          labels: ["alpha", "beta"],
+          language_model_id: "gpt-4o",
+          concurrency: 1,
+          new_column_name: newColumnName,
+        },
+      );
+      await waitForCompleted(created.result.new_column_id);
+      return created.result.new_column_id;
+    };
+
+    const sourceColumnId = await createClassification(
+      staticColumnId,
+      sourceName,
+    );
+    const directColumnId = await createClassification(
+      sourceColumnId,
+      directName,
+    );
+    const transitiveColumnId = await createClassification(
+      directColumnId,
+      transitiveName,
+    );
+
+    await testInfo.attach("seeded-dataset", {
+      body: JSON.stringify({
+        datasetId,
+        rowId,
+        staticColumnId,
+        sourceColumnId,
+        directColumnId,
+        transitiveColumnId,
+      }),
+      contentType: "application/json",
+    });
+
+    const rerunRequests: Array<{
+      columnId: string;
+      operationType: string | undefined;
+    }> = [];
+    page.on("request", (request) => {
+      if (request.method() !== "POST") return;
+      const match = new URL(request.url()).pathname.match(RERUN_PATH);
+      if (!match) return;
+
+      let operationType: string | undefined;
+      try {
+        operationType = request.postDataJSON()?.operation_type;
+      } catch {
+        operationType = undefined;
+      }
+      rerunRequests.push({ columnId: match[1], operationType });
+    });
+
+    await test.step("UI: update the source classification column", async () => {
+      await page.goto(`/dashboard/develop/${datasetId}?tab=data`, {
+        waitUntil: "domcontentloaded",
+      });
+
+      const sourceHeader = page
+        .locator(".ag-header-cell")
+        .filter({ hasText: sourceName });
+      await expect(sourceHeader).toBeVisible({ timeout: UI_READY });
+      await sourceHeader.getByRole("button").click();
+      await page.getByText("Configure Dynamic Column", { exact: true }).click();
+
+      await expect(
+        page.getByText("Edit Classification", { exact: true }),
+      ).toBeVisible({ timeout: UI_READY });
+      await page.getByRole("button", { name: "Update Column" }).click();
+    });
+
+    await test.step("UI: confirm the direct and transitive reruns", async () => {
+      const dialog = page.getByRole("dialog", {
+        name: "Rerun dependent columns?",
+      });
+      await expect(dialog).toBeVisible({ timeout: UI_READY });
+      await expect(
+        dialog.getByRole("checkbox", { name: directName }),
+      ).toBeChecked();
+      await expect(
+        dialog.getByRole("checkbox", { name: transitiveName }),
+      ).toBeChecked();
+
+      await dialog.getByRole("button", { name: "Rerun selected" }).click();
+      await expect(dialog).toBeHidden({ timeout: RERUN_CHAIN_READY });
+    });
+
+    await test.step("API: dependents rerun in topological order", async () => {
+      await expect
+        .poll(
+          () =>
+            rerunRequests.filter(
+              (request) => request.columnId !== sourceColumnId,
+            ),
+          POLL.ASYNC_JOB,
+        )
+        .toEqual([
+          { columnId: directColumnId, operationType: "classify" },
+          { columnId: transitiveColumnId, operationType: "classify" },
+        ]);
+    });
+
+    await test.step("API: the rerun chain reaches Completed", async () => {
+      const expectedIds = [
+        sourceColumnId,
+        directColumnId,
+        transitiveColumnId,
+      ].sort();
+      await expect
+        .poll(async () => {
+          const dataset = await readDataset();
+          return dataset.result.column_config
+            .filter((column) => expectedIds.includes(column.id))
+            .filter((column) => column.status === "Completed")
+            .map((column) => column.id)
+            .sort();
+        }, POLL.ASYNC_JOB)
+        .toEqual(expectedIds);
+    });
+  },
+);

--- a/frontend/src/sections/develop-detail/AddColumn/AddColumnApiCall/AddColumnApiCall.jsx
+++ b/frontend/src/sections/develop-detail/AddColumn/AddColumnApiCall/AddColumnApiCall.jsx
@@ -29,6 +29,7 @@ import {
 import { ShowComponent } from "src/components/show";
 import DynamicColumnSkeleton from "../DynamicColumnSkeleton";
 import { transformDynamicColumnConfig } from "../common";
+import useRerunDependentColumns from "../../DataTab/useRerunDependentColumns";
 
 const getDefaultValue = () => {
   return {
@@ -73,6 +74,7 @@ export const AddColumnApiCallChild = ({
 
   const allColumns = useDatasetColumnConfig(dataset);
   const { data: jsonSchemas = {} } = useGetJsonColumnSchema(dataset);
+  const promptToRerunDependents = useRerunDependentColumns(dataset);
 
   const { control, handleSubmit, reset, setError, getValues } = useForm({
     defaultValues: getDefaultValue(),
@@ -119,6 +121,7 @@ export const AddColumnApiCallChild = ({
         queryKey: ["dynamic-column-config", editId],
       });
       loadedEditIdRef.current = null;
+      promptToRerunDependents(editId);
       refreshGrid();
       onClose();
     },

--- a/frontend/src/sections/develop-detail/AddColumn/Classification/Classification.jsx
+++ b/frontend/src/sections/develop-detail/AddColumn/Classification/Classification.jsx
@@ -27,6 +27,7 @@ import { useDatasetColumnConfig } from "src/api/develop/develop-detail";
 import { transformDynamicColumnConfig } from "../common";
 import DynamicColumnSkeleton from "../DynamicColumnSkeleton";
 import { ShowComponent } from "../../../../components/show";
+import useRerunDependentColumns from "../../DataTab/useRerunDependentColumns";
 
 const getDefaultValue = () => {
   return {
@@ -55,6 +56,7 @@ export const ClassificationChild = ({
 
   const { dataset } = useParams();
   const allColumns = useDatasetColumnConfig(dataset);
+  const promptToRerunDependents = useRerunDependentColumns(dataset);
 
   useEffect(() => {
     if (initialData) {
@@ -107,6 +109,7 @@ export const ClassificationChild = ({
       enqueueSnackbar("Classification column updated successfully", {
         variant: "success",
       });
+      promptToRerunDependents(editId);
       refreshGrid();
       onClose();
     },

--- a/frontend/src/sections/develop-detail/AddColumn/ConditionalNode/ConditionalNodeMainForm.jsx
+++ b/frontend/src/sections/develop-detail/AddColumn/ConditionalNode/ConditionalNodeMainForm.jsx
@@ -28,6 +28,7 @@ import axios, { endpoints } from "src/utils/axios";
 import { useConditionalNodeStoreShallow } from "../../states";
 import { enqueueSnackbar } from "src/components/snackbar";
 import { useDevelopDetailContext } from "../../Context/DevelopDetailContext";
+import useRerunDependentColumns from "../../DataTab/useRerunDependentColumns";
 
 const COLUMN_TYPE_OPTIONS = [
   { label: "Run Prompt", value: "run_prompt" },
@@ -188,6 +189,7 @@ const ConditionalNodeMainForm = ({
     name: "config",
   });
   const { dataset } = useParams();
+  const promptToRerunDependents = useRerunDependentColumns(dataset);
 
   const { mutate: addColumn, isPending: isSubmitting } = useMutation({
     mutationFn: (data) =>
@@ -211,6 +213,7 @@ const ConditionalNodeMainForm = ({
       enqueueSnackbar("API Call column updated successfully", {
         variant: "success",
       });
+      promptToRerunDependents(editId);
       refreshGrid();
       onClose();
     },

--- a/frontend/src/sections/develop-detail/AddColumn/ExecuteCode/ExecuteCode.jsx
+++ b/frontend/src/sections/develop-detail/AddColumn/ExecuteCode/ExecuteCode.jsx
@@ -17,6 +17,7 @@ import { useExecuteCodeStore } from "../../states";
 import { useDevelopDetailContext } from "../../Context/DevelopDetailContext";
 import DynamicColumnSkeleton from "../DynamicColumnSkeleton";
 import { ShowComponent } from "../../../../components/show";
+import useRerunDependentColumns from "../../DataTab/useRerunDependentColumns";
 
 const getDefaultValue = () => {
   return {
@@ -55,6 +56,7 @@ export const ExecuteCodeChild = ({
   });
 
   const { dataset } = useParams();
+  const promptToRerunDependents = useRerunDependentColumns(dataset);
   useEffect(() => {
     if (initialData) {
       reset(initialData);
@@ -91,6 +93,7 @@ export const ExecuteCodeChild = ({
       enqueueSnackbar("API Call column updated successfully", {
         variant: "success",
       });
+      promptToRerunDependents(editId);
       refreshGrid();
       onClose();
     },

--- a/frontend/src/sections/develop-detail/AddColumn/ExtractEntities/ExtractEntities.jsx
+++ b/frontend/src/sections/develop-detail/AddColumn/ExtractEntities/ExtractEntities.jsx
@@ -20,6 +20,7 @@ import { useDevelopDetailContext } from "../../Context/DevelopDetailContext";
 import { useDatasetColumnConfig } from "src/api/develop/develop-detail";
 import DynamicColumnSkeleton from "../DynamicColumnSkeleton";
 import { ShowComponent } from "../../../../components/show";
+import useRerunDependentColumns from "../../DataTab/useRerunDependentColumns";
 
 const getDefaultValue = () => {
   return {
@@ -49,6 +50,7 @@ export const ExtractEntitiesChild = ({
 
   const { dataset } = useParams();
   const allColumns = useDatasetColumnConfig(dataset);
+  const promptToRerunDependents = useRerunDependentColumns(dataset);
   useEffect(() => {
     if (initialData) {
       reset(initialData);
@@ -98,6 +100,7 @@ export const ExtractEntitiesChild = ({
       enqueueSnackbar("API Call column updated successfully", {
         variant: "success",
       });
+      promptToRerunDependents(editId);
       refreshGrid();
       onClose();
     },

--- a/frontend/src/sections/develop-detail/AddColumn/ExtractJsonKey/ExtractJsonKey.jsx
+++ b/frontend/src/sections/develop-detail/AddColumn/ExtractJsonKey/ExtractJsonKey.jsx
@@ -22,6 +22,7 @@ import {
 import DynamicColumnSkeleton from "../DynamicColumnSkeleton";
 import { ShowComponent } from "../../../../components/show";
 import { isJsonColumn } from "./columnFilterUtils";
+import useRerunDependentColumns from "../../DataTab/useRerunDependentColumns";
 
 const getDefaultValue = () => {
   return {
@@ -49,6 +50,7 @@ export const ExtractJsonKeyChild = ({
 
   const { dataset } = useParams();
   const allColumns = useDatasetColumnConfig(dataset);
+  const promptToRerunDependents = useRerunDependentColumns(dataset);
   // refetchOnMount: "always" ensures the schema is fresh when the drawer opens,
   // so a newly-created api_call column isn't hidden by a stale cache entry.
   const { data: jsonSchemas = {} } = useGetJsonColumnSchema(dataset, {
@@ -117,6 +119,7 @@ export const ExtractJsonKeyChild = ({
       enqueueSnackbar("API Call column updated successfully", {
         variant: "success",
       });
+      promptToRerunDependents(editId);
       refreshGrid();
       onClose();
     },

--- a/frontend/src/sections/develop-detail/AddColumn/Retrieval/Retrieval.jsx
+++ b/frontend/src/sections/develop-detail/AddColumn/Retrieval/Retrieval.jsx
@@ -22,6 +22,7 @@ import { useDevelopDetailContext } from "../../Context/DevelopDetailContext";
 import { useDatasetColumnConfig } from "src/api/develop/develop-detail";
 import DynamicColumnSkeleton from "../DynamicColumnSkeleton";
 import { ShowComponent } from "src/components/show";
+import useRerunDependentColumns from "../../DataTab/useRerunDependentColumns";
 
 const getDefaultValue = () => {
   return {
@@ -51,6 +52,7 @@ export const RetrievalChild = ({
 
   const { dataset } = useParams();
   const allColumns = useDatasetColumnConfig(dataset);
+  const promptToRerunDependents = useRerunDependentColumns(dataset);
 
   useEffect(() => {
     if (initialData) {
@@ -120,6 +122,7 @@ export const RetrievalChild = ({
       enqueueSnackbar("API Call column updated successfully", {
         variant: "success",
       });
+      promptToRerunDependents(editId);
       refreshGrid();
       onClose();
     },

--- a/frontend/src/sections/develop-detail/DataTab/DevelopData.jsx
+++ b/frontend/src/sections/develop-detail/DataTab/DevelopData.jsx
@@ -31,6 +31,7 @@ import { getColumnConfig, getTypeDefinitions } from "./common";
 import "./developDataGrid.css";
 import DatapointDrawer from "./DatapointDrawer/DatapointDrawer";
 import ConfirmDeleteColumn from "./DeleteColumn";
+import RerunDependentColumns from "./RerunDependentColumns";
 import SingleImageViewerProvider from "../Common/SingleImageViewer/SingleImageViewerProvider";
 import AddRowData from "./AddRowData";
 import AddEvaluationFeeback from "./AddEvaluationFeeback/AddEvaluationFeeback";
@@ -1097,6 +1098,7 @@ const DevelopData = React.forwardRef(
           }}
           isLoading={isDeletingColumn}
         />
+        <RerunDependentColumns dataset={dataset} />
         <DatapointDrawer
           open={Boolean(datapointDrawerData)}
           onClose={handleDrawerClose}

--- a/frontend/src/sections/develop-detail/DataTab/DevelopDataV2.jsx
+++ b/frontend/src/sections/develop-detail/DataTab/DevelopDataV2.jsx
@@ -52,6 +52,7 @@ import {
 const EditColumnName = lazy(() => import("./EditColumnName"));
 const EditColumnType = lazy(() => import("./EditColumnType"));
 const ConfirmDeleteColumn = lazy(() => import("./DeleteColumn"));
+const RerunDependentColumns = lazy(() => import("./RerunDependentColumns"));
 const AddEvaluationFeeback = lazy(
   () => import("./AddEvaluationFeeback/AddEvaluationFeeback"),
 );
@@ -1374,6 +1375,7 @@ const DevelopDataV2 = ({ datasetId, viewOptions }) => {
       <Suspense fallback={null}>
         <EditColumnName />
         <EditColumnType />
+        <RerunDependentColumns dataset={dataset} />
         <ConfirmDeleteColumn dataset={dataset} />
         <AddEvaluationFeeback />
         <ImprovePrompt />

--- a/frontend/src/sections/develop-detail/DataTab/RerunDependentColumns.jsx
+++ b/frontend/src/sections/develop-detail/DataTab/RerunDependentColumns.jsx
@@ -1,0 +1,182 @@
+import React, { useEffect, useState } from "react";
+import PropTypes from "prop-types";
+import {
+  Box,
+  Button,
+  Checkbox,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  FormControlLabel,
+  IconButton,
+  Typography,
+} from "@mui/material";
+import { LoadingButton } from "@mui/lab";
+import { useParams } from "react-router";
+import Iconify from "src/components/iconify";
+import { enqueueSnackbar } from "src/components/snackbar";
+import { getDatasetQueryOptions } from "src/api/develop/develop-detail";
+import axios, { endpoints } from "src/utils/axios";
+import { useRerunDependentColumnsStore } from "../states";
+import { useDevelopDetailContext } from "../Context/DevelopDetailContext";
+import {
+  rerunDependentColumnsInOrder,
+  toggleDependentColumnSelection,
+} from "./dependentColumns";
+
+const RerunDependentColumns = ({ dataset: datasetId }) => {
+  const { dataset: urlDataset } = useParams();
+  const dataset = urlDataset ?? datasetId;
+  const { refreshGrid } = useDevelopDetailContext();
+  const { rerunDependentColumns, setRerunDependentColumns } =
+    useRerunDependentColumnsStore();
+  const [selectedIds, setSelectedIds] = useState([]);
+  const [isRerunning, setIsRerunning] = useState(false);
+
+  useEffect(() => {
+    setSelectedIds(
+      rerunDependentColumns?.dependents?.map((column) => column.id) ?? [],
+    );
+  }, [rerunDependentColumns]);
+
+  const onClose = () => {
+    if (!isRerunning) {
+      setRerunDependentColumns(null);
+    }
+  };
+
+  const toggleColumn = (columnId) => {
+    setSelectedIds((current) =>
+      toggleDependentColumnSelection({
+        columnId,
+        selectedIds: current,
+        dependentColumns: rerunDependentColumns.dependents,
+      }),
+    );
+  };
+
+  const fetchColumns = async () => {
+    const queryOptions = getDatasetQueryOptions(dataset, 0, [], [], "", {
+      enabled: true,
+      staleTime: 0,
+    });
+    const response = await queryOptions.queryFn();
+    return response?.data?.result?.column_config ?? [];
+  };
+
+  const onConfirm = async () => {
+    const selectedDependents = rerunDependentColumns.dependents.filter(
+      (column) => selectedIds.includes(column.id),
+    );
+
+    if (!selectedDependents.length) {
+      setRerunDependentColumns(null);
+      return;
+    }
+
+    setIsRerunning(true);
+    try {
+      await rerunDependentColumnsInOrder({
+        sourceColumnId: rerunDependentColumns.sourceColumn.id,
+        dependentColumns: selectedDependents,
+        fetchColumns,
+        rerunColumn: (column) =>
+          axios.post(
+            endpoints.develop.addColumns.updateDynamicColumn(column.id),
+            { operation_type: column.operationType },
+          ),
+      });
+      enqueueSnackbar("Dependent columns rerun successfully", {
+        variant: "success",
+      });
+      setRerunDependentColumns(null);
+      refreshGrid();
+    } catch (error) {
+      enqueueSnackbar(
+        error?.response?.data?.message ||
+          error?.message ||
+          "Failed to rerun dependent columns",
+        { variant: "error" },
+      );
+    } finally {
+      setIsRerunning(false);
+    }
+  };
+
+  return (
+    <Dialog
+      open={Boolean(rerunDependentColumns)}
+      onClose={onClose}
+      aria-labelledby="rerun-dependent-columns-title"
+      maxWidth="sm"
+      fullWidth
+    >
+      <DialogTitle
+        id="rerun-dependent-columns-title"
+        sx={{
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "space-between",
+          padding: 2,
+        }}
+      >
+        <Typography component="span" variant="h6">
+          Rerun dependent columns?
+        </Typography>
+        <IconButton aria-label="Close" onClick={onClose} disabled={isRerunning}>
+          <Iconify icon="mdi:close" />
+        </IconButton>
+      </DialogTitle>
+      <DialogContent sx={{ padding: 2 }}>
+        <Typography color="text.secondary" sx={{ mb: 2 }}>
+          These columns depend on{" "}
+          <Box component="span" sx={{ fontWeight: 600 }}>
+            {rerunDependentColumns?.sourceColumn?.name || "the updated column"}
+          </Box>
+          . Select the columns to rerun after it finishes.
+        </Typography>
+        <Box sx={{ display: "flex", flexDirection: "column" }}>
+          {rerunDependentColumns?.dependents?.map((column) => (
+            <FormControlLabel
+              key={column.id}
+              control={
+                <Checkbox
+                  checked={selectedIds.includes(column.id)}
+                  onChange={() => toggleColumn(column.id)}
+                  disabled={isRerunning}
+                />
+              }
+              label={column.name}
+            />
+          ))}
+        </Box>
+      </DialogContent>
+      <DialogActions sx={{ padding: 2 }}>
+        <Button
+          onClick={onClose}
+          variant="outlined"
+          size="small"
+          disabled={isRerunning}
+        >
+          Skip
+        </Button>
+        <LoadingButton
+          onClick={onConfirm}
+          variant="contained"
+          size="small"
+          loading={isRerunning}
+          disabled={!selectedIds.length}
+        >
+          Rerun selected
+        </LoadingButton>
+      </DialogActions>
+    </Dialog>
+  );
+};
+
+RerunDependentColumns.propTypes = {
+  dataset: PropTypes.string,
+};
+
+export default RerunDependentColumns;

--- a/frontend/src/sections/develop-detail/DataTab/__tests__/RerunDependentColumns.test.jsx
+++ b/frontend/src/sections/develop-detail/DataTab/__tests__/RerunDependentColumns.test.jsx
@@ -1,0 +1,148 @@
+import React from "react";
+import { fireEvent, render, screen, waitFor } from "src/utils/test-utils";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import RerunDependentColumns from "../RerunDependentColumns";
+import { useRerunDependentColumnsStore } from "../../states";
+
+const mocks = vi.hoisted(() => ({
+  enqueueSnackbar: vi.fn(),
+  getColumns: vi.fn(),
+  post: vi.fn(),
+  refreshGrid: vi.fn(),
+}));
+
+vi.mock("src/components/snackbar", () => ({
+  enqueueSnackbar: mocks.enqueueSnackbar,
+}));
+
+vi.mock("src/api/develop/develop-detail", () => ({
+  getDatasetQueryOptions: () => ({
+    queryFn: mocks.getColumns,
+  }),
+}));
+
+vi.mock("src/utils/axios", () => ({
+  default: { post: mocks.post },
+  endpoints: {
+    develop: {
+      addColumns: {
+        updateDynamicColumn: (columnId) =>
+          `/model-hub/columns/${columnId}/rerun-operation/`,
+      },
+    },
+  },
+}));
+
+vi.mock("../../Context/DevelopDetailContext", () => ({
+  useDevelopDetailContext: () => ({
+    refreshGrid: mocks.refreshGrid,
+  }),
+}));
+
+const openDialog = () => {
+  useRerunDependentColumnsStore.getState().setRerunDependentColumns({
+    sourceColumn: { id: "source-id", name: "Source" },
+    dependents: [
+      {
+        id: "dependent-id",
+        name: "Dependent",
+        operationType: "classify",
+        dependencyIds: ["source-id"],
+      },
+    ],
+  });
+};
+
+describe("RerunDependentColumns", () => {
+  beforeEach(() => {
+    mocks.enqueueSnackbar.mockReset();
+    mocks.getColumns.mockReset();
+    mocks.post.mockReset();
+    mocks.refreshGrid.mockReset();
+    useRerunDependentColumnsStore.getState().setRerunDependentColumns(null);
+  });
+
+  it("closes without starting dependent reruns when skipped", () => {
+    openDialog();
+    render(<RerunDependentColumns dataset="dataset-id" />);
+
+    expect(screen.getByRole("checkbox", { name: "Dependent" })).toBeChecked();
+    fireEvent.click(screen.getByRole("button", { name: "Skip" }));
+
+    expect(mocks.post).not.toHaveBeenCalled();
+    expect(
+      useRerunDependentColumnsStore.getState().rerunDependentColumns,
+    ).toBeNull();
+  });
+
+  it("reruns a selected dependent with its operation type", async () => {
+    mocks.getColumns.mockResolvedValue({
+      data: {
+        result: {
+          column_config: [
+            { id: "source-id", name: "Source", status: "Completed" },
+            {
+              id: "dependent-id",
+              name: "Dependent",
+              status: "Completed",
+            },
+          ],
+        },
+      },
+    });
+    mocks.post.mockResolvedValue({ data: { status: true } });
+    openDialog();
+    render(<RerunDependentColumns dataset="dataset-id" />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Rerun selected" }));
+
+    await waitFor(() =>
+      expect(mocks.post).toHaveBeenCalledWith(
+        "/model-hub/columns/dependent-id/rerun-operation/",
+        { operation_type: "classify" },
+      ),
+    );
+    await waitFor(() =>
+      expect(
+        useRerunDependentColumnsStore.getState().rerunDependentColumns,
+      ).toBeNull(),
+    );
+    expect(mocks.refreshGrid).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps the dialog open and reports an error when a rerun fails", async () => {
+    mocks.getColumns.mockResolvedValue({
+      data: {
+        result: {
+          column_config: [
+            { id: "source-id", name: "Source", status: "Completed" },
+            {
+              id: "dependent-id",
+              name: "Dependent",
+              status: "Completed",
+            },
+          ],
+        },
+      },
+    });
+    mocks.post.mockRejectedValue({
+      response: { data: { message: "Dependent rerun failed" } },
+    });
+    openDialog();
+    render(<RerunDependentColumns dataset="dataset-id" />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Rerun selected" }));
+
+    await waitFor(() =>
+      expect(mocks.enqueueSnackbar).toHaveBeenCalledWith(
+        "Dependent rerun failed",
+        { variant: "error" },
+      ),
+    );
+    expect(screen.getByRole("dialog")).toBeInTheDocument();
+    expect(
+      useRerunDependentColumnsStore.getState().rerunDependentColumns,
+    ).not.toBeNull();
+    expect(mocks.refreshGrid).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/sections/develop-detail/DataTab/__tests__/dependentColumns.test.js
+++ b/frontend/src/sections/develop-detail/DataTab/__tests__/dependentColumns.test.js
@@ -1,0 +1,315 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  findDependentColumns,
+  getColumnDependencyIds,
+  rerunDependentColumnsInOrder,
+  toggleDependentColumnSelection,
+  waitForColumnCompletion,
+} from "../dependentColumns";
+
+const source = {
+  id: "11111111-1111-1111-1111-111111111111",
+  name: "source",
+  origin_type: "OTHERS",
+  metadata: {},
+};
+
+const anotherSource = {
+  id: "22222222-2222-2222-2222-222222222222",
+  name: "another",
+  origin_type: "OTHERS",
+  metadata: {},
+};
+
+const dynamicColumn = (originType, metadata, overrides = {}) => ({
+  id: overrides.id ?? `${originType}-id`,
+  name: overrides.name ?? originType,
+  origin_type: originType,
+  metadata,
+  status: overrides.status ?? "Completed",
+});
+
+describe("getColumnDependencyIds", () => {
+  const allColumns = [source, anotherSource];
+
+  it.each([
+    ["classification", { column_id: source.id }],
+    ["extracted_entities", { column_id: source.id }],
+    ["extracted_json", { column_id: source.id }],
+    ["vector_db", { column_id: source.id, query_key: "vector" }],
+  ])("detects the %s source column", (originType, metadata) => {
+    expect(
+      getColumnDependencyIds(dynamicColumn(originType, metadata), allColumns),
+    ).toEqual([source.id]);
+  });
+
+  it("accepts an exact legacy vector query_key column reference", () => {
+    expect(
+      getColumnDependencyIds(
+        dynamicColumn("vector_db", {
+          column_id: anotherSource.id,
+          query_key: source.id,
+        }),
+        allColumns,
+      ),
+    ).toEqual([anotherSource.id, source.id]);
+  });
+
+  it("detects API call UUID templates without matching unrelated text", () => {
+    const column = dynamicColumn("api_call", {
+      url: `https://example.com/{{${source.id}.slug}}`,
+      params: {
+        direct: { type: "Variable", value: source.id },
+        ignored: { type: "PlainText", value: source.id },
+      },
+      headers: {
+        nested: { type: "Variable", value: `{{${anotherSource.id}[0]}}` },
+      },
+      body: {
+        selected: `{{${source.id}}}`,
+        nestedObjectIsNotResolvedByRuntime: {
+          value: `{{${anotherSource.id}}}`,
+        },
+      },
+      note: `prefix-${anotherSource.id}-suffix`,
+    });
+
+    expect(getColumnDependencyIds(column, allColumns)).toEqual([
+      source.id,
+      anotherSource.id,
+    ]);
+  });
+
+  it("detects explicit Python kwargs access by column name", () => {
+    const column = dynamicColumn("python_code", {
+      code: `def main(**kwargs):
+    first = kwargs.get("source")
+    second = kwargs['another']
+    return first or second
+`,
+    });
+
+    expect(getColumnDependencyIds(column, allColumns)).toEqual([
+      source.id,
+      anotherSource.id,
+    ]);
+  });
+
+  it("detects conditional condition and nested operation references", () => {
+    const column = dynamicColumn("conditional", {
+      config: [
+        {
+          condition: `{{${source.id}}} == "yes"`,
+          branch_node_config: {
+            type: "api_call",
+            config: {
+              config: {
+                url: `https://example.com/{{${anotherSource.id}}}`,
+                params: {},
+                headers: {},
+                body: {},
+              },
+            },
+          },
+        },
+      ],
+    });
+
+    expect(getColumnDependencyIds(column, allColumns)).toEqual([
+      source.id,
+      anotherSource.id,
+    ]);
+  });
+
+  it("does not match a UUID embedded in arbitrary metadata text", () => {
+    const column = dynamicColumn("api_call", {
+      url: "https://example.com",
+      params: {},
+      headers: {},
+      body: {},
+      note: `unrelated-${source.id}-text`,
+    });
+
+    expect(getColumnDependencyIds(column, allColumns)).toEqual([]);
+  });
+});
+
+describe("findDependentColumns", () => {
+  it("returns direct and transitive dependents in execution order", () => {
+    const direct = dynamicColumn(
+      "classification",
+      { column_id: source.id },
+      { id: "direct", name: "Direct" },
+    );
+    const transitive = dynamicColumn(
+      "extracted_json",
+      { column_id: direct.id },
+      { id: "transitive", name: "Transitive" },
+    );
+
+    expect(
+      findDependentColumns(source.id, [source, transitive, direct]),
+    ).toEqual([
+      {
+        id: direct.id,
+        name: "Direct",
+        operationType: "classify",
+        dependencyIds: [source.id],
+      },
+      {
+        id: transitive.id,
+        name: "Transitive",
+        operationType: "extract_json",
+        dependencyIds: [direct.id],
+      },
+    ]);
+  });
+
+  it("topologically orders dependents regardless of the dataset column order", () => {
+    const upstream = dynamicColumn(
+      "classification",
+      { column_id: source.id },
+      { id: "upstream", name: "Upstream" },
+    );
+    const downstream = dynamicColumn(
+      "api_call",
+      {
+        url: `https://example.com/{{${source.id}}}/{{${upstream.id}}}`,
+        params: {},
+        headers: {},
+        body: {},
+      },
+      { id: "downstream", name: "Downstream" },
+    );
+
+    expect(
+      findDependentColumns(source.id, [source, downstream, upstream]).map(
+        (column) => column.id,
+      ),
+    ).toEqual(["upstream", "downstream"]);
+  });
+});
+
+describe("toggleDependentColumnSelection", () => {
+  const dependentColumns = [
+    { id: "direct", dependencyIds: [source.id] },
+    { id: "transitive", dependencyIds: ["direct"] },
+  ];
+
+  it("removes downstream columns when an upstream dependency is deselected", () => {
+    expect(
+      toggleDependentColumnSelection({
+        columnId: "direct",
+        selectedIds: ["direct", "transitive"],
+        dependentColumns,
+      }),
+    ).toEqual([]);
+  });
+
+  it("selects required upstream columns with a downstream column", () => {
+    expect(
+      toggleDependentColumnSelection({
+        columnId: "transitive",
+        selectedIds: [],
+        dependentColumns,
+      }),
+    ).toEqual(["direct", "transitive"]);
+  });
+
+  it("handles cyclic metadata without recursing forever", () => {
+    const cyclicColumns = [
+      { id: "first", dependencyIds: ["second"] },
+      { id: "second", dependencyIds: ["first"] },
+    ];
+
+    expect(
+      toggleDependentColumnSelection({
+        columnId: "first",
+        selectedIds: [],
+        dependentColumns: cyclicColumns,
+      }),
+    ).toEqual(["first", "second"]);
+  });
+});
+
+describe("waitForColumnCompletion", () => {
+  it("polls until the column is completed", async () => {
+    const fetchColumns = vi
+      .fn()
+      .mockResolvedValueOnce([{ ...source, status: "Running" }])
+      .mockResolvedValueOnce([{ ...source, status: "Completed" }]);
+    const wait = vi.fn().mockResolvedValue(undefined);
+
+    await expect(
+      waitForColumnCompletion({
+        columnId: source.id,
+        fetchColumns,
+        wait,
+        pollInterval: 1,
+      }),
+    ).resolves.toMatchObject({ status: "Completed" });
+    expect(fetchColumns).toHaveBeenCalledTimes(2);
+    expect(wait).toHaveBeenCalledWith(1);
+  });
+
+  it("stops when the column fails", async () => {
+    await expect(
+      waitForColumnCompletion({
+        columnId: source.id,
+        fetchColumns: vi.fn().mockResolvedValue([
+          {
+            ...source,
+            status: "Failed",
+          },
+        ]),
+      }),
+    ).rejects.toThrow("finished with status Failed");
+  });
+});
+
+describe("rerunDependentColumnsInOrder", () => {
+  it("waits for the source and each dependent before starting the next", async () => {
+    const events = [];
+    const statuses = new Map([
+      [source.id, ["Running", "Completed"]],
+      ["direct", ["Completed"]],
+      ["transitive", ["Completed"]],
+    ]);
+    const fetchColumns = vi.fn(async () =>
+      [...statuses.entries()].map(([id, values]) => {
+        const status = values.length > 1 ? values.shift() : values[0];
+        events.push(`status:${id}:${status}`);
+        return { id, name: id, status };
+      }),
+    );
+    const rerunColumn = vi.fn(async (column) => {
+      events.push(`rerun:${column.id}`);
+      statuses.set(column.id, ["Running", "Completed"]);
+    });
+
+    await rerunDependentColumnsInOrder({
+      sourceColumnId: source.id,
+      dependentColumns: [{ id: "direct" }, { id: "transitive" }],
+      fetchColumns,
+      rerunColumn,
+      waitOptions: { wait: vi.fn().mockResolvedValue(undefined) },
+    });
+
+    expect(rerunColumn.mock.calls.map(([column]) => column.id)).toEqual([
+      "direct",
+      "transitive",
+    ]);
+    expect(
+      events.indexOf("status:11111111-1111-1111-1111-111111111111:Completed"),
+    ).toBeLessThan(events.indexOf("rerun:direct"));
+    const directRerunIndex = events.indexOf("rerun:direct");
+    const directCompletionIndex = events.indexOf(
+      "status:direct:Completed",
+      directRerunIndex,
+    );
+    expect(directRerunIndex).toBeLessThan(directCompletionIndex);
+    expect(directCompletionIndex).toBeLessThan(
+      events.indexOf("rerun:transitive"),
+    );
+  });
+});

--- a/frontend/src/sections/develop-detail/DataTab/dependentColumns.js
+++ b/frontend/src/sections/develop-detail/DataTab/dependentColumns.js
@@ -1,0 +1,410 @@
+const ORIGIN_TO_OPERATION_TYPE = {
+  api_call: "api_call",
+  classification: "classify",
+  conditional: "conditional",
+  extracted_entities: "extract_entities",
+  extracted_json: "extract_json",
+  python_code: "execute_code",
+  vector_db: "vector_db",
+};
+
+const RUNNING_COLUMN_STATUSES = new Set([
+  "Editing",
+  "ExperimentEvaluation",
+  "NotStarted",
+  "PartialRun",
+  "Queued",
+  "Running",
+]);
+
+const FAILED_COLUMN_STATUSES = new Set(["Cancelled", "Error", "Failed"]);
+
+const getColumnId = (column) =>
+  String(column?.field ?? column?.id ?? column?.col?.id ?? "");
+
+const getColumnName = (column) =>
+  column?.headerName ?? column?.name ?? column?.col?.name ?? "";
+
+const getColumnOriginType = (column) =>
+  column?.originType ??
+  column?.origin_type ??
+  column?.col?.originType ??
+  column?.col?.origin_type;
+
+const getColumnMetadata = (column) =>
+  column?.metadata ?? column?.col?.metadata ?? {};
+
+const getColumnStatus = (column) => column?.status ?? column?.col?.status ?? "";
+
+const addExactReference = (value, knownColumnIds, references) => {
+  if (typeof value !== "string") return;
+
+  const reference = value.trim();
+  const columnId = knownColumnIds.find(
+    (candidateId) =>
+      reference === candidateId ||
+      reference.startsWith(`${candidateId}.`) ||
+      reference.startsWith(`${candidateId}[`),
+  );
+  if (columnId) {
+    references.add(columnId);
+  }
+};
+
+const addTemplateReferences = (value, knownColumnIds, references) => {
+  if (typeof value !== "string") return;
+
+  Array.from(value.matchAll(/\{\{\s*([^}]+?)\s*\}\}/g)).forEach((match) =>
+    addExactReference(match[1], knownColumnIds, references),
+  );
+};
+
+const addTemplateReferencesDeep = (value, knownColumnIds, references) => {
+  if (typeof value === "string") {
+    addTemplateReferences(value, knownColumnIds, references);
+    return;
+  }
+
+  if (Array.isArray(value)) {
+    value.forEach((item) =>
+      addTemplateReferencesDeep(item, knownColumnIds, references),
+    );
+    return;
+  }
+
+  if (value && typeof value === "object") {
+    Object.values(value).forEach((item) =>
+      addTemplateReferencesDeep(item, knownColumnIds, references),
+    );
+  }
+};
+
+const addApiBodyReferences = (body, knownColumnIds, references) => {
+  if (typeof body === "string") {
+    addTemplateReferences(body, knownColumnIds, references);
+    return;
+  }
+
+  if (body && typeof body === "object" && !Array.isArray(body)) {
+    Object.values(body).forEach((value) =>
+      addTemplateReferences(value, knownColumnIds, references),
+    );
+  }
+};
+
+const addApiCallReferences = (metadata, knownColumnIds, references) => {
+  const config = metadata?.config ?? metadata ?? {};
+
+  addTemplateReferences(config.url, knownColumnIds, references);
+  addApiBodyReferences(config.body, knownColumnIds, references);
+
+  Object.values(config.params ?? {}).forEach((parameter) => {
+    if (parameter?.type === "Variable") {
+      addExactReference(parameter.value, knownColumnIds, references);
+      addTemplateReferences(parameter.value, knownColumnIds, references);
+    }
+  });
+
+  Object.values(config.headers ?? {}).forEach((header) => {
+    if (header?.type === "Variable") {
+      addExactReference(header.value, knownColumnIds, references);
+      addTemplateReferences(header.value, knownColumnIds, references);
+    }
+  });
+};
+
+const addPythonCodeReferences = (code, columnsByName, references) => {
+  if (typeof code !== "string") return;
+
+  const referencedNames = new Set();
+  const accessPatterns = [
+    /kwargs\s*\.\s*get\s*\(\s*(["'])(.*?)\1/g,
+    /kwargs\s*\[\s*(["'])(.*?)\1\s*\]/g,
+  ];
+
+  accessPatterns.forEach((pattern) => {
+    Array.from(code.matchAll(pattern)).forEach((match) =>
+      referencedNames.add(match[2]),
+    );
+  });
+
+  referencedNames.forEach((name) => {
+    (columnsByName.get(name) ?? []).forEach((columnId) =>
+      references.add(columnId),
+    );
+  });
+};
+
+const addConditionalReferences = (
+  metadata,
+  knownColumnIds,
+  columnsByName,
+  references,
+) => {
+  (metadata?.config ?? []).forEach((branch) => {
+    addTemplateReferences(branch?.condition, knownColumnIds, references);
+
+    const node = branch?.branch_node_config ?? {};
+    const config = node?.config ?? {};
+
+    switch (node?.type) {
+      case "classification":
+      case "extract_entities":
+      case "extract_json":
+      case "column_value":
+        addExactReference(config.column_id, knownColumnIds, references);
+        break;
+      case "retrieval":
+      case "vector_db":
+        addExactReference(config.column_id, knownColumnIds, references);
+        addExactReference(config.query_key, knownColumnIds, references);
+        break;
+      case "extract_code":
+      case "execute_code":
+        addPythonCodeReferences(config.code, columnsByName, references);
+        break;
+      case "api_call":
+        addApiCallReferences(config, knownColumnIds, references);
+        break;
+      case "run_prompt":
+        addTemplateReferencesDeep(config, knownColumnIds, references);
+        break;
+      case "conditional":
+        addConditionalReferences(
+          config,
+          knownColumnIds,
+          columnsByName,
+          references,
+        );
+        break;
+      default:
+        break;
+    }
+  });
+};
+
+export const getColumnDependencyIds = (column, allColumns) => {
+  const knownColumnIds = allColumns.map(getColumnId).filter(Boolean);
+  const columnsByName = new Map();
+
+  allColumns.forEach((candidate) => {
+    const name = getColumnName(candidate);
+    const id = getColumnId(candidate);
+    if (!name || !id) return;
+    columnsByName.set(name, [...(columnsByName.get(name) ?? []), id]);
+  });
+
+  const references = new Set();
+  const metadata = getColumnMetadata(column);
+
+  switch (getColumnOriginType(column)) {
+    case "classification":
+    case "extracted_entities":
+    case "extracted_json":
+      addExactReference(metadata.column_id, knownColumnIds, references);
+      break;
+    case "vector_db":
+      addExactReference(metadata.column_id, knownColumnIds, references);
+      addExactReference(metadata.query_key, knownColumnIds, references);
+      break;
+    case "api_call":
+      addApiCallReferences(metadata, knownColumnIds, references);
+      break;
+    case "python_code":
+      addPythonCodeReferences(metadata.code, columnsByName, references);
+      break;
+    case "conditional":
+      addConditionalReferences(
+        metadata,
+        knownColumnIds,
+        columnsByName,
+        references,
+      );
+      break;
+    default:
+      break;
+  }
+
+  return [...references];
+};
+
+export const findDependentColumns = (sourceColumnId, allColumns) => {
+  const normalizedSourceId = String(sourceColumnId);
+  const queuedSourceIds = [normalizedSourceId];
+  const visitedColumnIds = new Set([normalizedSourceId]);
+  const dependentsById = new Map();
+
+  while (queuedSourceIds.length) {
+    const currentSourceId = queuedSourceIds.shift();
+
+    allColumns.forEach((column) => {
+      const columnId = getColumnId(column);
+      if (!columnId || visitedColumnIds.has(columnId)) return;
+
+      const dependencyIds = getColumnDependencyIds(column, allColumns);
+      if (!dependencyIds.includes(currentSourceId)) return;
+
+      const operationType =
+        ORIGIN_TO_OPERATION_TYPE[getColumnOriginType(column)];
+      if (operationType) {
+        visitedColumnIds.add(columnId);
+        queuedSourceIds.push(columnId);
+        dependentsById.set(columnId, {
+          id: columnId,
+          name: getColumnName(column),
+          operationType,
+          dependencyIds,
+        });
+      }
+    });
+  }
+
+  const sortedDependents = [];
+  const remainingDependents = [...dependentsById.values()];
+  const completedIds = new Set([normalizedSourceId]);
+
+  while (remainingDependents.length) {
+    const nextIndex = remainingDependents.findIndex((column) =>
+      column.dependencyIds
+        .filter((dependencyId) => dependentsById.has(dependencyId))
+        .every((dependencyId) => completedIds.has(dependencyId)),
+    );
+
+    const selectedIndex = nextIndex === -1 ? 0 : nextIndex;
+    const [nextColumn] = remainingDependents.splice(selectedIndex, 1);
+    sortedDependents.push(nextColumn);
+    completedIds.add(nextColumn.id);
+  }
+
+  return sortedDependents;
+};
+
+export const getColumnDescriptor = (column, fallbackId = "") => ({
+  id: getColumnId(column) || String(fallbackId),
+  name: getColumnName(column),
+});
+
+export const toggleDependentColumnSelection = ({
+  columnId,
+  selectedIds,
+  dependentColumns,
+}) => {
+  const selected = new Set(selectedIds);
+  const dependentsById = new Map(
+    dependentColumns.map((column) => [column.id, column]),
+  );
+
+  if (selected.has(columnId)) {
+    selected.delete(columnId);
+
+    let changed = true;
+    while (changed) {
+      changed = false;
+      dependentColumns.forEach((column) => {
+        if (
+          selected.has(column.id) &&
+          column.dependencyIds.some(
+            (dependencyId) =>
+              dependentsById.has(dependencyId) && !selected.has(dependencyId),
+          )
+        ) {
+          selected.delete(column.id);
+          changed = true;
+        }
+      });
+    }
+  } else {
+    const selecting = new Set();
+    const selectWithDependencies = (id) => {
+      if (selected.has(id) || selecting.has(id)) return;
+      selecting.add(id);
+      const column = dependentsById.get(id);
+      column?.dependencyIds.forEach((dependencyId) => {
+        if (dependentsById.has(dependencyId)) {
+          selectWithDependencies(dependencyId);
+        }
+      });
+      selecting.delete(id);
+      selected.add(id);
+    };
+
+    selectWithDependencies(columnId);
+  }
+
+  return dependentColumns
+    .map((column) => column.id)
+    .filter((id) => selected.has(id));
+};
+
+export const waitForColumnCompletion = async ({
+  columnId,
+  fetchColumns,
+  pollInterval = 1500,
+  maxAttempts = 400,
+  wait = (duration) =>
+    new Promise((resolve) => {
+      setTimeout(resolve, duration);
+    }),
+}) => {
+  const poll = async (attempt) => {
+    const columns = await fetchColumns();
+    const column = columns.find(
+      (candidate) => getColumnId(candidate) === String(columnId),
+    );
+
+    if (!column) {
+      throw new Error(`Column ${columnId} is no longer available.`);
+    }
+
+    const status = getColumnStatus(column);
+    if (status === "Completed") return column;
+
+    if (FAILED_COLUMN_STATUSES.has(status)) {
+      throw new Error(
+        `${getColumnName(column) || "Column"} finished with status ${status}.`,
+      );
+    }
+
+    if (!RUNNING_COLUMN_STATUSES.has(status)) {
+      throw new Error(
+        `${getColumnName(column) || "Column"} has unexpected status ${status || "unknown"}.`,
+      );
+    }
+
+    if (attempt >= maxAttempts - 1) {
+      throw new Error(`Timed out waiting for column ${columnId} to finish.`);
+    }
+
+    await wait(pollInterval);
+    return poll(attempt + 1);
+  };
+
+  return poll(0);
+};
+
+export const rerunDependentColumnsInOrder = async ({
+  sourceColumnId,
+  dependentColumns,
+  fetchColumns,
+  rerunColumn,
+  waitOptions,
+}) => {
+  await waitForColumnCompletion({
+    columnId: sourceColumnId,
+    fetchColumns,
+    ...waitOptions,
+  });
+
+  await dependentColumns.reduce(
+    (previous, column) =>
+      previous.then(async () => {
+        await rerunColumn(column);
+        await waitForColumnCompletion({
+          columnId: column.id,
+          fetchColumns,
+          ...waitOptions,
+        });
+      }),
+    Promise.resolve(),
+  );
+};

--- a/frontend/src/sections/develop-detail/DataTab/useRerunDependentColumns.js
+++ b/frontend/src/sections/develop-detail/DataTab/useRerunDependentColumns.js
@@ -1,0 +1,31 @@
+import { useCallback } from "react";
+import { useDatasetColumnConfig } from "src/api/develop/develop-detail";
+import { useRerunDependentColumnsStore } from "../states";
+import { findDependentColumns, getColumnDescriptor } from "./dependentColumns";
+
+const useRerunDependentColumns = (dataset) => {
+  const allColumns = useDatasetColumnConfig(dataset);
+  const setRerunDependentColumns = useRerunDependentColumnsStore(
+    (state) => state.setRerunDependentColumns,
+  );
+
+  return useCallback(
+    (sourceColumnId) => {
+      const dependents = findDependentColumns(sourceColumnId, allColumns);
+      if (!dependents.length) return;
+
+      const sourceColumn = allColumns.find(
+        (column) =>
+          String(column?.field ?? column?.id) === String(sourceColumnId),
+      );
+
+      setRerunDependentColumns({
+        sourceColumn: getColumnDescriptor(sourceColumn, sourceColumnId),
+        dependents,
+      });
+    },
+    [allColumns, setRerunDependentColumns],
+  );
+};
+
+export default useRerunDependentColumns;

--- a/frontend/src/sections/develop-detail/states.jsx
+++ b/frontend/src/sections/develop-detail/states.jsx
@@ -229,6 +229,12 @@ export const useDeleteColumnStore = create((set) => ({
   setDeleteColumn: (value) => set(() => ({ deleteColumn: value })),
 }));
 
+export const useRerunDependentColumnsStore = create((set) => ({
+  rerunDependentColumns: null,
+  setRerunDependentColumns: (value) =>
+    set(() => ({ rerunDependentColumns: value })),
+}));
+
 export const useAddEvaluationFeebackStore = create((set) => ({
   addEvaluationFeeback: null,
   setAddEvaluationFeeback: (value) =>
@@ -369,6 +375,7 @@ export const resetAllStates = () => {
   useEditColumnNameStore.getState().setEditColumnName(null);
   useEditColumnTypeStore.getState().setEditColumnType(null);
   useDeleteColumnStore.getState().setDeleteColumn(null);
+  useRerunDependentColumnsStore.getState().setRerunDependentColumns(null);
   useAddEvaluationFeebackStore.getState().setAddEvaluationFeeback(null);
   useImprovePromptStore.getState().setImprovePrompt(null);
   useEditCellStore.getState().setEditCell(null);


### PR DESCRIPTION
## Summary

When a dynamic column is updated, columns that consume its output can keep stale values. This PR detects direct and transitive dependencies from the dataset column metadata, asks which affected columns should rerun, and waits for each selected upstream column to complete before starting the next one.

The implementation uses the column configuration already loaded by the frontend and the existing single-column rerun endpoint. It does not add or change an API contract.

## Linked issues

Closes #934
Linear: N/A

## AI use

AI use: OpenAI Codex implemented the change under my direction; I reviewed the dependency rules, backend status transitions, tests, and final diff.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation only
- [ ] Chore / refactor (no user-visible change)
- [ ] Performance improvement
- [ ] Test-only change

## E2E coverage

E2E: new DATA-E2E-001

---

## 1) What changes were done

**A. Dependency detection**

- Detect exact dependencies for classification, entity extraction, JSON extraction, vector retrieval, API call, Python code, and conditional columns.
- Traverse direct and transitive dependencies and return them in topological execution order.
- Avoid arbitrary UUID substring matching in unrelated metadata.

**B. Rerun confirmation and execution**

- Show a confirmation dialog after an updated source column has dependent columns.
- Select all affected columns by default while keeping upstream/downstream selections consistent.
- Wait for the source column to complete, then rerun each selected dependent sequentially through the existing rerun endpoint.
- Stop the chain if a column fails, is cancelled, disappears, reports an unexpected status, or exceeds the polling timeout.

**C. Existing edit flows**

- Wire the prompt into the successful update paths for classification, entity extraction, JSON extraction, vector retrieval, Python code, API call, and conditional columns.
- Mount the dialog in both dataset data views.

## 2) Why the changes were done

- **Product/UX:** Users can keep derived dataset values synchronized without manually finding and rerunning every downstream column.
- **Data correctness:** A downstream operation does not start until its selected upstream dependency has completed, preventing it from reading cleared, partial, or stale values.
- **Architecture:** Dependency lookup stays client-side using `useDatasetColumnConfig`, as requested in the issue history, while execution reuses the existing `POST /model-hub/columns/{column_id}/rerun-operation/` contract.

## 3) Tests written + scenarios each covers

**`frontend/src/sections/develop-detail/DataTab/__tests__/dependentColumns.test.js`**

- Covers dependency metadata for all seven dynamic column families.
- Covers exact template and Python `kwargs` references without arbitrary metadata matches.
- Covers direct and transitive dependency discovery and topological ordering.
- Covers selection constraints, cyclic metadata safety, polling success/failure, and sequential execution.

**`frontend/src/sections/develop-detail/DataTab/__tests__/RerunDependentColumns.test.jsx`**

- Verifies Skip closes the dialog without a rerun request.
- Verifies confirmation posts the selected column's correct `operation_type` and refreshes the grid.
- Verifies a failed rerun keeps the dialog open, reports the backend error, and does not refresh the grid.

**`e2e/flows/datasets/rerun-dependent-columns.spec.ts`**

- Seeds a real dataset with a three-level classification dependency chain.
- Updates the source column through the browser and verifies the confirmation dialog lists both direct and transitive dependents.
- Verifies dependent rerun requests are posted in topological order with the stored operation type.
- Verifies the source and both selected dependents reach `Completed`.

```text
✓ src/sections/develop-detail/DataTab/__tests__/dependentColumns.test.js (17 tests) 14ms
✓ src/sections/develop-detail/AddColumn/ConditionalNode/common.test.js (2 tests) 4ms
✓ src/sections/develop-detail/DataTab/__tests__/RerunDependentColumns.test.jsx (3 tests)
✓ src/sections/develop-detail/DataTab/__tests__/common.test.js (9 tests) 35ms

Test Files  4 passed (4)
Tests  31 passed (31)
```

Focused ESLint completed with `0 errors`; it reported 11 pre-existing warnings in `DevelopData.jsx` and `DevelopDataV2.jsx`. Prettier passed for the changed product, test, and E2E source files.

```text
Checking formatting...
All matched files use Prettier code style!
```

The E2E type check, generated catalog check, harness self-test, and Playwright collection check passed:

```text
FLOWS.md is current.
106 tests passed.
DATA-E2E-001: editing a dynamic column reruns selected dependents in order
```

The production frontend build completed successfully:

```text
✓ 10039 modules transformed.
✓ built in 2m 20s
```

## 4) How to run / test

### Frontend tests

```bash
cd frontend
source ~/.nvm/nvm.sh
nvm use 22.22.1
./node_modules/.bin/vitest run \
  src/sections/develop-detail/DataTab/__tests__/dependentColumns.test.js \
  src/sections/develop-detail/DataTab/__tests__/RerunDependentColumns.test.jsx \
  src/sections/develop-detail/DataTab/__tests__/common.test.js \
  src/sections/develop-detail/AddColumn/ConditionalNode/common.test.js
```

### Production build

```bash
cd frontend
node --max-old-space-size=8192 ./node_modules/.bin/vite build
```

### E2E static checks

```bash
corepack yarn --cwd e2e typecheck
corepack yarn --cwd e2e catalog:check
corepack yarn --cwd e2e playwright test \
  flows/datasets/rerun-dependent-columns.spec.ts --list
```

### UI steps

1. Open a dataset containing a dynamic column referenced by another dynamic column.
2. Configure and rerun the source column.
3. Verify the dependent-column dialog lists direct and transitive dependents with all selected.
4. Deselect an upstream dependent and verify downstream selections are also removed.
5. Confirm the dialog and verify the source completes before selected dependents rerun in dependency order.
6. Repeat with a source column that has no dependents and verify no extra dialog appears.

The managed E2E stack and fallibility proof were not run in this environment. The flow was type-checked, catalogued, collected by Playwright, and reviewed against the real API serializers and UI route; the dialog interaction, sequential request path, and failure recovery are also covered by the focused frontend tests above.

## 5) Screenshots / recordings

Not included because the authenticated dataset stack was not available for manual capture in this environment.

## 6) Edge cases & considerations

- A source column with no dependents preserves the current behavior and shows no prompt.
- Deselecting a selected upstream column also deselects selected downstream columns that require it.
- Selecting a downstream column automatically selects its affected upstream dependencies.
- Cyclic dependency metadata does not recurse indefinitely.
- Failed, cancelled, missing, unexpected-status, and timed-out columns stop the rerun sequence and display an error.
- API call references are parsed only from supported URL/body/variable fields; unrelated metadata text is ignored.

## 7) Pre-existing issues (NOT introduced by this PR)

- The broader frontend lint run currently reports 427 repository warnings and 0 errors.
- The production build reports existing chunk-size and mixed static/dynamic import warnings. It also prints a Sentry authentication warning after bundle generation, but exits successfully.

## 8) Architectural / important decisions

- **No new backend endpoint:** The browser already has the sibling column metadata required for reverse dependency lookup.
- **Sequential instead of concurrent reruns:** Each selected dependent waits for its upstream result, preventing downstream jobs from reading incomplete values.
- **Exact dependency parsing:** Operation-specific fields are parsed rather than stringifying all metadata and searching for UUID substrings.

## Checklist

- [x] My code follows the style guide
- [x] I've added tests that prove the feature works
- [ ] `bin/test` passes locally (backend not changed)
- [x] Focused frontend tests pass locally
- [x] No API surface changed; contract verification is not required
- [x] Documentation is not required for this scoped dataset workflow
- [x] No hardcoded secrets, URLs, or PII
- [ ] I've signed the CLA
- [x] PR title follows Conventional Commits
- [ ] Linear issue is linked and updated with status (no Linear issue provided)

