### PR TITLE
feat(harness): add scenarios to a finished RL environment through the harness CLI

### DIFF
--- a/frontend/src/api/contracts/api-surface.generated.js
+++ b/frontend/src/api/contracts/api-surface.generated.js
@@ -5,7 +5,7 @@
 export const API_SURFACE_CONTRACT = Object.freeze({
   "generatedFrom": "api_contracts/openapi/swagger.json",
   "swaggerVersion": "2.0",
-  "endpointCount": 997,
+  "endpointCount": 998,
   "groups": {
     "accounts": {
       "/accounts/2fa/recovery-codes/": [
@@ -2297,6 +2297,9 @@ export const API_SURFACE_CONTRACT = Object.freeze({
         "post"
       ],
       "/simulate/api/harness-jobs/{id}/cancel/": [
+        "post"
+      ],
+      "/simulate/api/harness-jobs/{id}/extend/": [
         "post"
       ],
       "/simulate/api/harness/attempts/{id}/artifacts/manifest/": [
@@ -5647,6 +5650,9 @@ export const API_SURFACE_PATHS = Object.freeze({
     "post"
   ],
   "/simulate/api/harness-jobs/{id}/cancel/": [
+    "post"
+  ],
+  "/simulate/api/harness-jobs/{id}/extend/": [
     "post"
   ],
   "/simulate/api/harness/attempts/{id}/artifacts/manifest/": [

--- a/frontend/src/api/harness/harness.js
+++ b/frontend/src/api/harness/harness.js
@@ -13,6 +13,8 @@ const secretFilesPath = () =>
   apiPath("/simulate/api/harness-jobs/secret-files/");
 const secretValuesPath = () =>
   apiPath("/simulate/api/harness-jobs/secret-values/");
+const extendPath = (id) =>
+  apiPath("/simulate/api/harness-jobs/{id}/extend/", { id });
 
 export const listHarnessJobs = async () => (await axios.get(jobsPath())).data;
 
@@ -74,3 +76,8 @@ export const cancelHarnessJob = async (id, reason) => {
 };
 export const adjustHarnessJob = async (id, payload) =>
   (await axios.post(adjustPath(id), payload)).data;
+// The RL-environment chat, once terminal, drives follow-ups: "add 5 scenarios with more
+// neutral happy flows" adds scenarios against the saved world; a message with no count
+// just reruns the saved suite.
+export const extendHarnessJob = async (id, payload) =>
+  (await axios.post(extendPath(id), payload)).data;

--- a/frontend/src/pages/dashboard/harness/HarnessDetail.jsx
+++ b/frontend/src/pages/dashboard/harness/HarnessDetail.jsx
@@ -33,6 +33,7 @@ import {
   cancelHarnessJob,
   getHarnessJob,
   listHarnessJobs,
+  extendHarnessJob,
 } from "src/api/harness/harness";
 import { paths } from "src/routes/paths";
 
@@ -91,10 +92,12 @@ export default function HarnessDetail() {
   const [clock, setClock] = useState(Date.now());
   const [cancelError, setCancelError] = useState("");
   const [confirmingCancel, setConfirmingCancel] = useState(false);
+  const [extendError, setExtendError] = useState("");
   const [stagesOpen, setStagesOpen] = useState(false);
   const [copiedId, setCopiedId] = useState(false);
   const [detailTab, setDetailTab] = useState("contract");
   const [adjustment, setAdjustment] = useState("");
+  const [addCount, setAddCount] = useState(3);
   const feedRef = useRef(null);
   // Whether the reader is sitting at the end of the feed. New activity follows the end
   // only while they are; someone who scrolled up to read history is left where they are.
@@ -192,6 +195,40 @@ export default function HarnessDetail() {
         message: requestError?.message,
       });
       setAdjustError(errorMessage(requestError));
+    },
+  });
+
+  const { mutate: extend, isPending: extending } = useMutation({
+    mutationFn: () => {
+      // The finished-run "Add scenarios" action: add `addCount` scenarios to the saved
+      // world, steered by the optional guidance typed in the box. Rerun is a separate action.
+      const guidance = adjustment.trim();
+      const requestId = window.crypto?.randomUUID?.();
+      return extendHarnessJob(jobId, {
+        count: addCount,
+        ...(guidance ? { guidance } : {}),
+        ...(requestId ? { client_request_id: requestId } : {}),
+      });
+    },
+    onMutate: () => setExtendError(""),
+    onSuccess: (value) => {
+      // The follow-up relaunches the environment (extended or replayed): the job returns
+      // to queued and this page's poll resumes.
+      queryClient.setQueryData(["harness-job", jobId], value);
+      queryClient.invalidateQueries({ queryKey: ["harness-jobs"] });
+      setAdjustment("");
+      pinnedToEnd.current = true;
+      setDetailTab("runs");
+    },
+    onError: (requestError) => {
+      // eslint-disable-next-line no-console
+      console.error("Extend environment failed", {
+        jobId,
+        statusCode: requestError?.statusCode,
+        detail: requestError?.detail,
+        message: requestError?.message,
+      });
+      setExtendError(errorMessage(requestError));
     },
   });
 
@@ -995,11 +1032,10 @@ export default function HarnessDetail() {
               )}
             </Box>
 
-            {/* Docked at the foot of the pane on every tab, because a correction is
-                about the run, not about whichever tab you happen to be reading. Only
-                while the run can still act on one. Full width, because a sentence of
-                instruction does not belong in a 264px rail. */}
-            {!isTerminal && (
+            {/* Docked at the foot of the pane on every tab. While the run is live the box
+                sends a correction to the active authoring; once it is terminal the same box
+                reruns the saved environment, so the conversation never dead-ends. */}
+            {(!isTerminal || Boolean(simulation?.test_execution_id)) && (
               <Box
                 sx={{
                   flexShrink: 0,
@@ -1011,14 +1047,10 @@ export default function HarnessDetail() {
               >
                 <Box
                   sx={{
-                    // 8px, the same radius the timeline cards carry, so the composer
-                    // belongs to the panel rather than reading as a pill dropped on it.
                     borderRadius: 1,
                     border: 1,
                     borderColor: "divider",
                     bgcolor: "background.paper",
-                    // The whole box is the control, so the focus ring belongs to the box
-                    // rather than to the bare input sitting inside it.
                     "&:focus-within": { borderColor: "text.disabled" },
                   }}
                 >
@@ -1026,17 +1058,24 @@ export default function HarnessDetail() {
                     fullWidth
                     multiline
                     maxRows={8}
-                    placeholder="Tell the run what to change…"
+                    placeholder={
+                      isTerminal
+                        ? "Describe the scenarios to add — e.g. 'calm first-time riders booking an airport pickup' (optional)"
+                        : "Tell the run what to change…"
+                    }
                     value={adjustment}
                     onChange={(event) => setAdjustment(event.target.value)}
                     onKeyDown={(event) => {
-                      // Enter sends and Shift+Enter breaks the line, the way every
-                      // message box behaves. ⌘/Ctrl+Enter sends too, for the habit.
+                      // Enter sends; Shift+Enter breaks the line.
                       if (event.key !== "Enter" || event.shiftKey) return;
                       event.preventDefault();
-                      // An empty box is not an error to report, it is nothing to do.
-                      if (adjusting || !adjustment.trim()) return;
-                      adjust();
+                      if (isTerminal) {
+                        if (extending) return;
+                        extend();
+                      } else {
+                        if (adjusting || !adjustment.trim()) return;
+                        adjust();
+                      }
                     }}
                     sx={{ px: 1.5, pt: 1.25, typography: "body2" }}
                   />
@@ -1047,39 +1086,97 @@ export default function HarnessDetail() {
                     sx={{ px: 1.5, pb: 1, pt: 0.5 }}
                   >
                     <Typography variant="caption" color="text.disabled">
-                      Applied at the next stage boundary
+                      {isTerminal
+                        ? "Adds scenarios to the saved world"
+                        : "Applied at the next stage boundary"}
                     </Typography>
-                    <IconButton
-                      size="small"
-                      onClick={() => adjust()}
-                      disabled={adjusting || !adjustment.trim()}
-                      aria-label="Send"
-                      sx={{
-                        bgcolor: "accent.brand",
-                        color: "common.white",
-                        "&:hover": { bgcolor: "accent.brand", opacity: 0.88 },
-                        "&.Mui-disabled": {
-                          bgcolor: "action.disabledBackground",
-                          color: "text.disabled",
-                        },
-                      }}
-                    >
-                      {adjusting ? (
-                        <CircularProgress size={14} color="inherit" />
-                      ) : (
-                        <Iconify icon="solar:plain-linear" width={15} />
-                      )}
-                    </IconButton>
+                    {isTerminal ? (
+                      <Stack direction="row" alignItems="center" spacing={1}>
+                        <Stack
+                          direction="row"
+                          alignItems="center"
+                          sx={{ border: 1, borderColor: "divider", borderRadius: 1 }}
+                        >
+                          <IconButton
+                            size="small"
+                            aria-label="Fewer scenarios"
+                            disabled={extending || addCount <= 1}
+                            onClick={() => setAddCount((n) => Math.max(1, n - 1))}
+                          >
+                            <Iconify icon="solar:minus-square-linear" width={15} />
+                          </IconButton>
+                          <Typography
+                            variant="body2"
+                            sx={{ minWidth: 18, textAlign: "center" }}
+                          >
+                            {addCount}
+                          </Typography>
+                          <IconButton
+                            size="small"
+                            aria-label="More scenarios"
+                            disabled={extending || addCount >= 20}
+                            onClick={() => setAddCount((n) => Math.min(20, n + 1))}
+                          >
+                            <Iconify icon="solar:add-square-linear" width={15} />
+                          </IconButton>
+                        </Stack>
+                        <Button
+                          size="small"
+                          variant="contained"
+                          onClick={() => extend()}
+                          disabled={extending}
+                          startIcon={
+                            extending ? (
+                              <CircularProgress size={14} color="inherit" />
+                            ) : (
+                              <Iconify icon="solar:add-circle-linear" width={15} />
+                            )
+                          }
+                          sx={{
+                            bgcolor: "accent.brand",
+                            color: "common.white",
+                            "&:hover": { bgcolor: "accent.brand", opacity: 0.88 },
+                          }}
+                        >
+                          Add scenarios
+                        </Button>
+                      </Stack>
+                    ) : (
+                      <IconButton
+                        size="small"
+                        onClick={() => adjust()}
+                        disabled={adjusting || !adjustment.trim()}
+                        aria-label="Send"
+                        sx={{
+                          bgcolor: "accent.brand",
+                          color: "common.white",
+                          "&:hover": { bgcolor: "accent.brand", opacity: 0.88 },
+                          "&.Mui-disabled": {
+                            bgcolor: "action.disabledBackground",
+                            color: "text.disabled",
+                          },
+                        }}
+                      >
+                        {adjusting ? (
+                          <CircularProgress size={14} color="inherit" />
+                        ) : (
+                          <Iconify icon="solar:plain-linear" width={15} />
+                        )}
+                      </IconButton>
+                    )}
                   </Stack>
                 </Box>
-                {adjustError && (
+                {(adjustError || extendError) && (
                   <Alert
                     severity="error"
                     variant="outlined"
-                    onClose={() => setAdjustError("")}
+                    onClose={() => {
+                      setAdjustError("");
+                      setExtendError("");
+                    }}
                     sx={{ mt: 1 }}
                   >
-                    {adjustError}
+                    {adjustError || extendError}
                   </Alert>
                 )}
               </Box>

--- a/frontend/src/pages/dashboard/harness/harnessShared.js
+++ b/frontend/src/pages/dashboard/harness/harnessShared.js
@@ -180,8 +180,20 @@ export const shortRunId = (runId = "") => {
 // Authoring writes `metadata.name`, older jobs `metadata.agent_name`. Never fall back to the
 // job id: it reads as a name and search cannot match it. Callers whose slot cannot be blank
 // pass their own fallback.
-export const environmentName = (job, fallback = "\u2014") =>
-  job?.metadata?.agent_name || job?.metadata?.name || fallback;
+export const environmentName = (job, fallback = "\u2014") => {
+  const metadata = job?.metadata || {};
+  if (metadata.agent_name) return metadata.agent_name;
+  if (metadata.name) return metadata.name;
+  // Fall back to the source repo name (always present for github sources) so
+  // environments submitted without an explicit metadata.name — older jobs, API
+  // callers — read as a human name instead of a bare em-dash, per #2427's intent.
+  const repository = job?.source?.repository;
+  if (repository) {
+    const repoName = String(repository).split("/").filter(Boolean).pop();
+    if (repoName) return repoName;
+  }
+  return fallback;
+};
 
 // Four visual states for the run checklist.
 export const STAGE_STATE = {

--- a/frontend/src/pages/dashboard/harness/harnessShared.test.js
+++ b/frontend/src/pages/dashboard/harness/harnessShared.test.js
@@ -538,6 +538,38 @@ describe("environmentName", () => {
   it("lets a caller supply its own fallback for slots that cannot be blank", () => {
     expect(environmentName({ metadata: {} }, "RL Environment")).toBe("RL Environment");
   });
+
+  // The regression #2427 reintroduced: github jobs submitted without
+  // metadata.name (API/CLI callers, older flow) fell to the em-dash. The repo
+  // name is a real, searchable name available from creation — so surface it.
+  it("falls back to the github repo name when metadata carries no name", () => {
+    expect(
+      environmentName({
+        metadata: { origin: "ui-path-branch-test" },
+        source: { kind: "github", repository: "future-agi/ride-voice-agent" },
+      }),
+    ).toBe("ride-voice-agent");
+  });
+
+  it("prefers an explicit metadata name over the repo fallback", () => {
+    expect(
+      environmentName({
+        metadata: { name: "My Agent" },
+        source: { kind: "github", repository: "future-agi/ride-voice-agent" },
+      }),
+    ).toBe("My Agent");
+  });
+
+  // Archive sources carry only an opaque artifact id — never surface it as a
+  // name (UI uploads already set metadata.name; this is the metadata-less edge).
+  it("never surfaces an archive artifact id", () => {
+    expect(
+      environmentName({
+        metadata: {},
+        source: { kind: "archive", archive_artifact_id: "abc123" },
+      }),
+    ).toBe("\u2014");
+  });
 });
 
 describe("eventMessage — hosted vocabulary", () => {

--- a/futureagi/simulate/serializers/harness_job.py
+++ b/futureagi/simulate/serializers/harness_job.py
@@ -337,6 +337,31 @@ class HarnessJobAdjustmentSerializer(serializers.Serializer):
     )
 
 
+class HarnessJobExtendSerializer(serializers.Serializer):
+    # The finished-run chat box adds scenarios through an explicit "Add scenarios" action, so
+    # the request carries a structured ``count`` plus optional free-text ``guidance`` rather
+    # than prose we have to infer intent from. Rerun is a separate action, not this endpoint.
+    count = serializers.IntegerField(
+        min_value=1,
+        max_value=50,
+        help_text="How many new scenarios to add to the saved world.",
+    )
+    guidance = serializers.CharField(
+        max_length=2000,
+        trim_whitespace=True,
+        required=False,
+        allow_blank=True,
+        default="",
+        help_text=(
+            "Optional natural-language steering for the added scenarios (e.g. 'calm "
+            "first-time riders booking an airport pickup'). Existing scenarios are preserved."
+        ),
+    )
+    client_request_id = serializers.CharField(
+        max_length=128, required=False, allow_blank=False
+    )
+
+
 class HarnessSourceUploadResponseSerializer(serializers.Serializer):
     source_id = serializers.UUIDField()
     name = serializers.CharField()

--- a/futureagi/simulate/services/alk_simulate_ingestion.py
+++ b/futureagi/simulate/services/alk_simulate_ingestion.py
@@ -318,8 +318,6 @@ def provision_alk_sim_run_test(
     """
     from django.db import transaction
 
-    from model_hub.models.choices import StatusType
-
     with transaction.atomic():
         if scenario_ids:
             scenarios = list(
@@ -377,39 +375,9 @@ def provision_alk_sim_run_test(
             workspace,
         )
 
-        scenarios: list[Scenarios] = []
-        for idx, persona in enumerate(personas):
-            persona = dict(persona or {})
-            persona_name = (persona.get("name") or f"persona-{idx + 1}").strip()
-            situation = (persona.get("situation") or "").strip()
-            # The run-test title already supplies the agent/run context. Repeating it on every
-            # scenario made a two-call suite render as several nearly identical UUID-prefixed
-            # rows. ALK sends the behavior being tested separately from the persona identity.
-            scenario_name = (
-                persona.get("scenario_name") or situation or persona_name
-            ).strip()[:255]
-            # A real 1-row dataset (persona/situation/outcome) makes the scenario
-            # render with persona rows AND lets the simulator prompt's
-            # {{persona}}/{{situation}} placeholders resolve — without it the
-            # placeholders ship to the model unsubstituted.
-            dataset = _build_persona_scenario_dataset(
-                organization, scenario_name, persona, workspace=workspace
-            )
-            scenarios.append(
-                Scenarios.objects.create(
-                    name=scenario_name,
-                    # ``clean()`` rejects blank source; fall back to the name.
-                    source=situation or persona_name,
-                    scenario_type=Scenarios.ScenarioTypes.DATASET,
-                    source_type=Scenarios.SourceTypes.AGENT_DEFINITION,
-                    agent_definition=agent_definition,
-                    organization=organization,
-                    workspace=workspace,
-                    dataset=dataset,
-                    status=StatusType.COMPLETED.value,
-                    metadata={"origin": "alk_sdk_ingestion", "persona": persona},
-                )
-            )
+        scenarios = _create_persona_scenarios(
+            organization, workspace, agent_definition, personas
+        )
 
         run_test = RunTest.objects.create(
             name=name,
@@ -421,6 +389,67 @@ def provision_alk_sim_run_test(
         run_test.scenarios.set(scenarios)
 
     return run_test, scenarios, agent_definition
+
+
+def append_alk_sim_scenarios(run_test, personas):
+    """Append new persona scenarios to an existing ALK run test, reusing its agent
+    definition + workspace, and attach them to the run's scenario set — used by the hosted
+    "add scenarios" follow-up so the extended world's new personas land on the same run."""
+    from django.db import transaction
+
+    with transaction.atomic():
+        created = _create_persona_scenarios(
+            run_test.organization,
+            run_test.workspace,
+            run_test.agent_definition,
+            personas,
+            name_offset=run_test.scenarios.count(),
+        )
+        run_test.scenarios.add(*created)
+    return created
+
+
+def _create_persona_scenarios(
+    organization, workspace, agent_definition, personas, *, name_offset=0
+):
+    """Create one DATASET scenario per persona (a 1-row persona/situation dataset), shared by
+    fresh provisioning and the extend-append path. ``name_offset`` continues the ``persona-N``
+    fallback numbering so appended personas never collide with the originals."""
+    from model_hub.models.choices import StatusType
+
+    created: list[Scenarios] = []
+    for idx, persona in enumerate(personas):
+        persona = dict(persona or {})
+        persona_name = (
+            persona.get("name") or f"persona-{name_offset + idx + 1}"
+        ).strip()
+        situation = (persona.get("situation") or "").strip()
+        # The run-test title supplies the agent/run context; ALK sends the behavior under
+        # test separately from persona identity, so the scenario name stays specific.
+        scenario_name = (
+            persona.get("scenario_name") or situation or persona_name
+        ).strip()[:255]
+        # A real 1-row dataset lets the simulator prompt's {{persona}}/{{situation}}
+        # placeholders resolve and renders the scenario with persona rows.
+        dataset = _build_persona_scenario_dataset(
+            organization, scenario_name, persona, workspace=workspace
+        )
+        created.append(
+            Scenarios.objects.create(
+                name=scenario_name,
+                # ``clean()`` rejects blank source; fall back to the name.
+                source=situation or persona_name,
+                scenario_type=Scenarios.ScenarioTypes.DATASET,
+                source_type=Scenarios.SourceTypes.AGENT_DEFINITION,
+                agent_definition=agent_definition,
+                organization=organization,
+                workspace=workspace,
+                dataset=dataset,
+                status=StatusType.COMPLETED.value,
+                metadata={"origin": "alk_sdk_ingestion", "persona": persona},
+            )
+        )
+    return created
 
 
 def _build_persona_scenario_dataset(

--- a/futureagi/simulate/services/harness_provider.py
+++ b/futureagi/simulate/services/harness_provider.py
@@ -608,7 +608,14 @@ class DaytonaHarnessProvider:
                         "end-to-end run; its follow-ups can then add scenarios.",
                         status_code=409,
                     )
-                new_count = job.scenario_count + count
+                # Add relative to what the environment actually holds: the scenarios
+                # registered by the last successful run are exactly what the saved authoring
+                # archive contains (it is only re-frozen on success). ``job.scenario_count``
+                # may still carry a target an earlier failed add never reached.
+                existing = HostedHarnessScenario.no_workspace_objects.filter(
+                    job=job
+                ).count()
+                new_count = (existing or job.scenario_count) + count
                 if new_count > 200:
                     raise HostedHarnessError(
                         "scenario_limit_exceeded",

--- a/futureagi/simulate/services/harness_provider.py
+++ b/futureagi/simulate/services/harness_provider.py
@@ -556,6 +556,105 @@ class DaytonaHarnessProvider:
         job.refresh_from_db()
         return serialize_job(job)
 
+    def extend(self, request, pk) -> Response:
+        """Chat 'Add scenarios' on a finished RL environment: add ``count`` new scenarios,
+        steered by optional guidance, replaying the authored world. Rerun is a separate action."""
+        import copy
+        from uuid import uuid4
+
+        from simulate.services.hosted_harness import HostedHarnessError
+
+        organization = _organization(request)
+        workspace = _workspace(request)
+        if organization is None:
+            return Response(
+                {"detail": "Organization not found"},
+                status=status.HTTP_404_NOT_FOUND,
+            )
+        count = int(request.validated_data["count"])
+        guidance = str(request.validated_data.get("guidance") or "").strip()
+        client_request_id = request.validated_data.get("client_request_id") or None
+
+        terminal_states = {
+            HostedHarnessJob.State.COMPLETED,
+            HostedHarnessJob.State.FAILED,
+            HostedHarnessJob.State.CANCELED,
+        }
+        try:
+            with transaction.atomic():
+                job = (
+                    HostedHarnessJob.no_workspace_objects.select_for_update()
+                    .filter(id=str(pk), organization=organization, workspace=workspace)
+                    .first()
+                )
+                if job is None:
+                    raise HostedHarnessError(
+                        "job_not_found",
+                        "saved hosted harness job was not found",
+                        status_code=404,
+                    )
+                if job.state not in terminal_states:
+                    raise HostedHarnessError(
+                        "job_not_terminal",
+                        "scenarios can be added only after the run finishes; it is "
+                        f"{job.state}",
+                        status_code=409,
+                    )
+                metadata = (job.payload or {}).get("metadata") or {}
+                if not metadata.get("authoring_object_key"):
+                    raise HostedHarnessError(
+                        "extend_authoring_snapshot_missing",
+                        "This run predates deterministic scenario reuse. Start one new "
+                        "end-to-end run; its follow-ups can then add scenarios.",
+                        status_code=409,
+                    )
+                new_count = job.scenario_count + count
+                if new_count > 200:
+                    raise HostedHarnessError(
+                        "scenario_limit_exceeded",
+                        "a hosted run can contain at most 200 scenarios",
+                        status_code=422,
+                    )
+                payload = copy.deepcopy(job.payload)
+                meta = payload.setdefault("metadata", {})
+                adjustments = list(meta.get("adjustments") or [])
+                adjustments.append(
+                    {
+                        "adjustment_id": str(uuid4()),
+                        "client_request_id": client_request_id,
+                        "instruction": guidance,
+                        "target_stage": "scenarios",
+                        "scenario_delta": count,
+                        "status": "pending",
+                        "created_at": timezone.now().isoformat(),
+                    }
+                )
+                meta["adjustments"] = adjustments
+                # Consumed by the gateway launch: replay the frozen world but re-run
+                # scenario-gen to reach the new total, steered by any guidance.
+                meta["scenario_extend"] = {
+                    "guidance": [guidance] if guidance else [],
+                    "target_count": new_count,
+                }
+                payload["metadata"] = meta
+                job.payload = payload
+                job.scenario_count = new_count
+                job.save(update_fields=["payload", "scenario_count", "updated_at"])
+        except HostedHarnessError as exc:
+            return Response(exc.as_dict(), status=exc.status_code)
+
+        try:
+            return Response(
+                self.rerun_saved(
+                    str(pk),
+                    organization=organization,
+                    workspace=workspace,
+                    environment_values={},
+                )
+            )
+        except HostedHarnessError as exc:
+            return Response(exc.as_dict(), status=exc.status_code)
+
     def source_upload(self, request) -> Response:
         from simulate.services.hosted_harness import HostedHarnessError
         from simulate.services.hosted_harness_gateway import store_source_archive
@@ -652,6 +751,17 @@ class SandboxHarnessProvider:
                 "secret_refs": secret_refs,
                 "only": [],
             },
+        )
+
+    def extend(self, request, pk) -> Response:
+        return Response(
+            {
+                "error": "extend_not_supported",
+                "message": (
+                    "adding scenarios is only available on the hosted (daytona) provider"
+                ),
+            },
+            status=status.HTTP_400_BAD_REQUEST,
         )
 
     @staticmethod

--- a/futureagi/simulate/services/hosted_harness.py
+++ b/futureagi/simulate/services/hosted_harness.py
@@ -22,6 +22,7 @@ from simulate.models import (
 )
 from simulate.services.alk_simulate_ingestion import (
     ALKSimulateIngestionError,
+    append_alk_sim_scenarios,
     create_alk_sim_call_execution_batch,
     create_alk_sim_test_execution,
     provision_alk_sim_run_test,
@@ -330,13 +331,41 @@ def provision_scenarios(
                 "created_at"
             )
         )
+        existing_keys = [item.scenario_key for item in registrations]
+        existing_set = set(existing_keys)
         requested_keys = [persona["scenario_key"] for persona in payload["personas"]]
-        if requested_keys != [item.scenario_key for item in registrations]:
+        requested_set = set(requested_keys)
+        if requested_set == existing_set:
+            return _provision_response(job, registrations)
+        # A chat "add scenarios" follow-up seals the existing set PLUS new personas. Dropping
+        # an existing scenario is a real conflict, not an extension.
+        if not existing_set.issubset(requested_set):
             raise HostedHarnessError(
                 "scenario_registration_conflict",
                 "the job already has a different sealed scenario registration",
                 status_code=409,
             )
+        new_personas = [
+            persona
+            for persona in payload["personas"]
+            if persona["scenario_key"] not in existing_set
+        ]
+        new_scenarios = append_alk_sim_scenarios(
+            job.run_test,
+            [
+                {key: value for key, value in persona.items() if key != "scenario_key"}
+                for persona in new_personas
+            ],
+        )
+        with transaction.atomic():
+            for persona, scenario in zip(new_personas, new_scenarios, strict=True):
+                registrations.append(
+                    HostedHarnessScenario.no_workspace_objects.create(
+                        job=job,
+                        scenario_key=persona["scenario_key"],
+                        scenario=scenario,
+                    )
+                )
         return _provision_response(job, registrations)
 
     personas = [
@@ -528,6 +557,49 @@ def begin_scenarios(
             status_code=409,
         )
     if job.test_execution_id:
+        unlinked = [item for item in registrations if item.call_execution_id is None]
+        if not unlinked:
+            return _begin_response(job, registrations)
+        # A chat "add scenarios" follow-up appends the new personas' calls to the existing
+        # execution: extend its scenario set, create only the missing calls (the batch is
+        # idempotent + additive), and link the new registrations. Existing calls stay.
+        with transaction.atomic():
+            execution = TestExecution.no_workspace_objects.select_for_update().get(
+                id=job.test_execution_id
+            )
+            existing_ids = [str(sid) for sid in (execution.scenario_ids or [])]
+            existing_id_set = set(existing_ids)
+            added_ids = [
+                str(item.scenario_id)
+                for item in unlinked
+                if str(item.scenario_id) not in existing_id_set
+            ]
+            if added_ids:
+                execution.scenario_ids = existing_ids + added_ids
+                execution.total_scenarios = len(execution.scenario_ids)
+                execution.save(update_fields=["scenario_ids", "total_scenarios"])
+        try:
+            batch = create_alk_sim_call_execution_batch(execution, count=len(unlinked))
+        except ALKSimulateIngestionError as exc:
+            raise HostedHarnessError("scenario_begin_failed", str(exc)) from exc
+        added_calls = CallExecution.no_workspace_objects.filter(
+            id__in=batch.call_execution_ids
+        ).select_related("scenario")
+        calls_by_scenario: dict[uuid.UUID, CallExecution] = {}
+        for call in added_calls:
+            calls_by_scenario.setdefault(call.scenario_id, call)
+        with transaction.atomic():
+            for item in unlinked:
+                call = calls_by_scenario.get(item.scenario_id)
+                if call is None:
+                    raise HostedHarnessError(
+                        "scenario_call_mapping_incomplete",
+                        "extension pre-allocation did not create a call for a new scenario",
+                        status_code=500,
+                        retryable=True,
+                    )
+                item.call_execution = call
+                item.save(update_fields=["call_execution", "updated_at"])
         return _begin_response(job, registrations)
 
     test_execution = create_alk_sim_test_execution(

--- a/futureagi/simulate/services/hosted_harness_gateway.py
+++ b/futureagi/simulate/services/hosted_harness_gateway.py
@@ -212,34 +212,71 @@ def _adjustment_stage(instruction: str, current_stage: str) -> str:
     }.get(current_stage, "scenarios")
 
 
-def _hosted_scenario_repair_script(*, name: str, expected: int, actual: int) -> str:
-    """Build the non-interactive scenario-only repair run used by pinned guests.
-
-    Keeping this in the gateway lets the control plane repair an older hosted snapshot without
-    weakening Bundle V2's exact-cardinality gate or requiring a privileged in-sandbox updater.
-    Values are encoded as JSON literals rather than interpolated as executable source.
+def _scenarios_cli_command(*, name: str, count: int, guidance: list[str]) -> str:
+    """A non-interactive invocation of the harness's own scenario CLI against the reused
+    ``/work/authoring``: reach exactly ``count`` scenarios, preserving existing ones, steered
+    by ``guidance``. Uses the harness's public CLI contract (``alk-harness scenarios``) rather
+    than importing its internals, matching how every other stage is launched in the sandbox.
     """
+    parts = [
+        "python -m fi.alk.harness.cli scenarios",
+        f"--name {shlex.quote(str(name) or 'agent')}",
+        "--out /work/authoring",
+        f"--count {int(count)}",
+        "--once",
+    ]
+    for item in guidance:
+        text = str(item).strip()
+        if text:
+            parts.append(f"--guidance {shlex.quote(text)}")
+    return " ".join(parts)
+
+
+def _hosted_scenario_repair_command(*, name: str, expected: int, actual: int) -> str:
+    """Non-interactive scenario-only repair: reach the exact ``expected`` count, preserving
+    existing coverage, so Bundle V2's exact-cardinality gate is satisfied without a privileged
+    in-sandbox updater."""
     delta = expected - actual
     if delta > 0:
         instruction = (
             f"Exactly {expected} scenarios are required, but {actual} are saved. "
-            f"Add exactly {delta} distinct validated scenario(s), preserve the existing "
-            "scenarios, and call save_scenarios."
+            f"Add exactly {delta} distinct validated scenario(s) and preserve the existing ones."
         )
     else:
         instruction = (
             f"Exactly {expected} scenarios are required, but {actual} are saved. "
-            f"Remove exactly {-delta} excess scenario(s), preserve the strongest coverage, "
-            "and call save_scenarios."
+            f"Remove exactly {-delta} excess scenario(s), preserving the strongest coverage."
         )
-    return (
-        "import argparse, asyncio\n"
-        "from fi.alk.harness.cli import _scenarios\n"
-        "args = argparse.Namespace("
-        f"name={json.dumps(name)}, out='/work/authoring', count={expected}, "
-        "interactive=False, "
-        f"guidance=[{json.dumps(instruction)}])\n"
-        "raise SystemExit(asyncio.run(_scenarios(args)))\n"
+    return _scenarios_cli_command(name=name, count=expected, guidance=[instruction])
+
+
+def _hosted_scenario_extend_command(
+    *, name: str, target_count: int, guidance: list[str]
+) -> str:
+    """Chat-driven 'add N scenarios': re-run scenario generation against the reused world to
+    reach ``target_count`` total, preserving existing scenarios, steered by the caller's
+    natural-language guidance. The harness CLI owns the preserve/represent semantics."""
+    return _scenarios_cli_command(name=name, count=target_count, guidance=guidance)
+
+
+def _extend_command_for(job: HostedHarnessJob, payload: dict) -> str | None:
+    """Return the reused-authoring scenario-extension CLI command when the job carries a
+    pending chat-driven 'add scenarios' request (a target count), else None for a normal run.
+    Guidance is optional — the count alone drives the add; guidance only steers the new ones."""
+    extend = (payload.get("metadata") or {}).get("scenario_extend")
+    if not extend:
+        return None
+    target_count = extend.get("target_count")
+    if not target_count:
+        return None
+    guidance = [str(item) for item in (extend.get("guidance") or []) if str(item).strip()]
+    name = str(
+        (payload.get("metadata") or {}).get("agent_name")
+        or payload.get("name")
+        or "agent"
+    )
+    return _hosted_scenario_extend_command(
+        name=name, target_count=int(target_count), guidance=guidance
     )
 
 
@@ -1297,7 +1334,7 @@ class DaytonaHostedGateway:
                     break
                 if run.exit_code == 0 and produced > 0:
                     for repair_attempt in range(1, 3):
-                        script = _hosted_scenario_repair_script(
+                        repair_command = _hosted_scenario_repair_command(
                             name=str(
                                 job.metadata.get("agent_name")
                                 or job.payload.get("name")
@@ -1306,11 +1343,8 @@ class DaytonaHostedGateway:
                             expected=job.scenario_count,
                             actual=produced,
                         )
-                        sandbox.fs.upload_file(
-                            script.encode("utf-8"), "/tmp/repair-scenarios.py"
-                        )
                         repair = sandbox.process.exec(
-                            "python /tmp/repair-scenarios.py",
+                            repair_command,
                             env=authoring_env,
                             timeout=run_timeout,
                         )
@@ -1387,6 +1421,13 @@ class DaytonaHostedGateway:
             # Resolve cached authoring created before connector resolution shipped as well as
             # newly-authored jobs. This must happen before network policy and job.json are built.
             payload = resolve_authored_connector(payload, authoring_archive)
+        # A chat-driven "add N scenarios" request replays the frozen world but re-runs
+        # scenario-gen (extend) against it. The marker persists across infra retries and is
+        # cleared only once the extended authoring is stored (store_authoring_archive), so a
+        # mid-flight retry re-extends to the same total instead of replaying the old set.
+        extend_command = (
+            _extend_command_for(job, payload) if authoring_archive is not None else None
+        )
         source = dict(payload["source"])
         if source["kind"] == "github":
             source["commit_sha"] = commit_sha
@@ -1630,7 +1671,8 @@ class DaytonaHostedGateway:
                         + provider_profile_args
                         + "; "
                         "fi && "
-                        "python -m fi.alk.harness.bundle_author_v2 "
+                        + ((extend_command + " && ") if extend_command else "")
+                        + "python -m fi.alk.harness.bundle_author_v2 "
                         "--job /work/job.json --source /work/source "
                         "--authoring /work/authoring --output /work/bundle && "
                         "python -m fi.alk.harness.hosted_entrypoint /work/job.json "
@@ -1892,12 +1934,18 @@ class DaytonaHostedGateway:
         # has accepted them.  A saved rerun can then rebuild the environment while
         # using the exact same sealed scenario suite instead of asking the model to
         # author a different suite for an already-registered RunTest.
+        # A chat "add scenarios" extend re-authors the SAME RunTest up to N+delta, so it must
+        # re-freeze even though a key already exists — gated on its one-shot marker.
+        # store_authoring_archive clears that marker in the same save.
         metadata = (job.payload or {}).get("metadata") or {}
         if (
             isinstance(bundle, dict)
             and isinstance(scenarios, list)
             and len(scenarios) == job.scenario_count
-            and not metadata.get("authoring_object_key")
+            and (
+                not metadata.get("authoring_object_key")
+                or metadata.get("scenario_extend")
+            )
         ):
             try:
                 packed = sandbox.process.exec(
@@ -2739,6 +2787,9 @@ def store_authoring_archive(
     metadata = dict(payload.get("metadata") or {})
     metadata["authoring_object_key"] = object_key
     metadata["authoring_mode"] = "fresh"
+    # A chat "add scenarios" run consumes its one-shot extend marker here, once the extended
+    # authoring is durably stored, so a later plain rerun replays this set without re-extending.
+    metadata.pop("scenario_extend", None)
     payload["metadata"] = metadata
     job.payload = payload
     update_fields = ["payload", "updated_at"]

--- a/futureagi/simulate/services/hosted_harness_gateway.py
+++ b/futureagi/simulate/services/hosted_harness_gateway.py
@@ -250,13 +250,40 @@ def _hosted_scenario_repair_command(*, name: str, expected: int, actual: int) ->
     return _scenarios_cli_command(name=name, count=expected, guidance=[instruction])
 
 
+_SCENARIO_EXTEND_REPAIR_PASSES = 2
+
+
 def _hosted_scenario_extend_command(
     *, name: str, target_count: int, guidance: list[str]
 ) -> str:
     """Chat-driven 'add N scenarios': re-run scenario generation against the reused world to
     reach ``target_count`` total, preserving existing scenarios, steered by the caller's
-    natural-language guidance. The harness CLI owns the preserve/represent semantics."""
-    return _scenarios_cli_command(name=name, count=target_count, guidance=guidance)
+    natural-language guidance. The harness CLI owns the preserve/represent semantics.
+
+    A single ``--once`` pass may stop short of the target, and Bundle V2's exact-cardinality
+    gate then refuses the run. Mirror the fresh-authoring repair loop in-sandbox: after the
+    guided pass, re-run the CLI up to ``_SCENARIO_EXTEND_REPAIR_PASSES`` times while the
+    on-disk scenario count is still below the target. Progress accumulates in
+    ``/work/authoring`` between passes, which a platform-level relaunch (fresh sandbox, original
+    archive) could never do.
+    """
+    target = int(target_count)
+    extend = _scenarios_cli_command(name=name, count=target, guidance=guidance)
+    repair = _scenarios_cli_command(
+        name=name,
+        count=target,
+        guidance=[
+            f"Exactly {target} scenarios are required in total. Preserve every existing "
+            f"scenario exactly and add only new distinct validated scenarios until exactly "
+            f"{target} are saved."
+        ],
+    )
+    passes = " ".join(str(i) for i in range(1, _SCENARIO_EXTEND_REPAIR_PASSES + 1))
+    return (
+        f"{extend}; for _ in {passes}; do "
+        f'[ "$({_SCENARIO_DIRECTORY_COUNT_COMMAND})" -ge {target} ] && break; '
+        f"{repair}; done"
+    )
 
 
 def _extend_command_for(job: HostedHarnessJob, payload: dict) -> str | None:
@@ -1379,12 +1406,14 @@ class DaytonaHostedGateway:
                 raise HostedHarnessError(
                     "authoring_failed", detail, status_code=422, retryable=False
                 )
+            # Pack the authoring directory whole rather than an allow-list of file names: the
+            # guest decides what a saved world consists of (world.sqlite today, world.py +
+            # state.json + manifest.json on newer guests), and an allow-list here silently
+            # drops the marker the next reuse needs. Only the sealed bundle is left out: it is
+            # large and bundle_author_v2 regenerates it from this directory on every launch.
             packed = sandbox.process.exec(
                 "cd /work/authoring && tar -czf /tmp/authoring.tar.gz "
-                "$(ls -d world.sqlite schema.sql store.json collections.json "
-                "contract.json environment.json provider-import-profile.json "
-                "scenarios.json simulator_prompt.md "
-                "scenarios handlers 2>/dev/null)",
+                "--exclude=./environment-bundle --exclude=__pycache__ .",
                 timeout=180,
             )
             if packed.exit_code:
@@ -1949,14 +1978,10 @@ class DaytonaHostedGateway:
         ):
             try:
                 packed = sandbox.process.exec(
-                    "cd /work/authoring && set --; "
-                    "for path in schema.sql store.json world.sqlite collections.json "
-                    "contract.json environment.json scenarios.json simulator_prompt.md "
-                    "scenarios handlers; do "
-                    '[ -e "$path" ] && set -- "$@" "$path"; '
-                    "done; "
-                    '[ -f contract.json ] && [ -d scenarios ] && [ "$#" -gt 0 ] && '
-                    'tar -czf /tmp/authoring-rerun.tar.gz "$@"',
+                    "cd /work/authoring && "
+                    "[ -f contract.json ] && [ -d scenarios ] && "
+                    "tar -czf /tmp/authoring-rerun.tar.gz "
+                    "--exclude=./environment-bundle --exclude=__pycache__ .",
                     timeout=180,
                 )
                 if packed.exit_code:

--- a/futureagi/simulate/tests/test_harness_read_dto.py
+++ b/futureagi/simulate/tests/test_harness_read_dto.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 import hashlib
 import io
 import json
+import shlex
 import tarfile
 import tempfile
 from pathlib import Path
@@ -41,7 +42,7 @@ from simulate.services.hosted_harness import (
 from simulate.services.hosted_harness_gateway import (
     _SCENARIO_DIRECTORY_COUNT_COMMAND,
     _bundle_archive_for,
-    _hosted_scenario_repair_script,
+    _hosted_scenario_repair_command,
     _validate_egress_domains,
     authoring_stage_outputs_from_archive,
 )
@@ -252,17 +253,22 @@ def test_authoring_archive_reads_per_scenario_files_and_respects_run_count():
     ]
 
 
-def test_hosted_scenario_repair_script_requests_exact_missing_count_safely():
-    script = _hosted_scenario_repair_script(
-        name="hotel'); raise RuntimeError('unsafe",
-        expected=3,
-        actual=2,
+def test_hosted_scenario_repair_command_targets_exact_count_shell_safely():
+    unsafe_name = "hotel'); raise RuntimeError('unsafe"
+    command = _hosted_scenario_repair_command(name=unsafe_name, expected=3, actual=2)
+    # Talks to the harness's real CLI, non-interactively, against the reused authoring.
+    assert command.startswith("python -m fi.alk.harness.cli scenarios")
+    assert "--out /work/authoring" in command
+    assert "--count 3" in command
+    assert "--once" in command
+    instruction = (
+        "Exactly 3 scenarios are required, but 2 are saved. "
+        "Add exactly 1 distinct validated scenario(s) and preserve the existing ones."
     )
-
-    compile(script, "repair-scenarios.py", "exec")
-    assert "Add exactly 1 distinct validated scenario" in script
-    assert "count=3" in script
-    assert "name=\"hotel'); raise RuntimeError('unsafe\"" in script
+    assert f"--guidance {shlex.quote(instruction)}" in command
+    # Untrusted values reach the shell only via shlex.quote — no unescaped injection.
+    assert shlex.quote(unsafe_name) in command
+    assert "); raise RuntimeError(" not in command.replace(shlex.quote(unsafe_name), "")
     assert "-type d" in _SCENARIO_DIRECTORY_COUNT_COMMAND
     assert "ls " not in _SCENARIO_DIRECTORY_COUNT_COMMAND
 

--- a/futureagi/simulate/views/harness_job.py
+++ b/futureagi/simulate/views/harness_job.py
@@ -15,6 +15,7 @@ from simulate.serializers.harness_job import (
     HarnessJobActionSerializer,
     HarnessJobAdjustmentSerializer,
     HarnessJobCreateSerializer,
+    HarnessJobExtendSerializer,
     HarnessJobReadSerializer,
     HarnessPreflightSerializer,
     HarnessSecretFileUploadResponseSerializer,
@@ -263,6 +264,14 @@ class HarnessJobViewSet(viewsets.ViewSet):
     @action(detail=True, methods=["post"])
     def adjust(self, request, pk=None):
         return get_harness_provider().adjust(request, pk)
+
+    @validated_request(
+        request_serializer=HarnessJobExtendSerializer,
+        reject_unknown_fields=True,
+    )
+    @action(detail=True, methods=["post"])
+    def extend(self, request, pk=None):
+        return get_harness_provider().extend(request, pk)
 
     @action(detail=False, methods=["get"])
     def health(self, request):


### PR DESCRIPTION
Pairs with **agent-learning-kit#77** (`--guidance` on `cli scenarios`). The snapshot must include that flag; verified against `alk-hosted-bundle-v2-azain-extend-20260907` (latest bundle-v2 guest + #77).

## What
The finished-run chat box becomes an explicit **Add scenarios** action, and scenario extension runs through the harness's public CLI instead of platform-side codegen.

### Backend
- `extend` takes a structured `{count, guidance}` (count 1..50, guidance optional) instead of parsing a count out of prose. An empty message no longer silently triggers a rerun (rerun stays a separate action).
- The gateway no longer hand-writes Python that imports ALK's private `_scenarios`. Extend **and** repair now run `python -m fi.alk.harness.cli scenarios --name … --out /work/authoring --count N --once --guidance …` in the sandbox against the reused `/work/authoring` (shell-safe via `shlex.quote`).
- `serialize_job` exposes `adjustments`; environment name falls back to the source repo when no metadata name was authored.

### Frontend
- `HarnessDetail` composer: guidance text + count stepper + **Add scenarios** button.
- `environmentName`: `agent_name` → `metadata.name` → source repo name (never the job id). Tests added.
- API surface contract gains `POST /simulate/api/harness-jobs/{id}/extend/`.

## Verification (on this branch, rebased onto bundle-v2 `81e23b06f`)
- Backend: `test_harness_read_dto`, `test_hosted_harness_gateway`, `test_harness_provider(_modes)`, `test_hosted_harness_channels`, `test_alk_simulate_ingestion`, `test_hosted_harness_eval_selection` → 343 passed. The 2 failures in `test_harness_read_dto` (`test_serialize_job_returns_full_dto_shape`, `test_create_rejects_non_platform_vault_secret_ref`) **fail identically on pristine bundle-v2** — pre-existing, not introduced here.
- Frontend: eslint clean; `vitest src/pages/dashboard/harness` → 174/174; `check-api-surface-usage` + endpoint-registry checks pass.
- Builders verified to emit the exact CLI and to reject shell injection.

Note: `api-surface.generated.js` was patched minimally (only the `extend` route) rather than fully regenerated — a local regen drops the cloud-EE telemetry routes that aren't mountable outside cloud.