### PR TITLE
fix(ci): repair the disposable-domains refresh, and block two new domains

### DIFF
--- a/.github/workflows/refresh-disposable-domains.yml
+++ b/.github/workflows/refresh-disposable-domains.yml
@@ -56,9 +56,17 @@ jobs:
           echo "version=$version" >> "$GITHUB_OUTPUT"
 
           curl -sfL "$sdist_url" -o /tmp/pkg.tar.gz
-          tar xzf /tmp/pkg.tar.gz -C /tmp
 
-          conf=$(find /tmp -maxdepth 3 -name disposable_email_blocklist.conf)
+          # Unpack into a directory of our own. Searching /tmp itself makes
+          # find walk the runner's root-owned systemd-private-* dirs, and the
+          # resulting "Permission denied" makes it exit 1 even when it did
+          # match the file -- which set -e then turns into a failed job.
+          # --strip-components=1 drops the version-numbered top directory so
+          # the path below stays the same across releases.
+          mkdir -p /tmp/desrc
+          tar xzf /tmp/pkg.tar.gz -C /tmp/desrc --strip-components=1
+
+          conf=$(find /tmp/desrc -name disposable_email_blocklist.conf)
           sort -u "$conf" > /tmp/upstream_domains.txt
           echo "Upstream domain count: $(wc -l < /tmp/upstream_domains.txt)"
 

--- a/futureagi/accounts/tests/test_signup.py
+++ b/futureagi/accounts/tests/test_signup.py
@@ -2150,6 +2150,23 @@ class TestDisposableEmailDomains:
 
         assert not is_disposable_email_domain("com")
 
+    def test_locally_added_providers_are_disposable(self):
+        """Domains we saw at signup before upstream listed them. The packaged
+        list is regenerated wholesale, so these live in a separate set that the
+        weekly refresh cannot clobber."""
+        from accounts.utils import is_disposable_email_domain
+
+        assert is_disposable_email_domain("insight-travel.my.id")
+        assert is_disposable_email_domain("uberip.com")
+        assert is_disposable_email_domain("mail.uberip.com")
+
+    def test_the_local_set_does_not_swallow_its_parent_domain(self):
+        """`insight-travel.my.id` is one host under the `my.id` public suffix,
+        not the whole namespace -- listing it must not block every `.my.id`."""
+        from accounts.utils import is_disposable_email_domain
+
+        assert not is_disposable_email_domain("acme.my.id")
+
     def test_free_providers_are_absent_from_the_package_list(self):
         """gmail and friends are permanent mailboxes, not throwaways, so the
         package does not list them. Dropping the hand-maintained set in favour

--- a/futureagi/accounts/utils.py
+++ b/futureagi/accounts/utils.py
@@ -165,6 +165,19 @@ class WorkEmailRequired(Exception):
         super().__init__(message)
 
 
+# Throwaway providers we have seen at signup but upstream has not picked up.
+# accounts/disposable_domains.py is regenerated wholesale every Thursday, so an
+# entry added there by hand disappears at the next refresh -- this set is the
+# durable place for them. Drop one once upstream ships it; keeping it is
+# harmless, just noise.
+EXTRA_DISPOSABLE_EMAIL_DOMAINS = frozenset(
+    {
+        "insight-travel.my.id",
+        "uberip.com",
+    }
+)
+
+
 def is_disposable_email_domain(domain):
     """True if the domain, or any parent of it, is a known throwaway provider.
 
@@ -175,7 +188,8 @@ def is_disposable_email_domain(domain):
     """
     domain_parts = domain.split(".")
     for i in range(len(domain_parts) - 1):
-        if ".".join(domain_parts[i:]) in DISPOSABLE_EMAIL_DOMAINS:
+        suffix = ".".join(domain_parts[i:])
+        if suffix in DISPOSABLE_EMAIL_DOMAINS or suffix in EXTRA_DISPOSABLE_EMAIL_DOMAINS:
             return True
     return False
 


### PR DESCRIPTION
Two related changes to the disposable-email signup gate.

## 1. The weekly refresh workflow has never succeeded

[Run 33716844842](https://github.com/future-agi/future-agi/actions/runs/33716844842) failed, and it was the workflow's first scheduled run, so this is a bug in the step rather than a regression.

The "Fetch the latest source list" step fetched and unpacked the sdist fine, then died on:

```bash
conf=$(find /tmp -maxdepth 3 -name disposable_email_blocklist.conf)
```

On a hosted `ubuntu-24.04` runner `/tmp` contains root-owned `systemd-private-*` and `snap-private-tmp` directories. `find` cannot descend into them, prints `Permission denied` for each, and **exits 1 even though it did match the file**. Under `set -euo pipefail` the assignment inherits that status and the job aborts.

The fix unpacks into `/tmp/desrc` and searches only that. `--strip-components=1` drops the version-numbered top directory so the path stays stable across releases.

Verified against live PyPI: the step now resolves 0.0.251, finds the conf and writes 8,725 domains, exit 0. Feeding that to `scripts/generate_disposable_domains.py` against the current vendored file gives `changed=true added=415 removed=0` — so once this merges, the next run will open a real refresh PR and the vendored list is 415 domains behind upstream today.

## 2. Block `insight-travel.my.id` and `uberip.com`

Neither is in upstream 0.0.251 or the vendored list, and no parent domain covers them, so both currently pass the gate.

They are deliberately **not** added to `accounts/disposable_domains.py` — that file is regenerated wholesale each Thursday and a hand-added entry would disappear at the next refresh. Its docstring directs permanent additions to `accounts/utils.py`, which had no such set yet, so this adds `EXTRA_DISPOSABLE_EMAIL_DOMAINS` there and has `is_disposable_email_domain` consult both sets.

Note `insight-travel.my.id` sits under the `my.id` public suffix. Because the matcher walks suffixes, listing a bare `my.id` would block every `.my.id` domain, so only the specific host is listed and there is a test asserting `acme.my.id` stays allowed.

## Testing

`pytest` and Django are not installed in `futureagi/.venv`, so **I could not run the suite** — please run it before merging. What I did verify: I exec'd the real `is_disposable_email_domain` source and the new set out of `utils.py` against the actual generated blocklist, exercising the shipped code without the Django import chain. All 14 cases pass — both new domains and their subdomains match, `mailinator.com` and its subdomains still match, and `futureagi.com`, `gmail.com` and bare TLDs still do not.

Two tests were added to `TestDisposableEmailDomains` in `accounts/tests/test_signup.py`.

Refs TH-7620.