### PR TITLE
fix(evals): preserve system eval binding config (TH-7897)

### DIFF
--- a/frontend/src/sections/common/EvalPicker/EvalPickerConfigFull.jsx
+++ b/frontend/src/sections/common/EvalPicker/EvalPickerConfigFull.jsx
@@ -521,6 +521,8 @@ const EvalPickerConfigFull = ({ evalData, onBack, onSave, isSaving }) => {
         evalData?.config?.run_config ||
         evalData?.config?.runConfig ||
         {};
+      const bindingConfig =
+        evalData?.bindingConfig || evalData?.binding_config || {};
 
       const normalizedRunConfig = {
         ...rawRunConfig,
@@ -576,8 +578,13 @@ const EvalPickerConfigFull = ({ evalData, onBack, onSave, isSaving }) => {
           evalData?.config?.messages ??
           fullEval?.config?.messages,
       };
+      Object.keys(normalizedRunConfig).forEach((key) => {
+        if (normalizedRunConfig[key] === undefined)
+          delete normalizedRunConfig[key];
+      });
       const config = {
         ...(fullEval.config || {}),
+        ...bindingConfig,
         ...normalizedRunConfig,
       };
       const promptText = getEvalPromptText(fullEval, config);
@@ -1025,7 +1032,10 @@ const EvalPickerConfigFull = ({ evalData, onBack, onSave, isSaving }) => {
       evalData?.template_type;
 
     const resolvedConfig = buildEvalTemplateConfig({
-      baseConfig: fullEval?.config || evalData?.config || {},
+      baseConfig: {
+        ...(fullEval?.config || {}),
+        ...(isEditMode ? evalData?.bindingConfig || {} : {}),
+      },
       evalType,
       instructions,
       code,

--- a/frontend/src/sections/common/EvalPicker/EvalPickerConfigFull.test.jsx
+++ b/frontend/src/sections/common/EvalPicker/EvalPickerConfigFull.test.jsx
@@ -1,13 +1,13 @@
 import React from "react";
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render } from "src/utils/test-utils";
-import { screen } from "@testing-library/react";
+import { screen, waitFor } from "@testing-library/react";
 
 import EvalPickerProvider from "./context/EvalPickerProvider";
 import EvalPickerConfigFull from "./EvalPickerConfigFull";
 
 const { capturedProps } = vi.hoisted(() => ({
-  capturedProps: { tracing: null },
+  capturedProps: { tracing: null, instruction: null },
 }));
 
 vi.mock("src/sections/evals/components/TracingTestMode", () => {
@@ -49,7 +49,10 @@ vi.mock("src/sections/evals/components/ModelSelector", () => ({
 }));
 
 vi.mock("src/sections/evals/components/InstructionEditor", () => ({
-  default: () => <div />,
+  default: (props) => {
+    capturedProps.instruction = props;
+    return <div />;
+  },
 }));
 
 vi.mock("src/sections/evals/components/LLMPromptEditor", () => ({
@@ -93,9 +96,11 @@ const {
     data: {
       id: "tpl-1",
       name: "toxicity",
-      eval_type: "llm",
+      owner: "system",
+      eval_type: "agent",
       output_type: "pass_fail",
-      config: {},
+      instructions: "Template instructions",
+      config: { model: "template-model", tools: { template: true } },
     },
     isLoading: false,
     isError: false,
@@ -158,7 +163,7 @@ const TIME_WINDOW = {
   endDate: "2026-05-18T18:29:59.000Z",
 };
 
-const renderConfigFull = ({ sourceTimeWindow } = {}) =>
+const renderConfigFull = ({ sourceTimeWindow, evalData } = {}) =>
   render(
     <EvalPickerProvider
       source="task"
@@ -169,15 +174,44 @@ const renderConfigFull = ({ sourceTimeWindow } = {}) =>
       onEvalAdded={() => {}}
       onClose={() => {}}
       sourceTimeWindow={sourceTimeWindow}
+      initialEval={evalData || null}
     >
       <EvalPickerConfigFull
-        evalData={{ id: "tpl-1", templateId: "tpl-1", name: "toxicity" }}
+        evalData={
+          evalData || { id: "tpl-1", templateId: "tpl-1", name: "toxicity" }
+        }
         onBack={() => {}}
         onSave={() => {}}
         isSaving={false}
       />
     </EvalPickerProvider>,
   );
+
+it("restores saved system-eval binding configuration", async () => {
+  renderConfigFull({
+    evalData: {
+      id: "tpl-1",
+      templateId: "tpl-1",
+      userEvalId: "binding-1",
+      name: "toxicity_dataset",
+      bindingConfig: {
+        template_format: "jinja",
+      },
+      runConfig: {
+        model: "saved-model",
+        tools: { github: true },
+      },
+    },
+  });
+
+  await waitFor(() =>
+    expect(capturedProps.instruction).toMatchObject({
+      model: "saved-model",
+      templateFormat: "jinja",
+    }),
+  );
+  expect(capturedProps.instruction.activeConnectorIds).toEqual(["github"]);
+});
 
 describe("EvalPickerConfigFull — task preview time window", () => {
   beforeEach(() => {

--- a/frontend/src/sections/common/EvaluationDrawer/EvaluationDrawer.jsx
+++ b/frontend/src/sections/common/EvaluationDrawer/EvaluationDrawer.jsx
@@ -122,6 +122,7 @@ const EvaluationDrawerChild = ({
             ? { error_localizer_enabled: evalItem.error_localizer }
             : {}),
         },
+        bindingConfig: evalItem.config?.config || {},
         mapping: evalItem.mapping || {},
         outputType: evalItem.output_type,
         // Existing UserEvalMetric id — handleAdd routes via editEval


### PR DESCRIPTION
## Summary

Preserves dataset-bound system evaluation configuration when an existing evaluation is reopened and saved. Previously, direct settings such as the selected model, connectors, and template format could be replaced by template defaults.

Linear: [TH-7897](https://linear.app/future-agi/issue/TH-7897/preserve-system-eval-configuration-when-editing-dataset-bindings)

## Changes by file

- `frontend/src/sections/common/EvaluationDrawer/EvaluationDrawer.jsx`: retain the raw binding configuration when entering edit mode.
- `frontend/src/sections/common/EvalPicker/EvalPickerConfigFull.jsx`: hydrate and save system evals by merging template defaults, persisted binding configuration, and defined runtime settings.
- `frontend/src/sections/common/EvalPicker/EvalPickerConfigFull.test.jsx`: add regression coverage for persisted model, connector, and template-format settings.

## Flows touched

- Dataset → attached evaluation → edit system evaluation → update evaluation.
- User-eval versioning and evaluation-track behavior are unchanged.
- E2E: exempt (targeted component regression covers system-eval binding hydration; no existing dataset system-eval edit flow)

## Test coverage

- Added a component regression proving persisted system-eval model, GitHub connector, and Jinja template format are restored instead of template defaults.
- EvalPicker suite: 7 files passed, 59 tests passed.

## How tested

- `yarn vitest run src/sections/common/EvalPicker --reporter=dot --silent`
- Targeted Prettier check for all changed files.
- Targeted ESLint check: 0 errors; 6 pre-existing warnings on untouched lines.
- `git diff --check`

## Media

[Screen recording: system eval configuration preservation](https://github.com/user-attachments/assets/516e7256-b427-4b72-9f65-c31808f8fb80)

## AI use

AI use: Codex implemented the focused fix and regression test; the changes were reviewed and verified locally.

<details>
<summary>Test logs</summary>

```text
yarn run v1.22.22
$ /Users/tanmayarora/future-agi/frontend/node_modules/.bin/vitest run src/sections/common/EvalPicker --reporter=dot --silent
[sentry-vite-plugin] Info: Sending telemetry data on issues and performance to Sentry. To disable telemetry, set `options.telemetry` to `false`.

 RUN  v3.2.3 /Users/tanmayarora/future-agi/frontend

···································(node:73082) Warning: `--localstorage-file` was provided without a valid path
(Use `node --trace-warnings ...` to show where the warning was created)
·····(node:73083) Warning: `--localstorage-file` was provided without a valid path
(Use `node --trace-warnings ...` to show where the warning was created)
(node:73088) Warning: `--localstorage-file` was provided without a valid path
(Use `node --trace-warnings ...` to show where the warning was created)
·······(node:73084) Warning: `--localstorage-file` was provided without a valid path
(Use `node --trace-warnings ...` to show where the warning was created)
············

 Test Files  7 passed (7)
      Tests  59 passed (59)
   Start at  18:13:08
   Duration  7.29s (transform 3.43s, setup 881ms, collect 22.71s, tests 1.10s, environment 3.05s, prepare 684ms)

Done in 8.73s.
```

</details>
