### PR TITLE
feat(admin): show Custom Tools to staff as read-only [TH-7898]

### DIFF
--- a/futureagi/ee/usage/admin.py
+++ b/futureagi/ee/usage/admin.py
@@ -600,12 +600,24 @@ def _build_org_choices(orgs_qs):
     return [{"id": str(o["id"]), "label": o["display_name"] or o["name"]} for o in orgs]
 
 
+def _custom_tools_read_only(request) -> bool | None:
+    """Staff get the Custom Tools pages read-only; superusers get full access.
+
+    Returns None when the user may not open the page at all.
+    """
+    user = request.user
+    if not (user.is_active and user.is_staff):
+        return None
+    return not user.is_superuser
+
+
 def custom_pricing_view(request):
-    """Custom pricing admin page — superuser only."""
-    if not request.user.is_superuser:
+    """Custom pricing admin page — staff read-only, superuser read/write."""
+    read_only = _custom_tools_read_only(request)
+    if read_only is None:
         from django.http import HttpResponseForbidden
 
-        return HttpResponseForbidden("Superuser access required")
+        return HttpResponseForbidden("Staff access required")
 
     from accounts.models.organization import Organization
 
@@ -622,6 +634,7 @@ def custom_pricing_view(request):
         **admin.site.each_context(request),
         "title": "Custom Pricing Manager",
         "subtitle": "",
+        "read_only": read_only,
         "org_choices_json": json.dumps(org_choices),
         "feature_keys_json": json.dumps(feature_keys),
     }
@@ -629,11 +642,12 @@ def custom_pricing_view(request):
 
 
 def generate_invoice_view(request):
-    """Generate invoice admin page — superuser only."""
-    if not request.user.is_superuser:
+    """Generate invoice admin page — staff may preview, superuser may generate."""
+    read_only = _custom_tools_read_only(request)
+    if read_only is None:
         from django.http import HttpResponseForbidden
 
-        return HttpResponseForbidden("Superuser access required")
+        return HttpResponseForbidden("Staff access required")
 
     import json
 
@@ -645,6 +659,7 @@ def generate_invoice_view(request):
         **admin.site.each_context(request),
         "title": "Generate Invoice",
         "subtitle": "",
+        "read_only": read_only,
         "org_choices_json": json.dumps(org_choices),
     }
     return TemplateResponse(request, "admin/usage/generate_invoice.html", context)

--- a/futureagi/ee/usage/tests/test_custom_tools_admin_access.py
+++ b/futureagi/ee/usage/tests/test_custom_tools_admin_access.py
@@ -1,0 +1,57 @@
+"""Who may open the admin Custom Tools pages, and in which mode.
+
+The page/template rendering and the API boundary are covered in the
+future-agi/ee repo (``ee/cloud/tests/test_admin_custom_tools_access.py``);
+this pins the role → mode decision that lives in this repo.
+"""
+
+import uuid
+
+import pytest
+from django.test import RequestFactory
+
+from accounts.models.user import User
+from ee.usage.admin import (
+    _custom_tools_read_only,
+    custom_pricing_view,
+    generate_invoice_view,
+)
+
+
+def _request(user):
+    request = RequestFactory().get("/admin/usage/")
+    request.user = user
+    return request
+
+
+def _user(organization, label, **flags):
+    return User.objects.create(
+        email=f"{label}-{uuid.uuid4().hex[:8]}@futureagi.com",
+        name=label.title(),
+        organization=organization,
+        **flags,
+    )
+
+
+@pytest.mark.django_db
+class TestCustomToolsReadOnlyMode:
+    def test_staff_gets_read_only(self, organization):
+        staff = _user(organization, "staff", is_staff=True, is_superuser=False)
+        assert _custom_tools_read_only(_request(staff)) is True
+
+    def test_superuser_gets_full_access(self, organization):
+        root = _user(organization, "root", is_staff=True, is_superuser=True)
+        assert _custom_tools_read_only(_request(root)) is False
+
+    def test_non_staff_is_refused(self, organization):
+        customer = _user(organization, "customer", is_staff=False)
+        assert _custom_tools_read_only(_request(customer)) is None
+
+    def test_inactive_staff_is_refused(self, organization):
+        gone = _user(organization, "gone", is_staff=True, is_active=False)
+        assert _custom_tools_read_only(_request(gone)) is None
+
+    def test_pages_return_403_for_refused_users(self, organization):
+        customer = _user(organization, "customer", is_staff=False)
+        assert custom_pricing_view(_request(customer)).status_code == 403
+        assert generate_invoice_view(_request(customer)).status_code == 403

--- a/futureagi/ee/usage/tests/test_custom_tools_admin_access.py
+++ b/futureagi/ee/usage/tests/test_custom_tools_admin_access.py
@@ -1,14 +1,16 @@
-"""Who may open the admin Custom Tools pages, and in which mode.
+"""Admin Custom Tools for staff: who may open the pages, and what they render.
 
-The page/template rendering and the API boundary are covered in the
-future-agi/ee repo (``ee/cloud/tests/test_admin_custom_tools_access.py``);
-this pins the role → mode decision that lives in this repo.
+The API boundary behind the pages is covered in the future-agi/ee repo
+(``ee/cloud/tests/test_admin_custom_tools_access.py``); everything here
+exercises only this repo's views and templates.
 """
 
+import re
 import uuid
 
 import pytest
-from django.test import RequestFactory
+from django.contrib.messages.storage.fallback import FallbackStorage
+from django.test import Client, RequestFactory
 
 from accounts.models.user import User
 from ee.usage.admin import (
@@ -17,11 +19,14 @@ from ee.usage.admin import (
     generate_invoice_view,
 )
 
-
-def _request(user):
-    request = RequestFactory().get("/admin/usage/")
-    request.user = user
-    return request
+# Inputs that stay in the DOM on the read-only page (their values are shown)
+# but must not look editable.
+FEE_INPUT_IDS = (
+    "platform-fee",
+    "platform-fee-billing-cycle",
+    "contract-end-date",
+    "start-date",
+)
 
 
 def _user(organization, label, **flags):
@@ -33,25 +38,135 @@ def _user(organization, label, **flags):
     )
 
 
+@pytest.fixture
+def staff(db, organization):
+    return _user(organization, "staff", is_staff=True, is_superuser=False)
+
+
+@pytest.fixture
+def superuser(db, organization):
+    return _user(organization, "root", is_staff=True, is_superuser=True)
+
+
+@pytest.fixture
+def non_staff(db, organization):
+    return _user(organization, "customer", is_staff=False)
+
+
+def _request(user):
+    request = RequestFactory().get("/admin/usage/")
+    request.user = user
+    request.session = {}
+    request._messages = FallbackStorage(request)
+    return request
+
+
+def _render(view, user):
+    response = view(_request(user))
+    if hasattr(response, "render"):
+        response.render()
+    return response
+
+
+def _control_tag(html, element_id):
+    match = re.search(rf'<(?:input|select)[^>]*\bid="{element_id}"[^>]*>', html)
+    assert match, f"{element_id} not rendered"
+    return match.group(0)
+
+
 @pytest.mark.django_db
 class TestCustomToolsReadOnlyMode:
-    def test_staff_gets_read_only(self, organization):
-        staff = _user(organization, "staff", is_staff=True, is_superuser=False)
+    def test_staff_gets_read_only(self, staff):
         assert _custom_tools_read_only(_request(staff)) is True
 
-    def test_superuser_gets_full_access(self, organization):
-        root = _user(organization, "root", is_staff=True, is_superuser=True)
-        assert _custom_tools_read_only(_request(root)) is False
+    def test_superuser_gets_full_access(self, superuser):
+        assert _custom_tools_read_only(_request(superuser)) is False
 
-    def test_non_staff_is_refused(self, organization):
-        customer = _user(organization, "customer", is_staff=False)
-        assert _custom_tools_read_only(_request(customer)) is None
+    def test_non_staff_is_refused(self, non_staff):
+        assert _custom_tools_read_only(_request(non_staff)) is None
 
     def test_inactive_staff_is_refused(self, organization):
         gone = _user(organization, "gone", is_staff=True, is_active=False)
         assert _custom_tools_read_only(_request(gone)) is None
 
-    def test_pages_return_403_for_refused_users(self, organization):
-        customer = _user(organization, "customer", is_staff=False)
-        assert custom_pricing_view(_request(customer)).status_code == 403
-        assert generate_invoice_view(_request(customer)).status_code == 403
+    def test_pages_return_403_for_refused_users(self, non_staff):
+        assert custom_pricing_view(_request(non_staff)).status_code == 403
+        assert generate_invoice_view(_request(non_staff)).status_code == 403
+
+
+@pytest.mark.django_db
+class TestCustomPricingPage:
+    def test_staff_page_has_no_editing_controls(self, staff):
+        response = _render(custom_pricing_view, staff)
+        html = response.content.decode()
+
+        assert response.status_code == 200
+        assert response.context_data["read_only"] is True
+        assert 'id="read-only-banner"' in html
+        assert "const READ_ONLY = true;" in html
+        assert 'id="submit-btn"' not in html
+        assert 'onclick="addTierLocal()"' not in html
+        assert 'onclick="addEntitlementLocal()"' not in html
+        assert 'id="new-ent-feature"' not in html
+
+    def test_staff_page_fee_inputs_are_disabled(self, staff):
+        html = _render(custom_pricing_view, staff).content.decode()
+        for element_id in FEE_INPUT_IDS:
+            assert " disabled" in _control_tag(html, element_id), element_id
+
+    def test_staff_page_startup_script_tolerates_missing_feature_select(self, staff):
+        # The dropdown-population IIFE runs on load; without this guard the
+        # read-only page threw before the fee-preview listeners attached.
+        html = _render(custom_pricing_view, staff).content.decode()
+        assert re.search(
+            r'const fSel = document\.getElementById\("new-ent-feature"\);\s*if \(fSel\)',
+            html,
+        )
+
+    def test_superuser_page_has_editing_controls(self, superuser):
+        response = _render(custom_pricing_view, superuser)
+        html = response.content.decode()
+
+        assert response.context_data["read_only"] is False
+        assert 'id="read-only-banner"' not in html
+        assert 'id="submit-btn"' in html
+        assert 'id="new-ent-feature"' in html
+        for element_id in FEE_INPUT_IDS:
+            assert " disabled" not in _control_tag(html, element_id), element_id
+
+
+@pytest.mark.django_db
+class TestGenerateInvoicePage:
+    def test_staff_page_keeps_preview_but_not_generate(self, staff):
+        response = _render(generate_invoice_view, staff)
+        html = response.content.decode()
+
+        assert response.status_code == 200
+        assert response.context_data["read_only"] is True
+        assert 'id="read-only-banner"' in html
+        assert 'id="preview-btn"' in html
+        assert 'id="generate-btn"' not in html
+
+    def test_superuser_page_has_generate(self, superuser):
+        html = _render(generate_invoice_view, superuser).content.decode()
+        assert 'id="generate-btn"' in html
+        assert 'id="read-only-banner"' not in html
+
+
+@pytest.mark.django_db
+class TestAdminIndexShowsCustomTools:
+    def _index(self, user):
+        client = Client()
+        client.force_login(user)
+        return client.get("/admin/").content.decode()
+
+    def test_staff_sees_read_only_section(self, staff):
+        html = self._index(staff)
+        assert "Custom Tools (read only)" in html
+        assert "/admin/usage/custom-pricing/" in html
+        assert "/admin/usage/generate-invoice/" in html
+
+    def test_superuser_sees_full_section(self, superuser):
+        html = self._index(superuser)
+        assert "Custom Tools" in html
+        assert "(read only)" not in html

--- a/futureagi/tfc/templates/admin/index.html
+++ b/futureagi/tfc/templates/admin/index.html
@@ -2,18 +2,18 @@
 {% load i18n %}
 
 {% block content %}
-{% if user.is_superuser %}
+{% if user.is_staff %}
 <div id="custom-admin-links" style="margin-bottom: 20px;">
   <div class="module" style="margin-bottom: 0;">
     <table>
-      <caption><a href="{% url 'admin:custom-pricing' %}" class="section" title="Custom Tools">Custom Tools</a></caption>
+      <caption><a href="{% url 'admin:custom-pricing' %}" class="section" title="Custom Tools">Custom Tools{% if not user.is_superuser %} (read only){% endif %}</a></caption>
       <tr>
         <th scope="row"><a href="{% url 'admin:custom-pricing' %}">Custom Pricing Manager</a></th>
-        <td><a href="{% url 'admin:custom-pricing' %}">Open</a></td>
+        <td><a href="{% url 'admin:custom-pricing' %}">{% if user.is_superuser %}Open{% else %}View{% endif %}</a></td>
       </tr>
       <tr>
         <th scope="row"><a href="{% url 'admin:generate-invoice' %}">Generate Invoice</a></th>
-        <td><a href="{% url 'admin:generate-invoice' %}">Open</a></td>
+        <td><a href="{% url 'admin:generate-invoice' %}">{% if user.is_superuser %}Open{% else %}View{% endif %}</a></td>
       </tr>
     </table>
   </div>

--- a/futureagi/tfc/templates/admin/usage/custom_pricing.html
+++ b/futureagi/tfc/templates/admin/usage/custom_pricing.html
@@ -34,6 +34,11 @@
 
 <div class="cp-container">
   <h2>Custom Pricing Manager</h2>
+  {% if read_only %}
+  <div class="cp-warning" id="read-only-banner">
+    <strong>Read only.</strong> You can view an organization's plan, entitlements and pricing tiers, but only superusers can change them.
+  </div>
+  {% endif %}
   <div id="message"></div>
   <div id="loading">Loading...</div>
 
@@ -105,6 +110,7 @@
       <thead><tr><th>Feature</th><th>Value</th><th></th></tr></thead>
       <tbody id="ent-body"></tbody>
     </table>
+    {% if not read_only %}
     <div class="cp-ent-row" style="margin-top:12px">
       <div class="cp-field" style="margin:0">
         <label>Feature Key</label>
@@ -118,6 +124,7 @@
       </div>
       <div><button class="cp-btn cp-btn-primary cp-btn-sm" onclick="addEntitlementLocal()">Add</button></div>
     </div>
+    {% endif %}
   </div>
 
   <!-- Pricing Tiers -->
@@ -131,6 +138,7 @@
       <thead><tr><th>Dimension</th><th>Range</th><th>$/Unit</th><th></th></tr></thead>
       <tbody id="pricing-body"></tbody>
     </table>
+    {% if not read_only %}
     <div style="margin-top:16px; border-top:1px solid var(--hairline-color,#ddd); padding-top:12px">
       <strong>Add Tier</strong>
       <div class="cp-tier-row" style="margin-top:8px">
@@ -166,8 +174,10 @@
         <div><button class="cp-btn cp-btn-primary cp-btn-sm" onclick="addTierLocal()">Add</button></div>
       </div>
     </div>
+    {% endif %}
   </div>
 
+  {% if not read_only %}
   <!-- Warning + Create/Update Button -->
   <div id="create-section" style="display:none">
     <div class="cp-warning" id="create-warning">
@@ -183,12 +193,15 @@
       Create Custom Plan &amp; Stripe Subscription
     </button>
   </div>
+  {% endif %}
 </div>
 
 <script>
 // Session auth only — no API key needed for admin pages
 const ORG_CHOICES = {{ org_choices_json|safe }};
 const FEATURE_KEYS = {{ feature_keys_json|safe }};
+// Staff view: editing controls are not rendered; the API rejects writes anyway.
+const READ_ONLY = {% if read_only %}true{% else %}false{% endif %};
 
 // Local state — collected before final submit
 let localEntitlements = {};
@@ -259,16 +272,18 @@ async function loadOrg() {
     updatePerChargePreview();
 
     // Show sections
-    ["status-section", "fee-section", "ent-section", "pricing-section", "create-section"].forEach(
-      s => document.getElementById(s).style.display = ""
-    );
+    const sections = ["status-section", "fee-section", "ent-section", "pricing-section"];
+    if (!READ_ONLY) sections.push("create-section");
+    sections.forEach(s => document.getElementById(s).style.display = "");
 
-    // Toggle button text and warning based on existing subscription
-    const isUpdate = r.has_stripe_subscription && r.is_custom;
-    const btn = document.getElementById("submit-btn");
-    btn.textContent = isUpdate ? "Update Custom Plan & Stripe Subscription" : "Create Custom Plan & Stripe Subscription";
-    document.getElementById("create-warning").style.display = isUpdate ? "none" : "";
-    document.getElementById("update-warning").style.display = isUpdate ? "" : "none";
+    if (!READ_ONLY) {
+      // Toggle button text and warning based on existing subscription
+      const isUpdate = r.has_stripe_subscription && r.is_custom;
+      const btn = document.getElementById("submit-btn");
+      btn.textContent = isUpdate ? "Update Custom Plan & Stripe Subscription" : "Create Custom Plan & Stripe Subscription";
+      document.getElementById("create-warning").style.display = isUpdate ? "none" : "";
+      document.getElementById("update-warning").style.display = isUpdate ? "" : "none";
+    }
 
     // Load existing entitlements into local state
     localEntitlements = {};
@@ -309,9 +324,10 @@ function renderEntitlements() {
     tbody.innerHTML = '<tr><td colspan="3" style="color:var(--body-quiet-color,#666)">No per-org overrides. Using plan defaults.</td></tr>';
     return;
   }
-  tbody.innerHTML = entries.map(([feature, val]) =>
-    `<tr><td>${feature}</td><td>${val}</td><td><button class="cp-x" onclick="removeEntitlement('${feature}')">&times;</button></td></tr>`
-  ).join("");
+  tbody.innerHTML = entries.map(([feature, val]) => {
+    const remove = READ_ONLY ? "" : `<button class="cp-x" onclick="removeEntitlement('${feature}')">&times;</button>`;
+    return `<tr><td>${feature}</td><td>${val}</td><td>${remove}</td></tr>`;
+  }).join("");
 }
 
 function renderTiers() {
@@ -322,7 +338,8 @@ function renderTiers() {
   }
   tbody.innerHTML = localTiers.map((t, idx) => {
     const end = t.tier_end != null ? parseFloat(t.tier_end).toLocaleString() : "+";
-    return `<tr><td>${t.dimension}</td><td>${parseFloat(t.tier_start).toLocaleString()} - ${end} ${t.display_unit}</td><td>$${t.price_per_unit}</td><td><button class="cp-x" onclick="removeTier(${idx})">&times;</button></td></tr>`;
+    const remove = READ_ONLY ? "" : `<button class="cp-x" onclick="removeTier(${idx})">&times;</button>`;
+    return `<tr><td>${t.dimension}</td><td>${parseFloat(t.tier_start).toLocaleString()} - ${end} ${t.display_unit}</td><td>$${t.price_per_unit}</td><td>${remove}</td></tr>`;
   }).join("");
 }
 

--- a/futureagi/tfc/templates/admin/usage/custom_pricing.html
+++ b/futureagi/tfc/templates/admin/usage/custom_pricing.html
@@ -72,11 +72,11 @@
     <div class="cp-grid">
       <div class="cp-field">
         <label>Annual Platform Fee ($)</label>
-        <input type="number" id="platform-fee" step="0.01" placeholder="18000.00" value="0">
+        <input type="number" id="platform-fee" step="0.01" placeholder="18000.00" value="0"{% if read_only %} disabled{% endif %}>
       </div>
       <div class="cp-field">
         <label>Billing Cycle</label>
-        <select id="platform-fee-billing-cycle">
+        <select id="platform-fee-billing-cycle"{% if read_only %} disabled{% endif %}>
           <option value="1">Monthly (12 payments/year)</option>
           <option value="3">Quarterly (4 payments/year)</option>
           <option value="6">Semi-Annual (2 payments/year)</option>
@@ -85,11 +85,11 @@
       </div>
       <div class="cp-field">
         <label>Contract End Date</label>
-        <input type="date" id="contract-end-date">
+        <input type="date" id="contract-end-date"{% if read_only %} disabled{% endif %}>
       </div>
       <div class="cp-field">
         <label>Subscription Start Date <span style="font-weight:400;color:var(--body-quiet-color,#666)">(only for backdated contracts)</span></label>
-        <input type="date" id="start-date">
+        <input type="date" id="start-date"{% if read_only %} disabled{% endif %}>
       </div>
     </div>
     <div style="margin-top:8px; font-size:0.8em; color:var(--body-quiet-color,#666); line-height:1.5">
@@ -216,14 +216,17 @@ let localTiers = [];
     opt.textContent = o.label + " (" + o.id.substring(0, 8) + "...)";
     sel.appendChild(opt);
   });
+  // Not rendered on the read-only (staff) page.
   const fSel = document.getElementById("new-ent-feature");
-  // Hide free_* keys — they're auto-derived from leading $0 pricing tier.
-  FEATURE_KEYS.filter(f => !f.startsWith("free_")).forEach(f => {
-    const opt = document.createElement("option");
-    opt.value = f;
-    opt.textContent = f;
-    fSel.appendChild(opt);
-  });
+  if (fSel) {
+    // Hide free_* keys — they're auto-derived from leading $0 pricing tier.
+    FEATURE_KEYS.filter(f => !f.startsWith("free_")).forEach(f => {
+      const opt = document.createElement("option");
+      opt.value = f;
+      opt.textContent = f;
+      fSel.appendChild(opt);
+    });
+  }
 })();
 
 function getCookie(name) {

--- a/futureagi/tfc/templates/admin/usage/generate_invoice.html
+++ b/futureagi/tfc/templates/admin/usage/generate_invoice.html
@@ -40,6 +40,11 @@
   <div style="font-size:0.85em; color:var(--body-quiet-color,#666); margin-bottom:16px; line-height:1.5">
     Works for any paid plan (PAYG / Boost / Scale / Enterprise / Custom). Free-plan orgs cannot be invoiced. The invoice bundles the platform fee for the selected period (advance, prorated if the plan started mid-month) with the prior period's usage (arrears) — matching how Stripe issues its monthly invoice.
   </div>
+  {% if read_only %}
+  <div class="gi-msg gi-msg-warning" id="read-only-banner">
+    <strong>Read only.</strong> You can preview what would be billed, but only superusers can generate an invoice.
+  </div>
+  {% endif %}
   <div id="gi-message"></div>
   <div id="gi-loading">Processing...</div>
 
@@ -84,11 +89,13 @@
       <tbody id="preview-tbody"></tbody>
     </table>
     <div class="gi-summary" id="preview-summary"></div>
+    {% if not read_only %}
     <div style="margin-top: 20px;">
       <button class="gi-btn gi-btn-generate" onclick="generateInvoice()" id="generate-btn" disabled>
         Generate Invoice
       </button>
     </div>
+    {% endif %}
   </div>
 
   <!-- Step 3: Result -->
@@ -104,6 +111,12 @@
 const ORG_CHOICES = {{ org_choices_json|safe }};
 
 let previewData = null;
+
+// Absent on the staff (read-only) page.
+function setGenerateEnabled(enabled) {
+  const btn = document.getElementById("generate-btn");
+  if (btn) btn.disabled = !enabled;
+}
 
 // Populate dropdowns
 (function() {
@@ -201,7 +214,7 @@ async function previewUsage() {
     previewData = data.result;
     renderPreview(previewData);
     document.getElementById("preview-section").style.display = "block";
-    document.getElementById("generate-btn").disabled = false;
+    setGenerateEnabled(true);
 
     if (previewData.invoice_exists) {
       showMsg("Warning: An invoice already exists for this period. Generation will fail unless it is deleted first.", "warning");
@@ -335,7 +348,7 @@ function resetForm() {
   document.getElementById("gi-org-id").value = "";
   document.getElementById("preview-section").style.display = "none";
   document.getElementById("result-section").style.display = "none";
-  document.getElementById("generate-btn").disabled = true;
+  setGenerateEnabled(false);
   document.getElementById("preview-tbody").innerHTML = "";
   document.getElementById("preview-summary").innerHTML = "";
   document.getElementById("preview-notices").innerHTML = "";


### PR DESCRIPTION
## Summary

Staff (`is_staff`, non-superuser) accounts saw only **SOS Login** on the Django admin index. They now also see the **Custom Tools** section (Custom Pricing Manager, Generate Invoice) in a **read-only** mode: they can load and view an org's plan / entitlements / pricing tiers and preview an invoice, but cannot create or update a custom plan, touch Stripe, or generate an invoice. Superusers are unchanged.

**Pairs with future-agi/ee#233** (the server-side permission boundary — `APIKeyOrStaff` for reads, `APIKeyOrSuperuser` for writes). Each PR's tests now pass on its own against `dev`. Merge ee first: without it, staff opening these pages get a 403 from the `custom-plan` GET / invoice-preview calls.

## Linked issues

Closes # — no GitHub issue; internal work tracked in Linear (maintainer PR).
Linear: [TH-7898](https://linear.app/future-agi/issue/TH-7898)

## AI use

AI use: Claude Code (Claude Opus 4.8) produced the diff, the tests and this description under my direction; I made the product calls (what staff may run — Preview yes, Generate no) and reviewed the result.

## Type of change

- [x] ✨ New feature (non-breaking change which adds functionality)

## E2E coverage

E2E: exempt (backend-internal)

Django admin is not in the e2e stack. `yarn coverage` verdict: pass — exempt (backend-internal); no declaration needed.

---

## 1) What changes were done

**A. Admin index shows Custom Tools to staff**

- `tfc/templates/admin/index.html` — section gated on `is_staff` (was `is_superuser`); caption reads "Custom Tools (read only)" and the row links say "View" for non-superusers.

**B. Custom Tools pages open for staff in read-only mode**

- `ee/usage/admin.py` — `custom_pricing_view` / `generate_invoice_view` accept active staff (still 403 otherwise) and pass `read_only = not is_superuser` to their templates via `_custom_tools_read_only`.
- `custom_pricing.html` — read-only banner; the add-entitlement / add-tier rows, per-row remove buttons and the Create/Update-Stripe block are not rendered under `read_only`; the Platform Fee / Billing Cycle / Contract End Date / Subscription Start Date controls are `disabled` (values still shown); the startup script only populates the feature dropdown when it exists; `loadOrg()` no longer touches `create-section` in that mode.
- `generate_invoice.html` — read-only banner; the Generate button is not rendered under `read_only`; `generate-btn` accesses go through a null-safe `setGenerateEnabled()` so Preview works for staff.

| Page | Staff can | Staff cannot |
|---|---|---|
| Custom Pricing Manager | select an org, load and view plan / fee / entitlements / pricing tiers | edit the fee or contract fields, add or remove entitlements or tiers, Create/Update Custom Plan & Stripe |
| Generate Invoice | select org + period, **Preview Usage** | **Generate Invoice** |

---

## 2) Why the changes were done

- **Product/UX:** support/ops staff need to *see* an org's custom pricing and what an invoice would come to, without being able to change billing or push anything to Stripe. Nothing on the read-only page should look editable when it cannot be submitted.
- **Technical:** the unrendered/disabled controls are convenience only; the API in ee#233 rejects the writes regardless of what the page shows. Fail-closed: the page views still 403 for non-staff and inactive staff.

---

## 3) Tests written + scenarios each covers

**`ee/usage/tests/test_custom_tools_admin_access.py`** (this repo, 13 tests) — the role → mode decision, both pages' rendering, and the admin index

- `TestCustomToolsReadOnlyMode`
  - `test_staff_gets_read_only` — staff, non-superuser → `read_only=True`
  - `test_superuser_gets_full_access` — superuser → `read_only=False`
  - `test_non_staff_is_refused` / `test_inactive_staff_is_refused` — → `None`
  - `test_pages_return_403_for_refused_users` — both page views 403
- `TestCustomPricingPage`
  - `test_staff_page_has_no_editing_controls` — banner present; no submit button, add rows, or feature select
  - `test_staff_page_fee_inputs_are_disabled` — the four fee/contract controls carry `disabled`
  - `test_staff_page_startup_script_tolerates_missing_feature_select` — the `if (fSel)` guard is in the rendered script
  - `test_superuser_page_has_editing_controls` — everything above present and enabled for a superuser
- `TestGenerateInvoicePage`
  - `test_staff_page_keeps_preview_but_not_generate` / `test_superuser_page_has_generate`
- `TestAdminIndexShowsCustomTools`
  - `test_staff_sees_read_only_section` / `test_superuser_sees_full_section`

```
$ NO_STARTUP_DB_MUTATIONS=false bin/test --no-services ee/usage/tests/test_custom_tools_admin_access.py -q
============================== 13 passed in 7.27s ==============================
```

Related suites run alongside (unchanged by this PR; ee#233 overlaid for its 13 API-boundary tests):

```
$ NO_STARTUP_DB_MUTATIONS=false bin/test --no-services \
    ee/usage/tests/test_custom_tools_admin_access.py ee/cloud/tests/test_admin_custom_tools_access.py \
    accounts/tests/test_sos_login_admin.py ee/cloud/tests/test_admin_entitlements.py -q
ee/usage/tests/test_custom_tools_admin_access.py .............           [ 18%]
ee/cloud/tests/test_admin_custom_tools_access.py .............           [ 37%]
accounts/tests/test_sos_login_admin.py ...............................   [ 81%]
ee/cloud/tests/test_admin_entitlements.py .............                  [100%]
============================== 70 passed in 7.98s ==============================
```

**JS runtime check (not a repo test):** an HTML-string test cannot catch a `TypeError`, so the staff and superuser pages were rendered from the local stack and executed under jsdom 26. Current templates: no script errors, fee input `disabled`, fee-preview listener attached. Same staff page with the guard removed: `Uncaught TypeError: Cannot read properties of null (reading 'appendChild')` and the preview never updates — the review finding, reproduced.

---

## 4) How to run / test

```bash
cd futureagi
NO_STARTUP_DB_MUTATIONS=false bin/test ee/usage/tests/test_custom_tools_admin_access.py -v
```

### UI steps (manual)

1. With ee#233 checked out under `futureagi/ee/cloud`, log in to `http://localhost:8000/admin/` as a staff (non-superuser) account.
2. Index shows **Custom Tools (read only)** above **SOS Login**.
3. Custom Pricing Manager → pick an org → **Load**: status / fee / entitlements / tiers render; fee and contract fields are greyed out; no Add rows, no ×, no Create/Update button; console is clean.
4. Generate Invoice → pick org + period → **Preview Usage** works; no Generate button.
5. Log in as a superuser: same pages with the full controls.

---

## 5) Screenshots / recordings

Recording of the staff (read-only) vs superuser view against the local stack: **to be added in a follow-up comment.**

---

## 6) Edge cases & considerations

- Inactive staff / inactive superuser: refused on the pages (`_custom_tools_read_only` → `None`) and on the API (both permission classes require `is_active`, ee#233).
- Staff hand-crafting a POST to `custom-plan` or `invoice/generate`: 403 from the API, independent of the UI.
- Read-only page and the shared inline script: every top-level DOM access is against an element that is rendered in both modes, or guarded (`new-ent-feature`, `generate-btn`, `create-section`). `loadOrg()` still writes the fee/contract values into the disabled inputs so staff see the current contract.

---

## 7) Pre-existing issues (NOT introduced by this PR)

- `ee/usage/admin.py` `CustomPricingAdminSite` is dead code (never instantiated). Left alone as a drive-by.
- `tfc/templates/admin/index.html` (OSS) reverses `admin:custom-pricing`, a URL only `ee/` registers — pre-existing OSS-boundary smell, shape unchanged here.

---

## 8) Architectural / important decisions

- **Preview allowed, Generate blocked for staff:** preview is the only way to *see* what an invoice would come to; it does backfill missing `UsageSummary` rows (a data-completion write, not a billing action), which we accepted as the one staff-reachable write. Documented on `APIKeyOrStaff` in ee#233.
- **Render vs hide vs disable:** controls that *submit* are not rendered for staff (nothing to un-hide); the fee/contract fields stay in the DOM `disabled` because the page shows their current values.
- **Tests live with the code they exercise:** page/index tests are in this repo, API-boundary tests in ee, so each PR's suite passes on its own `dev`.

---

## Checklist

- [x] My code follows the style guide
- [x] I've added tests that prove my fix is effective or that my feature works
- [x] `bin/test` passes locally (backend) — targeted runs above
- [ ] `yarn test:run` passes locally (frontend) — n/a, no frontend change
- [ ] `yarn contracts:check` passes if API surface changed — n/a, no contract change
- [x] No hardcoded secrets, URLs, or PII
- [x] PR title follows Conventional Commits
- [x] Linear issue is linked and updated with status

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018CiTkYygSyTFkNCEbbytdk