### PR TITLE
fix(harness-ui): order the stage checklist by when the runner reaches each stage

### DIFF
--- a/frontend/src/pages/dashboard/harness/HarnessDetail.test.jsx
+++ b/frontend/src/pages/dashboard/harness/HarnessDetail.test.jsx
@@ -135,8 +135,8 @@ describe("HarnessDetail run checklist", () => {
     renderDetail();
 
     expect(await screen.findByText("Validating environment")).toBeInTheDocument();
-    // Five stages preceded it, so they fold away rather than padding the column.
-    expect(screen.getByText("5 stages complete")).toBeInTheDocument();
+    // Seven stages preceded it, so they fold away rather than padding the column.
+    expect(screen.getByText("7 stages complete")).toBeInTheDocument();
     expect(screen.queryByText("Queued")).not.toBeInTheDocument();
   });
 

--- a/frontend/src/pages/dashboard/harness/harnessShared.js
+++ b/frontend/src/pages/dashboard/harness/harnessShared.js
@@ -4,7 +4,12 @@ import { STATUS_TYPES } from "src/utils/statusUtils";
 
 export const terminalStages = new Set(["completed", "failed", "canceled"]);
 
-// The ordered pipeline, mirroring HarnessStage in the ALK wheel (fi/alk/harness/job.py).
+// The ordered pipeline. Ordered by when the runner actually reaches each stage, which is not
+// the declaration order of HarnessStage in the ALK wheel (fi/alk/harness/job.py): the runner
+// validates the environment after the scenarios exist, because that validation runs their
+// reference solutions. Listing it in enum order made the checklist rewind, ticking scenario
+// stages green and then back to pending. This is the same divergence already noted below for
+// cleaning_up and uploading_artifacts.
 // "failed" and "canceled" are outcomes rather than positions, so they stay out: a stage
 // missing from this list indexes to -1, which strands the checklist showing nothing reached
 // and pins the progress bar at its 2% floor.
@@ -14,9 +19,9 @@ export const stages = [
   "understanding_agent",
   "generating_environment",
   "building_environment",
-  "validating_environment",
   "generating_data",
   "generating_scenarios",
+  "validating_environment",
   "validating_scenarios",
   "connecting_agent",
   "running",

--- a/frontend/src/pages/dashboard/harness/harnessShared.test.js
+++ b/frontend/src/pages/dashboard/harness/harnessShared.test.js
@@ -127,7 +127,12 @@ describe("stageState", () => {
     expect(stageState(status, at("validating_environment"))).toBe(
       STAGE_STATE.FAILED,
     );
-    expect(stageState(status, at("generating_data"))).toBe(STAGE_STATE.PENDING);
+    // Environment validation runs after the scenarios exist, so data generation and scenario
+    // writing precede the failure rather than following it.
+    expect(stageState(status, at("generating_data"))).toBe(STAGE_STATE.DONE);
+    expect(stageState(status, at("validating_scenarios"))).toBe(
+      STAGE_STATE.PENDING,
+    );
   });
 
   it("completes every stage once the run completes", () => {


### PR DESCRIPTION
## Summary

The run checklist moves backwards. A run reaches `Generating scenarios`, then rewinds to `Validating environment` — stages that were ticked green revert to pending.

Nothing is being redone. The checklist was ordered by the declaration order of `HarnessStage`, and the runner does not reach the stages in that order.

## Why the order was wrong

`validating_environment` runs the scenarios' reference solutions against the world, so it can only happen once the scenarios exist. The runner's own event stream shows it, on a completed run:

```
seq 1  validating_environment  stage_changed     10:38:02
seq 2  validating_environment  baseline_frozen   10:38:21
seq 3  validating_scenarios    stage_changed     10:38:21
seq 4  running                 stage_changed     10:38:23
```

and the platform derives the earlier stages from which artefacts exist, reaching `generating_scenarios` before the runner reports `validating_environment`.

`stageState` marks every stage before `stages.indexOf(current)` as done. With `validating_environment` listed at index 5 and `generating_scenarios` at index 7, arriving at the former after the latter walks the checklist back two rows.

The file already documented this class of divergence for a different pair: "the runner does not emit in list order (it emits cleaning_up before uploading_artifacts, the reverse of the declared enum)". This is the same thing, one pair further up, and it is the one that is visible on every run rather than only on a cancel.

## Change

`validating_environment` now follows `generating_scenarios`, and `generating_data` moves with the environment work that precedes them both. The comment says the list is ordered by when the runner arrives, not by the enum, so the next person does not "correct" it back.

No execution changes. This is the checklist's ordering only.

## Two tests moved with it

Both encoded the old positions rather than an independent truth:

- a failure at `validating_environment` left `generating_data` pending; data generation now precedes that failure, so it is done. The assertion that a later stage is still pending is kept, against `validating_scenarios`.
- the collapsed checklist reported "5 stages complete" for the same failure; seven stages now precede it.

## Verification

`npx vitest run src/pages/dashboard/harness/` — 174 passed, 12 files.

## Left alone

`cleaning_up` and `uploading_artifacts` are still listed in the reverse of their emission order. Cancelled-run progress is credited by event group rather than list position, so it does not produce the same visible rewind, and it is worth its own change rather than being folded in here.

The `HarnessStage` enum in the ALK wheel keeps its declaration order. Nothing compares it, so it carries no ordering meaning there.
