### PR TITLE
fix(catalog): recover snapshot startup and controller liveness

### DIFF
--- a/docs/catalog-prod-startup-hotfix.md
+++ b/docs/catalog-prod-startup-hotfix.md
@@ -1,0 +1,78 @@
+# Catalog production startup hotfix
+
+## Scope
+
+Fix the two failing containers in the existing Kafka catalog pipeline. This is
+not the managed-lifecycle redesign or the polling-based suggestion catalog.
+No new catalog schema, periodic source scan, epoch migration, or source-span
+write is part of this patch. Keep existing workspace/project authorization,
+lease/digest validation, Kafka delivery, and activation checks.
+
+Base: main `2d244e6b0566f265337c42ea50299dc5f0dbf96e`.
+No production rollout is authorized here. This branch is independent of the
+managed-lifecycle draft PR #2589.
+
+## Read-only production evidence, 2026-09-07
+
+Cluster: `gke_futureagiprimary_us-east5_futureagi-us-production`.
+Namespace: `futureagi`.
+
+- `fi-property-catalog-consumer-74c46c7cd9-bbpnz`: Ready, zero restarts at
+  inspection. Readiness alone is not end-to-end delivery evidence.
+- `fi-property-catalog-sequencer-0`, sequencer container: 762 restarts;
+  last exit 1 at 12:35:08 UTC. Error: `producer retirement 0: retirement
+  lifecycle mode differs from its build plan`.
+- Its existing retirement file contains 3,284 records with the same contract:
+  initial_backfill, epoch 1, revision 3, projection 3; ten streams labeled
+  physical_snapshot_r3 with one consistent non-zero generation. These are
+  observed values, not constants to add to the compatibility check.
+- Lifecycle-controller container: 128 restarts; the prior process exited 0
+  following shutdown. Kubernetes reports repeated failed startup probes.
+- All three controller probes currently require `healthy=true`. Startup permits
+  181 failures at 10-second intervals. The v1 health file is written after a
+  full cycle with the cycle-start timestamp, making large cycles appear stale.
+- The inspected health record was unhealthy, with 3,256 workspace failures
+  and zero processed; errors say an expired incomplete revision requires repair.
+- The deployed bootstrap and expired-incomplete-repair gates are both false.
+
+## Minimal changes
+
+1. Accept the validated revision-scoped physical-snapshot retirement format.
+   Do not bypass plan identity, inventory, lineage, or digest validation, and
+   do not hardcode a production epoch, revision, projection, or workspace.
+2. Report controller liveness separately from catalog readiness. Publish a
+   heartbeat during bounded work; an expired operation deadline must fail
+   liveness even if the heartbeat thread still runs. Workspace failures must
+   continue to fail readiness.
+3. Update only the matching startup/liveness probes in the deployment chart;
+   keep readiness strict and validate health-file format, timestamps and fields.
+
+## Release gates and follow-up
+
+- PASS: reproduced physical-snapshot rejection before the fix; package and
+  sequencer-command Go tests pass, including invalid-proof rejection.
+- PASS: patched loader validated all 3,284 retirement proofs from a read-only
+  copy of the production file. The local copy was unchanged. Proof bytes and
+  the one-off replay harness are not included in the commit. This does not
+  qualify the remaining startup fence/checkpoint reads or actual Kafka delivery.
+- PASS: 13 focused controller-health tests and 42 existing production-lifecycle
+  tests (actual Django test settings, mocked runtime boundaries, no services).
+- PASS: nine rendered Helm probe/projection tests, existing data-Kafka chart
+  regressions and strict Helm lint. Missing, malformed, stale and future-dated
+  health records still fail; v1 retains its existing strict behavior.
+- PASS: Python lint/format checks and whitespace checks.
+- Build and verify the collector and controller-sidecar images, then pin their
+  actual digests. Image builds and deployment have not happened for this patch.
+- Review the rendered workload diff before rollout. Source spans, database
+  grants, Kafka offsets and catalog data must remain unchanged.
+- The existing chart enforces a shared collector/sequencer/consumer image and
+  matching lifecycle-sidecar/web-backend digests. This patch does not change
+  those constraints or any pins. A normal Helm rollout with new pins therefore
+  includes those workloads; do not claim a sidecar-only rollout is supported.
+- Expired incomplete revisions are a separate operational blocker. A reviewed,
+  bounded use of the existing repair path is required after validating the
+  pending/active state and writer ownership. Do not enable fleet-wide repair,
+  discard spool files, relabel rows, or delete data as a startup workaround.
+- Passing these local tests proves the narrow patch, not production catalog
+  freshness. Verify actual consumer progress and scoped property/value APIs
+  after the approved rollout and repair.

--- a/fi-collector/pkg/propertycatalog/producer_retirement.go
+++ b/fi-collector/pkg/propertycatalog/producer_retirement.go
@@ -218,15 +218,37 @@ func validateProducerRetirement(value ProducerStateRetirement) error {
 		return err
 	}
 	prefix := value.LifecycleMode + "_"
+	lifecycleMatches := true
 	for _, stream := range plan.Streams {
 		if !strings.HasPrefix(stream.SourceCutoff.Label, prefix) {
-			return errors.New("retirement lifecycle mode differs from its build plan")
+			lifecycleMatches = false
+			break
 		}
+	}
+	if !lifecycleMatches && !isPhysicalSnapshotRetirement(value, plan) {
+		return errors.New("retirement lifecycle mode differs from its build plan")
 	}
 	if value.RetirementSHA256 != producerRetirementSHA256(value) {
 		return errors.New("retirement digest does not match its fields")
 	}
 	return nil
+}
+
+func isPhysicalSnapshotRetirement(value ProducerStateRetirement, validatedPlan buildPlanDocumentJSON) bool {
+	// validateBuildPlan already checked the exact lease, digest, and role/adapter
+	// inventory. This exception only recognizes an initial physical snapshot's
+	// revision-scoped label and shared nonzero opaque generation.
+	if value.LifecycleMode != "initial_backfill" || len(validatedPlan.Streams) == 0 {
+		return false
+	}
+	label := fmt.Sprintf("physical_snapshot_r%d", value.CatalogRevision)
+	generation := validatedPlan.Streams[0].SourceCutoff.Value
+	for _, stream := range validatedPlan.Streams {
+		if stream.SourceCutoff.Label != label || stream.SourceCutoff.Value != generation {
+			return false
+		}
+	}
+	return generation != 0
 }
 
 func (r *HotRuntime) compactProducerState(ctx context.Context, fences []RevisionFence) error {

--- a/fi-collector/pkg/propertycatalog/producer_retirement_test.go
+++ b/fi-collector/pkg/propertycatalog/producer_retirement_test.go
@@ -3,7 +3,9 @@ package propertycatalog
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -34,6 +36,159 @@ func writePythonRetirementFixture(t *testing.T, directory string) {
 		0o600,
 	); err != nil {
 		t.Fatal(err)
+	}
+}
+
+func physicalSnapshotRetirementFixture(t *testing.T) (ProducerStateRetirement, buildPlanDocumentJSON) {
+	t.Helper()
+	var document producerRetirementDocument
+	if err := json.Unmarshal(pythonRetirementFixture(t), &document); err != nil {
+		t.Fatal(err)
+	}
+	value := document.Retirements[0]
+	var plan buildPlanDocumentJSON
+	if err := json.Unmarshal([]byte(value.BuildPlanJSON), &plan); err != nil {
+		t.Fatal(err)
+	}
+	for index := range plan.Streams {
+		plan.Streams[index].SourceCutoff.Label = fmt.Sprintf("physical_snapshot_r%d", value.CatalogRevision)
+		plan.Streams[index].SourceCutoff.Value = 123456789
+	}
+	setPhysicalRetirementPlan(t, &value, plan)
+	return value, plan
+}
+
+func setPhysicalRetirementPlan(t *testing.T, value *ProducerStateRetirement, plan buildPlanDocumentJSON) {
+	t.Helper()
+	raw, err := json.Marshal(plan)
+	if err != nil {
+		t.Fatal(err)
+	}
+	value.BuildPlanJSON = string(raw)
+	value.BuildLeaseSHA256 = testDigest(value.BuildPlanJSON)
+	value.RetirementSHA256 = producerRetirementSHA256(*value)
+}
+
+func TestProducerRetirementPhysicalSnapshotCompatibility(t *testing.T) {
+	for _, revision := range []uint64{3, 41} {
+		t.Run(fmt.Sprintf("revision_%d", revision), func(t *testing.T) {
+			value, plan := physicalSnapshotRetirementFixture(t)
+			value.CatalogEpoch, value.ProjectionVersion = 7, 9
+			value.CatalogRevision, value.LineageAnchorRevision = revision, revision
+			plan.CatalogEpoch, plan.ProjectionVersion = value.CatalogEpoch, value.ProjectionVersion
+			plan.CatalogRevision = revision
+			for index := range plan.Streams {
+				plan.Streams[index].SourceCutoff.Label = fmt.Sprintf("physical_snapshot_r%d", revision)
+			}
+			setPhysicalRetirementPlan(t, &value, plan)
+			if err := validateProducerRetirement(value); err != nil {
+				t.Fatalf("valid physical snapshot retirement rejected: %v", err)
+			}
+			raw, err := json.Marshal(producerRetirementDocument{
+				Format: producerRetirementFormat, Version: producerRetirementVersion,
+				Retirements: []ProducerStateRetirement{value},
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+			raw = append(raw, '\n')
+			directory := t.TempDir()
+			path := filepath.Join(directory, producerRetirementFileName)
+			if err := os.WriteFile(path, raw, 0o600); err != nil {
+				t.Fatal(err)
+			}
+			loaded, err := loadProducerRetirements(directory)
+			if err != nil || loaded[producerRetirementTenant{value.OrganizationID, value.WorkspaceID}] != value {
+				t.Fatalf("loading did not preserve the exact retirement: %v", err)
+			}
+			after, err := os.ReadFile(path)
+			if err != nil || !bytes.Equal(raw, after) {
+				t.Fatalf("loading changed persisted proof bytes: %v", err)
+			}
+		})
+	}
+}
+
+func TestProducerRetirementPhysicalSnapshotRejectsInvalidProofs(t *testing.T) {
+	tests := []struct {
+		name   string
+		mutate func(*ProducerStateRetirement, *buildPlanDocumentJSON)
+		want   string
+	}{
+		{"wrong revision label", func(_ *ProducerStateRetirement, p *buildPlanDocumentJSON) {
+			p.Streams[0].SourceCutoff.Label = "physical_snapshot_r999"
+		}, "lifecycle mode differs"},
+		{"mixed labels", func(_ *ProducerStateRetirement, p *buildPlanDocumentJSON) {
+			p.Streams[0].SourceCutoff.Label = "initial_backfill_source_cutoff"
+		}, "lifecycle mode differs"},
+		{"mixed generations", func(_ *ProducerStateRetirement, p *buildPlanDocumentJSON) { p.Streams[0].SourceCutoff.Value++ }, "lifecycle mode differs"},
+		{"zero generation", func(_ *ProducerStateRetirement, p *buildPlanDocumentJSON) {
+			for i := range p.Streams {
+				p.Streams[i].SourceCutoff.Value = 0
+			}
+		}, "stream 0 is invalid"},
+		{"full repair", func(v *ProducerStateRetirement, _ *buildPlanDocumentJSON) { v.LifecycleMode = "full_repair" }, "lifecycle mode differs"},
+		{"incremental", func(v *ProducerStateRetirement, _ *buildPlanDocumentJSON) {
+			v.LifecycleMode = "incremental"
+			v.LineageAnchorRevision--
+			v.ActivationSequence++
+			v.ActiveRevisionsSinceAnchor = 1
+		}, "lifecycle mode differs"},
+		{"empty inventory", func(_ *ProducerStateRetirement, p *buildPlanDocumentJSON) { p.Streams = nil }, "exact revision lease"},
+		{"missing stream", func(_ *ProducerStateRetirement, p *buildPlanDocumentJSON) { p.Streams = p.Streams[1:] }, "exact revision lease"},
+		{"wrong role", func(_ *ProducerStateRetirement, p *buildPlanDocumentJSON) { p.Streams[0].Role = "hot_values" }, "only span_attribute"},
+		{"wrong tenant", func(_ *ProducerStateRetirement, p *buildPlanDocumentJSON) { p.WorkspaceID = testStream }, "exact revision lease"},
+		{"wrong hot stream", func(v *ProducerStateRetirement, _ *buildPlanDocumentJSON) { v.HotProducerStreamID = testStream }, "current source stream is absent"},
+		{"wrong lineage", func(v *ProducerStateRetirement, _ *buildPlanDocumentJSON) { v.LineageAnchorRevision-- }, "not its own lineage anchor"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			value, plan := physicalSnapshotRetirementFixture(t)
+			test.mutate(&value, &plan)
+			// Re-sign mutations so structural failures are not masked by checksums.
+			setPhysicalRetirementPlan(t, &value, plan)
+			if err := validateProducerRetirement(value); err == nil || !strings.Contains(err.Error(), test.want) {
+				t.Fatalf("want %q, got %v", test.want, err)
+			}
+		})
+	}
+	for _, digest := range []string{"lease", "retirement"} {
+		t.Run(digest+" digest", func(t *testing.T) {
+			value, _ := physicalSnapshotRetirementFixture(t)
+			want := "retirement digest does not match"
+			if digest == "lease" {
+				value.BuildLeaseSHA256 = testDigest("corrupt lease")
+				value.RetirementSHA256 = producerRetirementSHA256(value)
+				want = "build plan digest does not match"
+			} else {
+				value.RetirementSHA256 = testDigest("corrupt retirement")
+			}
+			if err := validateProducerRetirement(value); err == nil || !strings.Contains(err.Error(), want) {
+				t.Fatalf("want %q, got %v", want, err)
+			}
+		})
+	}
+}
+
+func TestProducerRetirementPreservesNormalLifecycleCutoffs(t *testing.T) {
+	for _, mode := range []string{"initial_backfill", "full_repair", "incremental"} {
+		t.Run(mode, func(t *testing.T) {
+			value, plan := physicalSnapshotRetirementFixture(t)
+			value.LifecycleMode = mode
+			if mode == "incremental" {
+				value.LineageAnchorRevision--
+				value.ActivationSequence++
+				value.ActiveRevisionsSinceAnchor = 1
+			}
+			for index := range plan.Streams {
+				plan.Streams[index].SourceCutoff.Label = mode + "_source_cutoff"
+				plan.Streams[index].SourceCutoff.Value += uint64(index)
+			}
+			setPhysicalRetirementPlan(t, &value, plan)
+			if err := validateProducerRetirement(value); err != nil {
+				t.Fatalf("normal lifecycle retirement rejected: %v", err)
+			}
+		})
 	}
 }
 

--- a/futureagi/tracer/management/commands/ch25_property_catalog_lifecycle_controller.py
+++ b/futureagi/tracer/management/commands/ch25_property_catalog_lifecycle_controller.py
@@ -14,7 +14,7 @@ import signal
 import tempfile
 import threading
 from collections.abc import Callable, Iterator, Mapping
-from contextlib import contextmanager
+from contextlib import ExitStack, contextmanager
 from dataclasses import dataclass, replace
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
@@ -31,6 +31,9 @@ from tracer.services.clickhouse.v2.property_catalog import dev_runtime
 from tracer.services.clickhouse.v2.property_catalog.codec import (
     canonical_json,
     canonical_uuid,
+)
+from tracer.services.clickhouse.v2.property_catalog.controller_health import (
+    ControllerHealth,
 )
 from tracer.services.clickhouse.v2.property_catalog.dev_rollout import (
     DEV_INITIAL_BACKFILL_MAX_WALL_MS,
@@ -67,7 +70,7 @@ logger = logging.getLogger(__name__)
 _MAX_PROJECTS_PER_WORKSPACE = 256
 _WORKSPACE_SCOPE_MODES = frozenset({"all", "allowlist"})
 _HEALTH_FORMAT = "futureagi.property-catalog-lifecycle-health"
-_HEALTH_VERSION = 1
+_HEALTH_VERSION = 2
 
 
 class ProductionLifecycleControllerError(RuntimeError):
@@ -221,6 +224,7 @@ class Command(BaseCommand):
         status_only = bool(options.get("status_only"))
         initial_backfill_wall_ms = options.get("initial_backfill_wall_ms")
         stop = threading.Event()
+        health_lifetime = ExitStack()
         previous_handlers = _install_signal_handlers(stop)
         try:
             config = controller_config(settings_object=settings)
@@ -230,8 +234,32 @@ class Command(BaseCommand):
                 bootstrap_enabled=config.bootstrap_enabled,
                 initial_backfill_wall_ms=initial_backfill_wall_ms,
             )
+            health = health_lifetime.enter_context(
+                ControllerHealth(
+                    lambda **snapshot: _write_health(config.health_file, **snapshot),
+                    stop=stop,
+                )
+            )
+            # Cover discovery and each workspace's admitted reconcile wall,
+            # including bounded teardown. Do not use the shorter source wall.
+            operation_timeout = (
+                max(
+                    config.scheduled_reconcile_wall_ms,
+                    initial_backfill_wall_ms or 0,
+                )
+                / 1000
+                + 120
+            )
+
+            def report_error(workspace_id: str, exc: Exception) -> None:
+                health.set_ready(False)
+                self.stderr.write(
+                    self.style.ERROR(f"workspace {workspace_id} failed safely: {exc}")
+                )
+
             while not stop.is_set():
                 observed_at = datetime.now(UTC)
+                health.progress("discovering", timeout_seconds=operation_timeout)
                 try:
                     scopes, skipped = discover_workspace_scopes(
                         config.workspace_ids
@@ -247,19 +275,21 @@ class Command(BaseCommand):
                         status_only=status_only,
                         initial_backfill_wall_ms=initial_backfill_wall_ms,
                         stop=stop,
-                        on_error=lambda workspace_id, exc: self.stderr.write(
-                            self.style.ERROR(
-                                f"workspace {workspace_id} failed safely: {exc}"
-                            )
+                        on_progress=lambda scope: health.progress(
+                            "reconciling",
+                            timeout_seconds=operation_timeout,
+                            detail={"workspace_id": scope.workspace_id},
                         ),
+                        on_error=report_error,
                     )
                 except Exception as exc:
-                    _write_health(
-                        config.health_file,
-                        healthy=False,
-                        observed_at=observed_at,
+                    health.progress(
+                        "retrying",
+                        timeout_seconds=config.failure_backoff_seconds + 120,
+                        ready=False,
                         detail={"cycle_error": str(exc)[:2048]},
                     )
+                    health.publish()
                     if once:
                         raise CommandError(str(exc)) from exc
                     logger.exception(
@@ -268,13 +298,13 @@ class Command(BaseCommand):
                     stop.wait(config.failure_backoff_seconds)
                     continue
 
-                healthy = not result.failures
-                _write_health(
-                    config.health_file,
-                    healthy=healthy,
-                    observed_at=observed_at,
+                health.progress(
+                    "idle",
+                    timeout_seconds=config.poll_seconds + 120,
+                    ready=not result.stopped and not result.failures,
                     detail=result.as_dict(summary=True),
                 )
+                health.publish()
                 if once:
                     if result.failures:
                         failed = ", ".join(sorted(result.failures))
@@ -288,7 +318,10 @@ class Command(BaseCommand):
         except (ProductionLifecycleControllerError, DevRolloutError, ValueError) as exc:
             raise CommandError(str(exc)) from exc
         finally:
-            _restore_signal_handlers(previous_handlers)
+            try:
+                health_lifetime.close()
+            finally:
+                _restore_signal_handlers(previous_handlers)
         return None
 
 
@@ -541,6 +574,7 @@ def run_cycle(
     stop: threading.Event,
     on_error: Callable[[str, Exception], None],
     initial_backfill_wall_ms: int | None = None,
+    on_progress: Callable[[WorkspaceScope], None] | None = None,
 ) -> CycleResult:
     authorized_workspaces = tuple(
         sorted((*skipped, *(scope.workspace_id for scope in scopes)))
@@ -562,6 +596,8 @@ def run_cycle(
     for scope in scopes:
         if stop.is_set():
             break
+        if on_progress is not None:
+            on_progress(scope)
         try:
             run_workspace(
                 scope=scope,
@@ -842,6 +878,10 @@ def _write_health(
     healthy: bool,
     observed_at: datetime,
     detail: Mapping[str, Any],
+    live: bool | None = None,
+    ready: bool | None = None,
+    phase: str = "idle",
+    progress_at: datetime | None = None,
 ) -> None:
     raw = (
         canonical_json(
@@ -849,6 +889,10 @@ def _write_health(
                 "detail": dict(detail),
                 "format": _HEALTH_FORMAT,
                 "healthy": healthy,
+                "live": healthy if live is None else live,
+                "ready": healthy if ready is None else ready,
+                "phase": phase,
+                "progress_at": iso_z(progress_at or observed_at),
                 "observed_at": iso_z(observed_at),
                 "version": _HEALTH_VERSION,
             },

--- a/futureagi/tracer/services/clickhouse/v2/property_catalog/controller_health.py
+++ b/futureagi/tracer/services/clickhouse/v2/property_catalog/controller_health.py
@@ -1,0 +1,121 @@
+"""Process heartbeat independent of reconciliation success, with bounded work.
+
+Only progress() renews the monotonic operation deadline. A running heartbeat
+thread cannot keep a stuck operation live. No lifecycle or configuration policy
+is implemented here. The command owns atomic publication of the v2 record.
+"""
+
+from __future__ import annotations
+
+import math
+import threading
+import time
+from collections.abc import Callable, Mapping
+from datetime import UTC, datetime
+from typing import Any
+
+
+class ControllerHealth:
+    def __init__(
+        self,
+        publish: Callable[..., None],
+        *,
+        stop: threading.Event,
+        interval_seconds: float = 10,
+        monotonic: Callable[[], float] = time.monotonic,
+        utc_now: Callable[[], datetime] = lambda: datetime.now(UTC),
+    ) -> None:
+        if not math.isfinite(interval_seconds) or interval_seconds <= 0:
+            raise ValueError("health interval must be positive and finite")
+        self._publish = publish
+        self._stop = stop
+        self._interval = interval_seconds
+        self._monotonic = monotonic
+        self._utc_now = utc_now
+        self._lock = threading.Lock()
+        self._publication_lock = threading.Lock()
+        self._shutdown = threading.Event()
+        self._thread: threading.Thread | None = None
+        self._failure: Exception | None = None
+        self._ready = False
+        self._detail: dict[str, Any] = {}
+        self._phase = "starting"
+        self._progress_at = utc_now()
+        self._deadline = monotonic() + 120
+
+    def set_ready(self, ready: bool) -> None:
+        """An observed failure clears readiness without extending a deadline."""
+        with self._lock:
+            self._ready = ready
+
+    def progress(
+        self,
+        phase: str,
+        *,
+        timeout_seconds: float,
+        ready: bool | None = None,
+        detail: Mapping[str, Any] | None = None,
+    ) -> None:
+        if not math.isfinite(timeout_seconds) or timeout_seconds <= 0:
+            raise ValueError("health deadline must be positive and finite")
+        with self._lock:
+            if self._failure is not None:
+                raise RuntimeError("catalog health publisher failed") from self._failure
+            self._phase = phase
+            self._deadline = self._monotonic() + timeout_seconds
+            self._progress_at = self._utc_now()
+            if ready is not None:
+                self._ready = ready
+            if detail is not None:
+                self._detail = dict(detail)
+
+    def snapshot(self) -> dict[str, Any]:
+        with self._lock:
+            live = (
+                not self._shutdown.is_set()
+                and not self._stop.is_set()
+                and self._failure is None
+                and self._monotonic() <= self._deadline
+            )
+            ready = self._ready and live
+            return {
+                "healthy": ready,
+                "live": live,
+                "ready": ready,
+                "phase": self._phase,
+                "observed_at": self._utc_now(),
+                "progress_at": self._progress_at,
+                "detail": dict(self._detail),
+            }
+
+    def publish(self) -> None:
+        # Serialize snapshot and write so no old heartbeat overwrites shutdown.
+        with self._publication_lock:
+            try:
+                self._publish(**self.snapshot())
+            except Exception as exc:
+                with self._lock:
+                    self._failure = exc
+                raise
+
+    def _heartbeat(self) -> None:
+        while not self._shutdown.wait(self._interval):
+            try:
+                self.publish()
+            except Exception:
+                # Fail the next progress update; the last file also expires.
+                return
+
+    def __enter__(self) -> ControllerHealth:
+        self.publish()
+        self._thread = threading.Thread(
+            target=self._heartbeat, name="catalog-health", daemon=True
+        )
+        self._thread.start()
+        return self
+
+    def __exit__(self, *_exc: Any) -> None:
+        self._shutdown.set()
+        if self._thread is not None:
+            self._thread.join(timeout=self._interval + 1)
+        self.publish()

--- a/futureagi/tracer/tests/test_property_catalog_controller_health.py
+++ b/futureagi/tracer/tests/test_property_catalog_controller_health.py
@@ -1,0 +1,336 @@
+"""Health-only tests: stdlib, no Django startup, credentials or external services.
+
+Run: python -m unittest discover -s tracer/tests -p test_property_catalog_controller_health.py
+Command bodies are executed with model/runtime boundaries replaced, following
+the repository's isolated command-test pattern. No reconcile writes occur.
+"""
+
+import ast
+import importlib.util
+import json
+import os
+import signal
+import tempfile
+import threading
+import unittest
+from contextlib import ExitStack
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from types import MappingProxyType, SimpleNamespace
+from unittest.mock import Mock
+
+TRACER = Path(__file__).resolve().parents[1]
+HELPER = TRACER / "services/clickhouse/v2/property_catalog/controller_health.py"
+spec = importlib.util.spec_from_file_location("isolated_controller_health", HELPER)
+module = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(module)
+ControllerHealth = module.ControllerHealth
+
+
+class HealthTests(unittest.TestCase):
+    def setUp(self):
+        self.tick = 100.0
+        self.stop = threading.Event()
+        self.snapshots = []
+        self.health = ControllerHealth(
+            lambda **snapshot: self.snapshots.append(snapshot),
+            stop=self.stop,
+            monotonic=lambda: self.tick,
+            utc_now=lambda: (
+                datetime(2026, 1, 1, tzinfo=UTC) + timedelta(seconds=self.tick)
+            ),
+        )
+
+    def test_1200_second_work_live_until_deadline_not_100_second_source_wall(self):
+        self.health.progress("reconciling", timeout_seconds=1320)
+        self.tick += 1201
+        self.health.publish()
+        self.assertTrue(self.snapshots[-1]["live"])
+        self.assertFalse(self.snapshots[-1]["ready"])
+        self.tick += 120
+        self.health.publish()
+        self.assertFalse(self.snapshots[-1]["live"])
+
+    def test_heartbeat_and_readiness_changes_do_not_extend_deadline(self):
+        self.health.progress("reconciling", timeout_seconds=20, ready=True)
+        before = self.health.snapshot()["progress_at"]
+        for _ in range(3):
+            self.tick += 10
+            self.health.publish()
+        self.health.set_ready(True)
+        self.assertEqual(self.health.snapshot()["progress_at"], before)
+        self.assertFalse(self.health.snapshot()["live"])
+        self.assertFalse(self.health.snapshot()["healthy"])
+
+    def test_next_workspace_renews_bounded_deadline(self):
+        for _ in range(3):
+            self.health.progress("reconciling", timeout_seconds=1320)
+            self.tick += 1200
+            self.assertTrue(self.health.snapshot()["live"])
+        self.tick += 121
+        self.assertFalse(self.health.snapshot()["live"])
+
+    def test_failures_and_retry_keep_liveness_without_readiness(self):
+        for phase, detail in (
+            ("idle", {"failed_count": 3256, "processed_count": 0}),
+            ("retrying", {"cycle_error": "unavailable"}),
+        ):
+            self.health.progress(phase, timeout_seconds=180, ready=False, detail=detail)
+            self.assertTrue(self.health.snapshot()["live"])
+            self.assertFalse(self.health.snapshot()["healthy"])
+        self.health.progress("idle", timeout_seconds=180, ready=True, detail={})
+        self.assertTrue(self.health.snapshot()["healthy"])
+
+    def test_shutdown_and_stop_event_clear_health(self):
+        self.health.progress("idle", timeout_seconds=180, ready=True)
+        self.stop.set()
+        self.assertFalse(self.health.snapshot()["live"])
+        self.assertFalse(self.health.snapshot()["ready"])
+        self.health.__exit__()
+        self.assertFalse(self.snapshots[-1]["healthy"])
+
+    def test_background_heartbeat_and_final_shutdown_record(self):
+        observed = threading.Event()
+        snapshots = []
+
+        def publish(**snapshot):
+            snapshots.append(snapshot)
+            if len(snapshots) >= 2:
+                observed.set()
+
+        with ControllerHealth(publish, stop=self.stop, interval_seconds=0.01):
+            self.assertTrue(observed.wait(1))
+            self.assertTrue(snapshots[-1]["live"])
+        self.assertFalse(snapshots[-1]["live"])
+        self.assertFalse(snapshots[-1]["ready"])
+
+    def test_publisher_failure_stops_heartbeat_and_propagates(self):
+        failed = threading.Event()
+        calls = []
+
+        def publish(**snapshot):
+            calls.append(snapshot)
+            if len(calls) == 2:
+                failed.set()
+                raise OSError("disk failure")
+
+        with ControllerHealth(publish, stop=self.stop, interval_seconds=0.01) as health:
+            self.assertTrue(failed.wait(1))
+            health._thread.join(timeout=1)
+            self.assertFalse(health.snapshot()["live"])
+            with self.assertRaisesRegex(RuntimeError, "publisher failed"):
+                health.progress("idle", timeout_seconds=180)
+        self.assertFalse(calls[-1]["live"])
+
+    def test_invalid_deadlines_rejected(self):
+        for value in (0, -1, float("inf"), float("nan")):
+            with self.assertRaises(ValueError):
+                self.health.progress("idle", timeout_seconds=value)
+
+
+class CommandTests(unittest.TestCase):
+    def setUp(self):
+        source = (
+            TRACER / "management/commands/ch25_property_catalog_lifecycle_controller.py"
+        )
+        tree = ast.parse(source.read_text())
+        command = next(
+            n for n in tree.body if isinstance(n, ast.ClassDef) and n.name == "Command"
+        )
+        handle = next(
+            n
+            for n in command.body
+            if isinstance(n, ast.FunctionDef) and n.name == "handle"
+        )
+        functions = [
+            n
+            for n in tree.body
+            if isinstance(n, ast.FunctionDef)
+            and n.name
+            in {
+                "run_cycle",
+                "_write_health",
+                "_install_signal_handlers",
+                "_restore_signal_handlers",
+                "iso_z",
+            }
+        ]
+
+        class CommandError(Exception):
+            pass
+
+        self.error = CommandError
+        self.config = SimpleNamespace(
+            health_file="unused",
+            bootstrap_enabled=False,
+            repair_expired_incomplete=False,
+            scheduled_reconcile_wall_ms=1200000,
+            poll_seconds=60,
+            failure_backoff_seconds=30,
+            workspace_ids=(),
+            workspace_scope_mode="all",
+        )
+        self.snapshots = []
+        self.healths = []
+
+        def health_factory(publish, **kwargs):
+            health = ControllerHealth(publish, **kwargs)
+            original = health.progress
+            health.progress = Mock(side_effect=original)
+            self.healths.append(health)
+            return health
+
+        self.ns = {
+            "threading": threading,
+            "signal": signal,
+            "ExitStack": ExitStack,
+            "datetime": datetime,
+            "UTC": UTC,
+            "os": os,
+            "tempfile": tempfile,
+            "Path": Path,
+            "MappingProxyType": MappingProxyType,
+            "ControllerHealth": health_factory,
+            "CommandError": CommandError,
+            "ProductionLifecycleControllerError": type(
+                "ControllerError", (Exception,), {}
+            ),
+            "DevRolloutError": type("RolloutError", (Exception,), {}),
+            "logger": Mock(),
+            "settings": object(),
+            "controller_config": Mock(return_value=self.config),
+            "_validate_initial_backfill_mode": Mock(),
+            "discover_workspace_scopes": Mock(
+                return_value=((SimpleNamespace(workspace_id="one"),), ())
+            ),
+            "canonical_json": lambda value, **kwargs: json.dumps(value),
+            "_HEALTH_FORMAT": "futureagi.property-catalog-lifecycle-health",
+            "_HEALTH_VERSION": 2,
+            "CycleResult": lambda **kwargs: SimpleNamespace(**kwargs),
+        }
+        future = ast.ImportFrom(
+            module="__future__", names=[ast.alias(name="annotations")], level=0
+        )
+        code = ast.fix_missing_locations(
+            ast.Module(body=[future, *functions, handle], type_ignores=[])
+        )
+        exec(compile(code, str(source), "exec"), self.ns)
+        self.actual_cycle = self.ns["run_cycle"]
+        self.actual_writer = self.ns["_write_health"]
+        self.ns["_write_health"] = lambda path, **snapshot: self.snapshots.append(
+            snapshot
+        )
+        self.view = SimpleNamespace(
+            stderr=Mock(), style=SimpleNamespace(ERROR=lambda text: text)
+        )
+
+    def cycle(self, failures, processed, *, stopped=False):
+        def run(**kwargs):
+            kwargs["on_progress"](SimpleNamespace(workspace_id="one"))
+            if failures:
+                kwargs["on_error"]("one", RuntimeError("expired incomplete"))
+            return SimpleNamespace(
+                failures=failures,
+                processed=processed,
+                stopped=stopped,
+                as_dict=lambda **kw: {
+                    "failed_count": len(failures),
+                    "processed_count": len(processed),
+                },
+            )
+
+        self.ns["run_cycle"] = Mock(side_effect=run)
+
+    def test_all_failed_and_mixed_cycles_remain_unready_but_live(self):
+        for processed in ((), ("other",)):
+            self.cycle({str(i): "expired" for i in range(3256)}, processed)
+            with self.assertRaises(self.error):
+                self.ns["handle"](self.view, once=True)
+            idle = next(
+                s
+                for s in reversed(self.snapshots)
+                if s["phase"] == "idle" and s["live"]
+            )
+            self.assertFalse(idle["healthy"])
+            self.assertFalse(idle["ready"])
+            self.assertFalse(self.snapshots[-1]["live"])
+            progress = self.healths[-1].progress.call_args_list
+            self.assertEqual(progress[0].kwargs["timeout_seconds"], 1320)
+            self.assertEqual(progress[1].kwargs["timeout_seconds"], 1320)
+            self.assertFalse(self.config.bootstrap_enabled)
+            self.assertFalse(self.config.repair_expired_incomplete)
+
+    def test_success_ready_and_discovery_failure_unready(self):
+        self.cycle({}, ("one",))
+        self.ns["handle"](self.view, once=True)
+        self.assertTrue(any(s["healthy"] for s in self.snapshots))
+        self.snapshots.clear()
+        self.ns["discover_workspace_scopes"].side_effect = RuntimeError(
+            "db unavailable"
+        )
+        with self.assertRaises(self.error):
+            self.ns["handle"](self.view, once=True)
+        self.assertTrue(
+            any(s["phase"] == "retrying" and s["live"] for s in self.snapshots)
+        )
+        self.assertTrue(all(not s["ready"] for s in self.snapshots))
+
+    def test_cycle_progress_is_per_workspace_without_changing_clock_or_mode(self):
+        scopes = (SimpleNamespace(workspace_id="a"), SimpleNamespace(workspace_id="b"))
+        self.ns["run_workspace"] = Mock()
+        progress = Mock()
+        now = datetime(2026, 1, 1, tzinfo=UTC)
+        self.actual_cycle(
+            scopes=scopes,
+            skipped=(),
+            settings_object=self.ns["settings"],
+            config=self.config,
+            now=now,
+            status_only=True,
+            stop=threading.Event(),
+            on_error=Mock(),
+            on_progress=progress,
+        )
+        self.assertEqual([c.args[0] for c in progress.call_args_list], list(scopes))
+        for call in self.ns["run_workspace"].call_args_list:
+            self.assertEqual(call.kwargs["now"], now)
+            self.assertTrue(call.kwargs["status_only"])
+
+    def test_signal_handler_sets_stop_and_restores_original(self):
+        stop = threading.Event()
+        original = signal.getsignal(signal.SIGTERM)
+        handlers = self.ns["_install_signal_handlers"](stop)
+        try:
+            signal.getsignal(signal.SIGTERM)(signal.SIGTERM, None)
+            self.assertTrue(stop.is_set())
+        finally:
+            self.ns["_restore_signal_handlers"](handlers)
+        self.assertEqual(signal.getsignal(signal.SIGTERM), original)
+
+    def test_atomic_v2_record_and_legacy_writer_call_compatibility(self):
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "health.json"
+            now = datetime(2026, 1, 1, tzinfo=UTC)
+            self.actual_writer(
+                str(path),
+                healthy=False,
+                observed_at=now,
+                detail={"failed_count": 3256},
+                live=True,
+                ready=False,
+                phase="idle",
+                progress_at=now,
+            )
+            value = json.loads(path.read_text())
+            self.assertEqual(value["version"], 2)
+            self.assertTrue(value["live"])
+            self.assertFalse(value["ready"])
+            self.assertEqual(path.stat().st_mode & 0o777, 0o600)
+            self.assertEqual(list(Path(directory).iterdir()), [path])
+            self.actual_writer(str(path), healthy=True, observed_at=now, detail={})
+            value = json.loads(path.read_text())
+            self.assertTrue(value["healthy"] and value["ready"] and value["live"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Small startup hotfix from current `main`, separate from draft #2589. Keep the existing Kafka pipeline and catalog data. Matching probe change: https://github.com/future-agi/deployment/pull/321 (draft pending image pins).

- Accept an already-validated initial physical snapshot's revision-scoped label and consistent non-zero generation when loading producer retirement proofs. Tenant, lease, inventory, lineage, and digest checks remain mandatory. No production-specific epoch/revision/projection constants.
- Publish bounded-progress controller heartbeats independently of workspace success. A stuck operation eventually fails liveness; workspace failures still fail readiness.
- Add regression tests. Three runtime files, two test files, one scope/evidence document; no frontend, schema, ingestion topology, manual-version-management redesign or data repair changes.

## Production evidence (read-only, 2026-09-07)

- Sequencer exits with `producer retirement 0: retirement lifecycle mode differs from its build plan`.
- Lifecycle controller is repeatedly restarted by a startup probe that incorrectly requires successful reconciliation and reads a stale cycle-start timestamp.
- Consumer was Ready with zero restarts at inspection; that is not end-to-end delivery proof.

## Validation

- Reproduced the sequencer error before the compatibility fix.
- Full Go `propertycatalog` and sequencer-command tests pass with bounded concurrency.
- Patched loader validates all **3,284** retirement proofs from a read-only copy of the production file; local copy unchanged. Proof bytes and one-off harness are not committed.
- **42** existing production-lifecycle tests pass under actual Django test settings with mocked runtime boundaries and no external services.
- **13** new health tests pass: long operations, deadlines, failed workspaces, progress renewal, publisher failure, atomic health writes, and shutdown.
- Python lint/format and diff checks pass.

## Rollout requirements / explicitly not fixed

- Requires rebuilt fi-collector and backend/EE controller-sidecar images plus matching Helm probe changes. Images have not been built or deployed by this work.
- Current Helm validation couples lifecycle-sidecar/backend image digests and collector/sequencer/consumer images. Do not describe the normal Helm rollout as sidecar-only.
- Existing expired incomplete revisions remain a separate readiness/delivery blocker. The production repair gate is false. This PR does not silently enable repair, alter metadata, remove proofs, or modify/delete spans.
- Probe health is not delivery health: qualify remaining fence/checkpoint startup and actual consumer/API progress after the separately approved rollout and bounded repair.
- Full automatic removal of operator epoch/projection/recovery settings remains outside this narrow hotfix.

Production state has not been changed. Draft #2589 is untouched.
