### PR TITLE
fix(model_hub): raise on unsupported filter ops and escape LIKE wildcards (#2560)

### DIFF
--- a/futureagi/model_hub/tests/test_build_sql_filters.py
+++ b/futureagi/model_hub/tests/test_build_sql_filters.py
@@ -1,0 +1,164 @@
+"""Regression tests for ``build_sql_filters``.
+
+Covers two defects in ``model_hub.utils.SQL_queries.build_sql_filters``:
+
+  * Filter operations that matched no branch used to be silently dropped, so
+    the caller ran an unfiltered query that looked filtered. They now raise.
+  * Text ILIKE operations interpolated the raw value into the pattern, so a
+    literal ``%`` or ``_`` acted as a wildcard. They are now escaped and the
+    clause carries an explicit ``ESCAPE`` character.
+
+The function is pure (no DB access); these tests exercise the SQL fragment and
+parameters it returns.
+"""
+
+import unittest
+
+from model_hub.utils.SQL_queries import build_sql_filters
+
+
+def _text_filter(op, value):
+    return [
+        {
+            "column_id": "name",
+            "filter_config": {
+                "filter_op": op,
+                "filter_value": value,
+                "filter_type": "text",
+            },
+        }
+    ]
+
+
+class BuildSqlFiltersTextTests(unittest.TestCase):
+    def test_contains_escapes_wildcards_and_sets_escape_clause(self):
+        sql, params = build_sql_filters(
+            _text_filter("contains", "100%_off"), {"name": "eu.user_id"}
+        )
+        self.assertEqual(sql, " AND eu.user_id ILIKE %s ESCAPE '\\'")
+        # % and _ are escaped so they match literally, wrapped for "contains".
+        self.assertEqual(params, ["%100\\%\\_off%"])
+
+    def test_equals_is_exact_not_wildcard(self):
+        sql, params = build_sql_filters(
+            _text_filter("equals", "100%"), {"name": "eu.user_id"}
+        )
+        self.assertEqual(sql, " AND eu.user_id ILIKE %s ESCAPE '\\'")
+        self.assertEqual(params, ["100\\%"])
+
+    def test_starts_with_and_ends_with(self):
+        _, start_params = build_sql_filters(
+            _text_filter("starts_with", "a_b"), {"name": "eu.user_id"}
+        )
+        self.assertEqual(start_params, ["a\\_b%"])
+        _, end_params = build_sql_filters(
+            _text_filter("ends_with", "a_b"), {"name": "eu.user_id"}
+        )
+        self.assertEqual(end_params, ["%a\\_b"])
+
+    def test_in_builds_placeholders(self):
+        sql, params = build_sql_filters(
+            _text_filter("in", ["a", "b", "c"]), {"name": "eu.user_id"}
+        )
+        self.assertEqual(sql, " AND eu.user_id IN (%s, %s, %s)")
+        self.assertEqual(params, ["a", "b", "c"])
+
+
+class BuildSqlFiltersUnsupportedOpTests(unittest.TestCase):
+    def test_text_op_with_default_number_type_raises(self):
+        # A text op sent without filter_type defaults to "number" and used to be
+        # silently dropped, returning an unfiltered result set.
+        filters = [
+            {
+                "column_id": "name",
+                "filter_config": {"filter_op": "contains", "filter_value": "abc"},
+            }
+        ]
+        with self.assertRaises(ValueError):
+            build_sql_filters(filters, {"name": "eu.user_id"})
+
+    def test_unhandled_text_op_raises(self):
+        with self.assertRaises(ValueError):
+            build_sql_filters(
+                _text_filter("is_null", ""), {"name": "eu.user_id"}
+            )
+
+    def test_unhandled_number_op_raises(self):
+        filters = [
+            {
+                "column_id": "score",
+                "filter_config": {
+                    "filter_op": "is_null",
+                    "filter_value": 1,
+                    "filter_type": "number",
+                },
+            }
+        ]
+        with self.assertRaises(ValueError):
+            build_sql_filters(filters, {"score": "os.score"})
+
+    def test_unknown_data_type_raises(self):
+        filters = [
+            {
+                "column_id": "name",
+                "filter_config": {
+                    "filter_op": "equals",
+                    "filter_value": "x",
+                    "filter_type": "boolean",
+                },
+            }
+        ]
+        with self.assertRaises(ValueError):
+            build_sql_filters(filters, {"name": "eu.user_id"})
+
+    def test_unknown_column_still_raises(self):
+        with self.assertRaises(Exception):
+            build_sql_filters(
+                _text_filter("contains", "x"), {"other": "eu.user_id"}
+            )
+
+
+class BuildSqlFiltersMiscTests(unittest.TestCase):
+    def test_number_equals(self):
+        filters = [
+            {
+                "column_id": "score",
+                "filter_config": {
+                    "filter_op": "equals",
+                    "filter_value": 5,
+                    "filter_type": "number",
+                },
+            }
+        ]
+        sql, params = build_sql_filters(filters, {"score": "os.score"})
+        self.assertEqual(sql, " AND os.score = %s")
+        self.assertEqual(params, [5])
+
+    def test_created_at_is_skipped(self):
+        filters = [
+            {
+                "column_id": "created_at",
+                "filter_config": {"filter_op": "equals", "filter_value": "x"},
+            }
+        ]
+        self.assertEqual(build_sql_filters(filters, {}), ("", []))
+
+    def test_empty_and_default_args(self):
+        self.assertEqual(build_sql_filters(), ("", []))
+        self.assertEqual(build_sql_filters([], {}), ("", []))
+
+    def test_mutable_default_not_shared_between_calls(self):
+        # Guards against the previous mutable default-argument signature.
+        first_sql, first_params = build_sql_filters(
+            _text_filter("contains", "a"), {"name": "eu.user_id"}
+        )
+        second_sql, second_params = build_sql_filters(
+            _text_filter("contains", "b"), {"name": "eu.user_id"}
+        )
+        self.assertEqual(first_params, ["%a%"])
+        self.assertEqual(second_params, ["%b%"])
+        self.assertEqual(first_sql, second_sql)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/futureagi/model_hub/utils/SQL_queries.py
+++ b/futureagi/model_hub/utils/SQL_queries.py
@@ -81,7 +81,20 @@ MODEL_COST_CALCULATION_SQL = """
 """
 
 
-def build_sql_filters(filters=[], column_map={}):
+def _escape_like_wildcards(value):
+    """Escape ILIKE/LIKE metacharacters so they match literally.
+
+    Filter values are always bound as parameters (never interpolated into the
+    SQL text), so this is not about SQL injection -- it prevents a literal
+    ``%`` or ``_`` inside a user's value from being treated as a wildcard.
+    Callers pair the escaped value with ``ESCAPE '\\'`` on the clause.
+    """
+    return str(value).replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
+
+
+def build_sql_filters(filters=None, column_map=None):
+    filters = filters if filters is not None else []
+    column_map = column_map if column_map is not None else {}
     filter_clauses = []
     params = []
     for f in filters:
@@ -97,23 +110,23 @@ def build_sql_filters(filters=[], column_map={}):
 
         if data_type == "text":
             if op == "contains":
-                filter_clauses.append(f"{col} ILIKE %s")
-                params.append(f"%{values}%")
+                filter_clauses.append(f"{col} ILIKE %s ESCAPE '\\'")
+                params.append(f"%{_escape_like_wildcards(values)}%")
             elif op == "not_contains":
-                filter_clauses.append(f"{col} NOT ILIKE %s")
-                params.append(f"%{values}%")
+                filter_clauses.append(f"{col} NOT ILIKE %s ESCAPE '\\'")
+                params.append(f"%{_escape_like_wildcards(values)}%")
             elif op == "equals":
-                filter_clauses.append(f"{col} ILIKE %s")
-                params.append(values)
+                filter_clauses.append(f"{col} ILIKE %s ESCAPE '\\'")
+                params.append(_escape_like_wildcards(values))
             elif op == "not_equals":
-                filter_clauses.append(f"{col} NOT ILIKE %s")
-                params.append(values)
+                filter_clauses.append(f"{col} NOT ILIKE %s ESCAPE '\\'")
+                params.append(_escape_like_wildcards(values))
             elif op == "starts_with":
-                filter_clauses.append(f"{col} ILIKE %s")
-                params.append(f"{values}%")
+                filter_clauses.append(f"{col} ILIKE %s ESCAPE '\\'")
+                params.append(f"{_escape_like_wildcards(values)}%")
             elif op == "ends_with":
-                filter_clauses.append(f"{col} ILIKE %s")
-                params.append(f"%{values}")
+                filter_clauses.append(f"{col} ILIKE %s ESCAPE '\\'")
+                params.append(f"%{_escape_like_wildcards(values)}")
             elif op == "in":
                 placeholders = ", ".join(["%s"] * len(values))
                 filter_clauses.append(f"{col} IN ({placeholders})")
@@ -122,6 +135,10 @@ def build_sql_filters(filters=[], column_map={}):
                 placeholders = ", ".join(["%s"] * len(values))
                 filter_clauses.append(f"{col} NOT IN ({placeholders})")
                 params.extend(values)
+            else:
+                raise ValueError(
+                    f"Unsupported filter operation '{op}' for text column '{col}'"
+                )
 
         elif data_type == "number":
             if op == "between":
@@ -148,6 +165,10 @@ def build_sql_filters(filters=[], column_map={}):
             elif op == "less_than_or_equal":
                 filter_clauses.append(f"{col} <= %s")
                 params.append(values)
+            else:
+                raise ValueError(
+                    f"Unsupported filter operation '{op}' for number column '{col}'"
+                )
 
         elif data_type == "datetime":
             if isinstance(values, list) and len(values) > 1:
@@ -155,6 +176,11 @@ def build_sql_filters(filters=[], column_map={}):
             sql, dt_params = build_datetime_filter_sql(values, op, col)
             filter_clauses.append(sql)
             params.extend(dt_params)
+
+        else:
+            raise ValueError(
+                f"Unsupported filter type '{data_type}' for column '{col}'"
+            )
 
     sql_query = ""
     if filter_clauses:


### PR DESCRIPTION
## Summary
- Raise `ValueError` for unsupported filter ops / filter types in `build_sql_filters` (was silently dropped → unfiltered queries).
- Escape `%` / `_` / `\\` in text ILIKE values and add `ESCAPE '\\'` so literals match literally.
- Fix mutable default args on `build_sql_filters`.
- Add unit tests in `futureagi/model_hub/tests/test_build_sql_filters.py`.

Competing with open PR #2561 (stale >24h per team rule).

Closes #2560

## Test plan
- [x] Unit tests cover unsupported ops, LIKE escaping, mutable defaults
- [ ] `PYTHONPATH=futureagi python -m unittest model_hub.tests.test_build_sql_filters -v`
- [ ] unsupported text/number ops raise
- [ ] `contains` with `100%_off` escapes wildcards