### PR TITLE
fix(harness): stop offering the voicemail evals in the guest catalogue

### DIFF
--- a/futureagi/simulate/services/harness_evals.py
+++ b/futureagi/simulate/services/harness_evals.py
@@ -29,6 +29,9 @@ MOST_SELECTED_EVALS = 8
 _OFFERED_NAME_PREFIX = "customer_agent"
 _OFFERED_FROM_EVAL_ID = 200
 
+# Judge a premise a suite need not contain, so they are never offered.
+_NOT_OFFERED = frozenset({"voice_mail_detection", "voicemail_handling"})
+
 # These have no analogue in a chat transcript.
 _VOICE_ONLY_EVALS = frozenset(
     {
@@ -101,6 +104,8 @@ def offered_evals(organization, workspace, modality: str) -> list[dict[str, Any]
             name.startswith(_OFFERED_NAME_PREFIX)
             or (template.eval_id or 0) >= _OFFERED_FROM_EVAL_ID
         ):
+            continue
+        if name in _NOT_OFFERED:
             continue
         if modality != "voice" and name in _VOICE_ONLY_EVALS:
             continue


### PR DESCRIPTION
## Summary

Stops offering `voice_mail_detection` and `voicemail_handling` in the eval catalogue put in front of a harness job.

Both judge a premise a suite need not contain. Evals are chosen by the understand stage before a single scenario exists, so an outbound agent was offered the voicemail evals whether or not the scenario writer ever wrote a mailbox. On a suite with no mailbox that is two wasted judge calls per call in the run, each answering "not applicable", and an optimiser reading those verdicts then recommends fixing voicemail handling in an agent that was never asked to do it.

Removing them from the catalogue is the whole fix. Selection stays entirely the model's: it picks freely from whatever the list contains, and the list simply no longer contains these two. No conditional logic, no scenario inspection, nothing deterministic added anywhere.

## Note on granularity

`chosen_evals` is a per-suite field. Even a correct suite-level selection applies every chosen eval to every call in the run, so a premise-conditional eval over-applies whenever the suite is mixed. Binding evals per scenario would need a new field in the provision contract and per-scenario configs on the platform. That is worth doing separately; it is not this change.

## Verification

- `offered_evals` is the only place the catalogue is assembled, so this is the single point where the two names can be withheld
- `dead_air_detection` is untouched and still offered for voice runs
