### PR TITLE
fix(compose): cap per-service memory in the self-host stack

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -17,6 +17,27 @@ CH_DATABASE=default
 CH_CPUS=2.0
 CH_MEMORY=4G
 
+# Guardrails for the remaining always-on services. These are ceilings, not
+# reservations — Docker does not pre-allocate, so the total may exceed host RAM.
+# They exist to stop one service starving the rest, not to tune throughput.
+# Observed at-rest usage on an idle stack is in brackets.
+FRONTEND_MEMORY=256M
+BACKEND_MEMORY=2G
+WORKER_MEMORY=2G
+WORKER_EXACT_AGGREGATION_MEMORY=1G
+AGENTCC_GATEWAY_MEMORY=512M
+# Embedding models load lazily on first request and several can be resident.
+SERVING_MEMORY=4G
+PG_MEMORY=1G          # [~62 MiB idle]
+REDIS_MEMORY=512M     # [~11 MiB idle]
+MINIO_MEMORY=1G       # [~69 MiB idle]
+TEMPORAL_MEMORY=1G
+# RabbitMQ does not read the cgroup limit when sizing its own watermark. If you
+# change this, update total_memory_available_override_value in
+# futureagi/config/rabbitmq/rabbitmq.conf to match, or it will be OOM-killed
+# before its backpressure engages.
+RABBITMQ_MEMORY=1G    # [~170 MiB idle]
+
 # Each image has an independent version. Empty = use `:latest`. Pin per
 # service to lock a specific release.
 FUTURE_AGI_VERSION=

--- a/.env.example
+++ b/.env.example
@@ -11,6 +11,12 @@
 # so overriding it here points all three at the same DB.
 CH_DATABASE=default
 
+# ClickHouse sizes its own memory budget at 90% of whatever RAM it can see and
+# reads the cgroup limit, so this cap bounds it. Unset, it budgets 90% of the
+# whole Docker VM. Raise it if you ingest real trace volume locally.
+CH_CPUS=2.0
+CH_MEMORY=4G
+
 # Each image has an independent version. Empty = use `:latest`. Pin per
 # service to lock a specific release.
 FUTURE_AGI_VERSION=

--- a/.env.example
+++ b/.env.example
@@ -20,23 +20,24 @@ CH_MEMORY=4G
 # Guardrails for the remaining always-on services. These are ceilings, not
 # reservations — Docker does not pre-allocate, so the total may exceed host RAM.
 # They exist to stop one service starving the rest, not to tune throughput.
-# Observed at-rest usage on an idle stack is in brackets.
-FRONTEND_MEMORY=256M
-BACKEND_MEMORY=2G
-WORKER_MEMORY=2G
-WORKER_EXACT_AGGREGATION_MEMORY=1G
-AGENTCC_GATEWAY_MEMORY=512M
+# Brackets show usage measured on an idle 18-container stack; each limit leaves
+# at least ~2.5x headroom over that.
+FRONTEND_MEMORY=256M  # [~15 MiB idle]
+BACKEND_MEMORY=4G     # [~1.43 GiB idle — the largest consumer in the stack]
+WORKER_MEMORY=3G      # [~709 MiB idle]
+WORKER_EXACT_AGGREGATION_MEMORY=1G  # [~162 MiB idle]
+AGENTCC_GATEWAY_MEMORY=512M  # [~6 MiB idle]
 # Embedding models load lazily on first request and several can be resident.
-SERVING_MEMORY=4G
-PG_MEMORY=1G          # [~62 MiB idle]
-REDIS_MEMORY=512M     # [~11 MiB idle]
-MINIO_MEMORY=1G       # [~69 MiB idle]
-TEMPORAL_MEMORY=1G
+SERVING_MEMORY=4G     # [~466 MiB idle, before any model loads]
+PG_MEMORY=2G          # [~559 MiB idle with the stack connected]
+REDIS_MEMORY=512M     # [~7 MiB idle]
+MINIO_MEMORY=1G       # [~124 MiB idle]
+TEMPORAL_MEMORY=1G    # [~273 MiB idle]
 # RabbitMQ does not read the cgroup limit when sizing its own watermark. If you
 # change this, update total_memory_available_override_value in
 # futureagi/config/rabbitmq/rabbitmq.conf to match, or it will be OOM-killed
 # before its backpressure engages.
-RABBITMQ_MEMORY=1G    # [~170 MiB idle]
+RABBITMQ_MEMORY=1G    # [~150 MiB idle]
 
 # Each image has an independent version. Empty = use `:latest`. Pin per
 # service to lock a specific release.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -452,6 +452,13 @@ services:
     # CH 24.x volume) to v2 the first time it boots — so an existing
     # volume does not strictly require `docker compose down -v`.
     image: clickhouse/clickhouse-server:25.3-alpine
+    # Without a limit ClickHouse derives max_server_memory_usage from
+    # max_server_memory_usage_to_ram_ratio (0.9) against the *host* — on an
+    # 8 GB Docker VM it budgets 6.87 GiB for itself and the other 17
+    # always-on containers contend for the rest. It reads the cgroup limit,
+    # so capping here bounds that budget (4G -> 3.60 GiB).
+    cpus: "${CH_CPUS:-2.0}"
+    mem_limit: "${CH_MEMORY:-4G}"
     environment:
       # The 25.3-alpine image ships a default-user.xml that restricts
       # the `default` user to 127.0.0.1 / ::1 only. Backend connects
@@ -482,6 +489,11 @@ services:
       interval: 10s
       timeout: 5s
       retries: 5
+    deploy:
+      resources:
+        limits:
+          cpus: "${CH_CPUS:-2.0}"
+          memory: "${CH_MEMORY:-4G}"
     restart: unless-stopped
 
   # ------------------------------------------------------------------------

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -166,6 +166,7 @@ services:
 
   frontend:
     image: futureagi/frontend:${FRONTEND_VERSION:-latest}
+    mem_limit: "${FRONTEND_MEMORY:-256M}"
     ports:
       - "${FRONTEND_PORT:-3000}:80"
     environment:
@@ -182,6 +183,7 @@ services:
 
   backend:
     image: futureagi/future-agi:${FUTURE_AGI_VERSION:-latest}
+    mem_limit: "${BACKEND_MEMORY:-2G}"
     ports:
       - "${BACKEND_PORT:-8000}:80"
     env_file:
@@ -215,6 +217,7 @@ services:
 
   worker:
     image: futureagi/future-agi:${FUTURE_AGI_VERSION:-latest}
+    mem_limit: "${WORKER_MEMORY:-2G}"
     env_file:
       - path: .env
         required: false
@@ -292,6 +295,8 @@ services:
     # Unlike the other per-queue workers this admission boundary is always on;
     # the generic worker deliberately excludes exact_aggregation.
     profiles: []
+    # Concurrency is pinned to 1 activity, so this needs far less than `worker`.
+    mem_limit: "${WORKER_EXACT_AGGREGATION_MEMORY:-1G}"
     environment:
       <<: *backend-env
       SERVICE_TYPE: temporal-worker
@@ -367,6 +372,7 @@ services:
   # the shipped example via AGENTCC_CONFIG_PATH).
   agentcc-gateway:
     image: futureagi/agentcc-gateway:${AGENTCC_GATEWAY_VERSION:-latest}
+    mem_limit: "${AGENTCC_GATEWAY_MEMORY:-512M}"
     ports:
       - "${AGENTCC_GATEWAY_PORT:-8090}:8080"
     env_file:
@@ -388,6 +394,9 @@ services:
 
   serving:
     image: futureagi/serving:${SERVING_VERSION:-latest}
+    # Loads embedding models lazily on first request, so this needs real
+    # headroom — several models can be resident at once.
+    mem_limit: "${SERVING_MEMORY:-4G}"
     ports:
       - "${SERVING_PORT:-8080}:8080"
     env_file:
@@ -420,6 +429,7 @@ services:
 
   postgres:
     image: postgres:16
+    mem_limit: "${PG_MEMORY:-1G}"
     # wal_level=logical + slots enable PeerDB CDC replication.
     command: >
       postgres
@@ -899,6 +909,7 @@ services:
 
   redis:
     image: redis:7-alpine
+    mem_limit: "${REDIS_MEMORY:-512M}"
     command: redis-server --appendonly yes
     ports:
       - "127.0.0.1:${REDIS_PORT:-6379}:6379"
@@ -913,11 +924,15 @@ services:
 
   rabbitmq:
     image: rabbitmq:3-management
+    mem_limit: "${RABBITMQ_MEMORY:-1G}"
     environment:
       RABBITMQ_DEFAULT_USER: ${RABBITMQ_USER:-user}
       RABBITMQ_DEFAULT_PASS: ${RABBITMQ_PASSWORD:-password}
     volumes:
       - rabbitmq-data:/var/lib/rabbitmq
+      # RabbitMQ ignores the cgroup limit when sizing its memory watermark, so
+      # the limit above is not self-enforcing. This realigns it — see the file.
+      - ./futureagi/config/rabbitmq/rabbitmq.conf:/etc/rabbitmq/conf.d/20-memory.conf:ro
     healthcheck:
       test: ["CMD", "rabbitmq-diagnostics", "check_running"]
       interval: 10s
@@ -927,6 +942,7 @@ services:
 
   minio:
     image: minio/minio:RELEASE.2025-02-07T23-21-09Z
+    mem_limit: "${MINIO_MEMORY:-1G}"
     command: server /data --console-address ":9001"
     environment:
       MINIO_ROOT_USER: ${MINIO_ROOT_USER:-futureagi}
@@ -949,6 +965,7 @@ services:
 
   temporal:
     image: temporalio/auto-setup:1.29.1
+    mem_limit: "${TEMPORAL_MEMORY:-1G}"
     environment:
       DB: postgres12
       DB_PORT: 5432

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -183,7 +183,7 @@ services:
 
   backend:
     image: futureagi/future-agi:${FUTURE_AGI_VERSION:-latest}
-    mem_limit: "${BACKEND_MEMORY:-2G}"
+    mem_limit: "${BACKEND_MEMORY:-4G}"
     ports:
       - "${BACKEND_PORT:-8000}:80"
     env_file:
@@ -217,7 +217,7 @@ services:
 
   worker:
     image: futureagi/future-agi:${FUTURE_AGI_VERSION:-latest}
-    mem_limit: "${WORKER_MEMORY:-2G}"
+    mem_limit: "${WORKER_MEMORY:-3G}"
     env_file:
       - path: .env
         required: false
@@ -429,7 +429,7 @@ services:
 
   postgres:
     image: postgres:16
-    mem_limit: "${PG_MEMORY:-1G}"
+    mem_limit: "${PG_MEMORY:-2G}"
     # wal_level=logical + slots enable PeerDB CDC replication.
     command: >
       postgres

--- a/futureagi/config/rabbitmq/rabbitmq.conf
+++ b/futureagi/config/rabbitmq/rabbitmq.conf
@@ -1,0 +1,9 @@
+# RabbitMQ derives vm_memory_high_watermark from the memory it believes the
+# machine has, and it does NOT read the container's cgroup limit — under a 1G
+# limit it still computed a 3.28 GB watermark against the host. It would then
+# be OOM-killed by the kernel long before its own backpressure engaged.
+#
+# Overriding the detected total realigns the watermark with the container
+# limit, so RabbitMQ throttles publishers instead of dying. Keep this value in
+# sync with RABBITMQ_MEMORY in docker-compose.yml.
+total_memory_available_override_value = 1GB


### PR DESCRIPTION
## Summary

No always-on service in the OSS compose stack had a memory ceiling except the property-catalog group. ClickHouse leaves `max_server_memory_usage` unset, so it falls back to `max_server_memory_usage_to_ram_ratio` (0.9) measured against the *host* — on an 8 GB Docker VM it budgets 6.87 GiB for itself while the other 17 always-on containers contend for the rest. This adds env-overridable `mem_limit` to every always-on service, plus a `rabbitmq.conf` that RabbitMQ needs because it ignores the cgroup limit when sizing its own watermark. User-facing impact: the self-host stack stops being able to starve itself on a laptop.

## Linked issues

Closes #2616 
Linear: n/a (outside contributor)

## AI use

AI use: Claude Code did the investigation and measurement runs and wrote the compose/env changes from my direction; I set the scope, reviewed every limit value, and made the call on which findings were in scope. The measurement numbers in §3 are real command output from my machine, not model-generated.

## Type of change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📖 Documentation only
- [ ] 🧹 Chore / refactor (no user-visible change)
- [x] 🚀 Performance improvement
- [ ] 🧪 Test-only change

## E2E coverage

E2E: exempt (tooling: compose resource limits + one config file; no application code changed)

---

## 1) What changes were done

**A. ClickHouse memory cap (`docker-compose.yml`)**

- `cpus: "${CH_CPUS:-2.0}"` and `mem_limit: "${CH_MEMORY:-4G}"`, plus the matching `deploy.resources.limits` block the other limited services already declare.
- Nothing else about the service changed — no config mount, no image change, no env change.

**B. Ceilings for the remaining 11 always-on services (`docker-compose.yml`)**

- `frontend` 256M · `backend` 4G · `worker` 3G · `worker-exact-aggregation` 1G · `agentcc-gateway` 512M · `serving` 4G · `postgres` 2G · `redis` 512M · `rabbitmq` 1G · `minio` 1G · `temporal` 1G
- All follow the existing `${SERVICE_MEMORY:-default}` convention, so operators can raise any of them without editing YAML.
- CPU limits deliberately **not** added here — throttling surfaces as unexplained slowness, and memory is what was measurably misbehaving.

**C. RabbitMQ watermark realignment (`futureagi/config/rabbitmq/rabbitmq.conf`, new)**

- Sets `total_memory_available_override_value = 1GB`, mounted at `/etc/rabbitmq/conf.d/20-memory.conf`.
- Needed because a `mem_limit` alone would make RabbitMQ *worse*, not better — see §2.

**D. Documented defaults (`.env.example`)**

- New `CH_CPUS`, `CH_MEMORY`, and one `*_MEMORY` var per service, each annotated with the measured idle usage so the next person tuning these has the baseline.

---

## 2) Why the changes were done

- **Product/UX:** this is the "first-time stack is compute heavy" feedback from Discord. Worth being precise: the stack is not especially heavy at idle (~3.9 GiB steady state). The problem is that nothing *stops* one service expanding into everyone else's headroom, so on a smaller machine the stack becomes unpredictable rather than merely busy.
- **Technical:** ClickHouse reads the cgroup limit, so `mem_limit` alone bounds it — verified, no server config change required. This keeps the diff small and avoids mounting a config tuned for a different machine.
- **Technical (RabbitMQ):** it does *not* read the cgroup. Under a 1G limit it still computed a 3.28 GB watermark against the host, so the kernel would OOM-kill it long before its own backpressure engaged — converting graceful publisher throttling into a hard kill. The added conf file is what makes the limit safe rather than harmful.
- **Architecture:** the property-catalog services already declare `cpus`/`mem_limit` plus a `deploy.resources.limits` block with env-overridable values. This applies that same convention to the rest of the stack rather than inventing a second pattern.

---

## 3) Tests written + scenarios each covers

**No unit tests.** This changes compose resource limits and adds one config file; there is no application code to assert against. Following the precedent set by #2572 (`No unit tests (workflow + markdown)`), verification is empirical instead.

**To be clear about what the numbers are:** nothing here is a benchmark. No timings, no throughput, no cost, no dataset. They are values the servers report about their *own resolved configuration* — via `system.server_settings` for ClickHouse and `rabbitmq-diagnostics status` for RabbitMQ — plus `docker stats` readings. There is no harness to ship because nothing is being benchmarked; the commands in §4 reproduce every figure in seconds.

**A — ClickHouse resolves a bounded budget.** As shipped, `max_server_memory_usage` resolves to **6.87 GiB** (7,372,405,555 bytes). That is 7,372,405,555 ÷ 8,191,561,728 = **0.90** — the default ratio applied against the whole VM. With the cap it resolves to **3.60 GiB** (3,865,470,566 bytes). At-rest usage is materially unchanged (254 MiB → 161 MiB): this bounds the ceiling, it does not reclaim held memory.

**B — RabbitMQ watermark.** Uncapped it computes **3.2766 GB**. With `mem_limit: 1G` and no config it *still* computes **3.2766 GB** — it ignores the cgroup, so the limit alone would get it OOM-killed before its own backpressure engaged. With the added `rabbitmq.conf` it computes **0.4 GB**, safely inside the 1 GiB limit.

**C — Full stack, 18 containers.** Steady state totals ≈ **3.89 GiB**, first boot ≈ **5.17 GiB**. Largest consumers at steady state: clickhouse 1.121 GiB (28% of its 4 GiB ceiling), worker 634 MiB (21% of 3 GiB), serving 453 MiB (11% of 4 GiB). No service exceeded 29% of its ceiling.

**D — Nothing was killed.** `docker inspect` across all 18: `OOMKilled=false` on every container, `RestartCount=0` on every container except `property-catalog-supervisor` (pre-existing, §7).

Full per-container output for C and D is posted as a comment below, to keep this section readable.

**Backend test suite:** not run — no Python, JS, or API surface is touched by this diff. Happy to run it if you'd like it on the record.

---

## 4) How to run / test

The repo's suites (`bin/test`, `yarn test:run`) are unaffected by this diff — it
changes compose resource limits and adds one config file, touching no Python, JS,
or API surface. Happy to run either on request. To reproduce the finding and the
fix directly:

```bash
# 1. BEFORE — on dev, boot the stack and ask ClickHouse what it budgeted
docker compose up -d clickhouse
docker compose exec clickhouse clickhouse-client --query \
  "SELECT name, formatReadableSize(toUInt64(value)), value FROM system.server_settings \
   WHERE name = 'max_server_memory_usage' FORMAT PrettyCompact"
# -> 6.87 GiB / 7372405555 on an 8 GB Docker VM (scales to 90% of whatever you have)

# 2. AFTER — same query on this branch
# -> 3.60 GiB / 3865470566

# 3. RabbitMQ watermark, before and after
docker compose exec rabbitmq rabbitmq-diagnostics status | grep -i "watermark setting"
# -> before: computed to: 3.2766 gb
# -> after:  computed to: 0.4 gb

# 4. Whole stack: confirm nothing is killed by its limit
docker compose up -d
docker stats --no-stream
for c in $(docker compose ps -q); do \
  docker inspect "$c" --format '{{.Name}} OOM={{.State.OOMKilled}} restarts={{.RestartCount}}'; done
```

### UI steps (manual)

Not applicable — no user-facing surface changes. The stack starts and serves exactly as before; only container ceilings differ.

---

## 5) Screenshots / recordings

Not applicable — no UI change. All verification is terminal output, pasted inline in §3 rather than as screenshots so the values are greppable and copy-pastable.

---

## 6) Edge cases & considerations

- **Limits sized to first boot, not steady state.** The backend peaks at **1.43 GiB** during Django migrations plus ClickHouse schema init, then settles to **272 MiB** after restart; postgres goes **559 MiB → 147 MiB**. My first pass sized to steady state and would have OOM-killed the backend during the very first startup — the exact run this change protects. Final values are ~2.5x the observed first-boot peak.
- **Ceilings are not reservations.** Docker does not pre-allocate, so the limits summing above host RAM is expected and harmless; nothing is carved out in advance.
- **`serving` gets a larger ceiling (4G)** because it loads embedding models lazily and several can be resident at once. It idles at ~453 MiB before any model loads.
- **RabbitMQ conf must stay in sync with `RABBITMQ_MEMORY`.** If someone raises the env var without updating `total_memory_available_override_value`, the watermark stays at 0.4 GB — conservative, not dangerous, but noted in both files.
- **Machines larger than 8 GB.** These are fixed ceilings, not ratios, so a 32 GB machine now gets a *smaller* ClickHouse budget than before. That is the intent — it is a guardrail, not a tuning — and every value is env-overridable for anyone who wants more.
- **Services that ignore cgroups.** ClickHouse and RabbitMQ were checked explicitly. The rest do not read cgroup limits at all, so their safety comes purely from headroom (6-48x observed idle), which is why the values are generous rather than tight.

---

## 7) Pre-existing issues (NOT introduced by this PR)

Both found while booting the stack to verify this change. Neither is caused by it, and neither is fixed here.

**A. `property-catalog-supervisor` crash-loops on `:latest` images**

```
Unknown command: 'ch25_property_catalog_oss_supervisor'
```

The `dev` compose references a management command absent from the published `futureagi/future-agi:latest` image. 16 restarts during my run, reloading Django each time. This is the only non-zero `RestartCount` in §3's verification, and it is not memory-related (`OOMKilled=false`).

**B. The stack cannot boot on Windows — shell scripts get CRLF on checkout**

Git's default `core.autocrlf=true` on Windows rewrites `*.sh` to CRLF. The repo stores LF correctly (confirmed with `git show HEAD:...`), but there is no `.gitattributes` protecting them, so the mounted bootstrap script fails:

```
/bootstrap/bootstrap_clickhouse.sh: set: line 2: illegal option -
```

`property-catalog-clickhouse-bootstrap` exits 2 and the catalog never initialises. Affects `bootstrap_clickhouse.sh`, `bootstrap_postgres.sh`, `peerdb-*.sh`, `run-e2e.sh`. Fix is a `.gitattributes` with `*.sh text eol=lf`. Happy to open that as a separate issue/PR — it is unrelated to memory and blocks Windows users entirely rather than just slowing them down.

---

## 8) Architectural / important decisions

- **`mem_limit` alone rather than mounting the repo's ClickHouse config:** `futureagi/config/clickhouse/config.xml` exists and sets 9 GiB, and the internal compose mounts it. I tested mounting it here — it works, but ClickHouse clamps the configured value to the cgroup anyway, so it changes nothing about the budget while adding a config surface tuned for a box that sets its own 12G limit. Smaller diff, same result.
- **A config file for RabbitMQ rather than just a limit:** the limit alone is not merely insufficient, it is harmful — it converts graceful backpressure into a kernel OOM kill. The conf file is what makes capping RabbitMQ safe.
- **Memory limits only, no CPU limits:** CPU throttling manifests as slowness that is hard to attribute, and memory is what was measurably misbehaving. (`CH_CPUS` is the one exception, since ClickHouse can saturate cores during merges.)
- **Generous ceilings over tuned ones:** every value is a guardrail against runaway, not a throughput target. Only ClickHouse and RabbitMQ were actually misbehaving; the other nine are insurance, deliberately set well clear of observed usage so they never bind in normal operation.

---

## Checklist

- [x] My code follows the [style guide](../CONTRIBUTING.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works — *no application code changed; empirical verification in §3 instead*
- [ ] `bin/test` passes locally (backend) — *not run; no backend code touched*
- [ ] `yarn test:run` passes locally (frontend) — *not run; no frontend code touched*
- [x] `yarn contracts:check` passes if API surface changed — *n/a, no API surface change*
- [x] I've updated the documentation where relevant — *`.env.example` documents every new variable*
- [x] No hardcoded secrets, URLs, or PII
- [x] I've signed the [CLA](../CONTRIBUTING.md#contributor-license-agreement-cla)
- [x] PR title follows Conventional Commits
- [ ] Linear issue is linked and updated with status — *n/a, outside contributor*