### PR TITLE
docs(gateway): fix source quickstart entrypoint and config flag [agent]

### DIFF
--- a/agentcc-gateway/README.md
+++ b/agentcc-gateway/README.md
@@ -17,7 +17,7 @@ Route · cache · govern · guard · observe. Single Go binary. Drop-in OpenAI A
 
 <p>
   <a href="https://github.com/future-agi/future-agi/blob/main/LICENSE"><img src="https://img.shields.io/badge/license-Apache%202.0-blue?style=flat-square" alt="Apache 2.0"></a>
-  <a href="../../LICENSE"><img src="https://img.shields.io/badge/built%20with-Go%201.23-00ADD8?style=flat-square&logo=go" alt="Go 1.23"></a>
+  <a href="../LICENSE"><img src="https://img.shields.io/badge/built%20with-Go%201.25-00ADD8?style=flat-square&logo=go" alt="Go 1.25"></a>
   <a href="https://docs.futureagi.com/docs/prism"><img src="https://img.shields.io/badge/docs-docs.futureagi.com-fafafa?style=flat-square" alt="Docs"></a>
   <a href="https://discord.com/invite/n2tCUKBkAw"><img src="https://img.shields.io/badge/community-Discord-5865F2?style=flat-square" alt="Discord"></a>
 </p>
@@ -276,14 +276,19 @@ curl http://localhost:8080/v1/chat/completions \
   }'
 ```
 
-<details><summary><b>Run from source (Go 1.23+)</b></summary>
+<details><summary><b>Run from source (Go 1.25+)</b></summary>
 
 ```bash
 git clone https://github.com/future-agi/future-agi.git
 cd future-agi/agentcc-gateway
 cp config.example.yaml config.yaml
-go run ./cmd/server
+# Set OPENAI_API_KEY in your environment, or configure another provider in config.yaml.
+go run ./cmd/agentcc --config config.yaml
 ```
+
+The `--config` flag explicitly loads the file you just copied. Alternatively,
+set `AGENTCC_CONFIG_FILE` to its path. Once the server starts, the example
+configuration listens on `http://localhost:8080`.
 
 </details>
 


### PR DESCRIPTION
## Summary

The source quickstart runs `go run ./cmd/server`, but the executable lives in `cmd/agentcc`. It also copies config.yaml without passing it to the executable: main loads a path only from `--config` or `AGENTCC_CONFIG_FILE`. Correct the command and bring the stated Go requirement into line with go.mod. Fix the Go badge's license link while updating it.

## Linked issues

Small documentation fix; no linked issue or Linear ticket.

## AI use

AI use: OpenAI Codex inspected the code, authored the entire change and this description, ran the check below, and is submitting this PR at the account owner's request. This is an agent-authored submission, not a claim of independent human verification.

## Type of change

- [x] Documentation only

## E2E coverage

E2E: exempt (docs)

## Verification

Ran the real command with Go 1.25.0 on macOS arm64:

```text
$ go run ./cmd/agentcc --help
Usage of /var/folders/5d/5jv9m53555qd21yd7qntlfsh0000gn/T/go-build1598359965/b001/exe/agentcc:
  -config string
        Path to config file (YAML/JSON)
```

Exit 0. `git diff --check` passed. Checked config loading in `cmd/agentcc/main.go` and the 8080 listener in `config.example.yaml`. No live provider request or full platform boot was performed; this is a source-entrypoint documentation correction.
