### PR TITLE
feat(simulate): Retell outbound phone simulation on the hosted runner

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -87,6 +87,54 @@ SYSTEM_VOICE_PROVIDER=
 VAPI_API_KEY=
 VAPI_API_BASE_URL=
 VAPI_PHONE_NUMBER_ID=
+
+# ---- Hosted voice simulation runner (worker-simulation-runner) ----
+# The runner reads these from its own process environment and refuses a run
+# per missing name. Verify the runner's EFFECTIVE environment before rollout,
+# without helm or docker (a shared .env is not it: other services may carry
+# keys the runner must not see):
+#   docker exec <runner-container> env > runner.env
+#   scripts/verify-simulation-runner-deployment.sh --env-only \
+#     --runner-env-file runner.env --voice-transports sip_outbound
+# Always, for any hosted voice run:
+#   LIVEKIT_URL / LIVEKIT_API_KEY / LIVEKIT_API_SECRET — the LiveKit project the
+#     simulator joins; must be the same project that owns the trunk below.
+#   INTERNAL_API_SECRET — fleet-wide bearer the SDK child uses to report results
+#     back to the backend (see simulate/authentication.py).
+#   ALK_RUNNER_API_URL — backend URL the child reports to (Compose and the
+#     chart set it; only a hand-built environment needs it here). The check
+#     also accepts FI_BASE_URL in its place.
+# sip_outbound (the platform dials the customer's agent):
+#   LIVEKIT_OUTBOUND_TRUNK_ID — LiveKit SIP trunk the simulator dials out on.
+#   PSTN_CALLER_NUMBER — E.164 number provisioned on that trunk; the call's
+#     caller id.
+# sip_inbound_retell (the customer's Retell agent dials our leased number):
+#   ALK_SIM_SLOT_LEASE_SCRIPT — path, inside the runner, to the LiveKit infra
+#     repo's lease_sim_slot.py that leases a pool number + room per run.
+#   SIM_SLOT_LEASE_STORE — where that script records active leases. Its own
+#     default is a per-container path, so replicas would not see each other's
+#     leases; point every runner at one shared location.
+# Optional — leave unset for the default; an assigned-but-empty value is
+# refused by the check because the worker fails at import on it:
+#   HOSTED_RUNNER_PARENT_SLACK_SECONDS — seconds the workflow timeout and the
+#     number lease exceed the child's own run budget (unset = 600).
+#   HOSTED_RUNNER_LEASED_ROOM_REUSE — false/0/no rolls back to one room per
+#     row (unset = true).
+# Never on the runner: FI_API_KEY / FI_SECRET_KEY. The SDK submitter prefers
+#   the org key pair over the internal bearer, and ingestion then authenticates
+#   the wrong org. HOSTED_RUNNER_MAX_DURATION_SECONDS is retired: no code reads it.
+LIVEKIT_URL=
+LIVEKIT_API_KEY=
+LIVEKIT_API_SECRET=
+INTERNAL_API_SECRET=
+LIVEKIT_OUTBOUND_TRUNK_ID=
+PSTN_CALLER_NUMBER=
+# Set the next two together, only for the Retell-originator path: an empty
+# SIM_SLOT_LEASE_STORE with the script set resolves to the working directory.
+# ALK_SIM_SLOT_LEASE_SCRIPT=
+# SIM_SLOT_LEASE_STORE=
+# HOSTED_RUNNER_PARENT_SLACK_SECONDS=600
+# HOSTED_RUNNER_LEASED_ROOM_REUSE=true
 MAILGUN_API_KEY=
 MAILGUN_SENDER_DOMAIN=
 

--- a/.env.example
+++ b/.env.example
@@ -118,8 +118,15 @@ VAPI_PHONE_NUMBER_ID=
 # refused by the check because the worker fails at import on it:
 #   HOSTED_RUNNER_PARENT_SLACK_SECONDS — seconds the workflow timeout and the
 #     number lease exceed the child's own run budget (unset = 600).
-#   HOSTED_RUNNER_LEASED_ROOM_REUSE — false/0/no rolls back to one room per
-#     row (unset = true).
+#   HOSTED_RUNNER_LEASED_ROOM_REUSE — read by the platform. true/1/yes serves a
+#     multi-row phone run over one reused leased room (unset = false). Turn it
+#     on only once a runner whose simulator kit supports that reuse is deployed
+#     and verified; the released kit rejects such a job at SDK hydration.
+#   HOSTED_RUNNER_LEASED_ROOM_MAX_CASES — read by the platform. Most scenario
+#     rows a single leased-number phone run may reserve (unset = 25, 0 = no cap).
+#   HOSTED_RUNNER_LEASED_ROOM_MAX_WALLCLOCK_SECONDS — read by the platform.
+#     Longest a single leased-number run may hold the number, refused before the
+#     lease (unset = 14400 = 4h, 0 = no cap).
 # Never on the runner: FI_API_KEY / FI_SECRET_KEY. The SDK submitter prefers
 #   the org key pair over the internal bearer, and ingestion then authenticates
 #   the wrong org. HOSTED_RUNNER_MAX_DURATION_SECONDS is retired: no code reads it.
@@ -134,7 +141,10 @@ PSTN_CALLER_NUMBER=
 # ALK_SIM_SLOT_LEASE_SCRIPT=
 # SIM_SLOT_LEASE_STORE=
 # HOSTED_RUNNER_PARENT_SLACK_SECONDS=600
+# Turn reuse on only after the kit that supports it is deployed and verified:
 # HOSTED_RUNNER_LEASED_ROOM_REUSE=true
+# HOSTED_RUNNER_LEASED_ROOM_MAX_CASES=25
+# HOSTED_RUNNER_LEASED_ROOM_MAX_WALLCLOCK_SECONDS=14400
 MAILGUN_API_KEY=
 MAILGUN_SENDER_DOMAIN=
 

--- a/.env.example
+++ b/.env.example
@@ -127,6 +127,14 @@ VAPI_PHONE_NUMBER_ID=
 #   HOSTED_RUNNER_LEASED_ROOM_MAX_WALLCLOCK_SECONDS — read by the platform.
 #     Longest a single leased-number run may hold the number, refused before the
 #     lease (unset = 14400 = 4h, 0 = no cap).
+#   HOSTED_RUNNER_MAX_CASES — read by the platform. Most scenario rows ANY
+#     hosted voice run may reserve (unset = 500, 0 = no cap); the leased cap
+#     above is a tighter limit layered on top for the phone-originator path.
+#   HOSTED_RUNNER_MAX_WALLCLOCK_SECONDS — read by the platform. Longest ANY
+#     hosted voice run may reserve a runner child slot, refused before dispatch
+#     (unset = 21600 = 6h, 0 = no cap). Telephony and single-concurrency web
+#     runs are serial, so this bounds them; parsed leniently, a bad value never
+#     crashes settings import.
 # Never on the runner: FI_API_KEY / FI_SECRET_KEY. The SDK submitter prefers
 #   the org key pair over the internal bearer, and ingestion then authenticates
 #   the wrong org. HOSTED_RUNNER_MAX_DURATION_SECONDS is retired: no code reads it.
@@ -145,6 +153,8 @@ PSTN_CALLER_NUMBER=
 # HOSTED_RUNNER_LEASED_ROOM_REUSE=true
 # HOSTED_RUNNER_LEASED_ROOM_MAX_CASES=25
 # HOSTED_RUNNER_LEASED_ROOM_MAX_WALLCLOCK_SECONDS=14400
+# HOSTED_RUNNER_MAX_CASES=500
+# HOSTED_RUNNER_MAX_WALLCLOCK_SECONDS=21600
 MAILGUN_API_KEY=
 MAILGUN_SENDER_DOMAIN=
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -349,6 +349,11 @@ services:
       ALK_SIM_SLOT_LEASE_SCRIPT: ${ALK_SIM_SLOT_LEASE_SCRIPT:-}
       TEMPORAL_MAX_CONCURRENT_ACTIVITIES: ${ALK_RUNNER_MAX_CONCURRENCY:-4}
       TEMPORAL_MAX_CONCURRENT_WORKFLOW_TASKS: ${TEMPORAL_SIMRUNNER_MAX_WORKFLOWS:-8}
+      # A stop must let a phone call in flight finish: the worker drains for
+      # this long, and stop_grace_period below must exceed it, or Docker
+      # force-kills the child mid-call and the leased number stays taken until
+      # its TTL. Raise both together for long phone runs (the prod chart: 4200).
+      TEMPORAL_GRACEFUL_SHUTDOWN_TIMEOUT: ${SIMULATION_RUNNER_GRACEFUL_SHUTDOWN_TIMEOUT:-300}
       # Absolute so the SDK child (runs from a mkdtemp cwd) resolves the key.
       GOOGLE_APPLICATION_CREDENTIALS: /app/backend/Vertex_AI_Creds.json
       # gemini-3.1 is 404 in regional endpoints; only served on `global`.
@@ -359,6 +364,7 @@ services:
       # (_voice_simulator_config): English -> Deepgram aura-2-andromeda-en,
       # other/unknown -> streaming Gemini (multilingual). Set
       # SIMULATOR_TTS_PROVIDER / SIMULATOR_TTS_MODEL here to force one engine.
+    stop_grace_period: ${SIMULATION_RUNNER_STOP_GRACE_PERIOD:-330s}
     volumes:
       # Runner image lacks the key (only the backend image has it); mount it.
       - ${GOOGLE_APPLICATION_CREDENTIALS:-/dev/null}:/app/backend/Vertex_AI_Creds.json:ro

--- a/futureagi/simulate/services/hosted_runner.py
+++ b/futureagi/simulate/services/hosted_runner.py
@@ -20,7 +20,9 @@ from __future__ import annotations
 
 import ast
 import json
+import math
 import os
+import re
 import uuid
 from collections import defaultdict
 from enum import StrEnum
@@ -52,6 +54,7 @@ class ConversationDirection(StrEnum):
     SIMULATOR_FIRST = "simulator_first"
     AGENT_FIRST = "agent_first"
 
+
 _MODE_TO_ENVIRONMENT = {
     "chat": ("chat", "conversation"),
 }
@@ -69,6 +72,28 @@ _PROVIDER_ENV = {
     "livekit": {"api_key": "LIVEKIT_API_KEY", "api_secret": "LIVEKIT_API_SECRET"},
 }
 
+
+def _require(value, label: str):
+    if value is None or (isinstance(value, str) and not value.strip()):
+        raise HostedRunnerBuildError(f"voice runner job missing {label}")
+    return value
+
+
+# Duplicated from the SDK's source of truth (agent-learning-kit
+# src/fi/simulate/agent/definition.py:7) so a malformed number is caught here,
+# before any DID is leased, rather than only at SDK hydration.
+_E164 = re.compile(r"^\+[1-9]\d{6,14}$")
+
+
+def _require_e164(value, label: str):
+    value = _require(value, label)
+    # fullmatch (not match) so a trailing newline can't sneak past "$"; isinstance
+    # guard so a non-string value raises the typed build error, not a bare TypeError.
+    if not isinstance(value, str) or not _E164.fullmatch(value):
+        raise HostedRunnerBuildError(f"voice runner job invalid {label}")
+    return value
+
+
 # Provider profiles — the factory that replaces the hardcoded provider->transport
 # and per-provider agent-definition branches. Adding a web provider is one entry
 # here, with no dispatch edits. This is the Django-side twin of the SDK's
@@ -83,13 +108,18 @@ _PROVIDER_PROFILES: dict[str, dict[str, Any]] = {
         "api_key_env": _PROVIDER_ENV["vapi"]["api_key"],
         "emits_web_evidence": True,
         "sip_inbound_originator": "vapi",
+        "sip_inbound_originator_fields": (),
     },
     "retell": {
         "web_transport_kind": "retell_webcall",
         "target_id_field": "agent_id",
         "api_key_env": _PROVIDER_ENV["retell"]["api_key"],
         "emits_web_evidence": True,
-        "sip_inbound_originator": None,
+        "sip_inbound_originator": "retell",
+        "sip_inbound_originator_fields": (
+            ("originator_agent_id", "assistant_id", _require),
+            ("originator_from_number", "contact_number", _require_e164),
+        ),
     },
     "livekit": {
         "web_transport_kind": "webrtc",
@@ -97,6 +127,7 @@ _PROVIDER_PROFILES: dict[str, dict[str, Any]] = {
         "api_key_env": None,
         "emits_web_evidence": False,
         "sip_inbound_originator": None,
+        "sip_inbound_originator_fields": (),
     },
 }
 
@@ -111,19 +142,27 @@ class HostedRunnerBuildError(Exception):
     """Raised when a runner job cannot be assembled from the run test."""
 
 
-def resolve_runner_mode(agent_definition) -> str:
+def resolve_runner_mode(agent_definition, agent_version=None) -> str:
     """Runner mode for a run test's agent definition (view + builder share this).
 
     TEXT → ``chat``. VOICE resolves to ``voice_sip`` when the target is reached
     over the phone (a ``contact_number`` is set) and ``voice_webrtc`` otherwise
     (web bridge / native LiveKit). Only ``voice_sip`` leases a DID slot — mirrors
     the native ``_needs_phone`` gate.
+
+    ``agent_type`` is read the same "pinned version's snapshot is authoritative"
+    way as every other field the builder cares about (``_agent_field``) — a
+    definition edited to a different ``agent_type`` after a version was pinned
+    must not change what an already-pinned run resolves to.
     """
     if agent_definition is None:
         raise HostedRunnerBuildError("run test has no agent definition")
-    if agent_definition.agent_type == AgentDefinition.AgentTypeChoices.TEXT:
+    agent_type = _agent_field(
+        agent_definition, agent_version, "agent_type", agent_definition.agent_type
+    )
+    if agent_type == AgentDefinition.AgentTypeChoices.TEXT:
         return _CHAT_MODE
-    if _target_uses_phone(agent_definition):
+    if _target_uses_phone(agent_definition, agent_version):
         return _VOICE_SIP_MODE
     return _VOICE_WEBRTC_MODE
 
@@ -133,21 +172,26 @@ def resolve_runner_mode(agent_definition) -> str:
 _HOSTED_UNSUPPORTED_PROVIDERS = {"bland"}
 
 
-def hosted_runner_supports(agent_definition) -> bool:
+def hosted_runner_supports(agent_definition, agent_version=None) -> bool:
     """False when the target's provider isn't supported by the released SDK
-    (e.g. Bland) so the caller can route the run to the native runner."""
+    (e.g. Bland) so the caller can route the run to the native runner.
+
+    A safety rail, not a field read: reject if either the snapshot or the
+    (possibly stale) definition column names an unsupported provider — a
+    rail must not be bypassable by a stale column or a versionless snapshot.
+    Credentials are not consulted: ``ProviderCredentials.ProviderType`` has
+    no Bland member (every other provider is coerced to vapi), so a
+    credentials-derived rejection could never fire and would only cost a
+    query.
+    """
     if agent_definition is None:
         return False
-    provider = (
-        getattr(
-            getattr(agent_definition, "provider_credentials", None),
-            "provider_type",
-            None,
-        )
-        or getattr(agent_definition, "provider", None)
-        or ""
-    )
-    return str(provider).strip().lower() not in _HOSTED_UNSUPPORTED_PROVIDERS
+    declared_provider = _agent_field(agent_definition, agent_version, "provider", "")
+    declared = str(declared_provider or "").strip().lower()
+    if declared in _HOSTED_UNSUPPORTED_PROVIDERS:
+        return False
+    column = str(getattr(agent_definition, "provider", "") or "").strip().lower()
+    return column not in _HOSTED_UNSUPPORTED_PROVIDERS
 
 
 def build_start_runner_job(
@@ -182,11 +226,17 @@ def build_start_runner_job(
     # Rerun scope: when specific calls are requested, build only their cases,
     # keyed the way ALK /batch adopts rows — (scenario_id, row_id) in canonical
     # scenario→row order — so the SDK's positional case→row mapping still lines
-    # up with exactly the rows /batch hands back. A rerun also picks up the
-    # RunTest's currently-selected agent version (the version pinned on the
-    # execution can be stale after a later edit).
+    # up with exactly the rows /batch hands back.
+    #
+    # The version used to build the job is always ``resolve_run_agent_version``
+    # — the one ladder shared with the view: the RunTest's own pin wins (what
+    # a fresh dispatch or rerun request carries), then the execution's pin
+    # (the native path backfills this after the run starts), then the
+    # definition's current version. A single shared ladder keeps the view's
+    # resolved mode and the builder's resolved transport looking at the same
+    # version for the same execution.
     selected_keys: set[tuple[str, str | None]] | None = None
-    agent_version = test_execution.agent_version
+    agent_version = resolve_run_agent_version(run_test, test_execution)
     if call_execution_ids:
         requested = {str(cid) for cid in call_execution_ids}
         selected_calls = list(
@@ -202,11 +252,6 @@ def build_start_runner_job(
             (str(call.scenario_id), str(call.row_id) if call.row_id else None)
             for call in selected_calls
         }
-        agent_version = (
-            run_test.agent_version
-            or test_execution.agent_version
-            or getattr(agent_definition, "latest_version", None)
-        )
 
     run_id = str(test_execution.id)
 
@@ -448,6 +493,13 @@ _ENV_LIVEKIT_API_KEY = "LIVEKIT_API_KEY"
 _ENV_LIVEKIT_API_SECRET = "LIVEKIT_API_SECRET"
 
 
+def _leased_room_reuse_enabled() -> bool:
+    # Read as an attribute only (never through ``_voice_setting``): its
+    # settings-or-env fallback would let a stray environment string override
+    # an explicit ``False`` and would read the string "false" as true.
+    return bool(getattr(settings, "HOSTED_RUNNER_LEASED_ROOM_REUSE", False))
+
+
 def _build_voice_job(
     *,
     mode: str,
@@ -460,10 +512,12 @@ def _build_voice_job(
     selected_keys: set[tuple[str, str | None]] | None = None,
 ) -> dict[str, Any]:
     credentials = _voice_credentials(agent_definition, agent_version)
-    provider = _voice_provider(agent_definition, credentials)
+    provider = _voice_provider(agent_definition, credentials, agent_version)
     inbound = _resolve_agent_inbound(agent_version, agent_definition)
     target_speaks_first = _resolve_target_speaks_first(agent_version, agent_definition)
-    transport_kind = _voice_transport_kind(agent_definition, provider, inbound)
+    transport_kind = _voice_transport_kind(
+        agent_definition, provider, inbound, agent_version
+    )
     dataset = _personas_for_scenarios(scenarios, selected_keys=selected_keys)
 
     if (transport_kind in {"sip_inbound", "sip_outbound"}) != (mode == _VOICE_SIP_MODE):
@@ -471,9 +525,27 @@ def _build_voice_job(
             f"mode {mode} does not match transport {transport_kind}"
         )
 
+    # A run whose target DIALS our leased number (sip_inbound with an
+    # originator) serves one scenario per leased room; a multi-scenario run
+    # is refused unless reuse is switched on (D10).
+    originator = _provider_profile(provider)["sip_inbound_originator"]
+    if transport_kind == "sip_inbound" and originator and len(dataset) > 1:
+        if not _leased_room_reuse_enabled():
+            raise HostedRunnerBuildError(
+                f"phone simulation selected {len(dataset)} scenario rows but "
+                "this runner serves one scenario per leased number; select a "
+                "single scenario row, or enable HOSTED_RUNNER_LEASED_ROOM_REUSE "
+                "on a runner whose simulator kit supports sequential room "
+                "reuse"
+            )
+
     secret_env: list[dict[str, Any]] = []
     agent_def, target_secret = _voice_agent_definition(
-        agent_definition, provider, transport_kind, credentials
+        agent_definition,
+        provider,
+        transport_kind,
+        credentials,
+        agent_version=agent_version,
     )
     secret_env.extend(target_secret)
 
@@ -501,6 +573,7 @@ def _build_voice_job(
                 max_concurrency=_target_max_concurrency(credentials),
                 max_call_minutes=_max_call_minutes(simulator_agent),
                 target_speaks_first=target_speaks_first,
+                leased_room=(transport_kind == "sip_inbound" and bool(originator)),
             ),
         },
         "sink": {
@@ -524,14 +597,116 @@ def _build_voice_job(
     return job
 
 
-def _target_uses_phone(agent_definition) -> bool:
-    return bool((getattr(agent_definition, "contact_number", "") or "").strip())
+def _resolve_agent_version(agent_definition, agent_version):
+    """The version whose ``configuration_snapshot`` is the source of truth.
+
+    One versionless ladder for the whole module: active_version, else
+    latest_version — same rung ``resolve_run_agent_version`` ends on.
+    """
+    if agent_version is not None:
+        return agent_version
+    return getattr(agent_definition, "active_version", None) or getattr(
+        agent_definition, "latest_version", None
+    )
+
+
+def _agent_field(agent_definition, agent_version, name: str, default=None):
+    """Read an agent attribute from the version snapshot, never the definition.
+
+    ``AgentDefinition``'s columns mirror only the latest save and are slated
+    for retirement; a run is pinned to an ``AgentVersion`` and must see that
+    version's ``configuration_snapshot``. When the snapshot is a dict it is
+    authoritative — a key it lacks means "unset", the definition is not
+    consulted. Only an agent with no version at all (no snapshot dict) falls
+    back to the definition column.
+    """
+    version = _resolve_agent_version(agent_definition, agent_version)
+    snapshot = getattr(version, "configuration_snapshot", None)
+    if isinstance(snapshot, dict):
+        return snapshot.get(name, default)
+    return getattr(agent_definition, name, default)
+
+
+def agent_field_for_version(agent_definition, agent_version, name: str, default=None):
+    """Read an agent field for an exact, already-resolved version — for a
+    caller with no ``RunTest`` row to hand ``agent_field_for_run`` (e.g. one
+    not yet saved)."""
+    return _agent_field(agent_definition, agent_version, name, default)
+
+
+def resolve_run_agent_version(run_test, test_execution=None):
+    """The one version ladder shared by the builder and the view.
+
+    ``run_test.agent_version`` (the RunTest's own pin — what a fresh dispatch
+    or a rerun request carries) wins; then ``test_execution.agent_version``
+    (the native activity backfills this after a run starts, so a rerun of a
+    natively-executed run can carry a pin the RunTest itself never had); then
+    the definition's ``active_version``, falling back to ``latest_version`` —
+    the same last rung every other version-resolving call site in this app
+    uses (``views/agent_definition.py``, ``views/agent_version.py``,
+    ``serializers/agent_definition.py``), so an unpinned run picks the same
+    version the rest of the platform would call current.
+    """
+    if run_test.agent_version is not None:
+        return run_test.agent_version
+    backfilled = getattr(test_execution, "agent_version", None)
+    if backfilled is not None:
+        return backfilled
+    agent_definition = run_test.agent_definition
+    return getattr(agent_definition, "active_version", None) or getattr(
+        agent_definition, "latest_version", None
+    )
+
+
+# Distinguishes an omitted ``agent_version=`` from an explicit ``None``: an
+# explicit ``None`` skips the run/execution rungs below, but ``_agent_field``
+# still resolves the definition's own active/latest ladder for that ``None``
+# (it reaches the column only when the agent has neither).
+_UNSET = object()
+
+
+def agent_field_for_run(
+    run_test, name: str, default=None, *, test_execution=None, agent_version=_UNSET
+):
+    """Read an agent field for a run test the same way the builder does.
+
+    Resolves the version with :func:`resolve_run_agent_version` and reads the
+    field through :func:`_agent_field`, so a view-side eligibility check (an
+    ``agent_type`` gate, say) agrees with what the builder will read for the
+    same run/execution instead of re-deriving its own, possibly different,
+    answer from the definition column directly. ``agent_version``, when
+    given (including an explicit ``None``), is read verbatim instead of going
+    through the run/execution ladder — for a caller that already resolved the
+    exact version to check (e.g. a version change pending in the same
+    request that hasn't been saved onto ``run_test`` yet). An explicit
+    ``None`` still resolves through ``_agent_field``'s own definition-level
+    fallback (``active_version`` or ``latest_version``), not straight to the
+    column.
+    """
+    resolved_version = (
+        agent_version
+        if agent_version is not _UNSET
+        else resolve_run_agent_version(run_test, test_execution)
+    )
+    return _agent_field(run_test.agent_definition, resolved_version, name, default)
+
+
+def _target_uses_phone(agent_definition, agent_version=None) -> bool:
+    contact_number = _agent_field(agent_definition, agent_version, "contact_number", "")
+    return bool(str(contact_number or "").strip())
 
 
 def _voice_credentials(agent_definition, agent_version):
     """Provider credentials for the target, preferring the versioned row (the
     native path reads ``agent_version.credentials``) then the legacy 1:1 on the
-    agent definition. Returns None when neither exists."""
+    agent definition. Returns None when neither exists.
+
+    An unpinned run now reaches here with ``agent_version`` resolved to
+    active/latest (``resolve_run_agent_version``) rather than ``None``, so
+    this prefers that version's own credentials over ``credentials_legacy`` —
+    intended: the platform's credential-editing endpoints write to the
+    version-scoped row, not the legacy one.
+    """
     if agent_version is not None:
         credentials = getattr(agent_version, "credentials", None)
         if credentials is not None:
@@ -539,10 +714,10 @@ def _voice_credentials(agent_definition, agent_version):
     return getattr(agent_definition, "credentials_legacy", None)
 
 
-def _voice_provider(agent_definition, credentials) -> str:
+def _voice_provider(agent_definition, credentials, agent_version=None) -> str:
     provider = (
         getattr(credentials, "provider_type", None)
-        or getattr(agent_definition, "provider", None)
+        or _agent_field(agent_definition, agent_version, "provider", None)
         or "livekit"
     )
     return str(provider).strip().lower()
@@ -551,19 +726,14 @@ def _voice_provider(agent_definition, credentials) -> str:
 def _resolve_agent_inbound(agent_version, agent_definition) -> bool:
     """Resolve the agent's inbound/outbound intent the way native does.
 
-    Mirrors the TestExecutor dynamic-prompt precedence: prefer the per-version
-    ``configuration_snapshot['inbound']`` the UI toggle writes, fall back to the
-    ``AgentDefinition.inbound`` column, default inbound. The bare column is stale
-    for versioned edits (the toggle only updates the snapshot), so the job
-    direction must read the snapshot first — otherwise an inbound agent runs
-    ``simulator_first`` while ingestion already treats it as inbound.
+    Same whole-dict precedence as ``_agent_field``: once the pinned version has
+    a snapshot dict, it alone decides — a key it lacks means "unset" and
+    defaults to inbound, the ``AgentDefinition.inbound`` column is NOT
+    consulted. Only an agent with no version at all (no snapshot dict) falls
+    back to the column. A later definition-level toggle must not reach back
+    and flip the call direction of an older pinned version that predates it.
     """
-    raw_inbound = None
-    snapshot = getattr(agent_version, "configuration_snapshot", None) or {}
-    if isinstance(snapshot, dict):
-        raw_inbound = snapshot.get("inbound", None)
-    if raw_inbound is None:
-        raw_inbound = getattr(agent_definition, "inbound", True)
+    raw_inbound = _agent_field(agent_definition, agent_version, "inbound", True)
     if isinstance(raw_inbound, str):
         return raw_inbound.strip().lower() == "true"
     return bool(raw_inbound)
@@ -573,17 +743,15 @@ def _resolve_target_speaks_first(agent_version, agent_definition) -> bool | None
     """Resolve the explicit "does the target agent speak first?" toggle.
 
     Tri-state: ``True``/``False`` override the conversation direction; ``None``
-    means "auto" (derive from inbound/outbound). Mirrors
-    ``_resolve_agent_inbound``'s snapshot-first precedence so a versioned edit is
-    honored, and coerces the ``"true"``/``"false"`` strings the snapshot may hold
-    (``bool("false")`` is truthy — must parse, not cast).
+    means "auto" (derive from inbound/outbound). Same whole-dict precedence as
+    ``_agent_field`` (see ``_resolve_agent_inbound``): a snapshot dict silent on
+    the key means "unset" (``None`` — auto), not a column fallback; only a
+    version with no snapshot dict at all falls back to the
+    ``AgentDefinition.target_speaks_first`` column. Coerces the
+    ``"true"``/``"false"`` strings the snapshot may hold (``bool("false")`` is
+    truthy — must parse, not cast).
     """
-    raw = None
-    snapshot = getattr(agent_version, "configuration_snapshot", None) or {}
-    if isinstance(snapshot, dict):
-        raw = snapshot.get("target_speaks_first", None)
-    if raw is None:
-        raw = getattr(agent_definition, "target_speaks_first", None)
+    raw = _agent_field(agent_definition, agent_version, "target_speaks_first", None)
     if raw is None:
         return None
     if isinstance(raw, str):
@@ -591,8 +759,10 @@ def _resolve_target_speaks_first(agent_version, agent_definition) -> bool | None
     return bool(raw)
 
 
-def _voice_transport_kind(agent_definition, provider: str, inbound: bool) -> str:
-    if _target_uses_phone(agent_definition):
+def _voice_transport_kind(
+    agent_definition, provider: str, inbound: bool, agent_version=None
+) -> str:
+    if _target_uses_phone(agent_definition, agent_version):
         # From the target agent's perspective: an inbound agent receives the
         # call, so the simulator dials out to it (sip_outbound); an outbound
         # agent places the call, so it dials the simulator's leased DID
@@ -615,11 +785,18 @@ def _env_passthrough_ref(env_var: str) -> dict[str, Any]:
 
 
 def _voice_agent_definition(
-    agent_definition, provider: str, transport_kind: str, credentials
+    agent_definition,
+    provider: str,
+    transport_kind: str,
+    credentials,
+    agent_version=None,
 ) -> tuple[dict[str, Any], list[dict[str, Any]]]:
-    name = agent_definition.agent_name or f"{provider}-target"
+    def field(name: str, default=None):
+        return _agent_field(agent_definition, agent_version, name, default)
+
+    name = field("agent_name") or f"{provider}-target"
     system_prompt = (
-        agent_definition.description or ""
+        str(field("description") or "")
     ).strip() or "You are a helpful voice agent."
     agent_def: dict[str, Any] = {"name": name, "system_prompt": system_prompt}
     secret_env: list[dict[str, Any]] = []
@@ -629,9 +806,7 @@ def _voice_agent_definition(
         if profile["target_id_field"] is None:
             # webrtc: reached by managed dispatch on the agent name, no target
             agent_def["agent_name"] = (
-                getattr(credentials, "agent_name", "")
-                or agent_definition.assistant_id
-                or name
+                getattr(credentials, "agent_name", "") or field("assistant_id") or name
             )
             agent_def["transport"] = {"kind": transport_kind}
         else:
@@ -639,8 +814,7 @@ def _voice_agent_definition(
             agent_def["target"] = {
                 "provider": provider,
                 profile["target_id_field"]: _require(
-                    getattr(credentials, "assistant_id", None)
-                    or agent_definition.assistant_id,
+                    getattr(credentials, "assistant_id", None) or field("assistant_id"),
                     f"{provider} {profile['target_id_field']}",
                 ),
                 "api_key_env": env_var,
@@ -661,9 +835,7 @@ def _voice_agent_definition(
             "sip_number": _require(
                 _voice_setting("PSTN_CALLER_NUMBER"), "PSTN_CALLER_NUMBER"
             ),
-            "sip_call_to": _require(
-                agent_definition.contact_number, "agent contact_number"
-            ),
+            "sip_call_to": _require(field("contact_number"), "agent contact_number"),
             "participant_identity": "sip-caller-{invocation_id}-{test_case_id}",
             "answer_timeout_seconds": 60,
         }
@@ -679,13 +851,23 @@ def _voice_agent_definition(
             transport["inbound_call_originator"] = originator
             env_var = _PROVIDER_ENV[originator]["api_key"]
             secret_env.append(_credential_or_env(env_var, credentials, "api_key"))
-            # ALK requires provider evidence for an API-originated Vapi call so
-            # the originator response's call id is retained and reconciled.
-            if originator == "vapi":
-                agent_def["provider_evidence"] = {
-                    "provider": "vapi",
-                    "call_id_source": "originator_response",
-                }
+            for job_field_name, source_attribute, validator in profile[
+                "sip_inbound_originator_fields"
+            ]:
+                value = getattr(credentials, source_attribute, None) or field(
+                    source_attribute
+                )
+                label = f"{provider} {job_field_name}"
+                transport[job_field_name] = validator(value, label)
+            # ALK requires provider evidence for any API-originated call so the
+            # originator response's call id is retained and reconciled, with an
+            # explicit poll budget rather than an inherited model default.
+            agent_def["provider_evidence"] = {
+                "provider": originator,
+                "call_id_source": "originator_response",
+                "poll_interval_seconds": 3,
+                "poll_deadline_seconds": 45,
+            }
         agent_def["transport"] = transport
     else:  # pragma: no cover - guarded upstream
         raise HostedRunnerBuildError(f"unknown transport: {transport_kind}")
@@ -749,7 +931,10 @@ def _voice_simulator_config(
     if _is_english_language(language):
         default_tts_provider, default_tts_model = "deepgram", "aura-2-andromeda-en"
     else:
-        default_tts_provider, default_tts_model = "gemini", "gemini-3.1-flash-tts-preview"
+        default_tts_provider, default_tts_model = (
+            "gemini",
+            "gemini-3.1-flash-tts-preview",
+        )
     tts = {
         "provider": _voice_setting("SIMULATOR_TTS_PROVIDER") or default_tts_provider,
         "model": _voice_setting("SIMULATOR_TTS_MODEL") or default_tts_model,
@@ -835,9 +1020,8 @@ def _voice_params(
     max_concurrency: int = 1,
     max_call_minutes: int = _DEFAULT_MAX_CALL_MINUTES,
     target_speaks_first: bool | None = None,
+    leased_room: bool = False,
 ) -> dict[str, Any]:
-    from simulate.temporal.constants import HOSTED_RUNNER_MAX_DURATION_SECONDS
-
     is_telephony = transport_kind in {"sip_inbound", "sip_outbound"}
     # Who opens the conversation. The explicit ``target_speaks_first`` toggle on
     # the agent definition wins when set (True: wait for the target's greeting;
@@ -881,25 +1065,37 @@ def _voice_params(
     )
 
     # The child sums ``max_seconds + connect + readiness + cleanup + 60`` into
-    # its outer run deadline. Keep that strictly under the activity's
-    # start_to_close: the SDK's own timeout is graceful (still submits a partial
-    # report), but the Temporal activity timeout SIGTERMs the child, which
-    # aborts WITHOUT submitting — zero rows + "activity task failed".
-    deadline_cap = 0.9 * HOSTED_RUNNER_MAX_DURATION_SECONDS
+    # its own outer run deadline (child_run_seconds mirrors this). D15: that
+    # deadline is the child's budget, not capped against a parent ceiling —
+    # the parent derives its timeout from the child's number instead.
     fixed_overhead = connect_timeout + readiness_timeout + 60.0
-    # A single call must fit under the cap on its own.
-    max_seconds = min(max_seconds, deadline_cap - fixed_overhead - base_cleanup)
+    # A leased pool room hosts one case at a time and pays the drain's
+    # connect_timeout on top of the usual per-case overhead.
+    leased_overhead = fixed_overhead + connect_timeout
 
     cleanup_timeout = base_cleanup
     # Cases run in parallel up to ``effective_concurrency``, so the run's
     # wall-clock is ``ceil(N/C)`` case budgets; contribute those extra budgets
-    # through cleanup_timeout, then clamp the whole deadline under the cap.
-    if case_count > 1:
+    # through cleanup_timeout. A leased room serialises every case (telephony
+    # forces effective_concurrency to 1) and pays the drain's connect_timeout
+    # per case, so its real cost is the deadline identity below rather than
+    # the batch heuristic used for non-leased runs.
+    if case_count > 1 and leased_room:
+        cleanup_timeout = (
+            (case_count - 1) * max_seconds
+            + case_count * leased_overhead
+            - fixed_overhead
+            + base_cleanup
+        )
+    elif case_count > 1:
         per_case_budget = max_seconds + fixed_overhead + base_cleanup
         batches = -(-case_count // effective_concurrency)  # ceil division
         cleanup_timeout = base_cleanup + (batches - 1) * per_case_budget
-        max_cleanup = deadline_cap - max_seconds - fixed_overhead
-        cleanup_timeout = max(base_cleanup, min(cleanup_timeout, max_cleanup))
+    elif leased_room:
+        # A single leased case never reaches the accumulation above but still
+        # pays the drain (K1 runs it on every leased-room run, not only
+        # multi-case ones), so it needs its own standalone allowance.
+        cleanup_timeout = base_cleanup + connect_timeout
 
     return {
         "record_audio": True,
@@ -917,6 +1113,25 @@ def _voice_params(
     }
 
 
+def child_run_seconds(params: dict[str, Any]) -> int:
+    """The child's own run deadline (D15) — line-for-line the same sum the
+    kit computes from these same voice params (agent-learning-kit
+    src/fi/simulate/hosted/child_entrypoint.py:140), so the parent's timeout
+    can derive from it instead of imposing a second, competing cap."""
+    # Round up, not truncate: a fractional second must never make the
+    # parent's derived deadline shorter than what the child actually needs.
+    return math.ceil(
+        max(
+            300.0,
+            float(params.get("max_seconds", 45.0))
+            + float(params.get("connect_timeout", 15.0))
+            + float(params.get("readiness_timeout", 30.0))
+            + float(params.get("cleanup_timeout", 30.0))
+            + 60.0,
+        )
+    )
+
+
 def _credential_or_env(env_var: str, credentials, field: str) -> dict[str, Any]:
     if credentials is not None and getattr(credentials, "id", None) is not None:
         return _provider_credential_ref(env_var, credentials, field)
@@ -925,9 +1140,3 @@ def _credential_or_env(env_var: str, credentials, field: str) -> dict[str, Any]:
 
 def _voice_setting(name: str) -> str | None:
     return getattr(settings, name, None) or os.getenv(name)
-
-
-def _require(value, label: str):
-    if value is None or (isinstance(value, str) and not value.strip()):
-        raise HostedRunnerBuildError(f"voice runner job missing {label}")
-    return value

--- a/futureagi/simulate/services/hosted_runner.py
+++ b/futureagi/simulate/services/hosted_runner.py
@@ -44,6 +44,43 @@ _JOB_SCHEMA_VERSION = "futureagi.runner-job.v1"
 # at the previous hard 120s.
 _DEFAULT_MAX_CALL_MINUTES = 30
 
+# Per-case overheads shared by the deadline computation and the leased-room
+# admission estimate, so both read the same numbers.
+_CONNECT_TIMEOUT_SECONDS = 60.0
+_READINESS_TIMEOUT_SECONDS = 120.0
+_BASE_CLEANUP_SECONDS = 30.0
+
+
+def _max_seconds_for(max_call_minutes: int) -> float:
+    """The per-call hard ceiling in seconds (never below 120)."""
+    return float(max(120, int(max_call_minutes or _DEFAULT_MAX_CALL_MINUTES) * 60))
+
+
+def _fixed_overhead_seconds() -> float:
+    """Per-case connect + readiness + child slack, shared by the deadline math
+    and the leased-room estimate so they cannot drift apart."""
+    return _CONNECT_TIMEOUT_SECONDS + _READINESS_TIMEOUT_SECONDS + 60.0
+
+
+def _leased_overhead_seconds() -> float:
+    """A leased-room case also pays the room drain's connect timeout."""
+    return _fixed_overhead_seconds() + _CONNECT_TIMEOUT_SECONDS
+
+
+def _leased_room_run_seconds(case_count: int, max_seconds: float) -> float:
+    """Estimated wall-clock a leased-room run reserves the single leased number.
+
+    Cases on one leased number run strictly serially, each paying the call
+    ceiling plus the fixed connect/readiness overhead and the room drain, so
+    the run holds the number for about ``N * (max_seconds + overhead)``. This
+    mirrors the leased-room branch of :func:`_voice_params` and the child's own
+    outer deadline.
+    """
+    return (
+        case_count * (max_seconds + _leased_overhead_seconds())
+        + _BASE_CLEANUP_SECONDS
+    )
+
 
 class ConversationDirection(StrEnum):
     """Who opens a hosted voice conversation. The value is the wire string the
@@ -500,6 +537,46 @@ def _leased_room_reuse_enabled() -> bool:
     return bool(getattr(settings, "HOSTED_RUNNER_LEASED_ROOM_REUSE", False))
 
 
+def _positive_setting(name: str, default: int) -> int:
+    """A non-negative admission limit from settings; a bad value falls back to
+    the default, and 0 disables the limit."""
+    try:
+        value = int(getattr(settings, name, default))
+    except (TypeError, ValueError):
+        return default
+    return value if value >= 0 else default
+
+
+def _enforce_leased_room_admission(case_count: int, *, max_call_minutes: int) -> None:
+    """Refuse a leased-room phone run that would hold the one scarce leased
+    number for too many cases or too much wall-clock, before any number is
+    leased. Either limit set to 0 disables that check.
+    """
+    max_cases = _positive_setting("HOSTED_RUNNER_LEASED_ROOM_MAX_CASES", 25)
+    if max_cases and case_count > max_cases:
+        raise HostedRunnerBuildError(
+            f"phone simulation selected {case_count} scenario rows but a leased-"
+            f"number run is capped at {max_cases}; split it into smaller runs "
+            "or raise HOSTED_RUNNER_LEASED_ROOM_MAX_CASES"
+        )
+    max_wallclock = _positive_setting(
+        "HOSTED_RUNNER_LEASED_ROOM_MAX_WALLCLOCK_SECONDS", 4 * 60 * 60
+    )
+    if max_wallclock:
+        estimated = _leased_room_run_seconds(
+            case_count, _max_seconds_for(max_call_minutes)
+        )
+        if estimated > max_wallclock:
+            raise HostedRunnerBuildError(
+                f"phone simulation would hold the leased number about "
+                f"{int(estimated // 60)} min ({case_count} rows at "
+                f"{max_call_minutes} min each), over the "
+                f"{int(max_wallclock // 60)} min cap; reduce the row count or "
+                "the per-call ceiling, or raise "
+                "HOSTED_RUNNER_LEASED_ROOM_MAX_WALLCLOCK_SECONDS"
+            )
+
+
 def _build_voice_job(
     *,
     mode: str,
@@ -529,8 +606,8 @@ def _build_voice_job(
     # originator) serves one scenario per leased room; a multi-scenario run
     # is refused unless reuse is switched on (D10).
     originator = _provider_profile(provider)["sip_inbound_originator"]
-    if transport_kind == "sip_inbound" and originator and len(dataset) > 1:
-        if not _leased_room_reuse_enabled():
+    if transport_kind == "sip_inbound" and originator:
+        if len(dataset) > 1 and not _leased_room_reuse_enabled():
             raise HostedRunnerBuildError(
                 f"phone simulation selected {len(dataset)} scenario rows but "
                 "this runner serves one scenario per leased number; select a "
@@ -538,6 +615,13 @@ def _build_voice_job(
                 "on a runner whose simulator kit supports sequential room "
                 "reuse"
             )
+        # The whole run holds the one scarce leased number for its full
+        # wall-clock, so bound it before any number is leased (D15 dropped the
+        # old flat ceilings; these replace them with settings-tunable ones).
+        _enforce_leased_room_admission(
+            len(dataset),
+            max_call_minutes=_max_call_minutes(simulator_agent),
+        )
 
     secret_env: list[dict[str, Any]] = []
     agent_def, target_secret = _voice_agent_definition(
@@ -1053,25 +1137,23 @@ def _voice_params(
         1 if is_telephony else max(1, min(int(max_concurrency or 1), case_count))
     )
 
-    connect_timeout = 60.0
-    readiness_timeout = 120.0
-    base_cleanup = 30.0
+    connect_timeout = _CONNECT_TIMEOUT_SECONDS
+    readiness_timeout = _READINESS_TIMEOUT_SECONDS
+    base_cleanup = _BASE_CLEANUP_SECONDS
     # A conversation runs until it ends naturally (min turns + quiet, provider
     # disconnect); ``max_seconds`` is only the hard ceiling. Use the simulator's
     # configured call duration (native default 30 min) — the old flat 120s
     # ceiling cut real calls off at ~2 minutes.
-    max_seconds = float(
-        max(120, int(max_call_minutes or _DEFAULT_MAX_CALL_MINUTES) * 60)
-    )
+    max_seconds = _max_seconds_for(max_call_minutes)
 
     # The child sums ``max_seconds + connect + readiness + cleanup + 60`` into
     # its own outer run deadline (child_run_seconds mirrors this). D15: that
     # deadline is the child's budget, not capped against a parent ceiling —
     # the parent derives its timeout from the child's number instead.
-    fixed_overhead = connect_timeout + readiness_timeout + 60.0
+    fixed_overhead = _fixed_overhead_seconds()
     # A leased pool room hosts one case at a time and pays the drain's
     # connect_timeout on top of the usual per-case overhead.
-    leased_overhead = fixed_overhead + connect_timeout
+    leased_overhead = _leased_overhead_seconds()
 
     cleanup_timeout = base_cleanup
     # Cases run in parallel up to ``effective_concurrency``, so the run's

--- a/futureagi/simulate/services/hosted_runner.py
+++ b/futureagi/simulate/services/hosted_runner.py
@@ -82,6 +82,38 @@ def _leased_room_run_seconds(case_count: int, max_seconds: float) -> float:
     )
 
 
+def _effective_voice_concurrency(
+    transport_kind: str, max_concurrency: int, case_count: int
+) -> int:
+    """Cases that actually run in parallel. Telephony leases a single DID and
+    stays strictly serial regardless of the requested ceiling; any other voice
+    run parallelises up to the requested concurrency, bounded by the case count.
+    Mirrors :func:`_voice_params` so the admission estimate and the emitted
+    deadline cannot drift."""
+    if transport_kind in {"sip_inbound", "sip_outbound"}:
+        return 1
+    return max(1, min(int(max_concurrency or 1), case_count))
+
+
+def _hosted_run_seconds(
+    case_count: int,
+    max_seconds: float,
+    *,
+    effective_concurrency: int,
+    leased_room: bool,
+) -> float:
+    """Estimated wall-clock a hosted voice run reserves a runner child slot.
+
+    A leased-room run holds the one scarce DID for the serial leased estimate;
+    any other run reserves the child for ``ceil(N / concurrency)`` case budgets.
+    Mirrors the deadline math in :func:`_voice_params`."""
+    if leased_room:
+        return _leased_room_run_seconds(case_count, max_seconds)
+    per_case_budget = max_seconds + _fixed_overhead_seconds() + _BASE_CLEANUP_SECONDS
+    batches = -(-case_count // max(1, effective_concurrency))  # ceil division
+    return batches * per_case_budget
+
+
 class ConversationDirection(StrEnum):
     """Who opens a hosted voice conversation. The value is the wire string the
     SDK engine reads from the job (``livekit.py`` validates against exactly
@@ -547,34 +579,68 @@ def _positive_setting(name: str, default: int) -> int:
     return value if value >= 0 else default
 
 
-def _enforce_leased_room_admission(case_count: int, *, max_call_minutes: int) -> None:
-    """Refuse a leased-room phone run that would hold the one scarce leased
-    number for too many cases or too much wall-clock, before any number is
-    leased. Either limit set to 0 disables that check.
+def _enforce_hosted_voice_admission(
+    case_count: int,
+    *,
+    max_call_minutes: int,
+    effective_concurrency: int,
+    leased_room: bool,
+) -> None:
+    """Refuse a hosted voice run that would reserve a runner child slot — and,
+    for a leased-DID run, the one scarce leased number — for too many cases or
+    too much wall-clock, before the workflow is dispatched. A global cap guards
+    every hosted voice job (telephony and single-concurrency web runs are serial
+    and otherwise unbounded); a leased-DID run additionally honours a tighter
+    cap. Any limit set to 0 disables that specific check.
     """
-    max_cases = _positive_setting("HOSTED_RUNNER_LEASED_ROOM_MAX_CASES", 25)
+    estimated = _hosted_run_seconds(
+        case_count,
+        _max_seconds_for(max_call_minutes),
+        effective_concurrency=effective_concurrency,
+        leased_room=leased_room,
+    )
+
+    max_cases = _positive_setting("HOSTED_RUNNER_MAX_CASES", 500)
     if max_cases and case_count > max_cases:
         raise HostedRunnerBuildError(
-            f"phone simulation selected {case_count} scenario rows but a leased-"
-            f"number run is capped at {max_cases}; split it into smaller runs "
-            "or raise HOSTED_RUNNER_LEASED_ROOM_MAX_CASES"
+            f"hosted voice run selected {case_count} scenario rows but a run is "
+            f"capped at {max_cases}; split it into smaller runs or raise "
+            "HOSTED_RUNNER_MAX_CASES"
         )
     max_wallclock = _positive_setting(
+        "HOSTED_RUNNER_MAX_WALLCLOCK_SECONDS", 6 * 60 * 60
+    )
+    if max_wallclock and estimated > max_wallclock:
+        raise HostedRunnerBuildError(
+            f"hosted voice run would reserve a runner slot about "
+            f"{int(estimated // 60)} min ({case_count} rows at "
+            f"{max_call_minutes} min each), over the {int(max_wallclock // 60)} "
+            "min cap; reduce the row count or the per-call ceiling, chunk the "
+            "run, or raise HOSTED_RUNNER_MAX_WALLCLOCK_SECONDS"
+        )
+
+    if not leased_room:
+        return
+
+    max_leased_cases = _positive_setting("HOSTED_RUNNER_LEASED_ROOM_MAX_CASES", 25)
+    if max_leased_cases and case_count > max_leased_cases:
+        raise HostedRunnerBuildError(
+            f"phone simulation selected {case_count} scenario rows but a leased-"
+            f"number run is capped at {max_leased_cases}; split it into smaller "
+            "runs or raise HOSTED_RUNNER_LEASED_ROOM_MAX_CASES"
+        )
+    max_leased_wallclock = _positive_setting(
         "HOSTED_RUNNER_LEASED_ROOM_MAX_WALLCLOCK_SECONDS", 4 * 60 * 60
     )
-    if max_wallclock:
-        estimated = _leased_room_run_seconds(
-            case_count, _max_seconds_for(max_call_minutes)
+    if max_leased_wallclock and estimated > max_leased_wallclock:
+        raise HostedRunnerBuildError(
+            f"phone simulation would hold the leased number about "
+            f"{int(estimated // 60)} min ({case_count} rows at "
+            f"{max_call_minutes} min each), over the "
+            f"{int(max_leased_wallclock // 60)} min cap; reduce the row count or "
+            "the per-call ceiling, or raise "
+            "HOSTED_RUNNER_LEASED_ROOM_MAX_WALLCLOCK_SECONDS"
         )
-        if estimated > max_wallclock:
-            raise HostedRunnerBuildError(
-                f"phone simulation would hold the leased number about "
-                f"{int(estimated // 60)} min ({case_count} rows at "
-                f"{max_call_minutes} min each), over the "
-                f"{int(max_wallclock // 60)} min cap; reduce the row count or "
-                "the per-call ceiling, or raise "
-                "HOSTED_RUNNER_LEASED_ROOM_MAX_WALLCLOCK_SECONDS"
-            )
 
 
 def _build_voice_job(
@@ -606,22 +672,30 @@ def _build_voice_job(
     # originator) serves one scenario per leased room; a multi-scenario run
     # is refused unless reuse is switched on (D10).
     originator = _provider_profile(provider)["sip_inbound_originator"]
-    if transport_kind == "sip_inbound" and originator:
-        if len(dataset) > 1 and not _leased_room_reuse_enabled():
-            raise HostedRunnerBuildError(
-                f"phone simulation selected {len(dataset)} scenario rows but "
-                "this runner serves one scenario per leased number; select a "
-                "single scenario row, or enable HOSTED_RUNNER_LEASED_ROOM_REUSE "
-                "on a runner whose simulator kit supports sequential room "
-                "reuse"
-            )
-        # The whole run holds the one scarce leased number for its full
-        # wall-clock, so bound it before any number is leased (D15 dropped the
-        # old flat ceilings; these replace them with settings-tunable ones).
-        _enforce_leased_room_admission(
-            len(dataset),
-            max_call_minutes=_max_call_minutes(simulator_agent),
+    leased_room = transport_kind == "sip_inbound" and bool(originator)
+    # A run whose target DIALS our leased number serves one scenario per leased
+    # room; a multi-scenario run is refused unless reuse is switched on (D10).
+    if leased_room and len(dataset) > 1 and not _leased_room_reuse_enabled():
+        raise HostedRunnerBuildError(
+            f"phone simulation selected {len(dataset)} scenario rows but "
+            "this runner serves one scenario per leased number; select a "
+            "single scenario row, or enable HOSTED_RUNNER_LEASED_ROOM_REUSE "
+            "on a runner whose simulator kit supports sequential room "
+            "reuse"
         )
+    # Every hosted voice job reserves a runner child slot for its full
+    # wall-clock (telephony and single-concurrency web runs are serial), and a
+    # leased-DID run also holds the one scarce number; bound the reservation
+    # before the workflow is dispatched (D15 dropped the old flat ceilings;
+    # these replace them with settings-tunable global and leased caps).
+    _enforce_hosted_voice_admission(
+        len(dataset),
+        max_call_minutes=_max_call_minutes(simulator_agent),
+        effective_concurrency=_effective_voice_concurrency(
+            transport_kind, _target_max_concurrency(credentials), len(dataset)
+        ),
+        leased_room=leased_room,
+    )
 
     secret_env: list[dict[str, Any]] = []
     agent_def, target_secret = _voice_agent_definition(
@@ -657,7 +731,7 @@ def _build_voice_job(
                 max_concurrency=_target_max_concurrency(credentials),
                 max_call_minutes=_max_call_minutes(simulator_agent),
                 target_speaks_first=target_speaks_first,
-                leased_room=(transport_kind == "sip_inbound" and bool(originator)),
+                leased_room=leased_room,
             ),
         },
         "sink": {
@@ -1106,7 +1180,6 @@ def _voice_params(
     target_speaks_first: bool | None = None,
     leased_room: bool = False,
 ) -> dict[str, Any]:
-    is_telephony = transport_kind in {"sip_inbound", "sip_outbound"}
     # Who opens the conversation. The explicit ``target_speaks_first`` toggle on
     # the agent definition wins when set (True: wait for the target's greeting;
     # False: the simulator opens). When unset (None), fall back to the target's
@@ -1133,8 +1206,8 @@ def _voice_params(
         conversation_direction = ConversationDirection.SIMULATOR_FIRST
     # Telephone leases a single DID, so the engine keeps those cases serial
     # regardless of the requested ceiling; mirror that here for the deadline.
-    effective_concurrency = (
-        1 if is_telephony else max(1, min(int(max_concurrency or 1), case_count))
+    effective_concurrency = _effective_voice_concurrency(
+        transport_kind, max_concurrency, case_count
     )
 
     connect_timeout = _CONNECT_TIMEOUT_SECONDS

--- a/futureagi/simulate/temporal/activities/hosted_runner.py
+++ b/futureagi/simulate/temporal/activities/hosted_runner.py
@@ -15,6 +15,8 @@ safety).
 from __future__ import annotations
 
 import asyncio
+import contextlib
+import functools
 import json
 import os
 import shutil
@@ -26,6 +28,7 @@ from django.conf import settings
 from django.db import close_old_connections
 from django.utils import timezone
 from temporalio import activity
+from temporalio.exceptions import ApplicationError
 
 from simulate.temporal.types.hosted_runner import (
     BuildRunnerJobInput,
@@ -45,6 +48,20 @@ _SINK_ENV_BY_PURPOSE = {
     "secret_key": "FI_SECRET_KEY",
     "internal_api_secret": "FI_INTERNAL_SUBMIT_SECRET",
 }
+
+
+@functools.lru_cache(maxsize=1)
+def _customer_provider_env_keys() -> frozenset[str]:
+    """Env keys that carry a CUSTOMER provider's secret. Derived from the profile
+    table so a new provider cannot silently miss the C5 rule; LiveKit falls out
+    because its api_key_env is None."""
+    from simulate.services.hosted_runner import _PROVIDER_PROFILES
+
+    return frozenset(
+        p["api_key_env"] for p in _PROVIDER_PROFILES.values() if p.get("api_key_env")
+    )
+
+
 _CHILD_SLOT_HEARTBEAT_SECONDS = float(
     os.getenv("ALK_RUNNER_SLOT_HEARTBEAT_SECONDS", "20")
 )
@@ -68,7 +85,14 @@ async def _run_db(fn, /, *args, **kwargs):
 
 @activity.defn(name="build_runner_job")
 async def build_runner_job(input: BuildRunnerJobInput) -> BuildRunnerJobOutput:
-    from simulate.services.hosted_runner import build_start_runner_job
+    from simulate.services.hosted_runner import (
+        build_start_runner_job,
+        child_run_seconds,
+    )
+    from simulate.temporal.constants import (
+        HOSTED_RUNNER_CHAT_MODE,
+        HOSTED_RUNNER_CHAT_TIMEOUT_SECONDS,
+    )
 
     job = await _run_db(
         build_start_runner_job,
@@ -78,17 +102,42 @@ async def build_runner_job(input: BuildRunnerJobInput) -> BuildRunnerJobOutput:
         mode=input.mode,
         call_execution_ids=list(input.call_execution_ids or []),
     )
+    # "or {}" — an explicit "params": null must not crash child_run_seconds,
+    # which indexes into params via .get().
+    voice_params = (job.get("voice") or {}).get("params") or {}
+    # Keyed on mode, matching the workflow's own branch (D15) — not on
+    # whether params happen to be present, so the two decisions can't drift.
+    run_seconds = (
+        HOSTED_RUNNER_CHAT_TIMEOUT_SECONDS
+        if job["mode"] == HOSTED_RUNNER_CHAT_MODE
+        else child_run_seconds(voice_params)
+    )
     return BuildRunnerJobOutput(
         job_id=job["job_id"],
         run_id=job["metadata"]["run_id"],
         mode=job["mode"],
         job_json=json.dumps(job),
+        run_seconds=run_seconds,
     )
 
 
 @activity.defn(name="run_hosted_sdk_job")
 async def run_hosted_sdk_job(input: RunHostedJobInput) -> RunHostedJobOutput:
     """Spawn the SDK child, stream its status lines as heartbeats, await exit."""
+    from simulate.temporal.constants import HOSTED_RUNNER_CHAT_MODE
+
+    # Chat has no budget to derive, matching build_runner_job's own
+    # chat/not-chat split; this activity never replays, so — unlike the
+    # workflow — it is safe to refuse here, before any child slot or DID
+    # lease is touched.
+    has_budget = isinstance(input.run_seconds, (int, float)) and input.run_seconds > 0
+    if input.mode != HOSTED_RUNNER_CHAT_MODE and not has_budget:
+        raise ApplicationError(
+            "this run was built by an older worker and carries no time "
+            "budget; start it again",
+            type="hosted_run_budget_missing",
+            non_retryable=True,
+        )
     job = json.loads(input.job_json)
     # Wait for child capacity before creating scratch state or leasing a scarce
     # DID. Heartbeats keep the Temporal activity alive while all local child
@@ -99,6 +148,8 @@ async def run_hosted_sdk_job(input: RunHostedJobInput) -> RunHostedJobOutput:
     # _needs_phone gate). Lease before spawning, inject the slot into the job,
     # release in finally. Web/chat never lease.
     did_slot = None
+    work_dir: str | None = None
+    proc: asyncio.subprocess.Process | None = None
     try:
         # Scratch + run-root setup can fail (disk full, bad ALK_RUNNER_RUN_ROOT).
         # Keep it INSIDE the try so the finally still releases the child slot
@@ -116,9 +167,54 @@ async def run_hosted_sdk_job(input: RunHostedJobInput) -> RunHostedJobOutput:
         status_path = os.path.join(work_dir, "status.jsonl")
 
         if input.mode == "voice_sip":
-            did_slot = await _acquire_did_slot(input.job_id)
+            did_slot = await _acquire_did_slot(input.job_id, input.run_seconds)
             if did_slot:
                 _inject_did_slot(job, did_slot)
+
+        # An originator job with no leased DID has nothing to dial — fail before
+        # spawning the child instead of a hung readiness wait for a call that
+        # never arrives; keyed on the injected DID, not the lease result, since
+        # a lease can succeed with a slot carrying no phone number.
+        voice = job.get("voice") or {}
+        # "or {}" throughout, incl. transport — an explicit "transport": null must
+        # not raise AttributeError instead of falling through the guard.
+        transport = (voice.get("agent_definition") or {}).get("transport") or {}
+        originator = transport.get("inbound_call_originator")
+        # leased_did lives in metadata, not voice.params — the SDK splats
+        # voice.params into a closed-kwarg function and a stray key raises TypeError.
+        inbound_did = (job.get("metadata") or {}).get("leased_did")
+        # A whitespace-only DID is not a phone number — treat it the
+        # same as absent rather than letting it satisfy the guard.
+        if isinstance(inbound_did, str) and not inbound_did.strip():
+            inbound_did = None
+        if originator and not inbound_did:
+            raise ApplicationError(
+                "Outbound simulation needs a leased phone number (DID) for the "
+                f"{originator} originator but none was injected; check that "
+                "ALK_SIM_SLOT_LEASE_SCRIPT is configured on the runner worker "
+                "and that the leased pool slot carries a phone number",
+                type="inbound_originator_requires_leased_did",
+                non_retryable=True,
+            )
+
+        # A leased slot that names a routing rule but no room can never route
+        # a call to the simulator; catch this before spawning, not only when
+        # the child's dispatch check fails mid-run.
+        kind = transport.get("kind")  # the same transport dict the DID guard reads
+        rule = str(did_slot.get("dispatch_rule_name") or "").strip() if did_slot else ""
+        room = str(did_slot.get("room_name") or "").strip() if did_slot else ""
+        if did_slot and kind == "sip_inbound" and rule and not room:
+            # A malformed lease is exactly the case this guard exists for, so
+            # the id itself can be missing too — fall back rather than
+            # rendering the literal "None" into an operator-facing message.
+            slot_id = did_slot.get("slot_id") or did_slot.get("slot") or "<unknown>"
+            raise ApplicationError(
+                f"Leased phone-number slot {slot_id} names a routing rule "
+                "but no room, so calls on it cannot reach the simulator; "
+                "check the pool lease script output",
+                type="leased_slot_requires_room",
+                non_retryable=True,
+            )
 
         with open(job_path, "w", encoding="utf-8") as handle:
             handle.write(json.dumps(job))
@@ -173,6 +269,15 @@ async def run_hosted_sdk_job(input: RunHostedJobInput) -> RunHostedJobOutput:
                     f"artifacts preserved at {run_root} (scratch {work_dir})"
                 )
     finally:
+        # A typed raise above (the DID guard, or credential resolution) exits
+        # before the child is ever spawned, so the inner try/finally's rmtree
+        # (only reached once create_subprocess_exec succeeds) never runs and
+        # the scratch dir leaks. `proc is None` here means exactly that: no
+        # child was started, so nothing else could still be reading work_dir.
+        if proc is None and work_dir is not None:
+            shutil.rmtree(work_dir, ignore_errors=True)
+            with contextlib.suppress(OSError):
+                os.rmdir(run_root)
         if did_slot is not None:
             await _release_did_slot(did_slot)
         _child_semaphore.release()
@@ -299,6 +404,27 @@ def _is_backend_only_secret(key: str) -> bool:
     return key in _CHILD_ENV_DENY_EXACT or key.startswith(_CHILD_ENV_DENY_PREFIXES)
 
 
+def _secret_env_ref_keys(job: dict[str, Any]) -> set[str]:
+    """Every env-var NAME any secret ref in this job claims to supply.
+
+    WHY: an unresolved ref must yield NO value — never whatever the worker
+    process happens to already have under that name — so these names are
+    scrubbed from the inherited copy before the resolved values are overlaid.
+    """
+    keys: set[str] = set()
+    for ref in (job.get("metadata") or {}).get("secret_env") or []:
+        if ref.get("key"):
+            keys.add(str(ref["key"]))
+    for ref in ((job.get("sink") or {}).get("secret_refs") or {}).values():
+        if ref.get("key"):
+            keys.add(str(ref["key"]))
+    target = (job.get("spec") or {}).get("target") or {}
+    for ref in (target.get("secret_refs") or {}).values():
+        if ref.get("key"):
+            keys.add(str(ref["key"]))
+    return keys
+
+
 def _child_environment(job: dict[str, Any]) -> dict[str, str]:
     # Copy the worker env MINUS backend-only secrets the SDK child never needs
     # (DB creds, the internal API secret — the child instead receives that by
@@ -308,6 +434,33 @@ def _child_environment(job: dict[str, Any]) -> dict[str, str]:
     # leak without that breakage risk. TODO: tighten to an allowlist once the
     # child's required env is enumerated.
     env = {k: v for k, v in os.environ.items() if not _is_backend_only_secret(k)}
+    # Deny every CUSTOMER-provider secret key by its EXACT name — derived
+    # from the same profile table as the hoisted customer-key raise in
+    # _resolve_voice_secret_env, so a new provider with an api_key_env is
+    # denied automatically. Key-scoped complement to the ref-scoped
+    # scrub below (_secret_env_ref_keys): that scrub only pops a name a job's
+    # OWN secret_env/sink/target refs declare, so a job shape that declares
+    # no ref for the OTHER provider's key (e.g. a Vapi sip_inbound job never
+    # mentions RETELL_API_KEY) would otherwise inherit it straight from the
+    # worker process. Deliberately EXACT-KEY, not prefix: non-secret
+    # RETELL_*/VAPI_* config the SDK reads from env — base URLs, phone
+    # number ids, assistant ids — is NOT stripped, only the platform's own
+    # provider API key is. This cannot starve a legitimate resolution: a job
+    # that DOES declare its own provider's key ref still gets it back via the
+    # provider_credentials overlay applied after _child_environment returns
+    # (run_hosted_sdk_job: child_env.update(...)), because that overlay reads
+    # os.environ directly, not this dict. LiveKit is unaffected: its
+    # api_key_env is None, so it never joins _customer_provider_env_keys() —
+    # LiveKit system creds are the platform's own runtime vars by design (C5)
+    # and stay inherited-then-scrubbed via the ref-scoped pop only.
+    for name in _customer_provider_env_keys():
+        env.pop(name, None)
+    # A job-declared secret ref (provider key, sink/target secret) must never
+    # be satisfied by simply inheriting the worker's own value for that name —
+    # pop it here so only a successful resolution (below, or the metadata
+    # overlay in run_hosted_sdk_job) can put it back.
+    for name in _secret_env_ref_keys(job):
+        env.pop(name, None)
     # Child cwd is a mkdtemp dir; absolutize a relative key path so it resolves.
     creds = env.get("GOOGLE_APPLICATION_CREDENTIALS")
     if creds and not os.path.isabs(creds):
@@ -335,7 +488,9 @@ def _child_environment(job: dict[str, Any]) -> dict[str, str]:
     # The DID is allocated after the job is built, so it cannot ride the
     # normal metadata.secret_env path. The SDK's inbound originator reads this
     # exact env var when it asks Vapi to dial the leased simulator number.
-    inbound_did = ((job.get("voice") or {}).get("params") or {}).get("inbound_did")
+    # Read from metadata (never voice.params — the SDK splats params as kwargs).
+    inbound_did = (job.get("metadata") or {}).get("leased_did")
+    env.pop("LIVEKIT_INBOUND_DID", None)
     if inbound_did:
         env["LIVEKIT_INBOUND_DID"] = str(inbound_did)
     return env
@@ -369,6 +524,30 @@ async def _resolve_voice_secret_env(job: dict[str, Any]) -> dict[str, str]:
             if not key:
                 continue
             manager = ref.get("manager")
+            # A customer-account provider key must never be sourced from
+            # anything but provider_credentials — not a plain env
+            # passthrough, not a "setting" ref, not any manager added later
+            # (§10.1) — because any value found through another manager is
+            # the WORKER's (platform's) own key, not this job's customer
+            # credential. Checked here, up front, before the manager
+            # dispatch below, so the rule is keyed on "this IS a customer
+            # key" rather than living inside the env-passthrough `else`
+            # branch, where a manager:"setting" ref (or any future manager)
+            # would silently bypass it. Unlike the LiveKit system runtime
+            # vars, which are the platform's key by design, so raise
+            # unconditionally rather than only when unset.
+            if (
+                str(key) in _customer_provider_env_keys()
+                and manager != "provider_credentials"
+            ):
+                source = str(ref.get("source") or ref.get("setting") or key)
+                raise ApplicationError(
+                    f"{key} for a customer job must resolve via "
+                    f"provider_credentials, not any other manager "
+                    f"(source={source})",
+                    type="provider_credentials_missing",
+                    non_retryable=True,
+                )
             if manager == "provider_credentials":
                 value = _resolve_provider_credential(ref, cache)
             elif manager == "setting":
@@ -376,7 +555,8 @@ async def _resolve_voice_secret_env(job: dict[str, Any]) -> dict[str, str]:
                     settings, ref.get("setting", ""), None
                 ) or os.environ.get(str(ref.get("setting", "")))
             else:  # env passthrough
-                value = os.environ.get(str(ref.get("source") or key))
+                source = str(ref.get("source") or key)
+                value = os.environ.get(source)
             if value:
                 resolved[str(key)] = str(value)
         return resolved
@@ -390,6 +570,7 @@ def _resolve_provider_credential(
     from simulate.models.agent_definition import ProviderCredentials
 
     credential_id = ref.get("credential_id")
+    env_key = str(ref.get("key") or "")
     if not credential_id:
         return None
     credentials = cache.get(credential_id)
@@ -397,15 +578,32 @@ def _resolve_provider_credential(
         try:
             credentials = ProviderCredentials.objects.get(id=credential_id)
         except ProviderCredentials.DoesNotExist:
-            return None
+            # Never fall through to the worker's own env — a stale/deleted ref
+            # would otherwise let the child dial on the platform's own key.
+            raise ApplicationError(
+                f"provider credential {credential_id} (for env {env_key}) "
+                "does not exist",
+                type="provider_credentials_missing",
+                non_retryable=True,
+            ) from None
         cache[credential_id] = credentials
     field = ref.get("field")
-    if field == "api_secret":
-        return credentials.get_api_secret()
-    return credentials.get_api_key()
+    value = (
+        credentials.get_api_secret()
+        if field == "api_secret"
+        else credentials.get_api_key()
+    )
+    if not value:
+        raise ApplicationError(
+            f"provider credential {credential_id} has no {field or 'api_key'} "
+            f"(for env {env_key})",
+            type="provider_credentials_missing",
+            non_retryable=True,
+        )
+    return value
 
 
-async def _acquire_did_slot(job_id: str) -> dict[str, Any] | None:
+async def _acquire_did_slot(job_id: str, run_seconds: int) -> dict[str, Any] | None:
     """Lease one DID slot from the livekit-infra inbound-simulator pool
     (tasks #115-119). Returns a normalized slot dict (``did``,
     ``dispatch_rule_name``, ``slot_id``) or None when no lease script is
@@ -416,6 +614,10 @@ async def _acquire_did_slot(job_id: str) -> dict[str, Any] | None:
     backend keeps no LiveKit-infra import. Failures degrade to None rather than
     aborting the run, allowing the SDK to provision its own inbound rule.
     """
+    # Local import: a module-level one would run before simulate.temporal's
+    # package __init__ finishes if this module were ever imported first.
+    from simulate.temporal.constants import HOSTED_RUNNER_PARENT_SLACK_SECONDS
+
     script = os.getenv("ALK_SIM_SLOT_LEASE_SCRIPT")
     if not script:
         return None
@@ -427,6 +629,8 @@ async def _acquire_did_slot(job_id: str) -> dict[str, Any] | None:
             "acquire",
             "--run-id",
             job_id,
+            "--ttl",
+            str(run_seconds + HOSTED_RUNNER_PARENT_SLACK_SECONDS),
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.STDOUT,
         )
@@ -445,6 +649,9 @@ async def _acquire_did_slot(job_id: str) -> dict[str, Any] | None:
             slot["slot_id"] = slot["slot"]
         if slot.get("phone_number") and not slot.get("did"):
             slot["did"] = slot["phone_number"]
+        # Ownership tag so the release call can arm the script's guard against
+        # freeing a slot another run now holds.
+        slot["run_id"] = job_id
         return slot
     except Exception as exc:  # noqa: BLE001
         activity.logger.warning(f"DID lease acquire error for {job_id}: {exc}")
@@ -457,17 +664,28 @@ async def _release_did_slot(slot: dict[str, Any]) -> None:
     if not script or not slot_id:
         return
     python = os.getenv("ALK_RUNNER_PYTHON", "python")
+    argv = [python, script, "release", "--slot", str(slot_id)]
+    run_id = slot.get("run_id")
+    if run_id:
+        argv.extend(["--run-id", str(run_id)])
     try:
         proc = await asyncio.create_subprocess_exec(
-            python,
-            script,
-            "release",
-            "--slot",
-            str(slot_id),
+            *argv,
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.STDOUT,
         )
-        await proc.communicate()
+        out, _ = await proc.communicate()
+        if proc.returncode != 0:
+            code: Any = proc.returncode
+            try:
+                parsed = json.loads(out.decode("utf-8", "replace").strip())
+                if isinstance(parsed, dict) and parsed.get("code"):
+                    code = parsed["code"]
+            except ValueError:
+                pass
+            # Never log the phone number — only our own slot id and the
+            # script's own error code.
+            activity.logger.warning(f"DID lease release failed for {slot_id}: {code}")
     except Exception as exc:  # noqa: BLE001
         activity.logger.warning(f"DID lease release error for {slot_id}: {exc}")
 
@@ -479,28 +697,47 @@ def _inject_did_slot(job: dict[str, Any], slot: dict[str, Any]) -> None:
     number, routed by the dispatch rule). sip_outbound dials the target's own
     number over the outbound trunk and needs no pool slot.
     """
-    transport = (
-        (job.get("voice") or {}).get("agent_definition", {}).get("transport", {})
-    )
+    # "or {}" throughout, incl. transport — an explicit "transport": null (or
+    # "agent_definition": null) must not raise AttributeError, matching the
+    # activity's own guard a few lines up.
+    transport = ((job.get("voice") or {}).get("agent_definition") or {}).get(
+        "transport"
+    ) or {}
     if transport.get("kind") != "sip_inbound":
         return
     rule = slot.get("dispatch_rule_name")
     if rule:
         transport["dispatch_rule_name"] = rule
     did = slot.get("did")
+    # Store the STRIPPED value, not just check it for blankness — an
+    # unstripped DID (e.g. " +15557654321 ") would reach LIVEKIT_INBOUND_DID
+    # and metadata.leased_did verbatim, the same class of bug room_name has.
+    if isinstance(did, str):
+        did = did.strip() or None
     if did:
-        job.setdefault("voice", {}).setdefault("params", {})["inbound_did"] = did
-        (job.setdefault("metadata", {}))["leased_did"] = did
+        # metadata only — voice.params is splatted as kwargs by the SDK, which
+        # has no inbound_did parameter and would raise TypeError. An explicit
+        # "metadata": null must not raise either, so replace rather than rely
+        # on setdefault (which only fires when the key is absent, not None).
+        metadata = job.get("metadata")
+        if not isinstance(metadata, dict):
+            metadata = {}
+            job["metadata"] = metadata
+        metadata["leased_did"] = did
 
-    # A pool dispatch rule targets its slot's fixed room. ALK normally adds a
-    # per-invocation suffix to managed room names, so a single-case leased run
-    # must opt into the exact slot room or LiveKit rejects the rule as a
-    # different destination. Multi-case inbound runs require SDK support for
-    # sequential reuse of a leased room and intentionally keep the templated
-    # runtime here.
+    # Pin the pool room only where the build guard and D12 budget already
+    # cover it (a single case, or a multi-case run with an originator) —
+    # reuse only where the guard and budget apply; any other multi-case job
+    # keeps the templated runtime exactly as today.
     room_name = slot.get("room_name")
-    dataset = (job.get("voice") or {}).get("scenario", {}).get("dataset") or []
-    if room_name and len(dataset) == 1:
+    # Store the STRIPPED value, not just check it — an unstripped pin (e.g.
+    # " sim-slot-01 ") will not match the pool rule's destination downstream.
+    if isinstance(room_name, str):
+        room_name = room_name.strip() or None
+    # "or {}" on scenario too — an explicit "scenario": null must not raise.
+    scenario = (job.get("voice") or {}).get("scenario") or {}
+    dataset = scenario.get("dataset") or []
+    if room_name and (len(dataset) == 1 or transport.get("inbound_call_originator")):
         runtime = job.setdefault("voice", {}).setdefault("livekit_runtime", {})
         runtime["room_name"] = str(room_name)
         runtime["room_name_verbatim"] = True

--- a/futureagi/simulate/temporal/constants.py
+++ b/futureagi/simulate/temporal/constants.py
@@ -66,13 +66,22 @@ DISPATCHER_CONTINUE_AS_NEW_THRESHOLD = 2000
 # Temporal recommends max ~1000 child workflows per parent
 MAX_CALLS_PER_ORCHESTRATOR = 500
 
-# Hosted SDK jobs execute dataset rows sequentially inside one child process.
-# Ten voice cases can legitimately consume almost an hour when each reaches its
-# readiness/conversation ceiling, so the supervising activity must not inherit
-# the single-call deadline.
-HOSTED_RUNNER_MAX_DURATION_SECONDS = int(
-    os.getenv("HOSTED_RUNNER_MAX_DURATION_SECONDS", str(65 * 60))
+# D15: the run budget belongs to the child (its own summed deadline, mirrored
+# in child_run_seconds); this only covers spawn/lease/upload around it, so a
+# parent timeout never becomes the binding limit on a job's own row budget.
+HOSTED_RUNNER_PARENT_SLACK_SECONDS = int(
+    os.getenv("HOSTED_RUNNER_PARENT_SLACK_SECONDS", "600")
 )
+
+# Chat jobs carry no voice params, so there's no child deadline to derive
+# from (D15); kept as its own constant, not env-driven (C9 forbids a second
+# hosted-runner timeout env var), so it can't silently re-widen via env.
+HOSTED_RUNNER_CHAT_TIMEOUT_SECONDS = 65 * 60
+
+# Mirrors services.hosted_runner._CHAT_MODE. Duplicated here (rather than
+# imported) because the workflow sandbox must not import the Django-backed
+# services module; this module has no such import, so it's safe there.
+HOSTED_RUNNER_CHAT_MODE = "chat"
 
 
 # =============================================================================

--- a/futureagi/simulate/temporal/retry_policies.py
+++ b/futureagi/simulate/temporal/retry_policies.py
@@ -23,7 +23,11 @@ DB_RETRY_POLICY = RetryPolicy(
     # Exponential backoff
     backoff_coefficient=2.0,
     # Don't retry on validation errors
-    non_retryable_error_types=["ValueError", "ValidationError"],
+    non_retryable_error_types=[
+        "ValueError",
+        "ValidationError",
+        "HostedRunnerBuildError",
+    ],
 )
 
 

--- a/futureagi/simulate/temporal/types/hosted_runner.py
+++ b/futureagi/simulate/temporal/types/hosted_runner.py
@@ -47,6 +47,12 @@ class BuildRunnerJobOutput:
     run_id: str
     mode: str
     job_json: str
+    # The child's own deadline (D15); the parent derives its timeout from
+    # this instead of imposing a separate cap. Optional with a None
+    # default so a payload recorded by an older (pre-field) worker still
+    # decodes during replay; the loud-failure guard moved to the
+    # workflow/activity call sites instead of living in the shape itself.
+    run_seconds: int | None = None
 
 
 @dataclass
@@ -55,6 +61,8 @@ class RunHostedJobInput:
     run_id: str
     mode: str
     job_json: str
+    # See BuildRunnerJobOutput.run_seconds — same replay-decode reason.
+    run_seconds: int | None = None
 
 
 @dataclass

--- a/futureagi/simulate/temporal/workflows/simulation_runner_workflow.py
+++ b/futureagi/simulate/temporal/workflows/simulation_runner_workflow.py
@@ -14,7 +14,9 @@ from temporalio import workflow
 from temporalio.exceptions import CancelledError
 
 from simulate.temporal.constants import (
-    HOSTED_RUNNER_MAX_DURATION_SECONDS,
+    HOSTED_RUNNER_CHAT_MODE,
+    HOSTED_RUNNER_CHAT_TIMEOUT_SECONDS,
+    HOSTED_RUNNER_PARENT_SLACK_SECONDS,
     QUEUE_RUNNER,
 )
 from simulate.temporal.retry_policies import DB_RETRY_POLICY, NO_RETRY_POLICY
@@ -50,6 +52,34 @@ class SimulationRunnerWorkflow:
                 result_type=BuildRunnerJobOutput,
             )
 
+            # D15: chat has no per-job child deadline to derive from (no voice
+            # params), so it keeps its own fixed budget; every other mode's
+            # timeout derives from the child's own run_seconds instead of a
+            # shared parent cap.
+            #
+            # This workflow's command sequence must not depend on
+            # run_seconds: an older worker's replayed history already has
+            # run_hosted_sdk_job scheduled next, and code that emits any
+            # other command here (a raise included) fails that replay
+            # forever. Only the activity, which never replays, may refuse a
+            # missing budget — so a missing/invalid value here just falls
+            # back to a placeholder instead of branching the command out.
+            if job.mode == HOSTED_RUNNER_CHAT_MODE:
+                sdk_timeout = timedelta(seconds=HOSTED_RUNNER_CHAT_TIMEOUT_SECONDS)
+            elif isinstance(job.run_seconds, (int, float)) and job.run_seconds > 0:
+                sdk_timeout = timedelta(
+                    seconds=job.run_seconds + HOSTED_RUNNER_PARENT_SLACK_SECONDS
+                )
+            else:
+                # The placeholder never becomes a real budget: the activity
+                # fails the run with a typed error before it does anything
+                # else, so this only needs to let that activity start.
+                workflow.logger.warning(
+                    f"run_hosted_sdk_job has no run_seconds budget for job "
+                    f"{job.job_id}; using a placeholder parent timeout"
+                )
+                sdk_timeout = timedelta(seconds=HOSTED_RUNNER_CHAT_TIMEOUT_SECONDS)
+
             outcome = await workflow.execute_activity(
                 "run_hosted_sdk_job",
                 RunHostedJobInput(
@@ -57,10 +87,9 @@ class SimulationRunnerWorkflow:
                     run_id=job.run_id,
                     mode=job.mode,
                     job_json=job.job_json,
+                    run_seconds=job.run_seconds,
                 ),
-                start_to_close_timeout=timedelta(
-                    seconds=HOSTED_RUNNER_MAX_DURATION_SECONDS
-                ),
+                start_to_close_timeout=sdk_timeout,
                 heartbeat_timeout=timedelta(seconds=60),
                 retry_policy=NO_RETRY_POLICY,
                 task_queue=QUEUE_RUNNER,

--- a/futureagi/simulate/tests/test_alk_simulate_ingestion.py
+++ b/futureagi/simulate/tests/test_alk_simulate_ingestion.py
@@ -2002,12 +2002,16 @@ class TestBuildVoiceRunnerJob:
     def test_leased_room_admission_disabled_with_zero_caps(
         self, organization, workspace, simulator_agent
     ):
-        # Issue 2: both caps at 0 disable admission — a large run builds.
+        # Issue 2 + re-review: admission now has a global layer as well as the
+        # leased one, so fully disabling it means zeroing both. With all four
+        # caps at 0 a large run builds.
         from django.test import override_settings
 
         agent = self._retell_originator_agent(organization, workspace)
         with override_settings(
             HOSTED_RUNNER_LEASED_ROOM_REUSE=True,
+            HOSTED_RUNNER_MAX_CASES=0,
+            HOSTED_RUNNER_MAX_WALLCLOCK_SECONDS=0,
             HOSTED_RUNNER_LEASED_ROOM_MAX_CASES=0,
             HOSTED_RUNNER_LEASED_ROOM_MAX_WALLCLOCK_SECONDS=0,
         ):
@@ -2015,6 +2019,102 @@ class TestBuildVoiceRunnerJob:
                 organization, workspace, simulator_agent, agent, 40
             )
         assert mode == "voice_sip"
+
+    def test_sip_outbound_admission_refuses_excess_wallclock(
+        self, organization, workspace, simulator_agent
+    ):
+        # Re-review: the wall-clock bound must cover every hosted voice job, not
+        # only the leased-DID path. sip_outbound is forced serial, so an
+        # oversized dataset reserves a runner child slot without bound; refuse
+        # it before the workflow is dispatched.
+        from django.test import override_settings
+
+        from simulate.services.hosted_runner import HostedRunnerBuildError
+
+        agent = self._voice_agent(
+            organization,
+            workspace,
+            provider="livekit",
+            phone="+15551230000",
+            inbound=True,
+        )
+        with override_settings(
+            LIVEKIT_OUTBOUND_TRUNK_ID="ST_trunk",
+            PSTN_CALLER_NUMBER="+15550009999",
+            HOSTED_RUNNER_MAX_WALLCLOCK_SECONDS=600,
+        ):
+            with pytest.raises(HostedRunnerBuildError) as excinfo:
+                self._build_multi(
+                    organization, workspace, simulator_agent, agent, 3
+                )
+        message = str(excinfo.value)
+        assert "cap" in message
+        assert "HOSTED_RUNNER_MAX_WALLCLOCK_SECONDS" in message
+
+    def test_sip_outbound_admission_refuses_excess_rows(
+        self, organization, workspace, simulator_agent
+    ):
+        # The global case cap also protects the non-leased telephony path.
+        from django.test import override_settings
+
+        from simulate.services.hosted_runner import HostedRunnerBuildError
+
+        agent = self._voice_agent(
+            organization,
+            workspace,
+            provider="livekit",
+            phone="+15551230000",
+            inbound=True,
+        )
+        with override_settings(
+            LIVEKIT_OUTBOUND_TRUNK_ID="ST_trunk",
+            PSTN_CALLER_NUMBER="+15550009999",
+            HOSTED_RUNNER_MAX_CASES=2,
+        ):
+            with pytest.raises(HostedRunnerBuildError) as excinfo:
+                self._build_multi(
+                    organization, workspace, simulator_agent, agent, 3
+                )
+        assert "capped at 2" in str(excinfo.value)
+
+    def test_web_transport_admission_refuses_excess_wallclock(
+        self, organization, workspace, simulator_agent
+    ):
+        # The global wall-clock bound covers non-telephony webrtc too, not only
+        # the telephony paths — a serial or low-concurrency web run has the same
+        # unbounded child-slot problem. The cap is set below the minimum
+        # per-case budget so the refusal holds regardless of the fixture's call
+        # ceiling or the credentials' default concurrency.
+        from django.test import override_settings
+
+        from simulate.services.hosted_runner import HostedRunnerBuildError
+
+        agent = self._voice_agent(
+            organization,
+            workspace,
+            provider="vapi",
+            phone="",
+            assistant_id="asst_123",
+        )
+        with override_settings(HOSTED_RUNNER_MAX_WALLCLOCK_SECONDS=100):
+            with pytest.raises(HostedRunnerBuildError) as excinfo:
+                self._build_multi(
+                    organization, workspace, simulator_agent, agent, 3
+                )
+        assert "HOSTED_RUNNER_MAX_WALLCLOCK_SECONDS" in str(excinfo.value)
+
+    def test_admission_env_int_is_lenient(self, monkeypatch):
+        # Issue B: a bad HOSTED_RUNNER_*_MAX_* override must fall back to the
+        # default rather than crash settings import with a ValueError.
+        from tfc.settings.settings import _admission_env_int
+
+        for bad in ("not-an-int", "", "  ", "12.5"):
+            monkeypatch.setenv("FI_TEST_ADMISSION_INT", bad)
+            assert _admission_env_int("FI_TEST_ADMISSION_INT", 25) == 25
+        monkeypatch.delenv("FI_TEST_ADMISSION_INT", raising=False)
+        assert _admission_env_int("FI_TEST_ADMISSION_INT", 25) == 25
+        monkeypatch.setenv("FI_TEST_ADMISSION_INT", "50")
+        assert _admission_env_int("FI_TEST_ADMISSION_INT", 25) == 50
 
     def _assert_leased_deadline_identity(self, job, case_count):
         """D15: pin ``cleanup_timeout`` and the derived child deadline from

--- a/futureagi/simulate/tests/test_alk_simulate_ingestion.py
+++ b/futureagi/simulate/tests/test_alk_simulate_ingestion.py
@@ -11,6 +11,7 @@ object-storage upload. Everything else — metric computation, DB writes,
 the API envelope — runs for real.
 """
 
+import importlib
 import json
 from types import SimpleNamespace
 from unittest.mock import patch
@@ -98,6 +99,9 @@ def run_test(db, organization, workspace, agent_definition, scenario, simulator_
 @pytest.fixture(autouse=True)
 def _patch_side_effects():
     """No-op the async dispatch + websocket so the service runs inline."""
+    # The string targets below are attribute paths; make sure the module is
+    # imported even when a -k selection runs only tests that never import it.
+    importlib.import_module("simulate.services.alk_simulate_ingestion")
     targets = (
         "simulate.services.alk_simulate_ingestion.notify_simulation_update",
         "simulate.services.test_executor._run_simulate_evaluations_task.apply_async",
@@ -1097,6 +1101,41 @@ class TestBuildVoiceRunnerJob:
         )
         return job, mode
 
+    def _build_multi(self, organization, workspace, simulator_agent, agent, n):
+        """Like ``_build`` but attaches ``n`` scenarios with no dataset rows,
+        so the builder derives one persona per scenario (mirrors ``_build``'s
+        single-scenario attach)."""
+        from simulate.services.alk_simulate_ingestion import (
+            create_alk_sim_test_execution,
+        )
+        from simulate.services.hosted_runner import (
+            build_start_runner_job,
+            resolve_runner_mode,
+        )
+
+        scenarios = [
+            self._scenario(organization, workspace, agent, simulator_agent)
+            for _ in range(n)
+        ]
+        rt = RunTest.objects.create(
+            name="Voice Run",
+            description="voice",
+            agent_definition=agent,
+            simulator_agent=simulator_agent,
+            organization=organization,
+            workspace=workspace,
+        )
+        rt.scenarios.add(*scenarios)
+        te = create_alk_sim_test_execution(rt)
+        mode = resolve_runner_mode(agent)
+        job = build_start_runner_job(
+            test_execution_id=str(te.id),
+            run_test_id=str(rt.id),
+            scenario_ids=[str(s.id) for s in scenarios],
+            mode=mode,
+        )
+        return job, mode
+
     def test_resolve_runner_mode(self, organization, workspace):
         from simulate.services.hosted_runner import resolve_runner_mode
 
@@ -1247,11 +1286,9 @@ class TestBuildVoiceRunnerJob:
         # (>=120s), not the old flat 120s that cut real calls at ~2 minutes.
         params = job["voice"]["params"]
         assert params["max_seconds"] >= 120.0
-        # The child sums these into its outer run deadline; it must stay under
-        # the activity's start_to_close so the SDK's graceful timeout (which
-        # still submits a partial report) beats the activity SIGTERM (which
-        # submits nothing -> "activity task failed").
-        from simulate.temporal.constants import HOSTED_RUNNER_MAX_DURATION_SECONDS
+        # D15: the child's own deadline (no parent cap to fit under anymore)
+        # — the parent's timeout is derived FROM this, not compared against it.
+        from simulate.services.hosted_runner import child_run_seconds
 
         deadline = (
             params["max_seconds"]
@@ -1260,7 +1297,7 @@ class TestBuildVoiceRunnerJob:
             + params["cleanup_timeout"]
             + 60.0
         )
-        assert deadline <= 0.9 * HOSTED_RUNNER_MAX_DURATION_SECONDS
+        assert child_run_seconds(params) == int(deadline)
 
     def test_rerun_scopes_job_to_selected_calls(
         self, organization, workspace, simulator_agent
@@ -1388,7 +1425,620 @@ class TestBuildVoiceRunnerJob:
         assert job["voice"]["agent_definition"]["provider_evidence"] == {
             "provider": "vapi",
             "call_id_source": "originator_response",
+            "poll_interval_seconds": 3,
+            "poll_deadline_seconds": 45,
         }
+
+    def test_builds_retell_sip_inbound_job(
+        self, organization, workspace, simulator_agent
+    ):
+        agent = self._voice_agent(
+            organization,
+            workspace,
+            provider="retell",
+            phone="+14155550123",
+            inbound=False,
+            assistant_id="agent_xyz",
+        )
+        job, mode = self._build(organization, workspace, simulator_agent, agent)
+        assert mode == "voice_sip"
+        t = job["voice"]["agent_definition"]["transport"]
+        assert t["kind"] == "sip_inbound"
+        assert t["inbound_call_originator"] == "retell"
+        assert t["originator_agent_id"] == "agent_xyz"
+        assert t["originator_from_number"] == "+14155550123"
+        assert job["voice"]["agent_definition"]["provider_evidence"] == {
+            "provider": "retell",
+            "call_id_source": "originator_response",
+            "poll_interval_seconds": 3,
+            "poll_deadline_seconds": 45,
+        }
+        secret_env = job["metadata"]["secret_env"]
+        assert any(
+            ref["key"] == "RETELL_API_KEY" and ref["manager"] == "provider_credentials"
+            for ref in secret_env
+        )
+
+    def test_retell_sip_inbound_missing_agent_id_raises(
+        self, organization, workspace, simulator_agent
+    ):
+        from simulate.services.hosted_runner import HostedRunnerBuildError
+
+        agent = self._voice_agent(
+            organization,
+            workspace,
+            provider="retell",
+            phone="+14155550123",
+            inbound=False,
+            assistant_id="",
+        )
+        with pytest.raises(HostedRunnerBuildError) as excinfo:
+            self._build(organization, workspace, simulator_agent, agent)
+        assert (
+            str(excinfo.value) == "voice runner job missing retell originator_agent_id"
+        )
+
+    def test_retell_sip_inbound_missing_number_raises(self, organization, workspace):
+        # An empty contact_number resolves mode to voice_webrtc, not sip_inbound
+        # (§7 D7), so the validator can't be reached through build_start_runner_job
+        # with a blank number — exercise it directly the way _build_voice_job does.
+        from simulate.models.agent_definition import ProviderCredentials
+        from simulate.services.hosted_runner import (
+            HostedRunnerBuildError,
+            _voice_agent_definition,
+        )
+
+        agent = self._voice_agent(
+            organization,
+            workspace,
+            provider="retell",
+            phone="",
+            inbound=False,
+            assistant_id="agent_xyz",
+        )
+        credentials = ProviderCredentials.objects.get(agent_definition=agent)
+        with pytest.raises(HostedRunnerBuildError) as excinfo:
+            _voice_agent_definition(agent, "retell", "sip_inbound", credentials)
+        assert (
+            str(excinfo.value)
+            == "voice runner job missing retell originator_from_number"
+        )
+
+    def test_retell_sip_inbound_malformed_number_raises(
+        self, organization, workspace, simulator_agent
+    ):
+        from simulate.services.hosted_runner import HostedRunnerBuildError
+
+        agent = self._voice_agent(
+            organization,
+            workspace,
+            provider="retell",
+            phone="4155550123",
+            inbound=False,
+            assistant_id="agent_xyz",
+        )
+        with pytest.raises(HostedRunnerBuildError) as excinfo:
+            self._build(organization, workspace, simulator_agent, agent)
+        assert (
+            str(excinfo.value)
+            == "voice runner job invalid retell originator_from_number"
+        )
+
+    @pytest.mark.parametrize(
+        "number,valid",
+        [
+            ("+1234567", True),
+            ("+123456", False),
+            ("+01234567", False),
+            ("4155550123", False),
+            ("+14155550123\n", False),
+        ],
+    )
+    def test_retell_originator_from_number_e164_boundaries(
+        self, organization, workspace, simulator_agent, number, valid
+    ):
+        from simulate.services.hosted_runner import HostedRunnerBuildError
+
+        agent = self._voice_agent(
+            organization,
+            workspace,
+            provider="retell",
+            phone=number,
+            inbound=False,
+            assistant_id="agent_xyz",
+        )
+        if valid:
+            job, mode = self._build(organization, workspace, simulator_agent, agent)
+            assert (
+                job["voice"]["agent_definition"]["transport"]["originator_from_number"]
+                == number
+            )
+        else:
+            with pytest.raises(HostedRunnerBuildError):
+                self._build(organization, workspace, simulator_agent, agent)
+
+    def test_pinned_version_snapshot_wins_over_definition_in_full_build(
+        self, organization, workspace, simulator_agent
+    ):
+        """Pins the run to an OLDER version and cuts a NEWER one afterward
+        (mirrors an edit reaching the definition columns after a version was
+        already pinned), so ``_agent_field``'s own versionless fallback to
+        ``latest_version`` cannot coincidentally match the pin — with only
+        one version ever created, that fallback would still find the right
+        snapshot even if ``agent_version`` were dropped somewhere on the path
+        from ``build_start_runner_job`` through to ``_voice_agent_definition``,
+        masking a real wiring break.
+
+        Credentials are created once with ``assistant_id=""`` and never
+        resynced, so ``credentials.assistant_id`` stays falsy throughout and
+        cannot mask either version's own ``assistant_id``."""
+        from simulate.services.alk_simulate_ingestion import (
+            create_alk_sim_test_execution,
+        )
+        from simulate.services.hosted_runner import (
+            build_start_runner_job,
+            resolve_runner_mode,
+        )
+
+        # Outbound target (inbound=False) -> sip_inbound transport, so Retell's
+        # originator_from_number / originator_agent_id fields are populated.
+        agent = self._voice_agent(
+            organization,
+            workspace,
+            provider="retell",
+            phone="+15559999999",
+            inbound=False,
+            assistant_id="",
+        )
+        agent.assistant_id = "snap_agent"
+        agent.agent_name = "Snap Name"
+        agent.description = "snap prompt"
+        agent.save(update_fields=["assistant_id", "agent_name", "description"])
+        version_pinned = agent.create_version(
+            description="pinned version", commit_message="v1", status="active"
+        )
+
+        # A later edit reaches the definition columns directly (today's edit
+        # endpoints do exactly this) and a new version is cut from it, so
+        # latest_version now differs from the pin.
+        agent.contact_number = "+15550000001"
+        agent.assistant_id = "def_agent"
+        agent.agent_name = "Def Name"
+        agent.description = "def prompt"
+        agent.save(
+            update_fields=[
+                "contact_number",
+                "assistant_id",
+                "agent_name",
+                "description",
+            ]
+        )
+        agent.create_version(
+            description="later edit", commit_message="v2", status="active"
+        )
+        assert agent.latest_version.id != version_pinned.id
+
+        scenario = self._scenario(organization, workspace, agent, simulator_agent)
+        rt = self._run_test(organization, workspace, agent, simulator_agent, scenario)
+        rt.agent_version = version_pinned
+        rt.save(update_fields=["agent_version"])
+
+        te = create_alk_sim_test_execution(rt)
+        assert te.agent_version_id == version_pinned.id  # pin carried to the execution
+
+        mode = resolve_runner_mode(agent, version_pinned)
+        assert mode == "voice_sip"
+        job = build_start_runner_job(
+            test_execution_id=str(te.id),
+            run_test_id=str(rt.id),
+            scenario_ids=[str(scenario.id)],
+            mode=mode,
+        )
+        transport = job["voice"]["agent_definition"]["transport"]
+        assert transport["originator_from_number"] == "+15559999999"
+        assert transport["originator_agent_id"] == "snap_agent"
+        assert job["voice"]["agent_definition"]["name"] == "Snap Name"
+        assert job["voice"]["agent_definition"]["system_prompt"] == "snap prompt"
+
+    def test_pinned_version_snapshot_clears_phone_and_falls_back_to_webrtc(
+        self, organization, workspace, simulator_agent
+    ):
+        """Same two-version wiring as the previous test, but for the
+        mode/transport gate rather than the originator fields: the pinned
+        version's snapshot silencing contact_number must win over a stale
+        phone column, dropping the run to voice_webrtc/retell_webcall with no
+        DID lease and no originator."""
+        from simulate.services.alk_simulate_ingestion import (
+            create_alk_sim_test_execution,
+        )
+        from simulate.services.hosted_runner import (
+            build_start_runner_job,
+            resolve_runner_mode,
+        )
+
+        agent = self._voice_agent(
+            organization,
+            workspace,
+            provider="retell",
+            phone="+15551234567",
+            assistant_id="agent_xyz",
+        )
+        version = agent.create_version(
+            description="pinned for hosted run",
+            commit_message="clear phone",
+            status="active",
+        )
+        version.configuration_snapshot = {
+            **version.configuration_snapshot,
+            "contact_number": "",
+        }
+        version.save(update_fields=["configuration_snapshot"])
+
+        scenario = self._scenario(organization, workspace, agent, simulator_agent)
+        rt = self._run_test(organization, workspace, agent, simulator_agent, scenario)
+        rt.agent_version = version
+        rt.save(update_fields=["agent_version"])
+
+        te = create_alk_sim_test_execution(rt)
+        mode = resolve_runner_mode(agent, version)
+        assert mode == "voice_webrtc"
+        job = build_start_runner_job(
+            test_execution_id=str(te.id),
+            run_test_id=str(rt.id),
+            scenario_ids=[str(scenario.id)],
+            mode=mode,
+        )
+        transport = job["voice"]["agent_definition"]["transport"]
+        assert transport["kind"] == "retell_webcall"
+        assert "inbound_call_originator" not in transport
+
+    def _retell_originator_agent(self, organization, workspace):
+        return self._voice_agent(
+            organization,
+            workspace,
+            provider="retell",
+            phone="+14155550123",
+            inbound=False,
+            assistant_id="agent_xyz",
+        )
+
+    def test_multi_scenario_sip_inbound_originator_refused_without_reuse(
+        self, organization, workspace, simulator_agent
+    ):
+        from django.test import override_settings
+
+        from simulate.services.hosted_runner import HostedRunnerBuildError
+
+        agent = self._retell_originator_agent(organization, workspace)
+        with override_settings(HOSTED_RUNNER_LEASED_ROOM_REUSE=False):
+            with pytest.raises(HostedRunnerBuildError) as excinfo:
+                self._build_multi(organization, workspace, simulator_agent, agent, 3)
+        message = str(excinfo.value)
+        assert "3 scenario rows" in message
+        assert "select a single scenario row" in message
+        assert "HOSTED_RUNNER_LEASED_ROOM_REUSE" in message
+
+    def test_multi_scenario_sip_inbound_originator_builds_with_reuse_on(
+        self, organization, workspace, simulator_agent
+    ):
+        from django.test import override_settings
+
+        agent = self._retell_originator_agent(organization, workspace)
+        with override_settings(HOSTED_RUNNER_LEASED_ROOM_REUSE=True):
+            job, mode = self._build_multi(
+                organization, workspace, simulator_agent, agent, 3
+            )
+        assert mode == "voice_sip"
+        params = job["voice"]["params"]
+        assert params["max_concurrency"] == 1
+        # The budget follows the rows: each call keeps the full ceiling and the
+        # cleanup carries the other calls plus one drain allowance per call.
+        assert params["max_seconds"] == 30 * 60.0
+        fixed_overhead = params["connect_timeout"] + params["readiness_timeout"] + 60.0
+        leased_overhead = fixed_overhead + params["connect_timeout"]
+        assert params["cleanup_timeout"] == (
+            2 * params["max_seconds"] + 3 * leased_overhead - fixed_overhead + 30.0
+        )
+
+    def test_switch_off_ignores_env_true(
+        self, organization, workspace, simulator_agent, monkeypatch
+    ):
+        from django.test import override_settings
+
+        from simulate.services.hosted_runner import HostedRunnerBuildError
+
+        agent = self._retell_originator_agent(organization, workspace)
+        monkeypatch.setenv("HOSTED_RUNNER_LEASED_ROOM_REUSE", "true")
+        with override_settings(HOSTED_RUNNER_LEASED_ROOM_REUSE=False):
+            with pytest.raises(HostedRunnerBuildError):
+                self._build_multi(organization, workspace, simulator_agent, agent, 3)
+
+    def test_single_scenario_sip_inbound_originator_builds_with_reuse_off(
+        self, organization, workspace, simulator_agent
+    ):
+        from django.test import override_settings
+
+        agent = self._retell_originator_agent(organization, workspace)
+        with override_settings(HOSTED_RUNNER_LEASED_ROOM_REUSE=False):
+            job, mode = self._build(organization, workspace, simulator_agent, agent)
+        assert mode == "voice_sip"
+
+    def test_multi_scenario_sip_inbound_no_originator_builds_with_reuse_off(
+        self, organization, workspace, simulator_agent
+    ):
+        from django.test import override_settings
+
+        agent = self._voice_agent(
+            organization,
+            workspace,
+            provider="livekit",
+            phone="+15551230000",
+            inbound=False,
+        )
+        with override_settings(HOSTED_RUNNER_LEASED_ROOM_REUSE=False):
+            job, mode = self._build_multi(
+                organization, workspace, simulator_agent, agent, 3
+            )
+        assert mode == "voice_sip"
+        transport = job["voice"]["agent_definition"]["transport"]
+        assert transport["kind"] == "sip_inbound"
+        assert "inbound_call_originator" not in transport
+
+    def test_multi_scenario_sip_outbound_builds_with_reuse_off(
+        self, organization, workspace, simulator_agent
+    ):
+        from django.test import override_settings
+
+        agent = self._voice_agent(
+            organization,
+            workspace,
+            provider="livekit",
+            phone="+15551230000",
+            inbound=True,
+        )
+        with override_settings(
+            HOSTED_RUNNER_LEASED_ROOM_REUSE=False,
+            LIVEKIT_OUTBOUND_TRUNK_ID="ST_trunk",
+            PSTN_CALLER_NUMBER="+15550009999",
+        ):
+            job, mode = self._build_multi(
+                organization, workspace, simulator_agent, agent, 3
+            )
+        assert mode == "voice_sip"
+        assert job["voice"]["agent_definition"]["transport"]["kind"] == "sip_outbound"
+
+    def test_multi_scenario_web_transport_builds_with_reuse_off(
+        self, organization, workspace, simulator_agent
+    ):
+        from django.test import override_settings
+
+        agent = self._voice_agent(
+            organization, workspace, provider="vapi", phone="", assistant_id="asst_123"
+        )
+        with override_settings(HOSTED_RUNNER_LEASED_ROOM_REUSE=False):
+            job, mode = self._build_multi(
+                organization, workspace, simulator_agent, agent, 3
+            )
+        assert mode == "voice_webrtc"
+
+    def test_leased_room_budget_default_ceiling_n3(
+        self, organization, workspace, simulator_agent
+    ):
+        # D15: max_seconds is the call ceiling, full stop — no per-case
+        # shrink for however many rows are leased into one room.
+        from django.test import override_settings
+
+        agent = self._retell_originator_agent(organization, workspace)
+        with override_settings(HOSTED_RUNNER_LEASED_ROOM_REUSE=True):
+            job, _ = self._build_multi(
+                organization, workspace, simulator_agent, agent, 3
+            )
+        assert job["voice"]["params"]["max_seconds"] == 1800.0
+
+    def test_leased_room_budget_two_minute_ceiling_n3(
+        self, organization, workspace, simulator_agent
+    ):
+        from django.test import override_settings
+
+        simulator_agent.max_call_duration_in_minutes = 2
+        simulator_agent.save(update_fields=["max_call_duration_in_minutes"])
+        agent = self._retell_originator_agent(organization, workspace)
+        with override_settings(HOSTED_RUNNER_LEASED_ROOM_REUSE=True):
+            job, _ = self._build_multi(
+                organization, workspace, simulator_agent, agent, 3
+            )
+        assert job["voice"]["params"]["max_seconds"] == 120.0
+
+    def test_leased_room_budget_two_minute_ceiling_n6_builds(
+        self, organization, workspace, simulator_agent
+    ):
+        from django.test import override_settings
+
+        simulator_agent.max_call_duration_in_minutes = 2
+        simulator_agent.save(update_fields=["max_call_duration_in_minutes"])
+        agent = self._retell_originator_agent(organization, workspace)
+        with override_settings(HOSTED_RUNNER_LEASED_ROOM_REUSE=True):
+            job, _ = self._build_multi(
+                organization, workspace, simulator_agent, agent, 6
+            )
+        assert job["voice"]["params"]["max_seconds"] == 120.0
+
+    def test_leased_room_budget_two_minute_ceiling_n10_builds(
+        self, organization, workspace, simulator_agent
+    ):
+        # D15: a row count that used to be refused now simply builds — the
+        # child owns however long its own budget needs to be.
+        from django.test import override_settings
+
+        simulator_agent.max_call_duration_in_minutes = 2
+        simulator_agent.save(update_fields=["max_call_duration_in_minutes"])
+        agent = self._retell_originator_agent(organization, workspace)
+        with override_settings(HOSTED_RUNNER_LEASED_ROOM_REUSE=True):
+            job, _ = self._build_multi(
+                organization, workspace, simulator_agent, agent, 10
+            )
+        assert job["voice"]["params"]["max_seconds"] == 120.0
+
+    def _assert_leased_deadline_identity(self, job, case_count):
+        """D15: pin ``cleanup_timeout`` and the derived child deadline from
+        the budget constants (not by echoing the function's own output), so a
+        regression that reverts to the old per-case shrink is caught here
+        even though every other assertion in this class only pins
+        ``max_seconds``."""
+        from simulate.services.hosted_runner import child_run_seconds
+
+        connect_timeout = 60.0
+        readiness_timeout = 120.0
+        base_cleanup = 30.0
+        fixed_overhead = connect_timeout + readiness_timeout + 60.0
+        leased_overhead = fixed_overhead + connect_timeout
+
+        params = job["voice"]["params"]
+        max_seconds = params["max_seconds"]
+        cleanup_timeout = (
+            (case_count - 1) * max_seconds
+            + case_count * leased_overhead
+            - fixed_overhead
+            + base_cleanup
+        )
+        assert params["cleanup_timeout"] == cleanup_timeout
+        run_seconds = child_run_seconds(params)
+        expected = case_count * (max_seconds + leased_overhead) + base_cleanup
+        assert run_seconds == expected
+
+    def test_leased_room_budget_fits_every_case_n3(
+        self, organization, workspace, simulator_agent
+    ):
+        from django.test import override_settings
+
+        agent = self._retell_originator_agent(organization, workspace)
+        with override_settings(HOSTED_RUNNER_LEASED_ROOM_REUSE=True):
+            job, _ = self._build_multi(
+                organization, workspace, simulator_agent, agent, 3
+            )
+        self._assert_leased_deadline_identity(job, 3)
+
+    def test_leased_room_budget_fits_every_case_n5(
+        self, organization, workspace, simulator_agent
+    ):
+        from django.test import override_settings
+
+        agent = self._retell_originator_agent(organization, workspace)
+        with override_settings(HOSTED_RUNNER_LEASED_ROOM_REUSE=True):
+            job, _ = self._build_multi(
+                organization, workspace, simulator_agent, agent, 5
+            )
+        self._assert_leased_deadline_identity(job, 5)
+
+    def test_leased_room_budget_fits_every_case_n2(
+        self, organization, workspace, simulator_agent
+    ):
+        # N=2 used to disagree with the N>=3 formula only because the old
+        # max_cleanup clamp bound differently at low case counts; with the
+        # clamp gone, the same identity now covers every N >= 2 uniformly.
+        from django.test import override_settings
+
+        agent = self._retell_originator_agent(organization, workspace)
+        with override_settings(HOSTED_RUNNER_LEASED_ROOM_REUSE=True):
+            job, _ = self._build_multi(
+                organization, workspace, simulator_agent, agent, 2
+            )
+        assert job["voice"]["params"]["max_seconds"] == 1800.0
+        self._assert_leased_deadline_identity(job, 2)
+
+    def test_single_scenario_leased_budget_untouched_at_defaults(
+        self, organization, workspace, simulator_agent
+    ):
+        # The single-case drain allowance lives in cleanup_timeout, not
+        # max_seconds — unaffected by D15 either way.
+        from django.test import override_settings
+
+        from simulate.services.hosted_runner import child_run_seconds
+
+        agent = self._retell_originator_agent(organization, workspace)
+        with override_settings(HOSTED_RUNNER_LEASED_ROOM_REUSE=False):
+            job, _ = self._build(organization, workspace, simulator_agent, agent)
+        params = job["voice"]["params"]
+        leased_overhead = 300.0
+
+        assert params["max_seconds"] == 1800.0
+        assert params["cleanup_timeout"] == 90.0
+        run_seconds = child_run_seconds(params)
+        need = params["max_seconds"] + leased_overhead + 30
+        assert need == 2130.0
+        assert run_seconds == 2130.0
+        assert run_seconds == need
+
+    def test_single_scenario_leased_budget_at_55_minute_ceiling(
+        self, organization, workspace, simulator_agent
+    ):
+        # D15: the single-case clamp that used to cap max_seconds at 3180s is
+        # gone — the full 55-minute ceiling (3300s) now passes through.
+        from django.test import override_settings
+
+        from simulate.services.hosted_runner import child_run_seconds
+
+        simulator_agent.max_call_duration_in_minutes = 55
+        simulator_agent.save(update_fields=["max_call_duration_in_minutes"])
+        agent = self._retell_originator_agent(organization, workspace)
+        with override_settings(HOSTED_RUNNER_LEASED_ROOM_REUSE=False):
+            job, _ = self._build(organization, workspace, simulator_agent, agent)
+        params = job["voice"]["params"]
+        leased_overhead = 300.0
+
+        assert params["max_seconds"] == 3300.0
+        assert params["cleanup_timeout"] == 90.0
+        run_seconds = child_run_seconds(params)
+        need = params["max_seconds"] + leased_overhead + 30
+        assert need == 3630.0
+        assert run_seconds == 3630.0
+        assert run_seconds == need
+
+    def test_sip_outbound_multi_scenario_budget_untouched_n7(
+        self, organization, workspace, simulator_agent
+    ):
+        from django.test import override_settings
+
+        agent = self._voice_agent(
+            organization,
+            workspace,
+            provider="livekit",
+            phone="+15551230000",
+            inbound=True,
+        )
+        with override_settings(
+            HOSTED_RUNNER_LEASED_ROOM_REUSE=True,
+            LIVEKIT_OUTBOUND_TRUNK_ID="ST_trunk",
+            PSTN_CALLER_NUMBER="+15550009999",
+        ):
+            job, _ = self._build_multi(
+                organization, workspace, simulator_agent, agent, 7
+            )
+        assert job["voice"]["agent_definition"]["transport"]["kind"] == "sip_outbound"
+        # sip_outbound is untouched by D12 — today's value, unshortened.
+        assert job["voice"]["params"]["max_seconds"] == 1800.0
+
+    def test_no_originator_sip_inbound_budget_untouched_n7(
+        self, organization, workspace, simulator_agent
+    ):
+        from django.test import override_settings
+
+        agent = self._voice_agent(
+            organization,
+            workspace,
+            provider="livekit",
+            phone="+15551230000",
+            inbound=False,
+        )
+        with override_settings(HOSTED_RUNNER_LEASED_ROOM_REUSE=True):
+            job, _ = self._build_multi(
+                organization, workspace, simulator_agent, agent, 7
+            )
+        transport = job["voice"]["agent_definition"]["transport"]
+        assert transport["kind"] == "sip_inbound"
+        assert "inbound_call_originator" not in transport
+        # No-originator sip_inbound is untouched by D12 — today's value.
+        assert job["voice"]["params"]["max_seconds"] == 1800.0
 
 
 class TestHostedRunnerActivityHelpers:
@@ -1451,10 +2101,111 @@ class TestHostedRunnerActivityHelpers:
             == "simulator_first"
         )
 
+    @pytest.mark.parametrize("case_count", [1, 3, 5, 20, 40])
+    @pytest.mark.parametrize("max_call_minutes", [30, 2, 55])
+    def test_leased_budget_never_shrinks_or_refuses(self, case_count, max_call_minutes):
+        # D15: the builder no longer clamps against a parent cap or refuses a
+        # row count — max_seconds always equals the call ceiling, and
+        # cleanup_timeout/run_seconds follow the child's own deadline
+        # identity, however large. 55 min is where the deleted max_seconds
+        # clamp used to bind (3240s), so this sweep now catches that
+        # regression without a DB-backed test.
+        from simulate.services.hosted_runner import _voice_params, child_run_seconds
+
+        params = _voice_params(
+            "sip_inbound",
+            inbound=False,
+            case_count=case_count,
+            max_concurrency=5,
+            max_call_minutes=max_call_minutes,
+            leased_room=True,
+        )
+        ceiling = float(max(120, max_call_minutes * 60))
+        assert params["max_seconds"] == ceiling
+
+        connect_timeout = 60.0
+        readiness_timeout = 120.0
+        base_cleanup = 30.0
+        fixed_overhead = connect_timeout + readiness_timeout + 60.0
+        leased_overhead = fixed_overhead + connect_timeout
+        if case_count > 1:
+            expected_cleanup = (
+                (case_count - 1) * ceiling
+                + case_count * leased_overhead
+                - fixed_overhead
+                + base_cleanup
+            )
+        else:
+            # N = 1 form: the single-case drain allowance, no accumulation.
+            expected_cleanup = base_cleanup + connect_timeout
+        assert params["cleanup_timeout"] == expected_cleanup
+
+        run_seconds = child_run_seconds(params)
+        assert run_seconds == case_count * (ceiling + leased_overhead) + base_cleanup
+
+    def test_child_run_seconds_rounds_a_fractional_sum_up(self):
+        # A fractional term (cleanup_timeout=30.5) must round the parent's
+        # derived deadline UP, never down — truncation could leave the
+        # child's own budget a fraction of a second longer than what the
+        # parent is willing to wait for it.
+        from simulate.services.hosted_runner import child_run_seconds
+
+        params = {
+            "max_seconds": 1800.0,
+            "connect_timeout": 60.0,
+            "readiness_timeout": 120.0,
+            "cleanup_timeout": 30.5,
+        }
+        # kit sum = 1800 + 60 + 120 + 30.5 + 60 = 2070.5
+        assert child_run_seconds(params) == 2071
+
+    def test_non_leased_web_budget_unclamped_n1_n2_matched_n7_grows(self):
+        # N=1/N=2 never hit HEAD's cap, so both fields are byte-identical to
+        # before; N=7 only changes cleanup_timeout — HEAD clamped it to 1470
+        # (0.9 * the old 65-minute constant, minus overhead), the unclamped
+        # identity now gives 2100. max_seconds is unaffected at every N since
+        # a single case never needed the deleted clamp either.
+        from simulate.services.hosted_runner import _voice_params
+
+        for case_count, expected_cleanup in ((1, 30.0), (2, 30.0), (7, 2100.0)):
+            params = _voice_params(
+                "webrtc",
+                inbound=True,
+                case_count=case_count,
+                max_concurrency=5,
+                max_call_minutes=30,
+                leased_room=False,
+            )
+            assert params["max_seconds"] == 1800.0
+            assert params["cleanup_timeout"] == expected_cleanup
+
+    def test_no_originator_sip_inbound_budget_unclamped_n1_matched_n7_grows(self):
+        # Telephony without a leased room serialises every case
+        # (effective_concurrency pinned to 1), so N=7's unclamped
+        # cleanup_timeout (12450) grows far past HEAD's capped 1470 — the
+        # child now gets the whole real drain instead of a truncated one.
+        from simulate.services.hosted_runner import _voice_params
+
+        for case_count, expected_cleanup in ((1, 30.0), (7, 12450.0)):
+            params = _voice_params(
+                "sip_inbound",
+                inbound=False,
+                case_count=case_count,
+                max_concurrency=5,
+                max_call_minutes=30,
+                leased_room=False,
+            )
+            assert params["max_seconds"] == 1800.0
+            assert params["cleanup_timeout"] == expected_cleanup
+
     def test_resolve_agent_inbound_prefers_version_snapshot(self):
-        """The per-version configuration_snapshot['inbound'] (what the UI toggle
-        writes) wins over the stale AgentDefinition.inbound column, matching the
-        native TestExecutor dynamic-prompt precedence."""
+        """Once the pinned version has a snapshot dict, it alone decides
+        inbound/outbound — same whole-dict precedence as ``_agent_field``. A
+        key it lacks means "unset" (defaults to inbound=True); the
+        ``AgentDefinition.inbound`` column is NOT consulted in that case, only
+        when the agent has no version at all (no snapshot dict). This stops a
+        later definition-level toggle from reaching back and flipping the call
+        direction of an older pinned version that predates it."""
         from types import SimpleNamespace
 
         from simulate.services.hosted_runner import _resolve_agent_inbound
@@ -1472,9 +2223,10 @@ class TestHostedRunnerActivityHelpers:
         version = SimpleNamespace(configuration_snapshot={"inbound": "true"})
         assert _resolve_agent_inbound(version, agent_def_outbound) is True
 
-        # Snapshot missing the key → fall back to the AgentDefinition column.
+        # Snapshot missing the key → default inbound=True; the column is NOT
+        # consulted (a versioned run must not see a later column edit).
         version = SimpleNamespace(configuration_snapshot={})
-        assert _resolve_agent_inbound(version, agent_def_outbound) is False
+        assert _resolve_agent_inbound(version, agent_def_outbound) is True
         assert _resolve_agent_inbound(version, agent_def_inbound) is True
 
         # No version at all → column fallback (default inbound when absent).
@@ -1507,7 +2259,10 @@ class TestHostedRunnerActivityHelpers:
         _inject_did_slot(inbound, slot)
         t = inbound["voice"]["agent_definition"]["transport"]
         assert t["dispatch_rule_name"] == "rule-1"
-        assert inbound["voice"]["params"]["inbound_did"] == "+15557654321"
+        assert inbound["metadata"]["leased_did"] == "+15557654321"
+        # Never in voice.params — the SDK splats params as kwargs and has no
+        # inbound_did parameter, so a stray key there raises TypeError.
+        assert "inbound_did" not in inbound["voice"]["params"]
         assert _child_environment(inbound)["LIVEKIT_INBOUND_DID"] == "+15557654321"
         assert inbound["voice"]["livekit_runtime"] == {
             "room_name": "sim-slot-01",
@@ -1528,13 +2283,718 @@ class TestHostedRunnerActivityHelpers:
             not in (outbound["voice"]["agent_definition"]["transport"])
         )
 
+    def test_inject_did_slot_pins_multi_row_originator_job(self):
+        # The multi-scenario reuse population (an originator job): pinned
+        # identically to the single-row case.
+        from simulate.temporal.activities.hosted_runner import _inject_did_slot
+
+        slot = {
+            "did": "+15557654321",
+            "dispatch_rule_name": "rule-1",
+            "room_name": "sim-slot-01",
+            "slot_id": "s1",
+        }
+        job = {
+            "voice": {
+                "agent_definition": {
+                    "transport": {
+                        "kind": "sip_inbound",
+                        "inbound_call_originator": "retell",
+                    }
+                },
+                "livekit_runtime": {"room_name": "hosted-{test_case_id}"},
+                "params": {},
+                "scenario": {
+                    "dataset": [
+                        {"persona": {"name": "A"}},
+                        {"persona": {"name": "B"}},
+                        {"persona": {"name": "C"}},
+                    ]
+                },
+            },
+            "metadata": {},
+        }
+        _inject_did_slot(job, slot)
+        assert job["voice"]["livekit_runtime"] == {
+            "room_name": "sim-slot-01",
+            "room_name_verbatim": True,
+        }
+
+    def test_inject_did_slot_leaves_multi_row_no_originator_job_templated(self):
+        # A multi-row job without an originator is not the reuse population —
+        # the guard and D12 budget do not cover it, so it keeps the templated
+        # runtime exactly as today.
+        from simulate.temporal.activities.hosted_runner import _inject_did_slot
+
+        slot = {
+            "did": "+15557654321",
+            "dispatch_rule_name": "rule-1",
+            "room_name": "sim-slot-01",
+            "slot_id": "s1",
+        }
+        job = {
+            "voice": {
+                "agent_definition": {"transport": {"kind": "sip_inbound"}},
+                "livekit_runtime": {"room_name": "hosted-{test_case_id}"},
+                "params": {},
+                "scenario": {
+                    "dataset": [
+                        {"persona": {"name": "A"}},
+                        {"persona": {"name": "B"}},
+                        {"persona": {"name": "C"}},
+                    ]
+                },
+            },
+            "metadata": {},
+        }
+        _inject_did_slot(job, slot)
+        assert job["voice"]["livekit_runtime"] == {"room_name": "hosted-{test_case_id}"}
+
+    def test_inject_did_slot_pins_single_row_no_originator_job(self):
+        # Today's behaviour: a single-row job is pinned even without an
+        # originator.
+        from simulate.temporal.activities.hosted_runner import _inject_did_slot
+
+        slot = {
+            "did": "+15557654321",
+            "dispatch_rule_name": "rule-1",
+            "room_name": "sim-slot-01",
+            "slot_id": "s1",
+        }
+        job = {
+            "voice": {
+                "agent_definition": {"transport": {"kind": "sip_inbound"}},
+                "livekit_runtime": {"room_name": "hosted-{test_case_id}"},
+                "params": {},
+                "scenario": {"dataset": [{"persona": {"name": "A"}}]},
+            },
+            "metadata": {},
+        }
+        _inject_did_slot(job, slot)
+        assert job["voice"]["livekit_runtime"] == {
+            "room_name": "sim-slot-01",
+            "room_name_verbatim": True,
+        }
+
+    def test_inject_did_slot_treats_whitespace_number_as_absent(self):
+        # Pin _inject_did_slot's OWN .strip() independently of the
+        # guard's — a whitespace-only did in the leased slot must never reach
+        # metadata.leased_did, even though the guard downstream would also
+        # strip it if it somehow did.
+        from simulate.temporal.activities.hosted_runner import _inject_did_slot
+
+        job = {
+            "voice": {
+                "agent_definition": {"transport": {"kind": "sip_inbound"}},
+                "params": {},
+            },
+            "metadata": {},
+        }
+        _inject_did_slot(job, {"slot_id": "s1", "dispatch_rule_name": "r1", "did": " "})
+
+        assert "leased_did" not in job.get("metadata", {})
+
+    def test_inject_did_slot_treats_whitespace_room_name_as_absent(self):
+        # A whitespace-only room_name must not be pinned — the templated
+        # runtime is left untouched exactly as when room_name is absent.
+        from simulate.temporal.activities.hosted_runner import _inject_did_slot
+
+        job = {
+            "voice": {
+                "agent_definition": {"transport": {"kind": "sip_inbound"}},
+                "livekit_runtime": {"room_name": "hosted-{test_case_id}"},
+                "params": {},
+                "scenario": {"dataset": [{"persona": {"name": "A"}}]},
+            },
+            "metadata": {},
+        }
+        _inject_did_slot(
+            job,
+            {"slot_id": "s1", "dispatch_rule_name": "r1", "room_name": "   "},
+        )
+
+        assert job["voice"]["livekit_runtime"] == {"room_name": "hosted-{test_case_id}"}
+
+    def test_inject_did_slot_strips_pinned_room_name(self):
+        # The pinned value itself must be stripped, not just checked for
+        # blankness — an unstripped pin will not match the pool rule's
+        # destination downstream.
+        from simulate.temporal.activities.hosted_runner import _inject_did_slot
+
+        job = {
+            "voice": {
+                "agent_definition": {"transport": {"kind": "sip_inbound"}},
+                "livekit_runtime": {"room_name": "hosted-{test_case_id}"},
+                "params": {},
+                "scenario": {"dataset": [{"persona": {"name": "A"}}]},
+            },
+            "metadata": {},
+        }
+        slot = {
+            "slot_id": "s1",
+            "dispatch_rule_name": "r1",
+            "room_name": "  sim-slot-01 ",
+        }
+        _inject_did_slot(job, slot)
+
+        assert job["voice"]["livekit_runtime"] == {
+            "room_name": "sim-slot-01",
+            "room_name_verbatim": True,
+        }
+
+    def test_inject_did_slot_tolerates_explicit_null_transport(self):
+        # An explicit "transport": null must not raise AttributeError — the
+        # helper returns without pinning or raising, matching the activity's
+        # own "or {}" guard.
+        from simulate.temporal.activities.hosted_runner import _inject_did_slot
+
+        job = {
+            "voice": {
+                "agent_definition": {"transport": None},
+                "params": {},
+            },
+            "metadata": {},
+        }
+        _inject_did_slot(
+            job, {"slot_id": "s1", "dispatch_rule_name": "r1", "did": "+15557654321"}
+        )
+
+        assert "leased_did" not in job.get("metadata", {})
+        assert "livekit_runtime" not in job["voice"]
+
+    def test_inject_did_slot_tolerates_explicit_null_scenario(self):
+        # C5a: an explicit "scenario": null must not raise — the room-name
+        # sizing check falls back to an empty dataset instead.
+        from simulate.temporal.activities.hosted_runner import _inject_did_slot
+
+        job = {
+            "voice": {
+                "agent_definition": {"transport": {"kind": "sip_inbound"}},
+                "params": {},
+                "scenario": None,
+            },
+            "metadata": {},
+        }
+        _inject_did_slot(job, {"slot_id": "s1", "room_name": "sim-slot-01"})
+
+        # No dataset to size against, so the single-row room pin never fires.
+        assert "livekit_runtime" not in job["voice"]
+
+    def test_inject_did_slot_tolerates_explicit_null_dataset(self):
+        # C5a: an explicit "dataset": null (scenario present) must not raise.
+        from simulate.temporal.activities.hosted_runner import _inject_did_slot
+
+        job = {
+            "voice": {
+                "agent_definition": {"transport": {"kind": "sip_inbound"}},
+                "params": {},
+                "scenario": {"dataset": None},
+            },
+            "metadata": {},
+        }
+        _inject_did_slot(job, {"slot_id": "s1", "room_name": "sim-slot-01"})
+
+        assert "livekit_runtime" not in job["voice"]
+
+    def test_inject_did_slot_tolerates_explicit_null_metadata(self):
+        # C5a: an explicit "metadata": null must not raise — setdefault only
+        # fires when the key is absent, not when it is present but None.
+        from simulate.temporal.activities.hosted_runner import _inject_did_slot
+
+        job = {
+            "voice": {
+                "agent_definition": {"transport": {"kind": "sip_inbound"}},
+                "params": {},
+            },
+            "metadata": None,
+        }
+        _inject_did_slot(job, {"slot_id": "s1", "did": "+15557654321"})
+
+        assert job["metadata"]["leased_did"] == "+15557654321"
+
+    def test_inject_did_slot_strips_pinned_did(self):
+        # The stored DID must be the stripped value, not just checked for
+        # blankness — the same fix already applied to room_name — or a
+        # padded number reaches LIVEKIT_INBOUND_DID and metadata.leased_did
+        # verbatim.
+        from simulate.temporal.activities.hosted_runner import _inject_did_slot
+
+        job = {
+            "voice": {
+                "agent_definition": {"transport": {"kind": "sip_inbound"}},
+                "params": {},
+            },
+            "metadata": {},
+        }
+        _inject_did_slot(
+            job,
+            {"slot_id": "s1", "dispatch_rule_name": "r1", "did": " +15557654321 "},
+        )
+
+        assert job["metadata"]["leased_did"] == "+15557654321"
+
     def test_acquire_did_slot_none_without_script(self, monkeypatch):
         import asyncio
 
         from simulate.temporal.activities.hosted_runner import _acquire_did_slot
 
         monkeypatch.delenv("ALK_SIM_SLOT_LEASE_SCRIPT", raising=False)
-        assert asyncio.run(_acquire_did_slot("job-1")) is None
+        assert asyncio.run(_acquire_did_slot("job-1", 900)) is None
+
+    def test_build_runner_job_fills_run_seconds_for_voice(self, monkeypatch):
+        # D15: BuildRunnerJobOutput.run_seconds comes from the job's own
+        # voice.params via child_run_seconds, not a shared parent cap.
+        # No DB touch: build_start_runner_job and close_old_connections are
+        # both stubbed, so _run_db's executor thread issues no query.
+        import asyncio
+
+        from simulate.temporal.activities import hosted_runner as hr
+        from simulate.temporal.types.hosted_runner import BuildRunnerJobInput
+
+        fake_job = {
+            "job_id": "job-1",
+            "mode": "voice_webrtc",
+            "metadata": {"run_id": "run-1"},
+            "voice": {
+                "params": {
+                    "max_seconds": 1800.0,
+                    "connect_timeout": 60.0,
+                    "readiness_timeout": 120.0,
+                    "cleanup_timeout": 90.0,
+                }
+            },
+        }
+        monkeypatch.setattr(hr, "close_old_connections", lambda: None)
+        monkeypatch.setattr(
+            "simulate.services.hosted_runner.build_start_runner_job",
+            lambda **kwargs: fake_job,
+        )
+
+        inp = BuildRunnerJobInput(
+            test_execution_id="te-1",
+            run_test_id="rt-1",
+            scenario_ids=["s-1"],
+            mode="voice_webrtc",
+        )
+        out = asyncio.run(hr.build_runner_job(inp))
+
+        assert out.run_seconds == 2130  # 1800 + 60 + 120 + 90 + 60
+
+    def test_build_runner_job_run_seconds_for_chat_uses_its_own_constant(
+        self, monkeypatch
+    ):
+        # Chat carries no voice params, so it can't derive a child deadline
+        # (D15 rule 7) — it falls back to the chat runner's own fixed budget.
+        import asyncio
+
+        from simulate.temporal.activities import hosted_runner as hr
+        from simulate.temporal.constants import HOSTED_RUNNER_CHAT_TIMEOUT_SECONDS
+        from simulate.temporal.types.hosted_runner import BuildRunnerJobInput
+
+        fake_job = {
+            "job_id": "job-2",
+            "mode": "chat",
+            "metadata": {"run_id": "run-2"},
+            "spec": {},
+        }
+        monkeypatch.setattr(hr, "close_old_connections", lambda: None)
+        monkeypatch.setattr(
+            "simulate.services.hosted_runner.build_start_runner_job",
+            lambda **kwargs: fake_job,
+        )
+
+        inp = BuildRunnerJobInput(
+            test_execution_id="te-2",
+            run_test_id="rt-2",
+            scenario_ids=["s-2"],
+            mode="chat",
+        )
+        out = asyncio.run(hr.build_runner_job(inp))
+
+        assert out.run_seconds == HOSTED_RUNNER_CHAT_TIMEOUT_SECONDS
+
+    def test_chat_mode_constant_matches_the_service_module_literal(self):
+        # The workflow sandbox can't import the Django-backed services
+        # module, so the "chat" literal is duplicated there on purpose
+        # (constants.py:81-83) — pin the two copies together so they can't
+        # drift apart silently.
+        from simulate.services.hosted_runner import _CHAT_MODE
+        from simulate.temporal.constants import HOSTED_RUNNER_CHAT_MODE
+
+        assert HOSTED_RUNNER_CHAT_MODE == _CHAT_MODE
+
+    def test_build_runner_job_voice_params_none_does_not_crash(self, monkeypatch):
+        # child_run_seconds indexes into params via .get(); an explicit
+        # "params": null on a voice job must fall back to {} (the kit's own
+        # floor) instead of raising AttributeError/TypeError.
+        import asyncio
+
+        from simulate.temporal.activities import hosted_runner as hr
+        from simulate.temporal.types.hosted_runner import BuildRunnerJobInput
+
+        fake_job = {
+            "job_id": "job-3",
+            "mode": "voice_webrtc",
+            "metadata": {"run_id": "run-3"},
+            "voice": {"params": None},
+        }
+        monkeypatch.setattr(hr, "close_old_connections", lambda: None)
+        monkeypatch.setattr(
+            "simulate.services.hosted_runner.build_start_runner_job",
+            lambda **kwargs: fake_job,
+        )
+
+        inp = BuildRunnerJobInput(
+            test_execution_id="te-3",
+            run_test_id="rt-3",
+            scenario_ids=["s-3"],
+            mode="voice_webrtc",
+        )
+        out = asyncio.run(hr.build_runner_job(inp))
+
+        # 300 is child_run_seconds' own floor for an empty params dict.
+        assert out.run_seconds == 300
+
+    def test_run_seconds_decodes_to_none_without_the_field(self):
+        # Pins the absent default: a payload recorded before this field
+        # existed must still decode, yielding None rather than raising
+        # TypeError — the loud-failure guard lives at the workflow/activity
+        # call sites, not in the dataclass shape.
+        from simulate.temporal.types.hosted_runner import (
+            BuildRunnerJobOutput,
+            RunHostedJobInput,
+        )
+
+        build_out = BuildRunnerJobOutput(
+            job_id="j1", run_id="r1", mode="voice_sip", job_json="{}"
+        )
+        run_in = RunHostedJobInput(
+            job_id="j1", run_id="r1", mode="voice_sip", job_json="{}"
+        )
+        assert build_out.run_seconds is None
+        assert run_in.run_seconds is None
+
+    def test_workflow_command_sequence_is_independent_of_run_seconds(self):
+        # C9/D15: an older worker's replayed history already has
+        # run_hosted_sdk_job scheduled next, so nothing between the build
+        # and run activity calls may raise or branch which command gets
+        # emitted on run_seconds — only the timeout value may vary.
+        import ast
+        import pathlib
+
+        import simulate.temporal.workflows.simulation_runner_workflow as wf
+
+        wf_path = pathlib.Path(wf.__file__)
+        tree = ast.parse(wf_path.read_text(), filename=str(wf_path))
+
+        def activity_name(node):
+            if (
+                isinstance(node, ast.Call)
+                and isinstance(node.func, ast.Attribute)
+                and node.func.attr == "execute_activity"
+                and node.args
+                and isinstance(node.args[0], ast.Constant)
+            ):
+                return node.args[0].value
+            return None
+
+        run_method = next(
+            (
+                n
+                for n in ast.walk(tree)
+                if isinstance(n, ast.AsyncFunctionDef) and n.name == "run"
+            ),
+            None,
+        )
+        assert run_method is not None, "SimulationRunnerWorkflow.run not found"
+
+        try_node = next(n for n in ast.walk(run_method) if isinstance(n, ast.Try))
+        body = try_node.body
+
+        def index_containing(name):
+            for i, stmt in enumerate(body):
+                if any(activity_name(n) == name for n in ast.walk(stmt)):
+                    return i
+            return None
+
+        build_idx = index_containing("build_runner_job")
+        run_idx = index_containing("run_hosted_sdk_job")
+        finalize_idx = index_containing("finalize_hosted_execution")
+        assert build_idx is not None, "build_runner_job call not found"
+        assert run_idx is not None, "run_hosted_sdk_job call not found"
+        assert finalize_idx is not None, "finalize_hosted_execution call not found"
+        assert build_idx < run_idx < finalize_idx, (
+            "run() must call build, then run, then finalize in that order"
+        )
+
+        calls_before_finalize = [
+            name
+            for i, stmt in enumerate(body)
+            if i < finalize_idx
+            for name in (activity_name(n) for n in ast.walk(stmt))
+            if name is not None
+        ]
+        assert calls_before_finalize == ["build_runner_job", "run_hosted_sdk_job"], (
+            "exactly build_runner_job then run_hosted_sdk_job may execute "
+            "before the finalize path"
+        )
+
+        def references_run_seconds(test):
+            return any(
+                (isinstance(n, ast.Attribute) and n.attr == "run_seconds")
+                or (isinstance(n, ast.Name) and n.id == "run_seconds")
+                for n in ast.walk(test)
+            )
+
+        between = body[build_idx + 1 : run_idx]
+
+        raises = [
+            n for stmt in between for n in ast.walk(stmt) if isinstance(n, ast.Raise)
+        ]
+        assert raises == [], (
+            "no Raise may sit between build_runner_job and run_hosted_sdk_job"
+        )
+
+        run_seconds_ifs = [
+            n
+            for stmt in between
+            for n in ast.walk(stmt)
+            if isinstance(n, ast.If) and references_run_seconds(n.test)
+        ]
+        assert len(run_seconds_ifs) == 1, (
+            "the only If testing run_seconds between build and run must be "
+            "the timeout assignment's own branch"
+        )
+
+    def test_workflow_timeout_derives_from_run_seconds_not_a_shared_cap(self):
+        # AST check (C9/D15): this is the ONLY guard on the rule, so it must
+        # pin the expression actually feeding run_hosted_sdk_job's own
+        # timeout keyword byte-for-byte — an expression that merely
+        # *contains* the derivation lets a literal cap or a unit swap slip
+        # through with the suite green.
+        import ast
+        import pathlib
+
+        import simulate
+        import simulate.temporal.workflows.simulation_runner_workflow as wf
+
+        wf_path = pathlib.Path(wf.__file__)
+        tree = ast.parse(wf_path.read_text(), filename=str(wf_path))
+
+        def is_target_call(node):
+            return (
+                isinstance(node, ast.Call)
+                and isinstance(node.func, ast.Attribute)
+                and node.func.attr == "execute_activity"
+                and node.args
+                and isinstance(node.args[0], ast.Constant)
+                and node.args[0].value == "run_hosted_sdk_job"
+            )
+
+        call = owner = None
+        for func in ast.walk(tree):
+            if not isinstance(func, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                continue
+            for node in ast.walk(func):
+                if is_target_call(node):
+                    call, owner = node, func
+                    break
+            if call is not None:
+                break
+        assert call is not None, "run_hosted_sdk_job execute_activity call not found"
+
+        timeout_kw = next(
+            kw for kw in call.keywords if kw.arg == "start_to_close_timeout"
+        )
+        expr = timeout_kw.value
+        assert isinstance(expr, ast.Name), (
+            "start_to_close_timeout must be fed by a local, not inlined"
+        )
+        timeout_name = expr.id
+
+        def is_build_call(node):
+            return (
+                isinstance(node, ast.Call)
+                and isinstance(node.func, ast.Attribute)
+                and node.func.attr == "execute_activity"
+                and node.args
+                and isinstance(node.args[0], ast.Constant)
+                and node.args[0].value == "build_runner_job"
+            )
+
+        # Bind the build result's own local name rather than hardcoding
+        # "job", so a rename can't silently blind the checks below.
+        build_assign = next(
+            n
+            for n in ast.walk(owner)
+            if isinstance(n, ast.Assign)
+            and any(is_build_call(x) for x in ast.walk(n.value))
+        )
+        assert len(build_assign.targets) == 1 and isinstance(
+            build_assign.targets[0], ast.Name
+        ), "build_runner_job result must be assigned to a single local"
+        job_name = build_assign.targets[0].id
+
+        # Locate the specific `if job.mode == HOSTED_RUNNER_CHAT_MODE` (or
+        # `!=`) node, rather than trusting which physical branch reads
+        # "if" vs "else" — the comparison operator says which arm is chat.
+        def is_chat_mode_test(test):
+            return (
+                isinstance(test, ast.Compare)
+                and isinstance(test.left, ast.Attribute)
+                and test.left.attr == "mode"
+                and isinstance(test.left.value, ast.Name)
+                and test.left.value.id == job_name
+                and len(test.ops) == 1
+                and isinstance(test.ops[0], (ast.Eq, ast.NotEq))
+                and len(test.comparators) == 1
+                and isinstance(test.comparators[0], ast.Name)
+                and test.comparators[0].id == "HOSTED_RUNNER_CHAT_MODE"
+            )
+
+        if_node = next(
+            (
+                n
+                for n in ast.walk(owner)
+                if isinstance(n, ast.If) and is_chat_mode_test(n.test)
+            ),
+            None,
+        )
+        assert if_node is not None, "no job.mode/HOSTED_RUNNER_CHAT_MODE if"
+
+        is_eq = isinstance(if_node.test.ops[0], ast.Eq)
+        chat_arm = if_node.body if is_eq else if_node.orelse
+        other_top = if_node.orelse if is_eq else if_node.body
+        assert chat_arm and other_top, "both if/else arms must be present"
+
+        # The non-chat arm is a single nested If (an elif in source form):
+        # a positive-budget branch and a placeholder branch, never a flat
+        # unconditional assignment.
+        assert len(other_top) == 1 and isinstance(other_top[0], ast.If), (
+            "the non-chat arm must be a single nested If on run_seconds"
+        )
+        inner_if = other_top[0]
+
+        def assigns_to(stmts, name):
+            return [
+                stmt.value
+                for stmt in stmts
+                if isinstance(stmt, ast.Assign)
+                and any(isinstance(t, ast.Name) and t.id == name for t in stmt.targets)
+            ]
+
+        chat_assigns = assigns_to(chat_arm, timeout_name)
+        positive_assigns = assigns_to(inner_if.body, timeout_name)
+        placeholder_assigns = assigns_to(inner_if.orelse, timeout_name)
+        assert len(chat_assigns) == 1, (
+            f"chat arm must assign {timeout_name} exactly once"
+        )
+        assert len(positive_assigns) == 1, (
+            f"the positive-budget branch must assign {timeout_name} once"
+        )
+        assert len(placeholder_assigns) == 1, (
+            f"the placeholder branch must assign {timeout_name} exactly once"
+        )
+
+        def normalized_dump(node):
+            # ast.dump ignores position info by default; re-parsing an
+            # unparse of `node` gives a detached copy so renaming the job
+            # local for comparison can't mutate the tree under test.
+            copy = ast.parse(ast.unparse(node), mode="eval").body
+            for n in ast.walk(copy):
+                if isinstance(n, ast.Name) and n.id == job_name:
+                    n.id = "job"
+            return ast.dump(copy)
+
+        def expr_dump(src):
+            return ast.dump(ast.parse(src, mode="eval").body)
+
+        expected_chat = expr_dump(
+            "timedelta(seconds=HOSTED_RUNNER_CHAT_TIMEOUT_SECONDS)"
+        )
+        expected_voice = expr_dump(
+            "timedelta(seconds=job.run_seconds + HOSTED_RUNNER_PARENT_SLACK_SECONDS)"
+        )
+
+        # Pins which arm runs, not just what each arm computes: the two
+        # assertions above alone let a flipped comparison operator (or `<`
+        # for `>`) send every voice run down the placeholder branch while
+        # leaving both arm expressions untouched and the suite green.
+        expected_predicate = expr_dump(
+            "isinstance(job.run_seconds, (int, float)) and job.run_seconds > 0"
+        )
+        assert normalized_dump(inner_if.test) == expected_predicate, (
+            "the elif predicate must be exactly isinstance(run_seconds, "
+            "(int, float)) and run_seconds > 0"
+        )
+
+        assert normalized_dump(chat_assigns[0]) == expected_chat, (
+            "chat arm must be exactly timedelta(seconds="
+            "HOSTED_RUNNER_CHAT_TIMEOUT_SECONDS)"
+        )
+        assert normalized_dump(positive_assigns[0]) == expected_voice, (
+            "positive-budget branch must be exactly timedelta(seconds="
+            "run_seconds + HOSTED_RUNNER_PARENT_SLACK_SECONDS), not merely "
+            "contain that sum"
+        )
+        assert normalized_dump(placeholder_assigns[0]) == expected_chat, (
+            "placeholder branch must reuse the chat expression exactly, "
+            "not a different constant"
+        )
+
+        # Exactly these three assignments to the name exist anywhere in the
+        # function — catches a correct set of branches silently overwritten
+        # by a later, unconditional reassignment of the same local.
+        all_assigns = [
+            stmt
+            for stmt in ast.walk(owner)
+            if isinstance(stmt, ast.Assign)
+            and any(
+                isinstance(t, ast.Name) and t.id == timeout_name for t in stmt.targets
+            )
+        ]
+        assert len(all_assigns) == 3, (
+            f"{timeout_name} must be assigned exactly once per branch and nowhere else"
+        )
+
+        def names_and_attrs(t):
+            names = {n.id for n in ast.walk(t) if isinstance(n, ast.Name)}
+            attrs = {n.attr for n in ast.walk(t) if isinstance(n, ast.Attribute)}
+            return names | attrs
+
+        simulate_root = pathlib.Path(simulate.__file__).parent
+        offenders = [
+            str(path)
+            for path in simulate_root.rglob("*.py")
+            if "HOSTED_RUNNER_MAX_DURATION_SECONDS"
+            in names_and_attrs(ast.parse(path.read_text(), filename=str(path)))
+        ]
+        assert offenders == []
+
+        # Two more keywords a mutant could drop silently: no run_seconds
+        # means the activity always refuses a voice run; no heartbeat_timeout
+        # means Temporal loses its only liveness signal on the long-lived
+        # child. Neither is touched by the checks above.
+        input_call = call.args[1]
+        assert (
+            isinstance(input_call, ast.Call)
+            and isinstance(input_call.func, ast.Name)
+            and input_call.func.id == "RunHostedJobInput"
+        ), "run_hosted_sdk_job's 2nd arg must build RunHostedJobInput"
+
+        run_seconds_kw = next(
+            kw for kw in input_call.keywords if kw.arg == "run_seconds"
+        )
+        expected_run_seconds = expr_dump("job.run_seconds")
+        assert normalized_dump(run_seconds_kw.value) == expected_run_seconds, (
+            "run_seconds must be job.run_seconds verbatim"
+        )
+
+        heartbeat_kw = next(kw for kw in call.keywords if kw.arg == "heartbeat_timeout")
+        expected_heartbeat = expr_dump("timedelta(seconds=60)")
+        assert normalized_dump(heartbeat_kw.value) == expected_heartbeat, (
+            "heartbeat_timeout must be exactly timedelta(seconds=60)"
+        )
 
     def test_child_environment_maps_internal_sink_secret(self, monkeypatch):
         from simulate.temporal.activities.hosted_runner import _child_environment
@@ -1555,6 +3015,121 @@ class TestHostedRunnerActivityHelpers:
         child_env = _child_environment(job)
 
         assert child_env["FI_INTERNAL_SUBMIT_SECRET"] == "shared-service-secret"
+
+    def test_child_environment_denies_customer_provider_api_keys(self, monkeypatch):
+        # Exact-key, not prefix: a chat job
+        # declares no secret_env ref at all, so the ref-scoped scrub never
+        # touches RETELL_API_KEY/VAPI_API_KEY — the exact-key deny in
+        # _child_environment is what keeps them out of a job shape that has
+        # no business seeing either provider's key.
+        from simulate.temporal.activities.hosted_runner import _child_environment
+
+        monkeypatch.setenv("RETELL_API_KEY", "platform-retell")
+        monkeypatch.setenv("VAPI_API_KEY", "platform-vapi")
+
+        job = {
+            "spec": {"target": {"secret_refs": {}}},
+            "sink": {"api_url": "http://localhost:8000"},
+        }
+        child_env = _child_environment(job)
+
+        assert "RETELL_API_KEY" not in child_env
+        assert "VAPI_API_KEY" not in child_env
+
+    def test_child_environment_keeps_non_secret_provider_config(self, monkeypatch):
+        # The deny is by exact key, not by RETELL_/VAPI_ prefix, so
+        # non-secret config the SDK child reads straight from env — base
+        # URLs, phone number ids, assistant ids — must still reach it.
+        from simulate.temporal.activities.hosted_runner import _child_environment
+
+        monkeypatch.setenv("VAPI_PHONE_NUMBER_ID", "+15551234567")
+        monkeypatch.setenv("RETELL_API_BASE_URL", "https://api.retellai.com")
+
+        job = {
+            "spec": {"target": {"secret_refs": {}}},
+            "sink": {"api_url": "http://localhost:8000"},
+        }
+        child_env = _child_environment(job)
+
+        assert child_env["VAPI_PHONE_NUMBER_ID"] == "+15551234567"
+        assert child_env["RETELL_API_BASE_URL"] == "https://api.retellai.com"
+
+    def test_child_environment_still_inherits_livekit_system_key(self, monkeypatch):
+        # Complement to the exact-key deny above: LiveKit's api_key_env is
+        # None in _PROVIDER_PROFILES, so LIVEKIT_API_KEY never joins
+        # _customer_provider_env_keys() — it is the platform's own runtime
+        # var by design (C5) and must stay inherited when no ref scrubs it.
+        from simulate.temporal.activities.hosted_runner import _child_environment
+
+        monkeypatch.setenv("LIVEKIT_API_KEY", "system-lk-key")
+
+        job = {
+            "spec": {"target": {"secret_refs": {}}},
+            "sink": {"api_url": "http://localhost:8000"},
+        }
+        child_env = _child_environment(job)
+
+        assert child_env["LIVEKIT_API_KEY"] == "system-lk-key"
+
+    def test_child_environment_pops_stale_inbound_did_without_lease(self, monkeypatch):
+        # _child_environment only ever SETS LIVEKIT_INBOUND_DID when a DID
+        # was leased; an inherited value from the worker process must not
+        # leak into a job with no lease (defense-in-depth: the C5 guard
+        # blocks every originator job without an injected DID before spawn,
+        # but a non-originator sip_inbound job reaches the child regardless).
+        from simulate.temporal.activities.hosted_runner import _child_environment
+
+        monkeypatch.setenv("LIVEKIT_INBOUND_DID", "STALE")
+
+        job_without_lease = {
+            "spec": {"target": {"secret_refs": {}}},
+            "sink": {"api_url": "http://localhost:8000"},
+            "metadata": {},
+        }
+        assert "LIVEKIT_INBOUND_DID" not in _child_environment(job_without_lease)
+
+        job_with_lease = {
+            "spec": {"target": {"secret_refs": {}}},
+            "sink": {"api_url": "http://localhost:8000"},
+            "metadata": {"leased_did": "+15557654321"},
+        }
+        child_env = _child_environment(job_with_lease)
+        assert child_env["LIVEKIT_INBOUND_DID"] == "+15557654321"
+
+    def test_child_environment_denies_new_provider_key_via_profile_table(
+        self, monkeypatch
+    ):
+        # Pin: a new provider profile with an api_key_env must join
+        # the inheritance deny automatically, with no hand-maintained edit to
+        # this module — the same guarantee _customer_provider_env_keys()
+        # already gives the hoisted raise in _resolve_voice_secret_env.
+        from simulate.services.hosted_runner import _PROVIDER_PROFILES
+        from simulate.temporal.activities.hosted_runner import (
+            _child_environment,
+            _customer_provider_env_keys,
+        )
+
+        monkeypatch.setenv("ZZZ_API_KEY", "platform-zzz")
+        _PROVIDER_PROFILES["zzz_synthetic"] = {
+            "web_transport_kind": "zzz_websocket",
+            "target_id_field": "assistant_id",
+            "api_key_env": "ZZZ_API_KEY",
+            "emits_web_evidence": True,
+            "sip_inbound_originator": None,
+            "sip_inbound_originator_fields": (),
+        }
+        _customer_provider_env_keys.cache_clear()
+        try:
+            job = {
+                "spec": {"target": {"secret_refs": {}}},
+                "sink": {"api_url": "http://localhost:8000"},
+            }
+            child_env = _child_environment(job)
+
+            assert "ZZZ_API_KEY" not in child_env
+        finally:
+            del _PROVIDER_PROFILES["zzz_synthetic"]
+            _customer_provider_env_keys.cache_clear()
 
     def test_waiting_for_child_slot_heartbeats(self, monkeypatch):
         import asyncio
@@ -1581,6 +3156,7 @@ class TestHostedRunnerActivityHelpers:
         import asyncio
 
         from simulate.temporal.activities import hosted_runner as hr
+        from simulate.temporal.constants import HOSTED_RUNNER_PARENT_SLACK_SECONDS
 
         calls = []
 
@@ -1603,7 +3179,7 @@ class TestHostedRunnerActivityHelpers:
         monkeypatch.setenv("ALK_RUNNER_PYTHON", "/venv/bin/python")
         monkeypatch.setattr(hr.asyncio, "create_subprocess_exec", fake_exec)
 
-        slot = asyncio.run(hr._acquire_did_slot("job-123"))
+        slot = asyncio.run(hr._acquire_did_slot("job-123", 1200))
 
         assert calls == [
             (
@@ -1612,10 +3188,351 @@ class TestHostedRunnerActivityHelpers:
                 "acquire",
                 "--run-id",
                 "job-123",
+                "--ttl",
+                str(1200 + HOSTED_RUNNER_PARENT_SLACK_SECONDS),
             )
         ]
         assert slot["slot_id"] == "07"
         assert slot["did"] == "+15557654321"
+        assert slot["run_id"] == "job-123"
+
+    def test_acquire_did_slot_ttl_tracks_run_seconds(self, monkeypatch):
+        # D15: the lease TTL follows the job's own run_seconds, not a shared
+        # parent cap — check a second value past the one above.
+        import asyncio
+
+        from simulate.temporal.activities import hosted_runner as hr
+        from simulate.temporal.constants import HOSTED_RUNNER_PARENT_SLACK_SECONDS
+
+        calls = []
+
+        class LeaseProc:
+            returncode = 0
+
+            async def communicate(self):
+                return b'{\n  "slot": "01"\n}\n', b""
+
+        async def fake_exec(*args, **kwargs):
+            calls.append(args)
+            return LeaseProc()
+
+        monkeypatch.setenv("ALK_SIM_SLOT_LEASE_SCRIPT", "/infra/lease_sim_slot.py")
+        monkeypatch.setenv("ALK_RUNNER_PYTHON", "/venv/bin/python")
+        monkeypatch.setattr(hr.asyncio, "create_subprocess_exec", fake_exec)
+
+        asyncio.run(hr._acquire_did_slot("job-456", 42030))
+
+        assert calls[0][-1] == str(42030 + HOSTED_RUNNER_PARENT_SLACK_SECONDS)
+
+    def test_release_did_slot_argv_carries_run_id_when_present(self, monkeypatch):
+        import asyncio
+
+        from simulate.temporal.activities import hosted_runner as hr
+
+        calls = []
+
+        class ReleaseProc:
+            returncode = 0
+
+            async def communicate(self):
+                return (b'{"status": "ok"}', b"")
+
+        async def fake_exec(*args, **kwargs):
+            calls.append(args)
+            return ReleaseProc()
+
+        monkeypatch.setenv("ALK_SIM_SLOT_LEASE_SCRIPT", "/infra/lease_sim_slot.py")
+        monkeypatch.setenv("ALK_RUNNER_PYTHON", "/venv/bin/python")
+        monkeypatch.setattr(hr.asyncio, "create_subprocess_exec", fake_exec)
+
+        asyncio.run(hr._release_did_slot({"slot_id": "07", "run_id": "job-123"}))
+        assert calls == [
+            (
+                "/venv/bin/python",
+                "/infra/lease_sim_slot.py",
+                "release",
+                "--slot",
+                "07",
+                "--run-id",
+                "job-123",
+            )
+        ]
+
+        calls.clear()
+        asyncio.run(hr._release_did_slot({"slot_id": "07"}))
+        assert calls == [
+            (
+                "/venv/bin/python",
+                "/infra/lease_sim_slot.py",
+                "release",
+                "--slot",
+                "07",
+            )
+        ]
+
+    def test_release_did_slot_logs_warning_on_non_owner_error(self, monkeypatch):
+        import asyncio
+
+        from simulate.temporal.activities import hosted_runner as hr
+
+        warnings = []
+
+        class ReleaseProc:
+            returncode = 1
+
+            async def communicate(self):
+                return (b'{"status": "error", "code": "not_owner"}', b"")
+
+        async def fake_exec(*args, **kwargs):
+            return ReleaseProc()
+
+        monkeypatch.setenv("ALK_SIM_SLOT_LEASE_SCRIPT", "/infra/lease_sim_slot.py")
+        monkeypatch.setenv("ALK_RUNNER_PYTHON", "/venv/bin/python")
+        monkeypatch.setattr(hr.asyncio, "create_subprocess_exec", fake_exec)
+        monkeypatch.setattr(hr.activity.logger, "warning", warnings.append)
+
+        asyncio.run(hr._release_did_slot({"slot_id": "07", "run_id": "job-123"}))
+
+        assert any("not_owner" in message for message in warnings)
+
+
+class TestSimulationRunnerWorkflowReplay:
+    # The AST tests above cannot see a command-sequence change reached
+    # through indirection (e.g. a raise hoisted into a helper the walk
+    # never visits): they read run()'s statement list, not its behavior.
+    # A real replay against a recorded history is the only check that
+    # would catch a hidden branch or an extra activity call regardless of
+    # how it got there, so it is the guard of last resort on this
+    # invariant, not a duplicate of the AST tests.
+
+    @staticmethod
+    def _payload(obj):
+        import base64
+
+        return {
+            "metadata": {"encoding": base64.b64encode(b"json/plain").decode()},
+            "data": base64.b64encode(json.dumps(obj).encode()).decode(),
+        }
+
+    @classmethod
+    def _payloads(cls, *objs):
+        return {"payloads": [cls._payload(o) for o in objs]}
+
+    @classmethod
+    def _build_history(cls, *, include_run_seconds):
+        """A hand-built history: build_runner_job completes, then
+        run_hosted_sdk_job is already scheduled/started/completed --
+        matching what an older worker's history looks like whether or not
+        the build result carried a run_seconds field."""
+        task_queue = {"name": "simulation_runner", "kind": "TASK_QUEUE_KIND_NORMAL"}
+        events = []
+
+        def add(event_type, key, attrs):
+            n = len(events) + 1
+            events.append(
+                {
+                    "eventId": str(n),
+                    "eventTime": "2026-09-04T00:00:00Z",
+                    "eventType": event_type,
+                    "taskId": "1",
+                    key: attrs,
+                }
+            )
+            return n
+
+        started_input = {
+            "test_execution_id": "te-1",
+            "run_test_id": "rt-1",
+            "org_id": "org-1",
+            "scenario_ids": ["s-1"],
+            "mode": "voice_sip",
+            "simulator_id": None,
+            "call_execution_ids": [],
+        }
+        add(
+            "EVENT_TYPE_WORKFLOW_EXECUTION_STARTED",
+            "workflowExecutionStartedEventAttributes",
+            {
+                "workflowType": {"name": "SimulationRunnerWorkflow"},
+                "taskQueue": task_queue,
+                "input": cls._payloads(started_input),
+                "workflowTaskTimeout": "10s",
+                "originalExecutionRunId": "run-1",
+                "firstExecutionRunId": "run-1",
+                "attempt": 1,
+            },
+        )
+
+        def wft():
+            s = add(
+                "EVENT_TYPE_WORKFLOW_TASK_SCHEDULED",
+                "workflowTaskScheduledEventAttributes",
+                {
+                    "taskQueue": task_queue,
+                    "startToCloseTimeout": "10s",
+                    "attempt": 1,
+                },
+            )
+            st = add(
+                "EVENT_TYPE_WORKFLOW_TASK_STARTED",
+                "workflowTaskStartedEventAttributes",
+                {
+                    "scheduledEventId": str(s),
+                    "identity": "old-worker",
+                    "requestId": "r",
+                },
+            )
+            return s, st
+
+        def wft_complete(s, st):
+            add(
+                "EVENT_TYPE_WORKFLOW_TASK_COMPLETED",
+                "workflowTaskCompletedEventAttributes",
+                {
+                    "scheduledEventId": str(s),
+                    "startedEventId": str(st),
+                    "identity": "old-worker",
+                },
+            )
+
+        s, st = wft()
+        wft_complete(s, st)
+
+        build_scheduled = add(
+            "EVENT_TYPE_ACTIVITY_TASK_SCHEDULED",
+            "activityTaskScheduledEventAttributes",
+            {
+                "activityId": "1",
+                "activityType": {"name": "build_runner_job"},
+                "taskQueue": task_queue,
+                "input": cls._payloads({}),
+                "scheduleToCloseTimeout": "0s",
+                "scheduleToStartTimeout": "0s",
+                "startToCloseTimeout": "120s",
+                "heartbeatTimeout": "0s",
+                "workflowTaskCompletedEventId": "4",
+            },
+        )
+        build_started = add(
+            "EVENT_TYPE_ACTIVITY_TASK_STARTED",
+            "activityTaskStartedEventAttributes",
+            {
+                "scheduledEventId": str(build_scheduled),
+                "identity": "old-worker",
+                "requestId": "r",
+                "attempt": 1,
+            },
+        )
+        # The two histories under test differ only in whether the recorded
+        # build payload carries run_seconds.
+        build_out = {
+            "job_id": "j1",
+            "job_json": "{}",
+            "mode": "voice_sip",
+            "run_id": "r1",
+        }
+        if include_run_seconds:
+            build_out["run_seconds"] = 2130
+        add(
+            "EVENT_TYPE_ACTIVITY_TASK_COMPLETED",
+            "activityTaskCompletedEventAttributes",
+            {
+                "scheduledEventId": str(build_scheduled),
+                "startedEventId": str(build_started),
+                "identity": "old-worker",
+                "result": cls._payloads(build_out),
+            },
+        )
+
+        s, st = wft()
+        wft_complete(s, st)
+
+        sdk_timeout = "2730s" if include_run_seconds else "3900s"
+        sdk_scheduled = add(
+            "EVENT_TYPE_ACTIVITY_TASK_SCHEDULED",
+            "activityTaskScheduledEventAttributes",
+            {
+                "activityId": "2",
+                "activityType": {"name": "run_hosted_sdk_job"},
+                "taskQueue": task_queue,
+                "input": cls._payloads({}),
+                "scheduleToCloseTimeout": "0s",
+                "scheduleToStartTimeout": "0s",
+                "startToCloseTimeout": sdk_timeout,
+                "heartbeatTimeout": "60s",
+                "workflowTaskCompletedEventId": str(st + 1),
+            },
+        )
+        sdk_started = add(
+            "EVENT_TYPE_ACTIVITY_TASK_STARTED",
+            "activityTaskStartedEventAttributes",
+            {
+                "scheduledEventId": str(sdk_scheduled),
+                "identity": "old-worker",
+                "requestId": "r",
+                "attempt": 1,
+            },
+        )
+        add(
+            "EVENT_TYPE_ACTIVITY_TASK_COMPLETED",
+            "activityTaskCompletedEventAttributes",
+            {
+                "scheduledEventId": str(sdk_scheduled),
+                "startedEventId": str(sdk_started),
+                "identity": "old-worker",
+                "result": cls._payloads(
+                    {
+                        "phase": "completed",
+                        "return_code": 0,
+                        "report_hash": "h",
+                        "submission_status": "submitted",
+                        "detail": None,
+                    }
+                ),
+            },
+        )
+        wft()
+        return {"events": events}
+
+    @classmethod
+    def _replay(cls, *, include_run_seconds):
+        import asyncio
+
+        from temporalio.client import WorkflowHistory
+        from temporalio.worker import Replayer, UnsandboxedWorkflowRunner
+
+        from simulate.temporal.workflows.simulation_runner_workflow import (
+            SimulationRunnerWorkflow,
+        )
+
+        history = cls._build_history(include_run_seconds=include_run_seconds)
+        replayer = Replayer(
+            workflows=[SimulationRunnerWorkflow],
+            workflow_runner=UnsandboxedWorkflowRunner(),
+        )
+
+        async def _run():
+            return await replayer.replay_workflow(
+                WorkflowHistory.from_json("wf-1", json.dumps(history)),
+                raise_on_replay_failure=False,
+            )
+
+        return asyncio.run(_run())
+
+    def test_replay_pre_run_seconds_history_stays_deterministic(self):
+        # A worker running the previous release recorded histories
+        # with a four-field BuildRunnerJobOutput (no run_seconds) and
+        # run_hosted_sdk_job already scheduled next; today's workflow must
+        # still emit that exact same command against such a history.
+        result = self._replay(include_run_seconds=False)
+        assert result.replay_failure is None, result.replay_failure
+
+    def test_replay_current_history_stays_deterministic(self):
+        # Same shape, recorded by the current code: a five-field build
+        # result with a positive run_seconds. Confirms the new field
+        # itself introduces no divergence from what was already scheduled.
+        result = self._replay(include_run_seconds=True)
+        assert result.replay_failure is None, result.replay_failure
 
 
 class _FakeStdout:
@@ -1649,8 +3566,24 @@ class TestRunHostedSdkJob:
     """Runtime-exercise the restructured run_hosted_sdk_job (try/finally + DID
     lease + secret env), spawning a fake child instead of the real SDK."""
 
+    @pytest.fixture(autouse=True)
+    def _skip_db_connection_hygiene(self, monkeypatch):
+        """These tests stub the ORM lookups; the resolver's Django
+        connection-hygiene call must not open a real DB connection."""
+        from simulate.temporal.activities import hosted_runner as hr
+
+        monkeypatch.setattr(hr, "close_old_connections", lambda: None)
+
     def _run(
-        self, monkeypatch, *, mode, job, status_lines, acquire=None, released=None
+        self,
+        monkeypatch,
+        *,
+        mode,
+        job,
+        status_lines,
+        acquire=None,
+        released=None,
+        run_seconds=900,
     ):
         import asyncio
 
@@ -1669,9 +3602,67 @@ class TestRunHostedSdkJob:
             monkeypatch.setattr(hr, "_release_did_slot", released)
 
         inp = RunHostedJobInput(
-            job_id="job-x", run_id="run-x", mode=mode, job_json=json.dumps(job)
+            job_id="job-x",
+            run_id="run-x",
+            mode=mode,
+            job_json=json.dumps(job),
+            run_seconds=run_seconds,
         )
         return asyncio.run(hr.run_hosted_sdk_job(inp))
+
+    # Both voice modes share the same non-chat guard condition (`mode !=
+    # HOSTED_RUNNER_CHAT_MODE`), so the refusal is pinned for each of them
+    # rather than only the one mode that happened to be exercised first.
+    @pytest.mark.parametrize("mode", ["voice_sip", "voice_webrtc"])
+    @pytest.mark.parametrize("run_seconds", [None, 0, -5])
+    def test_missing_run_seconds_raises_before_slot_or_lease(
+        self, monkeypatch, run_seconds, mode
+    ):
+        # The workflow no longer guards this — only this activity does,
+        # since it never replays. Refuse loudly before the child slot
+        # semaphore, any DID lease, or the child is ever touched.
+        import asyncio
+
+        from temporalio.exceptions import ApplicationError
+
+        from simulate.temporal.activities import hosted_runner as hr
+        from simulate.temporal.types.hosted_runner import RunHostedJobInput
+
+        slot_calls = []
+        exec_calls = []
+        lease_calls = []
+
+        async def _acquire_slot():
+            slot_calls.append(True)
+
+        async def _fake_exec(*args, **kwargs):
+            exec_calls.append(args)
+            return _FakeProc([])
+
+        async def _acquire_did(job_id, run_seconds):
+            lease_calls.append(job_id)
+            return None
+
+        monkeypatch.setattr(hr, "_acquire_child_slot", _acquire_slot)
+        monkeypatch.setattr(hr.asyncio, "create_subprocess_exec", _fake_exec)
+        monkeypatch.setattr(hr.activity, "heartbeat", lambda *a, **k: None)
+        monkeypatch.setattr(hr, "_acquire_did_slot", _acquire_did)
+
+        inp = RunHostedJobInput(
+            job_id="job-x",
+            run_id="run-x",
+            mode=mode,
+            job_json=json.dumps({"mode": mode}),
+            run_seconds=run_seconds,
+        )
+
+        with pytest.raises(ApplicationError) as excinfo:
+            asyncio.run(hr.run_hosted_sdk_job(inp))
+        assert excinfo.value.type == "hosted_run_budget_missing"
+        assert excinfo.value.non_retryable
+        assert slot_calls == []
+        assert exec_calls == []
+        assert lease_calls == []
 
     def test_chat_job_runs_and_completes(self, monkeypatch):
         job = {
@@ -1690,13 +3681,37 @@ class TestRunHostedSdkJob:
         assert out.return_code == 0
         assert out.submission_status == "submitted"
 
+    def test_chat_mode_with_run_seconds_none_proceeds_to_spawn(self, monkeypatch):
+        # Chat never derives a budget from run_seconds, so a replayed
+        # pre-field payload (run_seconds=None) must not be blocked by the
+        # voice-only guard above.
+        job = {
+            "mode": "chat",
+            "spec": {"run_id": "run-x", "target": {"secret_refs": {}}},
+            "sink": {"api_url": "http://localhost:8000"},
+            "metadata": {"run_id": "run-x"},
+        }
+        lines = [
+            '{"phase": "completed", "job_id": "job-x", '
+            '"submission_status": "submitted"}'
+        ]
+        out = self._run(
+            monkeypatch,
+            mode="chat",
+            job=job,
+            status_lines=lines,
+            run_seconds=None,
+        )
+        assert out.phase == "completed"
+
     def test_voice_sip_leases_injects_and_releases(self, monkeypatch):
         released_slots = []
 
-        async def _acquire(job_id):
+        async def _acquire(job_id, run_seconds):
             return {
                 "did": "+15557654321",
                 "dispatch_rule_name": "rule-9",
+                "room_name": "sim-slot-01",
                 "slot_id": "s9",
             }
 
@@ -1728,7 +3743,9 @@ class TestRunHostedSdkJob:
         assert released_slots == ["s9"]
 
     def test_web_voice_never_leases(self, monkeypatch):
-        async def _acquire(job_id):  # pragma: no cover - must not be called
+        async def _acquire(  # pragma: no cover - must not be called
+            job_id, run_seconds
+        ):
             raise AssertionError("web voice must not lease a DID")
 
         job = {
@@ -1751,6 +3768,874 @@ class TestRunHostedSdkJob:
             acquire=_acquire,
         )
         assert out.phase == "completed"
+
+    def _originator_sip_job(self, originator):
+        return {
+            "mode": "voice_sip",
+            "voice": {
+                "agent_definition": {
+                    "transport": {
+                        "kind": "sip_inbound",
+                        "inbound_call_originator": originator,
+                    }
+                },
+                "params": {},
+            },
+            "sink": {"api_url": "http://localhost:8000"},
+            "metadata": {"run_id": "run-x", "secret_env": []},
+        }
+
+    @pytest.mark.parametrize("originator", ["retell", "vapi"])
+    @pytest.mark.parametrize(
+        "slot",
+        [
+            {"slot_id": "s1", "dispatch_rule_name": "r1"},
+            # A whitespace-only DID must be treated as absent, not as
+            # a real leased number — both _inject_did_slot and the guard's
+            # own .strip() must agree it never reaches metadata.leased_did.
+            {"slot_id": "s1", "dispatch_rule_name": "r1", "did": " "},
+        ],
+        ids=["no_did_key", "whitespace_only_did"],
+    )
+    def test_guard_blocks_originator_job_when_lease_has_no_did(
+        self, monkeypatch, originator, slot, tmp_path
+    ):
+        import asyncio
+
+        from temporalio.exceptions import ApplicationError
+
+        from simulate.temporal.activities import hosted_runner as hr
+        from simulate.temporal.types.hosted_runner import RunHostedJobInput
+
+        exec_calls = []
+        released = []
+
+        async def _fake_exec(*args, **kwargs):
+            exec_calls.append(args)
+            return _FakeProc([])
+
+        async def _acquire(job_id, run_seconds):
+            return slot
+
+        async def _release(slot):
+            released.append(slot)
+
+        # Pin the scratch dir so we can assert it is cleaned up when
+        # the guard raises before any child is ever spawned.
+        scratch_dir = tmp_path / "alk-runner-scratch"
+        scratch_dir.mkdir()
+        # Also pin _runs_base() into tmp_path so the run_root assertion below
+        # exercises the real path, not the host's system temp dir.
+        runs_base = tmp_path / "alk-runner-runs"
+        monkeypatch.setenv("ALK_RUNNER_RUN_ROOT", str(runs_base))
+
+        monkeypatch.setattr(hr.asyncio, "create_subprocess_exec", _fake_exec)
+        monkeypatch.setattr(hr.activity, "heartbeat", lambda *a, **k: None)
+        monkeypatch.setattr(hr, "_acquire_did_slot", _acquire)
+        monkeypatch.setattr(hr, "_release_did_slot", _release)
+        monkeypatch.setattr(hr.tempfile, "mkdtemp", lambda *a, **k: str(scratch_dir))
+
+        inp = RunHostedJobInput(
+            job_id="job-x",
+            run_id="run-x",
+            mode="voice_sip",
+            job_json=json.dumps(self._originator_sip_job(originator)),
+            run_seconds=900,
+        )
+
+        with pytest.raises(ApplicationError) as excinfo:
+            asyncio.run(hr.run_hosted_sdk_job(inp))
+        assert excinfo.value.non_retryable
+        assert excinfo.value.type == "inbound_originator_requires_leased_did"
+        assert exec_calls == []
+        # The leased slot must still be released even though the guard raised.
+        assert released == [slot]
+        # No child was ever started, so the scratch dir must not leak.
+        assert not scratch_dir.exists()
+        # Nor must the empty run_root the guard blocked before any child
+        # could write artifacts into it.
+        assert not (runs_base / "job-x").exists()
+
+    @pytest.mark.parametrize("originator", ["retell", "vapi"])
+    def test_guard_blocks_originator_job_when_lease_returns_none(
+        self, monkeypatch, originator
+    ):
+        import asyncio
+
+        from temporalio.exceptions import ApplicationError
+
+        from simulate.temporal.activities import hosted_runner as hr
+        from simulate.temporal.types.hosted_runner import RunHostedJobInput
+
+        exec_calls = []
+        release_calls = []
+
+        async def _fake_exec(*args, **kwargs):
+            exec_calls.append(args)
+            return _FakeProc([])
+
+        async def _acquire(job_id, run_seconds):
+            return None
+
+        async def _release(slot):  # pragma: no cover - must not be called
+            release_calls.append(slot)
+
+        monkeypatch.setattr(hr.asyncio, "create_subprocess_exec", _fake_exec)
+        monkeypatch.setattr(hr.activity, "heartbeat", lambda *a, **k: None)
+        monkeypatch.setattr(hr, "_acquire_did_slot", _acquire)
+        monkeypatch.setattr(hr, "_release_did_slot", _release)
+
+        inp = RunHostedJobInput(
+            job_id="job-x",
+            run_id="run-x",
+            mode="voice_sip",
+            job_json=json.dumps(self._originator_sip_job(originator)),
+            run_seconds=900,
+        )
+
+        with pytest.raises(ApplicationError):
+            asyncio.run(hr.run_hosted_sdk_job(inp))
+        assert exec_calls == []
+        assert release_calls == []
+
+    @pytest.mark.parametrize("originator", ["retell", "vapi"])
+    def test_guard_rejects_whitespace_leased_did_planted_directly(
+        self, monkeypatch, originator
+    ):
+        # Pin the guard's OWN .strip() independently of
+        # _inject_did_slot's — plant metadata.leased_did = " " directly
+        # (bypassing _inject_did_slot entirely: the lease returns no slot, so
+        # the injector never runs) and confirm the guard still treats
+        # whitespace-only as no DID rather than relying on the injector to
+        # have already cleaned it up.
+        import asyncio
+
+        from temporalio.exceptions import ApplicationError
+
+        from simulate.temporal.activities import hosted_runner as hr
+        from simulate.temporal.types.hosted_runner import RunHostedJobInput
+
+        exec_calls = []
+
+        async def _fake_exec(*args, **kwargs):
+            exec_calls.append(args)
+            return _FakeProc([])
+
+        async def _acquire(job_id, run_seconds):
+            return None
+
+        async def _release(slot):  # pragma: no cover - must not be called
+            pass
+
+        monkeypatch.setattr(hr.asyncio, "create_subprocess_exec", _fake_exec)
+        monkeypatch.setattr(hr.activity, "heartbeat", lambda *a, **k: None)
+        monkeypatch.setattr(hr, "_acquire_did_slot", _acquire)
+        monkeypatch.setattr(hr, "_release_did_slot", _release)
+
+        job = self._originator_sip_job(originator)
+        job["metadata"]["leased_did"] = " "
+
+        inp = RunHostedJobInput(
+            job_id="job-x",
+            run_id="run-x",
+            mode="voice_sip",
+            job_json=json.dumps(job),
+            run_seconds=900,
+        )
+
+        with pytest.raises(ApplicationError) as excinfo:
+            asyncio.run(hr.run_hosted_sdk_job(inp))
+        assert excinfo.value.non_retryable
+        assert excinfo.value.type == "inbound_originator_requires_leased_did"
+        assert exec_calls == []
+
+    @pytest.mark.parametrize("originator", ["retell", "vapi"])
+    def test_guard_blocks_originator_job_when_only_stale_params_inbound_did_set(
+        self, monkeypatch, originator
+    ):
+        # Regression guard: the guard predicate must read
+        # metadata.leased_did, not voice.params.inbound_did. A job that
+        # (incorrectly) carries only the stale params location and no
+        # metadata.leased_did must still be blocked.
+        import asyncio
+
+        from temporalio.exceptions import ApplicationError
+
+        from simulate.temporal.activities import hosted_runner as hr
+        from simulate.temporal.types.hosted_runner import RunHostedJobInput
+
+        exec_calls = []
+
+        async def _fake_exec(*args, **kwargs):
+            exec_calls.append(args)
+            return _FakeProc([])
+
+        async def _acquire(job_id, run_seconds):
+            return {"slot_id": "s1", "dispatch_rule_name": "r1"}  # no "did"
+
+        async def _release(slot):
+            pass
+
+        monkeypatch.setattr(hr.asyncio, "create_subprocess_exec", _fake_exec)
+        monkeypatch.setattr(hr.activity, "heartbeat", lambda *a, **k: None)
+        monkeypatch.setattr(hr, "_acquire_did_slot", _acquire)
+        monkeypatch.setattr(hr, "_release_did_slot", _release)
+
+        job = self._originator_sip_job(originator)
+        job["voice"]["params"]["inbound_did"] = "+15557654321"
+
+        inp = RunHostedJobInput(
+            job_id="job-x",
+            run_id="run-x",
+            mode="voice_sip",
+            job_json=json.dumps(job),
+            run_seconds=900,
+        )
+
+        with pytest.raises(ApplicationError) as excinfo:
+            asyncio.run(hr.run_hosted_sdk_job(inp))
+        assert excinfo.value.type == "inbound_originator_requires_leased_did"
+        assert exec_calls == []
+
+    def test_guard_blocks_originator_job_when_lease_has_rule_but_no_room(
+        self, monkeypatch
+    ):
+        # D11: a leased slot naming a routing rule but no room can never route
+        # a call to the simulator — refuse before spawning (mirrors
+        # test_guard_blocks_originator_job_when_lease_has_no_did).
+        import asyncio
+
+        from temporalio.exceptions import ApplicationError
+
+        from simulate.temporal.activities import hosted_runner as hr
+        from simulate.temporal.types.hosted_runner import RunHostedJobInput
+
+        exec_calls = []
+        released = []
+
+        async def _fake_exec(*args, **kwargs):
+            exec_calls.append(args)
+            return _FakeProc([])
+
+        async def _acquire(job_id, run_seconds):
+            return {
+                "did": "+15557654321",
+                "dispatch_rule_name": "rule-9",
+                "slot_id": "s9",
+            }
+
+        async def _release(slot):
+            released.append(slot["slot_id"])
+
+        monkeypatch.setattr(hr.asyncio, "create_subprocess_exec", _fake_exec)
+        monkeypatch.setattr(hr.activity, "heartbeat", lambda *a, **k: None)
+        monkeypatch.setattr(hr, "_acquire_did_slot", _acquire)
+        monkeypatch.setattr(hr, "_release_did_slot", _release)
+
+        inp = RunHostedJobInput(
+            job_id="job-x",
+            run_id="run-x",
+            mode="voice_sip",
+            job_json=json.dumps(self._originator_sip_job("retell")),
+            run_seconds=900,
+        )
+
+        with pytest.raises(ApplicationError) as excinfo:
+            asyncio.run(hr.run_hosted_sdk_job(inp))
+        assert excinfo.value.non_retryable
+        assert excinfo.value.type == "leased_slot_requires_room"
+        assert exec_calls == []
+        assert released == ["s9"]
+
+    def test_guard_room_message_falls_back_to_unknown_slot_id(self, monkeypatch):
+        # D11: a malformed lease is the very case this guard exists for, so
+        # slot_id/slot can both be missing too — the message must not render
+        # the literal "None" for the slot identity.
+        import asyncio
+
+        from temporalio.exceptions import ApplicationError
+
+        from simulate.temporal.activities import hosted_runner as hr
+        from simulate.temporal.types.hosted_runner import RunHostedJobInput
+
+        async def _fake_exec(*args, **kwargs):
+            return _FakeProc([])
+
+        async def _acquire(job_id, run_seconds):
+            return {"did": "+15557654321", "dispatch_rule_name": "rule-9"}
+
+        async def _release(slot):
+            pass
+
+        monkeypatch.setattr(hr.asyncio, "create_subprocess_exec", _fake_exec)
+        monkeypatch.setattr(hr.activity, "heartbeat", lambda *a, **k: None)
+        monkeypatch.setattr(hr, "_acquire_did_slot", _acquire)
+        monkeypatch.setattr(hr, "_release_did_slot", _release)
+
+        inp = RunHostedJobInput(
+            job_id="job-x",
+            run_id="run-x",
+            mode="voice_sip",
+            job_json=json.dumps(self._originator_sip_job("retell")),
+            run_seconds=900,
+        )
+
+        with pytest.raises(ApplicationError) as excinfo:
+            asyncio.run(hr.run_hosted_sdk_job(inp))
+        assert excinfo.value.type == "leased_slot_requires_room"
+        assert "<unknown>" in str(excinfo.value)
+        assert "None" not in str(excinfo.value)
+
+    def test_slot_with_did_and_no_routing_fields_spawns_normally(self, monkeypatch):
+        # A slot naming neither a rule nor a room is not a malformed lease —
+        # the kit self-provisions its own rule for it, exactly as today.
+        async def _acquire(job_id, run_seconds):
+            return {"did": "+15557654321", "slot_id": "s9"}
+
+        job = self._originator_sip_job("retell")
+        lines = [
+            '{"phase": "completed", "job_id": "job-x", "submission_status": "submitted"}'
+        ]
+        out = self._run(
+            monkeypatch,
+            mode="voice_sip",
+            job=job,
+            status_lines=lines,
+            acquire=_acquire,
+        )
+        assert out.phase == "completed"
+
+    def test_number_guard_fires_before_room_guard(self, monkeypatch):
+        # Guard order: a slot with a routing rule and no number is reported as
+        # the missing-number guard, not the missing-room guard.
+        import asyncio
+
+        from temporalio.exceptions import ApplicationError
+
+        from simulate.temporal.activities import hosted_runner as hr
+        from simulate.temporal.types.hosted_runner import RunHostedJobInput
+
+        exec_calls = []
+
+        async def _fake_exec(*args, **kwargs):
+            exec_calls.append(args)
+            return _FakeProc([])
+
+        async def _acquire(job_id, run_seconds):
+            return {"dispatch_rule_name": "rule-9", "slot_id": "s9"}
+
+        async def _release(slot):
+            pass
+
+        monkeypatch.setattr(hr.asyncio, "create_subprocess_exec", _fake_exec)
+        monkeypatch.setattr(hr.activity, "heartbeat", lambda *a, **k: None)
+        monkeypatch.setattr(hr, "_acquire_did_slot", _acquire)
+        monkeypatch.setattr(hr, "_release_did_slot", _release)
+
+        inp = RunHostedJobInput(
+            job_id="job-x",
+            run_id="run-x",
+            mode="voice_sip",
+            job_json=json.dumps(self._originator_sip_job("retell")),
+            run_seconds=900,
+        )
+
+        with pytest.raises(ApplicationError) as excinfo:
+            asyncio.run(hr.run_hosted_sdk_job(inp))
+        assert excinfo.value.type == "inbound_originator_requires_leased_did"
+        assert exec_calls == []
+
+    def test_sip_outbound_job_with_rule_only_slot_not_refused_by_d11(self, monkeypatch):
+        # A sip_outbound job also leases a slot today and must not trip the
+        # sip_inbound-only D11 guard.
+        async def _acquire(job_id, run_seconds):
+            return {
+                "did": "+15557654321",
+                "dispatch_rule_name": "rule-9",
+                "slot_id": "s9",
+            }
+
+        job = {
+            "mode": "voice_sip",
+            "voice": {
+                "agent_definition": {
+                    "transport": {"kind": "sip_outbound", "sip_call_to": "+1"}
+                },
+                "params": {},
+            },
+            "sink": {"api_url": "http://localhost:8000"},
+            "metadata": {"run_id": "run-x", "secret_env": []},
+        }
+        lines = [
+            '{"phase": "completed", "job_id": "job-x", "submission_status": "submitted"}'
+        ]
+        out = self._run(
+            monkeypatch,
+            mode="voice_sip",
+            job=job,
+            status_lines=lines,
+            acquire=_acquire,
+        )
+        assert out.phase == "completed"
+
+    def test_guard_leaves_chat_job_untouched(self, monkeypatch):
+        # A chat job has no "voice" key at all — the guard's safe .get() chain
+        # must not raise or block it.
+        job = {
+            "mode": "chat",
+            "spec": {"run_id": "run-x", "target": {"secret_refs": {}}},
+            "sink": {"api_url": "http://localhost:8000"},
+            "metadata": {"run_id": "run-x"},
+        }
+        lines = [
+            '{"phase": "completed", "job_id": "job-x", "submission_status": "submitted"}'
+        ]
+        out = self._run(monkeypatch, mode="chat", job=job, status_lines=lines)
+        assert out.phase == "completed"
+
+    def test_missing_provider_credential_blocks_child_and_releases_slot(
+        self, monkeypatch, tmp_path
+    ):
+        # A secret_env ref to a deleted/nonexistent ProviderCredentials row must
+        # never fall through to the worker's own env — it should fail loudly
+        # before the child ever dials on the platform's own key.
+        import asyncio
+
+        from temporalio.exceptions import ApplicationError
+
+        from simulate.models.agent_definition import ProviderCredentials
+        from simulate.temporal.activities import hosted_runner as hr
+        from simulate.temporal.types.hosted_runner import RunHostedJobInput
+
+        exec_calls = []
+        released = []
+
+        async def _fake_exec(*args, **kwargs):
+            exec_calls.append(args)
+            return _FakeProc([])
+
+        async def _acquire(job_id, run_seconds):
+            return {
+                "did": "+15557654321",
+                "dispatch_rule_name": "r1",
+                "room_name": "sim-slot-01",
+                "slot_id": "s1",
+            }
+
+        async def _release(slot):
+            released.append(slot["slot_id"])
+
+        def _raise_missing(*args, **kwargs):
+            raise ProviderCredentials.DoesNotExist
+
+        # Pin the scratch dir so we can assert it is cleaned up when
+        # credential resolution raises before any child is ever spawned.
+        scratch_dir = tmp_path / "alk-runner-scratch"
+        scratch_dir.mkdir()
+
+        monkeypatch.setattr(hr.asyncio, "create_subprocess_exec", _fake_exec)
+        monkeypatch.setattr(hr.activity, "heartbeat", lambda *a, **k: None)
+        monkeypatch.setattr(hr, "_acquire_did_slot", _acquire)
+        monkeypatch.setattr(hr, "_release_did_slot", _release)
+        monkeypatch.setattr(ProviderCredentials.objects, "get", _raise_missing)
+        monkeypatch.setattr(hr.tempfile, "mkdtemp", lambda *a, **k: str(scratch_dir))
+
+        job = {
+            "mode": "voice_sip",
+            "voice": {
+                "agent_definition": {
+                    "transport": {
+                        "kind": "sip_inbound",
+                        "inbound_call_originator": "retell",
+                    }
+                },
+                "params": {},
+            },
+            "sink": {"api_url": "http://localhost:8000"},
+            "metadata": {
+                "run_id": "run-x",
+                "secret_env": [
+                    {
+                        "key": "RETELL_API_KEY",
+                        "manager": "provider_credentials",
+                        "credential_id": "does-not-exist",
+                        "field": "api_key",
+                    }
+                ],
+            },
+        }
+        inp = RunHostedJobInput(
+            job_id="job-x",
+            run_id="run-x",
+            mode="voice_sip",
+            job_json=json.dumps(job),
+            run_seconds=900,
+        )
+
+        with pytest.raises(ApplicationError) as excinfo:
+            asyncio.run(hr.run_hosted_sdk_job(inp))
+        assert excinfo.value.type == "provider_credentials_missing"
+        assert excinfo.value.non_retryable
+        assert exec_calls == []
+        # The leased slot must still be released even though resolution raised.
+        assert released == ["s1"]
+        # No child was ever started, so the scratch dir must not leak.
+        assert not scratch_dir.exists()
+
+    def test_empty_provider_credential_field_blocks_child_and_releases_slot(
+        self, monkeypatch
+    ):
+        # An existing ProviderCredentials row whose resolved field
+        # decrypts to an empty string must fail exactly like a missing row —
+        # never let the child dial on an empty key.
+        import asyncio
+
+        from temporalio.exceptions import ApplicationError
+
+        from simulate.models.agent_definition import ProviderCredentials
+        from simulate.temporal.activities import hosted_runner as hr
+        from simulate.temporal.types.hosted_runner import RunHostedJobInput
+
+        exec_calls = []
+        released = []
+
+        async def _fake_exec(*args, **kwargs):
+            exec_calls.append(args)
+            return _FakeProc([])
+
+        async def _acquire(job_id, run_seconds):
+            return {
+                "did": "+15557654321",
+                "dispatch_rule_name": "r1",
+                "room_name": "sim-slot-01",
+                "slot_id": "s1",
+            }
+
+        async def _release(slot):
+            released.append(slot["slot_id"])
+
+        fake_credentials = SimpleNamespace(
+            get_api_key=lambda: "", get_api_secret=lambda: ""
+        )
+
+        monkeypatch.setattr(hr.asyncio, "create_subprocess_exec", _fake_exec)
+        monkeypatch.setattr(hr.activity, "heartbeat", lambda *a, **k: None)
+        monkeypatch.setattr(hr, "_acquire_did_slot", _acquire)
+        monkeypatch.setattr(hr, "_release_did_slot", _release)
+        monkeypatch.setattr(
+            ProviderCredentials.objects, "get", lambda *a, **k: fake_credentials
+        )
+
+        job = {
+            "mode": "voice_sip",
+            "voice": {
+                "agent_definition": {
+                    "transport": {
+                        "kind": "sip_inbound",
+                        "inbound_call_originator": "retell",
+                    }
+                },
+                "params": {},
+            },
+            "sink": {"api_url": "http://localhost:8000"},
+            "metadata": {
+                "run_id": "run-x",
+                "secret_env": [
+                    {
+                        "key": "RETELL_API_KEY",
+                        "manager": "provider_credentials",
+                        "credential_id": "cred-1",
+                        "field": "api_key",
+                    }
+                ],
+            },
+        }
+        inp = RunHostedJobInput(
+            job_id="job-x",
+            run_id="run-x",
+            mode="voice_sip",
+            job_json=json.dumps(job),
+            run_seconds=900,
+        )
+
+        with pytest.raises(ApplicationError) as excinfo:
+            asyncio.run(hr.run_hosted_sdk_job(inp))
+        assert excinfo.value.type == "provider_credentials_missing"
+        assert excinfo.value.non_retryable
+        assert exec_calls == []
+        assert released == ["s1"]
+
+    def test_livekit_webrtc_empty_api_secret_blocks_child(self, monkeypatch):
+        # Reachable for a backend-built job — a customer LiveKit
+        # ProviderCredentials row saved with an api_key but a blank
+        # api_secret (services/hosted_runner.py's _voice_livekit_runtime
+        # webrtc branch emits a provider_credentials ref for both fields).
+        # No DID lease is involved on the webrtc path.
+        import asyncio
+
+        from temporalio.exceptions import ApplicationError
+
+        from simulate.models.agent_definition import ProviderCredentials
+        from simulate.temporal.activities import hosted_runner as hr
+        from simulate.temporal.types.hosted_runner import RunHostedJobInput
+
+        exec_calls = []
+
+        async def _fake_exec(*args, **kwargs):
+            exec_calls.append(args)
+            return _FakeProc([])
+
+        fake_credentials = SimpleNamespace(
+            get_api_key=lambda: "customer-lk-key", get_api_secret=lambda: ""
+        )
+
+        monkeypatch.setattr(hr.asyncio, "create_subprocess_exec", _fake_exec)
+        monkeypatch.setattr(hr.activity, "heartbeat", lambda *a, **k: None)
+        monkeypatch.setattr(
+            ProviderCredentials.objects, "get", lambda *a, **k: fake_credentials
+        )
+
+        job = {
+            "mode": "voice_webrtc",
+            "voice": {
+                "agent_definition": {"transport": {"kind": "webrtc"}},
+                "params": {},
+            },
+            "sink": {"api_url": "http://localhost:8000"},
+            "metadata": {
+                "run_id": "run-x",
+                "secret_env": [
+                    {
+                        "key": "LIVEKIT_API_KEY",
+                        "manager": "provider_credentials",
+                        "credential_id": "cred-2",
+                        "field": "api_key",
+                    },
+                    {
+                        "key": "LIVEKIT_API_SECRET",
+                        "manager": "provider_credentials",
+                        "credential_id": "cred-2",
+                        "field": "api_secret",
+                    },
+                ],
+            },
+        }
+        inp = RunHostedJobInput(
+            job_id="job-x",
+            run_id="run-x",
+            mode="voice_webrtc",
+            job_json=json.dumps(job),
+            run_seconds=900,
+        )
+
+        with pytest.raises(ApplicationError) as excinfo:
+            asyncio.run(hr.run_hosted_sdk_job(inp))
+        assert excinfo.value.type == "provider_credentials_missing"
+        assert exec_calls == []
+
+    def test_env_passthrough_customer_key_blocks_child_even_when_worker_has_value(
+        self, monkeypatch
+    ):
+        # A manager:"env" ref for a CUSTOMER provider key must never
+        # let the child dial on the worker's own key — even when the worker
+        # process happens to have that exact env var set (e.g. for the
+        # platform's own, unrelated use). The ref itself is the bug signal,
+        # not just an unresolved lookup.
+        import asyncio
+
+        from temporalio.exceptions import ApplicationError
+
+        from simulate.temporal.activities import hosted_runner as hr
+        from simulate.temporal.types.hosted_runner import RunHostedJobInput
+
+        monkeypatch.setenv("RETELL_API_KEY", "platform-key")
+
+        exec_calls = []
+
+        async def _fake_exec(*args, **kwargs):
+            exec_calls.append(args)
+            return _FakeProc([])
+
+        async def _acquire(job_id, run_seconds):
+            return {
+                "did": "+15557654321",
+                "dispatch_rule_name": "r1",
+                "room_name": "sim-slot-01",
+                "slot_id": "s1",
+            }
+
+        async def _release(slot):
+            pass
+
+        monkeypatch.setattr(hr.asyncio, "create_subprocess_exec", _fake_exec)
+        monkeypatch.setattr(hr.activity, "heartbeat", lambda *a, **k: None)
+        monkeypatch.setattr(hr, "_acquire_did_slot", _acquire)
+        monkeypatch.setattr(hr, "_release_did_slot", _release)
+
+        job = self._originator_sip_job("retell")
+        job["metadata"]["secret_env"] = [
+            {"key": "RETELL_API_KEY", "manager": "env", "source": "RETELL_API_KEY"},
+        ]
+
+        inp = RunHostedJobInput(
+            job_id="job-x",
+            run_id="run-x",
+            mode="voice_sip",
+            job_json=json.dumps(job),
+            run_seconds=900,
+        )
+
+        with pytest.raises(ApplicationError) as excinfo:
+            asyncio.run(hr.run_hosted_sdk_job(inp))
+        assert excinfo.value.type == "provider_credentials_missing"
+        assert excinfo.value.non_retryable
+        assert exec_calls == []
+
+    def test_env_passthrough_system_livekit_key_still_reaches_child(self, monkeypatch):
+        # Positive case: a system LiveKit runtime var
+        # (platform-owned by design, see _voice_livekit_runtime) must still
+        # reach the child via env passthrough.
+        import asyncio
+
+        from simulate.temporal.activities import hosted_runner as hr
+        from simulate.temporal.types.hosted_runner import RunHostedJobInput
+
+        monkeypatch.setenv("LIVEKIT_API_KEY", "system-lk-key")
+
+        seen_env = {}
+
+        async def _fake_exec(*args, **kwargs):
+            seen_env.update(kwargs.get("env") or {})
+            return _FakeProc(
+                [
+                    b'{"phase": "completed", "job_id": "job-x", '
+                    b'"submission_status": "submitted"}'
+                ]
+            )
+
+        monkeypatch.setattr(hr.asyncio, "create_subprocess_exec", _fake_exec)
+        monkeypatch.setattr(hr.activity, "heartbeat", lambda *a, **k: None)
+
+        job = {
+            "mode": "voice_webrtc",
+            "voice": {
+                "agent_definition": {"transport": {"kind": "webrtc"}},
+                "params": {},
+            },
+            "sink": {"api_url": "http://localhost:8000"},
+            "metadata": {
+                "run_id": "run-x",
+                "secret_env": [
+                    {
+                        "key": "LIVEKIT_API_KEY",
+                        "manager": "env",
+                        "source": "LIVEKIT_API_KEY",
+                    },
+                ],
+            },
+        }
+        inp = RunHostedJobInput(
+            job_id="job-x",
+            run_id="run-x",
+            mode="voice_webrtc",
+            job_json=json.dumps(job),
+            run_seconds=900,
+        )
+        out = asyncio.run(hr.run_hosted_sdk_job(inp))
+        assert out.phase == "completed"
+        assert seen_env["LIVEKIT_API_KEY"] == "system-lk-key"
+
+    def test_declared_ref_that_resolves_to_nothing_is_scrubbed_not_inherited(
+        self, monkeypatch
+    ):
+        # A declared secret_env ref that resolves to
+        # nothing (here, a falsy credential_id -> _resolve_provider_credential
+        # returns None) must not fall back to whatever the worker process
+        # happens to have under that name. Only the ref-scoped scrub in
+        # _child_environment (_secret_env_ref_keys pop) protects this —
+        # deleting that pop lets the platform's own LIVEKIT_API_KEY leak
+        # through, since the overlay from _resolve_voice_secret_env adds
+        # nothing back for an unresolved ref.
+        import asyncio
+
+        from simulate.temporal.activities import hosted_runner as hr
+        from simulate.temporal.types.hosted_runner import RunHostedJobInput
+
+        monkeypatch.setenv("LIVEKIT_API_KEY", "platform-lk")
+
+        seen_env = {}
+
+        async def _fake_exec(*args, **kwargs):
+            seen_env.update(kwargs.get("env") or {})
+            return _FakeProc(
+                [
+                    b'{"phase": "completed", "job_id": "job-x", '
+                    b'"submission_status": "submitted"}'
+                ]
+            )
+
+        monkeypatch.setattr(hr.asyncio, "create_subprocess_exec", _fake_exec)
+        monkeypatch.setattr(hr.activity, "heartbeat", lambda *a, **k: None)
+
+        job = {
+            "mode": "voice_webrtc",
+            "voice": {
+                "agent_definition": {"transport": {"kind": "webrtc"}},
+                "params": {},
+            },
+            "sink": {"api_url": "http://localhost:8000"},
+            "metadata": {
+                "run_id": "run-x",
+                "secret_env": [
+                    {
+                        "key": "LIVEKIT_API_KEY",
+                        "manager": "provider_credentials",
+                        "credential_id": "",
+                        "field": "api_key",
+                    }
+                ],
+            },
+        }
+        inp = RunHostedJobInput(
+            job_id="job-x",
+            run_id="run-x",
+            mode="voice_webrtc",
+            job_json=json.dumps(job),
+            run_seconds=900,
+        )
+        out = asyncio.run(hr.run_hosted_sdk_job(inp))
+        assert out.phase == "completed"
+        assert "LIVEKIT_API_KEY" not in seen_env
+
+    def test_setting_manager_ref_for_customer_key_is_blocked(self):
+        # A manager:"setting" ref for a customer
+        # provider key must be blocked exactly like a manager:"env" ref —
+        # the customer-key rule must not live only inside the env-passthrough
+        # branch, where a "setting" ref (or any future manager) would
+        # silently bypass it.
+        import asyncio
+
+        from temporalio.exceptions import ApplicationError
+
+        from simulate.temporal.activities.hosted_runner import (
+            _resolve_voice_secret_env,
+        )
+
+        job = {
+            "metadata": {
+                "secret_env": [
+                    {
+                        "key": "RETELL_API_KEY",
+                        "manager": "setting",
+                        "setting": "RETELL_API_KEY",
+                    }
+                ]
+            }
+        }
+        with pytest.raises(ApplicationError) as excinfo:
+            asyncio.run(_resolve_voice_secret_env(job))
+        assert excinfo.value.type == "provider_credentials_missing"
+        assert excinfo.value.non_retryable
 
 
 @pytest.mark.integration
@@ -1891,7 +4776,7 @@ class TestHostedRunnerProviderSupport:
         from simulate.services.hosted_runner import hosted_runner_supports
 
         assert not hosted_runner_supports(
-            SimpleNamespace(provider="bland", provider_credentials=None)
+            SimpleNamespace(provider="bland", credentials_legacy=None)
         )
 
     def test_supported_providers(self):
@@ -1899,21 +4784,88 @@ class TestHostedRunnerProviderSupport:
 
         for prov in ("vapi", "retell", "livekit"):
             assert hosted_runner_supports(
-                SimpleNamespace(provider=prov, provider_credentials=None)
+                SimpleNamespace(provider=prov, credentials_legacy=None)
             )
 
-    def test_credentials_provider_type_takes_precedence(self):
+    def test_declared_bland_rejects_regardless_of_credentials_legacy(self):
+        # Credentials are not consulted (they can never name Bland — every
+        # other provider is coerced to vapi), so a stale credentials_legacy
+        # must not rescue a bland column.
         from simulate.services.hosted_runner import hosted_runner_supports
 
         creds = SimpleNamespace(provider_type="vapi")
-        assert hosted_runner_supports(
-            SimpleNamespace(provider="bland", provider_credentials=creds)
+        assert not hosted_runner_supports(
+            SimpleNamespace(provider="bland", credentials_legacy=creds)
         )
+
+    def test_supported_column_ignores_credentials_legacy(self):
+        # A supported column passes regardless of credentials_legacy, since
+        # the rail no longer reads it.
+        from simulate.services.hosted_runner import hosted_runner_supports
+
+        creds = SimpleNamespace(provider_type="retell")
+        assert hosted_runner_supports(
+            SimpleNamespace(provider="vapi", credentials_legacy=creds)
+        )
+
+    def test_snapshot_missing_provider_key_falls_back_to_stale_bland_column(self):
+        # exclude_none drops "provider" from a snapshot cut while the column
+        # was null; the rail must still reject on the column, not read the
+        # missing key as "unset" and let the run through.
+        from simulate.services.hosted_runner import hosted_runner_supports
+
+        agent = SimpleNamespace(provider="bland", credentials_legacy=None)
+        version = SimpleNamespace(
+            configuration_snapshot={},
+            credentials=SimpleNamespace(provider_type="vapi"),
+        )
+        assert not hosted_runner_supports(agent, version)
+
+    def test_credentials_rewrite_cannot_mask_a_stale_bland_column(self):
+        # sync_provider_credentials rewrites the pinned version's own
+        # credentials row (and can touch its snapshot) without touching the
+        # column; the rail must still reject on the column.
+        from simulate.services.hosted_runner import hosted_runner_supports
+
+        agent = SimpleNamespace(provider="bland", credentials_legacy=None)
+        version = SimpleNamespace(
+            configuration_snapshot={"provider": "vapi"},
+            credentials=SimpleNamespace(provider_type="vapi"),
+        )
+        assert not hosted_runner_supports(agent, version)
+
+    def test_hosted_runner_supports_agrees_across_both_rails(self):
+        from simulate.services.hosted_runner import hosted_runner_supports
+
+        agent = SimpleNamespace(provider="retell", credentials_legacy=None)
+        version = SimpleNamespace(configuration_snapshot={"provider": "retell"})
+        assert hosted_runner_supports(agent, version)
+
+    def test_hosted_runner_build_error_is_non_retryable(self):
+        # A deterministic build failure (bad job shape) must fail once, not be
+        # retried three times with backoff.
+        from simulate.temporal.retry_policies import DB_RETRY_POLICY
+
+        assert "HostedRunnerBuildError" in DB_RETRY_POLICY.non_retryable_error_types
 
     def test_none_agent_definition(self):
         from simulate.services.hosted_runner import hosted_runner_supports
 
         assert not hosted_runner_supports(None)
+
+    def test_customer_provider_env_keys_track_profile_table(self):
+        # Pin the derivation to the profile table so the two can
+        # never silently drift apart even if the derivation is later inlined
+        # for import reasons. A new provider profile with an api_key_env
+        # automatically joins this set with no hand-maintained edit required.
+        from simulate.services.hosted_runner import _PROVIDER_PROFILES
+        from simulate.temporal.activities.hosted_runner import (
+            _customer_provider_env_keys,
+        )
+
+        assert _customer_provider_env_keys() == {
+            p["api_key_env"] for p in _PROVIDER_PROFILES.values() if p["api_key_env"]
+        }
 
 
 @pytest.mark.integration
@@ -1972,69 +4924,765 @@ def test_dataset_language_none_single_multi():
     mixed = [{"persona": {"language": labels[0]}}, {"persona": {"language": labels[1]}}]
     assert _dataset_language(mixed) == "multi"
 
-    def test_target_speaks_first_toggle_overrides_direction(self):
-        """The explicit target_speaks_first toggle wins over the inbound/outbound
-        heuristic; None falls back to it; Retell stays pinned regardless."""
-        from simulate.services.hosted_runner import _voice_params
 
-        # True → wait for the target (agent_first) even for an inbound target
-        # that the heuristic would have opened simulator_first.
-        assert (
-            _voice_params("webrtc", inbound=True, target_speaks_first=True)[
-                "conversation_direction"
-            ]
-            == "agent_first"
-        )
-        # False → the simulator opens even for an outbound target.
-        assert (
-            _voice_params("webrtc", inbound=False, target_speaks_first=False)[
-                "conversation_direction"
-            ]
-            == "simulator_first"
-        )
-        # None → unchanged heuristic (inbound → simulator_first).
-        assert (
-            _voice_params("webrtc", inbound=True, target_speaks_first=None)[
-                "conversation_direction"
-            ]
-            == "simulator_first"
-        )
-        # Retell cannot greet first in the SDK → clamped even when the toggle
-        # asks for agent_first.
-        assert (
-            _voice_params("retell_webcall", inbound=False, target_speaks_first=True)[
-                "conversation_direction"
-            ]
-            == "simulator_first"
-        )
+# NOTE: the two tests below were previously nested inside
+# test_dataset_language_none_single_multi (an indentation slip that predates
+# this branch) and so were never collected by pytest — dedented to module
+# level so the coverage they claim actually runs.
+def test_target_speaks_first_toggle_overrides_direction():
+    """The explicit target_speaks_first toggle wins over the inbound/outbound
+    heuristic; None falls back to it; Retell stays pinned regardless."""
+    from simulate.services.hosted_runner import _voice_params
 
-    def test_resolve_target_speaks_first_precedence(self):
-        """Snapshot wins over the column; strings coerce; absent → None (auto)."""
+    # True → wait for the target (agent_first) even for an inbound target
+    # that the heuristic would have opened simulator_first.
+    assert (
+        _voice_params("webrtc", inbound=True, target_speaks_first=True)[
+            "conversation_direction"
+        ]
+        == "agent_first"
+    )
+    # False → the simulator opens even for an outbound target.
+    assert (
+        _voice_params("webrtc", inbound=False, target_speaks_first=False)[
+            "conversation_direction"
+        ]
+        == "simulator_first"
+    )
+    # None → unchanged heuristic (inbound → simulator_first).
+    assert (
+        _voice_params("webrtc", inbound=True, target_speaks_first=None)[
+            "conversation_direction"
+        ]
+        == "simulator_first"
+    )
+    # Retell cannot greet first in the SDK → clamped even when the toggle
+    # asks for agent_first.
+    assert (
+        _voice_params("retell_webcall", inbound=False, target_speaks_first=True)[
+            "conversation_direction"
+        ]
+        == "simulator_first"
+    )
+
+
+def test_resolve_target_speaks_first_precedence():
+    """Snapshot wins over the column; strings coerce. Once the pinned version
+    has a snapshot dict, it alone decides — same whole-dict precedence as
+    ``_agent_field`` (see ``_resolve_agent_inbound``): a key it lacks means
+    "unset" (``None`` — auto), the column is NOT consulted; only a version with
+    no snapshot dict at all falls back to the column."""
+    from types import SimpleNamespace
+
+    from simulate.services.hosted_runner import _resolve_target_speaks_first
+
+    agent_true = SimpleNamespace(target_speaks_first=True)
+    agent_none = SimpleNamespace(target_speaks_first=None)
+
+    # Snapshot overrides the column.
+    version = SimpleNamespace(configuration_snapshot={"target_speaks_first": False})
+    assert _resolve_target_speaks_first(version, agent_true) is False
+
+    # String "false" must not be truthy.
+    version = SimpleNamespace(configuration_snapshot={"target_speaks_first": "false"})
+    assert _resolve_target_speaks_first(version, agent_true) is False
+    version = SimpleNamespace(configuration_snapshot={"target_speaks_first": "true"})
+    assert _resolve_target_speaks_first(version, agent_none) is True
+
+    # Missing in snapshot → None (auto); the column is NOT consulted once the
+    # snapshot is a dict (a versioned run must not see a later column edit).
+    version = SimpleNamespace(configuration_snapshot={})
+    assert _resolve_target_speaks_first(version, agent_true) is None
+
+    # Absent everywhere → None (auto: derive from inbound/outbound).
+    assert _resolve_target_speaks_first(None, agent_none) is None
+    assert _resolve_target_speaks_first(None, SimpleNamespace()) is None
+
+
+class TestAgentFieldsReadFromVersionSnapshot:
+    """The version's configuration_snapshot is the source of truth for the
+    hosted builder; AgentDefinition columns mirror only the latest save and are
+    being retired. A run pinned to an older version must see that version."""
+
+    @staticmethod
+    def _agent(contact_number="", provider="retell", assistant_id="agent_1"):
         from types import SimpleNamespace
 
-        from simulate.services.hosted_runner import _resolve_target_speaks_first
-
-        agent_true = SimpleNamespace(target_speaks_first=True)
-        agent_none = SimpleNamespace(target_speaks_first=None)
-
-        # Snapshot overrides the column.
-        version = SimpleNamespace(configuration_snapshot={"target_speaks_first": False})
-        assert _resolve_target_speaks_first(version, agent_true) is False
-
-        # String "false" must not be truthy.
-        version = SimpleNamespace(
-            configuration_snapshot={"target_speaks_first": "false"}
+        return SimpleNamespace(
+            agent_type=AgentDefinition.AgentTypeChoices.VOICE,
+            agent_name="Def Name",
+            description="def prompt",
+            contact_number=contact_number,
+            provider=provider,
+            assistant_id=assistant_id,
+            credentials_legacy=None,
+            latest_version=None,
         )
-        assert _resolve_target_speaks_first(version, agent_true) is False
-        version = SimpleNamespace(
-            configuration_snapshot={"target_speaks_first": "true"}
+
+    @staticmethod
+    def _version(**snapshot):
+        from types import SimpleNamespace
+
+        return SimpleNamespace(configuration_snapshot=snapshot, credentials=None)
+
+    def test_snapshot_contact_number_decides_phone_mode(self):
+        from simulate.services.hosted_runner import resolve_runner_mode
+
+        # Definition says "no phone", the pinned version says phone → phone.
+        agent = self._agent(contact_number="")
+        assert (
+            resolve_runner_mode(agent, self._version(contact_number="+15551234567"))
+            == "voice_sip"
         )
-        assert _resolve_target_speaks_first(version, agent_none) is True
+        # Definition says phone, the pinned version says none → web. The stale
+        # column must not turn a web-call version into a leased-DID run.
+        agent = self._agent(contact_number="+15551234567")
+        assert (
+            resolve_runner_mode(agent, self._version(contact_number=""))
+            == "voice_webrtc"
+        )
 
-        # Missing in snapshot → column fallback.
-        version = SimpleNamespace(configuration_snapshot={})
-        assert _resolve_target_speaks_first(version, agent_true) is True
+    def test_snapshot_without_the_key_means_unset(self):
+        from simulate.services.hosted_runner import _target_uses_phone
 
-        # Absent everywhere → None (auto: derive from inbound/outbound).
-        assert _resolve_target_speaks_first(None, agent_none) is None
-        assert _resolve_target_speaks_first(None, SimpleNamespace()) is None
+        agent = self._agent(contact_number="+15551234567")
+        assert _target_uses_phone(agent, self._version(inbound=False)) is False
+
+    def test_non_dict_snapshot_falls_back_to_definition_column(self):
+        """A snapshot that is neither a dict nor None must not be read as
+        authoritative — only a dict snapshot is; anything else falls back to
+        the definition column."""
+        from simulate.services.hosted_runner import _agent_field
+
+        agent = self._agent(assistant_id="def_agent")
+        version = SimpleNamespace(configuration_snapshot=["not", "a", "dict"])
+        assert (
+            _agent_field(agent, version, "assistant_id", agent.assistant_id)
+            == "def_agent"
+        )
+
+    def test_whitespace_only_contact_number_is_not_a_phone_target(self):
+        """A whitespace-only contact_number must resolve to no-phone, not a
+        truthy non-empty string."""
+        from simulate.services.hosted_runner import _target_uses_phone
+
+        agent = self._agent(contact_number="   ")
+        assert _target_uses_phone(agent, None) is False
+
+    def test_versionless_agent_falls_back_to_definition(self):
+        from simulate.services.hosted_runner import resolve_runner_mode
+
+        agent = self._agent(contact_number="+15551234567")
+        assert resolve_runner_mode(agent, None) == "voice_sip"
+        agent = self._agent(contact_number="")
+        assert resolve_runner_mode(agent, None) == "voice_webrtc"
+
+    def test_latest_version_is_used_when_run_has_no_pinned_version(self):
+        from simulate.services.hosted_runner import resolve_runner_mode
+
+        agent = self._agent(contact_number="+15551234567")
+        agent.latest_version = self._version(contact_number="")
+        assert resolve_runner_mode(agent, None) == "voice_webrtc"
+
+    def test_resolve_agent_version_prefers_active_over_latest(self):
+        """_resolve_agent_version's own versionless fallback must match
+        resolve_run_agent_version's last rung — one ladder for the module,
+        not two that can silently disagree."""
+        from simulate.services.hosted_runner import _agent_field
+
+        agent = self._agent(assistant_id="def_agent")
+        agent.active_version = self._version(assistant_id="active_agent")
+        agent.latest_version = self._version(assistant_id="latest_agent")
+        assert (
+            _agent_field(agent, None, "assistant_id", agent.assistant_id)
+            == "active_agent"
+        )
+
+    def test_hosted_runner_supports_rejects_bland_from_either_rail(self):
+        # A safety rail, not a plain field read: unlike every other field, a
+        # stale Bland column still blocks routing even when the pinned
+        # snapshot names a supported provider, and vice versa.
+        from simulate.services.hosted_runner import hosted_runner_supports
+
+        agent = self._agent(provider="bland")
+        assert hosted_runner_supports(agent, self._version(provider="retell")) is False
+        agent = self._agent(provider="retell")
+        assert hosted_runner_supports(agent, self._version(provider="bland")) is False
+
+    def test_hosted_runner_supports_rejects_declared_bland_despite_vapi_credentials(
+        self,
+    ):
+        from simulate.services.hosted_runner import hosted_runner_supports
+
+        agent = self._agent(provider="retell")
+        version = self._version(provider="bland")
+        version.credentials = SimpleNamespace(provider_type="vapi")
+        assert hosted_runner_supports(agent, version) is False
+
+    def test_originator_from_number_and_prompt_come_from_snapshot(self):
+        from simulate.services.hosted_runner import _voice_agent_definition
+
+        agent = self._agent(contact_number="+15550000001", assistant_id="def_agent")
+        version = self._version(
+            contact_number="+15559999999",
+            assistant_id="snap_agent",
+            agent_name="Snap Name",
+            description="snap prompt",
+        )
+        agent_def, _secret_env = _voice_agent_definition(
+            agent, "retell", "sip_inbound", None, agent_version=version
+        )
+        transport = agent_def["transport"]
+        assert transport["inbound_call_originator"] == "retell"
+        assert transport["originator_from_number"] == "+15559999999"
+        assert transport["originator_agent_id"] == "snap_agent"
+        assert agent_def["name"] == "Snap Name"
+        assert agent_def["system_prompt"] == "snap prompt"
+
+    def test_web_target_id_comes_from_snapshot(self):
+        from simulate.services.hosted_runner import _voice_agent_definition
+
+        agent = self._agent(contact_number="", assistant_id="def_agent")
+        version = self._version(contact_number="", assistant_id="snap_agent")
+        agent_def, _ = _voice_agent_definition(
+            agent, "retell", "retell_webcall", None, agent_version=version
+        )
+        assert agent_def["target"]["agent_id"] == "snap_agent"
+
+    def test_agent_type_read_from_snapshot_for_mode(self):
+        """resolve_runner_mode must read agent_type via _agent_field, not
+        the bare AgentDefinition column, the same "pinned version wins" rule
+        as every other field the builder reads."""
+        from simulate.services.hosted_runner import resolve_runner_mode
+
+        # Definition says TEXT, the pinned version says VOICE + phone -> sip.
+        agent = self._agent(contact_number="+15551234567")
+        agent.agent_type = AgentDefinition.AgentTypeChoices.TEXT
+        version = self._version(
+            agent_type=AgentDefinition.AgentTypeChoices.VOICE,
+            contact_number="+15551234567",
+        )
+        assert resolve_runner_mode(agent, version) == "voice_sip"
+
+        # Definition says VOICE, the pinned version says TEXT -> chat.
+        agent = self._agent(contact_number="+15551234567")
+        version = self._version(agent_type=AgentDefinition.AgentTypeChoices.TEXT)
+        assert resolve_runner_mode(agent, version) == "chat"
+
+    def test_agent_field_for_run_agrees_with_resolve_runner_mode(self):
+        """The view-side helper (agent_field_for_run) must read agent_type
+        the same way resolve_runner_mode does for the same run, or the view's
+        eligibility gate could disagree with the builder's mode."""
+        from types import SimpleNamespace
+
+        from simulate.services.hosted_runner import agent_field_for_run
+
+        agent = self._agent(contact_number="+15551234567")
+        agent.agent_type = AgentDefinition.AgentTypeChoices.TEXT
+        version = self._version(agent_type=AgentDefinition.AgentTypeChoices.VOICE)
+        run_test = SimpleNamespace(agent_definition=agent, agent_version=version)
+        assert (
+            agent_field_for_run(run_test, "agent_type", agent.agent_type)
+            == AgentDefinition.AgentTypeChoices.VOICE
+        )
+
+    def test_agent_field_for_run_uses_the_passed_test_execution(self):
+        """agent_field_for_run must actually feed its test_execution keyword
+        into the ladder, not just accept and ignore it — otherwise a caller
+        passing an execution pin (a rerun, say) silently falls back to
+        run_test.agent_version / latest_version instead."""
+        from types import SimpleNamespace
+
+        from simulate.services.hosted_runner import agent_field_for_run
+
+        agent = self._agent()
+        agent.agent_type = AgentDefinition.AgentTypeChoices.VOICE
+        agent.latest_version = self._version(
+            agent_type=AgentDefinition.AgentTypeChoices.VOICE
+        )
+        run_test = SimpleNamespace(agent_definition=agent, agent_version=None)
+        test_execution = SimpleNamespace(
+            agent_version=self._version(
+                agent_type=AgentDefinition.AgentTypeChoices.TEXT
+            )
+        )
+        assert (
+            agent_field_for_run(
+                run_test, "agent_type", agent.agent_type, test_execution=test_execution
+            )
+            == AgentDefinition.AgentTypeChoices.TEXT
+        )
+
+    def test_agent_version_override_is_read_verbatim_not_the_ladder(self):
+        """The agent_version= override must win even though run_test itself
+        is pinned to a different (VOICE) snapshot — a caller with an
+        already-resolved version to check (e.g. a pending PATCH) must not be
+        silently overridden by the ladder."""
+        from types import SimpleNamespace
+
+        from simulate.services.hosted_runner import agent_field_for_run
+
+        agent = self._agent()
+        voice_pin = self._version(agent_type=AgentDefinition.AgentTypeChoices.VOICE)
+        text_override = self._version(agent_type=AgentDefinition.AgentTypeChoices.TEXT)
+        run_test = SimpleNamespace(agent_definition=agent, agent_version=voice_pin)
+        assert (
+            agent_field_for_run(
+                run_test, "agent_type", agent.agent_type, agent_version=text_override
+            )
+            == AgentDefinition.AgentTypeChoices.TEXT
+        )
+
+    def test_agent_version_none_still_resolves_the_definition_ladder(self):
+        """An explicit agent_version=None skips the run/execution rungs, but
+        _agent_field still resolves the definition's own active_version —
+        not a bypass straight to the column."""
+        from types import SimpleNamespace
+
+        from simulate.services.hosted_runner import agent_field_for_run
+
+        agent = self._agent()
+        agent.agent_type = AgentDefinition.AgentTypeChoices.TEXT
+        agent.active_version = self._version(
+            agent_type=AgentDefinition.AgentTypeChoices.VOICE
+        )
+        pinned = self._version(agent_type=AgentDefinition.AgentTypeChoices.TEXT)
+        run_test = SimpleNamespace(agent_definition=agent, agent_version=pinned)
+        assert (
+            agent_field_for_run(
+                run_test, "agent_type", agent.agent_type, agent_version=None
+            )
+            == AgentDefinition.AgentTypeChoices.VOICE
+        )
+
+    def test_voice_provider_reads_provider_from_snapshot(self):
+        """_voice_provider's own snapshot read (the credentials arm is already
+        covered by test_hosted_runner_supports_reads_provider_from_snapshot and
+        TestHostedRunnerProviderSupport). Reverting _voice_provider to the
+        definition column must fail this."""
+        from simulate.services.hosted_runner import _voice_provider
+
+        agent = self._agent(provider="vapi")
+        version = self._version(provider="retell")
+        assert _voice_provider(agent, None, version) == "retell"
+
+    def test_resolve_run_agent_version_ladder(self):
+        """run_test.agent_version wins, then test_execution.agent_version
+        (the native path backfills this), then the definition's
+        latest_version — the one ladder shared by the view and the builder."""
+        from types import SimpleNamespace
+
+        from simulate.services.hosted_runner import resolve_run_agent_version
+
+        latest = self._version(contact_number="+15550000000")
+        agent = self._agent()
+        agent.latest_version = latest
+        pinned = self._version(contact_number="+15551111111")
+        backfilled = self._version(contact_number="+15552222222")
+
+        run_test = SimpleNamespace(agent_version=pinned, agent_definition=agent)
+        assert resolve_run_agent_version(run_test) is pinned
+        assert (
+            resolve_run_agent_version(
+                run_test, SimpleNamespace(agent_version=backfilled)
+            )
+            is pinned
+        )
+
+        run_test_no_pin = SimpleNamespace(agent_version=None, agent_definition=agent)
+        assert (
+            resolve_run_agent_version(
+                run_test_no_pin, SimpleNamespace(agent_version=backfilled)
+            )
+            is backfilled
+        )
+        assert resolve_run_agent_version(run_test_no_pin, None) is latest
+
+    def test_resolve_run_agent_version_prefers_active_over_latest(self):
+        """The last rung must match every other version-resolving call site
+        in the app (active_version or latest_version), not latest_version
+        alone — otherwise an unpinned run can pick a different version (and
+        credentials row) than the rest of the platform treats as current."""
+        from types import SimpleNamespace
+
+        from simulate.services.hosted_runner import resolve_run_agent_version
+
+        active = self._version(contact_number="+15550000001")
+        latest = self._version(contact_number="+15550000002")
+        agent = self._agent()
+        agent.active_version = active
+        agent.latest_version = latest
+
+        run_test_no_pin = SimpleNamespace(agent_version=None, agent_definition=agent)
+        assert resolve_run_agent_version(run_test_no_pin, None) is active
+
+    def test_unpinned_full_build_prefers_resolved_version_credentials_over_legacy(
+        self,
+    ):
+        """An unpinned run now resolves active/latest before reading
+        credentials, so the version's own credentials row wins over the
+        definition-level legacy one — a deliberate repair (the version-scoped
+        row is what the platform's credential-editing endpoints write)."""
+        from types import SimpleNamespace
+
+        from simulate.services.hosted_runner import (
+            _voice_credentials,
+            resolve_run_agent_version,
+        )
+
+        version_creds = SimpleNamespace(provider_type="retell")
+        version = self._version()
+        version.credentials = version_creds
+        agent = self._agent()
+        agent.latest_version = version
+        agent.credentials_legacy = SimpleNamespace(provider_type="vapi")
+
+        run_test = SimpleNamespace(agent_version=None, agent_definition=agent)
+        resolved = resolve_run_agent_version(run_test, None)
+        assert _voice_credentials(agent, resolved) is version_creds
+
+    def test_view_mode_and_builder_transport_agree_when_pin_is_backfilled(self):
+        """When run_test.agent_version is None but the execution's pin was
+        backfilled (the native path does this before a hosted rerun), the
+        shared resolve_run_agent_version ladder must give the view
+        (resolve_runner_mode) and the builder (_voice_transport_kind) the same
+        version — otherwise the mode/transport mismatch guard at
+        _build_voice_job raises HostedRunnerBuildError."""
+        from simulate.services.hosted_runner import (
+            _voice_transport_kind,
+            resolve_run_agent_version,
+            resolve_runner_mode,
+        )
+
+        agent = self._agent(contact_number="")
+        backfilled = self._version(contact_number="+15551234567")
+        run_test = SimpleNamespace(agent_version=None, agent_definition=agent)
+        test_execution = SimpleNamespace(agent_version=backfilled)
+
+        resolved = resolve_run_agent_version(run_test, test_execution)
+        mode = resolve_runner_mode(agent, resolved)
+        transport = _voice_transport_kind(
+            agent, "retell", inbound=False, agent_version=resolved
+        )
+        assert mode == "voice_sip"
+        assert transport == "sip_inbound"
+
+
+@pytest.mark.django_db
+class TestViewGatesReadVersionSnapshot:
+    """The DB-free suites above stand in AgentDefinition/AgentVersion with
+    SimpleNamespace; these use real ORM instances (a real configuration_snapshot
+    JSONField round-trip) to prove each request-time gate still reads the
+    pinned version, not a column edited after the pin, the same way the
+    builder does for the same run/execution. Most tests pin ``run_test``
+    directly, so the ladder's active_version/latest_version querying
+    properties are exercised only where a test leaves the run unpinned."""
+
+    @staticmethod
+    def _pinned_voice_agent(organization, workspace, *, provider="retell", phone=""):
+        """Column says TEXT; the pinned version's snapshot, captured while the
+        column still said VOICE, says VOICE — mirrors an agent_type edit that
+        reached the column after a version was already pinned."""
+        agent = AgentDefinition.objects.create(
+            agent_name="Gate Agent",
+            agent_type=AgentDefinition.AgentTypeChoices.VOICE,
+            contact_number=phone,
+            inbound=True,
+            description="gate agent",
+            provider=provider,
+            assistant_id="gate_asst",
+            organization=organization,
+            workspace=workspace,
+            languages=["en"],
+        )
+        version = agent.create_version(
+            description="pinned", commit_message="v1", status="active"
+        )
+        agent.agent_type = AgentDefinition.AgentTypeChoices.TEXT
+        agent.save(update_fields=["agent_type"])
+        return agent, version
+
+    def test_hosted_runner_eligible_reads_snapshot_not_column(
+        self, organization, workspace
+    ):
+        import simulate.views.run_test as run_test_module
+        from simulate.views.run_test import RunTestExecutionView
+
+        agent, version = self._pinned_voice_agent(organization, workspace)
+        run_test = RunTest.objects.create(
+            name="Gate RT",
+            agent_definition=agent,
+            agent_version=version,
+            organization=organization,
+            workspace=workspace,
+        )
+        # Pin the flag instead of relying on its process default: a TEXT
+        # classification would short-circuit True regardless of the flag, so
+        # False here can only come from a genuine VOICE read of the snapshot.
+        with patch.object(
+            run_test_module.app_settings, "HOSTED_RUNNER_VOICE_ENABLED", False
+        ):
+            assert RunTestExecutionView()._hosted_runner_eligible(run_test) is False
+
+    def test_hosted_runner_eligible_routes_voice_when_enabled(
+        self, organization, workspace
+    ):
+        import simulate.views.run_test as run_test_module
+        from simulate.views.run_test import RunTestExecutionView
+
+        agent, version = self._pinned_voice_agent(organization, workspace)
+        run_test = RunTest.objects.create(
+            name="Gate RT",
+            agent_definition=agent,
+            agent_version=version,
+            organization=organization,
+            workspace=workspace,
+        )
+        with patch.object(
+            run_test_module.app_settings, "HOSTED_RUNNER_VOICE_ENABLED", True
+        ):
+            assert RunTestExecutionView()._hosted_runner_eligible(run_test) is True
+
+    def test_hosted_execution_eligible_reads_snapshot_not_column(
+        self, organization, workspace
+    ):
+        import simulate.views.run_test as run_test_module
+        from simulate.views.run_test import _hosted_execution_eligible
+
+        agent, version = self._pinned_voice_agent(organization, workspace)
+        run_test = RunTest.objects.create(
+            name="Gate RT",
+            agent_definition=agent,
+            agent_version=version,
+            organization=organization,
+            workspace=workspace,
+        )
+        test_execution = SimTestExecution.objects.create(run_test=run_test)
+        with patch.object(
+            run_test_module.app_settings, "HOSTED_RUNNER_VOICE_ENABLED", False
+        ):
+            assert _hosted_execution_eligible(run_test, test_execution) is False
+
+    def test_hosted_execution_eligible_routes_voice_when_enabled(
+        self, organization, workspace
+    ):
+        import simulate.views.run_test as run_test_module
+        from simulate.views.run_test import _hosted_execution_eligible
+
+        agent, version = self._pinned_voice_agent(organization, workspace)
+        run_test = RunTest.objects.create(
+            name="Gate RT",
+            agent_definition=agent,
+            agent_version=version,
+            organization=organization,
+            workspace=workspace,
+        )
+        test_execution = SimTestExecution.objects.create(run_test=run_test)
+        with patch.object(
+            run_test_module.app_settings, "HOSTED_RUNNER_VOICE_ENABLED", True
+        ):
+            assert _hosted_execution_eligible(run_test, test_execution) is True
+
+    def test_hosted_runner_mode_reads_snapshot_not_column(
+        self, organization, workspace
+    ):
+        from simulate.views.run_test import RunTestExecutionView
+
+        agent, version = self._pinned_voice_agent(
+            organization, workspace, phone="+15551234567"
+        )
+        run_test = RunTest.objects.create(
+            name="Gate RT",
+            agent_definition=agent,
+            agent_version=version,
+            organization=organization,
+            workspace=workspace,
+        )
+        # A TEXT read would resolve "chat"; the pinned snapshot's VOICE +
+        # phone must resolve voice_sip instead.
+        assert RunTestExecutionView()._hosted_runner_mode(run_test) == "voice_sip"
+
+    def test_components_patch_gate_reads_snapshot_not_column(
+        self, auth_client, organization, workspace
+    ):
+        # A TEXT read of the stale column would return 200 (no check run);
+        # only a VOICE read of the pinned snapshot 400s on the missing key.
+        agent, version = self._pinned_voice_agent(organization, workspace)
+        run_test = RunTest.objects.create(
+            name="Gate RT",
+            agent_definition=agent,
+            organization=organization,
+            workspace=workspace,
+        )
+        response = auth_client.patch(
+            f"/simulate/run-tests/{run_test.id}/components/",
+            {"version": str(version.id), "enable_tool_evaluation": True},
+            format="json",
+        )
+        assert response.status_code == 400
+        assert response.json()["result"]["error_code"] == (
+            "API_KEY_AND_ASSISTANT_ID_REQUIRED"
+        )
+
+    def test_create_run_test_view_gate_reads_snapshot_not_column(
+        self, auth_client, organization, workspace, scenario
+    ):
+        # A TEXT read of the stale column would skip the entitlement gate
+        # and 201; only a VOICE read of the version about to be pinned
+        # reaches check_feature and 403s, before any RunTest row exists.
+        from ee.usage.schemas.events import CheckResult
+
+        agent, version = self._pinned_voice_agent(organization, workspace)
+        with (
+            patch("ee.usage.deployment.DeploymentMode.is_cloud", return_value=True),
+            patch("tfc.ee_gates.voice_sim_oss_gate_response", return_value=None),
+            patch(
+                "ee.usage.services.entitlements.Entitlements.check_feature"
+            ) as mock_check,
+        ):
+            mock_check.return_value = CheckResult(
+                allowed=False,
+                reason="Voice simulation requires PAYG plan",
+                error_code="ENTITLEMENT_DENIED",
+            )
+            response = auth_client.post(
+                "/simulate/run-tests/create/",
+                {
+                    "name": "Gate Create RT",
+                    "agent_definition_id": str(agent.id),
+                    "agent_version": str(version.id),
+                    "scenario_ids": [str(scenario.id)],
+                },
+                format="json",
+            )
+        assert response.status_code == 403
+        mock_check.assert_called_once_with(str(organization.id), "has_voice_sim")
+
+    def test_bulk_rerun_routes_each_execution_by_its_own_pinned_version(
+        self, auth_client, organization, workspace, scenario
+    ):
+        """Two executions of the same unpinned run_test, pinned to different
+        versions whose OWN declared provider differs (one Bland/unsupported,
+        one Retell/supported) — the bulk rerun must dispatch each through the
+        runner its own pin resolves to, not one decision for the whole batch."""
+        import simulate.views.run_test as run_test_module
+
+        agent = AgentDefinition.objects.create(
+            agent_name="Bulk Rerun Agent",
+            agent_type=AgentDefinition.AgentTypeChoices.VOICE,
+            contact_number="",
+            inbound=True,
+            description="bulk rerun agent",
+            provider="bland",
+            organization=organization,
+            workspace=workspace,
+            languages=["en"],
+        )
+        unsupported_version = agent.create_version(
+            description="unsupported provider",
+            commit_message="v-bland",
+            status="active",
+        )
+        agent.provider = "retell"
+        agent.save(update_fields=["provider"])
+        supported_version = agent.create_version(
+            description="supported provider", commit_message="v-retell", status="active"
+        )
+
+        run_test = RunTest.objects.create(
+            name="Bulk Rerun RT",
+            agent_definition=agent,
+            organization=organization,
+            workspace=workspace,
+        )
+        run_test.scenarios.add(scenario)
+
+        native_execution = SimTestExecution.objects.create(
+            run_test=run_test,
+            agent_definition=agent,
+            agent_version=unsupported_version,
+            status=SimTestExecution.ExecutionStatus.COMPLETED,
+            total_scenarios=1,
+            scenario_ids=[str(scenario.id)],
+        )
+        hosted_execution = SimTestExecution.objects.create(
+            run_test=run_test,
+            agent_definition=agent,
+            agent_version=supported_version,
+            status=SimTestExecution.ExecutionStatus.COMPLETED,
+            total_scenarios=1,
+            scenario_ids=[str(scenario.id)],
+        )
+        CallExecution.objects.create(
+            test_execution=native_execution,
+            scenario=scenario,
+            phone_number="+1234567890",
+            status=CallExecution.CallStatus.COMPLETED,
+            service_provider_call_id="vapi-test-123",
+            eval_outputs={"eval1": {"score": 0.9}},
+            call_metadata={
+                "base_prompt": "You are a test agent",
+                "voice_settings": {"provider": "elevenlabs"},
+                "call_direction": "inbound",
+                "eval_started": True,
+                "eval_completed": True,
+            },
+        )
+        CallExecution.objects.create(
+            test_execution=hosted_execution,
+            scenario=scenario,
+            phone_number="+1234567890",
+            status=CallExecution.CallStatus.COMPLETED,
+            service_provider_call_id="vapi-test-456",
+            eval_outputs={"eval1": {"score": 0.7}},
+            call_metadata={
+                "base_prompt": "You are a test agent",
+                "voice_settings": {"provider": "elevenlabs"},
+                "call_direction": "inbound",
+                "eval_started": True,
+                "eval_completed": True,
+            },
+        )
+
+        with (
+            patch.object(
+                run_test_module.app_settings, "HOSTED_RUNNER_VOICE_ENABLED", True
+            ),
+            patch.object(
+                run_test_module, "_voice_sim_gate_response", return_value=None
+            ),
+            patch.object(
+                run_test_module,
+                "_dispatch_hosted_rerun",
+                return_value="hosted-wf",
+            ) as dispatch_hosted,
+            patch(
+                "simulate.temporal.client.rerun_call_executions",
+                return_value={"merged": False, "workflow_id": "native-wf"},
+            ) as dispatch_native,
+        ):
+            response = auth_client.post(
+                f"/simulate/run-tests/{run_test.id}/rerun-test-executions/",
+                {
+                    "rerun_type": "call_and_eval",
+                    "test_execution_ids": [
+                        str(native_execution.id),
+                        str(hosted_execution.id),
+                    ],
+                },
+                format="json",
+            )
+
+        assert response.status_code == 200
+        dispatch_hosted.assert_called_once()
+        assert dispatch_hosted.call_args[0][0].id == hosted_execution.id
+        dispatch_native.assert_called_once()
+        assert dispatch_native.call_args.kwargs["test_execution_id"] == str(
+            native_execution.id
+        )
+        # A swallowed per-call error (missing agent_definition, say) would
+        # still return 200 with a per-execution failure_count > 0 instead of
+        # tripping dispatch_native/dispatch_hosted — assert it directly too.
+        results_by_id = {r["test_execution_id"]: r for r in response.data["results"]}
+        assert results_by_id[str(native_execution.id)]["failure_count"] == 0
+        assert results_by_id[str(hosted_execution.id)]["failure_count"] == 0

--- a/futureagi/simulate/tests/test_alk_simulate_ingestion.py
+++ b/futureagi/simulate/tests/test_alk_simulate_ingestion.py
@@ -752,6 +752,77 @@ class TestResultIngest:
         assert cmd.get("total_tokens") == 1500
         assert cmd.get("input_tokens") is None
 
+    def test_retell_result_resolves_speaker_roles_through_the_retell_maps(
+        self, auth_client, run_test
+    ):
+        """A hosted Retell result stores provider_call_data['retell']; the transcript
+        the UI renders must resolve through the Retell maps, not fall back to VAPI
+        with an unknown-provider error. Direction defaults to outbound."""
+        from simulate.serializers.test_execution import (
+            CallExecutionDetailSerializer,
+        )
+        from simulate.utils.speaker_roles import SpeakerRoleResolver
+        from tracer.models.observability_provider import ProviderChoices
+
+        _, call_ids = _start_and_batch(auth_client, run_test)
+        call_id = call_ids[0]
+        resp = auth_client.patch(
+            f"{ALK_BASE}/call-executions/{call_id}/result/",
+            {
+                "status": "completed",
+                "transcript": _transcript_payload(),
+                "provider_call_data": {"retell": {"call_id": "call_abc"}},
+            },
+            format="json",
+        )
+        assert resp.status_code == 200, resp.content
+        call = CallExecution.objects.get(id=call_id)
+        assert (
+            SpeakerRoleResolver.detect_provider(call.provider_call_data)
+            == ProviderChoices.RETELL
+        )
+        with patch("simulate.utils.speaker_roles.logger") as resolver_log:
+            rows = CallExecutionDetailSerializer(
+                context={"detail_mode": True}
+            ).get_transcript(call)
+        resolver_log.error.assert_not_called()
+        # Outbound: the tested agent speaks as "assistant", the simulator as "user".
+        assert [row["speaker_role"] for row in rows] == ["user", "assistant", "user"]
+
+    def test_retell_inbound_result_swaps_speaker_roles(self, auth_client, run_test):
+        """Same hosted Retell result, inbound direction: the simulator placed the
+        call, so the raw 'assistant' turns are the simulator and 'user' turns are
+        the tested agent. The Retell inbound map must do the swap."""
+        from simulate.serializers.test_execution import (
+            CallExecutionDetailSerializer,
+        )
+
+        _, call_ids = _start_and_batch(auth_client, run_test)
+        call_id = call_ids[0]
+        resp = auth_client.patch(
+            f"{ALK_BASE}/call-executions/{call_id}/result/",
+            {
+                "status": "completed",
+                "transcript": _transcript_payload(),
+                "provider_call_data": {"retell": {"call_id": "call_abc"}},
+            },
+            format="json",
+        )
+        assert resp.status_code == 200, resp.content
+        call = CallExecution.objects.get(id=call_id)
+        call.call_metadata = {**(call.call_metadata or {}), "call_direction": "inbound"}
+        call.save(update_fields=["call_metadata"])
+        with patch("simulate.utils.speaker_roles.logger") as resolver_log:
+            rows = CallExecutionDetailSerializer(
+                context={"detail_mode": True}
+            ).get_transcript(call)
+        resolver_log.error.assert_not_called()
+        assert [row["speaker_role"] for row in rows] == [
+            "assistant",
+            "user",
+            "assistant",
+        ]
+
     def test_reingest_preserves_csat(self, auth_client, run_test):
         _, call_ids = _start_and_batch(auth_client, run_test)
         call_id = call_ids[0]

--- a/futureagi/simulate/tests/test_alk_simulate_ingestion.py
+++ b/futureagi/simulate/tests/test_alk_simulate_ingestion.py
@@ -1950,6 +1950,72 @@ class TestBuildVoiceRunnerJob:
             )
         assert job["voice"]["params"]["max_seconds"] == 120.0
 
+    def test_leased_room_reuse_defaults_off(
+        self, organization, workspace, simulator_agent
+    ):
+        # Issue 3: the committed default is off, so a multi-row originator run
+        # is refused without any override until the reuse-capable kit is on.
+        from simulate.services.hosted_runner import HostedRunnerBuildError
+
+        agent = self._retell_originator_agent(organization, workspace)
+        with pytest.raises(HostedRunnerBuildError) as excinfo:
+            self._build_multi(organization, workspace, simulator_agent, agent, 3)
+        assert "HOSTED_RUNNER_LEASED_ROOM_REUSE" in str(excinfo.value)
+
+    def test_leased_room_admission_refuses_excess_rows(
+        self, organization, workspace, simulator_agent
+    ):
+        # Issue 2: even with reuse on, a leased-number run over the case cap is
+        # refused before any number is leased.
+        from django.test import override_settings
+
+        from simulate.services.hosted_runner import HostedRunnerBuildError
+
+        agent = self._retell_originator_agent(organization, workspace)
+        with override_settings(
+            HOSTED_RUNNER_LEASED_ROOM_REUSE=True,
+            HOSTED_RUNNER_LEASED_ROOM_MAX_CASES=2,
+        ):
+            with pytest.raises(HostedRunnerBuildError) as excinfo:
+                self._build_multi(organization, workspace, simulator_agent, agent, 3)
+        assert "capped at 2" in str(excinfo.value)
+
+    def test_leased_room_admission_refuses_excess_wallclock(
+        self, organization, workspace, simulator_agent
+    ):
+        # Issue 2: a run within the case cap but over the wall-clock cap is
+        # still refused before the lease.
+        from django.test import override_settings
+
+        from simulate.services.hosted_runner import HostedRunnerBuildError
+
+        agent = self._retell_originator_agent(organization, workspace)
+        with override_settings(
+            HOSTED_RUNNER_LEASED_ROOM_REUSE=True,
+            HOSTED_RUNNER_LEASED_ROOM_MAX_CASES=0,
+            HOSTED_RUNNER_LEASED_ROOM_MAX_WALLCLOCK_SECONDS=60,
+        ):
+            with pytest.raises(HostedRunnerBuildError) as excinfo:
+                self._build_multi(organization, workspace, simulator_agent, agent, 3)
+        assert "cap" in str(excinfo.value)
+
+    def test_leased_room_admission_disabled_with_zero_caps(
+        self, organization, workspace, simulator_agent
+    ):
+        # Issue 2: both caps at 0 disable admission — a large run builds.
+        from django.test import override_settings
+
+        agent = self._retell_originator_agent(organization, workspace)
+        with override_settings(
+            HOSTED_RUNNER_LEASED_ROOM_REUSE=True,
+            HOSTED_RUNNER_LEASED_ROOM_MAX_CASES=0,
+            HOSTED_RUNNER_LEASED_ROOM_MAX_WALLCLOCK_SECONDS=0,
+        ):
+            job, mode = self._build_multi(
+                organization, workspace, simulator_agent, agent, 40
+            )
+        assert mode == "voice_sip"
+
     def _assert_leased_deadline_identity(self, job, case_count):
         """D15: pin ``cleanup_timeout`` and the derived child deadline from
         the budget constants (not by echoing the function's own output), so a
@@ -5628,6 +5694,65 @@ class TestViewGatesReadVersionSnapshot:
             )
         assert response.status_code == 403
         mock_check.assert_called_once_with(str(organization.id), "has_voice_sim")
+
+    def _other_agent_version(self, organization, workspace):
+        """A version belonging to a DIFFERENT same-org agent."""
+        other = AgentDefinition.objects.create(
+            agent_name="Other Agent",
+            agent_type=AgentDefinition.AgentTypeChoices.TEXT,
+            inbound=False,
+            description="other agent",
+            organization=organization,
+            workspace=workspace,
+            languages=["en"],
+        )
+        return other.create_version(
+            description="foreign", commit_message="v1", status="active"
+        )
+
+    def test_create_run_test_rejects_cross_agent_version(
+        self, auth_client, organization, workspace, scenario
+    ):
+        # Issue 1: pairing a voice definition with another same-org agent's
+        # version must be refused before any RunTest row exists — otherwise the
+        # foreign snapshot answers the voice gate and the run reads its
+        # snapshot/credentials.
+        voice_agent, _ = self._pinned_voice_agent(organization, workspace)
+        foreign_version = self._other_agent_version(organization, workspace)
+        before = RunTest.objects.count()
+        response = auth_client.post(
+            "/simulate/run-tests/create/",
+            {
+                "name": "Cross Agent RT",
+                "agent_definition_id": str(voice_agent.id),
+                "agent_version": str(foreign_version.id),
+                "scenario_ids": [str(scenario.id)],
+            },
+            format="json",
+        )
+        assert response.status_code == 404
+        assert RunTest.objects.count() == before
+
+    def test_components_patch_rejects_cross_agent_version(
+        self, auth_client, organization, workspace
+    ):
+        # Issue 1: the same constraint on the components-update version lookup.
+        voice_agent, _ = self._pinned_voice_agent(organization, workspace)
+        run_test = RunTest.objects.create(
+            name="Cross Agent Patch RT",
+            agent_definition=voice_agent,
+            organization=organization,
+            workspace=workspace,
+        )
+        foreign_version = self._other_agent_version(organization, workspace)
+        response = auth_client.patch(
+            f"/simulate/run-tests/{run_test.id}/components/",
+            {"version": str(foreign_version.id)},
+            format="json",
+        )
+        assert response.status_code == 404
+        run_test.refresh_from_db()
+        assert run_test.agent_version_id is None
 
     def test_bulk_rerun_routes_each_execution_by_its_own_pinned_version(
         self, auth_client, organization, workspace, scenario

--- a/futureagi/simulate/tests/test_speaker_role_resolver.py
+++ b/futureagi/simulate/tests/test_speaker_role_resolver.py
@@ -27,8 +27,12 @@ class TestDetectProvider:
         assert SpeakerRoleResolver.detect_provider({}) == ProviderChoices.VAPI
 
     def test_unknown_keys_falls_back_to_vapi(self):
-        data = {"retell": {"id": "x"}}
+        data = {"some_unhandled_provider": {"id": "x"}}
         assert SpeakerRoleResolver.detect_provider(data) == ProviderChoices.VAPI
+
+    def test_retell_key_is_detected(self):
+        data = {"retell": {"call_id": "x"}}
+        assert SpeakerRoleResolver.detect_provider(data) == ProviderChoices.RETELL
 
 
 # -------------------------------------------------------------------
@@ -37,7 +41,6 @@ class TestDetectProvider:
 
 
 class TestIsTestedAgent:
-
     # VAPI inbound: bot/assistant = simulator, user = tested_agent
     def test_vapi_inbound_user_is_tested_agent(self):
         assert (
@@ -141,7 +144,6 @@ class TestIsTestedAgent:
 
 
 class TestIsSimulator:
-
     # VAPI inbound: bot/assistant = simulator
     def test_vapi_inbound_bot_is_simulator(self):
         assert (
@@ -204,7 +206,6 @@ class TestIsSimulator:
 
 
 class TestGetEvalRoleLabel:
-
     # VAPI inbound: assistant/bot -> customer, user -> agent
     def test_vapi_inbound_bot_becomes_customer(self):
         assert (
@@ -292,7 +293,6 @@ class TestGetEvalRoleLabel:
 
 
 class TestGetTranscriptRoleSets:
-
     def test_vapi_inbound(self):
         ta, sim = SpeakerRoleResolver.get_transcript_role_sets(
             provider=ProviderChoices.VAPI, is_outbound=False
@@ -331,7 +331,6 @@ class TestGetTranscriptRoleSets:
 
 
 class TestGetSkipDecisionRoleSets:
-
     def test_returns_same_as_transcript_role_sets(self):
         for provider in [ProviderChoices.VAPI, ProviderChoices.LIVEKIT]:
             for is_outbound in [True, False]:
@@ -345,7 +344,6 @@ class TestGetSkipDecisionRoleSets:
 
 
 class TestStaticRoleLists:
-
     def test_conversational_roles_has_user_and_assistant(self):
         roles = SpeakerRoleResolver.get_conversational_roles()
         assert len(roles) == 2

--- a/futureagi/simulate/utils/speaker_roles.py
+++ b/futureagi/simulate/utils/speaker_roles.py
@@ -7,6 +7,8 @@ Provider raw shape:
   VAPI     | inbound   | simulator       | tested agent
   VAPI     | outbound  | tested agent    | simulator
   LiveKit  | both      | tested agent    | simulator
+  Bland    | outbound  | tested agent    | simulator
+  Retell   | outbound  | tested agent    | simulator
 
 Direction is tested-agent-perspective: inbound = tested agent receives, outbound
 = tested agent dials out. LiveKit rows are pre-normalised at the agent worker.
@@ -83,6 +85,24 @@ class SpeakerRoleResolver:
         "customer": "simulator",
     }
 
+    # Retell is a customer-only outbound provider (inbound Retell flows through
+    # VAPI). Its own maps — same values as VAPI today, but independent so a
+    # Retell payload change is edited here directly, not through a shared alias.
+    _RETELL_INBOUND: dict[str, str] = {
+        "bot": "simulator",
+        "assistant": "simulator",
+        "agent": "simulator",
+        "user": "tested_agent",
+        "customer": "tested_agent",
+    }
+    _RETELL_OUTBOUND: dict[str, str] = {
+        "bot": "tested_agent",
+        "assistant": "tested_agent",
+        "agent": "tested_agent",
+        "user": "simulator",
+        "customer": "simulator",
+    }
+
     @staticmethod
     def detect_provider(
         provider_call_data: dict[str, Any] | None,
@@ -101,6 +121,8 @@ class SpeakerRoleResolver:
             return ProviderChoices.VAPI
         if provider_call_data.get(ProviderChoices.BLAND.value):
             return ProviderChoices.BLAND
+        if provider_call_data.get(ProviderChoices.RETELL.value):
+            return ProviderChoices.RETELL
         logger.error(
             "speaker_role_resolver_unknown_provider",
             provider_call_data_keys=list(provider_call_data.keys()),
@@ -145,6 +167,8 @@ class SpeakerRoleResolver:
             return cls._LIVEKIT_OUTBOUND if is_outbound else cls._LIVEKIT_INBOUND
         if provider == ProviderChoices.BLAND:
             return cls._BLAND_OUTBOUND if is_outbound else cls._BLAND_INBOUND
+        if provider == ProviderChoices.RETELL:
+            return cls._RETELL_OUTBOUND if is_outbound else cls._RETELL_INBOUND
         logger.error(
             "speaker_role_resolver_unsupported_provider",
             provider=str(provider),

--- a/futureagi/simulate/views/run_test.py
+++ b/futureagi/simulate/views/run_test.py
@@ -667,9 +667,21 @@ class CreateRunTestView(APIView):
             )
             agent_version = validated_data.get("agent_version")
             if agent_version:
-                agent_version = AgentVersion.objects.get(
-                    id=agent_version, deleted=False, organization=user_organization
-                )
+                # Pin only a version that belongs to the selected definition —
+                # a same-org version from another agent would let a text agent's
+                # snapshot answer the voice gate and hand the run a foreign
+                # snapshot/credentials.
+                try:
+                    agent_version = AgentVersion.objects.get(
+                        id=agent_version,
+                        deleted=False,
+                        organization=user_organization,
+                        agent_definition=agent_definition,
+                    )
+                except AgentVersion.DoesNotExist:
+                    return self.gm.not_found(
+                        "Agent version not found for the selected agent definition."
+                    )
 
             from simulate.services.hosted_runner import agent_field_for_version
 
@@ -4433,15 +4445,26 @@ class RunTestComponentsUpdateView(APIView):
 
                 if "version" in data:
                     version_id = data["version"]
+                    # Constrain the version to the run's (possibly just-updated)
+                    # definition — a same-org version from another agent must
+                    # not be pinnable here. A definition-less run has no gate to
+                    # bypass, so it keeps the org-only lookup.
+                    version_filters = {
+                        "id": version_id,
+                        "organization": user_organization,
+                        "deleted": False,
+                    }
+                    if run_test.agent_definition_id is not None:
+                        version_filters["agent_definition"] = run_test.agent_definition
                     try:
-                        version = AgentVersion.objects.get(
-                            id=version_id, organization=user_organization, deleted=False
-                        )
+                        version = AgentVersion.objects.get(**version_filters)
                         run_test.agent_version = version
                         new_agent_version = version
                         agent_version_changed = True
                     except AgentVersion.DoesNotExist:
-                        return self.gm.not_found("Agent version not found")
+                        return self.gm.not_found(
+                            "Agent version not found for the selected agent definition."
+                        )
 
                 # Update SimulatorAgent if provided
                 if "simulator_agent_id" in data:

--- a/futureagi/simulate/views/run_test.py
+++ b/futureagi/simulate/views/run_test.py
@@ -656,27 +656,38 @@ class CreateRunTestView(APIView):
             if not user_organization:
                 return self.gm.not_found("Organization not found for the user.")
 
-            # Resolve the agent definition up-front so we can gate on its
-            # type. Only voice simulations are entitlement-gated; chat
-            # (text) simulations are available on every plan.
+            # Resolve the agent definition (and the version the new run test
+            # will be pinned to, if one was requested) up-front so we can gate
+            # on the pinned agent_type. Only voice simulations are
+            # entitlement-gated; chat (text) simulations are available on
+            # every plan.
             agent_definition = AgentDefinition.objects.get(
                 id=validated_data["agent_definition_id"],
                 organization=user_organization,
             )
+            agent_version = validated_data.get("agent_version")
+            if agent_version:
+                agent_version = AgentVersion.objects.get(
+                    id=agent_version, deleted=False, organization=user_organization
+                )
 
-            if agent_definition.agent_type == AgentDefinition.AgentTypeChoices.VOICE:
+            from simulate.services.hosted_runner import agent_field_for_version
+
+            # No RunTest row exists yet, so read the exact version this call
+            # will pin directly — no unsaved ORM instance needed.
+            agent_type = agent_field_for_version(
+                agent_definition,
+                agent_version,
+                "agent_type",
+                agent_definition.agent_type,
+            )
+            if agent_type == AgentDefinition.AgentTypeChoices.VOICE:
                 forbidden = _voice_sim_gate_response(user_organization, self.gm)
                 if forbidden is not None:
                     return forbidden
 
             # Create the RunTest
             with transaction.atomic():
-                agent_version = validated_data.get("agent_version")
-                if agent_version:
-                    agent_version = AgentVersion.objects.get(
-                        id=agent_version, deleted=False, organization=user_organization
-                    )
-
                 # simulator_agent = SimulatorAgent.objects.get(
                 #     id=validated_data['simulator_agent_id'],
                 #     organization=user_organization
@@ -984,14 +995,19 @@ class RunTestExecutionView(APIView):
                 deleted=False,
             )
 
-            if (
-                run_test.agent_definition
-                and run_test.agent_definition.agent_type
-                == AgentDefinition.AgentTypeChoices.VOICE
-            ):
-                forbidden = _voice_sim_gate_response(user_organization, self.gm)
-                if forbidden is not None:
-                    return forbidden
+            if run_test.agent_definition:
+                from simulate.services.hosted_runner import agent_field_for_run
+
+                # Read the pinned version's agent_type, not the column, so
+                # this gate cannot disagree with what the eligibility check
+                # and the builder resolve for the same run.
+                agent_type = agent_field_for_run(
+                    run_test, "agent_type", run_test.agent_definition.agent_type
+                )
+                if agent_type == AgentDefinition.AgentTypeChoices.VOICE:
+                    forbidden = _voice_sim_gate_response(user_organization, self.gm)
+                    if forbidden is not None:
+                        return forbidden
 
             # Get parameters from the runtime-validated request contract.
             scenario_ids = request.validated_data.get("scenario_ids", [])
@@ -1141,18 +1157,36 @@ class RunTestExecutionView(APIView):
     def _hosted_runner_eligible(self, run_test: RunTest) -> bool:
         """Chat (TEXT) always routes to the hosted runner. Voice routes only
         when HOSTED_RUNNER_VOICE_ENABLED is on (default off ⇒ voice stays on
-        the native path, no regression)."""
+        the native path, no regression).
+
+        ``agent_type`` is read via ``agent_field_for_run`` (pinned version's
+        snapshot first, same as the builder) rather than the bare
+        ``AgentDefinition.agent_type`` column, so this gate cannot disagree
+        with what ``build_start_runner_job`` resolves for the same run.
+        This call has no ``TestExecution`` yet (dispatched before one is
+        created), so it can only resolve ``run_test.agent_version`` /
+        ``latest_version`` — the fresh-run case, where the created execution's
+        pin always matches the RunTest's."""
         agent_definition = run_test.agent_definition
         if agent_definition is None:
             return False
-        if agent_definition.agent_type == AgentDefinition.AgentTypeChoices.TEXT:
+        from simulate.services.hosted_runner import agent_field_for_run
+
+        agent_type = agent_field_for_run(
+            run_test, "agent_type", agent_definition.agent_type
+        )
+        if agent_type == AgentDefinition.AgentTypeChoices.TEXT:
             return True
         return _hosted_execution_eligible(run_test)
 
-    def _hosted_runner_mode(self, run_test: RunTest) -> str:
-        from simulate.services.hosted_runner import resolve_runner_mode
+    def _hosted_runner_mode(self, run_test: RunTest, test_execution=None) -> str:
+        from simulate.services.hosted_runner import (
+            resolve_run_agent_version,
+            resolve_runner_mode,
+        )
 
-        return resolve_runner_mode(run_test.agent_definition)
+        agent_version = resolve_run_agent_version(run_test, test_execution)
+        return resolve_runner_mode(run_test.agent_definition, agent_version)
 
     def _execute_with_hosted_runner(
         self, run_test: RunTest, scenario_ids: list[str], simulator_id: str | None
@@ -1195,7 +1229,7 @@ class RunTestExecutionView(APIView):
                 run_test_id=str(run_test.id),
                 org_id=str(run_test.organization_id),
                 scenario_ids=[str(sid) for sid in scenario_ids],
-                mode=self._hosted_runner_mode(run_test),
+                mode=self._hosted_runner_mode(run_test, test_execution),
                 simulator_id=str(simulator_id) if simulator_id else None,
             )
 
@@ -4463,7 +4497,19 @@ class RunTestComponentsUpdateView(APIView):
                     )
 
                     if agent_version_to_check and run_test.agent_definition:
-                        agent_type = run_test.agent_definition.agent_type
+                        from simulate.services.hosted_runner import (
+                            agent_field_for_run,
+                        )
+
+                        # Check the exact version this update is about to pin
+                        # (may not be run_test.agent_version yet), not the
+                        # definition column.
+                        agent_type = agent_field_for_run(
+                            run_test,
+                            "agent_type",
+                            run_test.agent_definition.agent_type,
+                            agent_version=agent_version_to_check,
+                        )
                         if (
                             not agent_type
                             or agent_type == AgentDefinition.AgentTypeChoices.VOICE
@@ -6586,23 +6632,46 @@ def _rerun_call_executions(call_executions, rerun_type):
     return successful_reruns, failed_reruns, has_pending_calls, has_pending_evals
 
 
-def _hosted_execution_eligible(run_test) -> bool:
+def _hosted_execution_eligible(
+    run_test, test_execution=None, *, agent_version=None
+) -> bool:
     """Whether a run's execution routes to the hosted simulation runner — the
     same predicate the execute view uses. Rerun must mirror it so hosted
     executions re-dispatch through the runner instead of the native
     CallExecutionWorkflow (which would try to place a real provider call with no
-    phone number and fail with "activity task failed")."""
+    phone number and fail with "activity task failed").
+
+    ``test_execution``, when the caller already has one (a rerun), is passed
+    through the shared ``resolve_run_agent_version`` ladder so this agrees
+    with the version the builder resolves for the same execution rather than
+    only ever looking at ``run_test.agent_version``. ``agent_version``, when
+    the caller already resolved it (the bulk rerun loop does, once per
+    execution), is reused instead of resolving the ladder a second time here.
+    """
     agent_definition = run_test.agent_definition
     if agent_definition is None:
         return False
-    if agent_definition.agent_type == AgentDefinition.AgentTypeChoices.TEXT:
+    from simulate.services.hosted_runner import agent_field_for_run
+
+    if agent_version is None:
+        from simulate.services.hosted_runner import resolve_run_agent_version
+
+        agent_version = resolve_run_agent_version(run_test, test_execution)
+
+    agent_type = agent_field_for_run(
+        run_test,
+        "agent_type",
+        agent_definition.agent_type,
+        agent_version=agent_version,
+    )
+    if agent_type == AgentDefinition.AgentTypeChoices.TEXT:
         return True
-    if agent_definition.agent_type == AgentDefinition.AgentTypeChoices.VOICE:
+    if agent_type == AgentDefinition.AgentTypeChoices.VOICE:
         if not bool(getattr(app_settings, "HOSTED_RUNNER_VOICE_ENABLED", False)):
             return False
         from simulate.services.hosted_runner import hosted_runner_supports
 
-        return hosted_runner_supports(agent_definition)
+        return hosted_runner_supports(agent_definition, agent_version)
     return False
 
 
@@ -6614,18 +6683,28 @@ def _dispatch_hosted_rerun(test_execution, call_execution_ids=None) -> str:
 
     ``call_execution_ids`` scopes the rebuilt job to only those calls (a partial
     or single-call rerun); the runner builds exactly their cases so the SDK's
-    positional case→row mapping matches the rows ``/batch`` re-adopts."""
-    from simulate.services.hosted_runner import resolve_runner_mode
+    positional case→row mapping matches the rows ``/batch`` re-adopts.
+
+    The mode is resolved through ``resolve_run_agent_version`` (run_test pin →
+    this execution's pin → latest_version) — the same ladder
+    ``build_start_runner_job`` uses for the rebuilt job, so this dispatch's
+    mode cannot disagree with the transport the builder derives for it.
+    """
+    from simulate.services.hosted_runner import (
+        resolve_run_agent_version,
+        resolve_runner_mode,
+    )
     from simulate.temporal.client import start_simulation_runner_workflow
 
     run_test = test_execution.run_test
     scenario_ids = [str(sid) for sid in (test_execution.scenario_ids or [])]
+    agent_version = resolve_run_agent_version(run_test, test_execution)
     return start_simulation_runner_workflow(
         test_execution_id=str(test_execution.id),
         run_test_id=str(run_test.id),
         org_id=str(run_test.organization_id),
         scenario_ids=scenario_ids,
-        mode=resolve_runner_mode(run_test.agent_definition),
+        mode=resolve_runner_mode(run_test.agent_definition, agent_version),
         simulator_id=(
             str(test_execution.simulator_agent_id)
             if test_execution.simulator_agent_id
@@ -6698,12 +6777,26 @@ class CallExecutionRerunView(APIView):
 
             # Hosted executions re-run through the simulation runner, not the
             # native CallExecutionWorkflow (call_and_eval only; eval_only reruns
-            # just re-score existing transcripts).
-            is_hosted = _hosted_execution_eligible(test_execution.run_test)
+            # just re-score existing transcripts). Pass this execution so the
+            # eligibility check resolves the same pinned version the rerun
+            # dispatch/builder will.
+            is_hosted = _hosted_execution_eligible(
+                test_execution.run_test, test_execution
+            )
 
-            # Validate CHAT/TEXT agents can only use eval_only rerun type
+            # Validate CHAT/TEXT agents can only use eval_only rerun type.
             if rerun_type != "eval_only" and test_execution.run_test.agent_definition:
-                agent_type = test_execution.run_test.agent_definition.agent_type
+                from simulate.services.hosted_runner import agent_field_for_run
+
+                # Same pinned version is_hosted just resolved, not the column,
+                # so this guard cannot classify the run differently than the
+                # eligibility check above did.
+                agent_type = agent_field_for_run(
+                    test_execution.run_test,
+                    "agent_type",
+                    test_execution.run_test.agent_definition.agent_type,
+                    test_execution=test_execution,
+                )
                 if agent_type == AgentDefinition.AgentTypeChoices.TEXT:
                     return self._gm.bad_request(
                         "Text/Chat agents only support 'eval_only' rerun type."
@@ -7301,9 +7394,13 @@ class TestExecutionRerunView(APIView):
             # only); native ones keep the RerunCoordinatorWorkflow path.
             is_hosted = _hosted_execution_eligible(run_test)
 
-            # Validate CHAT/TEXT agents can only use eval_only rerun type
+            # Validate CHAT/TEXT agents can only use eval_only rerun type.
             if rerun_type != "eval_only" and run_test.agent_definition:
-                agent_type = run_test.agent_definition.agent_type
+                from simulate.services.hosted_runner import agent_field_for_run
+
+                agent_type = agent_field_for_run(
+                    run_test, "agent_type", run_test.agent_definition.agent_type
+                )
                 if agent_type == AgentDefinition.AgentTypeChoices.TEXT:
                     return self._gm.bad_request(
                         "Text/Chat agents only support 'eval_only' rerun type."
@@ -7319,16 +7416,24 @@ class TestExecutionRerunView(APIView):
                 TestExecution.ExecutionStatus.RUNNING,
                 TestExecution.ExecutionStatus.CANCELLING,
             ]
+            # select_related: each execution's own pin resolution (below) reads
+            # both FKs, so this avoids two extra queries per execution.
             if select_all:
-                test_executions = TestExecution.objects.filter(
-                    run_test=run_test
-                ).exclude(status__in=non_rerunnable_statuses)
+                test_executions = (
+                    TestExecution.objects.filter(run_test=run_test)
+                    .select_related("agent_version", "run_test__agent_version")
+                    .exclude(status__in=non_rerunnable_statuses)
+                )
                 if test_execution_ids:
                     test_executions = test_executions.exclude(id__in=test_execution_ids)
             else:
-                test_executions = TestExecution.objects.filter(
-                    id__in=test_execution_ids, run_test=run_test
-                ).exclude(status__in=non_rerunnable_statuses)
+                test_executions = (
+                    TestExecution.objects.filter(
+                        id__in=test_execution_ids, run_test=run_test
+                    )
+                    .select_related("agent_version", "run_test__agent_version")
+                    .exclude(status__in=non_rerunnable_statuses)
+                )
 
             if not test_executions.exists():
                 return self._gm.bad_request(
@@ -7347,6 +7452,19 @@ class TestExecutionRerunView(APIView):
                 pre_rerun_status = test_execution.status
                 call_executions = CallExecution.objects.filter(
                     test_execution=test_execution
+                )
+
+                # Resolved per execution (not once for the whole batch): each
+                # execution can be pinned to a different version than
+                # run_test's. Resolved once here and passed in so the
+                # eligibility check below doesn't resolve the ladder again.
+                from simulate.services.hosted_runner import (
+                    resolve_run_agent_version,
+                )
+
+                resolved_version = resolve_run_agent_version(run_test, test_execution)
+                is_hosted = _hosted_execution_eligible(
+                    run_test, test_execution, agent_version=resolved_version
                 )
 
                 if not call_executions.exists():

--- a/futureagi/tfc/settings/settings.py
+++ b/futureagi/tfc/settings/settings.py
@@ -84,6 +84,21 @@ def _bounded_env_int(
     return int(spec.parse(name, os.getenv(name)))
 
 
+def _admission_env_int(name: str, default: int) -> int:
+    """A hosted-runner admission ceiling from the environment. A missing,
+    empty, or non-integer value falls back to the default so a bad override can
+    never crash settings import (``_positive_setting`` in the service layer
+    documents the same lenient fallback and cannot help once import has already
+    failed). The service layer re-checks the bound and treats 0 as 'disabled'."""
+    raw = os.getenv(name)
+    if raw is None or not raw.strip():
+        return default
+    try:
+        return int(raw.strip())
+    except ValueError:
+        return default
+
+
 # Numeric runtime knobs are declared once in runtime_setting_specs.py. Parse
 # and cross-validate them before database/cache configuration consumes them.
 _runtime_numeric_settings = _load_numeric_settings(
@@ -701,15 +716,26 @@ HOSTED_RUNNER_LEASED_ROOM_REUSE = os.getenv(
     "HOSTED_RUNNER_LEASED_ROOM_REUSE", "false"
 ).lower() in ("true", "1", "yes")
 
-# Admission ceilings for the leased-room phone path (the target dials our one
-# scarce leased number, so cases run strictly serially and hold that number
-# for the whole run). Refuse a run before any number is leased when it would
-# reserve too many cases or too much wall-clock. 0 disables that limit.
-HOSTED_RUNNER_LEASED_ROOM_MAX_CASES = int(
-    os.getenv("HOSTED_RUNNER_LEASED_ROOM_MAX_CASES", "25")
+# Admission ceilings for hosted voice runs. Every run reserves a runner child
+# slot for its full wall-clock; a telephony or single-concurrency web run is
+# serial, so an arbitrary dataset otherwise reserves that slot without bound.
+# Refuse a run before the workflow is dispatched when it would reserve too many
+# cases or too much wall-clock. 0 disables that specific limit. Parsed leniently
+# so a bad override cannot crash settings import.
+#
+# Global cap — every hosted voice job.
+HOSTED_RUNNER_MAX_CASES = _admission_env_int("HOSTED_RUNNER_MAX_CASES", 500)
+HOSTED_RUNNER_MAX_WALLCLOCK_SECONDS = _admission_env_int(
+    "HOSTED_RUNNER_MAX_WALLCLOCK_SECONDS", 6 * 60 * 60
 )
-HOSTED_RUNNER_LEASED_ROOM_MAX_WALLCLOCK_SECONDS = int(
-    os.getenv("HOSTED_RUNNER_LEASED_ROOM_MAX_WALLCLOCK_SECONDS", str(4 * 60 * 60))
+# Tighter cap for the leased-room phone path (the target dials our one scarce
+# leased number, so cases run strictly serially and hold that number for the
+# whole run).
+HOSTED_RUNNER_LEASED_ROOM_MAX_CASES = _admission_env_int(
+    "HOSTED_RUNNER_LEASED_ROOM_MAX_CASES", 25
+)
+HOSTED_RUNNER_LEASED_ROOM_MAX_WALLCLOCK_SECONDS = _admission_env_int(
+    "HOSTED_RUNNER_LEASED_ROOM_MAX_WALLCLOCK_SECONDS", 4 * 60 * 60
 )
 
 # Structured logging configuration with django-structlog

--- a/futureagi/tfc/settings/settings.py
+++ b/futureagi/tfc/settings/settings.py
@@ -692,6 +692,12 @@ HOSTED_RUNNER_VOICE_ENABLED = os.getenv(
     "HOSTED_RUNNER_VOICE_ENABLED", "false"
 ).lower() in ("true", "1", "yes")
 
+# Rollback lever for sequential reuse of the leased simulator room (D10):
+# default on, flip off if reuse misbehaves at runtime without a redeploy.
+HOSTED_RUNNER_LEASED_ROOM_REUSE = os.getenv(
+    "HOSTED_RUNNER_LEASED_ROOM_REUSE", "true"
+).lower() in ("true", "1", "yes")
+
 # Structured logging configuration with django-structlog
 # This provides:
 # - JSON output in production, colored console in development

--- a/futureagi/tfc/settings/settings.py
+++ b/futureagi/tfc/settings/settings.py
@@ -692,11 +692,25 @@ HOSTED_RUNNER_VOICE_ENABLED = os.getenv(
     "HOSTED_RUNNER_VOICE_ENABLED", "false"
 ).lower() in ("true", "1", "yes")
 
-# Rollback lever for sequential reuse of the leased simulator room (D10):
-# default on, flip off if reuse misbehaves at runtime without a redeploy.
+# Sequential reuse of one leased simulator room across a multi-row phone run
+# (D10). Default OFF: only a runner whose simulator kit serves multiple
+# personas over a reused room can honour it; the released kit rejects such a
+# job at SDK hydration. Turn it on by env once that kit image is deployed and
+# verified, not before.
 HOSTED_RUNNER_LEASED_ROOM_REUSE = os.getenv(
-    "HOSTED_RUNNER_LEASED_ROOM_REUSE", "true"
+    "HOSTED_RUNNER_LEASED_ROOM_REUSE", "false"
 ).lower() in ("true", "1", "yes")
+
+# Admission ceilings for the leased-room phone path (the target dials our one
+# scarce leased number, so cases run strictly serially and hold that number
+# for the whole run). Refuse a run before any number is leased when it would
+# reserve too many cases or too much wall-clock. 0 disables that limit.
+HOSTED_RUNNER_LEASED_ROOM_MAX_CASES = int(
+    os.getenv("HOSTED_RUNNER_LEASED_ROOM_MAX_CASES", "25")
+)
+HOSTED_RUNNER_LEASED_ROOM_MAX_WALLCLOCK_SECONDS = int(
+    os.getenv("HOSTED_RUNNER_LEASED_ROOM_MAX_WALLCLOCK_SECONDS", str(4 * 60 * 60))
+)
 
 # Structured logging configuration with django-structlog
 # This provides:

--- a/scripts/verify-simulation-runner-deployment.sh
+++ b/scripts/verify-simulation-runner-deployment.sh
@@ -486,8 +486,10 @@ for region in eu us; do
         "$region runner enables dynamic memory tuning"
     assert_rendered_env_value "$rendered_worker" TEMPORAL_TARGET_CPU_USAGE "" \
         "$region runner enables dynamic CPU tuning"
-    assert_rendered_env_value "$rendered_worker" HOSTED_RUNNER_MAX_DURATION_SECONDS 3900 \
-        "$region runner duration ceiling is not 3900 seconds"
+    # The run budget now comes from each job's own deadline; a global ceiling
+    # in the worker env is a leftover that no code reads.
+    assert_rendered_env_value "$rendered_worker" HOSTED_RUNNER_MAX_DURATION_SECONDS "" \
+        "$region runner still sets the retired HOSTED_RUNNER_MAX_DURATION_SECONDS ceiling"
 
     assert_contains \
         "$rendered_worker" \

--- a/scripts/verify-simulation-runner-deployment.sh
+++ b/scripts/verify-simulation-runner-deployment.sh
@@ -513,6 +513,24 @@ runner_value() {
     ' "$values_file"
 }
 
+# Compose renders durations as 5m30s / 1h10m / 45s; the stop grace must be
+# compared in seconds against the worker's drain timeout.
+compose_duration_seconds() {
+    local text=$1 total=0 num unit
+    while [[ "$text" =~ ^([0-9]+)([hms]) ]]; do
+        num=${BASH_REMATCH[1]}
+        unit=${BASH_REMATCH[2]}
+        case "$unit" in
+            h) total=$((total + num * 3600)) ;;
+            m) total=$((total + num * 60)) ;;
+            s) total=$((total + num)) ;;
+        esac
+        text=${text#"${BASH_REMATCH[0]}"}
+    done
+    [[ -z "$text" ]] || return 1
+    printf '%s' "$total"
+}
+
 assert_integer_at_least() {
     local value=$1
     local minimum=$2
@@ -572,6 +590,17 @@ compose_workflow_concurrency=$(compose_field_value TEMPORAL_MAX_CONCURRENT_WORKF
 [[ "$compose_child_concurrency" == "$compose_activity_concurrency" ]] || \
     die "Compose runner concurrency caps differ"
 [[ "$compose_workflow_concurrency" == 8 ]] || die "Compose runner workflow-task concurrency default is not 8"
+# A stop that lands during a phone call must outlast the worker's drain, or
+# Docker force-kills the child mid-call and the leased number stays taken.
+compose_drain_seconds=$(compose_field_value TEMPORAL_GRACEFUL_SHUTDOWN_TIMEOUT "$compose_runner_render")
+compose_stop_grace=$(compose_field_value stop_grace_period "$compose_runner_render")
+[[ "$compose_drain_seconds" =~ ^[0-9]+$ ]] || \
+    die "Compose runner does not set an integer TEMPORAL_GRACEFUL_SHUTDOWN_TIMEOUT"
+[[ -n "$compose_stop_grace" ]] || die "Compose runner does not set stop_grace_period"
+compose_stop_grace_seconds=$(compose_duration_seconds "$compose_stop_grace") || \
+    die "Compose runner stop_grace_period is not a duration: $compose_stop_grace"
+((compose_stop_grace_seconds > compose_drain_seconds)) || \
+    die "Compose runner stop_grace_period must exceed TEMPORAL_GRACEFUL_SHUTDOWN_TIMEOUT"
 if [[ "$explicit_compose_set" == true ]]; then
     echo "Compose configuration (caller-specified set): OK"
 else

--- a/scripts/verify-simulation-runner-deployment.sh
+++ b/scripts/verify-simulation-runner-deployment.sh
@@ -42,7 +42,8 @@ Every problem is reported together; a value of only whitespace counts as missing
                     the internal bearer and ingestion then authenticates the wrong
                     org), HOSTED_RUNNER_MAX_DURATION_SECONDS (retired)
   optional          HOSTED_RUNNER_PARENT_SLACK_SECONDS (integer, default 600),
-                    HOSTED_RUNNER_LEASED_ROOM_REUSE (default true). Assigned-but-
+                    HOSTED_RUNNER_LEASED_ROOM_REUSE (default false; turn on only
+                    once a reuse-capable runner kit is deployed). Assigned-but-
                     empty is refused: int("") kills the worker at import.
   glued lines       a value containing one of these names followed by "=" is two
                     assignments joined by an append with no trailing newline.

--- a/scripts/verify-simulation-runner-deployment.sh
+++ b/scripts/verify-simulation-runner-deployment.sh
@@ -16,9 +16,36 @@ Options:
   --release NAME           Helm release name used for rendering
   --namespace NAME         Helm namespace used for rendering
   --runner-tag TAG         Override the runner image tag for rendering (latest is rejected)
+  --runner-env-file PATH   KEY=VALUE file holding the runner worker's EFFECTIVE
+                           environment, e.g. `docker exec <runner> env > file` or
+                           the rendered Secret. Not a shared .env: other services
+                           may legitimately carry keys the runner must not see.
+                           Repeat for layered files; later files win. Names are
+                           checked, values are never printed.
+  --voice-transports LIST  Comma-separated hosted voice transports the deployment
+                           must serve: sip_outbound (we dial the agent),
+                           sip_inbound_retell (the Retell agent dials our leased
+                           number). Adds that transport's required settings.
+  --env-only               Run only the runner environment contract check; skips
+                           the Compose and Helm renders (no docker/helm needed).
   -h, --help               Show this help
 
 Environment overrides use the SIMULATION_RUNNER_* prefix with the same names.
+
+Runner environment contract (what the hosted voice runner refuses without).
+Every problem is reported together; a value of only whitespace counts as missing.
+  always            LIVEKIT_URL LIVEKIT_API_KEY LIVEKIT_API_SECRET INTERNAL_API_SECRET
+                    and ALK_RUNNER_API_URL (or FI_BASE_URL) for result ingestion
+  sip_outbound      LIVEKIT_OUTBOUND_TRUNK_ID PSTN_CALLER_NUMBER (E.164)
+  sip_inbound_retell ALK_SIM_SLOT_LEASE_SCRIPT SIM_SLOT_LEASE_STORE
+  must be unset     FI_API_KEY FI_SECRET_KEY (the SDK submitter prefers them over
+                    the internal bearer and ingestion then authenticates the wrong
+                    org), HOSTED_RUNNER_MAX_DURATION_SECONDS (retired)
+  optional          HOSTED_RUNNER_PARENT_SLACK_SECONDS (integer, default 600),
+                    HOSTED_RUNNER_LEASED_ROOM_REUSE (default true). Assigned-but-
+                    empty is refused: int("") kills the worker at import.
+  glued lines       a value containing one of these names followed by "=" is two
+                    assignments joined by an append with no trailing newline.
 USAGE
 }
 
@@ -39,6 +66,12 @@ fi
 helm_release=${SIMULATION_RUNNER_HELM_RELEASE:-simulation-runner-preflight}
 helm_namespace=${SIMULATION_RUNNER_HELM_NAMESPACE:-default}
 runner_tag=${SIMULATION_RUNNER_IMAGE_TAG:-preflight-only}
+runner_env_files=()
+if [[ -n "${SIMULATION_RUNNER_RUNNER_ENV_FILE:-}" ]]; then
+    runner_env_files=("$SIMULATION_RUNNER_RUNNER_ENV_FILE")
+fi
+voice_transports=${SIMULATION_RUNNER_VOICE_TRANSPORTS:-}
+env_only=false
 
 while (($#)); do
     case "$1" in
@@ -75,6 +108,21 @@ while (($#)); do
             runner_tag=$2
             shift 2
             ;;
+        --runner-env-file)
+            (($# >= 2)) || die "--runner-env-file requires a path"
+            [[ -n "$2" ]] || die "--runner-env-file requires a non-empty path"
+            runner_env_files+=("$2")
+            shift 2
+            ;;
+        --voice-transports)
+            (($# >= 2)) || die "--voice-transports requires a list"
+            voice_transports=$2
+            shift 2
+            ;;
+        --env-only)
+            env_only=true
+            shift
+            ;;
         -h|--help)
             usage
             exit 0
@@ -98,10 +146,221 @@ if ((${#compose_files[@]} == 0)); then
 fi
 
 [[ -d "$repo_root" ]] || die "repository root does not exist: $repo_root"
-[[ -d "$deployment_root" ]] || die "deployment root does not exist: $deployment_root"
-for compose_file in "${compose_files[@]}"; do
-    [[ -f "$compose_file" ]] || die "Compose file does not exist: $compose_file"
-done
+if ((${#runner_env_files[@]} == 0)); then
+    [[ "$env_only" != true ]] || die "--env-only requires at least one --runner-env-file"
+    [[ -z "$voice_transports" ]] || \
+        die "--voice-transports names a contract to check but no --runner-env-file" \
+            "was given"
+fi
+if [[ "$env_only" != true ]]; then
+    [[ -d "$deployment_root" ]] || die "deployment root does not exist: $deployment_root"
+    for compose_file in "${compose_files[@]}"; do
+        [[ -f "$compose_file" ]] || die "Compose file does not exist: $compose_file"
+    done
+fi
+
+# ---- Runner environment contract -------------------------------------------
+# The hosted voice runner reads these from its process environment and refuses
+# one run per missing name. Check them here, once, before anything is rolled
+# out, and report every problem together. Only names are ever printed; values
+# stay in this process. Plain file scans, no bash-4 features: this must run
+# from a stock macOS bash 3.2 too.
+
+contract_failures=()
+
+contract_fail() {
+    contract_failures+=("$*")
+}
+
+runner_env_file_exists() {
+    local file
+    for file in "${runner_env_files[@]}"; do
+        [[ -f "$file" ]] || die "runner env file does not exist: $file"
+    done
+}
+
+strip_ws() {
+    local value=$1
+    value=${value#"${value%%[![:space:]]*}"}
+    value=${value%"${value##*[![:space:]]}"}
+    printf '%s' "$value"
+}
+
+# Last assignment across the files wins, matching dotenv/Compose semantics.
+# Whitespace around the value and then surrounding quotes are dropped the way
+# the builder's strip does, so a value of spaces counts as missing here as it
+# does there. The raw form is the value verbatim: the input is the runner's
+# effective environment, which the builder hands to the kit untouched, and the
+# kit's E.164 rule must hold on exactly that.
+runner_env_value() {
+    local name=$1
+    local raw=${2:-}
+    local file line value found=""
+    for file in "${runner_env_files[@]}"; do
+        while IFS= read -r line || [[ -n "$line" ]]; do
+            line=${line%$'\r'}
+            [[ "$line" == "$name="* ]] || continue
+            value=${line#*=}
+            if [[ -z "$raw" ]]; then
+                value=$(strip_ws "$value")
+                if [[ "$value" =~ ^\"(.*)\"$ || "$value" =~ ^\'(.*)\'$ ]]; then
+                    value=$(strip_ws "${BASH_REMATCH[1]}")
+                fi
+            fi
+            found=$value
+        done <"$file"
+    done
+    printf '%s' "$found"
+}
+
+runner_env_set() {
+    [[ -n "$(runner_env_value "$1")" ]]
+}
+
+# True when any file carries a NAME= line, even an empty one. An optional
+# setting that is assigned but empty is not "absent": int("") kills the worker
+# at import and an empty boolean silently reads as false.
+runner_env_assigned() {
+    local name=$1
+    local file
+    for file in "${runner_env_files[@]}"; do
+        grep -q "^$name=" "$file" && return 0
+    done
+    return 1
+}
+
+# A value that contains one of this contract's exact names followed by "=" is
+# two lines glued together by an append onto a file with no trailing newline;
+# both settings are then wrong and the failure surfaces one run later. Exact
+# names only: a prefix pattern would refuse a URL query like ?LIVEKIT_URL_HINT=.
+contract_names='LIVEKIT_URL|LIVEKIT_API_KEY|LIVEKIT_API_SECRET|LIVEKIT_OUTBOUND_TRUNK_ID'
+contract_names+='|INTERNAL_API_SECRET|ALK_RUNNER_API_URL|FI_BASE_URL|PSTN_CALLER_NUMBER'
+contract_names+='|ALK_SIM_SLOT_LEASE_SCRIPT|SIM_SLOT_LEASE_STORE'
+contract_names+='|HOSTED_RUNNER_PARENT_SLACK_SECONDS|HOSTED_RUNNER_LEASED_ROOM_REUSE'
+contract_names+='|HOSTED_RUNNER_MAX_DURATION_SECONDS|FI_API_KEY|FI_SECRET_KEY'
+glued_pattern="($contract_names)="
+
+check_runner_env_not_glued() {
+    local file line value lineno
+    for file in "${runner_env_files[@]}"; do
+        lineno=0
+        while IFS= read -r line || [[ -n "$line" ]]; do
+            lineno=$((lineno + 1))
+            line=${line%$'\r'}
+            [[ "$line" =~ ^[A-Za-z_][A-Za-z0-9_]*= ]] || continue
+            value=${line#*=}
+            if [[ "$value" =~ $glued_pattern ]]; then
+                contract_fail "$file line $lineno looks like two assignments glued on one line" \
+                    "(missing newline before the next KEY=)"
+            fi
+        done <"$file"
+    done
+}
+
+check_runner_env_present() {
+    local scope=$1
+    shift
+    local missing=()
+    local name
+    for name in "$@"; do
+        runner_env_set "$name" || missing+=("$name")
+    done
+    ((${#missing[@]} == 0)) || \
+        contract_fail "missing for $scope: ${missing[*]}"
+}
+
+check_runner_env_absent() {
+    local reason=$1
+    shift
+    local present=()
+    local name
+    for name in "$@"; do
+        runner_env_set "$name" && present+=("$name")
+    done
+    ((${#present[@]} == 0)) || \
+        contract_fail "must be unset: ${present[*]} ($reason)"
+}
+
+verify_runner_env() {
+    local transport value
+    runner_env_file_exists
+    check_runner_env_not_glued
+    check_runner_env_present "hosted voice runs" \
+        LIVEKIT_URL LIVEKIT_API_KEY LIVEKIT_API_SECRET INTERNAL_API_SECRET
+    # The child reports results to one of these; without either, nothing lands.
+    runner_env_set ALK_RUNNER_API_URL || runner_env_set FI_BASE_URL || \
+        contract_fail "missing for result ingestion: ALK_RUNNER_API_URL (or FI_BASE_URL)"
+    local transports=()
+    IFS=', ' read -r -a transports <<<"$voice_transports"
+    for transport in "${transports[@]+"${transports[@]}"}"; do
+        transport=${transport// /}
+        case "$transport" in
+            "")
+                ;;
+            sip_outbound)
+                check_runner_env_present "sip_outbound (we dial the agent)" \
+                    LIVEKIT_OUTBOUND_TRUNK_ID PSTN_CALLER_NUMBER
+                value=$(runner_env_value PSTN_CALLER_NUMBER raw)
+                # The kit's transport model rejects anything but E.164 at hydration,
+                # on the value as handed over: stray whitespace fails it there too.
+                if [[ -n "$value" && ! "$value" =~ ^\+[1-9][0-9]{6,14}$ ]]; then
+                    contract_fail "PSTN_CALLER_NUMBER is not E.164 (+ then 7-15 digits;" \
+                        "no spaces or quotes, exactly as the runner env holds it)"
+                fi
+                ;;
+            sip_inbound_retell)
+                check_runner_env_present \
+                    "sip_inbound_retell (the Retell agent dials our leased number)" \
+                    ALK_SIM_SLOT_LEASE_SCRIPT SIM_SLOT_LEASE_STORE
+                ;;
+            *)
+                contract_fail "unknown voice transport: $transport" \
+                    "(expected sip_outbound, sip_inbound_retell)"
+                ;;
+        esac
+    done
+    local key_pair_reason="the SDK submitter prefers the org key pair over the"
+    key_pair_reason+=" internal bearer, so ingestion authenticates the wrong org"
+    check_runner_env_absent "$key_pair_reason" FI_API_KEY FI_SECRET_KEY
+    check_runner_env_absent \
+        "retired: the run budget is the child's own deadline" \
+        HOSTED_RUNNER_MAX_DURATION_SECONDS
+    if runner_env_assigned HOSTED_RUNNER_PARENT_SLACK_SECONDS; then
+        value=$(runner_env_value HOSTED_RUNNER_PARENT_SLACK_SECONDS)
+        [[ "$value" =~ ^\+?[0-9]+$ ]] || \
+            contract_fail "HOSTED_RUNNER_PARENT_SLACK_SECONDS must be a non-negative integer" \
+                "(an empty assignment kills the worker at import)"
+    fi
+    if runner_env_assigned HOSTED_RUNNER_LEASED_ROOM_REUSE; then
+        value=$(runner_env_value HOSTED_RUNNER_LEASED_ROOM_REUSE)
+        # The code lowercases and treats true/1/yes as on and anything else as
+        # off, so a typo silently disables reuse; only the explicit spellings pass.
+        case "$(printf '%s' "$value" | tr '[:upper:]' '[:lower:]')" in
+            true|1|yes|false|0|no) ;;
+            *)
+                contract_fail "HOSTED_RUNNER_LEASED_ROOM_REUSE must be true/1/yes or false/0/no" \
+                    "(anything else reads as false; empty is refused)"
+                ;;
+        esac
+    fi
+    if ((${#contract_failures[@]} > 0)); then
+        local failure
+        for failure in "${contract_failures[@]}"; do
+            echo "ERROR: runner env contract: $failure" >&2
+        done
+        exit 1
+    fi
+    echo "Runner environment contract (${#runner_env_files[@]} file(s);" \
+        "transports: ${voice_transports:-none}): OK"
+}
+
+if ((${#runner_env_files[@]} > 0)); then
+    verify_runner_env
+fi
+if [[ "$env_only" == true ]]; then
+    echo "Simulation-runner deployment preflight (env only): PASS"
+    exit 0
+fi
 
 command -v helm >/dev/null 2>&1 || die "helm is required"
 helm_command=(helm)


### PR DESCRIPTION
## Summary

Ships Retell outbound voice simulation to `dev` on its own, independent of the RL-environment / hosted-harness architecture on `feat/hosted-bundle-v2-production`. A customer's outbound Retell agent dials a leased platform number, one phone run carries many scenarios over that single number, and the run budget belongs to the child process. Users see Retell outbound agents become runnable on the hosted (ALK) simulation path; the native simulation flow is deliberately not touched.

## Linked issues

Closes #
Linear:

## AI use

AI use: Claude Code did the cherry-pick from #2557, the conflict resolution in `run_test.py`, the speaker-map restoration and the two hosted tests, all under the author's direction and review; the underlying feature commit was written with Claude Code assistance and reviewed in #2557.

## Type of change

- [x] ✨ New feature (non-breaking change which adds functionality)

## E2E coverage

E2E: exempt (harness-gap: `yarn coverage` reports no simulate flows exist yet; hosted phone runs also need Retell and a leased trunk number that are not-in-stack)

---

## 1) What changes were done

### A. Hosted Retell outbound jobs (`simulate/services/hosted_runner.py`, temporal activities/workflow/types/constants)

- The hosted runner builds jobs for Retell outbound agents (their agent dials our leased number); the number lease is guarded so a job with nothing to dial never spawns.
- Every agent field the hosted path needs is read from the pinned agent-version snapshot, in the views as well as the builder (`agent_field_for_run`).
- One phone run carries many scenarios over a single leased number: the pool room is pinned for the whole run, the lease covers the run's full length and is released with the run id; `HOSTED_RUNNER_LEASED_ROOM_REUSE` is the rollback lever.
- Run budget belongs to the child: the builder states each job's deadline from the kit formula; workflow timeout and lease derive from it plus `HOSTED_RUNNER_PARENT_SLACK_SECONDS`; a missing budget is refused by the activity, never by the workflow, so histories recorded by the previous release still replay (in-repo Temporal replay test). `HOSTED_RUNNER_MAX_DURATION_SECONDS` and the row-count refusal are removed; `scripts/verify-simulation-runner-deployment.sh` asserts the retired variable is absent.

### B. Retell speaker-role maps (`simulate/utils/speaker_roles.py`)

- Hosted Retell results store `provider_call_data['retell']`, and the transcript the UI renders resolves roles from that key. Without a Retell entry the resolver logs unknown-provider and falls back to the VAPI maps. Retell now has its own inbound and outbound maps and is detected from the stored provider data.

### C. What is left out on purpose

- The native Retell provider engine from #2557 (`5cca1e21f`: RetellService, native voice activity wiring). Only the hosted path ships.
- The observability-poll pair from #2557 is already on `dev` as tracer migration 0098.
- The rerun guards in `simulate/views/run_test.py` were the only cherry-pick conflict: the source branch also consulted repository-harness helpers `dev` does not have. `dev`'s structure is kept and only the pinned-field lookup is added; no harness-job model, provider or helper is introduced.

## 2) How it was tested

This PR adds **146 test methods** — 145 in `simulate/tests/test_alk_simulate_ingestion.py`, 1 in `simulate/tests/test_speaker_role_resolver.py` — covering the hosted Retell outbound jobs, the speaker-role maps, the cross-agent version gate, and the hosted-voice admission bounds (global and leased, `sip_outbound`, web, and the lenient settings parse). Backend and E2E CI are green on `186cbfa`. The suites also run green locally against the isolated test stack (`docker-compose.test.yml`):

```
uv run pytest -q simulate/tests/test_alk_simulate_ingestion.py simulate/tests/test_speaker_role_resolver.py
```

New regressions worth calling out:

- Admission (`TestBuildVoiceRunnerJob`): `test_sip_outbound_admission_refuses_excess_wallclock`, `test_sip_outbound_admission_refuses_excess_rows`, `test_web_transport_admission_refuses_excess_wallclock`, `test_admission_env_int_is_lenient`, plus the cross-agent version gate and leased-room admission regressions.
- Speaker maps (`TestResultIngest`): `test_retell_result_resolves_speaker_roles_through_the_retell_maps`, `test_retell_inbound_result_swaps_speaker_roles` — ingested through the ALK result endpoint and rendered via `CallExecutionDetailSerializer.get_transcript`; run against `dev`'s resolver they fail (`ProviderChoices.VAPI == ProviderChoices.RETELL`), so they guard the maps.

Retell outbound was exercised end to end over SIP and webcall on the source branch before it merged into `feat/hosted-bundle-v2-production` (#2557).

Verify-script contract check, after two cold review rounds (both CLEAR; 3 Mediums each, all fixed): 24 permutations on macOS system bash 3.2 (7 PASS cases, 17 named refusals, every failure reported together, zero planted values in any output), plus the dev box's live runner environment (PASS for `sip_outbound`; named refusal for `sip_inbound_retell`: lease script and store; refusal of the shared `.env` because it carries the org key pair for other services). No-flag invocation is control-flow identical to before.

## 3) Deployment notes

The runner's environment contract now ships with the code, in three places: asserted by `scripts/verify-simulation-runner-deployment.sh` (new `--runner-env-file` / `--voice-transports` / `--env-only` options, runnable on a stock macOS bash 3.2 with neither helm nor docker), documented in `.env.example` under "Hosted voice simulation runner", and listed here.

| Scope | Settings |
|---|---|
| any hosted voice run | `LIVEKIT_URL`, `LIVEKIT_API_KEY`, `LIVEKIT_API_SECRET` (the project that owns the trunk), `INTERNAL_API_SECRET` (the child's bearer for result ingestion) |
| `sip_outbound`, we dial the agent | `LIVEKIT_OUTBOUND_TRUNK_ID`, `PSTN_CALLER_NUMBER` |
| `sip_inbound_retell`, the Retell agent dials our leased number | `ALK_SIM_SLOT_LEASE_SCRIPT` (LiveKit infra repo's `lease_sim_slot.py`, mounted into the runner), `SIM_SLOT_LEASE_STORE` |
| optional | `HOSTED_RUNNER_PARENT_SLACK_SECONDS` (integer, default 600), `HOSTED_RUNNER_LEASED_ROOM_REUSE` (true/false, default false — turn on only once a runner whose kit supports sequential room reuse is deployed and verified) |
| admission caps (optional) | `HOSTED_RUNNER_MAX_CASES` (default 500) and `HOSTED_RUNNER_MAX_WALLCLOCK_SECONDS` (default 21600 = 6h) bound every hosted voice run before dispatch; `HOSTED_RUNNER_LEASED_ROOM_MAX_CASES` (default 25) and `HOSTED_RUNNER_LEASED_ROOM_MAX_WALLCLOCK_SECONDS` (default 14400 = 4h) layer a tighter cap on the leased-DID path. 0 disables a check; a malformed value falls back to the default without crashing settings import |
| must be unset on the runner | `FI_API_KEY`, `FI_SECRET_KEY` (the SDK submitter prefers the org key pair over the internal bearer, and ingestion then authenticates the wrong org), `HOSTED_RUNNER_MAX_DURATION_SECONDS` (retired) |

Check a candidate runner environment before rollout, values never printed:

```
scripts/verify-simulation-runner-deployment.sh --env-only \
  --runner-env-file <runner effective env, e.g. docker exec <runner> env> \
  --voice-transports sip_outbound,sip_inbound_retell
```

The check also refuses a file with two assignments glued on one line, the failure mode of an append onto a file with no trailing newline.

Why this is here: the consuming code shipped in the first commit, but none of these names were documented anywhere, and the dev box on 2026-09-09 paid one refused run per missing setting (trunk id, caller number, LiveKit URL, lease script, then a 403 on ingestion from a stale key pair). Prod needed the same trunk-id fix on 2026-09-05.

Companion kit change, to be released and pinned via `FI_VERSION` in `Dockerfile.simulation-runner`: https://github.com/future-agi/agent-learning-kit/pull/83


