### PR TITLE
fix(gateway): configure provider API path prefixes in UI

### DIFF
--- a/agentcc-gateway/internal/contracts/generated/gateway_admin.go
+++ b/agentcc-gateway/internal/contracts/generated/gateway_admin.go
@@ -6,6 +6,7 @@ type ProviderConfig struct {
 	APIKey             *string  `json:"api_key,omitempty"`
 	BaseURL            *string  `json:"base_url,omitempty"`
 	APIFormat          *string  `json:"api_format,omitempty"`
+	APIPathPrefix      *string  `json:"api_path_prefix,omitempty"`
 	Models             []string `json:"models,omitempty"`
 	Timeout            *int     `json:"timeout,omitempty"`
 	Weight             *float64 `json:"weight,omitempty"`

--- a/agentcc-gateway/internal/contracts/generated/gateway_admin_test.go
+++ b/agentcc-gateway/internal/contracts/generated/gateway_admin_test.go
@@ -38,6 +38,18 @@ func TestOrgConfigContractRoundTripsIntoGatewayTenantConfig(t *testing.T) {
 	if openai.APIKey != "sk-test-openai" {
 		t.Fatalf("provider api key mismatch: %q", openai.APIKey)
 	}
+	emptyPrefix := ""
+	contract.Providers["openai"].APIPathPrefix = &emptyPrefix
+	encoded, err = json.Marshal(contract)
+	if err != nil {
+		t.Fatalf("encode generated contract with path prefix: %v", err)
+	}
+	if err := json.Unmarshal(encoded, &runtime); err != nil {
+		t.Fatalf("decode gateway runtime path prefix: %v", err)
+	}
+	if got := runtime.Providers["openai"].APIPathPrefix; got == nil || *got != "" {
+		t.Fatalf("provider api path prefix mismatch: %#v", got)
+	}
 	if runtime.Routing == nil || runtime.Routing.Strategy != "weighted" {
 		t.Fatalf("routing strategy mismatch: %#v", runtime.Routing)
 	}

--- a/agentcc-gateway/internal/providers/override.go
+++ b/agentcc-gateway/internal/providers/override.go
@@ -95,6 +95,7 @@ func (c *OrgProviderCache) GetOrCreateWithTenantConfig(orgID, providerID, apiKey
 			BaseURL:            tenantCfg.BaseURL,
 			APIKey:             apiKey,
 			APIFormat:          apiFormat,
+			APIPathPrefix:      tenantCfg.APIPathPrefix,
 			DefaultTimeout:     timeout,
 			MaxConcurrent:      maxConc,
 			ConnPoolSize:       poolSize,

--- a/agentcc-gateway/internal/tenant/config.go
+++ b/agentcc-gateway/internal/tenant/config.go
@@ -30,6 +30,7 @@ type ProviderConfig struct {
 	APIKey         string   `json:"api_key"`
 	BaseURL        string   `json:"base_url,omitempty"`
 	APIFormat      string   `json:"api_format,omitempty"`
+	APIPathPrefix  *string  `json:"api_path_prefix,omitempty"`
 	Models         []string `json:"models,omitempty"`
 	Timeout        int      `json:"timeout,omitempty"` // seconds
 	Weight         float64  `json:"weight,omitempty"`

--- a/api_contracts/gateway/agentcc-admin.schema.json
+++ b/api_contracts/gateway/agentcc-admin.schema.json
@@ -12,6 +12,7 @@
         "api_key": { "type": "string" },
         "base_url": { "type": "string" },
         "api_format": { "type": "string" },
+        "api_path_prefix": { "type": "string" },
         "models": { "type": "array", "items": { "type": "string" } },
         "timeout": { "type": "integer" },
         "weight": { "type": "number" },

--- a/api_contracts/openapi/swagger.json
+++ b/api_contracts/openapi/swagger.json
@@ -82752,6 +82752,11 @@
                     "type": "string",
                     "x-nullable": true
                 },
+                "api_path_prefix": {
+                    "title": "Api path prefix",
+                    "type": "string",
+                    "x-nullable": true
+                },
                 "models": {
                     "type": "array",
                     "items": {

--- a/e2e/FLOWS.md
+++ b/e2e/FLOWS.md
@@ -76,6 +76,28 @@
 - the stored explanation is exactly the verdict the judge prompt dictated, with the span's mapped attribute substituted in, and the result carries the mock LLM's token usage
 - the Pass verdict is parsed out of the model response into output_bool = true
 
+## gateway
+
+### GW-E2E-001 — custom provider keeps an explicitly empty API path prefix
+
+**Goal:** A user configures a custom OpenAI-compatible provider without an API version prefix  
+**Spec:** `flows/gateway/provider-path-prefix.spec.ts:30`  
+**Tags:** @smoke
+
+**User steps:**
+
+1. seed a custom provider for the current organization
+2. open Gateway provider configuration
+3. edit the provider and clear its API path prefix
+4. save and reopen the provider
+5. see that the empty prefix was preserved
+
+**Backend state verified:**
+
+- the provider credential API returns api_path_prefix as an explicit empty string
+- the Django gateway config returns api_path_prefix as an explicit empty string
+- the organization config pushed to the Go gateway retains api_path_prefix as an explicit empty string
+
 ## observe
 
 ### OBS-E2E-001 — SDK trace appears in Observe with coherent backend state

--- a/e2e/flows/gateway/provider-path-prefix.spec.ts
+++ b/e2e/flows/gateway/provider-path-prefix.spec.ts
@@ -1,0 +1,113 @@
+import { request } from '@playwright/test';
+import { test, expect } from '../../lib/fixtures';
+import { E2E } from '../../lib/env';
+import { flowAnnotation } from '../../lib/flow-meta';
+
+// Root docker-compose.yml AGENTCC_ADMIN_TOKEN default. This flow talks to the
+// managed E2E gateway's admin read endpoint to prove Django pushed the value.
+const GATEWAY_ADMIN_TOKEN = 'local-dev-only-admin-token-replace-me';
+const UI_READY = 60_000;
+
+interface ProviderCredentialResponse {
+  result: {
+    id: string;
+    extra_config: Record<string, unknown>;
+  };
+}
+
+interface GatewayConfigResponse {
+  result: {
+    providers: Record<string, { api_path_prefix?: string | null }>;
+  };
+}
+
+interface GatewayOrgConfigList {
+  data: Record<string, {
+    providers?: Record<string, { api_path_prefix?: string | null }>;
+  }>;
+}
+
+test('GW-E2E-001: custom provider keeps an explicitly empty API path prefix', {
+  tag: ['@flow', '@smoke'],
+  annotation: flowAnnotation({
+    id: 'GW-E2E-001',
+    area: 'gateway',
+    userGoal: 'A user configures a custom OpenAI-compatible provider without an API version prefix',
+    steps: [
+      'seed a custom provider for the current organization',
+      'open Gateway provider configuration',
+      'edit the provider and clear its API path prefix',
+      'save and reopen the provider',
+      'see that the empty prefix was preserved',
+    ],
+    backendChecks: [
+      'the provider credential API returns api_path_prefix as an explicit empty string',
+      'the Django gateway config returns api_path_prefix as an explicit empty string',
+      'the organization config pushed to the Go gateway retains api_path_prefix as an explicit empty string',
+    ],
+  }),
+}, async ({ page, actor }, testInfo) => {
+  const suffix = `${testInfo.workerIndex}-${Date.now().toString(36)}`;
+  const providerName = `e2e-prefix-${suffix}`;
+  const modelName = `e2e-model-${suffix}`;
+
+  // Pinned from AgentccProviderCredentialCreateSerializer. Seed through the
+  // credential API so model discovery never needs a live external provider.
+  const created = await actor.api.post<ProviderCredentialResponse>(
+    '/agentcc/provider-credentials/',
+    {
+      provider_name: providerName,
+      credentials: { api_key: `e2e-key-${suffix}` },
+      base_url: 'https://api.perplexity.ai',
+      api_format: 'openai',
+      models_list: [modelName],
+      extra_config: { api_path_prefix: '/v1' },
+    },
+  );
+  await testInfo.attach('provider-credential-id', {
+    body: created.result.id,
+    contentType: 'text/plain',
+  });
+
+  await page.goto('/dashboard/gateway/providers/config');
+  const providerCard = page.locator('.MuiCard-root').filter({ hasText: providerName });
+  await expect(providerCard).toBeVisible({ timeout: UI_READY });
+  await providerCard.getByTitle('Edit provider').click();
+
+  const prefixInput = page.getByLabel('API Path Prefix');
+  await expect(prefixInput).toHaveValue('/v1', { timeout: UI_READY });
+  await prefixInput.fill('');
+
+  const updateResponse = page.waitForResponse(
+    (response) => response.url().includes('/agentcc/gateways/default/update-provider/')
+      && response.request().method() === 'POST',
+    { timeout: UI_READY },
+  );
+  await page.getByRole('button', { name: 'Save Changes' }).click();
+  expect((await updateResponse).status()).toBe(200);
+
+  await providerCard.getByTitle('Edit provider').click();
+  await expect(page.getByLabel('API Path Prefix')).toHaveValue('', { timeout: UI_READY });
+
+  const credential = await actor.api.get<ProviderCredentialResponse>(
+    `/agentcc/provider-credentials/${created.result.id}/`,
+  );
+  expect(credential.result.extra_config.api_path_prefix).toBe('');
+
+  const backendConfig = await actor.api.get<GatewayConfigResponse>(
+    '/agentcc/gateways/default/config/',
+  );
+  expect(backendConfig.result.providers[providerName]?.api_path_prefix).toBe('');
+
+  const gatewayRequest = await request.newContext({
+    baseURL: E2E.gatewayUrl,
+    extraHTTPHeaders: { Authorization: `Bearer ${GATEWAY_ADMIN_TOKEN}` },
+  });
+  const gatewayResponse = await gatewayRequest.get('/-/orgs/configs');
+  expect(gatewayResponse.status()).toBe(200);
+  const gatewayConfigs = await gatewayResponse.json() as GatewayOrgConfigList;
+  expect(
+    gatewayConfigs.data[actor.organizationId]?.providers?.[providerName]?.api_path_prefix,
+  ).toBe('');
+  await gatewayRequest.dispose();
+});

--- a/frontend/src/api/contracts/openapi-contract.generated.js
+++ b/frontend/src/api/contracts/openapi-contract.generated.js
@@ -98019,6 +98019,11 @@ export const OPENAPI_CONTRACT = Object.freeze({
           type: "string",
           "x-nullable": true,
         },
+        api_path_prefix: {
+          title: "Api path prefix",
+          type: "string",
+          "x-nullable": true,
+        },
         models: {
           type: "array",
           items: {

--- a/frontend/src/generated/api-contracts/api.schemas.ts
+++ b/frontend/src/generated/api-contracts/api.schemas.ts
@@ -2599,6 +2599,7 @@ export interface GatewayConfigProviderApi {
   base_url: string;
   /** Gateway protocol adapter name. This intentionally remains a string because self-hosted/custom providers may register adapters outside the built-in openai/anthropic/gemini/google set. */
   api_format: string;
+  api_path_prefix?: string;
   models: GatewayConfigProviderApiModelsItem[];
   is_active: boolean;
   default_timeout: number;

--- a/frontend/src/generated/api-contracts/api.zod.ts
+++ b/frontend/src/generated/api-contracts/api.zod.ts
@@ -5218,6 +5218,7 @@ export const AgentccGatewaysConfigResponse = zod.object({
           .describe(
             "Gateway protocol adapter name. This intentionally remains a string because self-hosted/custom providers may register adapters outside the built-in openai/anthropic/gemini/google set.",
           ),
+        api_path_prefix: zod.string().optional(),
         models: zod.array(zod.object({}).passthrough()),
         is_active: zod.boolean(),
         default_timeout: zod.number(),

--- a/frontend/src/sections/gateway/providers/AddProviderDialog.jsx
+++ b/frontend/src/sections/gateway/providers/AddProviderDialog.jsx
@@ -23,7 +23,12 @@ import {
   useUpdateProvider,
   useFetchProviderModels,
 } from "./hooks/useGatewayConfig";
-import { parseTimeoutSeconds } from "./utils";
+import {
+  DEFAULT_API_PATH_PREFIX,
+  getApiPathPrefix,
+  parseTimeoutSeconds,
+  withApiPathPrefix,
+} from "./utils";
 
 const PROVIDER_PRESETS = {
   openai: {
@@ -171,6 +176,7 @@ const AddProviderDialog = ({ open, onClose, gatewayId, provider }) => {
   const [baseUrl, setBaseUrl] = useState(PROVIDER_PRESETS.openai.baseUrl);
   const [apiKey, setApiKey] = useState("");
   const [apiFormat, setApiFormat] = useState("openai");
+  const [apiPathPrefix, setApiPathPrefix] = useState(DEFAULT_API_PATH_PREFIX);
   const [models, setModels] = useState([]);
   const [timeoutVal, setTimeoutVal] = useState("");
   const [maxConcurrent, setMaxConcurrent] = useState("");
@@ -273,6 +279,7 @@ const AddProviderDialog = ({ open, onClose, gatewayId, provider }) => {
       setBaseUrl(c.base_url ?? c.baseUrl ?? "");
       setApiKey("");
       setApiFormat(c.api_format ?? c.apiFormat ?? "openai");
+      setApiPathPrefix(getApiPathPrefix(c));
       setModels(normalizeModels(c.models));
       const timeoutRaw = c.default_timeout ?? c.defaultTimeout;
       setTimeoutVal(timeoutRaw != null ? String(timeoutRaw) : "");
@@ -357,6 +364,7 @@ const AddProviderDialog = ({ open, onClose, gatewayId, provider }) => {
     setBaseUrl(defaultPreset.baseUrl);
     setApiKey("");
     setApiFormat(defaultPreset.apiFormat);
+    setApiPathPrefix(DEFAULT_API_PATH_PREFIX);
     setModels([]);
     setModelOptions([]);
     setFetchError("");
@@ -396,6 +404,7 @@ const AddProviderDialog = ({ open, onClose, gatewayId, provider }) => {
           : prev,
       );
     }
+    setApiPathPrefix(DEFAULT_API_PATH_PREFIX);
     // Clear models since provider changed
     setModels([]);
     setModelOptions([]);
@@ -489,7 +498,11 @@ const AddProviderDialog = ({ open, onClose, gatewayId, provider }) => {
       return;
     }
 
-    const config = { base_url: baseUrl, api_format: apiFormat };
+    const config = withApiPathPrefix(
+      { base_url: baseUrl, api_format: apiFormat },
+      apiFormat,
+      apiPathPrefix,
+    );
     if (isAwsAuth) {
       if (awsAccessKeyId) config.aws_access_key_id = awsAccessKeyId;
       if (awsSecretAccessKey) config.aws_secret_access_key = awsSecretAccessKey;
@@ -758,6 +771,17 @@ const AddProviderDialog = ({ open, onClose, gatewayId, provider }) => {
               </TextField>
             );
           })()}
+
+          {apiFormat === "openai" && (
+            <TextField
+              label="API Path Prefix"
+              fullWidth
+              value={apiPathPrefix}
+              onChange={(e) => setApiPathPrefix(e.target.value)}
+              placeholder="/v1"
+              helperText="Leave blank when the provider endpoint is not versioned, such as Perplexity Sonar."
+            />
+          )}
 
           <Box>
             <Stack

--- a/frontend/src/sections/gateway/providers/AddProviderDialog.test.jsx
+++ b/frontend/src/sections/gateway/providers/AddProviderDialog.test.jsx
@@ -1,7 +1,12 @@
 import React from "react";
 import { describe, expect, it, vi, beforeEach } from "vitest";
 import { render, screen, userEvent, waitFor } from "src/utils/test-utils";
-import { parseTimeoutSeconds } from "./utils";
+import {
+  DEFAULT_API_PATH_PREFIX,
+  getApiPathPrefix,
+  parseTimeoutSeconds,
+  withApiPathPrefix,
+} from "./utils";
 import AddProviderDialog from "./AddProviderDialog";
 
 const { updateMutate, fetchMutate, fetchState } = vi.hoisted(() => ({
@@ -486,5 +491,28 @@ describe("AddProviderDialog validation", () => {
 
     const save = await screen.findByRole("button", { name: "Save Changes" });
     expect(save.disabled).toBe(false);
+  });
+});
+
+describe("getApiPathPrefix", () => {
+  it("preserves an explicitly empty prefix", () => {
+    expect(getApiPathPrefix({ api_path_prefix: "" })).toBe("");
+  });
+
+  it("uses the default for providers saved before the field existed", () => {
+    expect(getApiPathPrefix({})).toBe(DEFAULT_API_PATH_PREFIX);
+  });
+
+  it("includes an explicit empty prefix in the saved OpenAI config", () => {
+    expect(
+      withApiPathPrefix(
+        { base_url: "https://api.perplexity.ai" },
+        "openai",
+        "",
+      ),
+    ).toEqual({
+      base_url: "https://api.perplexity.ai",
+      api_path_prefix: "",
+    });
   });
 });

--- a/frontend/src/sections/gateway/providers/utils.js
+++ b/frontend/src/sections/gateway/providers/utils.js
@@ -1,3 +1,17 @@
+export const DEFAULT_API_PATH_PREFIX = "/v1";
+
+export function getApiPathPrefix(config) {
+  return (
+    config?.api_path_prefix ?? config?.apiPathPrefix ?? DEFAULT_API_PATH_PREFIX
+  );
+}
+
+export function withApiPathPrefix(config, apiFormat, apiPathPrefix) {
+  return apiFormat === "openai"
+    ? { ...config, api_path_prefix: apiPathPrefix }
+    : config;
+}
+
 export function parseTimeoutSeconds(value) {
   const text = String(value ?? "")
     .trim()

--- a/futureagi/agentcc/contracts/gateway_admin.py
+++ b/futureagi/agentcc/contracts/gateway_admin.py
@@ -37,6 +37,7 @@ class ProviderConfig(GatewayAdminContractModel):
     api_key: str | None = Field(None, validation_alias=AliasChoices('api_key', 'apiKey'))
     base_url: str | None = Field(None, validation_alias=AliasChoices('base_url', 'baseUrl', 'baseURL'))
     api_format: str | None = Field(None, validation_alias=AliasChoices('api_format', 'apiFormat'))
+    api_path_prefix: str | None = Field(None, validation_alias=AliasChoices('api_path_prefix', 'apiPathPrefix'))
     models: list[str] | None = None
     timeout: int | None = None
     weight: float | None = None

--- a/futureagi/agentcc/serializers/contracts.py
+++ b/futureagi/agentcc/serializers/contracts.py
@@ -90,6 +90,9 @@ class GatewayConfigProviderSerializer(serializers.Serializer):
         allow_null=True,
         help_text=API_FORMAT_HELP_TEXT,
     )
+    api_path_prefix = serializers.CharField(
+        required=False, allow_blank=True, allow_null=True
+    )
     models = serializers.ListField(child=serializers.JSONField())
     is_active = serializers.BooleanField()
     default_timeout = serializers.IntegerField(allow_null=True)

--- a/futureagi/agentcc/tests/test_api.py
+++ b/futureagi/agentcc/tests/test_api.py
@@ -197,6 +197,7 @@ class TestAgentccGatewayAPI:
                     "max_concurrent": 3,
                     "conn_pool_size": 5,
                     "base_url": "https://api.example.com/v1",
+                    "api_path_prefix": "",
                 },
             },
             format="json",
@@ -216,6 +217,7 @@ class TestAgentccGatewayAPI:
         assert credential.display_name == "Gateway Action Provider"
         assert credential.models_list == ["gpt-4o-mini"]
         assert credential.default_timeout_seconds == 17
+        assert credential.extra_config == {"api_path_prefix": ""}
         assert CredentialManager.decrypt(credential.encrypted_credentials) == {
             "api_key": "sk-gateway-action-secret"
         }

--- a/futureagi/agentcc/tests/test_gateway_admin_contracts.py
+++ b/futureagi/agentcc/tests/test_gateway_admin_contracts.py
@@ -69,6 +69,16 @@ def test_gateway_org_config_accepts_camel_case_input_and_dumps_snake_case():
     assert dumped["cache"]["max_entries"] == 25
 
 
+def test_gateway_provider_contract_preserves_empty_api_path_prefix():
+    contract = GatewayOrgConfig.model_validate(
+        {"providers": {"perplexity": {"api_path_prefix": ""}}}
+    )
+
+    assert contract.model_dump(by_alias=True, exclude_none=True)["providers"][
+        "perplexity"
+    ]["api_path_prefix"] == ""
+
+
 def test_gateway_org_config_accepts_duplicate_saved_aliases():
     contract = GatewayOrgConfig.model_validate(
         {
@@ -171,7 +181,11 @@ def test_assemble_providers_maps_legacy_aws_credentials_to_gateway_contract(
         SimpleNamespace(
             provider_name="bedrock",
             encrypted_credentials=b"encrypted",
-            extra_config={"weight": 2, "ignored": "not-supported"},
+            extra_config={
+                "weight": 2,
+                "api_path_prefix": "",
+                "ignored": "not-supported",
+            },
             base_url="https://bedrock-runtime.us-east-1.amazonaws.com",
             api_format="bedrock",
             models_list=["anthropic.claude-3-5-sonnet-20241022-v2:0"],
@@ -188,6 +202,7 @@ def test_assemble_providers_maps_legacy_aws_credentials_to_gateway_contract(
     assert providers["bedrock"]["aws_secret_access_key"] == "sk"
     assert providers["bedrock"]["aws_region"] == "us-east-1"
     assert providers["bedrock"]["weight"] == 2
+    assert providers["bedrock"]["api_path_prefix"] == ""
     assert "access_key" not in providers["bedrock"]
     assert "ignored" not in providers["bedrock"]
 

--- a/futureagi/agentcc/tests/test_provider_credential_api.py
+++ b/futureagi/agentcc/tests/test_provider_credential_api.py
@@ -365,3 +365,50 @@ class TestAgentccProviderCredentialOrganizationIsolation:
         assert CredentialManager.decrypt(cred.encrypted_credentials) == {
             "api_key": raw_api_key
         }
+
+    def test_api_path_prefix_round_trips_through_credential_api(
+        self, secondary_org_context, secondary_org_client
+    ):
+        org_b, _ = secondary_org_context
+        with patch(
+            "agentcc.views.provider_credential.AgentccProviderCredentialViewSet._push_config_to_gateway",
+            return_value=True,
+        ):
+            response = secondary_org_client.post(
+                "/agentcc/provider-credentials/",
+                {
+                    "provider_name": "perplexity",
+                    "credentials": {"api_key": "sk-perplexity"},
+                    "api_format": "openai",
+                    "extra_config": {"api_path_prefix": ""},
+                },
+                format="json",
+            )
+
+        assert response.status_code == 201, response.json()
+        credential = AgentccProviderCredential.no_workspace_objects.get(
+            organization=org_b, provider_name="perplexity", deleted=False
+        )
+        assert credential.extra_config == {"api_path_prefix": ""}
+
+        read_response = secondary_org_client.get(
+            f"/agentcc/provider-credentials/{credential.id}/"
+        )
+        assert read_response.status_code == 200, read_response.json()
+        assert read_response.json()["result"]["extra_config"] == {
+            "api_path_prefix": ""
+        }
+
+        with patch(
+            "agentcc.views.provider_credential.AgentccProviderCredentialViewSet._push_config_to_gateway",
+            return_value=True,
+        ):
+            update_response = secondary_org_client.patch(
+                f"/agentcc/provider-credentials/{credential.id}/",
+                {"extra_config": {"api_path_prefix": "/v1"}},
+                format="json",
+            )
+
+        assert update_response.status_code == 200, update_response.json()
+        credential.refresh_from_db()
+        assert credential.extra_config == {"api_path_prefix": "/v1"}

--- a/futureagi/agentcc/views/gateway.py
+++ b/futureagi/agentcc/views/gateway.py
@@ -337,6 +337,7 @@ class AgentccGatewayViewSet(ViewSet):
                     "base_url",
                     "api_format",
                     "models_list",
+                    "extra_config",
                     "is_active",
                     "default_timeout_seconds",
                     "max_concurrent",
@@ -346,12 +347,14 @@ class AgentccGatewayViewSet(ViewSet):
             )
             providers_map = {}
             for p in providers:
+                extra_config = p.get("extra_config") or {}
                 providers_map[p["provider_name"]] = {
                     "id": str(p["id"]),
                     "name": p["provider_name"],
                     "display_name": p["display_name"] or p["provider_name"],
                     "base_url": p["base_url"],
                     "api_format": p["api_format"],
+                    "api_path_prefix": extra_config.get("api_path_prefix", "/v1"),
                     "models": p["models_list"] or [],
                     "is_active": p["is_active"],
                     "default_timeout": p["default_timeout_seconds"],
@@ -541,6 +544,7 @@ class AgentccGatewayViewSet(ViewSet):
                         "base_url",
                         "api_format",
                         "models",
+                        "display_name",
                         "default_timeout",
                         "default_timeout_seconds",
                         "max_concurrent",


### PR DESCRIPTION
## Summary

- Add API path prefix setting for UI-managed OpenAI-compatible providers; an empty value routes Sonar chat to /chat/completions rather than /v1/chat/completions.
- Preserve the value through Django credentials and contracts, config push, and Go tenant runtime.
- Keep the existing Vertex provider edit behavior while rebasing onto dev.
- Cover UI persistence and gateway config with GW-E2E-002. The flow adds a model manually when the provider cannot list models, matching the current form validation.

## Verification

- Focused provider dialog tests and targeted ESLint green.
- E2E TypeScript, catalog, and harness self-tests green.
- Database-free Django tests green locally; DB-backed tests require Postgres and Colima remains stopped.
- Full Go, Django, contract, and browser checks are running in CI on this head. Previous local browser proof was on the pre-rebase branch and is not claimed for this head.

E2E: new GW-E2E-002
AI use: Codex implemented and verified the change; a Luna subagent produced the initial UI and Django patch, which was reviewed and extended with runtime and E2E coverage.

Closes #2628