### PR TITLE
chore(contracts): regenerate api contracts for harness extend/ingress

### DIFF
--- a/api_contracts/openapi/management-api-contract-debt.generated.json
+++ b/api_contracts/openapi/management-api-contract-debt.generated.json
@@ -1,8 +1,8 @@
 {
   "generated_from": "api_contracts/openapi/swagger.json",
   "summary": {
-    "paths": 999,
-    "operations": 1345,
+    "paths": 1001,
+    "operations": 1347,
     "mutation_endpoints_without_body_schema": 0,
     "operations_without_response_schema": 0,
     "broad_success_response_schemas": 0,
@@ -128,8 +128,8 @@
       "broad_error_response_schemas": 0
     },
     "simulate": {
-      "paths": 128,
-      "operations": 149,
+      "paths": 130,
+      "operations": 151,
       "mutation_endpoints_without_body_schema": 0,
       "operations_without_response_schema": 0,
       "broad_success_response_schemas": 0,

--- a/api_contracts/openapi/swagger.json
+++ b/api_contracts/openapi/swagger.json
@@ -50126,6 +50126,49 @@
                 }
             ]
         },
+        "/simulate/api/harness-jobs/{id}/extend/": {
+            "post": {
+                "operationId": "simulate_api_harness-jobs_extend",
+                "summary": "Provider-neutral control plane for hosted ALK harness jobs.",
+                "description": "Validates the v1.6 request contract and delegates execution to the backend\nselected by ``settings.HARNESS_PROVIDER`` (``daytona`` default, or\n``sandbox``). See ``simulate.services.harness_provider``.",
+                "parameters": [
+                    {
+                        "name": "data",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/HarnessJobExtend"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "",
+                        "schema": {
+                            "$ref": "#/definitions/HarnessJobExtend"
+                        }
+                    },
+                    "default": {
+                        "description": "Default error response",
+                        "schema": {
+                            "$ref": "#/definitions/ManagementAPIErrorResponse"
+                        }
+                    }
+                },
+                "tags": [
+                    "simulate"
+                ],
+                "x-runtime-request-validation": true
+            },
+            "parameters": [
+                {
+                    "name": "id",
+                    "in": "path",
+                    "required": true,
+                    "type": "string"
+                }
+            ]
+        },
         "/simulate/api/harness/attempts/{id}/artifacts/manifest/": {
             "post": {
                 "operationId": "simulate_api_harness_attempts_artifacts_artifact_manifest",
@@ -50243,6 +50286,50 @@
                         "description": "",
                         "schema": {
                             "$ref": "#/definitions/HarnessEventBatchResponse"
+                        }
+                    },
+                    "default": {
+                        "description": "Default error response",
+                        "schema": {
+                            "$ref": "#/definitions/ManagementAPIErrorResponse"
+                        }
+                    }
+                },
+                "tags": [
+                    "simulate"
+                ],
+                "x-runtime-request-validation": true,
+                "x-runtime-response-validation": true
+            },
+            "parameters": [
+                {
+                    "name": "id",
+                    "in": "path",
+                    "required": true,
+                    "type": "string"
+                }
+            ]
+        },
+        "/simulate/api/harness/attempts/{id}/ingress/": {
+            "post": {
+                "operationId": "simulate_api_harness_attempts_ingress",
+                "summary": "Mint a short-lived, no-header Daytona URL for one guest-selected HTTP port.",
+                "description": "The attempt capability authenticates the trusted ALK guest. Customer processes never\nreceive that bearer and therefore cannot expose arbitrary sandbox ports themselves.",
+                "parameters": [
+                    {
+                        "name": "data",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/HarnessIngressRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "",
+                        "schema": {
+                            "$ref": "#/definitions/HarnessIngressResponse"
                         }
                     },
                     "default": {
@@ -60554,9 +60641,6 @@
                         }
                     }
                 },
-                "produces": [
-                    "text/csv"
-                ],
                 "tags": [
                     "tracer"
                 ],
@@ -64237,9 +64321,6 @@
                         }
                     }
                 },
-                "produces": [
-                    "text/csv"
-                ],
                 "tags": [
                     "tracer"
                 ],
@@ -65045,9 +65126,6 @@
                         }
                     }
                 },
-                "produces": [
-                    "text/csv"
-                ],
                 "tags": [
                     "tracer"
                 ],
@@ -117597,7 +117675,8 @@
                     "title": "Manager",
                     "type": "string",
                     "enum": [
-                        "platform-vault"
+                        "platform-vault",
+                        "platform-config"
                     ]
                 },
                 "key": {
@@ -117618,6 +117697,7 @@
                     "type": "string",
                     "enum": [
                         "target_provider",
+                        "simulator_provider",
                         "source_checkout"
                     ]
                 }
@@ -117638,6 +117718,16 @@
                         "retell",
                         "auto"
                     ]
+                },
+                "mode": {
+                    "title": "Mode",
+                    "type": "string",
+                    "enum": [
+                        "connect_only",
+                        "environment_backed",
+                        "provider_import"
+                    ],
+                    "x-nullable": true
                 },
                 "config": {
                     "title": "Config",
@@ -117879,7 +117969,7 @@
                     "title": "Scenario count",
                     "type": "integer",
                     "default": 10,
-                    "maximum": 10,
+                    "maximum": 200,
                     "minimum": 1
                 },
                 "seed": {
@@ -117948,7 +118038,7 @@
                     "title": "Scenario count",
                     "type": "integer",
                     "default": 10,
-                    "maximum": 10,
+                    "maximum": 200,
                     "minimum": 1
                 },
                 "seed": {
@@ -118088,6 +118178,34 @@
                         "ttl_exceeded"
                     ],
                     "default": "user_canceled"
+                }
+            }
+        },
+        "HarnessJobExtend": {
+            "required": [
+                "count"
+            ],
+            "type": "object",
+            "properties": {
+                "count": {
+                    "title": "Count",
+                    "description": "How many new scenarios to add to the saved world.",
+                    "type": "integer",
+                    "maximum": 50,
+                    "minimum": 1
+                },
+                "guidance": {
+                    "title": "Guidance",
+                    "description": "Optional natural-language steering for the added scenarios (e.g. 'calm first-time riders booking an airport pickup'). Existing scenarios are preserved.",
+                    "type": "string",
+                    "default": "",
+                    "maxLength": 2000
+                },
+                "client_request_id": {
+                    "title": "Client request id",
+                    "type": "string",
+                    "maxLength": 128,
+                    "minLength": 1
                 }
             }
         },
@@ -118350,6 +118468,48 @@
                     "items": {
                         "$ref": "#/definitions/HarnessEventRejection"
                     }
+                }
+            }
+        },
+        "HarnessIngressRequest": {
+            "required": [
+                "port"
+            ],
+            "type": "object",
+            "properties": {
+                "port": {
+                    "title": "Port",
+                    "type": "integer",
+                    "maximum": 65535,
+                    "minimum": 1
+                },
+                "expires_in_seconds": {
+                    "title": "Expires in seconds",
+                    "type": "integer",
+                    "default": 7200,
+                    "maximum": 86400,
+                    "minimum": 60
+                }
+            }
+        },
+        "HarnessIngressResponse": {
+            "required": [
+                "url",
+                "expires_in_seconds"
+            ],
+            "type": "object",
+            "properties": {
+                "url": {
+                    "title": "Url",
+                    "type": "string",
+                    "format": "uri",
+                    "minLength": 1
+                },
+                "expires_in_seconds": {
+                    "title": "Expires in seconds",
+                    "type": "integer",
+                    "maximum": 86400,
+                    "minimum": 60
                 }
             }
         },
@@ -118657,6 +118817,18 @@
                     "title": "Agent name",
                     "type": "string",
                     "maxLength": 255
+                },
+                "agent_prompt": {
+                    "title": "Agent prompt",
+                    "type": "string"
+                },
+                "chosen_evals": {
+                    "type": "array",
+                    "items": {
+                        "type": "string",
+                        "maxLength": 2000,
+                        "minLength": 1
+                    }
                 },
                 "run_test_id": {
                     "title": "Run test id",

--- a/frontend/src/api/contracts/api-surface.generated.js
+++ b/frontend/src/api/contracts/api-surface.generated.js
@@ -5,7 +5,7 @@
 export const API_SURFACE_CONTRACT = Object.freeze({
   generatedFrom: "api_contracts/openapi/swagger.json",
   swaggerVersion: "2.0",
-  endpointCount: 999,
+  endpointCount: 1001,
   groups: {
     accounts: {
       "/accounts/2fa/recovery-codes/": ["get"],
@@ -849,11 +849,13 @@ export const API_SURFACE_CONTRACT = Object.freeze({
       "/simulate/api/harness-jobs/{id}/": ["get"],
       "/simulate/api/harness-jobs/{id}/adjust/": ["post"],
       "/simulate/api/harness-jobs/{id}/cancel/": ["post"],
+      "/simulate/api/harness-jobs/{id}/extend/": ["post"],
       "/simulate/api/harness/attempts/{id}/artifacts/manifest/": ["post"],
       "/simulate/api/harness/attempts/{id}/artifacts/{artifact_digest}/": [
         "put",
       ],
       "/simulate/api/harness/attempts/{id}/events/": ["post"],
+      "/simulate/api/harness/attempts/{id}/ingress/": ["post"],
       "/simulate/api/harness/attempts/{id}/results/": ["post"],
       "/simulate/api/harness/attempts/{id}/scenarios/": ["post"],
       "/simulate/api/livekit/call-config/{call_id}/": ["get"],
@@ -2025,9 +2027,11 @@ export const API_SURFACE_PATHS = Object.freeze({
   "/simulate/api/harness-jobs/{id}/": ["get"],
   "/simulate/api/harness-jobs/{id}/adjust/": ["post"],
   "/simulate/api/harness-jobs/{id}/cancel/": ["post"],
+  "/simulate/api/harness-jobs/{id}/extend/": ["post"],
   "/simulate/api/harness/attempts/{id}/artifacts/manifest/": ["post"],
   "/simulate/api/harness/attempts/{id}/artifacts/{artifact_digest}/": ["put"],
   "/simulate/api/harness/attempts/{id}/events/": ["post"],
+  "/simulate/api/harness/attempts/{id}/ingress/": ["post"],
   "/simulate/api/harness/attempts/{id}/results/": ["post"],
   "/simulate/api/harness/attempts/{id}/scenarios/": ["post"],
   "/simulate/api/livekit/call-config/{call_id}/": ["get"],

--- a/frontend/src/api/contracts/openapi-contract.generated.js
+++ b/frontend/src/api/contracts/openapi-contract.generated.js
@@ -5,7 +5,7 @@
 export const OPENAPI_CONTRACT = Object.freeze({
   generatedFrom: "api_contracts/openapi/swagger.json",
   swaggerVersion: "2.0",
-  endpointCount: 999,
+  endpointCount: 1001,
   endpoints: {
     "/accounts/2fa/recovery-codes/": {
       get: {
@@ -27621,6 +27621,25 @@ export const OPENAPI_CONTRACT = Object.freeze({
         },
       },
     },
+    "/simulate/api/harness-jobs/{id}/extend/": {
+      post: {
+        operationId: "simulate_api_harness-jobs_extend",
+        runtimeRequestValidation: true,
+        runtimeResponseValidation: false,
+        requestBody: {
+          $ref: "#/definitions/HarnessJobExtend",
+        },
+        queryParameters: {},
+        responses: {
+          201: {
+            $ref: "#/definitions/HarnessJobExtend",
+          },
+          default: {
+            $ref: "#/definitions/ManagementAPIErrorResponse",
+          },
+        },
+      },
+    },
     "/simulate/api/harness/attempts/{id}/artifacts/manifest/": {
       post: {
         operationId:
@@ -27676,6 +27695,25 @@ export const OPENAPI_CONTRACT = Object.freeze({
         responses: {
           200: {
             $ref: "#/definitions/HarnessEventBatchResponse",
+          },
+          default: {
+            $ref: "#/definitions/ManagementAPIErrorResponse",
+          },
+        },
+      },
+    },
+    "/simulate/api/harness/attempts/{id}/ingress/": {
+      post: {
+        operationId: "simulate_api_harness_attempts_ingress",
+        runtimeRequestValidation: true,
+        runtimeResponseValidation: true,
+        requestBody: {
+          $ref: "#/definitions/HarnessIngressRequest",
+        },
+        queryParameters: {},
+        responses: {
+          200: {
+            $ref: "#/definitions/HarnessIngressResponse",
           },
           default: {
             $ref: "#/definitions/ManagementAPIErrorResponse",
@@ -58521,6 +58559,43 @@ export const OPENAPI_CONTRACT = Object.freeze({
         },
       },
     },
+    HarnessIngressRequest: {
+      required: ["port"],
+      type: "object",
+      properties: {
+        port: {
+          title: "Port",
+          type: "integer",
+          maximum: 65535,
+          minimum: 1,
+        },
+        expires_in_seconds: {
+          title: "Expires in seconds",
+          type: "integer",
+          default: 7200,
+          maximum: 86400,
+          minimum: 60,
+        },
+      },
+    },
+    HarnessIngressResponse: {
+      required: ["url", "expires_in_seconds"],
+      type: "object",
+      properties: {
+        url: {
+          title: "Url",
+          type: "string",
+          format: "uri",
+          minLength: 1,
+        },
+        expires_in_seconds: {
+          title: "Expires in seconds",
+          type: "integer",
+          maximum: 86400,
+          minimum: 60,
+        },
+      },
+    },
     HarnessJobAction: {
       type: "object",
       properties: {
@@ -58577,7 +58652,7 @@ export const OPENAPI_CONTRACT = Object.freeze({
           title: "Scenario count",
           type: "integer",
           default: 10,
-          maximum: 10,
+          maximum: 200,
           minimum: 1,
         },
         seed: {
@@ -58612,6 +58687,33 @@ export const OPENAPI_CONTRACT = Object.freeze({
             "x-nullable": true,
           },
           default: {},
+        },
+      },
+    },
+    HarnessJobExtend: {
+      required: ["count"],
+      type: "object",
+      properties: {
+        count: {
+          title: "Count",
+          description: "How many new scenarios to add to the saved world.",
+          type: "integer",
+          maximum: 50,
+          minimum: 1,
+        },
+        guidance: {
+          title: "Guidance",
+          description:
+            "Optional natural-language steering for the added scenarios (e.g. 'calm first-time riders booking an airport pickup'). Existing scenarios are preserved.",
+          type: "string",
+          default: "",
+          maxLength: 2000,
+        },
+        client_request_id: {
+          title: "Client request id",
+          type: "string",
+          maxLength: 128,
+          minLength: 1,
         },
       },
     },
@@ -58737,7 +58839,7 @@ export const OPENAPI_CONTRACT = Object.freeze({
           title: "Scenario count",
           type: "integer",
           default: 10,
-          maximum: 10,
+          maximum: 200,
           minimum: 1,
         },
         seed: {
@@ -58907,6 +59009,18 @@ export const OPENAPI_CONTRACT = Object.freeze({
           title: "Agent name",
           type: "string",
           maxLength: 255,
+        },
+        agent_prompt: {
+          title: "Agent prompt",
+          type: "string",
+        },
+        chosen_evals: {
+          type: "array",
+          items: {
+            type: "string",
+            maxLength: 2000,
+            minLength: 1,
+          },
         },
         run_test_id: {
           title: "Run test id",
@@ -84516,6 +84630,12 @@ export const OPENAPI_CONTRACT = Object.freeze({
           type: "string",
           enum: ["livekit", "vapi", "retell", "auto"],
         },
+        mode: {
+          title: "Mode",
+          type: "string",
+          enum: ["connect_only", "environment_backed", "provider_import"],
+          "x-nullable": true,
+        },
         config: {
           title: "Config",
           type: "object",
@@ -85207,7 +85327,7 @@ export const OPENAPI_CONTRACT = Object.freeze({
         manager: {
           title: "Manager",
           type: "string",
-          enum: ["platform-vault"],
+          enum: ["platform-vault", "platform-config"],
         },
         key: {
           title: "Key",
@@ -85225,7 +85345,7 @@ export const OPENAPI_CONTRACT = Object.freeze({
         purpose: {
           title: "Purpose",
           type: "string",
-          enum: ["target_provider", "source_checkout"],
+          enum: ["target_provider", "simulator_provider", "source_checkout"],
         },
       },
     },

--- a/frontend/src/generated/api-contracts/api.schemas.ts
+++ b/frontend/src/generated/api-contracts/api.schemas.ts
@@ -16977,11 +16977,21 @@ export const HarnessAgentApiConnector = {
   auto: "auto",
 } as const;
 
+export type HarnessAgentApiMode =
+  (typeof HarnessAgentApiMode)[keyof typeof HarnessAgentApiMode];
+
+export const HarnessAgentApiMode = {
+  connect_only: "connect_only",
+  environment_backed: "environment_backed",
+  provider_import: "provider_import",
+} as const;
+
 export type SecretReferenceApiManager =
   (typeof SecretReferenceApiManager)[keyof typeof SecretReferenceApiManager];
 
 export const SecretReferenceApiManager = {
   "platform-vault": "platform-vault",
+  "platform-config": "platform-config",
 } as const;
 
 export type SecretReferenceApiPurpose =
@@ -16989,6 +16999,7 @@ export type SecretReferenceApiPurpose =
 
 export const SecretReferenceApiPurpose = {
   target_provider: "target_provider",
+  simulator_provider: "simulator_provider",
   source_checkout: "source_checkout",
 } as const;
 
@@ -17013,6 +17024,7 @@ export type HarnessAgentApiSecretRefs = { [key: string]: SecretReferenceApi };
 
 export interface HarnessAgentApi {
   connector: HarnessAgentApiConnector;
+  mode?: HarnessAgentApiMode;
   config?: HarnessAgentApiConfig;
   secret_refs?: HarnessAgentApiSecretRefs;
 }
@@ -17120,7 +17132,7 @@ export interface HarnessJobCreateApi {
   agent: HarnessAgentApi;
   /**
    * @minimum 1
-   * @maximum 10
+   * @maximum 200
    */
   scenario_count?: number;
   seed?: number;
@@ -17152,7 +17164,7 @@ export interface HarnessPreflightApi {
   agent: HarnessAgentApi;
   /**
    * @minimum 1
-   * @maximum 10
+   * @maximum 200
    */
   scenario_count?: number;
   seed?: number;
@@ -17217,6 +17229,25 @@ export const HarnessJobActionApiReason = {
 
 export interface HarnessJobActionApi {
   reason?: HarnessJobActionApiReason;
+}
+
+export interface HarnessJobExtendApi {
+  /**
+   * How many new scenarios to add to the saved world.
+   * @minimum 1
+   * @maximum 50
+   */
+  count: number;
+  /**
+   * Optional natural-language steering for the added scenarios (e.g. 'calm first-time riders booking an airport pickup'). Existing scenarios are preserved.
+   * @maxLength 2000
+   */
+  guidance?: string;
+  /**
+   * @minLength 1
+   * @maxLength 128
+   */
+  client_request_id?: string;
 }
 
 export type HarnessManifestApiSchemaVersion =
@@ -17330,6 +17361,29 @@ export interface HarnessEventRejectionApi {
 export interface HarnessEventBatchResponseApi {
   acked_through_sequence: number;
   rejected: HarnessEventRejectionApi[];
+}
+
+export interface HarnessIngressRequestApi {
+  /**
+   * @minimum 1
+   * @maximum 65535
+   */
+  port: number;
+  /**
+   * @minimum 60
+   * @maximum 86400
+   */
+  expires_in_seconds?: number;
+}
+
+export interface HarnessIngressResponseApi {
+  /** @minLength 1 */
+  url: string;
+  /**
+   * @minimum 60
+   * @maximum 86400
+   */
+  expires_in_seconds: number;
 }
 
 export type HarnessResultReceiptApiSchemaVersion =
@@ -17489,6 +17543,8 @@ export interface HarnessScenarioOperationApi {
   agent_definition_id?: string;
   /** @maxLength 255 */
   agent_name?: string;
+  agent_prompt?: string;
+  chosen_evals?: string[];
   run_test_id?: string;
   scenario_keys?: string[];
 }

--- a/frontend/src/generated/api-contracts/api.ts
+++ b/frontend/src/generated/api-contracts/api.ts
@@ -554,9 +554,12 @@ import type {
   HarnessArtifactUploadResponseApi,
   HarnessEventBatchApi,
   HarnessEventBatchResponseApi,
+  HarnessIngressRequestApi,
+  HarnessIngressResponseApi,
   HarnessJobActionApi,
   HarnessJobAdjustmentApi,
   HarnessJobCreateApi,
+  HarnessJobExtendApi,
   HarnessJobReadApi,
   HarnessManifestApi,
   HarnessPreflightApi,
@@ -58401,6 +58404,55 @@ export const simulateApiHarnessJobsCancel = async (
   );
 };
 
+export type simulateApiHarnessJobsExtendResponse201 = {
+  data: HarnessJobExtendApi;
+  status: 201;
+};
+
+export type simulateApiHarnessJobsExtendResponseDefault = {
+  data: ManagementAPIErrorResponseApi;
+  status: Exclude<HTTPStatusCodes, 201>;
+};
+
+export type simulateApiHarnessJobsExtendResponseSuccess =
+  simulateApiHarnessJobsExtendResponse201 & {
+    headers: Headers;
+  };
+export type simulateApiHarnessJobsExtendResponseError =
+  simulateApiHarnessJobsExtendResponseDefault & {
+    headers: Headers;
+  };
+
+export type simulateApiHarnessJobsExtendResponse =
+  | simulateApiHarnessJobsExtendResponseSuccess
+  | simulateApiHarnessJobsExtendResponseError;
+
+export const getSimulateApiHarnessJobsExtendUrl = (id: string) => {
+  return `/simulate/api/harness-jobs/${id}/extend/`;
+};
+
+/**
+ * Validates the v1.6 request contract and delegates execution to the backend
+selected by ``settings.HARNESS_PROVIDER`` (``daytona`` default, or
+``sandbox``). See ``simulate.services.harness_provider``.
+ * @summary Provider-neutral control plane for hosted ALK harness jobs.
+ */
+export const simulateApiHarnessJobsExtend = async (
+  id: string,
+  harnessJobExtendApi: HarnessJobExtendApi,
+  options?: RequestInit,
+): Promise<simulateApiHarnessJobsExtendResponse> => {
+  return apiMutator<simulateApiHarnessJobsExtendResponse>(
+    getSimulateApiHarnessJobsExtendUrl(id),
+    {
+      ...options,
+      method: "POST",
+      headers: { "Content-Type": "application/json", ...options?.headers },
+      body: JSON.stringify(harnessJobExtendApi),
+    },
+  );
+};
+
 export type simulateApiHarnessAttemptsArtifactsArtifactManifestResponse200 = {
   data: HarnessAcceptedResponseApi;
   status: 200;
@@ -58540,6 +58592,54 @@ export const simulateApiHarnessAttemptsEvents = async (
       method: "POST",
       headers: { "Content-Type": "application/json", ...options?.headers },
       body: JSON.stringify(harnessEventBatchApi),
+    },
+  );
+};
+
+export type simulateApiHarnessAttemptsIngressResponse200 = {
+  data: HarnessIngressResponseApi;
+  status: 200;
+};
+
+export type simulateApiHarnessAttemptsIngressResponseDefault = {
+  data: ManagementAPIErrorResponseApi;
+  status: Exclude<HTTPStatusCodes, 200>;
+};
+
+export type simulateApiHarnessAttemptsIngressResponseSuccess =
+  simulateApiHarnessAttemptsIngressResponse200 & {
+    headers: Headers;
+  };
+export type simulateApiHarnessAttemptsIngressResponseError =
+  simulateApiHarnessAttemptsIngressResponseDefault & {
+    headers: Headers;
+  };
+
+export type simulateApiHarnessAttemptsIngressResponse =
+  | simulateApiHarnessAttemptsIngressResponseSuccess
+  | simulateApiHarnessAttemptsIngressResponseError;
+
+export const getSimulateApiHarnessAttemptsIngressUrl = (id: string) => {
+  return `/simulate/api/harness/attempts/${id}/ingress/`;
+};
+
+/**
+ * The attempt capability authenticates the trusted ALK guest. Customer processes never
+receive that bearer and therefore cannot expose arbitrary sandbox ports themselves.
+ * @summary Mint a short-lived, no-header Daytona URL for one guest-selected HTTP port.
+ */
+export const simulateApiHarnessAttemptsIngress = async (
+  id: string,
+  harnessIngressRequestApi: HarnessIngressRequestApi,
+  options?: RequestInit,
+): Promise<simulateApiHarnessAttemptsIngressResponse> => {
+  return apiMutator<simulateApiHarnessAttemptsIngressResponse>(
+    getSimulateApiHarnessAttemptsIngressUrl(id),
+    {
+      ...options,
+      method: "POST",
+      headers: { "Content-Type": "application/json", ...options?.headers },
+      body: JSON.stringify(harnessIngressRequestApi),
     },
   );
 };

--- a/frontend/src/generated/api-contracts/api.zod.ts
+++ b/frontend/src/generated/api-contracts/api.zod.ts
@@ -34966,7 +34966,7 @@ export const simulateApiHarnessJobsCreateBodyAgentSecretRefsVersionMax = 255;
 
 export const simulateApiHarnessJobsCreateBodyAgentSecretRefsDefault = {};
 export const simulateApiHarnessJobsCreateBodyScenarioCountDefault = 10;
-export const simulateApiHarnessJobsCreateBodyScenarioCountMax = 10;
+export const simulateApiHarnessJobsCreateBodyScenarioCountMax = 200;
 
 export const simulateApiHarnessJobsCreateBodyRuntimeIsolationDefault = `dedicated_vm`;
 export const simulateApiHarnessJobsCreateBodyRuntimeCpuUnitsDefault = 4;
@@ -35078,6 +35078,9 @@ export const SimulateApiHarnessJobsCreateBody = zod.object({
   }),
   agent: zod.object({
     connector: zod.enum(["livekit", "vapi", "retell", "auto"]),
+    mode: zod
+      .enum(["connect_only", "environment_backed", "provider_import"])
+      .optional(),
     config: zod
       .record(zod.string(), zod.string())
       .default(simulateApiHarnessJobsCreateBodyAgentConfigDefault),
@@ -35085,7 +35088,7 @@ export const SimulateApiHarnessJobsCreateBody = zod.object({
       .record(
         zod.string(),
         zod.object({
-          manager: zod.enum(["platform-vault"]),
+          manager: zod.enum(["platform-vault", "platform-config"]),
           key: zod
             .string()
             .min(1)
@@ -35095,7 +35098,11 @@ export const SimulateApiHarnessJobsCreateBody = zod.object({
             .min(1)
             .max(simulateApiHarnessJobsCreateBodyAgentSecretRefsVersionMax)
             .optional(),
-          purpose: zod.enum(["target_provider", "source_checkout"]),
+          purpose: zod.enum([
+            "target_provider",
+            "simulator_provider",
+            "source_checkout",
+          ]),
         }),
       )
       .default(simulateApiHarnessJobsCreateBodyAgentSecretRefsDefault),
@@ -35264,7 +35271,7 @@ export const simulateApiHarnessJobsPreflightBodyAgentSecretRefsVersionMax = 255;
 
 export const simulateApiHarnessJobsPreflightBodyAgentSecretRefsDefault = {};
 export const simulateApiHarnessJobsPreflightBodyScenarioCountDefault = 10;
-export const simulateApiHarnessJobsPreflightBodyScenarioCountMax = 10;
+export const simulateApiHarnessJobsPreflightBodyScenarioCountMax = 200;
 
 export const simulateApiHarnessJobsPreflightBodyRuntimeIsolationDefault = `dedicated_vm`;
 export const simulateApiHarnessJobsPreflightBodyRuntimeCpuUnitsDefault = 4;
@@ -35376,6 +35383,9 @@ export const SimulateApiHarnessJobsPreflightBody = zod.object({
   }),
   agent: zod.object({
     connector: zod.enum(["livekit", "vapi", "retell", "auto"]),
+    mode: zod
+      .enum(["connect_only", "environment_backed", "provider_import"])
+      .optional(),
     config: zod
       .record(zod.string(), zod.string())
       .default(simulateApiHarnessJobsPreflightBodyAgentConfigDefault),
@@ -35383,7 +35393,7 @@ export const SimulateApiHarnessJobsPreflightBody = zod.object({
       .record(
         zod.string(),
         zod.object({
-          manager: zod.enum(["platform-vault"]),
+          manager: zod.enum(["platform-vault", "platform-config"]),
           key: zod
             .string()
             .min(1)
@@ -35393,7 +35403,11 @@ export const SimulateApiHarnessJobsPreflightBody = zod.object({
             .min(1)
             .max(simulateApiHarnessJobsPreflightBodyAgentSecretRefsVersionMax)
             .optional(),
-          purpose: zod.enum(["target_provider", "source_checkout"]),
+          purpose: zod.enum([
+            "target_provider",
+            "simulator_provider",
+            "source_checkout",
+          ]),
         }),
       )
       .default(simulateApiHarnessJobsPreflightBodyAgentSecretRefsDefault),
@@ -35762,6 +35776,43 @@ export const SimulateApiHarnessJobsCancelResponse = zod.object({
   }),
 });
 
+/**
+ * Validates the v1.6 request contract and delegates execution to the backend
+selected by ``settings.HARNESS_PROVIDER`` (``daytona`` default, or
+``sandbox``). See ``simulate.services.harness_provider``.
+ * @summary Provider-neutral control plane for hosted ALK harness jobs.
+ */
+export const SimulateApiHarnessJobsExtendParams = zod.object({
+  id: zod.string(),
+});
+
+export const simulateApiHarnessJobsExtendBodyCountMax = 50;
+
+export const simulateApiHarnessJobsExtendBodyGuidanceDefault = ``;
+export const simulateApiHarnessJobsExtendBodyGuidanceMax = 2000;
+
+export const simulateApiHarnessJobsExtendBodyClientRequestIdMax = 128;
+
+export const SimulateApiHarnessJobsExtendBody = zod.object({
+  count: zod
+    .number()
+    .min(1)
+    .max(simulateApiHarnessJobsExtendBodyCountMax)
+    .describe("How many new scenarios to add to the saved world."),
+  guidance: zod
+    .string()
+    .max(simulateApiHarnessJobsExtendBodyGuidanceMax)
+    .default(simulateApiHarnessJobsExtendBodyGuidanceDefault)
+    .describe(
+      "Optional natural-language steering for the added scenarios (e.g. 'calm first-time riders booking an airport pickup'). Existing scenarios are preserved.",
+    ),
+  client_request_id: zod
+    .string()
+    .min(1)
+    .max(simulateApiHarnessJobsExtendBodyClientRequestIdMax)
+    .optional(),
+});
+
 export const SimulateApiHarnessAttemptsArtifactsArtifactManifestParams =
   zod.object({
     id: zod.string(),
@@ -35894,6 +35945,41 @@ export const SimulateApiHarnessAttemptsEventsResponse = zod.object({
       message: zod.string().min(1),
     }),
   ),
+});
+
+/**
+ * The attempt capability authenticates the trusted ALK guest. Customer processes never
+receive that bearer and therefore cannot expose arbitrary sandbox ports themselves.
+ * @summary Mint a short-lived, no-header Daytona URL for one guest-selected HTTP port.
+ */
+export const SimulateApiHarnessAttemptsIngressParams = zod.object({
+  id: zod.string(),
+});
+
+export const simulateApiHarnessAttemptsIngressBodyPortMax = 65535;
+
+export const simulateApiHarnessAttemptsIngressBodyExpiresInSecondsDefault = 7200;
+export const simulateApiHarnessAttemptsIngressBodyExpiresInSecondsMin = 60;
+export const simulateApiHarnessAttemptsIngressBodyExpiresInSecondsMax = 86400;
+
+export const SimulateApiHarnessAttemptsIngressBody = zod.object({
+  port: zod.number().min(1).max(simulateApiHarnessAttemptsIngressBodyPortMax),
+  expires_in_seconds: zod
+    .number()
+    .min(simulateApiHarnessAttemptsIngressBodyExpiresInSecondsMin)
+    .max(simulateApiHarnessAttemptsIngressBodyExpiresInSecondsMax)
+    .default(simulateApiHarnessAttemptsIngressBodyExpiresInSecondsDefault),
+});
+
+export const simulateApiHarnessAttemptsIngressResponseExpiresInSecondsMin = 60;
+export const simulateApiHarnessAttemptsIngressResponseExpiresInSecondsMax = 86400;
+
+export const SimulateApiHarnessAttemptsIngressResponse = zod.object({
+  url: zod.string().url().min(1),
+  expires_in_seconds: zod
+    .number()
+    .min(simulateApiHarnessAttemptsIngressResponseExpiresInSecondsMin)
+    .max(simulateApiHarnessAttemptsIngressResponseExpiresInSecondsMax),
 });
 
 export const SimulateApiHarnessAttemptsResultsParams = zod.object({
@@ -36034,6 +36120,8 @@ export const simulateApiHarnessAttemptsScenariosBodyPersonasItemRoleMax = 255;
 
 export const simulateApiHarnessAttemptsScenariosBodyAgentNameMax = 255;
 
+export const simulateApiHarnessAttemptsScenariosBodyChosenEvalsItemMax = 2000;
+
 export const simulateApiHarnessAttemptsScenariosBodyScenarioKeysItemMax = 255;
 
 export const SimulateApiHarnessAttemptsScenariosBody = zod.object({
@@ -36072,6 +36160,15 @@ export const SimulateApiHarnessAttemptsScenariosBody = zod.object({
   agent_name: zod
     .string()
     .max(simulateApiHarnessAttemptsScenariosBodyAgentNameMax)
+    .optional(),
+  agent_prompt: zod.string().optional(),
+  chosen_evals: zod
+    .array(
+      zod
+        .string()
+        .min(1)
+        .max(simulateApiHarnessAttemptsScenariosBodyChosenEvalsItemMax),
+    )
     .optional(),
   run_test_id: zod.string().uuid().optional(),
   scenario_keys: zod


### PR DESCRIPTION
## Why
`yarn contracts:check` fails on the branch head:

```
src/api/harness/harness.js:17: apiPath target is not in generated Swagger surface: /simulate/api/harness-jobs/{id}/extend/
```

The checked-in `swagger.json` predates two harness endpoints added on this branch.

## What
Regenerated the Swagger schema from the branch head (`4fa6487c8`, `generate_swagger --settings tfc.settings.openapi`) and re-ran `yarn contracts:generate`. Surface delta vs the checked-in schema is exactly:

- `POST /simulate/api/harness-jobs/{id}/extend/`
- `POST /simulate/api/harness/attempts/{id}/ingress/`

No paths, operations, or definitions removed (1345 -> 1347 ops, 1820 -> 1823 definitions). `yarn contracts:check` passes.