### PR TITLE
fix(tracer): apply ground truth to Observe simple evals (TH-7896)

### DIFF
--- a/futureagi/bin/test
+++ b/futureagi/bin/test
@@ -159,7 +159,11 @@ run_migrations() {
     local log_file
     log_file="$(mktemp "${TMPDIR:-/tmp}/futureagi-test-migrate.XXXXXX")"
 
-    if ! "$PYTHON_BIN" manage.py migrate --run-syncdb > "$log_file" 2>&1; then
+    # migrate is a one-shot operator command, not application startup. A stray
+    # load_dotenv() pulls CLOUD_DEPLOYMENT=DEV in, so NO_STARTUP_DB_MUTATIONS is
+    # not enough here.
+    if ! STARTUP_DB_MUTATION_MODE=operator SERVICE_TYPE=bootstrap \
+        "$PYTHON_BIN" manage.py migrate --run-syncdb > "$log_file" 2>&1; then
         echo -e "${RED}Error: migrations failed${NC}" >&2
         tail -n 80 "$log_file" >&2 || true
         echo "Full migration log: $log_file" >&2

--- a/futureagi/evaluations/constants.py
+++ b/futureagi/evaluations/constants.py
@@ -16,3 +16,14 @@ FUTUREAGI_EVAL_TYPES = [
 # eval_type_id value emitted by AgentEvaluator.name (see
 # agentic_eval.core_evals.fi_evals.llm.agent_evaluator.evaluator).
 AGENT_EVALUATOR_TYPE_ID = "AgentEvaluator"
+
+# eval_type_id value emitted by CustomPromptEvaluator.name (see
+# agentic_eval.core_evals.fi_evals.llm.custom_prompt_evaluator.evaluator).
+CUSTOM_PROMPT_EVALUATOR_TYPE_ID = "CustomPromptEvaluator"
+
+# The only evaluators that read a `ground_truth_blocks` kwarg. Every other
+# type splats its kwargs straight into a bare operation, so handing them the
+# key raises "unexpected keyword argument" and fails the run.
+GROUND_TRUTH_AWARE_EVAL_TYPES = frozenset(
+    {CUSTOM_PROMPT_EVALUATOR_TYPE_ID, AGENT_EVALUATOR_TYPE_ID}
+)

--- a/futureagi/tracer/tests/conftest.py
+++ b/futureagi/tracer/tests/conftest.py
@@ -384,7 +384,8 @@ def stub_run_eval(monkeypatch):
 
     Returns a callable ``set_result(value=..., reason=..., failure=...)`` so
     tests can flip pass/fail or simulate engine-side failures without
-    re-patching. Default outcome is a passing eval.
+    re-patching. Default outcome is a passing eval. The callable also carries
+    ``.requests``: every ``EvalRequest`` the engine was handed, in order.
 
     Patched at the package re-export (``evaluations.engine.run_eval``) AND at
     the underlying definition (``evaluations.engine.runner.run_eval``) because
@@ -393,6 +394,7 @@ def stub_run_eval(monkeypatch):
     from evaluations.engine.runner import EvalResult
 
     state = {"value": True, "reason": "stubbed pass", "failure": None}
+    requests = []
 
     def _make_result():
         return EvalResult(
@@ -413,6 +415,7 @@ def stub_run_eval(monkeypatch):
         )
 
     def _stub(_request):
+        requests.append(_request)
         return _make_result()
 
     monkeypatch.setattr("evaluations.engine.run_eval", _stub, raising=False)
@@ -423,6 +426,7 @@ def stub_run_eval(monkeypatch):
         state["reason"] = reason
         state["failure"] = failure
 
+    set_result.requests = requests
     return set_result
 
 

--- a/futureagi/tracer/tests/test_eval_ground_truth_observe_warning.py
+++ b/futureagi/tracer/tests/test_eval_ground_truth_observe_warning.py
@@ -1,10 +1,10 @@
-"""Ground-truth visibility on the simple-eval Observe path.
+"""Ground Truth on the simple-eval Observe path.
 
-Composite children reach ``GroundTruthService.inject_context`` through
-``run_eval_func``; the simple-eval path does not, so a template with Ground
-Truth switched on runs uncalibrated on spans, traces and sessions. These tests
-pin the run-level warning that makes that state visible, pin that it keys off
-the injected blocks rather than the config, and pin that the run still succeeds.
+Spans, traces and sessions retrieve Ground Truth few-shot examples and hand
+them to the judge, the same way composite children do through
+``run_eval_func``. These tests pin that the blocks reach the engine for the
+evaluators that read them, that every other evaluator is left untouched, and
+that the run-level warning still marks the runs Ground Truth cannot calibrate.
 """
 
 from __future__ import annotations
@@ -13,12 +13,18 @@ import pytest
 
 # Breaks the tracer.utils.eval <-> model_hub.tasks import cycle, as in test_eval_task_runtime.py.
 import model_hub.tasks  # noqa: F401
+from evaluations.constants import (
+    AGENT_EVALUATOR_TYPE_ID,
+    CUSTOM_PROMPT_EVALUATOR_TYPE_ID,
+)
 from model_hub.models.evals_metric import EvalGroundTruth
 from model_hub.utils.eval_input_validation import PARTIAL_INPUT_WARNING_TYPE
 from tracer.models.observation_span import EvalLogger
 from tracer.utils.eval import GROUND_TRUTH_NOT_APPLIED_WARNING_TYPE as GT_WARNING_TYPE
 
 RUN_PARAMS = {"input": "hello", "output": "world"}
+GT_ROW = {"question": "hello", "answer": "world"}
+GT_BLOCK = {"type": "text", "text": "Expected output: world"}
 
 
 def _make_ground_truth(
@@ -44,6 +50,32 @@ def _make_ground_truth(
         is_active=True,
         enabled=enabled,
     )
+
+
+def _stub_retrieval(monkeypatch, examples=(GT_ROW,)):
+    """Serve GT rows without the vector store, and record that it was asked."""
+    from model_hub.services.ground_truth_service import GroundTruthService
+
+    calls = []
+
+    def _retrieve(**_kwargs):
+        calls.append(_kwargs)
+        return list(examples), {"question": "text"}
+
+    monkeypatch.setattr(
+        GroundTruthService, "retrieve_few_shot", staticmethod(_retrieve)
+    )
+    return calls
+
+
+def _use_eval_type(eval_template, eval_type_id):
+    eval_template.config["eval_type_id"] = eval_type_id
+    eval_template.save(update_fields=["config"])
+
+
+def _engine_inputs(stub_run_eval):
+    assert stub_run_eval.requests, "the engine was never reached"
+    return stub_run_eval.requests[-1].inputs
 
 
 def _warnings_on(eval_log):
@@ -511,3 +543,272 @@ def test_task_logs_endpoint_counts_rows_while_groups_count_warnings(
     assert counts[PARTIAL_INPUT_WARNING_TYPE] == 1
     assert counts[GT_WARNING_TYPE] == 1
     assert sum(counts.values()) == 2
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize(
+    "eval_type_id", [CUSTOM_PROMPT_EVALUATOR_TYPE_ID, AGENT_EVALUATOR_TYPE_ID]
+)
+def test_span_eval_hands_ground_truth_blocks_to_the_engine(
+    eval_type_id,
+    organization,
+    workspace,
+    project,
+    trace,
+    observation_span,
+    eval_template,
+    custom_eval_config,
+    stub_run_eval,
+    stub_cost_log,
+    monkeypatch,
+):
+    _use_eval_type(eval_template, eval_type_id)
+    _make_ground_truth(eval_template, organization, workspace)
+    _stub_retrieval(monkeypatch)
+
+    _run_span_eval(observation_span, custom_eval_config)
+
+    assert GT_BLOCK in _engine_inputs(stub_run_eval)["ground_truth_blocks"]
+    assert _gt_warnings(_latest_log(custom_eval_config)) == []
+
+
+@pytest.mark.django_db
+def test_trace_eval_hands_ground_truth_blocks_to_the_engine(
+    organization,
+    workspace,
+    project,
+    trace,
+    observation_span,
+    eval_template,
+    custom_eval_config,
+    stub_run_eval,
+    stub_cost_log,
+    monkeypatch,
+):
+    from tracer.utils.eval import _execute_evaluation_for_trace
+
+    _use_eval_type(eval_template, CUSTOM_PROMPT_EVALUATOR_TYPE_ID)
+    _make_ground_truth(eval_template, organization, workspace)
+    _stub_retrieval(monkeypatch)
+
+    _execute_evaluation_for_trace(
+        trace=trace,
+        anchor_span=observation_span,
+        custom_eval_config=custom_eval_config,
+        eval_task_id=None,
+        run_params=dict(RUN_PARAMS),
+    )
+
+    assert GT_BLOCK in _engine_inputs(stub_run_eval)["ground_truth_blocks"]
+    assert _gt_warnings(_latest_log(custom_eval_config)) == []
+
+
+@pytest.mark.django_db
+def test_session_eval_hands_ground_truth_blocks_to_the_engine(
+    organization,
+    workspace,
+    observe_project,
+    trace_session,
+    eval_template,
+    custom_eval_config,
+    stub_run_eval,
+    stub_cost_log,
+    monkeypatch,
+):
+    from tracer.utils.eval import _execute_evaluation_for_session
+
+    _use_eval_type(eval_template, CUSTOM_PROMPT_EVALUATOR_TYPE_ID)
+    _make_ground_truth(eval_template, organization, workspace)
+    _stub_retrieval(monkeypatch)
+
+    _execute_evaluation_for_session(
+        trace_session=trace_session,
+        custom_eval_config=custom_eval_config,
+        eval_task_id=None,
+        run_params=dict(RUN_PARAMS),
+    )
+
+    assert GT_BLOCK in _engine_inputs(stub_run_eval)["ground_truth_blocks"]
+    assert _gt_warnings(_latest_log(custom_eval_config)) == []
+
+
+@pytest.mark.django_db
+def test_evaluators_that_cannot_read_the_blocks_are_never_handed_them(
+    organization,
+    workspace,
+    project,
+    trace,
+    observation_span,
+    eval_template,
+    custom_eval_config,
+    stub_run_eval,
+    stub_cost_log,
+    monkeypatch,
+):
+    """A function eval splats its kwargs into a bare operation, so the extra key
+    would raise. It keeps the warning instead, which names the remedy it can use."""
+    _use_eval_type(eval_template, "FunctionEvaluator")
+    _make_ground_truth(eval_template, organization, workspace)
+    _stub_retrieval(monkeypatch)
+
+    _run_span_eval(observation_span, custom_eval_config)
+
+    assert "ground_truth_blocks" not in _engine_inputs(stub_run_eval)
+    eval_log = _latest_log(custom_eval_config)
+    assert eval_log.error is False
+    assert len(_gt_warnings(eval_log)) == 1
+
+
+@pytest.mark.django_db
+def test_ground_truth_blocks_stay_out_of_the_cost_log_mappings(
+    organization,
+    workspace,
+    project,
+    trace,
+    observation_span,
+    eval_template,
+    custom_eval_config,
+    stub_run_eval,
+    stub_cost_log,
+    monkeypatch,
+):
+    """Blocks are prompt payload, not resolved inputs, so APICallLog rows stay lean."""
+    _use_eval_type(eval_template, CUSTOM_PROMPT_EVALUATOR_TYPE_ID)
+    _make_ground_truth(eval_template, organization, workspace)
+    _stub_retrieval(monkeypatch)
+
+    logged = []
+
+    def _spy(**kwargs):
+        logged.append(kwargs["config"])
+        return stub_cost_log(**kwargs)
+
+    monkeypatch.setattr("tracer.utils.eval.log_and_deduct_cost_for_api_request", _spy)
+
+    _run_span_eval(observation_span, custom_eval_config)
+
+    assert GT_BLOCK in _engine_inputs(stub_run_eval)["ground_truth_blocks"]
+    assert logged
+    assert logged[-1]["mappings"] == RUN_PARAMS
+    assert "ground_truth_blocks" not in logged[-1]["required_keys"]
+
+
+@pytest.mark.django_db
+def test_warning_still_fires_when_retrieval_finds_nothing(
+    organization,
+    workspace,
+    project,
+    trace,
+    observation_span,
+    eval_template,
+    custom_eval_config,
+    stub_run_eval,
+    stub_cost_log,
+    monkeypatch,
+):
+    _use_eval_type(eval_template, CUSTOM_PROMPT_EVALUATOR_TYPE_ID)
+    _make_ground_truth(eval_template, organization, workspace)
+    retrievals = _stub_retrieval(monkeypatch, examples=())
+
+    _run_span_eval(observation_span, custom_eval_config)
+
+    assert retrievals, "retrieval was never attempted"
+    assert "ground_truth_blocks" not in _engine_inputs(stub_run_eval)
+    assert len(_gt_warnings(_latest_log(custom_eval_config))) == 1
+
+
+@pytest.mark.django_db
+def test_eval_runs_when_ground_truth_injection_raises(
+    organization,
+    workspace,
+    project,
+    trace,
+    observation_span,
+    eval_template,
+    custom_eval_config,
+    stub_run_eval,
+    stub_cost_log,
+    monkeypatch,
+):
+    """Fail open: a broken retrieval leaves the run uncalibrated, never failed."""
+    from model_hub.services.ground_truth_service import GroundTruthService
+
+    attempts = []
+
+    def _boom(*_args, **_kwargs):
+        attempts.append(_kwargs)
+        raise RuntimeError("gt_injection_blew_up")
+
+    _use_eval_type(eval_template, CUSTOM_PROMPT_EVALUATOR_TYPE_ID)
+    _make_ground_truth(eval_template, organization, workspace)
+    monkeypatch.setattr(GroundTruthService, "inject_context", staticmethod(_boom))
+
+    _run_span_eval(observation_span, custom_eval_config)
+
+    assert attempts, "ground truth was never attempted"
+    assert _engine_inputs(stub_run_eval) == RUN_PARAMS
+    eval_log = _latest_log(custom_eval_config)
+    assert eval_log.error is False
+    assert len(_gt_warnings(eval_log)) == 1
+
+
+@pytest.mark.django_db
+def test_workspaceless_project_injects_from_the_default_workspace(
+    organization,
+    project,
+    trace,
+    observation_span,
+    eval_template,
+    custom_eval_config,
+    stub_run_eval,
+    stub_cost_log,
+    monkeypatch,
+):
+    """Retrieval resolves the default workspace; the eval request still must not.
+
+    ``workspace_id`` also picks the provider API key and the billing
+    attribution, so it stays the project's own.
+    """
+    from accounts.models.workspace import Workspace
+
+    default_ws = Workspace.objects.filter(
+        organization=organization, is_default=True, is_active=True
+    ).first()
+    project.workspace = None
+    project.save(update_fields=["workspace"])
+    _use_eval_type(eval_template, CUSTOM_PROMPT_EVALUATOR_TYPE_ID)
+    _make_ground_truth(eval_template, organization, default_ws)
+    _stub_retrieval(monkeypatch)
+
+    _run_span_eval(observation_span, custom_eval_config)
+
+    assert GT_BLOCK in _engine_inputs(stub_run_eval)["ground_truth_blocks"]
+    assert stub_run_eval.requests[-1].workspace_id is None
+    assert _gt_warnings(_latest_log(custom_eval_config)) == []
+
+
+@pytest.mark.django_db
+def test_another_tenants_ground_truth_is_never_injected(
+    organization,
+    workspace,
+    project,
+    trace,
+    observation_span,
+    eval_template,
+    custom_eval_config,
+    stub_run_eval,
+    stub_cost_log,
+    monkeypatch,
+):
+    from accounts.models.organization import Organization
+
+    other_org = Organization.objects.create(name="other org")
+    _use_eval_type(eval_template, CUSTOM_PROMPT_EVALUATOR_TYPE_ID)
+    _make_ground_truth(eval_template, other_org, None)
+    retrievals = _stub_retrieval(monkeypatch)
+
+    _run_span_eval(observation_span, custom_eval_config)
+
+    assert retrievals == []
+    assert "ground_truth_blocks" not in _engine_inputs(stub_run_eval)
+    assert _gt_warnings(_latest_log(custom_eval_config)) == []

--- a/futureagi/tracer/tests/test_eval_ground_truth_observe_warning.py
+++ b/futureagi/tracer/tests/test_eval_ground_truth_observe_warning.py
@@ -270,9 +270,7 @@ def test_no_warning_until_the_ground_truth_rows_are_embedded(
     stub_cost_log,
 ):
     """An unembedded row is not injected on any path, so Observe is not the fault."""
-    _make_ground_truth(
-        eval_template, organization, workspace, embedding_status=status
-    )
+    _make_ground_truth(eval_template, organization, workspace, embedding_status=status)
 
     _run_span_eval(observation_span, custom_eval_config)
 

--- a/futureagi/tracer/utils/eval.py
+++ b/futureagi/tracer/utils/eval.py
@@ -176,11 +176,12 @@ def _attach_warnings_to_metadata(response, output_metadata, run_warnings):
 GROUND_TRUTH_NOT_APPLIED_WARNING_TYPE = "ground_truth_not_applied"
 
 GROUND_TRUTH_NOT_APPLIED_MESSAGE = (
-    "Ground Truth is enabled on this eval template but is not applied to "
-    "evals run from Observe, so this result is uncalibrated. Ground Truth "
-    "adds few-shot reference examples to the judge prompt and never supplies "
-    "'expected_value'. To provide one here, emit it as a span attribute and "
-    "map 'expected_value' to that attribute name."
+    "Ground Truth is enabled on this eval template but no reference examples "
+    "reached this run, so the result is uncalibrated. Reference examples "
+    "apply to prompt and agent evals; other eval types cannot take them, and "
+    "a retrieval that matched no rows leaves the run uncalibrated too. "
+    "Ground Truth never supplies 'expected_value'. To provide one, emit it "
+    "as a span attribute and map 'expected_value' to that attribute name."
 )
 
 
@@ -189,9 +190,9 @@ def _ground_truth_not_applied_warning(
 ):
     """Warning when GT is embedded and enabled but this run carries none.
 
-    Composite children reach ``inject_context`` through ``run_eval_func``; the
-    simple-eval path does not. Keying off the injected blocks rather than off
-    the config means the warning stops on its own once that path is wired.
+    Keying off the injected blocks rather than off the config leaves the
+    warning on exactly the runs injection could not cover: evaluator types
+    that cannot take the blocks, and retrievals that came back empty.
     Fail-open: a lookup failure returns ``None`` so GT can never block a run.
     """
     if (run_params or {}).get("ground_truth_blocks"):
@@ -232,6 +233,39 @@ def _collect_run_warnings(
     if gt_warning:
         run_warnings.append(gt_warning)
     return run_warnings
+
+
+def _inject_ground_truth(
+    run_params, eval_template, eval_type_id, *, organization_id, workspace_id
+):
+    """Ground Truth few-shot blocks for the Observe simple-eval path.
+
+    Returns a copy so the pristine mapping still reaches ``source_config``.
+    Gated on the evaluators that read the blocks: every other type splats its
+    kwargs into a bare operation and raises on the unexpected key.
+    """
+    params = dict(run_params or {})
+    try:
+        from evaluations.constants import GROUND_TRUTH_AWARE_EVAL_TYPES
+
+        if eval_type_id not in GROUND_TRUTH_AWARE_EVAL_TYPES:
+            return params
+
+        from model_hub.services.ground_truth_service import GroundTruthService
+
+        return GroundTruthService.inject_context(
+            params,
+            eval_template,
+            organization_id=organization_id,
+            workspace_id=workspace_id,
+        )
+    except Exception as exc:
+        logger.warning(
+            "ground_truth_injection_skipped",
+            template_id=str(getattr(eval_template, "id", "") or ""),
+            error=str(exc),
+        )
+        return params
 
 
 def _resolve_attr(span_attrs: dict, candidate: str):
@@ -1683,14 +1717,23 @@ def _execute_evaluation(
         else None
     )
 
-    run_warnings = _collect_run_warnings(
-        partial_input_warning,
+    # GT rows are scoped to a real workspace, so both the retrieval and the
+    # warning use the resolved one, as the trace and session paths already do.
+    gt_workspace_id = str(workspace.id) if workspace else None
+    gt_params = _inject_ground_truth(
         run_params,
         eval_model,
+        eval_type_id,
         organization_id=org_id,
-        # GT rows are scoped to a real workspace, so the lookup uses the
-        # resolved one, as the trace and session paths already do.
-        workspace_id=str(workspace.id) if workspace else None,
+        workspace_id=gt_workspace_id,
+    )
+
+    run_warnings = _collect_run_warnings(
+        partial_input_warning,
+        gt_params,
+        eval_model,
+        organization_id=org_id,
+        workspace_id=gt_workspace_id,
     )
 
     # --- Cost tracking (caller-side) ---
@@ -1726,7 +1769,7 @@ def _execute_evaluation(
             raise ValueError("API call not allowed : ", api_call_log_row.status)
 
     # --- Build context for data_injection support ---
-    _eval_inputs = dict(run_params or {})
+    _eval_inputs = dict(gt_params)
     _di = _di_normalize(
         (custom_eval_config.config or {})
         .get("run_config", {})
@@ -3544,9 +3587,17 @@ def _execute_evaluation_for_trace(
         )
     ws_id = str(workspace.id) if workspace else None
 
+    gt_params = _inject_ground_truth(
+        run_params,
+        eval_template,
+        eval_type_id,
+        organization_id=org_id,
+        workspace_id=ws_id,
+    )
+
     run_warnings = _collect_run_warnings(
         partial_input_warning,
-        run_params,
+        gt_params,
         eval_template,
         organization_id=org_id,
         workspace_id=ws_id,
@@ -3605,7 +3656,7 @@ def _execute_evaluation_for_trace(
     #   span_context    → the anchor_span data, same shape as the span-level
     #                     handler. Useful when the eval is conceptually
     #                     trace-scoped but the anchor span has rich detail.
-    _eval_inputs = dict(run_params or {})
+    _eval_inputs = dict(gt_params)
     _di = _di_normalize(
         (custom_eval_config.config or {})
         .get("run_config", {})
@@ -3788,9 +3839,17 @@ def _execute_evaluation_for_session(
         )
     ws_id = str(workspace.id) if workspace else None
 
+    gt_params = _inject_ground_truth(
+        run_params,
+        eval_template,
+        eval_type_id,
+        organization_id=org_id,
+        workspace_id=ws_id,
+    )
+
     run_warnings = _collect_run_warnings(
         partial_input_warning,
-        run_params,
+        gt_params,
         eval_template,
         organization_id=org_id,
         workspace_id=ws_id,
@@ -3853,7 +3912,7 @@ def _execute_evaluation_for_session(
     #                     Agents can drill into individual traces via the
     #                     session_context.traces[] summaries + explore_trace.
     #   span_context    → not applicable at session-level.
-    _eval_inputs = dict(run_params or {})
+    _eval_inputs = dict(gt_params)
     _di = _di_normalize(
         (custom_eval_config.config or {})
         .get("run_config", {})


### PR DESCRIPTION
## The problem

Ground Truth lets you upload a labelled set for an eval and switch it on, so the judge sees a few real examples of the right answer before it grades anything.

Turn it on and run that eval from a Dataset, the prompt playground, the SDK or a Simulation, and it works.

Turn it on and run the same eval from an Observe eval task, and nothing reaches the judge. The toggle reads on, the run finishes, the score comes back. The examples were never fetched.

Every one of those runs is graded by a judge that was never calibrated, and the score looks exactly like a calibrated one.

## Why it looks fine

Nothing fails. There is no error, no red row, no empty result.

The only signal is a run warning that says Ground Truth was not applied, and it shows up on runs where the toggle is clearly switched on, which reads like the warning is wrong rather than the run.

Composite evals hide it further. A composite eval run from the same place does get its examples, because its children go down a different path. So the same Ground Truth set works or does not work depending on how the eval was built, and nothing on screen says why.

---

Ground Truth few-shot examples never reached the judge for simple evals dispatched from Observe eval tasks. The three Observe executors in `tracer/utils/eval.py` called `run_eval` without ever invoking `GroundTruthService.inject_context`, which is the only thing that populates `ground_truth_blocks`; composite children got it for free because they route through `run_eval_func`. The fix adds one shared, eval-type-gated injection helper and calls it in all three executors, before the warning is collected and before the inputs are handed to the engine.

E2E: exempt (backend-internal) · flows hit: none · `e2e-coverage.mjs --pr 2622` returns "no declaration needed"

AI use: Claude Code produced the diff and the tests; every claim in this body was verified against the repo and against a local run before raising.

## Why the changes are done — what is the problem

### Reproduce on main today (before this PR)

1. Create a custom prompt eval and upload a Ground Truth set for it. Map at least one eval variable to a ground truth column, set the expected-output column, and wait for embedding to reach `completed`.
2. Confirm the Ground Truth toggle is on for that eval.
3. Attach that eval to an Observe eval task on a project with traffic, and run the task.
4. Open the task's logs. Every row completes, and every row carries the `Ground Truth not applied` warning.
5. Inspect the APICallLog config for any of those runs: the judge received the mapped variables only. There is no `ground_truth_blocks` key.
6. Run the same eval from the prompt playground with the same inputs. The reference examples are there.

### Where it breaks — BE

`GroundTruthService.inject_context` is the single writer of `mapped["ground_truth_blocks"]`. It is called from four places: `model_hub/views/eval_runner.py` (datasets), `model_hub/views/prompt_template.py` (playground), `sdk/utils/evaluations.py` (SDK), and `model_hub/views/utils/evals.py::run_eval_func` (playground, protect, simulation, and composite children).

`tracer/utils/eval.py` calls none of them. Its three simple-eval executors — `_execute_evaluation` (span), `_execute_evaluation_for_trace`, `_execute_evaluation_for_session` — build `_eval_inputs` straight from the resolved `run_params` and hand it to `run_eval`, so `ground_truth_blocks` is never present and the judge prompt is never calibrated.

`_execute_composite_on_span` / `_on_trace` / `_on_session` delegate to `run_eval_func`, which is why composite children were already covered and the bug looked selective.

The `ground_truth_not_applied` warning added in #2449 keys off the injected blocks rather than off the config, exactly so it retires itself once this path is wired. Its own docstring says so.

### Why the injection has to be gated by eval type

`run_eval` ends in `eval_instance.run(**run_params)`, and `FunctionEvaluator._evaluate` then does `operator(**kwargs, **self._function_arguments)`. Most entries in `agentic_eval/core_evals/fi_evals/function/functions.py` take fixed positional parameters and no `**kwargs` — `calculate_rouge(reference, hypothesis)`, `recall_score(reference, hypothesis)`, `calculate_numeric_similarity(output, expected)`. Handing any of them a `ground_truth_blocks` kwarg raises `TypeError`, which `_evaluate` re-raises as `ValueError` and fails the run.

Only two evaluators read the key: `CustomPromptEvaluator` (`kwargs.get("ground_truth_blocks")`) and `AgentEvaluator` (`kwargs.pop("ground_truth_blocks", None)`). Injection is restricted to those two. Every other type keeps the warning instead, and the warning names the remedy that does work for it.

## What changed

### futureagi/evaluations/constants.py

- Added `CUSTOM_PROMPT_EVALUATOR_TYPE_ID`, matching the existing `AGENT_EVALUATOR_TYPE_ID` next to it.
- Added `GROUND_TRUTH_AWARE_EVAL_TYPES` as the single named set of evaluators that read `ground_truth_blocks`. It lives beside the other eval-type constants rather than as a literal tuple at the call site, so the gate and the two evaluator classes that define it stay in one place.

### futureagi/tracer/utils/eval.py

- New `_inject_ground_truth(run_params, eval_template, eval_type_id, *, organization_id, workspace_id)`, placed next to `_collect_run_warnings` because the two are two halves of one contract: inject, then warn about whatever injection could not cover.
- It works on a copy. The pristine `run_params` still goes into `source_config["mappings"]` and `required_keys`, so APICallLog rows keep carrying resolved inputs and do not grow a prompt payload.
- It fails open. `inject_context` already swallows its own retrieval errors; the outer guard also covers an import failure, so a broken Ground Truth path can never fail an eval run.
- Wired into all three simple-eval executors, in each case after `validate_eval_inputs` and after the workspace is resolved, and before `_collect_run_warnings`. Feeding the injected dict to the warning collector is what retires the warning on runs that are now calibrated, with no second lookup.
- Span path: the workspace used for retrieval is the resolved one (falling back to the org default), matching what the warning already did and what the trace and session paths do. `EvalRequest.workspace_id` stays the project's own, possibly `None`, because it also selects the provider API key in `run_eval` and the billing attribution in `_emit_eval_billing`. The two are deliberately different and there is a test pinning it.
- `GROUND_TRUTH_NOT_APPLIED_MESSAGE` rewritten. It said Ground Truth "is not applied to evals run from Observe", which stops being true with this PR and would now mislead anyone who reads it. It now names the two cases that still produce the warning: an evaluator type that cannot take reference examples, and a retrieval that matched no rows. The `expected_value` remedy is unchanged, because it is still the right answer for the first case.
- `_ground_truth_not_applied_warning`'s docstring described the missing call site. Rewritten for the same reason.

### futureagi/tracer/tests/conftest.py

- `stub_run_eval` now records every `EvalRequest` it is handed and exposes them as `.requests` on the returned callable. Existing callers are untouched. This is what lets a test assert on what the engine actually received rather than on a flag.

### futureagi/tracer/tests/test_eval_ground_truth_observe_warning.py

- Nine new tests folded into the existing sibling file, no new file.
- Module docstring updated: it described the missing path, which no longer describes the code.

### futureagi/bin/test

`run_migrations` called `manage.py migrate` bare, and the mutation-free-startup guard in `model_hub/apps.py` rejects it, so the runner could not migrate a clean database at all.

The obvious one-line fix, `NO_STARTUP_DB_MUTATIONS=false`, does **not** work, and it is worth writing down why. `explicit_management_mutation_authorized` also requires `not hosted_startup_environment()`, and by the time `AppConfig.ready()` runs, a stray `load_dotenv()` (`agentic_eval/observability/project_registrations.py:3`, the one `tfc/urls.py:109` already has a comment about) has pulled `CLOUD_DEPLOYMENT=DEV` out of the local `.env`. `DEV` is in `HOSTED_DEPLOYMENTS`, so every dev machine with a normal `.env` reads as a hosted deployment and the compatibility path is closed. Verified by spying on the call at `ready()` time: `ENV_TYPE='local' CLOUD='DEV' NO_STARTUP='false' hosted=True -> False`.

So the runner uses the operator pair instead, `STARTUP_DB_MUTATION_MODE=operator SERVICE_TYPE=bootstrap`, which is what the guard's own error message tells you to use and is true independent of what `.env` holds. `bin/test` now runs green with no environment variables set by hand.

### futureagi/tracer/tests/test_eval_ground_truth_observe_warning.py, formatting

One `ruff format` hunk on a pre-existing call (line 271). It is untouched by the fix itself; folded in rather than left failing while the file is open.

## Tests included — what each scenario covers

| # | Test | Setup | Action | What it pins |
|---|---|---|---|---|
| 1 | `test_span_eval_hands_ground_truth_blocks_to_the_engine[CustomPromptEvaluator]` | GT enabled + embedded, retrieval serves one row | Run a span eval | The rendered reference example reaches `EvalRequest.inputs["ground_truth_blocks"]`, and the warning is gone |
| 2 | `test_span_eval_hands_ground_truth_blocks_to_the_engine[AgentEvaluator]` | Same, agent evaluator | Run a span eval | The second evaluator that reads the key is covered, not just the first |
| 3 | `test_trace_eval_hands_ground_truth_blocks_to_the_engine` | Same | Run a trace eval | The trace twin injects, not only the span one |
| 4 | `test_session_eval_hands_ground_truth_blocks_to_the_engine` | Same | Run a session eval | The session twin injects, not only the span one |
| 5 | `test_evaluators_that_cannot_read_the_blocks_are_never_handed_them` | GT enabled, `FunctionEvaluator` template | Run a span eval | The key is withheld from evaluators that would raise on it, the run still succeeds, and the warning still fires |
| 6 | `test_ground_truth_blocks_stay_out_of_the_cost_log_mappings` | GT enabled, cost log spied | Run a span eval | Blocks reach the judge but never `source_config["mappings"]` / `required_keys` |
| 7 | `test_warning_still_fires_when_retrieval_finds_nothing` | GT enabled, retrieval returns zero rows | Run a span eval | Retrieval is attempted, and a run with nothing retrieved is still marked uncalibrated |
| 8 | `test_eval_runs_when_ground_truth_injection_raises` | `inject_context` raises | Run a span eval | Fail-open: injection was attempted, the eval completes, inputs are unchanged |
| 9 | `test_workspaceless_project_injects_from_the_default_workspace` | Project with `workspace=None`, GT on the org default | Run a span eval | Retrieval resolves the default workspace while `EvalRequest.workspace_id` stays `None` |
| 10 | `test_another_tenants_ground_truth_is_never_injected` | GT belongs to a different organization | Run a span eval | Retrieval is not even attempted across a tenant boundary, and no blocks leak in |

**Where 27 comes from:** the diff adds 9 `def test_` functions. One is parametrized over the two Ground Truth aware evaluator types, so those 9 collect as 10 cases. The file's 15 pre-existing functions collect as 17 cases, because one is parametrized over three embedding statuses. 10 + 17 = 27, which is the count `bin/test` reports above. All 17 pre-existing cases are unchanged and still pass. Tests 5 and 10 are the forbidden branches and are green with or without the fix by design; the other eight go red the moment `tracer/utils/eval.py` is reverted.

## Commands to run tests

```bash
# 1. Only this file
bin/test tracer/tests/test_eval_ground_truth_observe_warning.py -v

# 2. The tracer app
bin/test app tracer

# 3. Everything
bin/test
```

Tests that don't match appear as `deselected` — not broken, just not run.

## Local verification results

Before (fix reverted, tests kept):

```bash
FAILED test_span_eval_hands_ground_truth_blocks_to_the_engine[CustomPromptEvaluator] - KeyError: 'ground_truth_blocks'
FAILED test_span_eval_hands_ground_truth_blocks_to_the_engine[AgentEvaluator] - KeyError: 'ground_truth_blocks'
FAILED test_trace_eval_hands_ground_truth_blocks_to_the_engine - KeyError: 'ground_truth_blocks'
FAILED test_session_eval_hands_ground_truth_blocks_to_the_engine - KeyError: 'ground_truth_blocks'
FAILED test_ground_truth_blocks_stay_out_of_the_cost_log_mappings - KeyError: 'ground_truth_blocks'
FAILED test_warning_still_fires_when_retrieval_finds_nothing - AssertionError: retrieval was never attempted
FAILED test_eval_runs_when_ground_truth_injection_raises - AssertionError: ground truth was never attempted
FAILED test_workspaceless_project_injects_from_the_default_workspace - KeyError: 'ground_truth_blocks'
========================= 8 failed, 19 passed in 9.39s =========================
```

After:

```bash
test_span_eval_hands_ground_truth_blocks_to_the_engine[CustomPromptEvaluator] PASSED
test_span_eval_hands_ground_truth_blocks_to_the_engine[AgentEvaluator] PASSED
test_trace_eval_hands_ground_truth_blocks_to_the_engine PASSED
test_session_eval_hands_ground_truth_blocks_to_the_engine PASSED
test_evaluators_that_cannot_read_the_blocks_are_never_handed_them PASSED
test_ground_truth_blocks_stay_out_of_the_cost_log_mappings PASSED
test_warning_still_fires_when_retrieval_finds_nothing PASSED
test_eval_runs_when_ground_truth_injection_raises PASSED
test_workspaceless_project_injects_from_the_default_workspace PASSED
test_another_tenants_ground_truth_is_never_injected PASSED

======================== 27 passed in 421.63s (0:07:01) ========================
```

## Before / After — what the judge is given

![before and after](https://github.com/user-attachments/assets/771c45f0-33ba-42ba-b65d-ce37c898d23f)

## Video

https://github.com/user-attachments/assets/e101be52-6975-4e06-8396-bed43ab2b340

## Screenshot of test suite run

**Command** - `bin/test app tracer`

![test suite run](https://github.com/user-attachments/assets/53b91a72-06e8-4e11-84b0-5594601b9959)

## Deliberate deviations from the plan in the ticket

- **The eval-type gate is a named constant, not an inline tuple.** The ticket said to mirror the `("CustomPromptEvaluator", "AgentEvaluator")` literal in `evaluations/engine/params.py`. That literal governs `required_keys` injection, which is a different policy that happens to have the same two members today; wiring the Ground Truth gate to it would couple two unrelated rules and break silently when either moves. `GROUND_TRUTH_AWARE_EVAL_TYPES` names the real invariant, which is "the evaluators whose code reads the key". `params.py` is left alone.
- **The tests are folded into the existing sibling file, not a new one.** The ticket proposed `tracer/tests/test_eval_ground_truth_observe_injection.py`. `test_eval_ground_truth_observe_warning.py` already owns Ground Truth on this path, and a second file for the same behavior is the split Karthik flagged on #684. Its module docstring is updated to cover both halves.
- **The warning copy is updated too.** Not in the ticket, but the message describes exactly the behavior this PR changes, so leaving it would ship a string that contradicts the code.

## Out of scope, worth a ticket

- `run_eval_func` injects Ground Truth with no eval-type gate, so the same unexpected-kwarg risk exists for composite children whose child template is a function eval. Not touched here; it is a different call path with a different blast radius.
- `_run_evaluation` in `tracer/utils/eval.py` has zero callers (verified repo-wide; the other hits are comments and `EvaluationRunner._run_evaluation`, a different method). Dead code, left alone.
- The stray `load_dotenv()` at `agentic_eval/observability/project_registrations.py:3` runs at import time and injects the local `.env` into `os.environ` for the whole process. That is what makes a dev machine look like a hosted deployment to `model_hub/apps.py`. Worked around here rather than removed, because the blast radius of deleting it is its own piece of work.
- Retrieval runs once per eval row, as it does on every other surface. On a very large Observe task that is one vector lookup per row, with no batching or per-task caching. Unchanged in kind by this PR, but it becomes reachable from a higher-volume surface than before.

## Backwards compatibility

No schema change, no migration, no API contract change. The response shape of every endpoint is identical.

The one semantic change: an Observe eval run of a `CustomPromptEvaluator` or `AgentEvaluator` template whose Ground Truth is enabled, embedded, and retrieves at least one row now sends few-shot reference examples in the judge prompt. That is the point of the toggle, and it is what every other surface already does. Scores on those evals can move, in the direction the labelled set asks for.

| Caller | Pre-PR behavior | Post-PR behavior |
|---|---|---|
| Observe eval task, simple `CustomPromptEvaluator` / `AgentEvaluator`, GT on | No blocks, uncalibrated judge, `ground_truth_not_applied` warning on every run | Blocks injected, judge calibrated, warning gone |
| Observe eval task, simple eval, GT off / not embedded / no rows retrieved | No blocks, no warning (or warning when enabled-but-empty) | Unchanged |
| Observe eval task, any other evaluator type (function, deterministic, ranking, code) | No blocks, warning when GT is on | Unchanged. Blocks are deliberately withheld |
| Observe eval task, composite eval | Children get blocks via `run_eval_func` | Unchanged |
| Datasets / playground / SDK / simulation / protect | Blocks via their own `inject_context` call | Unchanged |
| APICallLog `config.mappings` | Resolved inputs only | Unchanged. Blocks are not written there |

## Manual verification (UI)

1. Open an eval with a Ground Truth set uploaded, mapped and embedded, toggle on.
2. Attach it to an Observe eval task and run the task.
3. Open the task logs. The `Ground Truth not applied` warning is gone and the warning count is 0.
4. Open a row and inspect the eval reasoning. It reflects the labelled examples.
5. Switch the same eval to a function-based template, re-run: runs still complete, and the warning is back, because that type cannot take the blocks.

## Type of change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📖 Documentation only
- [ ] 🧹 Chore / refactor (no user-visible change)
- [ ] 🚀 Performance improvement
- [ ] 🧪 Test-only change

## Checklist

- [x] My code follows the style guide
- [x] I've added tests that prove my fix is effective
- [x] No hardcoded secrets, URLs, or PII

## Backout / rollback

- No migration in this PR. Nothing to reverse in the database.
- No new module. Reverting removes `_inject_ground_truth` and the two constants cleanly, with no orphaned references.
- Reverting returns Observe simple evals to the prior uncalibrated behavior with no data loss. Rows already written keep their scores; nothing is rewritten or deleted.
- The `ground_truth_not_applied` warning returns on its own, because it keys off the injected blocks rather than off a flag.
- No frontend change, so no cached or persisted client state depends on this.

Base is `main` rather than `dev` at Jayasurya's request, so the fix reaches the release branch directly; `main` is currently ahead of `dev` and the two are reconciled by the existing `chore(sync): merge main into dev` PRs.

Closes #2647
Closes TH-7896
