### PR TITLE
fix(gateway): preserve submillisecond latency for routing [agent]

### DIFF
--- a/agentcc-gateway/internal/routing/latency.go
+++ b/agentcc-gateway/internal/routing/latency.go
@@ -26,7 +26,7 @@ func NewLatencyTracker(alpha float64) *LatencyTracker {
 
 // Record updates the EWMA for a provider with a new latency observation.
 func (t *LatencyTracker) Record(providerID string, d time.Duration) {
-	ms := float64(d.Milliseconds())
+	ms := float64(d) / float64(time.Millisecond)
 	t.mu.Lock()
 	defer t.mu.Unlock()
 

--- a/agentcc-gateway/internal/routing/latency_precision_test.go
+++ b/agentcc-gateway/internal/routing/latency_precision_test.go
@@ -1,0 +1,27 @@
+package routing
+
+import (
+	"testing"
+	"time"
+)
+
+func TestLeastLatency_PreservesSubmillisecondOrdering(t *testing.T) {
+	tracker := NewLatencyTracker(0.5)
+	tracker.Record("slow", 900*time.Microsecond)
+	tracker.Record("fast", 100*time.Microsecond)
+	tracker.Record("fast", 300*time.Microsecond)
+
+	if got := tracker.Get("fast"); got < 0.199999 || got > 0.200001 {
+		t.Errorf("EWMA = %v ms, want 0.2 ms", got)
+	}
+	idx, err := (&LeastLatencyStrategy{}).Select([]RoutingTarget{
+		{ProviderID: "slow", Healthy: true},
+		{ProviderID: "fast", Healthy: true},
+	}, tracker)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if idx != 1 {
+		t.Errorf("selected target %d, want faster target 1", idx)
+	}
+}


### PR DESCRIPTION
## Summary

Least-latency routing truncates every observation to whole milliseconds before calculating its EWMA. For example, a 900 microsecond provider and a provider averaging 200 microseconds both become 0ms, so selection falls back to their order and can pick the slower provider. Convert the duration to fractional milliseconds before averaging, preserving the existing unit and smoothing behavior.

## Linked issues

Small bug fix (one production line plus a regression test); no linked issue or Linear ticket.

## AI use

AI use: OpenAI Codex identified the bug, wrote the test and fix, authored this description, and ran the actual routing test package. Submitted at the account owner's request; no independent human verification is claimed.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## E2E coverage

E2E: exempt (gateway-internal)

## Tests and regression proof

The test records 900us for the first provider, then 100us and 300us for the second with alpha=0.5. It checks the 0.2ms EWMA and selection of the faster provider. It uses the real tracker and strategy, with no mocks or external services.

Before the production fix, on Go 1.25.0 / macOS arm64:

```text
$ go test ./internal/routing -run TestLeastLatency_PreservesSubmillisecondOrdering -count=1
--- FAIL: TestLeastLatency_PreservesSubmillisecondOrdering (0.00s)
    latency_precision_test.go:15: EWMA = 0 ms, want 0.2 ms
    latency_precision_test.go:25: selected target 0, want faster target 1
FAIL
FAIL github.com/futureagi/agentcc-gateway/internal/routing 0.976s
```

After the fix:

```text
$ go test -race ./internal/routing -count=1
ok  github.com/futureagi/agentcc-gateway/internal/routing 2.146s
```

`gofmt -d` and `git diff --check` produced no output. The full Django/frontend stack was not run; the change is confined to the gateway routing package. Submillisecond measurements now affect provider ordering instead of becoming ties.
