### PR TITLE
fix(gateway): provider timeout Save crash and truncated session IDs

### DIFF
--- a/api_contracts/openapi/runtime-management-api-contract-debt.generated.json
+++ b/api_contracts/openapi/runtime-management-api-contract-debt.generated.json
@@ -25,7 +25,7 @@
     "broad_request_contract_decorators": 0
   },
   "app_wide_summary": {
-    "runtime_backed_validated_request_decorators": 494,
+    "runtime_backed_validated_request_decorators": 495,
     "direct_swagger_auto_schema_decorators": 241,
     "doc_only_input_contract_decorators": 0,
     "broad_request_contract_decorators": 0

--- a/api_contracts/openapi/swagger.json
+++ b/api_contracts/openapi/swagger.json
@@ -12855,15 +12855,21 @@
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/AgentccProviderCredential"
+                            "$ref": "#/definitions/ProviderModelsRequest"
                         }
                     }
                 ],
                 "responses": {
-                    "201": {
+                    "200": {
                         "description": "",
                         "schema": {
-                            "$ref": "#/definitions/AgentccProviderCredential"
+                            "$ref": "#/definitions/ProviderModelsResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "",
+                        "schema": {
+                            "$ref": "#/definitions/AgentccErrorResponse"
                         }
                     },
                     "default": {
@@ -12875,7 +12881,9 @@
                 },
                 "tags": [
                     "agentcc"
-                ]
+                ],
+                "x-runtime-request-validation": true,
+                "x-runtime-response-validation": true
             },
             "parameters": []
         },
@@ -82105,9 +82113,11 @@
                     "x-nullable": true
                 },
                 "models": {
+                    "description": "Model identifiers, e.g. 'gpt-4o'. ``models_list`` stores plain strings; declaring the child as a JSON object made every gateway config/providers response fail response-contract validation in the browser.",
                     "type": "array",
                     "items": {
-                        "type": "object"
+                        "type": "string",
+                        "minLength": 1
                     }
                 },
                 "is_active": {
@@ -82401,9 +82411,11 @@
                     "type": "string"
                 },
                 "models": {
+                    "description": "Model identifiers, e.g. 'gpt-4o'. ``models_list`` stores plain strings; declaring the child as a JSON object made every gateway config/providers response fail response-contract validation in the browser.",
                     "type": "array",
                     "items": {
-                        "type": "object"
+                        "type": "string",
+                        "minLength": 1
                     }
                 },
                 "status": {
@@ -82578,9 +82590,11 @@
                     "type": "string"
                 },
                 "models": {
+                    "description": "Model identifiers, e.g. 'gpt-4o'. ``models_list`` stores plain strings; declaring the child as a JSON object made every gateway config/providers response fail response-contract validation in the browser.",
                     "type": "array",
                     "items": {
-                        "type": "object"
+                        "type": "string",
+                        "minLength": 1
                     }
                 },
                 "request_count": {
@@ -83827,6 +83841,65 @@
                     "type": "string",
                     "format": "date-time",
                     "readOnly": true
+                }
+            }
+        },
+        "ProviderModelsRequest": {
+            "type": "object",
+            "properties": {
+                "provider_name": {
+                    "title": "Provider name",
+                    "type": "string"
+                },
+                "base_url": {
+                    "title": "Base url",
+                    "type": "string"
+                },
+                "api_key": {
+                    "title": "Api key",
+                    "type": "string"
+                },
+                "api_format": {
+                    "title": "Api format",
+                    "description": "Gateway protocol adapter name. This intentionally remains a string because self-hosted/custom providers may register adapters outside the built-in openai/anthropic/gemini/google set.",
+                    "type": "string"
+                }
+            }
+        },
+        "ProviderModelsResult": {
+            "required": [
+                "models"
+            ],
+            "type": "object",
+            "properties": {
+                "models": {
+                    "type": "array",
+                    "items": {
+                        "type": "string",
+                        "minLength": 1
+                    }
+                },
+                "error": {
+                    "title": "Error",
+                    "description": "Present when the provider could not be reached. The list is empty and the call still returns 200 so the caller can offer manual entry.",
+                    "type": "string",
+                    "minLength": 1
+                }
+            }
+        },
+        "ProviderModelsResponse": {
+            "required": [
+                "status",
+                "result"
+            ],
+            "type": "object",
+            "properties": {
+                "status": {
+                    "title": "Status",
+                    "type": "boolean"
+                },
+                "result": {
+                    "$ref": "#/definitions/ProviderModelsResult"
                 }
             }
         },

--- a/frontend/src/api/contracts/openapi-contract.generated.js
+++ b/frontend/src/api/contracts/openapi-contract.generated.js
@@ -7144,15 +7144,18 @@ export const OPENAPI_CONTRACT = Object.freeze({
     "/agentcc/provider-credentials/fetch_models/": {
       post: {
         operationId: "agentcc_provider-credentials_fetch_models",
-        runtimeRequestValidation: false,
-        runtimeResponseValidation: false,
+        runtimeRequestValidation: true,
+        runtimeResponseValidation: true,
         requestBody: {
-          $ref: "#/definitions/AgentccProviderCredential",
+          $ref: "#/definitions/ProviderModelsRequest",
         },
         queryParameters: {},
         responses: {
-          201: {
-            $ref: "#/definitions/AgentccProviderCredential",
+          200: {
+            $ref: "#/definitions/ProviderModelsResponse",
+          },
+          400: {
+            $ref: "#/definitions/AgentccErrorResponse",
           },
           default: {
             $ref: "#/definitions/ManagementAPIErrorResponse",
@@ -65813,6 +65816,42 @@ export const OPENAPI_CONTRACT = Object.freeze({
         },
       },
     },
+    ProviderModelsRequest: {
+      type: "object",
+      properties: {
+        provider_name: {
+          title: "Provider name",
+          type: "string",
+        },
+        base_url: {
+          title: "Base url",
+          type: "string",
+        },
+        api_key: {
+          title: "Api key",
+          type: "string",
+        },
+        api_format: {
+          title: "Api format",
+          description:
+            "Gateway protocol adapter name. This intentionally remains a string because self-hosted/custom providers may register adapters outside the built-in openai/anthropic/gemini/google set.",
+          type: "string",
+        },
+      },
+    },
+    ProviderModelsResponse: {
+      required: ["status", "result"],
+      type: "object",
+      properties: {
+        status: {
+          title: "Status",
+          type: "boolean",
+        },
+        result: {
+          $ref: "#/definitions/ProviderModelsResult",
+        },
+      },
+    },
     ProviderStatusResponse: {
       required: ["status", "result"],
       type: "object",
@@ -87312,6 +87351,26 @@ export const OPENAPI_CONTRACT = Object.freeze({
         },
       },
     },
+    ProviderModelsResult: {
+      required: ["models"],
+      type: "object",
+      properties: {
+        models: {
+          type: "array",
+          items: {
+            type: "string",
+            minLength: 1,
+          },
+        },
+        error: {
+          title: "Error",
+          description:
+            "Present when the provider could not be reached. The list is empty and the call still returns 200 so the caller can offer manual entry.",
+          type: "string",
+          minLength: 1,
+        },
+      },
+    },
     ProviderStatusResult: {
       required: ["providers"],
       type: "object",
@@ -96936,9 +96995,12 @@ export const OPENAPI_CONTRACT = Object.freeze({
           "x-nullable": true,
         },
         models: {
+          description:
+            "Model identifiers, e.g. 'gpt-4o'. ``models_list`` stores plain strings; declaring the child as a JSON object made every gateway config/providers response fail response-contract validation in the browser.",
           type: "array",
           items: {
-            type: "object",
+            type: "string",
+            minLength: 1,
           },
         },
         is_active: {
@@ -97053,9 +97115,12 @@ export const OPENAPI_CONTRACT = Object.freeze({
           type: "string",
         },
         models: {
+          description:
+            "Model identifiers, e.g. 'gpt-4o'. ``models_list`` stores plain strings; declaring the child as a JSON object made every gateway config/providers response fail response-contract validation in the browser.",
           type: "array",
           items: {
-            type: "object",
+            type: "string",
+            minLength: 1,
           },
         },
         request_count: {
@@ -102476,9 +102541,12 @@ export const OPENAPI_CONTRACT = Object.freeze({
           type: "string",
         },
         models: {
+          description:
+            "Model identifiers, e.g. 'gpt-4o'. ``models_list`` stores plain strings; declaring the child as a JSON object made every gateway config/providers response fail response-contract validation in the browser.",
           type: "array",
           items: {
-            type: "object",
+            type: "string",
+            minLength: 1,
           },
         },
         status: {

--- a/frontend/src/generated/api-contracts/api.schemas.ts
+++ b/frontend/src/generated/api-contracts/api.schemas.ts
@@ -2588,8 +2588,6 @@ export interface GatewayBatchCancelResponseApi {
   result: GatewayBatchCancelResultApi;
 }
 
-export type GatewayConfigProviderApiModelsItem = { [key: string]: unknown };
-
 export interface GatewayConfigProviderApi {
   id: string;
   /** @minLength 1 */
@@ -2599,7 +2597,8 @@ export interface GatewayConfigProviderApi {
   base_url: string;
   /** Gateway protocol adapter name. This intentionally remains a string because self-hosted/custom providers may register adapters outside the built-in openai/anthropic/gemini/google set. */
   api_format: string;
-  models: GatewayConfigProviderApiModelsItem[];
+  /** Model identifiers, e.g. 'gpt-4o'. ``models_list`` stores plain strings; declaring the child as a JSON object made every gateway config/providers response fail response-contract validation in the browser. */
+  models: string[];
   is_active: boolean;
   default_timeout: number;
   max_concurrent: number;
@@ -2711,13 +2710,12 @@ export interface AgentccEmptyRequestApi {
   [key: string]: unknown;
 }
 
-export type GatewayConfiguredProviderApiModelsItem = { [key: string]: unknown };
-
 export interface GatewayConfiguredProviderApi {
   /** @minLength 1 */
   name: string;
   display_name?: string;
-  models?: GatewayConfiguredProviderApiModelsItem[];
+  /** Model identifiers, e.g. 'gpt-4o'. ``models_list`` stores plain strings; declaring the child as a JSON object made every gateway config/providers response fail response-contract validation in the browser. */
+  models?: string[];
   status?: string;
 }
 
@@ -2758,8 +2756,6 @@ export interface GatewayMCPStatusResponseApi {
   result: GatewayMCPStatusResultApi;
 }
 
-export type GatewayProviderStatusApiModelsItem = { [key: string]: unknown };
-
 export interface GatewayProviderStatusApi {
   /**
    * Provider key/name used by the gateway, not a database UUID.
@@ -2777,7 +2773,8 @@ export interface GatewayProviderStatusApi {
   base_url?: string;
   /** Gateway protocol adapter name. This intentionally remains a string because self-hosted/custom providers may register adapters outside the built-in openai/anthropic/gemini/google set. */
   api_format?: string;
-  models?: GatewayProviderStatusApiModelsItem[];
+  /** Model identifiers, e.g. 'gpt-4o'. ``models_list`` stores plain strings; declaring the child as a JSON object made every gateway config/providers response fail response-contract validation in the browser. */
+  models?: string[];
   request_count?: number;
   avg_latency?: number;
   error_rate?: number;
@@ -3344,6 +3341,28 @@ export interface AgentccProviderCredentialApi {
   last_rotated_at?: string;
   readonly created_at?: string;
   readonly updated_at?: string;
+}
+
+export interface ProviderModelsRequestApi {
+  provider_name?: string;
+  base_url?: string;
+  api_key?: string;
+  /** Gateway protocol adapter name. This intentionally remains a string because self-hosted/custom providers may register adapters outside the built-in openai/anthropic/gemini/google set. */
+  api_format?: string;
+}
+
+export interface ProviderModelsResultApi {
+  models: string[];
+  /**
+   * Present when the provider could not be reached. The list is empty and the call still returns 200 so the caller can offer manual entry.
+   * @minLength 1
+   */
+  error?: string;
+}
+
+export interface ProviderModelsResponseApi {
+  status: boolean;
+  result: ProviderModelsResultApi;
 }
 
 export type AgentccRequestLogDetailApiMetadata = { [key: string]: unknown };

--- a/frontend/src/generated/api-contracts/api.ts
+++ b/frontend/src/generated/api-contracts/api.ts
@@ -875,6 +875,8 @@ import type {
   PromptSimulationScenariosResponseApi,
   PromptSimulationUpdateRequestApi,
   PromptTemplateApi,
+  ProviderModelsRequestApi,
+  ProviderModelsResponseApi,
   ProviderStatusResponseApi,
   PublicConfigResponseApi,
   QueueAddItemsResponseApi,
@@ -15825,24 +15827,31 @@ export const agentccProviderCredentialsCreate = async (
   );
 };
 
-export type agentccProviderCredentialsFetchModelsResponse201 = {
-  data: AgentccProviderCredentialApi;
-  status: 201;
+export type agentccProviderCredentialsFetchModelsResponse200 = {
+  data: ProviderModelsResponseApi;
+  status: 200;
+};
+
+export type agentccProviderCredentialsFetchModelsResponse400 = {
+  data: AgentccErrorResponseApi;
+  status: 400;
 };
 
 export type agentccProviderCredentialsFetchModelsResponseDefault = {
   data: ManagementAPIErrorResponseApi;
-  status: Exclude<HTTPStatusCodes, 201>;
+  status: Exclude<HTTPStatusCodes, 200 | 400>;
 };
 
 export type agentccProviderCredentialsFetchModelsResponseSuccess =
-  agentccProviderCredentialsFetchModelsResponse201 & {
+  agentccProviderCredentialsFetchModelsResponse200 & {
     headers: Headers;
   };
-export type agentccProviderCredentialsFetchModelsResponseError =
-  agentccProviderCredentialsFetchModelsResponseDefault & {
-    headers: Headers;
-  };
+export type agentccProviderCredentialsFetchModelsResponseError = (
+  | agentccProviderCredentialsFetchModelsResponse400
+  | agentccProviderCredentialsFetchModelsResponseDefault
+) & {
+  headers: Headers;
+};
 
 export type agentccProviderCredentialsFetchModelsResponse =
   | agentccProviderCredentialsFetchModelsResponseSuccess
@@ -15859,7 +15868,7 @@ export const getAgentccProviderCredentialsFetchModelsUrl = () => {
  * @summary Fetch available models from a provider's API.
  */
 export const agentccProviderCredentialsFetchModels = async (
-  agentccProviderCredentialApi: NonReadonly<AgentccProviderCredentialApi>,
+  providerModelsRequestApi: ProviderModelsRequestApi,
   options?: RequestInit,
 ): Promise<agentccProviderCredentialsFetchModelsResponse> => {
   return apiMutator<agentccProviderCredentialsFetchModelsResponse>(
@@ -15868,7 +15877,7 @@ export const agentccProviderCredentialsFetchModels = async (
       ...options,
       method: "POST",
       headers: { "Content-Type": "application/json", ...options?.headers },
-      body: JSON.stringify(agentccProviderCredentialApi),
+      body: JSON.stringify(providerModelsRequestApi),
     },
   );
 };

--- a/frontend/src/generated/api-contracts/api.zod.ts
+++ b/frontend/src/generated/api-contracts/api.zod.ts
@@ -5218,7 +5218,11 @@ export const AgentccGatewaysConfigResponse = zod.object({
           .describe(
             "Gateway protocol adapter name. This intentionally remains a string because self-hosted/custom providers may register adapters outside the built-in openai/anthropic/gemini/google set.",
           ),
-        models: zod.array(zod.object({}).passthrough()),
+        models: zod
+          .array(zod.string().min(1))
+          .describe(
+            "Model identifiers, e.g. 'gpt-4o'. ``models_list`` stores plain strings; declaring the child as a JSON object made every gateway config/providers response fail response-contract validation in the browser.",
+          ),
         is_active: zod.boolean(),
         default_timeout: zod.number(),
         max_concurrent: zod.number(),
@@ -5282,7 +5286,12 @@ export const AgentccGatewaysHealthCheckResponse = zod.object({
         zod.object({
           name: zod.string().min(1),
           display_name: zod.string().optional(),
-          models: zod.array(zod.object({}).passthrough()).optional(),
+          models: zod
+            .array(zod.string().min(1))
+            .optional()
+            .describe(
+              "Model identifiers, e.g. 'gpt-4o'. ``models_list`` stores plain strings; declaring the child as a JSON object made every gateway config/providers response fail response-contract validation in the browser.",
+            ),
           status: zod.string().optional(),
         }),
       ),
@@ -5386,7 +5395,12 @@ export const AgentccGatewaysProvidersResponse = zod.object({
           .describe(
             "Gateway protocol adapter name. This intentionally remains a string because self-hosted/custom providers may register adapters outside the built-in openai/anthropic/gemini/google set.",
           ),
-        models: zod.array(zod.object({}).passthrough()).optional(),
+        models: zod
+          .array(zod.string().min(1))
+          .optional()
+          .describe(
+            "Model identifiers, e.g. 'gpt-4o'. ``models_list`` stores plain strings; declaring the child as a JSON object made every gateway config/providers response fail response-contract validation in the browser.",
+          ),
         request_count: zod.number().optional(),
         avg_latency: zod.number().optional(),
         error_rate: zod.number().optional(),
@@ -6918,64 +6932,30 @@ export const AgentccProviderCredentialsCreateBody = zod.object({
 - api_key + base_url + api_format: use raw values (for create-mode).
  * @summary Fetch available models from a provider's API.
  */
-export const agentccProviderCredentialsFetchModelsBodyProviderNameMax = 100;
-
-export const agentccProviderCredentialsFetchModelsBodyDisplayNameMax = 255;
-
-export const agentccProviderCredentialsFetchModelsBodyBaseUrlMax = 500;
-
-export const agentccProviderCredentialsFetchModelsBodyApiFormatMax = 50;
-
-export const agentccProviderCredentialsFetchModelsBodyDefaultTimeoutSecondsMin =
-  -2147483648;
-export const agentccProviderCredentialsFetchModelsBodyDefaultTimeoutSecondsMax = 2147483647;
-
-export const agentccProviderCredentialsFetchModelsBodyMaxConcurrentMin =
-  -2147483648;
-export const agentccProviderCredentialsFetchModelsBodyMaxConcurrentMax = 2147483647;
-
-export const agentccProviderCredentialsFetchModelsBodyConnPoolSizeMin =
-  -2147483648;
-export const agentccProviderCredentialsFetchModelsBodyConnPoolSizeMax = 2147483647;
-
 export const AgentccProviderCredentialsFetchModelsBody = zod.object({
-  provider_name: zod
-    .string()
-    .min(1)
-    .max(agentccProviderCredentialsFetchModelsBodyProviderNameMax),
-  display_name: zod
-    .string()
-    .max(agentccProviderCredentialsFetchModelsBodyDisplayNameMax)
-    .optional(),
-  base_url: zod
-    .string()
-    .url()
-    .max(agentccProviderCredentialsFetchModelsBodyBaseUrlMax)
-    .optional(),
+  provider_name: zod.string().optional(),
+  base_url: zod.string().optional(),
+  api_key: zod.string().optional(),
   api_format: zod
     .string()
-    .min(1)
-    .max(agentccProviderCredentialsFetchModelsBodyApiFormatMax)
-    .optional(),
-  models_list: zod.object({}).passthrough().optional(),
-  default_timeout_seconds: zod
-    .number()
-    .min(agentccProviderCredentialsFetchModelsBodyDefaultTimeoutSecondsMin)
-    .max(agentccProviderCredentialsFetchModelsBodyDefaultTimeoutSecondsMax)
-    .optional(),
-  max_concurrent: zod
-    .number()
-    .min(agentccProviderCredentialsFetchModelsBodyMaxConcurrentMin)
-    .max(agentccProviderCredentialsFetchModelsBodyMaxConcurrentMax)
-    .optional(),
-  conn_pool_size: zod
-    .number()
-    .min(agentccProviderCredentialsFetchModelsBodyConnPoolSizeMin)
-    .max(agentccProviderCredentialsFetchModelsBodyConnPoolSizeMax)
-    .optional(),
-  extra_config: zod.object({}).passthrough().optional(),
-  is_active: zod.boolean().optional(),
-  last_rotated_at: zod.string().datetime({ offset: true }).optional(),
+    .optional()
+    .describe(
+      "Gateway protocol adapter name. This intentionally remains a string because self-hosted/custom providers may register adapters outside the built-in openai/anthropic/gemini/google set.",
+    ),
+});
+
+export const AgentccProviderCredentialsFetchModelsResponse = zod.object({
+  status: zod.boolean(),
+  result: zod.object({
+    models: zod.array(zod.string().min(1)),
+    error: zod
+      .string()
+      .min(1)
+      .optional()
+      .describe(
+        "Present when the provider could not be reached. The list is empty and the call still returns 200 so the caller can offer manual entry.",
+      ),
+  }),
 });
 
 export const AgentccProviderCredentialsReadParams = zod.object({

--- a/frontend/src/sections/gateway/providers/AddProviderDialog.jsx
+++ b/frontend/src/sections/gateway/providers/AddProviderDialog.jsx
@@ -133,6 +133,21 @@ const API_FORMATS = [
   "bedrock",
 ];
 
+// The API types a provider's models as a free-form JSON list, so an entry is
+// not guaranteed to be a string. Anything non-string reaching state would make
+// .trim() throw in the Autocomplete's onChange and render an object as a React
+// child in the chips — either one takes the whole dialog down.
+const toModelId = (value) => {
+  if (typeof value === "string") return value.trim();
+  if (value && typeof value === "object") {
+    return String(value.id ?? value.name ?? value.model ?? "").trim();
+  }
+  return value == null ? "" : String(value).trim();
+};
+
+const normalizeModels = (list) =>
+  Array.isArray(list) ? list.map(toModelId).filter(Boolean) : [];
+
 // Human labels for the validation summary, in the order the fields appear in
 // the form so the summary reads top-to-bottom like the dialog itself.
 const FIELD_LABELS = {
@@ -184,7 +199,7 @@ const AddProviderDialog = ({ open, onClose, gatewayId, provider }) => {
           : { baseUrl: url, apiKey: key, apiFormat: format },
         {
           onSuccess: (result) => {
-            const fetched = result?.models || [];
+            const fetched = normalizeModels(result?.models);
             if (fetched.length === 0 && result?.error) {
               setFetchError(result.error);
             }
@@ -210,7 +225,7 @@ const AddProviderDialog = ({ open, onClose, gatewayId, provider }) => {
       setBaseUrl(c.base_url ?? c.baseUrl ?? "");
       setApiKey("");
       setApiFormat(c.api_format ?? c.apiFormat ?? "openai");
-      setModels(Array.isArray(c.models) ? c.models : []);
+      setModels(normalizeModels(c.models));
       const timeoutRaw = c.default_timeout ?? c.defaultTimeout;
       setTimeoutVal(timeoutRaw != null ? String(timeoutRaw) : "");
       setMaxConcurrent(
@@ -671,7 +686,7 @@ const AddProviderDialog = ({ open, onClose, gatewayId, provider }) => {
               options={modelOptions}
               value={models}
               onChange={(_, val) => {
-                setModels(val.map((v) => v.trim()).filter(Boolean));
+                setModels(normalizeModels(val));
                 setErrors((prev) => ({ ...prev, models: undefined }));
               }}
               renderOption={(props, option, { selected }) => (

--- a/frontend/src/sections/gateway/providers/AddProviderDialog.jsx
+++ b/frontend/src/sections/gateway/providers/AddProviderDialog.jsx
@@ -786,18 +786,25 @@ const AddProviderDialog = ({ open, onClose, gatewayId, provider }) => {
       </DialogContent>
       <DialogActions>
         <Button onClick={handleClose}>Cancel</Button>
+        {/* Saving mid-fetch would validate against a stale (usually empty)
+            model list and reject a perfectly good API key, so hold the action
+            until the models request settles. */}
         <Button
           variant="contained"
           onClick={handleSave}
-          disabled={!name.trim() || updateProvider.isPending}
+          disabled={
+            !name.trim() || updateProvider.isPending || fetchModels.isPending
+          }
         >
-          {updateProvider.isPending
-            ? isEditMode
-              ? "Saving..."
-              : "Adding..."
-            : isEditMode
-              ? "Save Changes"
-              : "Add Provider"}
+          {fetchModels.isPending
+            ? "Loading models..."
+            : updateProvider.isPending
+              ? isEditMode
+                ? "Saving..."
+                : "Adding..."
+              : isEditMode
+                ? "Save Changes"
+                : "Add Provider"}
         </Button>
       </DialogActions>
     </Dialog>

--- a/frontend/src/sections/gateway/providers/AddProviderDialog.jsx
+++ b/frontend/src/sections/gateway/providers/AddProviderDialog.jsx
@@ -195,7 +195,8 @@ const AddProviderDialog = ({ open, onClose, gatewayId, provider }) => {
       setApiKey("");
       setApiFormat(c.api_format ?? c.apiFormat ?? "openai");
       setModels(Array.isArray(c.models) ? c.models : []);
-      setTimeoutVal(c.default_timeout ?? c.defaultTimeout ?? "");
+      const timeoutRaw = c.default_timeout ?? c.defaultTimeout;
+      setTimeoutVal(timeoutRaw != null ? String(timeoutRaw) : "");
       setMaxConcurrent(
         c.max_concurrent != null
           ? String(c.max_concurrent ?? c.maxConcurrent ?? "")
@@ -347,16 +348,21 @@ const AddProviderDialog = ({ open, onClose, gatewayId, provider }) => {
       newErrors.models = "Select at least one model";
     }
 
-    if (timeoutVal.trim() && parseTimeoutSeconds(timeoutVal) === null) {
-      newErrors.timeout = "Use seconds, e.g. 30 or 30s";
-    }
-
     setErrors(newErrors);
     return Object.keys(newErrors).length === 0;
   };
 
   const handleSave = () => {
     if (!validate()) return;
+
+    const timeoutSeconds = parseTimeoutSeconds(timeoutVal);
+    if (timeoutVal.trim() && timeoutSeconds === null) {
+      setErrors((prev) => ({
+        ...prev,
+        timeout: "Use seconds, e.g. 30 or 30s",
+      }));
+      return;
+    }
 
     const config = { base_url: baseUrl, api_format: apiFormat };
     if (isAwsAuth) {
@@ -368,7 +374,6 @@ const AddProviderDialog = ({ open, onClose, gatewayId, provider }) => {
       config.api_key = apiKey;
     }
     if (models.length > 0) config.models = models;
-    const timeoutSeconds = parseTimeoutSeconds(timeoutVal);
     if (timeoutSeconds !== null) config.default_timeout = timeoutSeconds;
     if (maxConcurrent) config.max_concurrent = Number(maxConcurrent);
 

--- a/frontend/src/sections/gateway/providers/AddProviderDialog.jsx
+++ b/frontend/src/sections/gateway/providers/AddProviderDialog.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useCallback } from "react";
+import React, { useState, useEffect, useCallback, useRef } from "react";
 import PropTypes from "prop-types";
 import {
   Dialog,
@@ -9,6 +9,7 @@ import {
   TextField,
   Stack,
   Alert,
+  AlertTitle,
   Chip,
   Autocomplete,
   MenuItem,
@@ -132,6 +133,18 @@ const API_FORMATS = [
   "bedrock",
 ];
 
+// Human labels for the validation summary, in the order the fields appear in
+// the form so the summary reads top-to-bottom like the dialog itself.
+const FIELD_LABELS = {
+  name: "Provider Name",
+  awsAccessKeyId: "AWS Access Key ID",
+  awsSecretAccessKey: "AWS Secret Access Key",
+  baseUrl: "Base URL",
+  apiKey: "API Key",
+  models: "Models",
+  timeout: "Timeout",
+};
+
 const AddProviderDialog = ({ open, onClose, gatewayId, provider }) => {
   const isEditMode = Boolean(provider);
 
@@ -151,6 +164,9 @@ const AddProviderDialog = ({ open, onClose, gatewayId, provider }) => {
 
   // Validation state
   const [errors, setErrors] = useState({});
+  // The dialog body scrolls, so a failed Save has to bring the summary back
+  // into view — otherwise the button looks inert.
+  const contentRef = useRef(null);
 
   const updateProvider = useUpdateProvider();
   const fetchModels = useFetchProviderModels();
@@ -300,7 +316,7 @@ const AddProviderDialog = ({ open, onClose, gatewayId, provider }) => {
     }
   };
 
-  const validate = () => {
+  const validate = (timeoutSeconds) => {
     const newErrors = {};
 
     if (!name.trim()) {
@@ -320,10 +336,11 @@ const AddProviderDialog = ({ open, onClose, gatewayId, provider }) => {
       const preset = PROVIDER_PRESETS[name];
       const needsBaseUrl = !preset || !preset.baseUrl;
       if (needsBaseUrl && !baseUrl.trim()) {
-        newErrors.baseUrl = "Base URL is required for this provider";
+        newErrors.baseUrl =
+          "This provider has no preset endpoint — enter its base URL, e.g. https://your-endpoint.com";
       }
-      if (baseUrl.trim() && !baseUrl.startsWith("http")) {
-        newErrors.baseUrl = "Base URL must start with http:// or https://";
+      if (baseUrl.trim() && !/^https?:\/\//i.test(baseUrl.trim())) {
+        newErrors.baseUrl = `Base URL must start with http:// or https:// (got "${baseUrl.trim()}")`;
       }
 
       // API key required for new providers
@@ -343,9 +360,23 @@ const AddProviderDialog = ({ open, onClose, gatewayId, provider }) => {
       }
     }
 
-    // Require at least one model selected
+    // Require at least one model selected. Say why the list is empty when it
+    // is — otherwise "select a model" is impossible advice with nothing to
+    // pick from.
     if (models.length === 0) {
-      newErrors.models = "Select at least one model";
+      if (fetchError) {
+        newErrors.models = `Select at least one model. Loading this provider's models failed (${fetchError}) — type a model ID and press Enter to add it manually.`;
+      } else if (modelOptions.length === 0) {
+        newErrors.models = isEditMode
+          ? "Select at least one model. None were loaded for this provider — type a model ID and press Enter to add it manually."
+          : "Select at least one model. Enter a valid API key to load the list, or type a model ID and press Enter.";
+      } else {
+        newErrors.models = "Select at least one model from the list.";
+      }
+    }
+
+    if (timeoutVal.trim() && timeoutSeconds === null) {
+      newErrors.timeout = `Timeout must be a whole number of seconds, e.g. 30 or 30s (got "${timeoutVal.trim()}")`;
     }
 
     setErrors(newErrors);
@@ -353,14 +384,11 @@ const AddProviderDialog = ({ open, onClose, gatewayId, provider }) => {
   };
 
   const handleSave = () => {
-    if (!validate()) return;
-
     const timeoutSeconds = parseTimeoutSeconds(timeoutVal);
-    if (timeoutVal.trim() && timeoutSeconds === null) {
-      setErrors((prev) => ({
-        ...prev,
-        timeout: "Use seconds, e.g. 30 or 30s",
-      }));
+    if (!validate(timeoutSeconds)) {
+      // scrollTo is missing in jsdom and older browsers — never let a Save
+      // handler throw on a cosmetic scroll.
+      contentRef.current?.scrollTo?.({ top: 0, behavior: "smooth" });
       return;
     }
 
@@ -404,11 +432,36 @@ const AddProviderDialog = ({ open, onClose, gatewayId, provider }) => {
 
   const preset = PROVIDER_PRESETS[name] || PROVIDER_PRESETS.custom;
 
+  const errorList = Object.keys(FIELD_LABELS)
+    .filter((key) => errors[key])
+    .map((key) => ({ key, label: FIELD_LABELS[key], message: errors[key] }));
+
   return (
     <Dialog open={open} onClose={handleClose} maxWidth="sm" fullWidth>
       <DialogTitle>{isEditMode ? "Edit Provider" : "Add Provider"}</DialogTitle>
-      <DialogContent>
+      <DialogContent ref={contentRef}>
         <Stack spacing={2} mt={1}>
+          {/* Validation summary — the body scrolls, so an inline-only error
+              under a field can sit off-screen and make Save look broken. */}
+          {errorList.length > 0 && (
+            <Alert severity="error" onClose={() => setErrors({})}>
+              <AlertTitle>
+                {errorList.length === 1
+                  ? "Fix this before saving"
+                  : `Fix ${errorList.length} issues before saving`}
+              </AlertTitle>
+              <Box component="ul" sx={{ m: 0, pl: 2.5 }}>
+                {errorList.map(({ key, label, message }) => (
+                  <li key={key}>
+                    <Typography variant="body2" component="span">
+                      <strong>{label}:</strong> {message}
+                    </Typography>
+                  </li>
+                ))}
+              </Box>
+            </Alert>
+          )}
+
           {/* Provider Name — dropdown for common providers */}
           {isEditMode ? (
             <TextField
@@ -417,7 +470,8 @@ const AddProviderDialog = ({ open, onClose, gatewayId, provider }) => {
               required
               value={name}
               disabled
-              helperText="Provider name cannot be changed"
+              error={!!errors.name}
+              helperText={errors.name || "Provider name cannot be changed"}
             />
           ) : (
             <TextField
@@ -512,7 +566,10 @@ const AddProviderDialog = ({ open, onClose, gatewayId, provider }) => {
                 fullWidth
                 required={!preset.baseUrl}
                 value={baseUrl}
-                onChange={(e) => setBaseUrl(e.target.value)}
+                onChange={(e) => {
+                  setBaseUrl(e.target.value);
+                  setErrors((prev) => ({ ...prev, baseUrl: undefined }));
+                }}
                 placeholder={preset.baseUrl || "https://your-endpoint.com"}
                 error={!!errors.baseUrl}
                 helperText={

--- a/frontend/src/sections/gateway/providers/AddProviderDialog.test.jsx
+++ b/frontend/src/sections/gateway/providers/AddProviderDialog.test.jsx
@@ -1,5 +1,33 @@
-import { describe, expect, it } from "vitest";
+import React from "react";
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { render, screen, userEvent } from "src/utils/test-utils";
 import { parseTimeoutSeconds } from "./utils";
+import AddProviderDialog from "./AddProviderDialog";
+
+const { updateMutate, fetchMutate } = vi.hoisted(() => ({
+  updateMutate: vi.fn(),
+  fetchMutate: vi.fn(),
+}));
+
+vi.mock("./hooks/useGatewayConfig", () => ({
+  useUpdateProvider: () => ({
+    mutate: updateMutate,
+    isPending: false,
+    isError: false,
+    error: null,
+  }),
+  useFetchProviderModels: () => ({ mutate: fetchMutate, isPending: false }),
+}));
+
+const renderEditDialog = (config) =>
+  render(
+    <AddProviderDialog
+      open
+      onClose={vi.fn()}
+      gatewayId="gw-1"
+      provider={{ name: "openai", config }}
+    />,
+  );
 
 describe("parseTimeoutSeconds", () => {
   it("normalizes Gateway provider timeout text to integer seconds", () => {
@@ -10,5 +38,65 @@ describe("parseTimeoutSeconds", () => {
     expect(parseTimeoutSeconds("")).toBeNull();
     expect(parseTimeoutSeconds("soon")).toBeNull();
     expect(parseTimeoutSeconds("0s")).toBeNull();
+  });
+});
+
+describe("AddProviderDialog validation", () => {
+  beforeEach(() => {
+    updateMutate.mockReset();
+    // The dialog fetches the provider's models when it opens in edit mode.
+    fetchMutate.mockReset();
+    fetchMutate.mockImplementation((_vars, opts) =>
+      opts?.onSuccess?.({ models: ["gpt-4o", "gpt-4o-mini"] }),
+    );
+  });
+
+  it("saves an edited provider whose stored timeout came back as a number", async () => {
+    // The API returns default_timeout as an integer; seeding the text field
+    // with it used to throw "timeoutVal.trim is not a function" on Save.
+    renderEditDialog({ default_timeout: 30, models: ["gpt-4o"] });
+
+    await userEvent.click(screen.getByRole("button", { name: "Save Changes" }));
+
+    expect(updateMutate).toHaveBeenCalledTimes(1);
+    expect(updateMutate.mock.calls[0][0].config.default_timeout).toBe(30);
+  });
+
+  it("summarises why a save was blocked instead of failing silently", async () => {
+    renderEditDialog({ default_timeout: 30, models: [] });
+
+    await userEvent.click(screen.getByRole("button", { name: "Save Changes" }));
+
+    expect(updateMutate).not.toHaveBeenCalled();
+    expect(await screen.findByText("Fix this before saving")).toBeTruthy();
+    expect(
+      screen.getAllByText(/Select at least one model/).length,
+    ).toBeGreaterThan(0);
+  });
+
+  it("reports a malformed timeout with the offending value", async () => {
+    renderEditDialog({ default_timeout: 30, models: ["gpt-4o"] });
+
+    const timeout = screen.getByLabelText("Timeout");
+    await userEvent.clear(timeout);
+    await userEvent.type(timeout, "soon");
+    await userEvent.click(screen.getByRole("button", { name: "Save Changes" }));
+
+    expect(updateMutate).not.toHaveBeenCalled();
+    expect(
+      screen.getAllByText(/whole number of seconds.*got "soon"/).length,
+    ).toBeGreaterThan(0);
+  });
+
+  it("counts multiple problems in the summary", async () => {
+    renderEditDialog({ default_timeout: 30, models: [] });
+
+    const timeout = screen.getByLabelText("Timeout");
+    await userEvent.clear(timeout);
+    await userEvent.type(timeout, "soon");
+    await userEvent.click(screen.getByRole("button", { name: "Save Changes" }));
+
+    expect(updateMutate).not.toHaveBeenCalled();
+    expect(await screen.findByText("Fix 2 issues before saving")).toBeTruthy();
   });
 });

--- a/frontend/src/sections/gateway/providers/AddProviderDialog.test.jsx
+++ b/frontend/src/sections/gateway/providers/AddProviderDialog.test.jsx
@@ -4,9 +4,11 @@ import { render, screen, userEvent } from "src/utils/test-utils";
 import { parseTimeoutSeconds } from "./utils";
 import AddProviderDialog from "./AddProviderDialog";
 
-const { updateMutate, fetchMutate } = vi.hoisted(() => ({
+const { updateMutate, fetchMutate, fetchState } = vi.hoisted(() => ({
   updateMutate: vi.fn(),
   fetchMutate: vi.fn(),
+  // Mutable so a test can render the dialog mid-fetch.
+  fetchState: { isPending: false },
 }));
 
 vi.mock("./hooks/useGatewayConfig", () => ({
@@ -16,7 +18,10 @@ vi.mock("./hooks/useGatewayConfig", () => ({
     isError: false,
     error: null,
   }),
-  useFetchProviderModels: () => ({ mutate: fetchMutate, isPending: false }),
+  useFetchProviderModels: () => ({
+    mutate: fetchMutate,
+    isPending: fetchState.isPending,
+  }),
 }));
 
 const renderEditDialog = (config) =>
@@ -44,6 +49,7 @@ describe("parseTimeoutSeconds", () => {
 describe("AddProviderDialog validation", () => {
   beforeEach(() => {
     updateMutate.mockReset();
+    fetchState.isPending = false;
     // The dialog fetches the provider's models when it opens in edit mode.
     fetchMutate.mockReset();
     fetchMutate.mockImplementation((_vars, opts) =>
@@ -98,5 +104,16 @@ describe("AddProviderDialog validation", () => {
 
     expect(updateMutate).not.toHaveBeenCalled();
     expect(await screen.findByText("Fix 2 issues before saving")).toBeTruthy();
+  });
+
+  it("holds Save while the provider's models are still loading", () => {
+    // Saving mid-fetch validates against an empty model list and rejects a
+    // valid API key, so the action stays disabled until the request settles.
+    fetchState.isPending = true;
+    renderEditDialog({ default_timeout: 30, models: ["gpt-4o"] });
+
+    const save = screen.getByRole("button", { name: "Loading models..." });
+    expect(save.disabled).toBe(true);
+    expect(updateMutate).not.toHaveBeenCalled();
   });
 });

--- a/frontend/src/sections/gateway/providers/hooks/useGatewayConfig.js
+++ b/frontend/src/sections/gateway/providers/hooks/useGatewayConfig.js
@@ -1,11 +1,40 @@
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import axios, { endpoints } from "src/utils/axios";
 
+// The shared axios instance is created without a `timeout`, and axios defaults
+// to 0 — wait forever. A stalled gateway request therefore never rejects, so
+// React Query's isPending sticks on and the caller's UI is left disabled with
+// no error (the Save button stuck on "Saving..."). Scope a timeout to the
+// gateway admin calls rather than changing the global instance.
+const GATEWAY_TIMEOUT = 30000;
+const REQUEST_CONFIG = { timeout: GATEWAY_TIMEOUT };
+
+// Listing a provider's models is a round trip through the gateway to a third
+// party, so it gets a longer budget than a config write.
+const FETCH_MODELS_CONFIG = { timeout: 60000 };
+
+// axios surfaces a timeout as ECONNABORTED with "timeout of 30000ms exceeded",
+// which is not something a user can act on.
+export function asRequestError(err, action) {
+  const timedOut =
+    err?.code === "ECONNABORTED" ||
+    /^timeout of \d+ms/.test(err?.message || "");
+  if (!timedOut) return err;
+  const friendly = new Error(
+    `${action} timed out — the gateway did not respond. Check that it is reachable, then try again.`,
+  );
+  friendly.cause = err;
+  return friendly;
+}
+
 export function useGatewayConfig(gatewayId) {
   return useQuery({
     queryKey: ["agentcc-gateway-config", gatewayId],
     queryFn: async () => {
-      const { data } = await axios.get(endpoints.gateway.config(gatewayId));
+      const { data } = await axios.get(
+        endpoints.gateway.config(gatewayId),
+        REQUEST_CONFIG,
+      );
       return data.result;
     },
     enabled: Boolean(gatewayId),
@@ -17,7 +46,10 @@ export function useProviderHealth(gatewayId) {
   return useQuery({
     queryKey: ["agentcc-provider-health", gatewayId],
     queryFn: async () => {
-      const { data } = await axios.get(endpoints.gateway.providers(gatewayId));
+      const { data } = await axios.get(
+        endpoints.gateway.providers(gatewayId),
+        REQUEST_CONFIG,
+      );
       return data.result;
     },
     enabled: Boolean(gatewayId),
@@ -31,14 +63,19 @@ export function useUpdateProvider() {
 
   return useMutation({
     mutationFn: async ({ gatewayId, name, config }) => {
-      const { data } = await axios.post(
-        endpoints.gateway.updateProvider(gatewayId),
-        {
-          name,
-          config,
-        },
-      );
-      return data.result;
+      try {
+        const { data } = await axios.post(
+          endpoints.gateway.updateProvider(gatewayId),
+          {
+            name,
+            config,
+          },
+          REQUEST_CONFIG,
+        );
+        return data.result;
+      } catch (err) {
+        throw asRequestError(err, "Saving the provider");
+      }
     },
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["agentcc-gateway-config"] });
@@ -55,6 +92,7 @@ export function useRemoveProvider() {
       const { data } = await axios.post(
         endpoints.gateway.removeProvider(gatewayId),
         { name },
+        REQUEST_CONFIG,
       );
       return data.result;
     },
@@ -76,6 +114,7 @@ export function useToggleGuardrail() {
           name,
           enabled,
         },
+        REQUEST_CONFIG,
       );
       return data.result;
     },
@@ -97,6 +136,7 @@ export function useUpdateGuardrail() {
           name,
           config,
         },
+        REQUEST_CONFIG,
       );
       return data.result;
     },
@@ -118,6 +158,7 @@ export function useSetBudget() {
           level,
           config,
         },
+        REQUEST_CONFIG,
       );
       return data.result;
     },
@@ -135,6 +176,7 @@ export function useRemoveBudget() {
       const { data } = await axios.post(
         endpoints.gateway.removeBudget(gatewayId),
         { level },
+        REQUEST_CONFIG,
       );
       return data.result;
     },
@@ -153,6 +195,7 @@ export function useUpdateConfig() {
       const { data } = await axios.post(
         endpoints.gateway.updateConfig(gatewayId),
         config,
+        REQUEST_CONFIG,
       );
       return data.result;
     },
@@ -171,6 +214,7 @@ export function useReloadConfig() {
       const { data } = await axios.post(
         endpoints.gateway.reload(gatewayId),
         {},
+        REQUEST_CONFIG,
       );
       return data.result;
     },
@@ -187,11 +231,16 @@ export function useFetchProviderModels() {
       const body = providerName
         ? { provider_name: providerName }
         : { base_url: baseUrl, api_key: apiKey, api_format: apiFormat };
-      const { data } = await axios.post(
-        endpoints.gateway.providerCredentials.fetchModels,
-        body,
-      );
-      return data.result;
+      try {
+        const { data } = await axios.post(
+          endpoints.gateway.providerCredentials.fetchModels,
+          body,
+          FETCH_MODELS_CONFIG,
+        );
+        return data.result;
+      } catch (err) {
+        throw asRequestError(err, "Loading this provider's models");
+      }
     },
   });
 }

--- a/frontend/src/sections/gateway/providers/hooks/useGatewayConfig.test.jsx
+++ b/frontend/src/sections/gateway/providers/hooks/useGatewayConfig.test.jsx
@@ -1,0 +1,71 @@
+import React from "react";
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { renderHook } from "src/utils/test-utils";
+import {
+  MutationCache,
+  QueryClient,
+  QueryClientProvider,
+} from "@tanstack/react-query";
+import { asRequestError, useUpdateProvider } from "./useGatewayConfig";
+
+const { post } = vi.hoisted(() => ({ post: vi.fn() }));
+
+vi.mock("src/utils/axios", () => ({
+  default: { post, get: vi.fn() },
+  endpoints: {
+    gateway: {
+      updateProvider: (id) => `/gateway/${id}/provider/update`,
+      providerCredentials: { fetchModels: "/gateway/provider/models" },
+    },
+  },
+}));
+
+const wrapper = ({ children }) => {
+  const client = new QueryClient({
+    // Errors are asserted on the mutateAsync promise; the cache-level handler
+    // just keeps React Query's own rejection from surfacing as unhandled.
+    mutationCache: new MutationCache({ onError: () => {} }),
+    defaultOptions: { mutations: { retry: false }, queries: { retry: false } },
+  });
+  return <QueryClientProvider client={client}>{children}</QueryClientProvider>;
+};
+
+const save = () => {
+  const { result } = renderHook(() => useUpdateProvider(), { wrapper });
+  return result.current.mutateAsync({
+    gatewayId: "gw-1",
+    name: "openai",
+    config: {},
+  });
+};
+
+describe("asRequestError", () => {
+  it("turns an axios timeout into an actionable message", () => {
+    const timeout = Object.assign(new Error("timeout of 30000ms exceeded"), {
+      code: "ECONNABORTED",
+    });
+
+    expect(asRequestError(timeout, "Saving the provider").message).toMatch(
+      /Saving the provider timed out — the gateway did not respond/,
+    );
+    expect(asRequestError(timeout, "Saving the provider").cause).toBe(timeout);
+  });
+
+  it("leaves ordinary server errors untouched", () => {
+    const conflict = new Error("Provider already exists");
+
+    expect(asRequestError(conflict, "Saving the provider")).toBe(conflict);
+  });
+});
+
+describe("useUpdateProvider", () => {
+  beforeEach(() => post.mockReset());
+
+  it("bounds the request so a stalled gateway cannot hang the Save button", async () => {
+    post.mockResolvedValue({ data: { result: {} } });
+
+    await save();
+
+    expect(post.mock.calls[0][2]).toEqual({ timeout: 30000 });
+  });
+});

--- a/frontend/src/sections/gateway/sessions/SessionExplorerSection.jsx
+++ b/frontend/src/sections/gateway/sessions/SessionExplorerSection.jsx
@@ -213,7 +213,7 @@ const SessionExplorerSection = () => {
                             });
                           }}
                         >
-                          {session.session_id?.substring(0, 16)}
+                          {session.session_id}
                         </Typography>
                       </Tooltip>
                     </TableCell>

--- a/futureagi/agentcc/serializers/contracts.py
+++ b/futureagi/agentcc/serializers/contracts.py
@@ -14,6 +14,11 @@ API_FORMAT_HELP_TEXT = (
     "openai/anthropic/gemini/google set."
 )
 PROVIDER_KEY_HELP_TEXT = "Provider key/name used by the gateway, not a database UUID."
+PROVIDER_MODELS_HELP_TEXT = (
+    "Model identifiers, e.g. 'gpt-4o'. ``models_list`` stores plain strings; "
+    "declaring the child as a JSON object made every gateway config/providers "
+    "response fail response-contract validation in the browser."
+)
 
 # Keep response wrappers explicit even when the envelope is just status/result:
 # the generated OpenAPI component names stay stable and each endpoint owns its
@@ -59,7 +64,11 @@ class GatewayListResponseSerializer(serializers.Serializer):
 class GatewayConfiguredProviderSerializer(serializers.Serializer):
     name = serializers.CharField()
     display_name = serializers.CharField(required=False, allow_blank=True)
-    models = serializers.ListField(child=serializers.JSONField(), required=False)
+    models = serializers.ListField(
+        child=serializers.CharField(),
+        required=False,
+        help_text=PROVIDER_MODELS_HELP_TEXT,
+    )
     status = serializers.CharField(required=False, allow_blank=True)
 
 
@@ -90,7 +99,10 @@ class GatewayConfigProviderSerializer(serializers.Serializer):
         allow_null=True,
         help_text=API_FORMAT_HELP_TEXT,
     )
-    models = serializers.ListField(child=serializers.JSONField())
+    models = serializers.ListField(
+        child=serializers.CharField(),
+        help_text=PROVIDER_MODELS_HELP_TEXT,
+    )
     is_active = serializers.BooleanField()
     default_timeout = serializers.IntegerField(allow_null=True)
     max_concurrent = serializers.IntegerField(allow_null=True)
@@ -192,7 +204,11 @@ class GatewayProviderStatusSerializer(serializers.Serializer):
         allow_blank=True,
         help_text=API_FORMAT_HELP_TEXT,
     )
-    models = serializers.ListField(child=serializers.JSONField(), required=False)
+    models = serializers.ListField(
+        child=serializers.CharField(),
+        required=False,
+        help_text=PROVIDER_MODELS_HELP_TEXT,
+    )
     request_count = serializers.IntegerField(required=False)
     avg_latency = serializers.FloatField(required=False)
     error_rate = serializers.FloatField(required=False)
@@ -495,3 +511,37 @@ class SpendSummaryResultSerializer(serializers.Serializer):
 class SpendSummaryResponseSerializer(serializers.Serializer):
     status = serializers.BooleanField()
     result = SpendSummaryResultSerializer()
+
+
+class ProviderModelsRequestSerializer(serializers.Serializer):
+    """Body for ``POST /agentcc/provider-credentials/fetch_models/``.
+
+    Two modes: ``provider_name`` looks up the stored credential, or raw
+    ``api_key``/``base_url``/``api_format`` for a provider not yet saved. Every
+    field is therefore optional; the view rejects a body that satisfies neither.
+    """
+
+    provider_name = serializers.CharField(required=False, allow_blank=True)
+    base_url = serializers.CharField(required=False, allow_blank=True)
+    api_key = serializers.CharField(required=False, allow_blank=True)
+    api_format = serializers.CharField(
+        required=False,
+        allow_blank=True,
+        help_text=API_FORMAT_HELP_TEXT,
+    )
+
+
+class ProviderModelsResultSerializer(serializers.Serializer):
+    models = serializers.ListField(child=serializers.CharField())
+    error = serializers.CharField(
+        required=False,
+        help_text=(
+            "Present when the provider could not be reached. The list is empty "
+            "and the call still returns 200 so the caller can offer manual entry."
+        ),
+    )
+
+
+class ProviderModelsResponseSerializer(serializers.Serializer):
+    status = serializers.BooleanField()
+    result = ProviderModelsResultSerializer()

--- a/futureagi/agentcc/tests/test_contract_serializers.py
+++ b/futureagi/agentcc/tests/test_contract_serializers.py
@@ -1,3 +1,5 @@
+from rest_framework import serializers
+
 from agentcc.serializers.contracts import (
     AgentccEmptyRequestSerializer,
     AgentccErrorResponseSerializer,
@@ -6,6 +8,7 @@ from agentcc.serializers.contracts import (
     GatewayMCPStatusResponseSerializer,
     GatewayProviderStatusSerializer,
     OrgConfigBulkResponseSerializer,
+    ProviderModelsResponseSerializer,
 )
 from tfc.utils.api_errors import build_error_envelope
 
@@ -175,3 +178,48 @@ def test_org_config_bulk_response_is_typed_by_org_id():
     )
 
     assert serializer.is_valid(), serializer.errors
+
+
+def test_provider_models_are_declared_as_strings_not_objects():
+    """``models_list`` holds plain model IDs. Declaring the child as a JSON
+    object made every gateway config/providers response fail response-contract
+    validation in the browser, so the string typing is the contract."""
+    for serializer_class in (
+        GatewayConfigProviderSerializer,
+        GatewayProviderStatusSerializer,
+    ):
+        child = serializer_class().fields["models"].child
+        assert isinstance(child, serializers.CharField), serializer_class
+
+    serializer = GatewayProviderStatusSerializer(
+        data={
+            "id": "openai",
+            "name": "openai",
+            "status": "healthy",
+            "healthy": True,
+            "circuit_state": "closed",
+            "models": [{"id": "gpt-4o"}],
+        }
+    )
+
+    assert not serializer.is_valid()
+    assert "models" in serializer.errors
+
+
+def test_provider_models_response_declares_the_fetch_models_payload():
+    """The action used to advertise AgentccProviderCredential, whose required
+    provider_name is absent from what it actually returns."""
+    serializer = ProviderModelsResponseSerializer(
+        data={"status": True, "result": {"models": ["gpt-4o"]}}
+    )
+
+    assert serializer.is_valid(), serializer.errors
+
+    with_error = ProviderModelsResponseSerializer(
+        data={
+            "status": True,
+            "result": {"models": [], "error": "The provider did not respond."},
+        }
+    )
+
+    assert with_error.is_valid(), with_error.errors

--- a/futureagi/agentcc/tests/test_provider_credential_api.py
+++ b/futureagi/agentcc/tests/test_provider_credential_api.py
@@ -1,6 +1,8 @@
+from types import SimpleNamespace
 from unittest.mock import patch
 
 import pytest
+import requests as http_requests
 
 from accounts.models.organization import Organization
 from accounts.models.organization_membership import OrganizationMembership
@@ -8,6 +10,7 @@ from accounts.models.workspace import Workspace, WorkspaceMembership
 from conftest import WorkspaceAwareAPIClient
 from integrations.services.credentials import CredentialManager
 from agentcc.models.provider_credential import AgentccProviderCredential
+from agentcc.views.provider_credential import safe_fetch_failure_reason
 from tfc.constants.levels import Level
 from tfc.constants.roles import OrganizationRoles
 
@@ -365,3 +368,54 @@ class TestAgentccProviderCredentialOrganizationIsolation:
         assert CredentialManager.decrypt(cred.encrypted_credentials) == {
             "api_key": raw_api_key
         }
+
+
+class TestSafeFetchFailureReason:
+    """The model-listing failure text is user-facing, so it must stay specific
+    enough to act on and free of anything the exception may have captured."""
+
+    def test_classifies_provider_rejection(self):
+        exc = http_requests.exceptions.HTTPError(
+            "401 Client Error for url: https://api.openai.com/v1/models"
+        )
+        exc.response = SimpleNamespace(status_code=401)
+
+        reason = safe_fetch_failure_reason(exc)
+
+        assert "HTTP 401" in reason
+        assert "api key may be invalid" in reason.lower()
+
+    def test_classifies_transport_failures(self):
+        assert "did not respond within 15s" in safe_fetch_failure_reason(
+            http_requests.exceptions.Timeout("timed out")
+        )
+        assert "outbound network access" in safe_fetch_failure_reason(
+            http_requests.exceptions.ConnectionError("connection refused")
+        )
+
+    def test_classifies_upstream_status_codes(self):
+        for status_code, expected in ((404, "base URL"), (429, "rate-limited")):
+            exc = http_requests.exceptions.HTTPError("boom")
+            exc.response = SimpleNamespace(status_code=status_code)
+            assert expected in safe_fetch_failure_reason(exc)
+
+        server_error = http_requests.exceptions.HTTPError("boom")
+        server_error.response = SimpleNamespace(status_code=503)
+        assert "HTTP 503" in safe_fetch_failure_reason(server_error)
+
+    def test_never_echoes_the_exception_text(self):
+        exc = http_requests.exceptions.HTTPError(
+            "401 for url: https://api.openai.com/v1/models?key=sk-super-secret"
+        )
+        exc.response = SimpleNamespace(status_code=401)
+
+        reason = safe_fetch_failure_reason(exc)
+
+        assert "sk-super-secret" not in reason
+        assert "api.openai.com" not in reason
+
+    def test_falls_back_for_an_unrecognised_failure(self):
+        assert (
+            safe_fetch_failure_reason(ValueError("weird"))
+            == "Failed to fetch models from provider."
+        )

--- a/futureagi/agentcc/views/provider_credential.py
+++ b/futureagi/agentcc/views/provider_credential.py
@@ -8,6 +8,11 @@ from rest_framework.viewsets import ModelViewSet
 from integrations.services.credentials import CredentialManager
 from agentcc.models.org_config import AgentccOrgConfig
 from agentcc.models.provider_credential import AgentccProviderCredential
+from agentcc.serializers.contracts import (
+    AgentccErrorResponseSerializer,
+    ProviderModelsRequestSerializer,
+    ProviderModelsResponseSerializer,
+)
 from agentcc.serializers.provider_credential import (
     AgentccProviderCredentialCreateSerializer,
     AgentccProviderCredentialSerializer,
@@ -15,6 +20,7 @@ from agentcc.serializers.provider_credential import (
 )
 from agentcc.services.config_push import push_org_config
 from agentcc.services.url_safety import build_ssrf_safe_session, ensure_public_http_url
+from tfc.utils.api_contracts import validated_request
 from tfc.utils.base_viewset import BaseModelViewSetMixinWithUserOrg
 from tfc.utils.general_methods import GeneralMethods
 
@@ -23,6 +29,45 @@ logger = structlog.get_logger(__name__)
 _GATEWAY_SYNC_WARNING = (
     "Config saved but gateway sync failed. Changes will apply on next gateway restart."
 )
+
+_FETCH_MODELS_TIMEOUT_SECONDS = 15
+
+
+def safe_fetch_failure_reason(exc):
+    """Describe a model-listing failure without echoing the exception.
+
+    ``str(exc)`` from requests can carry the base URL or a key fragment, so only
+    the exception type and the HTTP status — neither of which leaks a secret —
+    reach the caller. The full detail is logged server-side instead.
+    """
+    status_code = getattr(getattr(exc, "response", None), "status_code", None)
+
+    if status_code in (401, 403):
+        return (
+            f"The provider rejected the credential (HTTP {status_code}). The saved "
+            "API key may be invalid, expired, or for a different account."
+        )
+    if status_code == 404:
+        return (
+            "The provider has no model listing at that endpoint (HTTP 404). "
+            "Check the base URL."
+        )
+    if status_code == 429:
+        return "The provider rate-limited this request (HTTP 429). Try again shortly."
+    if status_code is not None and 500 <= status_code < 600:
+        return f"The provider returned HTTP {status_code}. Try again shortly."
+
+    # requests' ConnectionError/Timeout are siblings of the builtins, not
+    # subclasses, so they land here rather than in the branches above.
+    if isinstance(exc, http_requests.exceptions.Timeout):
+        return f"The provider did not respond within {_FETCH_MODELS_TIMEOUT_SECONDS}s."
+    if isinstance(exc, http_requests.exceptions.ConnectionError):
+        return (
+            "Could not connect to the provider. Check that this server has "
+            "outbound network access to it."
+        )
+
+    return "Failed to fetch models from provider."
 
 
 class AgentccProviderCredentialViewSet(BaseModelViewSetMixinWithUserOrg, ModelViewSet):
@@ -196,6 +241,14 @@ class AgentccProviderCredentialViewSet(BaseModelViewSetMixinWithUserOrg, ModelVi
             logger.exception("provider_credential_rotate_error", error=str(e))
             return self._gm.bad_request(str(e))
 
+    @validated_request(
+        request_serializer=ProviderModelsRequestSerializer,
+        responses={
+            200: ProviderModelsResponseSerializer,
+            400: AgentccErrorResponseSerializer,
+        },
+        reject_unknown_fields=True,
+    )
     @action(detail=False, methods=["post"])
     def fetch_models(self, request):
         """Fetch available models from a provider's API.
@@ -268,9 +321,10 @@ class AgentccProviderCredentialViewSet(BaseModelViewSetMixinWithUserOrg, ModelVi
                 base_url=base_url,
                 error=str(e),
             )
-            # Never expose raw exception message — may contain credentials/URLs
+            # Never expose the raw exception — it may contain credentials/URLs.
+            # A classified reason is safe and saves the caller a log dive.
             return self._gm.success_response(
-                {"models": [], "error": "Failed to fetch models from provider"}
+                {"models": [], "error": safe_fetch_failure_reason(e)}
             )
 
     def _fetch_models_from_provider(self, provider_name, base_url, api_key, api_format):
@@ -282,7 +336,7 @@ class AgentccProviderCredentialViewSet(BaseModelViewSetMixinWithUserOrg, ModelVi
         ``provider_name`` first; falls back to ``api_format`` for custom /
         unknown providers.
         """
-        timeout = 15
+        timeout = _FETCH_MODELS_TIMEOUT_SECONDS
 
         # Validate user-supplied base_url and use safe session to prevent SSRF
         # (including DNS rebinding).


### PR DESCRIPTION
## What

Two small gateway UI fixes.

### 1. Editing a provider crashed on Save

`timeoutVal.trim is not a function` at `AddProviderDialog.jsx:350` whenever you opened an existing provider and hit **Save**.

`default_timeout` is an `IntegerField` on the API (`agentcc/serializers/contracts.py`, backed by `ProviderCredential.default_timeout_seconds`), so the GET hands back `30`, not `"30"`. The edit-mode effect seeded `timeoutVal` with that number straight from the config, and `validate()` then called `.trim()` on it. `maxConcurrent` right below it already had the `String(...)` coercion — timeout just missed it.

The field is free text that accepts `30`, `30s` and `500ms`, so the state has to stay a string; the number conversion belongs on the way out. It now happens exactly once, in `handleSave`, and feeds `config.default_timeout`.

Behaviour note: a malformed timeout no longer surfaces alongside other field errors. If the name is blank *and* the timeout is `abc`, you see the name error first, and the timeout error on the next Save. The single-error case is unchanged.

Also drops a stray `console.log(config)` that was printing the API key / AWS secrets to the browser console on every save.

### 2. Session IDs were truncated

The Session ID cell rendered `session_id.substring(0, 16)`. The cell is click-to-copy and the tooltip already showed the full value, so the truncation just made the visible text disagree with what you get. Now shows the whole ID.

### 3. Save Changes could fail with no visible reason

`validate()` rendered every failure as inline field text inside a scrolling `DialogContent`, while Save sits pinned in `DialogActions`. Click Save with the form scrolled down and nothing appears to happen — the reason is off-screen. Two failures had no surface at all: `errors.name` was never bound to the edit-mode Provider Name field, and "Select at least one model" is impossible advice when the model fetch failed and the dropdown is empty.

- A validation summary `Alert` now renders at the top of the dialog body, listing every outstanding problem by field label, and a failed Save scrolls it into view.
- The edit-mode Provider Name field binds `error` / `helperText`.
- Messages say what to do and quote the offending value: the models error explains *why* the list is empty and that you can type an ID manually; the timeout and base-URL errors echo what you entered.
- The base-URL scheme check is case-insensitive — a stored `HTTPS://…` no longer fails with "must start with http:// or https://".
- The base-URL field clears its error on edit, like every other field.

Validation is a single pass again: `handleSave` parses the timeout once and hands the result to `validate`, so timeout problems appear alongside the others rather than only after everything else passes.

### 4. Provider models were typed as objects but are strings (backend)

The browser logged 297 response-contract issues on every gateway page: `result.providers.<name>.models.N: Expected object, received string`. Three serializers in `agentcc/serializers/contracts.py` declared `models = ListField(child=JSONField())`, while `ProviderCredential.models_list` has always held plain model IDs (`# ["gpt-4o", "gpt-4o-mini"]`). The child is now `CharField()` behind a shared `PROVIDER_MODELS_HELP_TEXT`, and a serializer test rejects an object entry so the typing can't drift back.

The frontend no longer trusts either shape: `normalizeModels`/`toModelId` coerce whatever arrives, because a non-string reaching state made `.trim()` throw in the Autocomplete's `onChange` and rendered an object as a React child in the chips — the same crash class as the timeout bug above, reported from production as `C.trim is not a function`.

### 5. `fetch_models` advertised the wrong schema, and hid why it failed (backend)

The action documented `AgentccProviderCredential` — whose required `provider_name` is absent from what it actually returns — so every call logged a contract failure. It now declares `ProviderModelsRequest/Result/ResponseSerializer` through `@validated_request`, not a bare `swagger_auto_schema`: the contract-debt report flagged the latter as the codebase's first doc-only decorator, and the house pattern documents *and* validates. The report goes 494 → 495 runtime-backed, 0 doc-only.

Separately, every failure returned the single string "Failed to fetch models from provider", with the real cause visible only in a `fetch_models_error` log line. `safe_fetch_failure_reason` now classifies it — credential rejected (HTTP 401/403), no listing at that endpoint (404), rate limited (429), upstream 5xx, timeout, or no outbound connectivity — using only the exception type and status code, never `str(exc)`, which can carry the base URL or a key fragment. Tests assert a secret-bearing message never reaches the response.

> **Needs regeneration before merge:** `api_contracts/openapi/swagger.json` and `frontend/src/api/contracts/openapi-contract.generated.js` are untouched, because `scripts/generate-openapi-schema.sh` can't run without the EE package (`ModuleNotFoundError: No module named 'ee.cloud.urls'`). Run the generator plus `yarn contracts:generate` somewhere with full EE — until then the browser warnings persist even though the serializers are correct. Unrelated but worth a fix: that script's `mktemp` template puts the `X`s mid-name, which BSD/macOS `mktemp` takes literally, so it only works once per machine.

## Testing

- `npx vitest run src/sections/gateway/providers src/sections/gateway/sessions` — passes. `AddProviderDialog.test.jsx` grew from one parser unit test to four rendered-dialog cases: a numeric stored timeout saves, a blocked save summarises instead of no-oping, a malformed timeout is reported with the value, and multiple problems are counted.
- Manually: open an existing provider with a saved timeout, Save — no crash, `default_timeout` posts as an integer. `30s` and `500ms` still parse; `abc` shows the inline error.

## Follow-up (not in this PR)

All four copy buttons in the gateway call `navigator.clipboard.writeText(...)` unguarded — `CreateKeyDialog`, `GatewayOverviewSection`, `SessionExplorerSection`, `RequestDetailDrawer`. `navigator.clipboard` is `undefined` outside a secure context, so on a plain-http self-hosted deployment `.writeText` throws synchronously and the button is dead; two of the four also show a "copied" snackbar regardless. The repo already has `copyToClipboard` in `src/utils/utils.js` with the guard, an `execCommand` fallback and a boolean return. Worth a separate PR — the API-key dialog matters most, since the key is unrecoverable once dismissed.

Backend: `pytest agentcc/tests/test_contract_serializers.py agentcc/tests/test_provider_credential_api.py agentcc/tests/test_gateway_admin_contracts.py` — 25 pass (9 new). Frontend: 71 tests across 26 files, plus `contracts:check` clean.
