### PR TITLE
fix(harness): give audio evals a source so they stop being dropped from the catalogue

### DIFF
--- a/futureagi/simulate/services/harness_evals.py
+++ b/futureagi/simulate/services/harness_evals.py
@@ -45,6 +45,8 @@ _VOICE_ONLY_EVALS = frozenset(
 _SOURCE_BY_KEY_VOICE = {
     # The combined recording; a per-channel mapping resolves empty on combined-only providers.
     "conversation": "voice_recording",
+    # Audio-analysing evals ask for the recording itself rather than a transcript of it.
+    "input_audio": "voice_recording",
     # A single-output eval on a call is judging the same conversation.
     "output": "voice_recording",
     "agent_prompt": "agent_prompt",
@@ -111,6 +113,12 @@ def offered_evals(organization, workspace, modality: str) -> list[dict[str, Any]
             continue
         mapping = resolve_eval_mapping(template, modality)
         if mapping is None:
+            logger.warning(
+                "harness_eval_not_offerable",
+                template=name,
+                required_keys=_required_keys(template),
+                modality=modality,
+            )
             continue
         offered.append(
             {

--- a/futureagi/simulate/services/harness_evals.py
+++ b/futureagi/simulate/services/harness_evals.py
@@ -29,8 +29,16 @@ MOST_SELECTED_EVALS = 8
 _OFFERED_NAME_PREFIX = "customer_agent"
 _OFFERED_FROM_EVAL_ID = 200
 
-# Judge a premise a suite need not contain, so they are never offered.
-_NOT_OFFERED = frozenset({"voice_mail_detection", "voicemail_handling"})
+# Never offered. The voicemail pair judge a premise a suite need not contain.
+# `conversation_hallucination` needs a `context` variable, and a call has no retrieval context to
+# bind it to, so it could only ever be pointed at something that is not what it is judging.
+_NOT_OFFERED = frozenset(
+    {
+        "voice_mail_detection",
+        "voicemail_handling",
+        "conversation_hallucination",
+    }
+)
 
 # These have no analogue in a chat transcript.
 _VOICE_ONLY_EVALS = frozenset(

--- a/futureagi/simulate/tests/test_hosted_harness_eval_selection.py
+++ b/futureagi/simulate/tests/test_hosted_harness_eval_selection.py
@@ -102,6 +102,22 @@ def test_the_catalogue_offers_the_family_and_the_numbered_voice_evals(
 
 
 @pytest.mark.django_db
+def test_an_audio_eval_is_offered_on_voice_and_withheld_from_text(organization, workspace):
+    """`dead_air_detection` asks for the recording itself, not a transcript of it.
+
+    Its required key had no source, so `resolve_eval_mapping` refused it and the catalogue
+    dropped it silently on every run, voice included.
+    """
+    _template("dead_air_detection", ["input_audio"], eval_id=201)
+
+    voice = {item["name"] for item in offered_evals(organization, workspace, "voice")}
+    assert "dead_air_detection" in voice
+
+    text = {item["name"] for item in offered_evals(organization, workspace, "text")}
+    assert "dead_air_detection" not in text
+
+
+@pytest.mark.django_db
 def test_a_chat_run_is_not_offered_the_voice_only_evals(organization, workspace):
     _template("dead_air_detection", ["conversation"], eval_id=201)
     _template("voicemail_handling", ["conversation"], eval_id=207)


### PR DESCRIPTION
## Summary

`dead_air_detection` has never been offered to a harness job, on voice or anywhere else.

It asks for `input_audio`, the recording itself rather than a transcript of it. The harness source map had no entry for that key, and `resolve_eval_mapping` refuses a template the moment any required key has no source, so `offered_evals` dropped it every time. Silently: nothing logged, no error, it simply was not in the catalogue.

That is worth stating plainly because it is the eval that measures the thing we most recently had to measure by hand. Dead air on completed calls was running at 36 to 43 seconds and was counted manually off transcripts, while an eval built to catch exactly that had never once run.

## Changes

`input_audio` now resolves to `voice_recording` on voice runs, and is deliberately absent from the text map. A chat run has no recording, so an audio eval must not be offered there. That also makes the existing `_VOICE_ONLY_EVALS` guard meaningful for this eval: until now it excluded `dead_air_detection` from text runs that were never going to be offered it anyway.

An unmappable template is now logged when it is withheld. The silence is why this went unnoticed; a template that cannot be offered should say so.

## conversation_hallucination is now withheld explicitly

It requires `conversation` and `context`. There is no harness source for `context` — the simulation context map carries call metadata such as `call_summary`, `duration` and `audio_url`, none of which is retrieval context. Binding it to something merely available would produce confident, wrong verdicts, which is worse than not running it.

It was already absent from every catalogue, but by accident: the mapping simply failed. It now sits in `_NOT_OFFERED` alongside the voicemail pair, so the omission is a decision on the record rather than a silent failure that looks identical to a bug.

## Catalogue count

```
match the name/id filter        21
  voicemail evals, withheld     -2
  unmappable                    -2  ->  -1  (dead_air_detection now resolves)
offered on voice                17  ->  18   (dead_air_detection resolves)
offered on text                 17      (unchanged; audio evals stay out)
```

## Verification

Backend CI does not run on pull requests targeting this branch: `backend-ci.yml` triggers only on `dev` and `main`. The added test therefore needs running locally:

```
bin/test app simulate -k eval_selection
```
