### PR TITLE
test(e2e): skip ALERT-E2E-001 on a backend without the fired window

### DIFF
--- a/e2e/flows/alerts/view-trace-scoping.spec.ts
+++ b/e2e/flows/alerts/view-trace-scoping.spec.ts
@@ -221,10 +221,30 @@ test(
       );
     });
 
+    const details = await actor.api.get<{
+      result: { window_start: string; window_end: string };
+    }>(monitorDetailsPath(monitorId));
+
+    // Everything below — this step's assertions and the header link, which
+    // `useAlertSheetView` builds from `window_start`/`window_end` — needs the
+    // rule-level window the details endpoint gained with this flow. e2e-ci
+    // only builds the backend from PR code when a PR touches `futureagi/**`
+    // (see "Build backend image from PR code" in e2e-ci.yml), so a
+    // frontend-only PR runs the last released image. Between this flow merging
+    // and the next release, that image has no `window_start` at all, and the
+    // flow died on `new Date(undefined).toISOString()` — a RangeError with
+    // nothing to say about the change under test. Treat a missing key as "this
+    // backend predates the feature" and skip.
+    //
+    // Key *absent* only. The columns are nullable, so `window_start: null` is a
+    // value this backend chose to send, and for the two fires seeded above with
+    // explicit windows it would be a real regression — that still fails below.
+    test.skip(
+      !('window_start' in details.result),
+      'backend predates the fired-window feature: /details/ does not report window_start',
+    );
+
     await test.step('API: the rule-level window spans every fire, whatever the issue list shows', async () => {
-      const details = await actor.api.get<{
-        result: { window_start: string; window_end: string };
-      }>(monitorDetailsPath(monitorId));
       // Aggregated over every fire: the earliest start and the latest end.
       expect(new Date(details.result.window_start).toISOString()).toBe(
         iso(fireEmptyStart),


### PR DESCRIPTION
## The problem

`ALERT-E2E-001` fails on **every frontend-only PR** and has since TH-7792 merged, four seconds into the run:

```
RangeError: Invalid time value
> 229 |  expect(new Date(details.result.window_start).toISOString()).toBe(iso(fireEmptyStart));
```

`window_start` / `window_end` are returned by `UserAlertMonitorView` on `dev` — but `e2e-ci.yml` says outright:

> A backend/gateway image whose filter did not fire is NOT built from this PR — the stack runs the released `:latest`. Deliberate speed trade.

So a PR that touches no `futureagi/**` file runs **v1.35.0** (cut 2026-09-04), which predates the change (`git merge-base --is-ancestor` confirms). The field comes back `undefined`, `new Date(undefined)` is `Invalid Date`, and `.toISOString()` throws instead of returning something the assertion could compare.

`#2529` was green for the right reason: it changed `futureagi/tracer/views/monitor.py`, so its run shows `✓ Build backend image from PR code`. Frontend-only PRs show `-`.

## The change

Read the details response once, before the assertions, and skip the flow when the key is missing. The whole test needs the feature, not just that step — `useAlertSheetView` builds the header link from `alertRuleDetails?.window_start`, so on an older backend `alertTraceLink` omits the date param and the header leg fails too.

**Absent key only.** Both columns are nullable, so `window_start: null` is a value the backend *chose* to send; for the two fires this flow seeds with explicit windows that is a real regression, and it still fails.

## Verified both ways, against the local stack

| Backend | Result |
| --- | --- |
| released `monitor.py` (no aggregate) | `1 skipped` — the guard fires |
| aggregate patched into the running backend | does **not** skip; runs through the API assertions and past them |

The second run then fails at the row-action UI leg, because attach mode was serving a frontend worktree without TH-7792's `alertTraceLink.js` — not the guard. `tsc --noEmit` clean, `yarn catalog:check` current.

## Why not the alternatives

- **Ship a release.** The actual fix, and it clears this on its own — but it does not stop the next e2e flow that asserts unreleased backend behaviour from doing the same thing.
- **Add `e2e/flows/alerts/**` to the backend filter.** Buys a ~16 min backend build on every PR touching those specs, to test a code path the PR did not change.
