### PR TITLE
feat: add SRE root cause accuracy evaluator

### DIFF
--- a/futureagi/agentic_eval/core_evals/fi_evals/__init__.py
+++ b/futureagi/agentic_eval/core_evals/fi_evals/__init__.py
@@ -109,6 +109,7 @@ except ImportError:
     RankingEvaluator = _ee_stub("RankingEvaluator")
 
 from ...core_evals.fi_evals.llm.custom_prompt_evaluator.evaluator import CustomPromptEvaluator
+from ...core_evals.fi_evals.sre_root_cause.sre_root_cause_evaluator import SRERootCauseAccuracyEvaluator
 
 try:
     from ee.evals.llm.agent_evaluator.evaluator import AgentEvaluator
@@ -222,4 +223,5 @@ __all__ = [
     "IsRefusal",
     "LatencyCheck",
     "FleissKappa",
+    "SRERootCauseAccuracyEvaluator",
 ]

--- a/futureagi/agentic_eval/core_evals/fi_evals/eval_type.py
+++ b/futureagi/agentic_eval/core_evals/fi_evals/eval_type.py
@@ -9,6 +9,7 @@ class FutureAgiEvalTypeId(Enum):
 class LlmEvalTypeId(Enum):
     CUSTOM_PROMPT_EVAL = "CustomPromptEvaluator"
     GROUNDEDNESS = "Groundedness"
+    SRE_ROOT_CAUSE_ACCURACY = "SRERootCauseAccuracy"
 
 
 class FunctionEvalTypeId(Enum):

--- a/futureagi/agentic_eval/core_evals/fi_evals/sre_root_cause/__init__.py
+++ b/futureagi/agentic_eval/core_evals/fi_evals/sre_root_cause/__init__.py
@@ -1,0 +1,3 @@
+from .sre_root_cause_evaluator import SRERootCauseAccuracyEvaluator
+
+__all__ = ["SRERootCauseAccuracyEvaluator"]

--- a/futureagi/agentic_eval/core_evals/fi_evals/sre_root_cause/prompt.py
+++ b/futureagi/agentic_eval/core_evals/fi_evals/sre_root_cause/prompt.py
@@ -1,0 +1,33 @@
+SYSTEM_PROMPT = """You are an expert AI Site Reliability Engineer (SRE) judge.
+Your task is to evaluate an AI agent's root cause diagnosis for an incident.
+
+You will be provided with:
+1. The agent's final diagnosis statement.
+2. The context (evidence) gathered during the incident (logs, metrics, traces, runbooks).
+3. (Optional) The agent's tool-use trajectory.
+
+Scoring Rubric (0.0 to 1.0):
+- 1.0: Perfect. The root cause statement correctly identifies the problem based on the evidence. Every claim cites a piece of the supplied context. No invented/hallucinated causes. Remediation suggestions are concrete, non-destructive, and actionable.
+- 0.7-0.9: Good. The root cause is mostly correct, claims are linked to evidence, but remediation might be slightly generic or missing minor details.
+- 0.4-0.6: Partial. The root cause is partially correct, or some claims lack evidence, or minor hallucinations are present.
+- 0.0-0.3: Fail. The root cause is incorrect, directly contradicts the evidence, contains major hallucinations, or suggests destructive remediation actions without basis.
+
+Instructions:
+1. The root-cause statement MUST match the evidence.
+2. There MUST BE NO invented causes.
+3. Every claim MUST cite a piece of the supplied context.
+4. Remediation suggestions MUST be concrete and non-destructive by default.
+5. Return a JSON object with 'score' (numeric 0.0 to 1.0) and 'reason' (string explanation).
+"""
+
+USER_PROMPT_TEMPLATE = """Evaluate the following diagnosis.
+
+### Context (Evidence)
+{{context}}
+
+### Agent Diagnosis
+{{diagnosis}}
+
+### Trajectory (Optional)
+{{trajectory}}
+"""

--- a/futureagi/agentic_eval/core_evals/fi_evals/sre_root_cause/sre_root_cause_evaluator.py
+++ b/futureagi/agentic_eval/core_evals/fi_evals/sre_root_cause/sre_root_cause_evaluator.py
@@ -1,0 +1,113 @@
+import json
+import time
+from typing import Any
+
+from agentic_eval.core.llm.llm import LLM
+from agentic_eval.core_evals.fi_evals.base_evaluator import BaseEvaluator
+from agentic_eval.core_evals.fi_utils.evals_result import EvalResult, EvalResultMetric
+from agentic_eval.core_evals.fi_utils.logging import logger
+
+from .prompt import SYSTEM_PROMPT, USER_PROMPT_TEMPLATE
+
+class SRERootCauseAccuracyEvaluator(BaseEvaluator):
+    """
+    Evaluator that scores an AI SRE / investigation agent's final diagnosis against evidence.
+    """
+
+    def __init__(self, failure_threshold: float = 0.7, model: str = "gpt-4o"):
+        self._failure_threshold = failure_threshold
+        self._model_name = model
+        self.llm = LLM(model_name=model)
+
+    @property
+    def name(self) -> str:
+        return "SRERootCauseAccuracy"
+
+    @property
+    def display_name(self) -> str:
+        return "SRE Root Cause Accuracy"
+
+    @property
+    def metric_ids(self) -> list[str]:
+        return ["sre_root_cause_accuracy"]
+
+    @property
+    def required_args(self) -> list[str]:
+        return ["diagnosis", "context"]
+
+    @property
+    def examples(self) -> list[Any]:
+        return []
+
+    def is_failure(self, score: float) -> bool | None:
+        return bool(score < self._failure_threshold)
+
+    def _evaluate(self, **kwargs) -> EvalResult:
+        start_time = time.perf_counter()
+        
+        self.validate_args(**kwargs)
+        
+        diagnosis = kwargs.get("diagnosis", "")
+        context = kwargs.get("context", "")
+        if isinstance(context, list):
+            context = "\n".join(str(c) for c in context)
+        
+        trajectory = kwargs.get("trajectory", "")
+        if isinstance(trajectory, list):
+            trajectory = "\n".join(str(t) for t in trajectory)
+
+        # Build messages
+        user_prompt = USER_PROMPT_TEMPLATE.replace("{{diagnosis}}", str(diagnosis))
+        user_prompt = user_prompt.replace("{{context}}", str(context))
+        user_prompt = user_prompt.replace("{{trajectory}}", str(trajectory))
+
+        messages = [
+            {"role": "system", "content": SYSTEM_PROMPT},
+            {"role": "user", "content": user_prompt}
+        ]
+
+        metrics = []
+        failure = False
+        explanation = ""
+        score = 0.0
+
+        try:
+            # We call _get_completion_content from LLM instance. 
+            # It requires response_format if we want JSON.
+            response_text = self.llm._get_completion_content(
+                messages=messages,
+                response_format={"type": "json_object"}
+            )
+            
+            result_json = json.loads(response_text)
+            score = float(result_json.get("score", 0.0))
+            explanation = result_json.get("reason", "")
+            failure = self.is_failure(score)
+
+            metrics.append(
+                EvalResultMetric(
+                    id="sre_root_cause_accuracy", value=score
+                )
+            )
+        except Exception as e:
+            logger.error(f"Error occurred during eval: {e}")
+            failure = True
+            explanation = f"Error during evaluation: {e}"
+            raise e
+
+        end_time = time.perf_counter()
+        eval_runtime_ms = int((end_time - start_time) * 1000)
+
+        eval_result = EvalResult(
+            name=self.name,
+            display_name=self.display_name,
+            data=kwargs,
+            reason=explanation,
+            runtime=eval_runtime_ms,
+            model=self._model_name,
+            metadata=None,
+            metrics=metrics,
+            failure=failure,
+            datapoint_field_annotations=None,
+        )
+        return eval_result

--- a/futureagi/agentic_eval/core_evals/fi_evals/sre_root_cause/tests/test_sre_root_cause_evaluator.py
+++ b/futureagi/agentic_eval/core_evals/fi_evals/sre_root_cause/tests/test_sre_root_cause_evaluator.py
@@ -1,0 +1,64 @@
+import pytest
+from unittest.mock import MagicMock, patch
+from agentic_eval.core_evals.fi_evals.sre_root_cause.sre_root_cause_evaluator import SRERootCauseAccuracyEvaluator
+from agentic_eval.core_evals.fi_evals.eval_type import LlmEvalTypeId
+import json
+
+@pytest.fixture
+def evaluator():
+    return SRERootCauseAccuracyEvaluator(failure_threshold=0.7)
+
+def test_evaluator_properties(evaluator):
+    assert evaluator.name == "SRERootCauseAccuracy"
+    assert evaluator.display_name == "SRE Root Cause Accuracy"
+    assert "sre_root_cause_accuracy" in evaluator.metric_ids
+    assert "diagnosis" in evaluator.required_args
+    assert "context" in evaluator.required_args
+
+def test_registration():
+    # Test that SRERootCauseAccuracy is registered correctly in LlmEvalTypeId
+    assert LlmEvalTypeId.SRE_ROOT_CAUSE_ACCURACY.value == "SRERootCauseAccuracy"
+
+@patch('agentic_eval.core_evals.fi_evals.sre_root_cause.sre_root_cause_evaluator.LLM._get_completion_content')
+def test_evaluate_correct_diagnosis(mock_llm_call, evaluator):
+    # Setup mock response
+    mock_llm_call.return_value = json.dumps({"score": 1.0, "reason": "Perfect diagnosis."})
+
+    context = "Logs show OutOfMemoryError in auth-service container at 10:05 PM due to large payload."
+    diagnosis = "The auth-service crashed because it ran out of memory while processing a large payload."
+    
+    result = evaluator._evaluate(diagnosis=diagnosis, context=context)
+    
+    assert result.failure is False
+    assert result.metrics[0].value == 1.0
+    assert result.reason == "Perfect diagnosis."
+
+@patch('agentic_eval.core_evals.fi_evals.sre_root_cause.sre_root_cause_evaluator.LLM._get_completion_content')
+def test_evaluate_partial_diagnosis(mock_llm_call, evaluator):
+    # Setup mock response
+    mock_llm_call.return_value = json.dumps({"score": 0.5, "reason": "Partial diagnosis."})
+
+    context = "Logs show OutOfMemoryError in auth-service container at 10:05 PM due to large payload."
+    diagnosis = "The auth-service crashed."
+    
+    result = evaluator._evaluate(diagnosis=diagnosis, context=context)
+    
+    assert result.failure is True
+    assert result.metrics[0].value == 0.5
+
+@patch('agentic_eval.core_evals.fi_evals.sre_root_cause.sre_root_cause_evaluator.LLM._get_completion_content')
+def test_evaluate_hallucinated_diagnosis(mock_llm_call, evaluator):
+    # Setup mock response
+    mock_llm_call.return_value = json.dumps({"score": 0.0, "reason": "Hallucinated diagnosis."})
+
+    context = "Logs show OutOfMemoryError in auth-service container at 10:05 PM due to large payload."
+    diagnosis = "The database went down because the CPU overheated and melted."
+    
+    result = evaluator._evaluate(diagnosis=diagnosis, context=context)
+    
+    assert result.failure is True
+    assert result.metrics[0].value == 0.0
+
+def test_missing_args(evaluator):
+    with pytest.raises(ValueError):
+        evaluator._evaluate(diagnosis="Only diagnosis provided")


### PR DESCRIPTION
## Summary

Adds the `SRERootCauseAccuracyEvaluator` to score an AI SRE/investigation agent's final diagnosis against evidence.

## Linked issues

Closes #
Linear:

## AI use

AI use: Antigravity generated the code based on the instructions in do.md and the existing evaluator patterns. I wrote the PR body and verified the tests locally.

## Type of change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📖 Documentation only
- [ ] 🧹 Chore / refactor (no user-visible change)
- [ ] 🚀 Performance improvement
- [ ] 🧪 Test-only change

## E2E coverage

E2E: exempt (evaluator backend logic, tested via unit tests)

---

## 1) What changes were done

**A. New Evaluator `SRERootCauseAccuracy`**

- Added `SRERootCauseAccuracyEvaluator` inheriting from `BaseEvaluator`.
- Added `prompt.py` with the scoring rubric (0 to 1).
- Registered the new evaluator in `LlmEvalTypeId` within `eval_type.py`.
- Added unit tests for properties, registration, and varying levels of correct diagnosis.

---

## 2) Why the changes were done

- **Product/UX:** Provides a new evaluator to accurately score AI SRE agents in identifying root causes based on incident evidence (logs, traces, metrics).
- **Technical:** Leverages the existing `BaseEvaluator` and LLM judge patterns for consistency.

---

## 3) Tests written + scenarios each covers

**`test_sre_root_cause_evaluator.py`** — Unit tests for the SRERootCauseAccuracy evaluator

- `test_evaluator_properties` — Checks evaluator name, required args, and metric IDs.
- `test_registration` — Validates the entry in `LlmEvalTypeId`.
- `test_evaluate_correct_diagnosis` — Checks 1.0 score when root cause is accurately identified.
- `test_evaluate_partial_diagnosis` — Checks 0.5 score for partial answers (failure).
- `test_evaluate_hallucinated_diagnosis` — Checks 0.0 score for hallucinated causes.
- `test_missing_args` — Validates error handling when required inputs are omitted.

```text
I could not run the real test suite locally because the test environment requires `uvloop` which currently does not support Windows natively. I have verified the tests as much as possible but would appreciate assistance running `make check-all` or `bin/test` in a Linux environment.
```

---

## 4) How to run / test

### Backend tests

```bash
cd futureagi
pytest agentic_eval/core_evals/fi_evals/sre_root_cause/tests/test_sre_root_cause_evaluator.py -v
```

---

## Checklist

- [x] My code follows the style guide
- [x] I've added tests that prove my fix is effective or that my feature works
- [ ] `bin/test` passes locally (backend)
- [ ] `yarn test:run` passes locally (frontend)
- [ ] `yarn contracts:check` passes if API surface changed
- [ ] I've updated the documentation where relevant
- [x] No hardcoded secrets, URLs, or PII
- [x] I've signed the CLA
- [x] PR title follows Conventional Commits
- [ ] Linear issue is linked and updated with status
