### PR TITLE
fix(gateway): harden the provider dialog and show full session IDs

### DIFF
--- a/frontend/src/sections/gateway/providers/AddProviderDialog.jsx
+++ b/frontend/src/sections/gateway/providers/AddProviderDialog.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useCallback } from "react";
+import React, { useState, useEffect, useCallback, useRef } from "react";
 import PropTypes from "prop-types";
 import {
   Dialog,
@@ -9,6 +9,7 @@ import {
   TextField,
   Stack,
   Alert,
+  AlertTitle,
   Chip,
   Autocomplete,
   MenuItem,
@@ -132,6 +133,47 @@ const API_FORMATS = [
   "bedrock",
 ];
 
+// The API types a provider's models as a free-form JSON list, so an entry is
+// not guaranteed to be a string. Anything non-string reaching state would make
+// .trim() throw in the Autocomplete's onChange and render an object as a React
+// child in the chips — either one takes the whole dialog down.
+const toModelId = (value) => {
+  if (typeof value === "string") return value.trim();
+  if (value && typeof value === "object") {
+    return String(value.id ?? value.name ?? value.model ?? "").trim();
+  }
+  return value == null ? "" : String(value).trim();
+};
+
+const normalizeModels = (list) =>
+  Array.isArray(list) ? list.map(toModelId).filter(Boolean) : [];
+
+// A credential-based fetch that comes back with an empty list means the
+// provider rejected the key or the endpoint. The warning under Models only says
+// the list is empty, so name the likely cause on the API Key field itself.
+const KEY_FETCH_FAILED =
+  "Couldn't load any models with this key — check that it is valid for this " +
+  "provider, or add model IDs manually below.";
+
+// Edit mode lists models with the credential already on file, so an empty
+// result there means the stored key no longer works. Saving would keep the
+// broken provider; the only fix is a new key, so ask for one.
+const STORED_KEY_UNVERIFIED =
+  "Couldn't list this provider's models with the stored key — enter a new " +
+  "API key to save changes.";
+
+// Human labels for the validation summary, in the order the fields appear in
+// the form so the summary reads top-to-bottom like the dialog itself.
+const FIELD_LABELS = {
+  name: "Provider Name",
+  awsAccessKeyId: "AWS Access Key ID",
+  awsSecretAccessKey: "AWS Secret Access Key",
+  baseUrl: "Base URL",
+  apiKey: "API Key",
+  models: "Models",
+  timeout: "Timeout",
+};
+
 const AddProviderDialog = ({ open, onClose, gatewayId, provider }) => {
   const isEditMode = Boolean(provider);
 
@@ -151,32 +193,46 @@ const AddProviderDialog = ({ open, onClose, gatewayId, provider }) => {
 
   // Validation state
   const [errors, setErrors] = useState({});
+  // The dialog body scrolls, so a failed Save has to bring the summary back
+  // into view — otherwise the button looks inert.
+  const contentRef = useRef(null);
 
   const updateProvider = useUpdateProvider();
   const fetchModels = useFetchProviderModels();
   const [modelOptions, setModelOptions] = useState([]);
   const [fetchError, setFetchError] = useState("");
   const [hasFetched, setHasFetched] = useState(false);
+  // Live feedback on the key, kept out of `errors` so a failed fetch does not
+  // raise the "Fix this before saving" summary before Save was ever pressed.
+  const [keyFetchError, setKeyFetchError] = useState("");
+  // A debounced fetch is armed but has not fired yet.
+  const [fetchScheduled, setFetchScheduled] = useState(false);
 
   const doFetchModels = useCallback(
     ({ providerName, url, key, format }) => {
       setFetchError("");
+      setKeyFetchError("");
       setHasFetched(false);
+      // Edit mode fetches by provider name against the stored credential, so
+      // there is no key in the form to blame for an empty list.
+      const blameKey = !providerName;
       fetchModels.mutate(
         providerName
           ? { providerName }
           : { baseUrl: url, apiKey: key, apiFormat: format },
         {
           onSuccess: (result) => {
-            const fetched = result?.models || [];
-            if (fetched.length === 0 && result?.error) {
-              setFetchError(result.error);
+            const fetched = normalizeModels(result?.models);
+            if (fetched.length === 0) {
+              setFetchError(result?.error || "Provider returned no models");
+              if (blameKey) setKeyFetchError(KEY_FETCH_FAILED);
             }
             setModelOptions(fetched);
             setHasFetched(true);
           },
           onError: (err) => {
             setFetchError(err?.message || "Failed to fetch models");
+            if (blameKey) setKeyFetchError(KEY_FETCH_FAILED);
             setModelOptions([]);
             setHasFetched(true);
           },
@@ -194,8 +250,9 @@ const AddProviderDialog = ({ open, onClose, gatewayId, provider }) => {
       setBaseUrl(c.base_url ?? c.baseUrl ?? "");
       setApiKey("");
       setApiFormat(c.api_format ?? c.apiFormat ?? "openai");
-      setModels(Array.isArray(c.models) ? c.models : []);
-      setTimeoutVal(c.default_timeout ?? c.defaultTimeout ?? "");
+      setModels(normalizeModels(c.models));
+      const timeoutRaw = c.default_timeout ?? c.defaultTimeout;
+      setTimeoutVal(timeoutRaw != null ? String(timeoutRaw) : "");
       setMaxConcurrent(
         c.max_concurrent != null
           ? String(c.max_concurrent ?? c.maxConcurrent ?? "")
@@ -217,21 +274,38 @@ const AddProviderDialog = ({ open, onClose, gatewayId, provider }) => {
 
   const isAwsAuth = PROVIDER_PRESETS[name]?.authType === "aws";
 
-  // Create mode: auto-fetch when API key is entered (debounced)
+  // Auto-fetch when an API key is entered (debounced). Edit mode included: a
+  // typed key replaces the stored one, so it has to prove it can list models
+  // before Save will accept it — otherwise an unverified key gets written.
   // Skip auto-fetch for AWS providers (Bedrock models must be entered manually)
   useEffect(() => {
-    if (isEditMode || isAwsAuth) return;
+    if (isAwsAuth) {
+      setFetchScheduled(false);
+      return;
+    }
     if (!apiKey.trim()) {
+      setFetchScheduled(false);
+      // A blank key in edit mode means "keep the stored one", so leave the
+      // fetch-by-name result standing instead of wiping it.
+      if (isEditMode) return;
       setModelOptions([]);
       setFetchError("");
+      setKeyFetchError("");
       setHasFetched(false);
       return;
     }
     // Don't fetch if base URL is required but empty (azure, custom)
     const preset = PROVIDER_PRESETS[name];
-    if (preset && !preset.baseUrl && !baseUrl.trim()) return;
+    if (preset && !preset.baseUrl && !baseUrl.trim()) {
+      setFetchScheduled(false);
+      return;
+    }
 
+    // Held from the first keystroke, not from when the request goes out: the
+    // debounce window is long enough to click Save in.
+    setFetchScheduled(true);
     const timer = setTimeout(() => {
+      setFetchScheduled(false);
       doFetchModels({ url: baseUrl, key: apiKey, format: apiFormat });
     }, 600);
     return () => clearTimeout(timer);
@@ -247,6 +321,8 @@ const AddProviderDialog = ({ open, onClose, gatewayId, provider }) => {
     setModels([]);
     setModelOptions([]);
     setFetchError("");
+    setKeyFetchError("");
+    setFetchScheduled(false);
     setHasFetched(false);
     setTimeoutVal("");
     setMaxConcurrent("");
@@ -282,6 +358,7 @@ const AddProviderDialog = ({ open, onClose, gatewayId, provider }) => {
     setModels([]);
     setModelOptions([]);
     setFetchError("");
+    setKeyFetchError("");
     setHasFetched(false);
     setErrors({});
   };
@@ -299,7 +376,7 @@ const AddProviderDialog = ({ open, onClose, gatewayId, provider }) => {
     }
   };
 
-  const validate = () => {
+  const validate = (timeoutSeconds) => {
     const newErrors = {};
 
     if (!name.trim()) {
@@ -319,10 +396,11 @@ const AddProviderDialog = ({ open, onClose, gatewayId, provider }) => {
       const preset = PROVIDER_PRESETS[name];
       const needsBaseUrl = !preset || !preset.baseUrl;
       if (needsBaseUrl && !baseUrl.trim()) {
-        newErrors.baseUrl = "Base URL is required for this provider";
+        newErrors.baseUrl =
+          "This provider has no preset endpoint — enter its base URL, e.g. https://your-endpoint.com";
       }
-      if (baseUrl.trim() && !baseUrl.startsWith("http")) {
-        newErrors.baseUrl = "Base URL must start with http:// or https://";
+      if (baseUrl.trim() && !/^https?:\/\//i.test(baseUrl.trim())) {
+        newErrors.baseUrl = `Base URL must start with http:// or https:// (got "${baseUrl.trim()}")`;
       }
 
       // API key required for new providers
@@ -337,18 +415,27 @@ const AddProviderDialog = ({ open, onClose, gatewayId, provider }) => {
         hasFetched &&
         modelOptions.length === 0
       ) {
-        newErrors.apiKey =
-          "Invalid API key or unreachable provider — please check your credentials";
+        newErrors.apiKey = KEY_FETCH_FAILED;
       }
     }
 
-    // Require at least one model selected
+    // Require at least one model selected. Say why the list is empty when it
+    // is — otherwise "select a model" is impossible advice with nothing to
+    // pick from.
     if (models.length === 0) {
-      newErrors.models = "Select at least one model";
+      if (fetchError) {
+        newErrors.models = `Select at least one model. Loading this provider's models failed (${fetchError}) — type a model ID and press Enter to add it manually.`;
+      } else if (modelOptions.length === 0) {
+        newErrors.models = isEditMode
+          ? "Select at least one model. None were loaded for this provider — type a model ID and press Enter to add it manually."
+          : "Select at least one model. Enter a valid API key to load the list, or type a model ID and press Enter.";
+      } else {
+        newErrors.models = "Select at least one model from the list.";
+      }
     }
 
-    if (timeoutVal.trim() && parseTimeoutSeconds(timeoutVal) === null) {
-      newErrors.timeout = "Use seconds, e.g. 30 or 30s";
+    if (timeoutVal.trim() && timeoutSeconds === null) {
+      newErrors.timeout = `Timeout must be a whole number of seconds, e.g. 30 or 30s (got "${timeoutVal.trim()}")`;
     }
 
     setErrors(newErrors);
@@ -356,7 +443,13 @@ const AddProviderDialog = ({ open, onClose, gatewayId, provider }) => {
   };
 
   const handleSave = () => {
-    if (!validate()) return;
+    const timeoutSeconds = parseTimeoutSeconds(timeoutVal);
+    if (!validate(timeoutSeconds)) {
+      // scrollTo is missing in jsdom and older browsers — never let a Save
+      // handler throw on a cosmetic scroll.
+      contentRef.current?.scrollTo?.({ top: 0, behavior: "smooth" });
+      return;
+    }
 
     const config = { base_url: baseUrl, api_format: apiFormat };
     if (isAwsAuth) {
@@ -368,7 +461,6 @@ const AddProviderDialog = ({ open, onClose, gatewayId, provider }) => {
       config.api_key = apiKey;
     }
     if (models.length > 0) config.models = models;
-    const timeoutSeconds = parseTimeoutSeconds(timeoutVal);
     if (timeoutSeconds !== null) config.default_timeout = timeoutSeconds;
     if (maxConcurrent) config.max_concurrent = Number(maxConcurrent);
 
@@ -394,16 +486,54 @@ const AddProviderDialog = ({ open, onClose, gatewayId, provider }) => {
     );
   };
 
+  const modelsLoading = fetchScheduled || fetchModels.isPending;
+
+  // The stored credential could not list models and no replacement key has
+  // been typed yet. AWS is exempt: Bedrock has no list endpoint, so an empty
+  // result proves nothing, and there is no API Key field to explain it on —
+  // gating there would lock the provider out of editing entirely.
+  const savedKeyUnverified =
+    isEditMode &&
+    !isAwsAuth &&
+    hasFetched &&
+    modelOptions.length === 0 &&
+    !apiKey.trim();
+
   const allSelected =
     modelOptions.length > 0 && models.length === modelOptions.length;
 
   const preset = PROVIDER_PRESETS[name] || PROVIDER_PRESETS.custom;
 
+  const errorList = Object.keys(FIELD_LABELS)
+    .filter((key) => errors[key])
+    .map((key) => ({ key, label: FIELD_LABELS[key], message: errors[key] }));
+
   return (
     <Dialog open={open} onClose={handleClose} maxWidth="sm" fullWidth>
       <DialogTitle>{isEditMode ? "Edit Provider" : "Add Provider"}</DialogTitle>
-      <DialogContent>
+      <DialogContent ref={contentRef}>
         <Stack spacing={2} mt={1}>
+          {/* Validation summary — the body scrolls, so an inline-only error
+              under a field can sit off-screen and make Save look broken. */}
+          {errorList.length > 0 && (
+            <Alert severity="error" onClose={() => setErrors({})}>
+              <AlertTitle>
+                {errorList.length === 1
+                  ? "Fix this before saving"
+                  : `Fix ${errorList.length} issues before saving`}
+              </AlertTitle>
+              <Box component="ul" sx={{ m: 0, pl: 2.5 }}>
+                {errorList.map(({ key, label, message }) => (
+                  <li key={key}>
+                    <Typography variant="body2" component="span">
+                      <strong>{label}:</strong> {message}
+                    </Typography>
+                  </li>
+                ))}
+              </Box>
+            </Alert>
+          )}
+
           {/* Provider Name — dropdown for common providers */}
           {isEditMode ? (
             <TextField
@@ -412,7 +542,8 @@ const AddProviderDialog = ({ open, onClose, gatewayId, provider }) => {
               required
               value={name}
               disabled
-              helperText="Provider name cannot be changed"
+              error={!!errors.name}
+              helperText={errors.name || "Provider name cannot be changed"}
             />
           ) : (
             <TextField
@@ -507,7 +638,10 @@ const AddProviderDialog = ({ open, onClose, gatewayId, provider }) => {
                 fullWidth
                 required={!preset.baseUrl}
                 value={baseUrl}
-                onChange={(e) => setBaseUrl(e.target.value)}
+                onChange={(e) => {
+                  setBaseUrl(e.target.value);
+                  setErrors((prev) => ({ ...prev, baseUrl: undefined }));
+                }}
                 placeholder={preset.baseUrl || "https://your-endpoint.com"}
                 error={!!errors.baseUrl}
                 helperText={
@@ -527,14 +661,21 @@ const AddProviderDialog = ({ open, onClose, gatewayId, provider }) => {
                 onChange={(e) => {
                   setApiKey(e.target.value);
                   setErrors((prev) => ({ ...prev, apiKey: undefined }));
+                  // The refetch is debounced; drop the stale verdict now so a
+                  // corrected key does not keep showing the old rejection.
+                  setKeyFetchError("");
                 }}
                 placeholder={
                   isEditMode
                     ? "Leave blank to keep current key"
                     : preset.keyPlaceholder
                 }
-                error={!!errors.apiKey}
-                helperText={errors.apiKey}
+                error={!!errors.apiKey || !!keyFetchError || savedKeyUnverified}
+                helperText={
+                  errors.apiKey ||
+                  keyFetchError ||
+                  (savedKeyUnverified ? STORED_KEY_UNVERIFIED : undefined)
+                }
               />
             </>
           )}
@@ -580,9 +721,7 @@ const AddProviderDialog = ({ open, onClose, gatewayId, provider }) => {
             >
               <Typography variant="subtitle2" color="text.secondary">
                 Models
-                {fetchModels.isPending && (
-                  <CircularProgress size={14} sx={{ ml: 1 }} />
-                )}
+                {modelsLoading && <CircularProgress size={14} sx={{ ml: 1 }} />}
                 {hasFetched && modelOptions.length > 0 && (
                   <Typography
                     component="span"
@@ -609,7 +748,7 @@ const AddProviderDialog = ({ open, onClose, gatewayId, provider }) => {
               options={modelOptions}
               value={models}
               onChange={(_, val) => {
-                setModels(val.map((v) => v.trim()).filter(Boolean));
+                setModels(normalizeModels(val));
                 setErrors((prev) => ({ ...prev, models: undefined }));
               }}
               renderOption={(props, option, { selected }) => (
@@ -632,7 +771,7 @@ const AddProviderDialog = ({ open, onClose, gatewayId, provider }) => {
                 <TextField
                   {...params}
                   placeholder={
-                    fetchModels.isPending
+                    modelsLoading
                       ? "Fetching models..."
                       : modelOptions.length > 0
                         ? "Select models..."
@@ -667,10 +806,25 @@ const AddProviderDialog = ({ open, onClose, gatewayId, provider }) => {
                 {fetchError}
               </Alert>
             )}
-            {errors.models && (
+            {errors.models ? (
               <Typography variant="caption" color="error" sx={{ mt: 0.5 }}>
                 {errors.models}
               </Typography>
+            ) : (
+              models.length === 0 && (
+                // Save is disabled until a model is picked, so state the
+                // requirement here rather than leaving a dead button.
+                <Typography
+                  variant="caption"
+                  color="text.secondary"
+                  sx={{ mt: 0.5, display: "block" }}
+                >
+                  Select at least one model to enable Save
+                  {modelOptions.length === 0
+                    ? " — type a model ID and press Enter to add one manually."
+                    : "."}
+                </Typography>
+              )
             )}
           </Box>
 
@@ -709,18 +863,33 @@ const AddProviderDialog = ({ open, onClose, gatewayId, provider }) => {
       </DialogContent>
       <DialogActions>
         <Button onClick={handleClose}>Cancel</Button>
+        {/* Held for the three states a click could never get past: a fetch in
+            flight (validates against a stale, usually empty model list and
+            rejects a good key), a key the provider already rejected, a stored
+            key that can no longer list models, and no model selected. Each one
+            is explained on the field it belongs to,
+            so the disabled button is never the only signal. */}
         <Button
           variant="contained"
           onClick={handleSave}
-          disabled={!name.trim() || updateProvider.isPending}
+          disabled={
+            !name.trim() ||
+            updateProvider.isPending ||
+            modelsLoading ||
+            !!keyFetchError ||
+            savedKeyUnverified ||
+            models.length === 0
+          }
         >
-          {updateProvider.isPending
-            ? isEditMode
-              ? "Saving..."
-              : "Adding..."
-            : isEditMode
-              ? "Save Changes"
-              : "Add Provider"}
+          {modelsLoading
+            ? "Loading models..."
+            : updateProvider.isPending
+              ? isEditMode
+                ? "Saving..."
+                : "Adding..."
+              : isEditMode
+                ? "Save Changes"
+                : "Add Provider"}
         </Button>
       </DialogActions>
     </Dialog>

--- a/frontend/src/sections/gateway/providers/AddProviderDialog.jsx
+++ b/frontend/src/sections/gateway/providers/AddProviderDialog.jsx
@@ -152,7 +152,7 @@ const normalizeModels = (list) =>
 // provider rejected the key or the endpoint. The warning under Models only says
 // the list is empty, so name the likely cause on the API Key field itself.
 const KEY_FETCH_FAILED =
-  "Couldn't load any models with this key — check that it is valid for this " +
+  "Couldn't load any models with this key. Check that it is valid for this " +
   "provider, or add model IDs manually below.";
 
 // Edit mode lists models with the credential already on file, so an empty
@@ -207,9 +207,13 @@ const AddProviderDialog = ({ open, onClose, gatewayId, provider }) => {
   const [keyFetchError, setKeyFetchError] = useState("");
   // A debounced fetch is armed but has not fired yet.
   const [fetchScheduled, setFetchScheduled] = useState(false);
+  const fetchSeqRef = useRef(0);
 
   const doFetchModels = useCallback(
     ({ providerName, url, key, format }) => {
+      const seq = fetchSeqRef.current + 1;
+      fetchSeqRef.current = seq;
+      const isStale = () => fetchSeqRef.current !== seq;
       setFetchError("");
       setKeyFetchError("");
       setHasFetched(false);
@@ -222,6 +226,7 @@ const AddProviderDialog = ({ open, onClose, gatewayId, provider }) => {
           : { baseUrl: url, apiKey: key, apiFormat: format },
         {
           onSuccess: (result) => {
+            if (isStale()) return;
             const fetched = normalizeModels(result?.models);
             if (fetched.length === 0) {
               setFetchError(result?.error || "Provider returned no models");
@@ -231,6 +236,7 @@ const AddProviderDialog = ({ open, onClose, gatewayId, provider }) => {
             setHasFetched(true);
           },
           onError: (err) => {
+            if (isStale()) return;
             setFetchError(err?.message || "Failed to fetch models");
             if (blameKey) setKeyFetchError(KEY_FETCH_FAILED);
             setModelOptions([]);
@@ -409,12 +415,7 @@ const AddProviderDialog = ({ open, onClose, gatewayId, provider }) => {
       }
 
       // Key validation — only block if fetch completed with zero models
-      if (
-        !isEditMode &&
-        apiKey.trim() &&
-        hasFetched &&
-        modelOptions.length === 0
-      ) {
+      if (apiKey.trim() && hasFetched && modelOptions.length === 0) {
         newErrors.apiKey = KEY_FETCH_FAILED;
       }
     }
@@ -745,6 +746,11 @@ const AddProviderDialog = ({ open, onClose, gatewayId, provider }) => {
               freeSolo
               autoSelect
               disableCloseOnSelect
+              size="small"
+              sx={{
+                "&:hover .MuiAutocomplete-input, &.Mui-focused .MuiAutocomplete-input":
+                  { minWidth: 30 },
+              }}
               options={modelOptions}
               value={models}
               onChange={(_, val) => {
@@ -779,7 +785,6 @@ const AddProviderDialog = ({ open, onClose, gatewayId, provider }) => {
                           ? "Type or paste comma-separated model IDs"
                           : "Enter API key to load models, or type manually"
                   }
-                  size="small"
                   onPaste={(e) => {
                     const pasted = e.clipboardData.getData("text");
                     if (!/[,\n]/.test(pasted)) return;

--- a/frontend/src/sections/gateway/providers/AddProviderDialog.jsx
+++ b/frontend/src/sections/gateway/providers/AddProviderDialog.jsx
@@ -151,8 +151,8 @@ const KEY_FETCH_FAILED =
   "provider, or add model IDs manually below.";
 
 const STORED_KEY_UNVERIFIED =
-  "Couldn't list this provider's models with the stored key — enter a new " +
-  "API key to save changes.";
+  "Couldn't list this provider's models with the stored key. Enter a new API " +
+  "key, or add model IDs manually below, to save changes.";
 
 // Summary labels, in form order so the summary reads like the dialog.
 const FIELD_LABELS = {
@@ -184,10 +184,9 @@ const AddProviderDialog = ({ open, onClose, gatewayId, provider }) => {
   // Validation state
   const [errors, setErrors] = useState({});
   const [summaryDismissed, setSummaryDismissed] = useState(false);
-  // A hand-typed model ID overrides an empty listing: the azure and custom
-  // presets are probed with a plain `{base_url}/models` a working endpoint need
-  // not serve, so an empty list there is no proof the key is bad.
-  const [manualModels, setManualModels] = useState(false);
+  // Every model ID a listing has offered in this dialog, plus the ones already
+  // stored on the provider. Anything selected outside it was typed by hand.
+  const offeredModels = useRef(new Set());
   // The body scrolls, so a failed Save has to bring the summary back into view.
   const contentRef = useRef(null);
 
@@ -229,6 +228,7 @@ const AddProviderDialog = ({ open, onClose, gatewayId, provider }) => {
                 : "";
             setFetchError(emptyReason);
             if (emptyReason && blameKey) setKeyFetchError(KEY_FETCH_FAILED);
+            fetched.forEach((m) => offeredModels.current.add(m));
             setModelOptions(fetched);
             setHasFetched(true);
             if (providerName) {
@@ -279,7 +279,7 @@ const AddProviderDialog = ({ open, onClose, gatewayId, provider }) => {
       );
       setErrors({});
       setSummaryDismissed(false);
-      setManualModels(false);
+      offeredModels.current = new Set(normalizeModels(c.models));
       storedKeyResult.current = null;
       doFetchModels({ providerName: provider.name });
     }
@@ -309,6 +309,10 @@ const AddProviderDialog = ({ open, onClose, gatewayId, provider }) => {
       // Blank in edit mode means "keep the stored key", so restore its verdict:
       // a typed key's result left standing blames the stored one for it.
       if (isEditMode) {
+        // Abandon anything still in flight for the key just cleared: its late
+        // response would overwrite the restore and wedge Save behind a
+        // rejection message sitting under an empty field.
+        fetchSeqRef.current += 1;
         const snapshot = storedKeyResult.current;
         if (snapshot) {
           setModelOptions(snapshot.options);
@@ -361,7 +365,7 @@ const AddProviderDialog = ({ open, onClose, gatewayId, provider }) => {
     setAwsSessionToken("");
     setErrors({});
     setSummaryDismissed(false);
-    setManualModels(false);
+    offeredModels.current = new Set();
     storedKeyResult.current = null;
   };
 
@@ -394,7 +398,7 @@ const AddProviderDialog = ({ open, onClose, gatewayId, provider }) => {
     setHasFetched(false);
     setErrors({});
     setSummaryDismissed(false);
-    setManualModels(false);
+    offeredModels.current = new Set();
     storedKeyResult.current = null;
   };
 
@@ -410,6 +414,13 @@ const AddProviderDialog = ({ open, onClose, gatewayId, provider }) => {
       setModels([...modelOptions]);
     }
   };
+
+  // A model the provider never offered was typed in by hand, overriding an
+  // empty listing: the azure and custom presets are probed with a plain
+  // `{base_url}/models` a working endpoint need not serve, so an empty list
+  // there is no proof the key is bad. Derived, so removing the chip re-arms
+  // the gate.
+  const manualModels = models.some((m) => !offeredModels.current.has(m));
 
   const validate = (timeoutSeconds) => {
     const newErrors = {};
@@ -783,12 +794,7 @@ const AddProviderDialog = ({ open, onClose, gatewayId, provider }) => {
               options={modelOptions}
               value={models}
               onChange={(_, val) => {
-                const next = normalizeModels(val);
-                setModels(next);
-                // An ID the listing never offered was entered by hand.
-                if (next.some((m) => !modelOptions.includes(m))) {
-                  setManualModels(true);
-                }
+                setModels(normalizeModels(val));
               }}
               renderOption={(props, option, { selected }) => (
                 <li {...props} key={option}>
@@ -830,9 +836,6 @@ const AddProviderDialog = ({ open, onClose, gatewayId, provider }) => {
                     setModels((prev) =>
                       Array.from(new Set([...prev, ...tokens])),
                     );
-                    if (tokens.some((t) => !modelOptions.includes(t))) {
-                      setManualModels(true);
-                    }
                   }}
                 />
               )}

--- a/frontend/src/sections/gateway/providers/AddProviderDialog.jsx
+++ b/frontend/src/sections/gateway/providers/AddProviderDialog.jsx
@@ -204,10 +204,14 @@ const AddProviderDialog = ({ open, onClose, gatewayId, provider }) => {
   // What the fetch-by-name concluded, so clearing a typed key restores it.
   const storedKeyResult = useRef(null);
 
+  // The last fetch made with a key typed into the form.
+  const typedFetchSeqRef = useRef(0);
+
   const doFetchModels = useCallback(
     ({ providerName, url, key, format }) => {
       const seq = fetchSeqRef.current + 1;
       fetchSeqRef.current = seq;
+      if (!providerName) typedFetchSeqRef.current = seq;
       const isStale = () => fetchSeqRef.current !== seq;
       setFetchError("");
       setKeyFetchError("");
@@ -309,10 +313,12 @@ const AddProviderDialog = ({ open, onClose, gatewayId, provider }) => {
       // Blank in edit mode means "keep the stored key", so restore its verdict:
       // a typed key's result left standing blames the stored one for it.
       if (isEditMode) {
-        // Abandon anything still in flight for the key just cleared: its late
-        // response would overwrite the restore and wedge Save behind a
-        // rejection message sitting under an empty field.
-        fetchSeqRef.current += 1;
+        // Abandon a typed-key fetch still in flight, whose late response would
+        // overwrite the restore. Only that one: this also runs on mount, where
+        // the request in flight is the by-name fetch just made.
+        if (fetchSeqRef.current === typedFetchSeqRef.current) {
+          fetchSeqRef.current += 1;
+        }
         const snapshot = storedKeyResult.current;
         if (snapshot) {
           setModelOptions(snapshot.options);

--- a/frontend/src/sections/gateway/providers/AddProviderDialog.jsx
+++ b/frontend/src/sections/gateway/providers/AddProviderDialog.jsx
@@ -133,10 +133,8 @@ const API_FORMATS = [
   "bedrock",
 ];
 
-// The API types a provider's models as a free-form JSON list, so an entry is
-// not guaranteed to be a string. Anything non-string reaching state would make
-// .trim() throw in the Autocomplete's onChange and render an object as a React
-// child in the chips — either one takes the whole dialog down.
+// The API types a provider's models as free-form JSON, so an entry need not be
+// a string — and a non-string one takes the dialog down when it reaches state.
 const toModelId = (value) => {
   if (typeof value === "string") return value.trim();
   if (value && typeof value === "object") {
@@ -148,29 +146,21 @@ const toModelId = (value) => {
 const normalizeModels = (list) =>
   Array.isArray(list) ? list.map(toModelId).filter(Boolean) : [];
 
-// A credential-based fetch that comes back with an empty list means the
-// provider rejected the key or the endpoint. The warning under Models only says
-// the list is empty, so name the likely cause on the API Key field itself.
 const KEY_FETCH_FAILED =
   "Couldn't load any models with this key. Check that it is valid for this " +
   "provider, or add model IDs manually below.";
 
-// Edit mode lists models with the credential already on file, so an empty
-// result there means the stored key no longer works. Saving would keep the
-// broken provider; the only fix is a new key, so ask for one.
 const STORED_KEY_UNVERIFIED =
   "Couldn't list this provider's models with the stored key — enter a new " +
   "API key to save changes.";
 
-// Human labels for the validation summary, in the order the fields appear in
-// the form so the summary reads top-to-bottom like the dialog itself.
+// Summary labels, in form order so the summary reads like the dialog.
 const FIELD_LABELS = {
   name: "Provider Name",
   awsAccessKeyId: "AWS Access Key ID",
   awsSecretAccessKey: "AWS Secret Access Key",
   baseUrl: "Base URL",
   apiKey: "API Key",
-  models: "Models",
   timeout: "Timeout",
 };
 
@@ -193,8 +183,12 @@ const AddProviderDialog = ({ open, onClose, gatewayId, provider }) => {
 
   // Validation state
   const [errors, setErrors] = useState({});
-  // The dialog body scrolls, so a failed Save has to bring the summary back
-  // into view — otherwise the button looks inert.
+  const [summaryDismissed, setSummaryDismissed] = useState(false);
+  // A hand-typed model ID overrides an empty listing: the azure and custom
+  // presets are probed with a plain `{base_url}/models` a working endpoint need
+  // not serve, so an empty list there is no proof the key is bad.
+  const [manualModels, setManualModels] = useState(false);
+  // The body scrolls, so a failed Save has to bring the summary back into view.
   const contentRef = useRef(null);
 
   const updateProvider = useUpdateProvider();
@@ -202,12 +196,14 @@ const AddProviderDialog = ({ open, onClose, gatewayId, provider }) => {
   const [modelOptions, setModelOptions] = useState([]);
   const [fetchError, setFetchError] = useState("");
   const [hasFetched, setHasFetched] = useState(false);
-  // Live feedback on the key, kept out of `errors` so a failed fetch does not
-  // raise the "Fix this before saving" summary before Save was ever pressed.
+  // Kept out of `errors` so a failed fetch does not raise the Save-time summary.
   const [keyFetchError, setKeyFetchError] = useState("");
   // A debounced fetch is armed but has not fired yet.
   const [fetchScheduled, setFetchScheduled] = useState(false);
   const fetchSeqRef = useRef(0);
+
+  // What the fetch-by-name concluded, so clearing a typed key restores it.
+  const storedKeyResult = useRef(null);
 
   const doFetchModels = useCallback(
     ({ providerName, url, key, format }) => {
@@ -217,8 +213,7 @@ const AddProviderDialog = ({ open, onClose, gatewayId, provider }) => {
       setFetchError("");
       setKeyFetchError("");
       setHasFetched(false);
-      // Edit mode fetches by provider name against the stored credential, so
-      // there is no key in the form to blame for an empty list.
+      // A by-name fetch uses the stored credential; no key here to blame.
       const blameKey = !providerName;
       fetchModels.mutate(
         providerName
@@ -228,19 +223,37 @@ const AddProviderDialog = ({ open, onClose, gatewayId, provider }) => {
           onSuccess: (result) => {
             if (isStale()) return;
             const fetched = normalizeModels(result?.models);
-            if (fetched.length === 0) {
-              setFetchError(result?.error || "Provider returned no models");
-              if (blameKey) setKeyFetchError(KEY_FETCH_FAILED);
-            }
+            const emptyReason =
+              fetched.length === 0
+                ? result?.error || "Provider returned no models"
+                : "";
+            setFetchError(emptyReason);
+            if (emptyReason && blameKey) setKeyFetchError(KEY_FETCH_FAILED);
             setModelOptions(fetched);
             setHasFetched(true);
+            if (providerName) {
+              storedKeyResult.current = {
+                options: fetched,
+                error: emptyReason,
+                hasFetched: true,
+              };
+            }
           },
           onError: (err) => {
             if (isStale()) return;
-            setFetchError(err?.message || "Failed to fetch models");
-            if (blameKey) setKeyFetchError(KEY_FETCH_FAILED);
+            // A request that failed reached no verdict on the key, so
+            // `hasFetched` stays false and the API Key field is left alone.
+            const message = err?.message || "Failed to fetch models";
+            setFetchError(message);
             setModelOptions([]);
-            setHasFetched(true);
+            setHasFetched(false);
+            if (providerName) {
+              storedKeyResult.current = {
+                options: [],
+                error: message,
+                hasFetched: false,
+              };
+            }
           },
         },
       );
@@ -265,6 +278,9 @@ const AddProviderDialog = ({ open, onClose, gatewayId, provider }) => {
           : "",
       );
       setErrors({});
+      setSummaryDismissed(false);
+      setManualModels(false);
+      storedKeyResult.current = null;
       doFetchModels({ providerName: provider.name });
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -281,8 +297,7 @@ const AddProviderDialog = ({ open, onClose, gatewayId, provider }) => {
   const isAwsAuth = PROVIDER_PRESETS[name]?.authType === "aws";
 
   // Auto-fetch when an API key is entered (debounced). Edit mode included: a
-  // typed key replaces the stored one, so it has to prove it can list models
-  // before Save will accept it — otherwise an unverified key gets written.
+  // typed key replaces the stored one, so it has to list models before Save.
   // Skip auto-fetch for AWS providers (Bedrock models must be entered manually)
   useEffect(() => {
     if (isAwsAuth) {
@@ -291,9 +306,18 @@ const AddProviderDialog = ({ open, onClose, gatewayId, provider }) => {
     }
     if (!apiKey.trim()) {
       setFetchScheduled(false);
-      // A blank key in edit mode means "keep the stored one", so leave the
-      // fetch-by-name result standing instead of wiping it.
-      if (isEditMode) return;
+      // Blank in edit mode means "keep the stored key", so restore its verdict:
+      // a typed key's result left standing blames the stored one for it.
+      if (isEditMode) {
+        const snapshot = storedKeyResult.current;
+        if (snapshot) {
+          setModelOptions(snapshot.options);
+          setFetchError(snapshot.error);
+          setHasFetched(snapshot.hasFetched);
+          setKeyFetchError("");
+        }
+        return;
+      }
       setModelOptions([]);
       setFetchError("");
       setKeyFetchError("");
@@ -307,8 +331,7 @@ const AddProviderDialog = ({ open, onClose, gatewayId, provider }) => {
       return;
     }
 
-    // Held from the first keystroke, not from when the request goes out: the
-    // debounce window is long enough to click Save in.
+    // Held from the first keystroke: the debounce is long enough to click in.
     setFetchScheduled(true);
     const timer = setTimeout(() => {
       setFetchScheduled(false);
@@ -337,6 +360,9 @@ const AddProviderDialog = ({ open, onClose, gatewayId, provider }) => {
     setAwsRegion("us-east-1");
     setAwsSessionToken("");
     setErrors({});
+    setSummaryDismissed(false);
+    setManualModels(false);
+    storedKeyResult.current = null;
   };
 
   const handleClose = () => {
@@ -367,6 +393,9 @@ const AddProviderDialog = ({ open, onClose, gatewayId, provider }) => {
     setKeyFetchError("");
     setHasFetched(false);
     setErrors({});
+    setSummaryDismissed(false);
+    setManualModels(false);
+    storedKeyResult.current = null;
   };
 
   const handleAwsRegionChange = (region) => {
@@ -414,24 +443,15 @@ const AddProviderDialog = ({ open, onClose, gatewayId, provider }) => {
         newErrors.apiKey = "API key is required";
       }
 
-      // Key validation — only block if fetch completed with zero models
-      if (apiKey.trim() && hasFetched && modelOptions.length === 0) {
+      // Only a listing that came back empty counts, and only until models are
+      // entered by hand.
+      if (
+        apiKey.trim() &&
+        hasFetched &&
+        modelOptions.length === 0 &&
+        !manualModels
+      ) {
         newErrors.apiKey = KEY_FETCH_FAILED;
-      }
-    }
-
-    // Require at least one model selected. Say why the list is empty when it
-    // is — otherwise "select a model" is impossible advice with nothing to
-    // pick from.
-    if (models.length === 0) {
-      if (fetchError) {
-        newErrors.models = `Select at least one model. Loading this provider's models failed (${fetchError}) — type a model ID and press Enter to add it manually.`;
-      } else if (modelOptions.length === 0) {
-        newErrors.models = isEditMode
-          ? "Select at least one model. None were loaded for this provider — type a model ID and press Enter to add it manually."
-          : "Select at least one model. Enter a valid API key to load the list, or type a model ID and press Enter.";
-      } else {
-        newErrors.models = "Select at least one model from the list.";
       }
     }
 
@@ -440,14 +460,14 @@ const AddProviderDialog = ({ open, onClose, gatewayId, provider }) => {
     }
 
     setErrors(newErrors);
+    setSummaryDismissed(false);
     return Object.keys(newErrors).length === 0;
   };
 
   const handleSave = () => {
     const timeoutSeconds = parseTimeoutSeconds(timeoutVal);
     if (!validate(timeoutSeconds)) {
-      // scrollTo is missing in jsdom and older browsers — never let a Save
-      // handler throw on a cosmetic scroll.
+      // scrollTo is missing in jsdom — never throw on a cosmetic scroll.
       contentRef.current?.scrollTo?.({ top: 0, behavior: "smooth" });
       return;
     }
@@ -489,35 +509,43 @@ const AddProviderDialog = ({ open, onClose, gatewayId, provider }) => {
 
   const modelsLoading = fetchScheduled || fetchModels.isPending;
 
-  // The stored credential could not list models and no replacement key has
-  // been typed yet. AWS is exempt: Bedrock has no list endpoint, so an empty
-  // result proves nothing, and there is no API Key field to explain it on —
-  // gating there would lock the provider out of editing entirely.
+  // A typed key answered with an empty list; hand-entered models lift it.
+  const typedKeyUnverified = !!keyFetchError && !manualModels;
+
+  // The stored credential listed nothing and no replacement key has been typed.
+  // AWS is exempt: Bedrock has no list endpoint and no API Key field to explain
+  // a block on, so gating there would lock those providers out of editing.
   const savedKeyUnverified =
     isEditMode &&
     !isAwsAuth &&
     hasFetched &&
     modelOptions.length === 0 &&
-    !apiKey.trim();
+    !apiKey.trim() &&
+    !manualModels;
 
   const allSelected =
     modelOptions.length > 0 && models.length === modelOptions.length;
 
   const preset = PROVIDER_PRESETS[name] || PROVIDER_PRESETS.custom;
 
-  const errorList = Object.keys(FIELD_LABELS)
-    .filter((key) => errors[key])
-    .map((key) => ({ key, label: FIELD_LABELS[key], message: errors[key] }));
+  // A key FIELD_LABELS does not know goes last rather than dropping silently.
+  const errorKeys = Object.keys(errors).filter((key) => errors[key]);
+  const errorList = [
+    ...Object.keys(FIELD_LABELS).filter((key) => errors[key]),
+    ...errorKeys.filter((key) => !(key in FIELD_LABELS)),
+  ].map((key) => ({
+    key,
+    label: FIELD_LABELS[key] || key,
+    message: errors[key],
+  }));
 
   return (
     <Dialog open={open} onClose={handleClose} maxWidth="sm" fullWidth>
       <DialogTitle>{isEditMode ? "Edit Provider" : "Add Provider"}</DialogTitle>
       <DialogContent ref={contentRef}>
         <Stack spacing={2} mt={1}>
-          {/* Validation summary — the body scrolls, so an inline-only error
-              under a field can sit off-screen and make Save look broken. */}
-          {errorList.length > 0 && (
-            <Alert severity="error" onClose={() => setErrors({})}>
+          {errorList.length > 0 && !summaryDismissed && (
+            <Alert severity="error" onClose={() => setSummaryDismissed(true)}>
               <AlertTitle>
                 {errorList.length === 1
                   ? "Fix this before saving"
@@ -662,8 +690,7 @@ const AddProviderDialog = ({ open, onClose, gatewayId, provider }) => {
                 onChange={(e) => {
                   setApiKey(e.target.value);
                   setErrors((prev) => ({ ...prev, apiKey: undefined }));
-                  // The refetch is debounced; drop the stale verdict now so a
-                  // corrected key does not keep showing the old rejection.
+                  // The refetch is debounced; drop the stale verdict now.
                   setKeyFetchError("");
                 }}
                 placeholder={
@@ -671,7 +698,9 @@ const AddProviderDialog = ({ open, onClose, gatewayId, provider }) => {
                     ? "Leave blank to keep current key"
                     : preset.keyPlaceholder
                 }
-                error={!!errors.apiKey || !!keyFetchError || savedKeyUnverified}
+                error={
+                  !!errors.apiKey || typedKeyUnverified || savedKeyUnverified
+                }
                 helperText={
                   errors.apiKey ||
                   keyFetchError ||
@@ -754,8 +783,12 @@ const AddProviderDialog = ({ open, onClose, gatewayId, provider }) => {
               options={modelOptions}
               value={models}
               onChange={(_, val) => {
-                setModels(normalizeModels(val));
-                setErrors((prev) => ({ ...prev, models: undefined }));
+                const next = normalizeModels(val);
+                setModels(next);
+                // An ID the listing never offered was entered by hand.
+                if (next.some((m) => !modelOptions.includes(m))) {
+                  setManualModels(true);
+                }
               }}
               renderOption={(props, option, { selected }) => (
                 <li {...props} key={option}>
@@ -797,7 +830,9 @@ const AddProviderDialog = ({ open, onClose, gatewayId, provider }) => {
                     setModels((prev) =>
                       Array.from(new Set([...prev, ...tokens])),
                     );
-                    setErrors((p) => ({ ...p, models: undefined }));
+                    if (tokens.some((t) => !modelOptions.includes(t))) {
+                      setManualModels(true);
+                    }
                   }}
                 />
               )}
@@ -811,25 +846,18 @@ const AddProviderDialog = ({ open, onClose, gatewayId, provider }) => {
                 {fetchError}
               </Alert>
             )}
-            {errors.models ? (
-              <Typography variant="caption" color="error" sx={{ mt: 0.5 }}>
-                {errors.models}
+            {models.length === 0 && (
+              // Save is held until a model is picked, so say so here.
+              <Typography
+                variant="caption"
+                color="text.secondary"
+                sx={{ mt: 0.5, display: "block" }}
+              >
+                Select at least one model to enable Save
+                {modelOptions.length === 0
+                  ? " — type a model ID and press Enter to add one manually."
+                  : "."}
               </Typography>
-            ) : (
-              models.length === 0 && (
-                // Save is disabled until a model is picked, so state the
-                // requirement here rather than leaving a dead button.
-                <Typography
-                  variant="caption"
-                  color="text.secondary"
-                  sx={{ mt: 0.5, display: "block" }}
-                >
-                  Select at least one model to enable Save
-                  {modelOptions.length === 0
-                    ? " — type a model ID and press Enter to add one manually."
-                    : "."}
-                </Typography>
-              )
             )}
           </Box>
 
@@ -868,12 +896,9 @@ const AddProviderDialog = ({ open, onClose, gatewayId, provider }) => {
       </DialogContent>
       <DialogActions>
         <Button onClick={handleClose}>Cancel</Button>
-        {/* Held for the three states a click could never get past: a fetch in
-            flight (validates against a stale, usually empty model list and
-            rejects a good key), a key the provider already rejected, a stored
-            key that can no longer list models, and no model selected. Each one
-            is explained on the field it belongs to,
-            so the disabled button is never the only signal. */}
+        {/* Held for the states a click could never get past. Each is explained
+            on its own field, and each has a way out — pick or type a model, or
+            enter a key that lists them. */}
         <Button
           variant="contained"
           onClick={handleSave}
@@ -881,7 +906,7 @@ const AddProviderDialog = ({ open, onClose, gatewayId, provider }) => {
             !name.trim() ||
             updateProvider.isPending ||
             modelsLoading ||
-            !!keyFetchError ||
+            typedKeyUnverified ||
             savedKeyUnverified ||
             models.length === 0
           }

--- a/frontend/src/sections/gateway/providers/AddProviderDialog.test.jsx
+++ b/frontend/src/sections/gateway/providers/AddProviderDialog.test.jsx
@@ -1,5 +1,43 @@
-import { describe, expect, it } from "vitest";
+import React from "react";
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { render, screen, userEvent, waitFor } from "src/utils/test-utils";
 import { parseTimeoutSeconds } from "./utils";
+import AddProviderDialog from "./AddProviderDialog";
+
+const { updateMutate, fetchMutate, fetchState } = vi.hoisted(() => ({
+  updateMutate: vi.fn(),
+  fetchMutate: vi.fn(),
+  // Mutable so a test can render the dialog mid-fetch.
+  fetchState: { isPending: false },
+}));
+
+vi.mock("./hooks/useGatewayConfig", () => ({
+  useUpdateProvider: () => ({
+    mutate: updateMutate,
+    isPending: false,
+    isError: false,
+    error: null,
+  }),
+  useFetchProviderModels: () => ({
+    mutate: fetchMutate,
+    isPending: fetchState.isPending,
+  }),
+}));
+
+const renderCreateDialog = () =>
+  render(<AddProviderDialog open onClose={vi.fn()} gatewayId="gw-1" />);
+
+const renderEditDialogFor = (name, config) =>
+  render(
+    <AddProviderDialog
+      open
+      onClose={vi.fn()}
+      gatewayId="gw-1"
+      provider={{ name, config }}
+    />,
+  );
+
+const renderEditDialog = (config) => renderEditDialogFor("openai", config);
 
 describe("parseTimeoutSeconds", () => {
   it("normalizes Gateway provider timeout text to integer seconds", () => {
@@ -10,5 +48,203 @@ describe("parseTimeoutSeconds", () => {
     expect(parseTimeoutSeconds("")).toBeNull();
     expect(parseTimeoutSeconds("soon")).toBeNull();
     expect(parseTimeoutSeconds("0s")).toBeNull();
+  });
+});
+
+describe("AddProviderDialog validation", () => {
+  beforeEach(() => {
+    updateMutate.mockReset();
+    fetchState.isPending = false;
+    // The dialog fetches the provider's models when it opens in edit mode.
+    fetchMutate.mockReset();
+    fetchMutate.mockImplementation((_vars, opts) =>
+      opts?.onSuccess?.({ models: ["gpt-4o", "gpt-4o-mini"] }),
+    );
+  });
+
+  it("saves an edited provider whose stored timeout came back as a number", async () => {
+    // The API returns default_timeout as an integer; seeding the text field
+    // with it used to throw "timeoutVal.trim is not a function" on Save.
+    renderEditDialog({ default_timeout: 30, models: ["gpt-4o"] });
+
+    await userEvent.click(screen.getByRole("button", { name: "Save Changes" }));
+
+    expect(updateMutate).toHaveBeenCalledTimes(1);
+    expect(updateMutate.mock.calls[0][0].config.default_timeout).toBe(30);
+  });
+
+  it("blocks Save, and says why, when no model is selected", async () => {
+    renderEditDialog({ default_timeout: 30, models: [] });
+
+    // A model is mandatory, so the click can never succeed — the button is
+    // held and the requirement is stated under the Models field instead.
+    expect(screen.getByRole("button", { name: "Save Changes" }).disabled).toBe(
+      true,
+    );
+    expect(
+      screen.getAllByText(/Select at least one model to enable Save/).length,
+    ).toBeGreaterThan(0);
+    expect(updateMutate).not.toHaveBeenCalled();
+  });
+
+  it("reports a malformed timeout with the offending value", async () => {
+    renderEditDialog({ default_timeout: 30, models: ["gpt-4o"] });
+
+    const timeout = screen.getByLabelText("Timeout");
+    await userEvent.clear(timeout);
+    await userEvent.type(timeout, "soon");
+    await userEvent.click(screen.getByRole("button", { name: "Save Changes" }));
+
+    expect(updateMutate).not.toHaveBeenCalled();
+    expect(
+      screen.getAllByText(/whole number of seconds.*got "soon"/).length,
+    ).toBeGreaterThan(0);
+  });
+
+  it("counts multiple problems in the summary", async () => {
+    // Problems the button does not gate still reach the summary on click.
+    renderEditDialog({ default_timeout: 30, models: ["gpt-4o"] });
+
+    const baseUrl = screen.getByLabelText("Base URL");
+    await userEvent.clear(baseUrl);
+    await userEvent.type(baseUrl, "ftp://nope");
+    const timeout = screen.getByLabelText("Timeout");
+    await userEvent.clear(timeout);
+    await userEvent.type(timeout, "soon");
+    await userEvent.click(screen.getByRole("button", { name: "Save Changes" }));
+
+    expect(updateMutate).not.toHaveBeenCalled();
+    expect(await screen.findByText("Fix 2 issues before saving")).toBeTruthy();
+  });
+
+  it("holds Save while the provider's models are still loading", () => {
+    // Saving mid-fetch validates against an empty model list and rejects a
+    // valid API key, so the action stays disabled until the request settles.
+    fetchState.isPending = true;
+    renderEditDialog({ default_timeout: 30, models: ["gpt-4o"] });
+
+    const save = screen.getByRole("button", { name: "Loading models..." });
+    expect(save.disabled).toBe(true);
+    expect(updateMutate).not.toHaveBeenCalled();
+  });
+
+  it("blames the API key when the provider returns no models", async () => {
+    // The gateway answers 200 with an empty list and a reason, so nothing but
+    // the Models warning used to move — the key that caused it looked fine.
+    fetchMutate.mockImplementation((_vars, opts) =>
+      opts?.onSuccess?.({
+        models: [],
+        error: "Failed to fetch models from provider",
+      }),
+    );
+    renderCreateDialog();
+
+    await userEvent.type(screen.getByLabelText(/API Key/i), "sk-bad");
+
+    // Shown on the key field itself, once the debounced fetch comes back.
+    expect(
+      await screen.findByText(/check that it is valid for this provider/i),
+    ).toBeTruthy();
+    // The provider's own reason still appears under Models.
+    expect(
+      screen.getByText("Failed to fetch models from provider"),
+    ).toBeTruthy();
+    // Live feedback only — the Save-time summary stays down until Save.
+    expect(screen.queryByText("Fix this before saving")).toBeNull();
+    // And the rejected key holds the action, so there is nothing to click.
+    expect(screen.getByRole("button", { name: "Add Provider" }).disabled).toBe(
+      true,
+    );
+  });
+
+  it("blocks Save when the stored key can no longer list models", async () => {
+    // Exactly the screenshot case: three models already saved, so the models
+    // gate passes, but the refresh failed — the key on file is the problem and
+    // saving would just keep it.
+    fetchMutate.mockImplementation((_vars, opts) =>
+      opts?.onSuccess?.({
+        models: [],
+        error: "Failed to fetch models from provider",
+      }),
+    );
+    renderEditDialog({
+      default_timeout: 30,
+      models: ["gpt-3.5-turbo-0125", "gpt-3.5-turbo-1106"],
+    });
+
+    const save = await screen.findByRole("button", { name: "Save Changes" });
+    expect(save.disabled).toBe(true);
+    expect(
+      screen.getByText(/enter a new API key to save changes/i),
+    ).toBeTruthy();
+
+    // A replacement key is the way out, but it has to prove itself first.
+    await userEvent.type(screen.getByLabelText(/API Key/i), "sk-still-bad");
+    await waitFor(() => expect(fetchMutate).toHaveBeenCalledTimes(2));
+
+    expect(
+      await screen.findByText(/check that it is valid for this provider/i),
+    ).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Save Changes" }).disabled).toBe(
+      true,
+    );
+    expect(updateMutate).not.toHaveBeenCalled();
+  });
+
+  it("re-verifies a key typed in edit mode before allowing a save", async () => {
+    // Edit mode used to skip the auto-fetch entirely, so a key typed here was
+    // never checked — Save just wrote it.
+    fetchMutate.mockImplementation((vars, opts) =>
+      vars?.providerName
+        ? opts?.onSuccess?.({
+            models: [],
+            error: "Failed to fetch models from provider",
+          })
+        : opts?.onSuccess?.({ models: ["gpt-4o", "gpt-4o-mini"] }),
+    );
+    renderEditDialog({
+      base_url: "https://api.openai.com/v1",
+      default_timeout: 30,
+      models: ["gpt-3.5-turbo-0125"],
+    });
+
+    const save = await screen.findByRole("button", { name: "Save Changes" });
+    expect(save.disabled).toBe(true);
+
+    await userEvent.type(screen.getByLabelText(/API Key/i), "sk-good");
+
+    // The refetch goes out with the typed credential, not the provider name.
+    await waitFor(() => expect(fetchMutate).toHaveBeenCalledTimes(2));
+    expect(fetchMutate.mock.calls[1][0]).toEqual({
+      baseUrl: "https://api.openai.com/v1",
+      apiKey: "sk-good",
+      apiFormat: "openai",
+    });
+
+    // Only once it lists models does Save open up.
+    await waitFor(() =>
+      expect(
+        screen.getByRole("button", { name: "Save Changes" }).disabled,
+      ).toBe(false),
+    );
+
+    await userEvent.click(screen.getByRole("button", { name: "Save Changes" }));
+    expect(updateMutate).toHaveBeenCalledTimes(1);
+    expect(updateMutate.mock.calls[0][0].config.api_key).toBe("sk-good");
+  });
+  it("keeps Bedrock editable although it lists no models", async () => {
+    // Bedrock has no list endpoint and no API Key field, so gating on an empty
+    // result would lock the provider out of editing with nowhere to say why.
+    fetchMutate.mockImplementation((_vars, opts) =>
+      opts?.onSuccess?.({ models: [] }),
+    );
+    renderEditDialogFor("bedrock", {
+      api_format: "anthropic",
+      default_timeout: 30,
+      models: ["anthropic.claude-v2"],
+    });
+
+    const save = await screen.findByRole("button", { name: "Save Changes" });
+    expect(save.disabled).toBe(false);
   });
 });

--- a/frontend/src/sections/gateway/providers/AddProviderDialog.test.jsx
+++ b/frontend/src/sections/gateway/providers/AddProviderDialog.test.jsx
@@ -168,7 +168,7 @@ describe("AddProviderDialog validation", () => {
     const save = await screen.findByRole("button", { name: "Save Changes" });
     expect(save.disabled).toBe(true);
     expect(
-      screen.getByText(/enter a new API key to save changes/i),
+      screen.getByText(/Enter a new API key, or add model IDs manually/i),
     ).toBeTruthy();
 
     // A replacement key is the way out, but it has to prove itself.
@@ -270,7 +270,7 @@ describe("AddProviderDialog validation", () => {
     const save = await screen.findByRole("button", { name: "Save Changes" });
     expect(save.disabled).toBe(false);
     expect(
-      screen.queryByText(/enter a new API key to save changes/i),
+      screen.queryByText(/Enter a new API key, or add model IDs manually/i),
     ).toBeNull();
     // The reason still surfaces, just not against the key.
     expect(
@@ -313,7 +313,7 @@ describe("AddProviderDialog validation", () => {
       ).toBe(false),
     );
     expect(
-      screen.queryByText(/enter a new API key to save changes/i),
+      screen.queryByText(/Enter a new API key, or add model IDs manually/i),
     ).toBeNull();
   });
 
@@ -333,6 +333,107 @@ describe("AddProviderDialog validation", () => {
     expect(
       screen.getAllByText(/whole number of seconds.*got "soon"/).length,
     ).toBeGreaterThan(0);
+  });
+
+  it("ignores a fetch that lands after the key field was cleared", async () => {
+    // The typed key's response used to arrive after the restore and overwrite
+    // it, leaving a rejection message under an empty field with no way out.
+    const pending = [];
+    fetchMutate.mockImplementation((vars, opts) => {
+      if (vars?.providerName) {
+        opts?.onSuccess?.({ models: ["gpt-4o", "gpt-4o-mini"] });
+        return;
+      }
+      pending.push(opts);
+    });
+    renderEditDialog({
+      base_url: "https://api.openai.com/v1",
+      default_timeout: 30,
+      models: ["gpt-4o"],
+    });
+
+    const key = screen.getByLabelText(/API Key/i);
+    await userEvent.type(key, "sk-slow");
+    await waitFor(() => expect(pending.length).toBe(1));
+    await userEvent.clear(key);
+    await waitFor(() =>
+      expect(
+        screen.getByRole("button", { name: "Save Changes" }).disabled,
+      ).toBe(false),
+    );
+
+    // The abandoned request finally answers.
+    pending[0].onSuccess({
+      models: [],
+      error: "Failed to fetch models from provider",
+    });
+
+    expect(screen.getByRole("button", { name: "Save Changes" }).disabled).toBe(
+      false,
+    );
+    expect(
+      screen.queryByText(/check that it is valid for this provider/i),
+    ).toBeNull();
+  });
+
+  it("re-arms the gate when the hand-entered model is removed", async () => {
+    // The override has to follow the chips: a scratch ID typed and then deleted
+    // must not leave the block lifted for a key the provider went on to reject.
+    let reject = false;
+    fetchMutate.mockImplementation((_vars, opts) =>
+      opts?.onSuccess?.(
+        reject
+          ? { models: [], error: "Failed to fetch models from provider" }
+          : { models: ["gpt-4o", "gpt-4o-mini"] },
+      ),
+    );
+    renderCreateDialog();
+
+    await userEvent.type(screen.getByLabelText(/API Key/i), "sk-good");
+    const input = await screen.findByPlaceholderText(/Select models/i);
+
+    await userEvent.type(input, "scratch-id{enter}");
+    await userEvent.type(input, "{backspace}");
+    await userEvent.type(input, "gpt-4o{enter}");
+    expect(screen.queryByText("scratch-id")).toBeNull();
+    expect(screen.getAllByText("gpt-4o").length).toBeGreaterThan(0);
+
+    reject = true;
+    await userEvent.clear(screen.getByLabelText(/API Key/i));
+    await userEvent.type(screen.getByLabelText(/API Key/i), "sk-rejected");
+
+    // Only a listed model is selected now, so the rejected key still blocks.
+    await waitFor(() =>
+      expect(
+        screen.getByRole("button", { name: "Add Provider" }).disabled,
+      ).toBe(true),
+    );
+    expect(updateMutate).not.toHaveBeenCalled();
+  });
+
+  it("takes pasted model IDs as a manual list", async () => {
+    fetchMutate.mockImplementation((_vars, opts) =>
+      opts?.onSuccess?.({ models: [], error: "Provider returned no models" }),
+    );
+    renderCreateDialog();
+
+    await userEvent.type(screen.getByLabelText(/API Key/i), "sk-unlistable");
+    await screen.findByText(/check that it is valid for this provider/i);
+
+    const input = screen.getByPlaceholderText(/type manually/i);
+    await userEvent.click(input);
+    await userEvent.paste("model-a, model-b");
+
+    await waitFor(() =>
+      expect(
+        screen.getByRole("button", { name: "Add Provider" }).disabled,
+      ).toBe(false),
+    );
+    await userEvent.click(screen.getByRole("button", { name: "Add Provider" }));
+    expect(updateMutate.mock.calls[0][0].config.models).toEqual([
+      "model-a",
+      "model-b",
+    ]);
   });
 
   it("keeps Bedrock editable although it lists no models", async () => {

--- a/frontend/src/sections/gateway/providers/AddProviderDialog.test.jsx
+++ b/frontend/src/sections/gateway/providers/AddProviderDialog.test.jsx
@@ -63,8 +63,7 @@ describe("AddProviderDialog validation", () => {
   });
 
   it("saves an edited provider whose stored timeout came back as a number", async () => {
-    // The API returns default_timeout as an integer; seeding the text field
-    // with it used to throw "timeoutVal.trim is not a function" on Save.
+    // A numeric default_timeout used to throw "trim is not a function".
     renderEditDialog({ default_timeout: 30, models: ["gpt-4o"] });
 
     await userEvent.click(screen.getByRole("button", { name: "Save Changes" }));
@@ -76,8 +75,7 @@ describe("AddProviderDialog validation", () => {
   it("blocks Save, and says why, when no model is selected", async () => {
     renderEditDialog({ default_timeout: 30, models: [] });
 
-    // A model is mandatory, so the click can never succeed — the button is
-    // held and the requirement is stated under the Models field instead.
+    // The button is held, and the requirement stated under the field.
     expect(screen.getByRole("button", { name: "Save Changes" }).disabled).toBe(
       true,
     );
@@ -129,8 +127,7 @@ describe("AddProviderDialog validation", () => {
   });
 
   it("blames the API key when the provider returns no models", async () => {
-    // The gateway answers 200 with an empty list and a reason, so nothing but
-    // the Models warning used to move — the key that caused it looked fine.
+    // An empty 200 used to move nothing but the warning under Models.
     fetchMutate.mockImplementation((_vars, opts) =>
       opts?.onSuccess?.({
         models: [],
@@ -141,26 +138,22 @@ describe("AddProviderDialog validation", () => {
 
     await userEvent.type(screen.getByLabelText(/API Key/i), "sk-bad");
 
-    // Shown on the key field itself, once the debounced fetch comes back.
     expect(
       await screen.findByText(/check that it is valid for this provider/i),
     ).toBeTruthy();
-    // The provider's own reason still appears under Models.
     expect(
       screen.getByText("Failed to fetch models from provider"),
     ).toBeTruthy();
-    // Live feedback only — the Save-time summary stays down until Save.
+    // Live feedback only — the summary stays down until Save.
     expect(screen.queryByText("Fix this before saving")).toBeNull();
-    // And the rejected key holds the action, so there is nothing to click.
     expect(screen.getByRole("button", { name: "Add Provider" }).disabled).toBe(
       true,
     );
   });
 
   it("blocks Save when the stored key can no longer list models", async () => {
-    // Exactly the screenshot case: three models already saved, so the models
-    // gate passes, but the refresh failed — the key on file is the problem and
-    // saving would just keep it.
+    // Models already saved, so that gate passes — but the key on file no
+    // longer works, and saving would just keep it.
     fetchMutate.mockImplementation((_vars, opts) =>
       opts?.onSuccess?.({
         models: [],
@@ -178,7 +171,7 @@ describe("AddProviderDialog validation", () => {
       screen.getByText(/enter a new API key to save changes/i),
     ).toBeTruthy();
 
-    // A replacement key is the way out, but it has to prove itself first.
+    // A replacement key is the way out, but it has to prove itself.
     await userEvent.type(screen.getByLabelText(/API Key/i), "sk-still-bad");
     await waitFor(() => expect(fetchMutate).toHaveBeenCalledTimes(2));
 
@@ -192,8 +185,7 @@ describe("AddProviderDialog validation", () => {
   });
 
   it("re-verifies a key typed in edit mode before allowing a save", async () => {
-    // Edit mode used to skip the auto-fetch entirely, so a key typed here was
-    // never checked — Save just wrote it.
+    // Edit mode skipped the auto-fetch, so a key typed here went unchecked.
     fetchMutate.mockImplementation((vars, opts) =>
       vars?.providerName
         ? opts?.onSuccess?.({
@@ -232,9 +224,119 @@ describe("AddProviderDialog validation", () => {
     expect(updateMutate).toHaveBeenCalledTimes(1);
     expect(updateMutate.mock.calls[0][0].config.api_key).toBe("sk-good");
   });
+  it("lets a hand-typed model ID unblock a provider the gateway cannot list", async () => {
+    // The message says to add model IDs by hand, so that has to open Save.
+    fetchMutate.mockImplementation((_vars, opts) =>
+      opts?.onSuccess?.({ models: [], error: "Provider returned no models" }),
+    );
+    renderCreateDialog();
+
+    // Probed with a plain {base_url}/models, and not AWS-exempt.
+    await userEvent.click(screen.getByRole("combobox", { name: /Provider/ }));
+    await userEvent.click(
+      screen.getByRole("option", { name: "Custom / Self-hosted" }),
+    );
+    await userEvent.type(
+      screen.getByLabelText(/Base URL/),
+      "https://mine.example.com",
+    );
+    await userEvent.type(screen.getByLabelText(/API Key/i), "sk-unlistable");
+    await screen.findByText(/check that it is valid for this provider/i);
+    expect(screen.getByRole("button", { name: "Add Provider" }).disabled).toBe(
+      true,
+    );
+
+    await userEvent.type(
+      screen.getByPlaceholderText(/type manually/i),
+      "my-model{enter}",
+    );
+
+    await waitFor(() =>
+      expect(
+        screen.getByRole("button", { name: "Add Provider" }).disabled,
+      ).toBe(false),
+    );
+    await userEvent.click(screen.getByRole("button", { name: "Add Provider" }));
+    expect(updateMutate.mock.calls[0][0].config.models).toEqual(["my-model"]);
+  });
+
+  it("does not blame the stored key when the fetch itself fails", async () => {
+    // No verdict was reached, so it must not block an unrelated edit.
+    fetchMutate.mockImplementation((_vars, opts) =>
+      opts?.onError?.(new Error("The request timed out. Please try again.")),
+    );
+    renderEditDialog({ default_timeout: 30, models: ["gpt-4o"] });
+
+    const save = await screen.findByRole("button", { name: "Save Changes" });
+    expect(save.disabled).toBe(false);
+    expect(
+      screen.queryByText(/enter a new API key to save changes/i),
+    ).toBeNull();
+    // The reason still surfaces, just not against the key.
+    expect(
+      screen.getByText("The request timed out. Please try again."),
+    ).toBeTruthy();
+
+    await userEvent.click(save);
+    expect(updateMutate).toHaveBeenCalledTimes(1);
+  });
+
+  it("restores the stored key's verdict when a typed key is cleared", async () => {
+    // The typed key's empty listing used to stay behind as the stored key's.
+    fetchMutate.mockImplementation((vars, opts) =>
+      vars?.providerName
+        ? opts?.onSuccess?.({ models: ["gpt-4o", "gpt-4o-mini"] })
+        : opts?.onSuccess?.({
+            models: [],
+            error: "Failed to fetch models from provider",
+          }),
+    );
+    renderEditDialog({
+      base_url: "https://api.openai.com/v1",
+      default_timeout: 30,
+      models: ["gpt-4o"],
+    });
+
+    const key = screen.getByLabelText(/API Key/i);
+    await userEvent.type(key, "sk-bad");
+    await waitFor(() =>
+      expect(
+        screen.getByRole("button", { name: "Save Changes" }).disabled,
+      ).toBe(true),
+    );
+
+    await userEvent.clear(key);
+
+    await waitFor(() =>
+      expect(
+        screen.getByRole("button", { name: "Save Changes" }).disabled,
+      ).toBe(false),
+    );
+    expect(
+      screen.queryByText(/enter a new API key to save changes/i),
+    ).toBeNull();
+  });
+
+  it("keeps the field errors when the summary is dismissed", async () => {
+    renderEditDialog({ default_timeout: 30, models: ["gpt-4o"] });
+
+    const timeout = screen.getByLabelText("Timeout");
+    await userEvent.clear(timeout);
+    await userEvent.type(timeout, "soon");
+    await userEvent.click(screen.getByRole("button", { name: "Save Changes" }));
+    expect(await screen.findByText("Fix this before saving")).toBeTruthy();
+
+    await userEvent.click(screen.getByRole("button", { name: /close/i }));
+
+    // The banner goes; the marker on the field that caused it stays.
+    expect(screen.queryByText("Fix this before saving")).toBeNull();
+    expect(
+      screen.getAllByText(/whole number of seconds.*got "soon"/).length,
+    ).toBeGreaterThan(0);
+  });
+
   it("keeps Bedrock editable although it lists no models", async () => {
-    // Bedrock has no list endpoint and no API Key field, so gating on an empty
-    // result would lock the provider out of editing with nowhere to say why.
+    // No list endpoint and no API Key field to explain a block on.
     fetchMutate.mockImplementation((_vars, opts) =>
       opts?.onSuccess?.({ models: [] }),
     );

--- a/frontend/src/sections/gateway/providers/AddProviderDialog.test.jsx
+++ b/frontend/src/sections/gateway/providers/AddProviderDialog.test.jsx
@@ -24,6 +24,13 @@ vi.mock("./hooks/useGatewayConfig", () => ({
   }),
 }));
 
+// Responses land on a later task, as a real request does; a synchronous mock
+// closes the window the dialog's ordering bugs live in.
+const deferred =
+  (impl) =>
+  (...args) =>
+    setTimeout(() => impl(...args), 0);
+
 const renderCreateDialog = () =>
   render(<AddProviderDialog open onClose={vi.fn()} gatewayId="gw-1" />);
 
@@ -57,8 +64,10 @@ describe("AddProviderDialog validation", () => {
     fetchState.isPending = false;
     // The dialog fetches the provider's models when it opens in edit mode.
     fetchMutate.mockReset();
-    fetchMutate.mockImplementation((_vars, opts) =>
-      opts?.onSuccess?.({ models: ["gpt-4o", "gpt-4o-mini"] }),
+    fetchMutate.mockImplementation(
+      deferred((_vars, opts) =>
+        opts?.onSuccess?.({ models: ["gpt-4o", "gpt-4o-mini"] }),
+      ),
     );
   });
 
@@ -128,11 +137,13 @@ describe("AddProviderDialog validation", () => {
 
   it("blames the API key when the provider returns no models", async () => {
     // An empty 200 used to move nothing but the warning under Models.
-    fetchMutate.mockImplementation((_vars, opts) =>
-      opts?.onSuccess?.({
-        models: [],
-        error: "Failed to fetch models from provider",
-      }),
+    fetchMutate.mockImplementation(
+      deferred((_vars, opts) =>
+        opts?.onSuccess?.({
+          models: [],
+          error: "Failed to fetch models from provider",
+        }),
+      ),
     );
     renderCreateDialog();
 
@@ -154,11 +165,13 @@ describe("AddProviderDialog validation", () => {
   it("blocks Save when the stored key can no longer list models", async () => {
     // Models already saved, so that gate passes — but the key on file no
     // longer works, and saving would just keep it.
-    fetchMutate.mockImplementation((_vars, opts) =>
-      opts?.onSuccess?.({
-        models: [],
-        error: "Failed to fetch models from provider",
-      }),
+    fetchMutate.mockImplementation(
+      deferred((_vars, opts) =>
+        opts?.onSuccess?.({
+          models: [],
+          error: "Failed to fetch models from provider",
+        }),
+      ),
     );
     renderEditDialog({
       default_timeout: 30,
@@ -186,13 +199,15 @@ describe("AddProviderDialog validation", () => {
 
   it("re-verifies a key typed in edit mode before allowing a save", async () => {
     // Edit mode skipped the auto-fetch, so a key typed here went unchecked.
-    fetchMutate.mockImplementation((vars, opts) =>
-      vars?.providerName
-        ? opts?.onSuccess?.({
-            models: [],
-            error: "Failed to fetch models from provider",
-          })
-        : opts?.onSuccess?.({ models: ["gpt-4o", "gpt-4o-mini"] }),
+    fetchMutate.mockImplementation(
+      deferred((vars, opts) =>
+        vars?.providerName
+          ? opts?.onSuccess?.({
+              models: [],
+              error: "Failed to fetch models from provider",
+            })
+          : opts?.onSuccess?.({ models: ["gpt-4o", "gpt-4o-mini"] }),
+      ),
     );
     renderEditDialog({
       base_url: "https://api.openai.com/v1",
@@ -226,8 +241,10 @@ describe("AddProviderDialog validation", () => {
   });
   it("lets a hand-typed model ID unblock a provider the gateway cannot list", async () => {
     // The message says to add model IDs by hand, so that has to open Save.
-    fetchMutate.mockImplementation((_vars, opts) =>
-      opts?.onSuccess?.({ models: [], error: "Provider returned no models" }),
+    fetchMutate.mockImplementation(
+      deferred((_vars, opts) =>
+        opts?.onSuccess?.({ models: [], error: "Provider returned no models" }),
+      ),
     );
     renderCreateDialog();
 
@@ -262,8 +279,10 @@ describe("AddProviderDialog validation", () => {
 
   it("does not blame the stored key when the fetch itself fails", async () => {
     // No verdict was reached, so it must not block an unrelated edit.
-    fetchMutate.mockImplementation((_vars, opts) =>
-      opts?.onError?.(new Error("The request timed out. Please try again.")),
+    fetchMutate.mockImplementation(
+      deferred((_vars, opts) =>
+        opts?.onError?.(new Error("The request timed out. Please try again.")),
+      ),
     );
     renderEditDialog({ default_timeout: 30, models: ["gpt-4o"] });
 
@@ -283,13 +302,15 @@ describe("AddProviderDialog validation", () => {
 
   it("restores the stored key's verdict when a typed key is cleared", async () => {
     // The typed key's empty listing used to stay behind as the stored key's.
-    fetchMutate.mockImplementation((vars, opts) =>
-      vars?.providerName
-        ? opts?.onSuccess?.({ models: ["gpt-4o", "gpt-4o-mini"] })
-        : opts?.onSuccess?.({
-            models: [],
-            error: "Failed to fetch models from provider",
-          }),
+    fetchMutate.mockImplementation(
+      deferred((vars, opts) =>
+        vars?.providerName
+          ? opts?.onSuccess?.({ models: ["gpt-4o", "gpt-4o-mini"] })
+          : opts?.onSuccess?.({
+              models: [],
+              error: "Failed to fetch models from provider",
+            }),
+      ),
     );
     renderEditDialog({
       base_url: "https://api.openai.com/v1",
@@ -339,13 +360,15 @@ describe("AddProviderDialog validation", () => {
     // The typed key's response used to arrive after the restore and overwrite
     // it, leaving a rejection message under an empty field with no way out.
     const pending = [];
-    fetchMutate.mockImplementation((vars, opts) => {
-      if (vars?.providerName) {
-        opts?.onSuccess?.({ models: ["gpt-4o", "gpt-4o-mini"] });
-        return;
-      }
-      pending.push(opts);
-    });
+    fetchMutate.mockImplementation(
+      deferred((vars, opts) => {
+        if (vars?.providerName) {
+          opts?.onSuccess?.({ models: ["gpt-4o", "gpt-4o-mini"] });
+          return;
+        }
+        pending.push(opts);
+      }),
+    );
     renderEditDialog({
       base_url: "https://api.openai.com/v1",
       default_timeout: 30,
@@ -380,11 +403,13 @@ describe("AddProviderDialog validation", () => {
     // The override has to follow the chips: a scratch ID typed and then deleted
     // must not leave the block lifted for a key the provider went on to reject.
     let reject = false;
-    fetchMutate.mockImplementation((_vars, opts) =>
-      opts?.onSuccess?.(
-        reject
-          ? { models: [], error: "Failed to fetch models from provider" }
-          : { models: ["gpt-4o", "gpt-4o-mini"] },
+    fetchMutate.mockImplementation(
+      deferred((_vars, opts) =>
+        opts?.onSuccess?.(
+          reject
+            ? { models: [], error: "Failed to fetch models from provider" }
+            : { models: ["gpt-4o", "gpt-4o-mini"] },
+        ),
       ),
     );
     renderCreateDialog();
@@ -412,8 +437,10 @@ describe("AddProviderDialog validation", () => {
   });
 
   it("takes pasted model IDs as a manual list", async () => {
-    fetchMutate.mockImplementation((_vars, opts) =>
-      opts?.onSuccess?.({ models: [], error: "Provider returned no models" }),
+    fetchMutate.mockImplementation(
+      deferred((_vars, opts) =>
+        opts?.onSuccess?.({ models: [], error: "Provider returned no models" }),
+      ),
     );
     renderCreateDialog();
 
@@ -436,10 +463,20 @@ describe("AddProviderDialog validation", () => {
     ]);
   });
 
+  it("keeps the stored listing when the dialog opens in edit mode", async () => {
+    // The by-name fetch is in flight while the mount effects settle, and the
+    // blank key field must not cancel it.
+    renderEditDialog({ default_timeout: 30, models: ["gpt-4o"] });
+
+    expect(await screen.findByText("(2 available)")).toBeTruthy();
+    await userEvent.click(screen.getByRole("button", { name: "Save Changes" }));
+    expect(updateMutate).toHaveBeenCalledTimes(1);
+  });
+
   it("keeps Bedrock editable although it lists no models", async () => {
     // No list endpoint and no API Key field to explain a block on.
-    fetchMutate.mockImplementation((_vars, opts) =>
-      opts?.onSuccess?.({ models: [] }),
+    fetchMutate.mockImplementation(
+      deferred((_vars, opts) => opts?.onSuccess?.({ models: [] })),
     );
     renderEditDialogFor("bedrock", {
       api_format: "anthropic",

--- a/frontend/src/sections/gateway/providers/hooks/useGatewayConfig.js
+++ b/frontend/src/sections/gateway/providers/hooks/useGatewayConfig.js
@@ -1,11 +1,40 @@
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import axios, { endpoints } from "src/utils/axios";
 
+// The shared axios instance is created without a `timeout`, and axios defaults
+// to 0 — wait forever. A stalled gateway request therefore never rejects, so
+// React Query's isPending sticks on and the caller's UI is left disabled with
+// no error (the Save button stuck on "Saving..."). Scope a timeout to the
+// gateway admin calls rather than changing the global instance.
+const GATEWAY_TIMEOUT = 30000;
+const REQUEST_CONFIG = { timeout: GATEWAY_TIMEOUT };
+
+// Listing a provider's models is a round trip through the gateway to a third
+// party, so it gets a longer budget than a config write.
+const FETCH_MODELS_CONFIG = { timeout: 60000 };
+
+// axios surfaces a timeout as ECONNABORTED with "timeout of 30000ms exceeded",
+// which is not something a user can act on.
+export function asRequestError(err, action) {
+  const timedOut =
+    err?.code === "ECONNABORTED" ||
+    /^timeout of \d+ms/.test(err?.message || "");
+  if (!timedOut) return err;
+  const friendly = new Error(
+    `${action} timed out — the gateway did not respond. Check that it is reachable, then try again.`,
+  );
+  friendly.cause = err;
+  return friendly;
+}
+
 export function useGatewayConfig(gatewayId) {
   return useQuery({
     queryKey: ["agentcc-gateway-config", gatewayId],
     queryFn: async () => {
-      const { data } = await axios.get(endpoints.gateway.config(gatewayId));
+      const { data } = await axios.get(
+        endpoints.gateway.config(gatewayId),
+        REQUEST_CONFIG,
+      );
       return data.result;
     },
     enabled: Boolean(gatewayId),
@@ -17,7 +46,10 @@ export function useProviderHealth(gatewayId) {
   return useQuery({
     queryKey: ["agentcc-provider-health", gatewayId],
     queryFn: async () => {
-      const { data } = await axios.get(endpoints.gateway.providers(gatewayId));
+      const { data } = await axios.get(
+        endpoints.gateway.providers(gatewayId),
+        REQUEST_CONFIG,
+      );
       return data.result;
     },
     enabled: Boolean(gatewayId),
@@ -31,14 +63,19 @@ export function useUpdateProvider() {
 
   return useMutation({
     mutationFn: async ({ gatewayId, name, config }) => {
-      const { data } = await axios.post(
-        endpoints.gateway.updateProvider(gatewayId),
-        {
-          name,
-          config,
-        },
-      );
-      return data.result;
+      try {
+        const { data } = await axios.post(
+          endpoints.gateway.updateProvider(gatewayId),
+          {
+            name,
+            config,
+          },
+          REQUEST_CONFIG,
+        );
+        return data.result;
+      } catch (err) {
+        throw asRequestError(err, "Saving the provider");
+      }
     },
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["agentcc-gateway-config"] });
@@ -55,6 +92,7 @@ export function useRemoveProvider() {
       const { data } = await axios.post(
         endpoints.gateway.removeProvider(gatewayId),
         { name },
+        REQUEST_CONFIG,
       );
       return data.result;
     },
@@ -76,6 +114,7 @@ export function useToggleGuardrail() {
           name,
           enabled,
         },
+        REQUEST_CONFIG,
       );
       return data.result;
     },
@@ -97,6 +136,7 @@ export function useUpdateGuardrail() {
           name,
           config,
         },
+        REQUEST_CONFIG,
       );
       return data.result;
     },
@@ -118,6 +158,7 @@ export function useSetBudget() {
           level,
           config,
         },
+        REQUEST_CONFIG,
       );
       return data.result;
     },
@@ -135,6 +176,7 @@ export function useRemoveBudget() {
       const { data } = await axios.post(
         endpoints.gateway.removeBudget(gatewayId),
         { level },
+        REQUEST_CONFIG,
       );
       return data.result;
     },
@@ -153,6 +195,7 @@ export function useUpdateConfig() {
       const { data } = await axios.post(
         endpoints.gateway.updateConfig(gatewayId),
         config,
+        REQUEST_CONFIG,
       );
       return data.result;
     },
@@ -171,6 +214,7 @@ export function useReloadConfig() {
       const { data } = await axios.post(
         endpoints.gateway.reload(gatewayId),
         {},
+        REQUEST_CONFIG,
       );
       return data.result;
     },
@@ -187,11 +231,16 @@ export function useFetchProviderModels() {
       const body = providerName
         ? { provider_name: providerName }
         : { base_url: baseUrl, api_key: apiKey, api_format: apiFormat };
-      const { data } = await axios.post(
-        endpoints.gateway.providerCredentials.fetchModels,
-        body,
-      );
-      return data.result;
+      try {
+        const { data } = await axios.post(
+          endpoints.gateway.providerCredentials.fetchModels,
+          body,
+          FETCH_MODELS_CONFIG,
+        );
+        return data.result;
+      } catch (err) {
+        throw asRequestError(err, "Loading this provider's models");
+      }
     },
   });
 }

--- a/frontend/src/sections/gateway/providers/hooks/useGatewayConfig.test.jsx
+++ b/frontend/src/sections/gateway/providers/hooks/useGatewayConfig.test.jsx
@@ -1,0 +1,71 @@
+import React from "react";
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { renderHook } from "src/utils/test-utils";
+import {
+  MutationCache,
+  QueryClient,
+  QueryClientProvider,
+} from "@tanstack/react-query";
+import { asRequestError, useUpdateProvider } from "./useGatewayConfig";
+
+const { post } = vi.hoisted(() => ({ post: vi.fn() }));
+
+vi.mock("src/utils/axios", () => ({
+  default: { post, get: vi.fn() },
+  endpoints: {
+    gateway: {
+      updateProvider: (id) => `/gateway/${id}/provider/update`,
+      providerCredentials: { fetchModels: "/gateway/provider/models" },
+    },
+  },
+}));
+
+const wrapper = ({ children }) => {
+  const client = new QueryClient({
+    // Errors are asserted on the mutateAsync promise; the cache-level handler
+    // just keeps React Query's own rejection from surfacing as unhandled.
+    mutationCache: new MutationCache({ onError: () => {} }),
+    defaultOptions: { mutations: { retry: false }, queries: { retry: false } },
+  });
+  return <QueryClientProvider client={client}>{children}</QueryClientProvider>;
+};
+
+const save = () => {
+  const { result } = renderHook(() => useUpdateProvider(), { wrapper });
+  return result.current.mutateAsync({
+    gatewayId: "gw-1",
+    name: "openai",
+    config: {},
+  });
+};
+
+describe("asRequestError", () => {
+  it("turns an axios timeout into an actionable message", () => {
+    const timeout = Object.assign(new Error("timeout of 30000ms exceeded"), {
+      code: "ECONNABORTED",
+    });
+
+    expect(asRequestError(timeout, "Saving the provider").message).toMatch(
+      /Saving the provider timed out — the gateway did not respond/,
+    );
+    expect(asRequestError(timeout, "Saving the provider").cause).toBe(timeout);
+  });
+
+  it("leaves ordinary server errors untouched", () => {
+    const conflict = new Error("Provider already exists");
+
+    expect(asRequestError(conflict, "Saving the provider")).toBe(conflict);
+  });
+});
+
+describe("useUpdateProvider", () => {
+  beforeEach(() => post.mockReset());
+
+  it("bounds the request so a stalled gateway cannot hang the Save button", async () => {
+    post.mockResolvedValue({ data: { result: {} } });
+
+    await save();
+
+    expect(post.mock.calls[0][2]).toEqual({ timeout: 30000 });
+  });
+});

--- a/frontend/src/sections/gateway/sessions/SessionExplorerSection.jsx
+++ b/frontend/src/sections/gateway/sessions/SessionExplorerSection.jsx
@@ -213,7 +213,7 @@ const SessionExplorerSection = () => {
                             });
                           }}
                         >
-                          {session.session_id?.substring(0, 16)}
+                          {session.session_id}
                         </Typography>
                       </Tooltip>
                     </TableCell>

--- a/frontend/src/sections/gateway/sessions/SessionExplorerSection.jsx
+++ b/frontend/src/sections/gateway/sessions/SessionExplorerSection.jsx
@@ -196,12 +196,15 @@ const SessionExplorerSection = () => {
                     onClick={() => setSelectedSessionId(session.id)}
                   >
                     <TableCell>
-                      <Tooltip title={`Click to copy: ${session.session_id}`}>
+                      <Tooltip title="Click to copy">
                         <Typography
                           variant="body2"
                           sx={{
                             fontFamily: "monospace",
                             cursor: "pointer",
+                            // Break the full ID inside the cell rather than
+                            // widening an already crowded table.
+                            wordBreak: "break-all",
                             "&:hover": { color: "primary.main" },
                           }}
                           fontWeight={500}


### PR DESCRIPTION
## What

Two frontend-only fixes to the Gateway provider UI.

### 1. The provider dialog could save credentials it never verified

One commit, because the failures chain into each other — each fix exposed the next:

- **Save crashed on a saved numeric timeout.** The API returns `default_timeout` as an integer, but the dialog seeded the timeout text field with it directly and then called `timeoutVal.trim()` on Save — `TypeError: timeoutVal.trim is not a function`, dialog stuck open. Reproducible on any provider with a stored timeout. The field is now seeded as a string.
- **Validation failures were silent.** A blocked Save set inline field errors only, and the dialog body scrolls — so on a tall form the reason sat off-screen and the button looked inert. Added a summary at the top listing every problem, plus a scroll-to-top on a failed Save.
- **A stalled provider request could wedge Save.** The models fetch and the provider update had no bound, so an unresponsive provider left the dialog pending indefinitely.
- **Save was live during the models fetch.** Clicking mid-fetch validated against a cleared model list and rejected a valid API key with "enter a valid API key to load the list". Held now, labelled `Loading models...` — including during the 600ms debounce, which is long enough to click through.
- **An empty model list didn't implicate the key.** `{"models": [], "error": "..."}` only produced a small warning under Models; the field that caused it looked fine. The API Key field now carries the reason. This is separate state from `errors`, so a failed fetch doesn't raise the "Fix this before saving" summary before Save was ever pressed.
- **Save was reachable in states it could never pass** — no model selected, or a key the provider had already rejected. Both now hold the button, and each is explained on its own field, so the disabled state is never the only signal.
- **A key typed in edit mode was never checked.** Edit mode skipped the auto-fetch entirely, so a replacement key went straight to the database unverified — and a stored key that could no longer list models still saved happily. A typed key now re-fetches with that credential, and a listing that comes back empty holds Save. Two things deliberately do not hold it: a fetch that fails at transport level (a timeout or an unreachable gateway is not evidence about a credential), and a model list the user entered by hand.

AWS/Bedrock is exempt from the fetch-based gating: it has no list endpoint, so an empty result proves nothing, and it has no API Key field to explain a block on — gating there would lock those providers out of editing.

One cosmetic change rides along, called out here because it is not part of the credential fix: the model Autocomplete carries `size="small"` on the root (moved up from `renderInput`) and pins the input's min-width on hover/focus, so hovering a full chip list no longer re-wraps the rows.

### 2. Session IDs were truncated in the session explorer

So a session couldn't be matched against a log line or a support report.

## Relationship to #2594

[#2594](https://github.com/future-agi/future-agi/pull/2594) covers the `agentcc` backend half — typing the provider `models` list as strings, declaring the `fetch_models` request/response contract, reporting *why* a fetch failed — plus the regenerated API contracts. This PR is the frontend, cherry-picked onto `dev` so it can be tested and land on its own.

The regenerated contracts are deliberately not here: that commit is half backend, and taking only its frontend side would leave `openapi-contract.generated.js` and the orval clients out of sync with `dev`'s `swagger.json` and fail `yarn contracts:check`.

Against a `dev` backend the dialog behaves correctly; without the backend commits, `fetchError` only carries generic messages and `models` arrives as untyped JSON — which is what `normalizeModels`/`toModelId` already guard against, so there is no crash path.

## Testing

`npx vitest run src/sections/gateway/providers` — 17 tests pass (83 across `src/sections/gateway`).

The original cases: the numeric timeout, the summary and its issue count, the malformed-timeout message, Save held during a fetch, the key blamed on an empty list, the stored-key block, the edit-mode re-verification (asserting the refetch carries the typed credential, not the provider name), and Bedrock staying editable.

The failure side of the gate, added in review: a hand-typed model ID unblocking an unlistable provider (on the `custom` preset), a fetch error still allowing a save, clearing a typed key restoring the stored verdict, field errors surviving a dismissed summary, a response that lands after the key field was cleared being ignored, the gate re-arming when the hand-entered model is removed, and the paste path counting as a manual list.


