### PR TITLE
fix(compose): restore the alk-harness-sandbox service to the dev overlay

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -48,6 +48,68 @@ services:
       CH25_TRACE_DUAL_WRITE: "false"
       CH_DUAL_WRITE: "false"
 
+  # Local implementation of the hosted ALK sandbox contract. It is reachable by the
+  # backend over the private Compose network; its host port is loopback-only.
+  alk-harness-sandbox:
+    build:
+      context: ${ALK_REPOSITORY_PATH:-../alk-pr58}
+      dockerfile: Dockerfile.sandbox
+    image: futureagi/alk-harness-sandbox:dev
+    pull_policy: never
+    env_file:
+      - path: ${ALK_HARNESS_ENV_FILE:-../alk-pr58/.env.acceptance}
+        required: false
+    environment:
+      ALK_SANDBOX_HOST: 0.0.0.0
+      ALK_SANDBOX_PORT: 8788
+      ALK_SANDBOX_ROOT: /var/lib/alk-sandbox
+      # The Docker daemon is on the host. Mount the workspace at the same
+      # absolute path inside the runner so Compose bind mounts resolve to a
+      # path both the client and daemon can see. A hosted provider uses the
+      # equivalent shared bundle/workspace mount.
+      ALK_SANDBOX_SOURCE_ROOTS: ${ALK_HOST_WORKSPACE_ROOT:?set ALK_HOST_WORKSPACE_ROOT to the directory containing agent repositories}
+      ALK_SANDBOX_PATH_MAP: ${ALK_HOST_WORKSPACE_ROOT}=${ALK_HOST_WORKSPACE_ROOT}
+      ALK_SANDBOX_UPLOAD_ROOT: ${ALK_HOST_WORKSPACE_ROOT}/.alk-harness-uploads
+      # Job-scoped credential files must be visible at the same absolute path to both the
+      # containerized runner and the host Docker daemon. Contents are mode 0400 and deleted at
+      # the terminal job boundary; they never enter source uploads or harness artifacts.
+      ALK_SANDBOX_SECRET_FILE_ROOT: ${ALK_HOST_WORKSPACE_ROOT}/.alk-harness-secret-files
+      # A local developer laptop runs the full platform and Docker workloads together. Keep
+      # hosted-validation jobs sequential by default so two simultaneous voice/model stacks do
+      # not starve the sandbox status API or Docker daemon. Hosted deployments override this
+      # according to their per-sandbox resource envelope.
+      ALK_SANDBOX_MAX_CONCURRENCY: ${ALK_SANDBOX_MAX_CONCURRENCY:-1}
+      ALK_HARNESS_MODEL: ${ALK_HARNESS_MODEL:-claude-sonnet-4-6}
+      CLOUD_ML_REGION: ${CLOUD_ML_REGION:-global}
+      # The sandbox reports canonical run events/results to the platform. Keep
+      # these separate from model-provider settings loaded above: in hosted
+      # execution they are short-lived job credentials supplied by the control
+      # plane rather than values baked into the runner image.
+      HARNESS_PLATFORM_URL: http://backend:80
+      HARNESS_PLATFORM_API_KEY: ${FI_API_KEY:?FI_API_KEY is required for harness result ingestion}
+      HARNESS_PLATFORM_SECRET_KEY: ${FI_SECRET_KEY:?FI_SECRET_KEY is required for harness result ingestion}
+      # ALK's reusable eval client uses the public SDK variable names. Point both
+      # reporting paths at the same local control/data plane for deployment parity.
+      FI_BASE_URL: http://backend:80
+      FI_API_KEY: ${FI_API_KEY:?FI_API_KEY is required for harness evaluation}
+      FI_SECRET_KEY: ${FI_SECRET_KEY:?FI_SECRET_KEY is required for harness evaluation}
+      GOOGLE_APPLICATION_CREDENTIALS: ${ALK_HOST_WORKSPACE_ROOT}/future-agi/Vertex_AI_Creds.json
+      DOCKER_HOST: tcp://docker-proxy:2375
+      ALK_DOCKER_PUBLISHED_HOST: host.docker.internal
+      ALK_RUNNER_CONTAINER: self
+      HARNESS_WEBHOOK_HOST: 0.0.0.0
+    volumes:
+      - ${ALK_HOST_WORKSPACE_ROOT}:${ALK_HOST_WORKSPACE_ROOT}:ro
+      - ${ALK_HOST_WORKSPACE_ROOT}/.alk-harness-uploads:${ALK_HOST_WORKSPACE_ROOT}/.alk-harness-uploads:rw
+      - ${ALK_HOST_WORKSPACE_ROOT}/.alk-harness-secret-files:${ALK_HOST_WORKSPACE_ROOT}/.alk-harness-secret-files:rw
+      - alk_harness_artifacts:/var/lib/alk-sandbox
+    ports:
+      - "127.0.0.1:${ALK_SANDBOX_PORT:-8788}:8788"
+    depends_on:
+      docker-proxy:
+        condition: service_started
+    restart: unless-stopped
+
   # The supervisor runs Django management commands from this checkout. Keep it
   # on the same locally-built image and bind mount as backend; inheriting the
   # root compose's release image can leave new commands unavailable on dev.
@@ -202,3 +264,6 @@ services:
     volumes:
       - ${DOCKER_SOCKET:-/var/run/docker.sock}:/var/run/docker.sock
     restart: unless-stopped
+
+volumes:
+  alk_harness_artifacts:


### PR DESCRIPTION
## Summary

Restores the `alk-harness-sandbox` service and its `alk_harness_artifacts` volume to `docker-compose.dev.yml`. Both were present on the pre-merge base and were lost in the dev catch-up merge, which leaves the dev overlay unusable:

```
service "alk-harness-sandbox" has neither an image nor a build context specified: invalid compose project
```

The service is still referenced by developers' local overrides, so compose rejects the whole project and no dev service starts.

## Cause

My conflict resolution on the catch-up merge. The dev overlay was hand-merged as a union of both sides, verified, and then clobbered: a later loop that resolved the generated contract artefacts ran `git checkout --theirs` over everything git still listed as unresolved, and this file had not been staged yet, so it was overwritten with the dev-side version before being added. The verification I ran was real but preceded the overwrite.

## Verification

- `docker compose -f docker-compose.yml -f docker-compose.dev.yml config` parses
- `alk-harness-sandbox`, `property-catalog-supervisor` and `dev-api-proxy` are all present, so the union is complete this time
- The restored block is byte-identical to the pre-merge base, including the build context, image tag and loopback-only port

## Not in this PR

`futureagi/uv.lock` was clobbered the same way and no longer contains `daytona` or `httpx-ws`, both of which `pyproject.toml` declares. That does not affect image builds, which install from `requirements.txt` and do carry them, but `backend-ci.yml` runs `uv sync --frozen`, so any job that exercises the Daytona gateway will run without it.

Regenerating the lock pulls a dozen unrelated dependency bumps and changes the `[options]` table, which is not something to land immediately before a deployment. It is worth its own PR and its own review.
