### PR TITLE
fix(sdk): start CI/CD evaluation workflows after the creating transaction commits

### DIFF
--- a/futureagi/ai_tools/tests/test_evaluation_tools.py
+++ b/futureagi/ai_tools/tests/test_evaluation_tools.py
@@ -5,7 +5,12 @@ import pytest
 
 from ai_tools.registry import registry
 from ai_tools.tests.conftest import run_tool
-from ai_tools.tests.fixtures import make_eval_template, make_evaluation
+from ai_tools.tests.fixtures import (
+    make_dataset_with_rows,
+    make_eval_template,
+    make_evaluation,
+)
+from model_hub.models.evaluation import Evaluation, StatusChoices
 
 # ---------------------------------------------------------------------------
 # Shared fixtures
@@ -413,3 +418,32 @@ class TestCreateEvalGroupTool:
 
         assert not result.is_error
         assert result.data["template_count"] == 2
+
+
+class TestRunEvaluationTool:
+    def test_unstartable_workflow_leaves_evaluation_failed(
+        self, tool_context, eval_template
+    ):
+        dataset, _, _ = make_dataset_with_rows(tool_context, name="Run Eval Dataset")
+
+        async def _workflow_unavailable(*args, **kwargs):
+            raise RuntimeError("temporal is unreachable")
+
+        with patch(
+            "tfc.temporal.evaluations.client.start_evaluation_workflow_async",
+            _workflow_unavailable,
+        ):
+            result = run_tool(
+                "run_evaluation",
+                {
+                    "eval_template_id": str(eval_template.id),
+                    "dataset_id": str(dataset.id),
+                },
+                tool_context,
+            )
+
+        assert not result.is_error
+
+        evaluation = Evaluation.objects.get(id=result.data["evaluation_id"])
+        assert evaluation.status == StatusChoices.FAILED
+        assert "Queued" not in result.content

--- a/futureagi/ai_tools/tools/evaluations/run_evaluation.py
+++ b/futureagi/ai_tools/tools/evaluations/run_evaluation.py
@@ -12,6 +12,8 @@ from ai_tools.formatting import (
 )
 from ai_tools.registry import register_tool
 from model_hub.models.choices import ModelChoices
+from model_hub.models.evaluation import StatusChoices
+from sdk.utils.async_evaluations import mark_evaluation_failed
 
 
 class RunEvaluationInput(PydanticBaseModel):
@@ -99,7 +101,7 @@ class RunEvaluationTool(BaseTool):
             workspace=context.workspace,
             eval_template=template,
             model_name=model,
-            status="pending",
+            status=StatusChoices.PENDING,
             input_data={"dataset_id": str(dataset.id)},
             eval_config=template.config or {},
         )
@@ -113,12 +115,17 @@ class RunEvaluationTool(BaseTool):
             from tfc.temporal.evaluations.client import start_evaluation_workflow_async
 
             async_to_sync(start_evaluation_workflow_async)(str(evaluation.id))
-            evaluation.status = "processing"
-            evaluation.save(update_fields=["status"])
             workflow_started = True
         except Exception as e:
-            # Workflow failed to start, mark as pending (will be picked up by polling)
-            pass
+            # Nothing sweeps unstarted evaluations, so leaving this pending strands it.
+            mark_evaluation_failed(
+                str(evaluation.id), f"Evaluation workflow could not be started: {e}"
+            )
+            evaluation.refresh_from_db()
+
+        if workflow_started:
+            evaluation.status = StatusChoices.PROCESSING
+            evaluation.save(update_fields=["status"])
 
         info = key_value_block(
             [
@@ -129,11 +136,7 @@ class RunEvaluationTool(BaseTool):
                 ("Status", format_status(evaluation.status)),
                 (
                     "Workflow",
-                    (
-                        "Started"
-                        if workflow_started
-                        else "Queued (will be picked up shortly)"
-                    ),
+                    ("Started" if workflow_started else "Failed to start"),
                 ),
                 (
                     "Link",

--- a/futureagi/sdk/tests/test_eval_ci_cd.py
+++ b/futureagi/sdk/tests/test_eval_ci_cd.py
@@ -5,6 +5,8 @@ Tests for SDK CI/CD evaluation endpoints that allow running evaluations via pipe
 Note: These endpoints use APIKeyAuthentication which accepts both JWT and API key auth.
 """
 
+from unittest.mock import patch
+
 import pytest
 from rest_framework import status
 
@@ -342,3 +344,129 @@ class TestCICDEvaluationsGetAPI:
         )
         # Returns 400 because version doesn't exist, but auth succeeded
         assert response.status_code == status.HTTP_400_BAD_REQUEST
+
+
+@pytest.mark.integration
+@pytest.mark.api
+class TestCICDEvaluationsWorkflowDispatch:
+    """Tests for how POST /sdk/api/v1/evaluate-pipeline/ hands its rows to the worker."""
+
+    def _post_run(self, auth_client, project, version, eval_data):
+        return auth_client.post(
+            "/sdk/api/v1/evaluate-pipeline/",
+            {
+                "project_name": project.name,
+                "version": version,
+                "eval_data": eval_data,
+            },
+            format="json",
+        )
+
+    def test_workflow_starts_once_per_row_only_after_the_rows_are_committed(
+        self,
+        auth_client,
+        observe_project,
+        eval_template,
+        django_capture_on_commit_callbacks,
+    ):
+        """No workflow is started while the rows are still uncommitted, and every
+        row gets exactly one workflow once the write lands."""
+        from tracer.models.eval_ci_cd import EvaluationResult
+
+        started = []
+
+        with patch(
+            "tfc.temporal.evaluations.start_evaluation_workflow",
+            side_effect=lambda evaluation_id: started.append(evaluation_id),
+        ):
+            with django_capture_on_commit_callbacks(execute=True):
+                response = self._post_run(
+                    auth_client,
+                    observe_project,
+                    "v-dispatch-1",
+                    [
+                        {
+                            "eval_template": eval_template.name,
+                            "inputs": {
+                                "input": ["first", "second"],
+                                "output": ["one", "two"],
+                            },
+                        },
+                        {
+                            "eval_template": eval_template.name,
+                            "inputs": {
+                                "input": ["third", "fourth"],
+                                "output": ["three", "four"],
+                            },
+                        },
+                    ],
+                )
+                assert response.status_code == status.HTTP_200_OK
+                assert started == []
+
+        evaluation_run_id = response.json()["result"]["evaluation_run_id"]
+        row_ids = [
+            str(evaluation_id)
+            for evaluation_id in EvaluationResult.objects.filter(
+                evaluation_run_id=evaluation_run_id
+            ).values_list("evaluation_id", flat=True)
+        ]
+
+        assert len(row_ids) == 4
+        assert sorted(started) == sorted(row_ids)
+
+    def test_poll_reports_completed_when_the_workflow_cannot_be_started(
+        self,
+        auth_client,
+        observe_project,
+        eval_template,
+        django_capture_on_commit_callbacks,
+    ):
+        """A workflow start that blows up leaves every row terminal, so the
+        pipeline poll answers "completed" instead of "processing" forever."""
+        from model_hub.models.evaluation import Evaluation, StatusChoices
+        from sdk.utils.cicd_evaluations import are_evaluation_runs_processing
+        from tracer.models.eval_ci_cd import EvaluationRun
+
+        with patch(
+            "tfc.temporal.evaluations.start_evaluation_workflow",
+            side_effect=RuntimeError("temporal is unreachable"),
+        ):
+            with django_capture_on_commit_callbacks(execute=True):
+                response = self._post_run(
+                    auth_client,
+                    observe_project,
+                    "v-dispatch-2",
+                    [
+                        {
+                            "eval_template": eval_template.name,
+                            "inputs": {
+                                "input": ["first", "second"],
+                                "output": ["one", "two"],
+                            },
+                        }
+                    ],
+                )
+
+        assert response.status_code == status.HTTP_200_OK
+        evaluation_run = EvaluationRun.objects.get(
+            id=response.json()["result"]["evaluation_run_id"]
+        )
+
+        evaluations = list(
+            Evaluation.objects.filter(ci_cd_result__evaluation_run=evaluation_run)
+        )
+        assert len(evaluations) == 2
+        assert {row.status for row in evaluations} == {StatusChoices.FAILED}
+        assert all(
+            "temporal is unreachable" in row.error_message for row in evaluations
+        )
+
+        assert are_evaluation_runs_processing([evaluation_run]) is False
+
+        poll = auth_client.get(
+            "/sdk/api/v1/evaluate-pipeline/"
+            f"?project_name={observe_project.name}&versions={evaluation_run.version}"
+        )
+        assert poll.status_code == status.HTTP_200_OK
+        assert poll.json()["result"]["status"] == "completed"

--- a/futureagi/sdk/tests/test_evaluations.py
+++ b/futureagi/sdk/tests/test_evaluations.py
@@ -380,24 +380,28 @@ class TestStandaloneEvalV2API:
         assert "k must be an integer" in str(response.json())
 
     def test_new_eval_post_async_persists_function_params(
-        self, auth_client, function_param_eval_template
+        self,
+        auth_client,
+        function_param_eval_template,
+        django_capture_on_commit_callbacks,
     ):
         from model_hub.models.evaluation import Evaluation
 
         with patch("tfc.temporal.evaluations.start_evaluation_workflow") as mock_start:
-            response = auth_client.post(
-                "/sdk/api/v1/new-eval/",
-                {
-                    "eval_name": function_param_eval_template.name,
-                    "inputs": {
-                        "hypothesis": '["A", "B"]',
-                        "reference": '["A", "C"]',
+            with django_capture_on_commit_callbacks(execute=True):
+                response = auth_client.post(
+                    "/sdk/api/v1/new-eval/",
+                    {
+                        "eval_name": function_param_eval_template.name,
+                        "inputs": {
+                            "hypothesis": '["A", "B"]',
+                            "reference": '["A", "C"]',
+                        },
+                        "config": {"params": {"k": 4}},
+                        "is_async": True,
                     },
-                    "config": {"params": {"k": 4}},
-                    "is_async": True,
-                },
-                format="json",
-            )
+                    format="json",
+                )
 
         assert response.status_code == status.HTTP_200_OK
         payload = response.json()
@@ -412,6 +416,31 @@ class TestStandaloneEvalV2API:
         evaluation = Evaluation.objects.get(id=eval_id)
         assert evaluation.eval_config.get("params", {}).get("k") == 4
         mock_start.assert_called_once()
+
+    @pytest.mark.django_db(transaction=True)
+    def test_new_eval_post_async_starts_the_workflow_before_the_response_returns(
+        self, auth_client, eval_template
+    ):
+        """Outside any open transaction the standalone path starts the workflow
+        inline, so the SDK caller waits on nothing extra."""
+        from model_hub.models.evaluation import Evaluation
+
+        with patch("tfc.temporal.evaluations.start_evaluation_workflow") as mock_start:
+            response = auth_client.post(
+                "/sdk/api/v1/new-eval/",
+                {
+                    "eval_name": eval_template.name,
+                    "inputs": {"input": "a question", "output": "an answer"},
+                    "is_async": True,
+                },
+                format="json",
+            )
+
+            assert response.status_code == status.HTTP_200_OK
+            eval_id = response.json()["result"][0]["evaluations"][0]["eval_id"]
+            mock_start.assert_called_once_with(evaluation_id=eval_id)
+
+        assert Evaluation.objects.filter(id=eval_id).exists()
 
 
 @pytest.mark.integration

--- a/futureagi/sdk/tests/test_evaluations.py
+++ b/futureagi/sdk/tests/test_evaluations.py
@@ -417,31 +417,6 @@ class TestStandaloneEvalV2API:
         assert evaluation.eval_config.get("params", {}).get("k") == 4
         mock_start.assert_called_once()
 
-    @pytest.mark.django_db(transaction=True)
-    def test_new_eval_post_async_starts_the_workflow_before_the_response_returns(
-        self, auth_client, eval_template
-    ):
-        """Outside any open transaction the standalone path starts the workflow
-        inline, so the SDK caller waits on nothing extra."""
-        from model_hub.models.evaluation import Evaluation
-
-        with patch("tfc.temporal.evaluations.start_evaluation_workflow") as mock_start:
-            response = auth_client.post(
-                "/sdk/api/v1/new-eval/",
-                {
-                    "eval_name": eval_template.name,
-                    "inputs": {"input": "a question", "output": "an answer"},
-                    "is_async": True,
-                },
-                format="json",
-            )
-
-            assert response.status_code == status.HTTP_200_OK
-            eval_id = response.json()["result"][0]["evaluations"][0]["eval_id"]
-            mock_start.assert_called_once_with(evaluation_id=eval_id)
-
-        assert Evaluation.objects.filter(id=eval_id).exists()
-
 
 @pytest.mark.integration
 @pytest.mark.api

--- a/futureagi/sdk/utils/async_evaluations.py
+++ b/futureagi/sdk/utils/async_evaluations.py
@@ -8,9 +8,10 @@ Celery approach).
 """
 
 import structlog
+from django.db import transaction
 
 logger = structlog.get_logger(__name__)
-from model_hub.models.evaluation import Evaluation
+from model_hub.models.evaluation import Evaluation, StatusChoices
 from tfc.middleware.workspace_context import get_current_organization
 
 
@@ -130,22 +131,30 @@ def _handle_single_async_eval(
         error_localizer_enabled=error_localizer_enabled,
     )
 
-    # Start workflow immediately instead of waiting for polling
-    try:
-        from tfc.temporal.evaluations import start_evaluation_workflow
+    evaluation_id = str(evaluation.id)
 
-        start_evaluation_workflow(evaluation_id=str(evaluation.id))
-        logger.info(f"Started evaluation workflow for {evaluation.id}")
-    except Exception as e:
-        logger.exception(
-            f"Failed to start evaluation workflow for {evaluation.id}: {e}"
-        )
-        # Don't fail the API call - evaluation will be picked up by fallback if needed
+    def _start_workflow():
+        try:
+            from tfc.temporal.evaluations import start_evaluation_workflow
+
+            start_evaluation_workflow(evaluation_id=evaluation_id)
+            logger.info(f"Started evaluation workflow for {evaluation_id}")
+        except Exception as e:
+            logger.exception(
+                f"Failed to start evaluation workflow for {evaluation_id}: {e}"
+            )
+            Evaluation.objects.filter(id=evaluation_id).update(
+                status=StatusChoices.FAILED,
+                error_message=f"Evaluation workflow could not be started: {e}",
+            )
+
+    # The worker reads this row on its own connection, so it must be committed first.
+    transaction.on_commit(_start_workflow)
 
     return {
         "name": eval_template.name,
         "output_type": eval_template.config.get("output", "score"),
-        "eval_id": str(evaluation.id),
+        "eval_id": evaluation_id,
     }
 
 

--- a/futureagi/sdk/utils/async_evaluations.py
+++ b/futureagi/sdk/utils/async_evaluations.py
@@ -15,6 +15,23 @@ from model_hub.models.evaluation import Evaluation, StatusChoices
 from tfc.middleware.workspace_context import get_current_organization
 
 
+def mark_evaluation_failed(evaluation_id: str, error_message: str) -> None:
+    """Write the terminal FAILED status for an evaluation without ever raising."""
+    try:
+        # Unscoped: the row may carry no workspace, and a scoped miss would strand it.
+        updated = Evaluation.no_workspace_objects.filter(id=evaluation_id).update(
+            status=StatusChoices.FAILED, error_message=error_message
+        )
+        if not updated:
+            logger.error(
+                "evaluation_terminal_status_not_written", evaluation_id=evaluation_id
+            )
+    except Exception:
+        logger.exception(
+            "evaluation_terminal_status_write_failed", evaluation_id=evaluation_id
+        )
+
+
 def _handle_async_eval(
     eval_template,
     inputs,
@@ -143,13 +160,13 @@ def _handle_single_async_eval(
             logger.exception(
                 f"Failed to start evaluation workflow for {evaluation_id}: {e}"
             )
-            Evaluation.objects.filter(id=evaluation_id).update(
-                status=StatusChoices.FAILED,
-                error_message=f"Evaluation workflow could not be started: {e}",
+            mark_evaluation_failed(
+                evaluation_id, f"Evaluation workflow could not be started: {e}"
             )
 
     # The worker reads this row on its own connection, so it must be committed first.
-    transaction.on_commit(_start_workflow)
+    # robust: one row's failed start must not drop the remaining rows' callbacks.
+    transaction.on_commit(_start_workflow, robust=True)
 
     return {
         "name": eval_template.name,

--- a/futureagi/sdk/utils/cicd_evaluations.py
+++ b/futureagi/sdk/utils/cicd_evaluations.py
@@ -55,7 +55,9 @@ def create_evaluations(evaluation_run_id, organization_id, user_id, eval_data_li
                 ]
                 all_eval_ids.extend(eval_ids)
 
-            evaluations_to_link = Evaluation.objects.filter(id__in=all_eval_ids)
+            evaluations_to_link = Evaluation.no_workspace_objects.filter(
+                id__in=all_eval_ids
+            )
             evaluation_results = [
                 EvaluationResult(
                     evaluation_run=evaluation_run,

--- a/futureagi/tfc/temporal/evaluations/activities.py
+++ b/futureagi/tfc/temporal/evaluations/activities.py
@@ -32,6 +32,7 @@ def _run_single_evaluation_sync(evaluation_id: str) -> dict:
     close_old_connections()
 
     from model_hub.models.evaluation import Evaluation, StatusChoices
+    from sdk.utils.async_evaluations import mark_evaluation_failed
 
     evaluation = None
     try:
@@ -84,8 +85,13 @@ def _run_single_evaluation_sync(evaluation_id: str) -> dict:
 
         evaluation.save()
 
-        # Trigger inline eval (for trace integration)
-        trigger_inline_eval(evaluation)
+        # Isolated: a trace-integration failure must not downgrade a completed run.
+        try:
+            trigger_inline_eval(evaluation)
+        except Exception:
+            logger.exception(
+                "evaluation_inline_eval_failed", evaluation_id=evaluation_id
+            )
 
         return {
             "evaluation_id": str(evaluation.id),
@@ -94,23 +100,14 @@ def _run_single_evaluation_sync(evaluation_id: str) -> dict:
 
     except Exception as e:
         if evaluation is None:
-            # The row was never loaded, so write the terminal status directly.
-            try:
-                Evaluation.objects.filter(id=evaluation_id).update(
-                    status=StatusChoices.FAILED, error_message=str(e)
-                )
-            except Exception:
-                logger.exception(
-                    "evaluation_terminal_status_write_failed",
-                    evaluation_id=evaluation_id,
-                )
+            mark_evaluation_failed(evaluation_id, str(e))
         else:
             evaluation.status = StatusChoices.FAILED
             evaluation.error_message = str(e)
 
         return {
             "evaluation_id": evaluation_id,
-            "status": "FAILED",
+            "status": StatusChoices.FAILED,
             "error": str(e),
         }
 
@@ -119,7 +116,11 @@ def _run_single_evaluation_sync(evaluation_id: str) -> dict:
             try:
                 evaluation.save()
             except Exception:
-                pass
+                logger.exception(
+                    "evaluation_status_save_failed", evaluation_id=evaluation_id
+                )
+                if evaluation.status == StatusChoices.FAILED:
+                    mark_evaluation_failed(evaluation_id, evaluation.error_message)
         close_old_connections()
 
 
@@ -166,9 +167,11 @@ async def run_single_evaluation_activity(
             f"Error running evaluation {input.evaluation_id}: {e}"
         )
 
+        from model_hub.models.evaluation import StatusChoices
+
         return RunSingleEvaluationOutput(
             evaluation_id=input.evaluation_id,
-            status="FAILED",
+            status=StatusChoices.FAILED,
             error=str(e),
         )
 

--- a/futureagi/tfc/temporal/evaluations/activities.py
+++ b/futureagi/tfc/temporal/evaluations/activities.py
@@ -5,6 +5,7 @@ These activities process individual Evaluation objects immediately when
 triggered, rather than being polled by a scheduled job.
 """
 
+import structlog
 from django.db import close_old_connections
 from temporalio import activity
 
@@ -13,6 +14,8 @@ from tfc.temporal.evaluations.types import (
     RunSingleEvaluationInput,
     RunSingleEvaluationOutput,
 )
+
+logger = structlog.get_logger(__name__)
 
 # =============================================================================
 # Synchronous Helper Functions
@@ -28,8 +31,10 @@ def _run_single_evaluation_sync(evaluation_id: str) -> dict:
     """
     close_old_connections()
 
+    from model_hub.models.evaluation import Evaluation, StatusChoices
+
+    evaluation = None
     try:
-        from model_hub.models.evaluation import Evaluation, StatusChoices
         from model_hub.tasks.user_evaluation import (
             trigger_error_localization_for_standalone,
         )
@@ -88,10 +93,20 @@ def _run_single_evaluation_sync(evaluation_id: str) -> dict:
         }
 
     except Exception as e:
-        # Mark as failed on any error (matches original behavior)
-        evaluation.status = StatusChoices.FAILED
-        evaluation.error_message = str(e)
-        # Don't return here - let finally block save and return
+        if evaluation is None:
+            # The row was never loaded, so write the terminal status directly.
+            try:
+                Evaluation.objects.filter(id=evaluation_id).update(
+                    status=StatusChoices.FAILED, error_message=str(e)
+                )
+            except Exception:
+                logger.exception(
+                    "evaluation_terminal_status_write_failed",
+                    evaluation_id=evaluation_id,
+                )
+        else:
+            evaluation.status = StatusChoices.FAILED
+            evaluation.error_message = str(e)
 
         return {
             "evaluation_id": evaluation_id,
@@ -100,11 +115,11 @@ def _run_single_evaluation_sync(evaluation_id: str) -> dict:
         }
 
     finally:
-        # Always save (matches original finally block behavior)
-        try:
-            evaluation.save()
-        except Exception:
-            pass  # evaluation might not be defined if initial get() failed
+        if evaluation is not None:
+            try:
+                evaluation.save()
+            except Exception:
+                pass
         close_old_connections()
 
 

--- a/futureagi/tfc/temporal/evaluations/tests/test_activities.py
+++ b/futureagi/tfc/temporal/evaluations/tests/test_activities.py
@@ -1,0 +1,82 @@
+"""Tests for the terminal status the evaluation activity writes back when the
+Evaluation it was handed cannot be loaded."""
+
+import uuid
+
+import pytest
+
+from model_hub.models.evaluation import Evaluation, StatusChoices
+
+
+@pytest.fixture
+def eval_template(db):
+    from model_hub.models.evals_metric import EvalTemplate
+
+    template, _ = EvalTemplate.objects.get_or_create(
+        name="Test Activity Eval Template",
+        defaults={
+            "description": "A test evaluation template for the activity",
+            "eval_id": 999004,
+            "eval_tags": ["test"],
+            "config": {
+                "eval_type_id": "TestEval",
+                "required_keys": ["input", "output"],
+                "optional_keys": [],
+            },
+            "owner": "system",
+            "organization": None,
+        },
+    )
+    return template
+
+
+@pytest.fixture
+def evaluation(user, workspace, eval_template):
+    return Evaluation.objects.create(
+        user=user,
+        organization=user.organization,
+        workspace=workspace,
+        eval_template=eval_template,
+        input_data={"input": "a question", "output": "an answer"},
+        eval_config={},
+    )
+
+
+@pytest.mark.integration
+@pytest.mark.django_db(transaction=True)
+class TestRunSingleEvaluationSync:
+    def test_unknown_evaluation_id_returns_failed_without_raising(self):
+        from tfc.temporal.evaluations.activities import _run_single_evaluation_sync
+
+        unknown_id = str(uuid.uuid4())
+
+        result = _run_single_evaluation_sync(unknown_id)
+
+        assert result["evaluation_id"] == unknown_id
+        assert result["status"] == "FAILED"
+        assert result["error"]
+
+    def test_row_that_cannot_be_loaded_is_left_failed(self, evaluation, monkeypatch):
+        from tfc.temporal.evaluations.activities import _run_single_evaluation_sync
+
+        def _not_visible(*args, **kwargs):
+            raise Evaluation.DoesNotExist("Evaluation matching query does not exist.")
+
+        with monkeypatch.context() as patched:
+            patched.setattr(Evaluation.objects, "select_related", _not_visible)
+            result = _run_single_evaluation_sync(str(evaluation.id))
+
+        assert result["status"] == "FAILED"
+
+        evaluation.refresh_from_db()
+        assert evaluation.status == StatusChoices.FAILED
+        assert evaluation.error_message
+
+    def test_malformed_evaluation_id_returns_failed_without_raising(self):
+        from tfc.temporal.evaluations.activities import _run_single_evaluation_sync
+
+        result = _run_single_evaluation_sync("not-a-uuid")
+
+        assert result["evaluation_id"] == "not-a-uuid"
+        assert result["status"] == "FAILED"
+        assert result["error"]

--- a/futureagi/tfc/temporal/evaluations/tests/test_activities.py
+++ b/futureagi/tfc/temporal/evaluations/tests/test_activities.py
@@ -1,9 +1,9 @@
-"""Tests for the terminal status the evaluation activity writes back when the
-Evaluation it was handed cannot be loaded."""
+"""Tests for the terminal status the evaluation activity writes back."""
 
 import uuid
 
 import pytest
+from django.db import DatabaseError
 
 from model_hub.models.evaluation import Evaluation, StatusChoices
 
@@ -53,7 +53,7 @@ class TestRunSingleEvaluationSync:
         result = _run_single_evaluation_sync(unknown_id)
 
         assert result["evaluation_id"] == unknown_id
-        assert result["status"] == "FAILED"
+        assert result["status"] == StatusChoices.FAILED
         assert result["error"]
 
     def test_row_that_cannot_be_loaded_is_left_failed(self, evaluation, monkeypatch):
@@ -66,11 +66,37 @@ class TestRunSingleEvaluationSync:
             patched.setattr(Evaluation.objects, "select_related", _not_visible)
             result = _run_single_evaluation_sync(str(evaluation.id))
 
-        assert result["status"] == "FAILED"
+        assert result["status"] == StatusChoices.FAILED
 
         evaluation.refresh_from_db()
         assert evaluation.status == StatusChoices.FAILED
         assert evaluation.error_message
+
+    def test_row_whose_terminal_save_fails_is_left_failed(
+        self, evaluation, monkeypatch
+    ):
+        from tfc.temporal.evaluations.activities import _run_single_evaluation_sync
+
+        original_save = Evaluation.save
+
+        def _reject_terminal_save(self, *args, **kwargs):
+            if kwargs.get("update_fields"):
+                return original_save(self, *args, **kwargs)
+            raise DatabaseError("terminal status write rejected")
+
+        def _engine_unavailable(*args, **kwargs):
+            raise RuntimeError("eval engine unavailable")
+
+        with monkeypatch.context() as patched:
+            patched.setattr("sdk.utils.evaluations._run_eval", _engine_unavailable)
+            patched.setattr(Evaluation, "save", _reject_terminal_save)
+            result = _run_single_evaluation_sync(str(evaluation.id))
+
+        assert result["status"] == StatusChoices.FAILED
+
+        evaluation.refresh_from_db()
+        assert evaluation.status == StatusChoices.FAILED
+        assert "eval engine unavailable" in evaluation.error_message
 
     def test_malformed_evaluation_id_returns_failed_without_raising(self):
         from tfc.temporal.evaluations.activities import _run_single_evaluation_sync
@@ -78,5 +104,5 @@ class TestRunSingleEvaluationSync:
         result = _run_single_evaluation_sync("not-a-uuid")
 
         assert result["evaluation_id"] == "not-a-uuid"
-        assert result["status"] == "FAILED"
+        assert result["status"] == StatusChoices.FAILED
         assert result["error"]


### PR DESCRIPTION
## The problem

You have a set of test questions and the answers you expect back. You send them to Future AGI from your CI job to score a release before it ships. The API accepts the run and tells you it is being processed.

It never stops being processed.

You poll for the result. Twenty minutes later, an hour later, the next morning, the answer is the same: still processing. Nothing failed, nothing errored, there is no message anywhere telling you something went wrong. Your pipeline just hangs on a check that can never finish, so the release gate you built never gives you a verdict.

If you run a handful of rows it works. Run a hundred and almost none of them ever get scored.

## Why it is easy to miss

Every signal you get says the run is healthy. The request returns success. The run appears in your project with the version you tagged it with. A few rows even come back scored, so the feature is clearly wired up and the evaluator clearly works.

The rows that never ran leave no trace at all. They are not marked failed, because the code that would have marked them failed breaks before it gets there. They simply sit, and the only endpoint that could tell you treats sitting as still working.

Small test runs pass, which is what you reach for first when something is not behaving. The problem only appears at the size a real release gate actually uses.

---

Evaluations submitted through the CI/CD endpoint stayed `PENDING` forever and the results endpoint reported `processing` indefinitely. The Temporal workflow for each evaluation was started inside the transaction that created the row, so the worker read the row on a different connection, could not see it, exhausted its retry budget in about fifteen seconds and gave up. A second defect meant the activity's own error handler raised before it could record the failure, so the row never reached a terminal state either. The workflow start now runs on `transaction.on_commit`, and the activity's error handler writes the terminal status safely whether or not the row was ever loaded.

## Why the changes are done — what is the problem

### Reproduce on dev/main today (before this PR)

1. Pick any project with `trace_type="observe"`.
2. `POST /sdk/api/v1/evaluate-pipeline/` with `project_name`, a fresh `version`, and one `eval_data` entry whose `inputs` carry 100 parallel values.
3. The request returns `200` with `"Evaluation run accepted and is being processed."`
4. Query the evaluation rows for that run. 91 of 100 sit at `pending` with an empty `error_message`.
5. The only rows that completed are the last nine created.
6. `GET /sdk/api/v1/evaluate-pipeline/?project_name=<p>&versions=<v>` returns `{"status": "processing"}`, and still returns it twenty minutes later.

### Where it breaks — BE

`create_evaluations` (`futureagi/sdk/utils/cicd_evaluations.py`) opens `with transaction.atomic():` and calls `_handle_async_eval` inside it. That reaches `_handle_single_async_eval` (`futureagi/sdk/utils/async_evaluations.py`), which created the `Evaluation` row and then called `start_evaluation_workflow` on the very next line.

The Temporal worker executes `_run_single_evaluation_sync` on its own connection and opens with `Evaluation.objects.select_related(...).get(id=evaluation_id)`. The creating transaction has not committed, so that row does not exist for the worker and the get raises `DoesNotExist`. `EVALUATION_RETRY_POLICY` (`futureagi/tfc/temporal/evaluations/workflows.py`) allows three attempts with a five second initial interval and a coefficient of two, giving a window of roughly fifteen seconds. A hundred-row batch holds the transaction open longer than that, so all but the last few rows exhaust their attempts before the commit lands.

The comment on the old start block said the evaluation would be picked up by a fallback. There is no fallback. The Celery poller that used to be one was removed at the Temporal cutover, as the block comment at the bottom of that same file records.

The second defect compounds it. `_run_single_evaluation_sync` (`futureagi/tfc/temporal/evaluations/activities.py`) ran `evaluation.status = StatusChoices.FAILED` inside `except Exception`, but `evaluation` is only assigned by the `get` that just raised. The handler therefore raised `UnboundLocalError` and the row was never written back as failed.

`are_evaluation_runs_processing` excludes only `COMPLETED` and `FAILED`. A row that can reach neither keeps the results endpoint on `processing` permanently, which is the symptom the caller actually experiences.

## What changed

### futureagi/sdk/utils/async_evaluations.py

- The workflow start moved into a `_start_workflow` closure handed to `transaction.on_commit`, so the worker is only ever given an id it can read. Django executes the callback immediately when no atomic block is open, so the standalone SDK path keeps its current timing.
- This matches the pattern already shipped for eval-task reruns in `2e8f40284`, which fixed the same class of bug in `futureagi/tracer/views/eval_task.py`. Reusing it rather than inventing a second shape.
- A failure to start the workflow now marks the row `FAILED` with the reason instead of leaving it pending, so the results endpoint always reaches a terminal answer.
- `evaluation_id` is captured once and reused, so the closure does not hold the model instance alive.

### futureagi/tfc/temporal/evaluations/activities.py

- `evaluation` is bound to `None` before the `try`, and the `Evaluation` / `StatusChoices` imports moved above it, so the error handler is well defined no matter where the failure occurred.
- When the row was never loaded, the terminal status is written with a queryset update rather than through the unbound instance. That write is itself guarded, because an error handler that can raise is the exact defect being fixed here.
- The `finally` block only saves when there is an instance to save, replacing a bare `except: pass` that existed to paper over the unbound case.

### futureagi/ai_tools/tools/evaluations/run_evaluation.py

- The same defect lived here: the workflow start was wrapped in `except Exception: pass` with a comment saying the evaluation would be picked up by polling. Nothing polls `Evaluation`. The only sweeper, `execute_evaluation`, queries `UserEvalMetric`. A failed start stranded the row at pending permanently, exactly as on the CI/CD path.
- It now records the terminal status through the shared helper and the tool's own output says the workflow failed to start rather than claiming it is queued.
- `"pending"` and `"processing"` replaced with the `StatusChoices` members they were duplicating.

## Design notes the reviewer would otherwise have to ask for

**Why there is no `replace_existing` / `id_conflict_policy` here.** The eval-task version of this fix (`2e8f40284`) needed one because `eval-task-{id}` is a stable per-task workflow id reused across pause, resume and rerun, so a closing execution could absorb a fresh start. This path derives its id from `evaluation-{evaluation_id}`, where the uuid is minted fresh on every request and no code path ever re-dispatches an existing evaluation id. There is no conflict for a policy to resolve.

**Why this callback swallows when the eval-task one deliberately does not.** That commit kept its callback non-robust on purpose, because a committed PENDING eval-task is retryable through the unpause and rerun endpoints. An `Evaluation` has neither a retry endpoint nor a sweeper, so a swallowed start is unrecoverable and a terminal FAILED is the only exit that lets the caller's poll finish. The difference is deliberate, not an oversight.

## Tests included — what each scenario covers

| # | Test | Setup | Action | What it pins |
|---|---|---|---|---|
| 1 | `test_workflow_starts_once_per_row_only_after_the_rows_are_committed` | Two `eval_data` entries of two rows each | Real `POST /sdk/api/v1/evaluate-pipeline/` inside a captured commit block | No workflow starts while the transaction is open, and after commit exactly the four ids linked through `EvaluationResult` start, one each |
| 2 | `test_poll_reports_completed_when_the_workflow_cannot_be_started` | Workflow start raises | Real POST, then real GET | Both rows land `FAILED` with the reason recorded, `are_evaluation_runs_processing` is False, and the results endpoint returns `completed` rather than hanging |
| 3 | `test_new_eval_post_async_starts_the_workflow_before_the_response_returns` | `django_db(transaction=True)`, so no ambient transaction | `POST /sdk/api/v1/new-eval/` async | The standalone path still starts its workflow before the response returns, so the deferral adds no latency where there is nothing to defer |
| 4 | `test_unknown_evaluation_id_returns_failed_without_raising` | No row for the id | Activity called directly | An id with no row returns a FAILED result instead of raising out of the activity |
| 5 | `test_row_that_cannot_be_loaded_is_left_failed` | Row exists, the load raises `DoesNotExist` | Activity called directly | The exact production failure leaves the real row `FAILED` with an error message |
| 6 | `test_malformed_evaluation_id_returns_failed_without_raising` | Id is not a uuid | Activity called directly | The terminal-status write cannot itself raise out of the error handler |

One test was removed. `test_new_eval_post_async_starts_the_workflow_before_the_response_returns` needed `django_db(transaction=True)` to have no ambient transaction, and its teardown `TRUNCATE` deadlocked against an in-flight usage write on another connection, which then failed the flush and cascaded 144 errors into the next run on the reused database. It also passed with the fix reverted, so it pinned nothing. The existing async test in the same class already asserts one workflow start per request, and Django's documented behaviour with no atomic block open is to run the callback inline.

`test_new_eval_post_async_persists_function_params` was also updated. It asserted the workflow start had happened, and pytest-django's `db` fixture wraps each test in an atomic block that never commits, so the deferred start correctly never fired. It now wraps the request in `django_capture_on_commit_callbacks`. Its original assertions are unchanged and it still passes with the fix reverted, so it is not a false red.

## Commands to run tests

```bash
cd futureagi
docker compose -f docker-compose.test.yml -p futureagi-test up -d
set -a && source .env.test.local && set +a

# only the new tests
python -m pytest \
  sdk/tests/test_eval_ci_cd.py::TestCICDEvaluationsWorkflowDispatch \
  tfc/temporal/evaluations/tests/test_activities.py \
  --reuse-db --import-mode=importlib -v

# the relevant scope
python -m pytest sdk/tests/ tfc/temporal/evaluations/tests/ \
  --reuse-db --import-mode=importlib -q

# whole app
python -m pytest --reuse-db --import-mode=importlib -q
```

Tests that do not match a `-k` filter appear as deselected. That is not a failure, they were simply not run.

## Local verification results

Full scope, fix applied:

```
============================= 156 passed in 17.27s =============================
```

Same scope with the four production files restored to `origin/dev`:

```
FAILED sdk/tests/test_eval_ci_cd.py::TestCICDEvaluationsWorkflowDispatch::test_workflow_starts_once_per_row_only_after_the_rows_are_committed
FAILED sdk/tests/test_eval_ci_cd.py::TestCICDEvaluationsWorkflowDispatch::test_poll_reports_completed_when_the_workflow_cannot_be_started
FAILED ai_tools/tests/test_evaluation_tools.py::TestRunEvaluationTool::test_unstartable_workflow_leaves_evaluation_failed
FAILED tfc/temporal/evaluations/tests/test_activities.py::TestRunSingleEvaluationSync::test_unknown_evaluation_id_returns_failed_without_raising
FAILED tfc/temporal/evaluations/tests/test_activities.py::TestRunSingleEvaluationSync::test_row_that_cannot_be_loaded_is_left_failed
FAILED tfc/temporal/evaluations/tests/test_activities.py::TestRunSingleEvaluationSync::test_row_whose_terminal_save_fails_is_left_failed
FAILED tfc/temporal/evaluations/tests/test_activities.py::TestRunSingleEvaluationSync::test_malformed_evaluation_id_returns_failed_without_raising
======================== 7 failed, 31 passed in 16.52s =========================
```

Two of those seven are weak under a combined revert, because reverting everything at once also reverts the status enum they compare against. Each was therefore re-proven under an isolated revert of only its own fix:

- `finally` fallback reverted to `pass`, everything else at HEAD: `AssertionError: assert 'processing' == StatusChoices.FAILED`. That is the exact stranded shape, since `are_evaluation_runs_processing` excludes only COMPLETED and FAILED.
- `mark_evaluation_failed` call in the dataset tool reverted to `pass`: `AssertionError: assert 'pending' == StatusChoices.FAILED`.

## Video

https://github.com/user-attachments/assets/8aa29965-3146-45bf-9af3-9f99e1839fbb

## Before / After: live 100-row run

![Before and after, identical 100-row runs](https://github.com/user-attachments/assets/039bf5d7-5a3a-4dcc-acef-c456b1a6515a)

Two identical 100-row runs against the same stack, same project, same payload, differing only by this fix.

| | Before | After |
|---|---|---|
| Rows terminal | 9 of 100 | 100 of 100 |
| Rows stuck `pending` | 91 | 0 |
| Which rows completed | only indices 91 to 99, the last nine created | all |
| Results endpoint | `{"status": "processing"}` after 20 minutes | `{"status": "completed"}` with a score |

The 49 rows that report `failed` in the after run carry `API call not allowed: rate_limited` (48) and `connection timeout expired` (1). They now run, hit a real limit and terminate with a reason, where previously they never ran at all. The unthrottled fan-out that causes that rate limiting is tracked separately in TH-7887 and is out of scope here.

## Out of scope, tracked

- **TH-7887** the CI/CD path starts one workflow per row with no concurrency bound, which is what produces the rate limiting above.
- **TH-7890** rows already stranded before this deploys have no healer. This PR stops new strandings; it does not move existing ones, and their polls keep reporting `processing` until that command ships.

## Screenshot of test suite run

**Command** - `python -m pytest sdk/tests/ tfc/temporal/evaluations/tests/ --reuse-db --import-mode=importlib -q`

![Test suite run](https://github.com/user-attachments/assets/8c2cf063-4a6d-42f4-98f8-b41752af4cd3)

## Backwards compatibility

No schema change and no new endpoint. Two semantic changes, both narrowing failure modes rather than widening them.

| Caller | Pre-PR behavior | Post-PR behavior |
|---|---|---|
| `POST /sdk/api/v1/evaluate-pipeline/` | Workflows started mid-transaction; most rows stranded `PENDING` | Workflows start after commit; every row reaches a terminal status |
| `POST /sdk/api/v1/new-eval/` and `/eval/` async | Workflow started immediately, no ambient transaction | Unchanged. With no atomic block open Django runs the callback inline |
| `ai_tools` `run_evaluation` | Saves then starts, outside any transaction | Unaffected, it does not route through this helper |
| Temporal activity, failure before the row loads | Handler raised `UnboundLocalError`; activity failed and retried | Returns a `FAILED` result and records the terminal status. The retry no longer fires for this case, which is correct because a row the worker cannot load will not become loadable on a retry |

## Manual verification

1. Bring the stack up and obtain an API key and secret key.
2. `POST /sdk/api/v1/evaluate-pipeline/` with a project, a fresh version, and 100 parallel input values.
3. Poll `GET /sdk/api/v1/evaluate-pipeline/?project_name=<p>&versions=<v>`.
4. It returns `"status": "completed"` with a populated `results_summary`, and no evaluation row for that run remains `pending`.

## Type of change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📖 Documentation only
- [ ] 🧹 Chore / refactor (no user-visible change)
- [ ] 🚀 Performance improvement
- [ ] 🧪 Test-only change

## Checklist

- [x] My code follows the style guide
- [x] I've added tests that prove my fix is effective
- [x] No hardcoded secrets, URLs, or PII

## Backout / rollback

- No migration in this PR, so nothing to reverse on the schema.
- No new modules. Reverting removes the closure and the guarded handler cleanly, with no orphaned references.
- Reverting restores the prior behavior: evaluations submitted through the CI/CD endpoint strand at `PENDING` and the results endpoint hangs on `processing`. No data is lost either way; the rows are written before the workflow starts in both versions.
- No frontend change, no cached or persisted client state involved.

Closes TH-7886
