### PR TITLE
fix(gcp-marketplace): entitlement-deleted crash, Pub/Sub client leak, duplicate approval

### DIFF
--- a/futureagi/accounts/gcp_marketplace_events.py
+++ b/futureagi/accounts/gcp_marketplace_events.py
@@ -438,7 +438,7 @@ def handle_entitlement_deleted(payload: dict) -> None:
         organization_id=row.organization_id
     ).first()
     continues = subscription is not None and (
-        subscription.is_marketplace_billed()
+        subscription.is_marketplace_billed
         or subscription.plan != PlanChoices.FREE
         or bool(subscription.stripe_subscription_id)
     )

--- a/futureagi/accounts/gcp_marketplace_utils.py
+++ b/futureagi/accounts/gcp_marketplace_utils.py
@@ -409,7 +409,10 @@ def approve_pending_entitlements(gcp_account: GCPMarketplaceAccount) -> int:
     """
     _link_orphan_entitlements(gcp_account)
 
-    from accounts.gcp_marketplace_events import reject_duplicate_entitlement
+    from accounts.gcp_marketplace_events import (
+        SECOND_ENTITLEMENT_REASON,
+        reject_duplicate_entitlement,
+    )
 
     pending = GCPMarketplaceEntitlement.objects.filter(
         account=gcp_account,
@@ -417,14 +420,32 @@ def approve_pending_entitlements(gcp_account: GCPMarketplaceAccount) -> int:
     ).order_by("effective_at", "created_at")
 
     approved = 0
+    kept_entitlement_id = None
     for entitlement in pending:
         try:
-            # Oldest first. Once one is approved the rest are duplicates of a
-            # subscription this organization already holds.
-            if approved and reject_duplicate_entitlement(entitlement):
+            if kept_entitlement_id is None:
+                # Oldest first. Approve it, unless the organization already
+                # holds a separate in-service subscription.
+                if reject_duplicate_entitlement(entitlement):
+                    continue
+                gcp_procurement.approve_entitlement(entitlement.entitlement_id)
+                kept_entitlement_id = entitlement.entitlement_id
+                approved += 1
                 continue
-            gcp_procurement.approve_entitlement(entitlement.entitlement_id)
-            approved += 1
+
+            # A further pending entitlement for the same account. The one just
+            # approved is still ACTIVATION_REQUESTED locally until its
+            # ENTITLEMENT_ACTIVE event lands, so reject_duplicate_entitlement
+            # cannot see it yet -- reject this one directly.
+            logger.warning(
+                "gcp_marketplace_duplicate_entitlement_rejected",
+                entitlement_id=entitlement.entitlement_id,
+                existing_entitlement_id=kept_entitlement_id,
+                organization_id=str(entitlement.organization_id),
+            )
+            gcp_procurement.reject_entitlement(
+                entitlement.entitlement_id, SECOND_ENTITLEMENT_REASON
+            )
         except Exception:
             logger.exception(
                 "gcp_marketplace_pending_entitlement_approve_failed",

--- a/futureagi/tfc/temporal/marketplace/activities.py
+++ b/futureagi/tfc/temporal/marketplace/activities.py
@@ -61,6 +61,7 @@ def _drain_sync(heartbeat) -> dict:
     from accounts.gcp_marketplace_events import process_event
 
     close_old_connections()
+    subscriber = None
     try:
         subscriber = pubsub_v1.SubscriberClient()
         path = _subscription_path(subscriber)
@@ -122,6 +123,12 @@ def _drain_sync(heartbeat) -> dict:
             "had_events": bool(response.received_messages),
         }
     finally:
+        if subscriber is not None:
+            # One SubscriberClient per activity run, and the consumer workflow
+            # runs this every 10-30s forever. Each client holds a gRPC channel
+            # with its own transport threads, so leaving them unclosed leaks
+            # channels and sockets in the worker until it is restarted.
+            subscriber.close()
         close_old_connections()
 
 


### PR DESCRIPTION
## Summary

Three independent bug fixes on top of `feat/gcp-marketplace`, branched from it. Each is small and self-contained. No schema changes, no API changes. 3 files, +35 / -7.

1. `handle_entitlement_deleted` crashed on every `ENTITLEMENT_DELETED` event (`is_marketplace_billed` property called as a method).
2. `_drain_sync` leaked a Pub/Sub `SubscriberClient` (and its gRPC channel) on every poll.
3. `approve_pending_entitlements` approved every pending entitlement on an account instead of only the first, when several were queued before sign-up completed.

## Linked issues

Closes #
Linear:

No tracking issue - found while reviewing the branch. Happy to file one if the team prefers.

## AI use

AI use: AI-assisted (code review and initial drafts). Every change was reviewed, compiled and verified by me before opening this PR.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change
- [ ] Documentation

## E2E coverage

E2E: exempt (not-in-stack) - the GCP Marketplace integration is cloud-only, gated behind `GCP_MARKETPLACE_*` settings that are unset outside cloud, and has no E2E coverage today. Fixes verified by tracing the code paths and `python -m py_compile`.

## 1) What changes were done

**A. `handle_entitlement_deleted`: call `is_marketplace_billed` as the property it is**

`futureagi/accounts/gcp_marketplace_events.py`

`OrganizationSubscription.is_marketplace_billed` is a `@property` returning a `bool` (added in `2e26b2101`). `handle_entitlement_deleted` called it as `subscription.is_marketplace_billed()` - invoking a `bool` - which raises `TypeError: 'bool' object is not callable`. It is the first operand of the `continues = subscription is not None and (...)` expression, so it always runs. Fix: drop the `()`.

**B. `_drain_sync`: close the Pub/Sub `SubscriberClient` after each run**

`futureagi/tfc/temporal/marketplace/activities.py`

`_drain_sync` constructs `pubsub_v1.SubscriberClient()` on every call and never closes it. `GCPMarketplaceConsumerWorkflow` invokes this activity every 10-30s for the lifetime of the worker, and each client owns a gRPC channel with its own transport threads and sockets. Fix: `subscriber.close()` in the existing `finally`, guarded with `if subscriber is not None` so a failure in the constructor itself is still safe.

**C. `approve_pending_entitlements`: reject same-batch duplicate entitlements**

`futureagi/accounts/gcp_marketplace_utils.py`

The loop approved every `ACTIVATION_REQUESTED` entitlement linked to the account. The `if approved and reject_duplicate_entitlement(entitlement)` guard cannot catch a second entitlement in the same batch: the one just approved via `gcp_procurement.approve_entitlement` stays `ACTIVATION_REQUESTED` locally until its `ENTITLEMENT_ACTIVE` event arrives, and `reject_duplicate_entitlement` -> `other_in_service_entitlement` only matches `IN_SERVICE_STATES`. So the second (and third...) entitlement was approved too.

Fix: track the entitlement being kept. The first (oldest) is approved unless the org already holds a separate in-service subscription (still routed through `reject_duplicate_entitlement`). Every later entitlement in the batch is rejected directly with `SECOND_ENTITLEMENT_REASON` and the same `gcp_marketplace_duplicate_entitlement_rejected` warning log - matching what `handle_entitlement_creation_requested` does for entitlements that arrive as separate events.

**C. Architecture / layering changes:** none.

## 2) Why the changes were done

- **A** - every entitlement that reaches ~60-day purge (`ENTITLEMENT_DELETED`) hit the `TypeError`, which propagates out of `process_event`, rolls back the `GCPMarketplaceProcessedEvent` dedupe row, and causes Pub/Sub to redeliver the message (stack trace each attempt) until the 24h poison window in `_is_poison` drops it.
- **B** - leaked gRPC channels / threads / sockets accumulate in the Temporal worker until it restarts.
- **C** - a customer with multiple queued entitlements for one org would have all of them approved and billed, when usage is metered per-organization and only the first is billable (`billable_entitlements` then logs `gcp_marketplace_multiple_entitlements_for_org` every run).

## 3) Tests written + scenarios each covers

None. This module has no test suite yet (no `test_gcp_marketplace*` under `futureagi/accounts`). Fixes verified by inspection + `py_compile`. Can add tests for `approve_pending_entitlements` and `handle_entitlement_deleted` in this PR if wanted.

## 4) How to run / test

```
cd futureagi
python -m py_compile accounts/gcp_marketplace_events.py accounts/gcp_marketplace_utils.py tfc/temporal/marketplace/activities.py
```

Manual review path for C: queue two `ENTITLEMENT_ACTIVATION_REQUESTED` entitlements for one account before completing sign-up, then run `_finish_signup` -> only the oldest is approved, the rest are rejected with `SECOND_ENTITLEMENT_REASON`.

## 5) Screenshots / recordings

N/A - backend only.

## 6) Edge cases & considerations

- **A**: after the fix `continues` is `True` when the sub is marketplace-billed, on a non-free plan, or has a Stripe subscription id - unchanged from the original intent.
- **B**: `SubscriberClient()` raising in the constructor leaves `subscriber = None`; the `finally` guard handles it. Early `return` paths still run the `finally`.
- **C**: the first pending entitlement is now also checked against pre-existing in-service subscriptions (previously it was not, because the guard was `if approved and ...`). During normal sign-up the org is new so this is a no-op; in reconcile it is a strict improvement.
- **C**: `reject_entitlement` failures stay caught per-iteration and logged, as before.

## 7) Pre-existing issues (NOT introduced by this PR)

- No E2E / unit coverage for the GCP Marketplace module.
- `approve_pending_entitlements` first entitlement was previously never checked against pre-existing in-service subscriptions - addressed here as part of C.

## 8) Architectural / important decisions

- C rejects the extras rather than leaving them pending, matching `handle_entitlement_creation_requested`. A rejected entitlement is not charged.
- B closes the client per-run rather than caching one on the service object, to keep the activity self-contained and match the existing `close_old_connections()` lifecycle in the same `finally`.

## Checklist

- [x] Conventional Commit messages
- [x] `python -m py_compile` passes on the changed files
- [ ] Tests added (no existing suite for this module - happy to add)
- [x] No schema or API changes