### PR TITLE
fix: check every link in contains_valid_link and no_invalid_links (#2554)

### DIFF
--- a/futureagi/agentic_eval/core_evals/fi_evals/function/functions.py
+++ b/futureagi/agentic_eval/core_evals/fi_evals/function/functions.py
@@ -1320,6 +1320,9 @@ def contains_valid_link(text, **kwargs):
     """
     Check if the text contains a valid link.
 
+    Every link in the text is checked; the result is True as soon as one of
+    them resolves successfully (status 200), regardless of position.
+
     Args:
         text (str): The text string to check for a valid link.
 
@@ -1327,34 +1330,37 @@ def contains_valid_link(text, **kwargs):
         dict: A dictionary containing the result of the link check and the reason for the result.
     """
     pattern = r"(?!.*@)(?:https?://)?(?:www\.)?\S+\.\S+"
-    link_match = re.search(pattern=pattern, string=text)
-    if link_match:
-        matched_url = link_match.group()
-        if matched_url:
-            standardized_url = _standardize_url(matched_url)
-            try:
-                text = requests.head(standardized_url)
-                if text.status_code == 200:
-                    return {
-                        "result": True,
-                        "reason": f"link {matched_url} found in output and is valid",
-                    }
-                else:
-                    return {
-                        "result": False,
-                        "reason": f"link {matched_url} found in output but is invalid",
-                    }
-            except:
+    matched_urls = re.findall(pattern=pattern, string=text)
+    if not matched_urls:
+        return {"result": False, "reason": "no link found in output"}
+
+    invalid_urls = []
+    for matched_url in matched_urls:
+        standardized_url = _standardize_url(matched_url)
+        try:
+            response = requests.head(standardized_url)
+            if response.status_code == 200:
                 return {
-                    "result": False,
-                    "reason": f"link {matched_url} found in output but is invalid",
+                    "result": True,
+                    "reason": f"link {matched_url} found in output and is valid",
                 }
-    return {"result": False, "reason": "no link found in output"}
+        except:
+            pass
+        invalid_urls.append(matched_url)
+
+    return {
+        "result": False,
+        "reason": f"link(s) {', '.join(invalid_urls)} found in output but none are valid",
+    }
 
 
 def no_invalid_links(text, **kwargs):
     """
     Check for invalid links in the text.
+
+    Every link in the text is checked; the result is False if any one of them
+    fails to resolve (non-200 or exception), matching the all-links contract
+    in model_hub/system_evals/function/no_invalid_links.yaml.
 
     Args:
         text (str): The text string to check for invalid links.
@@ -1363,29 +1369,29 @@ def no_invalid_links(text, **kwargs):
         dict: A dictionary containing the result of the link check and the reason for the result.
     """
     pattern = r"(?!.*@)(?:https?://)?(?:htp?://)?(?://?)?(?:http?://)?(?:www\.)?\S+\.\S+"
-    link_match = re.search(pattern=pattern, string=text)
-    if link_match:
-        matched_url = link_match.group()
-        if matched_url:
-            standardized_url = _standardize_url(matched_url)
-            try:
-                text = requests.head(standardized_url)
-                if text.status_code == 200:
-                    return {
-                        "result": True,
-                        "reason": f"link {matched_url} found in output and is valid",
-                    }
-                else:
-                    return {
-                        "result": False,
-                        "reason": f"link {matched_url} found in output but is invalid",
-                    }
-            except:
-                return {
-                    "result": False,
-                    "reason": f"link {matched_url} found in output but is invalid",
-                }
-    return {"result": True, "reason": "no invalid link found in output"}
+    matched_urls = re.findall(pattern=pattern, string=text)
+    if not matched_urls:
+        return {"result": True, "reason": "no invalid link found in output"}
+
+    invalid_urls = []
+    for matched_url in matched_urls:
+        standardized_url = _standardize_url(matched_url)
+        try:
+            response = requests.head(standardized_url)
+            if response.status_code != 200:
+                invalid_urls.append(matched_url)
+        except:
+            invalid_urls.append(matched_url)
+
+    if invalid_urls:
+        return {
+            "result": False,
+            "reason": f"link(s) {', '.join(invalid_urls)} found in output but are invalid",
+        }
+    return {
+        "result": True,
+        "reason": f"all {len(matched_urls)} link(s) found in output are valid",
+    }
 
 
 def api_call(

--- a/futureagi/agentic_eval/core_evals/fi_evals/function/tests/test_link_evaluators.py
+++ b/futureagi/agentic_eval/core_evals/fi_evals/function/tests/test_link_evaluators.py
@@ -1,0 +1,133 @@
+from unittest.mock import patch
+
+import requests
+
+from agentic_eval.core_evals.fi_evals.function.functions import (
+    contains_valid_link,
+    no_invalid_links,
+)
+
+# Reachable hosts for the fake transport. The reserved .invalid TLD (RFC 2606)
+# never resolves, so it stands in for a broken link without real network I/O.
+_REACHABLE = {
+    "http://example.com",
+    "https://example.com",
+    "http://ok.com",
+    "https://ok.com",
+}
+
+
+class _FakeResponse:
+    def __init__(self, status_code: int):
+        self.status_code = status_code
+
+
+def _fake_head(url, *args, **kwargs):
+    """Stand-in for requests.head.
+
+    Accepts *args/**kwargs so this stays valid if the evaluators later pass
+    timeout=/allow_redirects= (issues #1945/#1953).
+    """
+    if url in _REACHABLE:
+        return _FakeResponse(200)
+    if url.endswith(".invalid"):
+        raise requests.RequestException("name resolution failed")
+    return _FakeResponse(404)
+
+
+def _patch_head():
+    return patch(
+        "agentic_eval.core_evals.fi_evals.function.functions.requests.head",
+        side_effect=_fake_head,
+    )
+
+
+class TestNoInvalidLinks:
+    """Regression tests for no_invalid_links (issue #2554).
+
+    Previously used re.search, so only the first match was validated and a
+    broken later link incorrectly passed.
+    """
+
+    def test_no_links_is_valid(self):
+        with _patch_head():
+            result = no_invalid_links(text="no links here at all")
+        assert result["result"] is True
+
+    def test_all_links_valid(self):
+        with _patch_head():
+            result = no_invalid_links(text="http://ok.com and https://example.com")
+        assert result["result"] is True
+
+    def test_invalid_link_after_a_valid_one_fails(self):
+        # Reproducer for #2554: broken link is not first, so re.search missed it.
+        text = "Docs: https://example.com and mirror: http://broken-domain-xyz.invalid"
+        with _patch_head():
+            result = no_invalid_links(text=text)
+        assert result["result"] is False
+        assert "http://broken-domain-xyz.invalid" in result["reason"]
+
+    def test_invalid_link_before_a_valid_one_fails(self):
+        text = "http://broken-domain-xyz.invalid then https://example.com"
+        with _patch_head():
+            result = no_invalid_links(text=text)
+        assert result["result"] is False
+
+    def test_non_200_status_after_a_valid_link_fails(self):
+        text = "https://example.com then http://missing.com"
+        with _patch_head():
+            result = no_invalid_links(text=text)
+        assert result["result"] is False
+        assert "http://missing.com" in result["reason"]
+
+    def test_every_link_is_checked(self):
+        text = "https://example.com http://ok.com"
+        with _patch_head() as head:
+            no_invalid_links(text=text)
+        checked = {call.args[0] for call in head.call_args_list}
+        assert checked == {"https://example.com", "http://ok.com"}
+
+
+class TestContainsValidLink:
+    """Regression tests for contains_valid_link (issue #2554).
+
+    Previously validated only the first match, so a valid later link was
+    reported as absent.
+    """
+
+    def test_no_links_is_not_valid(self):
+        with _patch_head():
+            result = contains_valid_link(text="no links here at all")
+        assert result["result"] is False
+
+    def test_first_link_valid(self):
+        with _patch_head():
+            result = contains_valid_link(text="see https://example.com")
+        assert result["result"] is True
+
+    def test_valid_link_after_a_broken_one_passes(self):
+        # Mirror of #2554: only valid link is not first; re.search returned False.
+        text = "Bad: http://broken-domain-xyz.invalid good: http://ok.com"
+        with _patch_head():
+            result = contains_valid_link(text=text)
+        assert result["result"] is True
+        assert "http://ok.com" in result["reason"]
+
+    def test_valid_link_after_a_non_200_passes(self):
+        text = "http://missing.com then https://ok.com"
+        with _patch_head():
+            result = contains_valid_link(text=text)
+        assert result["result"] is True
+
+    def test_all_links_broken_fails(self):
+        text = "http://a-xyz.invalid and http://b-xyz.invalid"
+        with _patch_head():
+            result = contains_valid_link(text=text)
+        assert result["result"] is False
+
+    def test_stops_at_the_first_valid_link(self):
+        text = "http://missing.com http://ok.com https://example.com"
+        with _patch_head() as head:
+            contains_valid_link(text=text)
+        checked = [call.args[0] for call in head.call_args_list]
+        assert checked == ["http://missing.com", "http://ok.com"]


### PR DESCRIPTION
## Summary
- Fix `contains_valid_link` / `no_invalid_links` to validate all URLs via `re.findall` + loop (was `re.search` / first match only).
- `no_invalid_links`: fail if any link invalid; `contains_valid_link`: pass if any link valid.
- Leave HTTP call shape and regex unchanged (#1945/#1953/#1342).
- Add mocked regression tests for multi-link cases.

Competing with open PR #2559 (stale >24h per team rule).

Closes #2554

## Test plan
- [x] Focused mocked unit tests under `futureagi/agentic_eval/core_evals/fi_evals/function/tests/test_link_evaluators.py`
- [ ] `cd futureagi/agentic_eval && python -m pytest core_evals/fi_evals/function/tests/test_link_evaluators.py -v`
- [ ] valid-then-invalid → `no_invalid_links` fails
- [ ] invalid-then-valid → `contains_valid_link` passes