### PR TITLE
fix: [2/6] Preserve latest physical state in Trace reads [agent]

### DIFF
--- a/futureagi/tracer/selectors/trace_filter_reads.py
+++ b/futureagi/tracer/selectors/trace_filter_reads.py
@@ -1190,6 +1190,7 @@ def read_bounded_filter_page(
         and not candidate_witness_probe_enabled
     )
     identity_refill_limit = candidate_limit
+    identity_prefix_slice_end: datetime | None = None
     candidate_witness_probe_strata = 1
     # Slice-aware builders advertise their temporal probe contract through the
     # strata recommendation hook. Legacy one-shot probes expose only
@@ -2174,6 +2175,7 @@ def read_bounded_filter_page(
         """
 
         nonlocal initial_identity_flush_pending, adaptive_identity_start, empty_prefix_seed
+        nonlocal identity_prefix_slice_end
 
         if (
             not identity_only_classification
@@ -2245,8 +2247,17 @@ def read_bounded_filter_page(
             and callable(candidate_witness_probe_builder)
             else classify_batch_size
         )
+        # Recheck density once per new ordered slice, not after every sparse
+        # batch. A newer empty population says nothing about an older one.
+        new_slice_prefix = (
+            ordered_identity_refill
+            and not matched_by_id
+            and identity_prefix_slice_end != active_end
+            and pending_flush_size == 200
+            and len(pending_identity_candidates) >= pending_flush_size
+        )
         if (
-            initial_identity_flush_pending
+            (initial_identity_flush_pending or new_slice_prefix)
             and stop_on_ordered_prefix
             and pending_identity_candidates
             and (len(pending_identity_candidates) >= pending_flush_size or force)
@@ -2254,6 +2265,7 @@ def read_bounded_filter_page(
             # Split only the first scheduled batch. Lack of an exact ordered
             # prefix (including corrected root order) resumes baseline sizing.
             adaptive_identity_start = True
+            identity_prefix_slice_end = active_end
             scheduled = min(len(pending_identity_candidates), pending_flush_size)
             first = min(50, scheduled)
             prefix_proven = flush(first)

--- a/futureagi/tracer/services/clickhouse/query_service.py
+++ b/futureagi/tracer/services/clickhouse/query_service.py
@@ -580,10 +580,11 @@ class AnalyticsQueryService:
                 "start_time >= %(start_date)s - INTERVAL 1 DAY "
                 "AND start_time < %(end_date)s + INTERVAL 1 DAY"
             )
-        # Resolve ReplacingMergeTree state before checking live membership.
+        # Resolve the full CH25 ReplacingMergeTree key before live membership.
         # Filtering ``is_deleted = 0`` in the physical scan resurrects an older
-        # version after a tombstone. A span id can also be reused/reassigned;
-        # retain every live candidate trace so Python can reject ambiguity.
+        # version after a tombstone. Exact start_time is mutable within its
+        # storage hour; service, observation type and trace are distinct keys.
+        # Retain every live candidate trace so Python can reject ambiguity.
         physical_where = (
             list(where)
             if pair_scoped
@@ -596,6 +597,7 @@ class AnalyticsQueryService:
             ]
         )
         window_fragment = ""
+        physical_window_fragment = ""
         if (
             not pair_scoped
             and normalized_scored_span_ids is None
@@ -603,8 +605,16 @@ class AnalyticsQueryService:
             and end_date is not None
         ):
             window_fragment = (
-                "AND start_time >= %(start_date)s - INTERVAL 1 DAY "
-                "AND start_time < %(end_date)s + INTERVAL 1 DAY"
+                "AND latest_start_time >= %(start_date)s - INTERVAL 1 DAY "
+                "AND latest_start_time < %(end_date)s + INTERVAL 1 DAY"
+            )
+            # Coarse immutable-hour pruning retains all corrected versions;
+            # the exact compatibility window applies only to the winner.
+            physical_window_fragment = (
+                "AND toStartOfHour(start_time) >= "
+                "toStartOfHour(%(start_date)s - INTERVAL 1 DAY) "
+                "AND toStartOfHour(start_time) <= "
+                "toStartOfHour(%(end_date)s + INTERVAL 1 DAY)"
             )
         mapping_columns = (
             "project_id_string, span_id, live_trace_ids"
@@ -630,15 +640,18 @@ class AnalyticsQueryService:
                     project_id,
                     toString(project_id) AS project_id_string,
                     toString(id) AS span_id,
-                    start_time,
-                    toString(argMax(trace_id, _version)) AS latest_trace_id,
-                    argMax(is_deleted, _version) AS latest_is_deleted
+                    toString(trace_id) AS latest_trace_id,
+                    argMax(tuple(start_time, is_deleted), _version) AS latest_span,
+                    latest_span.1 AS latest_start_time,
+                    latest_span.2 AS latest_is_deleted
                 FROM spans
                 WHERE {" AND ".join(physical_where) or "1"}
-                  {window_fragment}
-                GROUP BY project_id, id, start_time
+                  {physical_window_fragment}
+                GROUP BY project_id, observation_type, service_name,
+                         toStartOfHour(start_time), trace_id, id
             ) AS latest_physical_spans
             WHERE latest_is_deleted = 0
+              {window_fragment}
               AND {membership_predicate}
             GROUP BY {candidate_group_by}
         ) AS scored_span_candidates
@@ -823,12 +836,16 @@ class AnalyticsQueryService:
                 raise ReadDeadlineExceeded("evaluation detail read deadline exceeded")
             return remaining
 
+        # A tombstone in one service/type/hour cannot delete another physical
+        # span sharing the external ID. Keep duplicate trace IDs as separate
+        # anchors too: the LIMIT 2 sentinel must reject that ambiguity.
         span_anchor_query = f"""
             SELECT toString(trace_id) AS trace_id
             FROM {_SPANS_TABLE}
             PREWHERE project_id = toUUID(%(project_id)s)
             WHERE id = %(span_id)s
-            GROUP BY trace_id, id
+            GROUP BY project_id, observation_type, service_name,
+                     toStartOfHour(start_time), trace_id, id
             HAVING argMax(is_deleted, _version) = 0
             LIMIT 2
         """

--- a/futureagi/tracer/services/clickhouse/v2/query_builders/trace_list.py
+++ b/futureagi/tracer/services/clickhouse/v2/query_builders/trace_list.py
@@ -506,10 +506,10 @@ class _TraceListQueryBuilderV2Core(_TraceRootReplayV2, TraceListQueryBuilder):
         # No inner LIMIT: an overflowing coordinate set must throw, not hide
         # a span. The outer full replacement-key argMax remains authoritative.
         # Read the project UUID only after trace_id filtering; WHERE still
-        # enforces project scope before DISTINCT and preserves index pruning.
+        # enforces project scope; IN already deduplicates coordinate tuples.
         return f"""
                   AND (observation_type, service_name, toStartOfHour(start_time), trace_id) IN (
-                      SELECT DISTINCT observation_type, service_name,
+                      SELECT observation_type, service_name,
                           toStartOfHour(start_time), trace_id
                       FROM {self.TABLE}
                       PREWHERE trace_id IN %(candidate_trace_ids)s

--- a/futureagi/tracer/services/clickhouse/v2/query_builders/trace_list.py
+++ b/futureagi/tracer/services/clickhouse/v2/query_builders/trace_list.py
@@ -505,13 +505,15 @@ class _TraceListQueryBuilderV2Core(_TraceRootReplayV2, TraceListQueryBuilder):
         # selected seed root is allowed to choose the replay population.
         # No inner LIMIT: an overflowing coordinate set must throw, not hide
         # a span. The outer full replacement-key argMax remains authoritative.
+        # Read the project UUID only after trace_id filtering; WHERE still
+        # enforces project scope before DISTINCT and preserves index pruning.
         return f"""
                   AND (observation_type, service_name, toStartOfHour(start_time), trace_id) IN (
                       SELECT DISTINCT observation_type, service_name,
                           toStartOfHour(start_time), trace_id
                       FROM {self.TABLE}
-                      PREWHERE {self.project_filter_sql()}
-                          AND trace_id IN %(candidate_trace_ids)s
+                      PREWHERE trace_id IN %(candidate_trace_ids)s
+                      WHERE {self.project_filter_sql()}
                   )
         """
 
@@ -823,8 +825,10 @@ class _TraceListQueryBuilderV2Core(_TraceRootReplayV2, TraceListQueryBuilder):
 
         A trace's physical span fanout is unbounded. Packing every span's full
         maps into one ``groupArray`` merely hides that fanout from the result-row
-        limit while retaining unbounded ClickHouse/Python memory. This query
-        projects only requested keys and deterministically selects one value per
+        limit while retaining unbounded ClickHouse/Python memory. Project requested
+        keys BEFORE argMax so its per-span state never retains unrelated maps/JSON.
+        This deterministic row projection preserves the same coherent winner,
+        including key removal, JSON null and type precedence. Select one value per
         ``(project, trace, key)``: the value on the latest live physical span by
         ``(latest_start_time, id, observation_type, service_name)``. Versions
         collapse on the six-part storage key with one coherent tuple before
@@ -906,21 +910,7 @@ class _TraceListQueryBuilderV2Core(_TraceRootReplayV2, TraceListQueryBuilder):
                 service_name,
                 latest_start_time,
                 attribute_key,
-                multiIf(
-                    notEmpty(JSONExtractRaw(latest_attributes_extra, attribute_key)),
-                        JSONExtractRaw(latest_attributes_extra, attribute_key),
-                    mapContains(latest_attrs_bool, attribute_key),
-                        if(latest_attrs_bool[attribute_key] != 0, 'true', 'false'),
-                    mapContains(latest_attrs_number, attribute_key),
-                        if(
-                            isFinite(latest_attrs_number[attribute_key]),
-                            toString(latest_attrs_number[attribute_key]),
-                            'null'
-                        ),
-                    mapContains(latest_attrs_string, attribute_key),
-                        toJSONString(latest_attrs_string[attribute_key]),
-                    ''
-                ) AS candidate_attribute_value_json
+                candidate_attribute_value_json
             FROM (
                 SELECT
                     project_id,
@@ -928,14 +918,23 @@ class _TraceListQueryBuilderV2Core(_TraceRootReplayV2, TraceListQueryBuilder):
                     id,
                     observation_type,
                     service_name,
-                    argMax(tuple(start_time, attributes_extra, attrs_string,
-                        attrs_number, attrs_bool, is_deleted), _version) AS latest_span,
+                    argMax(tuple(start_time,
+                        arrayMap(key -> multiIf(
+                            notEmpty(JSONExtractRaw(attributes_extra, key)),
+                                JSONExtractRaw(attributes_extra, key),
+                            mapContains(attrs_bool, key),
+                                if(attrs_bool[key] != 0, 'true', 'false'),
+                            mapContains(attrs_number, key),
+                                if(isFinite(attrs_number[key]),
+                                    toString(attrs_number[key]), 'null'),
+                            mapContains(attrs_string, key),
+                                toJSONString(attrs_string[key]),
+                            ''
+                        ), %(requested_attribute_keys)s),
+                        is_deleted), _version) AS latest_span,
                     latest_span.1 AS latest_start_time,
-                    latest_span.2 AS latest_attributes_extra,
-                    latest_span.3 AS latest_attrs_string,
-                    latest_span.4 AS latest_attrs_number,
-                    latest_span.5 AS latest_attrs_bool,
-                    latest_span.6 AS latest_is_deleted
+                    latest_span.2 AS latest_attribute_values,
+                    latest_span.3 AS latest_is_deleted
                 FROM {self.TABLE}
                 PREWHERE (toString(project_id), trace_id)
                     IN %(attr_trace_identities)s
@@ -943,7 +942,8 @@ class _TraceListQueryBuilderV2Core(_TraceRootReplayV2, TraceListQueryBuilder):
                 GROUP BY project_id, observation_type, service_name,
                     toStartOfHour(start_time), trace_id, id
             ) AS latest_physical_spans
-            ARRAY JOIN %(requested_attribute_keys)s AS attribute_key
+            ARRAY JOIN %(requested_attribute_keys)s AS attribute_key,
+                latest_attribute_values AS candidate_attribute_value_json
             WHERE latest_is_deleted = 0
         ) AS projected_attribute_values
         WHERE notEmpty(candidate_attribute_value_json)

--- a/futureagi/tracer/services/clickhouse/v2/schema/028_trace_id_bloom_strict.sql
+++ b/futureagi/tracer/services/clickhouse/v2/schema/028_trace_id_bloom_strict.sql
@@ -1,0 +1,7 @@
+-- Reduce false positives for batched trace ID lookups.
+-- Existing parts need a separate, partition-scoped MATERIALIZE INDEX operation.
+-- Keep historical materialization out of the schema applier.
+
+ALTER TABLE spans
+    ADD INDEX IF NOT EXISTS idx_trace_id_bloom_strict trace_id
+    TYPE bloom_filter(0.00001) GRANULARITY 1;

--- a/futureagi/tracer/tests/test_ch25_apply_schema_replicated.py
+++ b/futureagi/tracer/tests/test_ch25_apply_schema_replicated.py
@@ -431,6 +431,26 @@ class TestAttrValueBloomIndexFile:
             assert "ON CLUSTER 'default'" in out
 
 
+@pytest.mark.parametrize("replicated", [False, True])
+def test_strict_trace_id_index_is_metadata_only(replicated):
+    import pathlib
+
+    schema_dir = (
+        pathlib.Path(__file__).resolve().parents[1] / "services/clickhouse/v2/schema"
+    )
+    statements = split_statements(
+        (schema_dir / "028_trace_id_bloom_strict.sql").read_text()
+    )
+    # A schema apply must not rebuild historical parts or drop the existing index.
+    assert len(statements) == 1
+    stmt = _rewrite(statements[0]) if replicated else statements[0]
+    assert _extract_table_name(stmt) == "spans"
+    assert "ADD INDEX IF NOT EXISTS idx_trace_id_bloom_strict trace_id" in stmt
+    assert "TYPE bloom_filter(0.00001) GRANULARITY 1" in stmt
+    assert "MATERIALIZE" not in stmt and "DROP" not in stmt
+    assert ("ON CLUSTER 'default'" in stmt) is replicated
+
+
 class TestSpansCreatedAtIndexFile:
     """024_spans_created_at_index.sql — created_at minmax skip index on spans,
     so the continuous eval-task reconcile's arrival floor (created_at >= cursor)

--- a/futureagi/tracer/tests/test_direct_write_attribute_hydration.py
+++ b/futureagi/tracer/tests/test_direct_write_attribute_hydration.py
@@ -54,17 +54,12 @@ def test_trace_attribute_hydration_projects_latest_requested_key_value():
     )
 
     compact = " ".join(sql.split())
-    assert (
-        "argMax(tuple(start_time, attributes_extra, attrs_string, attrs_number, attrs_bool, is_deleted), _version) AS latest_span"
-        in compact
-    )
+    assert "argMax(tuple(start_time, arrayMap(key -> multiIf(" in compact
+    assert "%(requested_attribute_keys)s), is_deleted), _version) AS latest_span" in compact
     for slot, alias in enumerate(
         (
             "latest_start_time",
-            "latest_attributes_extra",
-            "latest_attrs_string",
-            "latest_attrs_number",
-            "latest_attrs_bool",
+            "latest_attribute_values",
             "latest_is_deleted",
         ),
         start=1,
@@ -85,10 +80,11 @@ def test_trace_attribute_hydration_projects_latest_requested_key_value():
         in compact
     )
     assert "attribute_value_json" in sql
-    assert "JSONExtractRaw(latest_attributes_extra, attribute_key)" in sql
-    assert "mapContains(latest_attrs_bool, attribute_key)" in sql
-    assert "mapContains(latest_attrs_number, attribute_key)" in sql
-    assert "mapContains(latest_attrs_string, attribute_key)" in sql
+    assert "JSONExtractRaw(attributes_extra, key)" in sql
+    assert "mapContains(attrs_bool, key)" in sql
+    assert "mapContains(attrs_number, key)" in sql
+    assert "mapContains(attrs_string, key)" in sql
+    assert "latest_attribute_values AS candidate_attribute_value_json" in sql
     assert "LIMIT" not in sql
     assert "INTERVAL 1 DAY" not in sql
     assert "start_time >= %(start_date)s" not in sql

--- a/futureagi/tracer/tests/test_eval_config_ids_resolution.py
+++ b/futureagi/tracer/tests/test_eval_config_ids_resolution.py
@@ -439,6 +439,10 @@ class TestEvalReadSelectors:
         assert "FROM spans" in anchor_query
         assert "project_id = toUUID(%(project_id)s)" in anchor_query
         assert "HAVING argMax(is_deleted, _version) = 0" in anchor_query
+        assert (
+            "GROUP BY project_id, observation_type, service_name, "
+            "toStartOfHour(start_time), trace_id, id"
+        ) in " ".join(anchor_query.split())
         assert "LIMIT 2" in anchor_query
         assert anchor_params == {"project_id": "project-1", "span_id": "span-1"}
 

--- a/futureagi/tracer/tests/test_eval_status_reads_ch25.py
+++ b/futureagi/tracer/tests/test_eval_status_reads_ch25.py
@@ -78,12 +78,16 @@ def spans_table(ch_client, monkeypatch):
         f"""
         CREATE TABLE {table} (
             project_id UUID,
+            observation_type String DEFAULT 'SPAN',
+            service_name String DEFAULT 'fixture-service',
+            start_time DateTime64(6, 'UTC') DEFAULT '2026-08-01 12:00:00',
             trace_id String,
             id String,
             is_deleted UInt8,
             _version UInt64
         ) ENGINE = MergeTree
-        ORDER BY (project_id, trace_id, id, _version)
+        ORDER BY (project_id, observation_type, service_name,
+                  toStartOfHour(start_time), trace_id, id)
         """
     )
     monkeypatch.setattr(query_service_config, "_SPANS_TABLE", table)
@@ -230,7 +234,7 @@ def test_eval_status_result_and_detail_use_latest_live_candidate_on_ch25(
     ]
     ch_client.execute(f"INSERT INTO {eval_table} VALUES", rows)
     ch_client.execute(
-        f"INSERT INTO {spans_table} VALUES",
+        f"INSERT INTO {spans_table} (project_id, trace_id, id, is_deleted, _version) VALUES",
         [
             (project_id, str(trace_id), "span-live", 0, 1),
             # Same span id in another project is a valid global collision and

--- a/futureagi/tracer/tests/test_raw_filter_integration_guards.py
+++ b/futureagi/tracer/tests/test_raw_filter_integration_guards.py
@@ -209,7 +209,7 @@ def test_all_explicit_raw_aliases_keep_custom_replay_envelope(key):
     assert builder._custom_span_attribute_filter_count() == 1
     assert builder.recommended_filter_classify_batch_size() == 200
     assert builder._uses_scalar_coordinate_replay()
-    assert "SELECT DISTINCT observation_type, service_name," in (
+    assert "SELECT observation_type, service_name," in (
         builder._filter_classifier_coordinate_predicate()
     )
     assert builder.recommended_filter_classify_read_settings() is not None

--- a/futureagi/tracer/tests/test_scored_span_physical_replay.py
+++ b/futureagi/tracer/tests/test_scored_span_physical_replay.py
@@ -1,0 +1,278 @@
+"""Scored-span mappings and eval anchors against constant CH25 rows; no DDL."""
+
+import json
+from datetime import datetime, timedelta
+from types import SimpleNamespace
+
+import pytest
+from clickhouse_driver.util.escape import escape_params
+
+from tracer.services.clickhouse.query_service import (
+    AnalyticsQueryService,
+    SpanTraceMapIntegrityError,
+)
+
+pytestmark = pytest.mark.unit
+PROJECT = "11111111-1111-4111-8111-111111111111"
+OTHER = "22222222-2222-4222-8222-222222222222"
+AT = datetime(2026, 8, 1, 12)
+CONTEXT = SimpleNamespace(server_info=SimpleNamespace(get_timezone=lambda: "UTC"))
+
+
+def row(**overrides):
+    return {
+        "project_id": PROJECT,
+        "observation_type": "SPAN",
+        "service_name": "svc",
+        "trace_id": "trace-a",
+        "id": "scored",
+        "start_time": AT,
+        "_version": 1,
+        "is_deleted": 0,
+    } | overrides
+
+
+@pytest.fixture(scope="module")
+def engine():
+    return pytest.importorskip("chdb", reason="optional constant-fixture engine")
+
+
+def execute_fixture(engine, rows, query, params):
+    # Substitute constant rows without changing scope or physical replay.
+    assert query.count("FROM spans") == 1
+    query = query.replace("FROM spans", "FROM fixture_spans")
+    if "PREWHERE" in query:
+        # VALUES lacks PREWHERE. Preserve the anchor's conjunction exactly.
+        assert query.count("PREWHERE") == query.count("WHERE id =") == 1
+        query = query.replace("PREWHERE", "WHERE").replace("WHERE id =", "AND id =")
+    rendered = query % escape_params(params, CONTEXT)
+    schema = (
+        "project_id UUID, observation_type String, service_name String, "
+        "trace_id String, id String, start_time DateTime64(6, 'UTC'), "
+        "_version UInt64, is_deleted UInt8"
+    )
+    values = [
+        tuple(r[k].isoformat(sep=" ") if k == "start_time" else r[k] for k in row())
+        for r in rows
+    ]
+    escaped = escape_params({"schema": schema, "rows": tuple(values)}, CONTEXT)
+    sql = (
+        f"WITH fixture_spans AS (SELECT * FROM values({escaped['schema']}, "
+        f"{escaped['rows'][1:-1]})) {rendered} "
+        "SETTINGS max_threads=1, max_execution_time=5, "
+        "max_memory_usage=134217728, max_result_rows=100, "
+        "max_result_bytes=1048576, result_overflow_mode='throw'"
+    )
+    return SimpleNamespace(
+        data=[
+            json.loads(line)
+            for line in str(engine.query(sql, "JSONEachRow")).splitlines()
+            if line
+        ]
+    )
+
+
+def mapping(engine, rows, *, pairs=False, finite=True, start=None, end=None):
+    service = AnalyticsQueryService()
+
+    def execute(query, params=None, **_kwargs):
+        return execute_fixture(engine, rows, query, params)
+
+    service.execute_ch_query = execute
+    traces = ["trace-a", "trace-b"]
+    options = {"start_date": start, "end_date": end}
+    if pairs:
+        options.update(
+            trace_identities=[(PROJECT, trace) for trace in traces],
+            scored_span_identities=[(PROJECT, "scored")],
+        )
+    else:
+        options.update(
+            project_id=PROJECT, scored_span_ids=["scored"] if finite else None
+        )
+    return service.get_span_trace_map(traces, **options)
+
+
+def latest_spans(rows):
+    latest = {}
+    for r in rows:
+        key = (
+            r["project_id"],
+            r["observation_type"],
+            r["service_name"],
+            r["start_time"].replace(minute=0, second=0, microsecond=0),
+            r["trace_id"],
+            r["id"],
+        )
+        if key not in latest or latest[key]["_version"] < r["_version"]:
+            latest[key] = r
+    return latest.values()
+
+
+def truth(rows, *, pairs=False):
+    matches = {
+        r["trace_id"]
+        for r in latest_spans(rows)
+        if r["project_id"] == PROJECT
+        and r["id"] == "scored"
+        and not r["is_deleted"]
+        and r["trace_id"] in {"trace-a", "trace-b"}
+    }
+    if len(matches) > 1:
+        raise ValueError("ambiguous fixture")
+    if not matches:
+        return {}
+    trace = matches.pop()
+    return {(PROJECT, "scored"): (PROJECT, trace)} if pairs else {"scored": trace}
+
+
+@pytest.mark.parametrize("pairs", [False, True])
+@pytest.mark.parametrize("minutes", [(-20, -10), (10, 20), (20, 10)])
+def test_timestamp_corrected_tombstone_does_not_resurrect_annotation(
+    engine, pairs, minutes
+):
+    rows = [
+        row(start_time=AT + timedelta(minutes=minutes[0])),
+        row(start_time=AT + timedelta(minutes=minutes[1]), _version=2, is_deleted=1),
+    ]
+    assert mapping(engine, rows, pairs=pairs) == truth(rows, pairs=pairs) == {}
+
+
+@pytest.mark.parametrize("pairs", [False, True])
+@pytest.mark.parametrize(
+    "other_identity",
+    [
+        {"service_name": "other-service"},
+        {"observation_type": "LLM"},
+        {"start_time": AT + timedelta(hours=1)},
+        {"project_id": OTHER},
+    ],
+)
+def test_tombstone_cannot_delete_another_physical_identity(
+    engine, pairs, other_identity
+):
+    rows = [row(), row(**other_identity, _version=2, is_deleted=1)]
+    assert mapping(engine, rows, pairs=pairs) == truth(rows, pairs=pairs)
+
+
+@pytest.mark.parametrize("pairs", [False, True])
+def test_same_span_id_in_two_live_traces_is_ambiguous(engine, pairs):
+    rows = [row(), row(trace_id="trace-b", _version=2)]
+    with pytest.raises(ValueError, match="ambiguous fixture"):
+        truth(rows, pairs=pairs)
+    with pytest.raises(SpanTraceMapIntegrityError, match="ambiguous live traces"):
+        mapping(engine, rows, pairs=pairs)
+
+
+@pytest.mark.parametrize("days", [7, 30, 365])
+@pytest.mark.parametrize("pairs", [False, True])
+def test_finite_scored_identity_keeps_children_outside_root_window(engine, days, pairs):
+    rows = [
+        row(start_time=AT + timedelta(days=days + 5)),
+        row(project_id=OTHER, trace_id="trace-b", _version=3),
+    ]
+    assert mapping(
+        engine, rows, pairs=pairs, start=AT, end=AT + timedelta(days=days)
+    ) == truth(rows, pairs=pairs)
+
+
+@pytest.mark.parametrize(
+    "edge,old_minute,new_minute,present",
+    [
+        ("start", 10, 20, True),
+        ("start", 20, 10, False),
+        ("start", 10, 15, True),
+        ("start", 15, 10, False),
+        ("end", 10, 20, False),
+        ("end", 20, 10, True),
+        ("end", 10, 15, False),
+        ("end", 15, 10, True),
+    ],
+)
+def test_generic_window_applies_after_timestamp_correction(
+    engine, edge, old_minute, new_minute, present
+):
+    rows = [
+        row(start_time=AT + timedelta(minutes=old_minute)),
+        row(start_time=AT + timedelta(minutes=new_minute), _version=2),
+    ]
+    # The generic compatibility lane widens by one day, unlike scored IDs.
+    if edge == "start":
+        start = AT + timedelta(days=1, minutes=15)
+        end = start + timedelta(days=7)
+    else:
+        end = AT + timedelta(days=-1, minutes=15)
+        start = end - timedelta(days=7)
+    expected = {"scored": "trace-a"} if present else {}
+    assert mapping(engine, rows, finite=False, start=start, end=end) == expected
+
+
+@pytest.mark.parametrize(
+    "other_identity",
+    [
+        {"service_name": "other-service"},
+        {"observation_type": "LLM"},
+        {"start_time": AT + timedelta(hours=1)},
+        {"trace_id": "trace-b"},
+        {"project_id": OTHER},
+        {"start_time": AT + timedelta(minutes=10)},
+    ],
+)
+@pytest.mark.parametrize("deleted", [0, 1])
+@pytest.mark.parametrize("reverse", [False, True])
+def test_eval_anchor_requires_one_live_physical_span(
+    engine, other_identity, deleted, reverse
+):
+    rows = [row(), row(**other_identity, _version=2, is_deleted=deleted)]
+    if reverse:
+        rows.reverse()
+    assert_eval_anchor(engine, rows)
+
+
+@pytest.mark.parametrize(
+    "absent",
+    [
+        {"project_id": OTHER},
+        {"id": "unrelated-span"},
+        {"is_deleted": 1},
+    ],
+)
+def test_eval_anchor_does_not_read_eval_without_authorized_live_span(engine, absent):
+    assert_eval_anchor(engine, [row(**absent)])
+
+
+def assert_eval_anchor(engine, rows):
+    live = [
+        r
+        for r in latest_spans(rows)
+        if r["project_id"] == PROJECT and r["id"] == "scored" and not r["is_deleted"]
+    ]
+    eval_calls = []
+    service = AnalyticsQueryService()
+
+    def execute(query, params=None, **_kwargs):
+        if "FROM spans" in query:
+            return execute_fixture(engine, rows, query, params)
+        # The eval payload is mocked: these tests qualify native span anchoring
+        # and binding only, not eval-table or HTTP/UI behavior.
+        assert len(live) == 1, "eval lookup must not follow an ambiguous/deleted anchor"
+        assert params == {
+            "span_id": "scored",
+            "config_id": "config",
+            "trace_id": live[0]["trace_id"],
+        }
+        assert "eval_scan.trace_id = toUUID(%(trace_id)s)" in query
+        assert "eval_scan.observation_span_id = %(span_id)s" in query
+        assert "eval_scan.custom_eval_config_id = %(config_id)s" in query
+        eval_calls.append(params)
+        return SimpleNamespace(data=[{"output_bool": True}])
+
+    service.execute_ch_query = execute
+    result = service.get_eval_detail_ch(
+        "scored",
+        "config",
+        project_id=PROJECT,
+        eval_logger_table="tracer_eval_logger_v2",
+    )
+    assert result == ({"output_bool": True} if len(live) == 1 else None)
+    assert len(eval_calls) == int(len(live) == 1)

--- a/futureagi/tracer/tests/test_trace.py
+++ b/futureagi/tracer/tests/test_trace.py
@@ -779,7 +779,8 @@ def test_get_span_trace_map_selects_from_spans(monkeypatch):
     assert out == {"s1": "t1"}
     assert "FROM spans" in captured["query"]
     assert "latest_trace_id IN %(trace_ids)s" in captured["query"]
-    assert "argMax(is_deleted, _version) AS latest_is_deleted" in captured["query"]
+    assert "argMax(tuple(start_time, is_deleted), _version) AS latest_span" in captured["query"]
+    assert "latest_span.2 AS latest_is_deleted" in captured["query"]
     assert "WHERE latest_is_deleted = 0" in captured["query"]
     assert (
         "groupArray(tuple(span_id, live_trace_ids)) AS span_mappings"
@@ -788,8 +789,8 @@ def test_get_span_trace_map_selects_from_spans(monkeypatch):
     assert captured["params"] == {"trace_ids": ["t1"]}
     assert captured["settings"] is None
     # The physical latest-state replay groups by the full ReplacingMergeTree
-    # identity, which includes project_id/start_time.  With no scope supplied,
-    # neither may appear as a pruning predicate.
+    # identity, including project/type/service/hour/trace/span. With no scope
+    # supplied, neither project nor time may appear as a pruning predicate.
     assert "project_id = %(project_id)s" not in captured["query"]
     assert "start_time >=" not in captured["query"]
     assert "start_time <" not in captured["query"]
@@ -891,13 +892,19 @@ def test_get_span_trace_map_uses_latest_state_before_trace_membership(monkeypatc
     )
     compact = " ".join(captured["query"].split())
 
-    assert "argMax(trace_id, _version)" in compact
-    assert "argMax(is_deleted, _version) AS latest_is_deleted" in compact
+    assert "toString(trace_id) AS latest_trace_id" in compact
+    assert "argMax(tuple(start_time, is_deleted), _version) AS latest_span" in compact
+    assert "latest_span.2 AS latest_is_deleted" in compact
     assert "WHERE latest_is_deleted = 0" in compact
     assert "latest_trace_id IN %(trace_ids)s" in compact
-    # Filtering physical versions by old trace/deleted state would resurrect
-    # stale rows before argMax classifies a reassignment/tombstone.
-    physical_scan = compact.split("GROUP BY project_id, id, start_time", 1)[0]
+    # A span ID may be reused across immutable trace identities. Resolve each
+    # key's tombstone before selecting the requested trace population.
+    physical_key = (
+        "GROUP BY project_id, observation_type, service_name, "
+        "toStartOfHour(start_time), trace_id, id"
+    )
+    assert physical_key in compact
+    physical_scan = compact.split(physical_key, 1)[0]
     assert "trace_id IN %(trace_ids)s" not in physical_scan
     assert "is_deleted = 0" not in physical_scan
 

--- a/futureagi/tracer/tests/test_trace_attribute_physical_snapshot.py
+++ b/futureagi/tracer/tests/test_trace_attribute_physical_snapshot.py
@@ -171,10 +171,11 @@ def test_query_uses_one_coherent_full_storage_key_winner_and_presentation_order(
         "GROUP BY project_id, observation_type, service_name, toStartOfHour(start_time), trace_id, id"
         in compact
     )
-    assert (
-        "argMax(tuple(start_time, attributes_extra, attrs_string, attrs_number, attrs_bool, is_deleted), _version) AS latest_span"
-        in compact
-    )
+    assert "argMax(tuple(start_time, arrayMap(key -> multiIf(" in compact
+    assert "%(requested_attribute_keys)s), is_deleted), _version) AS latest_span" in compact
+    assert "latest_attribute_values AS candidate_attribute_value_json" in compact
+    for full_map_state in ("latest_attrs_", "latest_attributes_extra"):
+        assert full_map_state not in sql
     assert sql.count("argMax(") == 2  # Physical winner + final page/key presentation.
     assert "tuple(latest_start_time, id, observation_type, service_name)" in compact
     assert "WHERE latest_is_deleted = 0" in sql
@@ -358,3 +359,36 @@ def test_many_physical_spans_emit_only_page_times_requested_keys(engine):
     assert execute(engine, rows, ("k", "b", "k"), fanout=5002) == expected(
         k="5001", b="v"
     )
+
+
+def test_requested_key_projection_keeps_position_and_coherent_removals(engine):
+    rows = [
+        row(strings={"a": "old", "b": "removed", "ignored": "x" * 65536}),
+        row(version=2, strings={"a": "new", "c": ""},
+            extra='{"d":null}', booleans={"e": 0}, numbers={"f": 0}),
+    ]
+    assert execute(engine, rows, ("f", "missing", "d", "b", "e", "c", "a")) == expected(
+        a="new", c="", d=None, e=False, f=0
+    )
+
+
+@pytest.mark.parametrize("key_count", [1, 10, 260])
+def test_projection_multiple_typed_keys_preserves_requested_order(engine, key_count):
+    strings, numbers, booleans, extra, values = {}, {}, {}, {}, {}
+    for index in range(key_count):
+        key = f"field_{index}"
+        if index % 4 == 0:
+            strings[key] = values[key] = 'quoted "value"\\suffix' * 32
+        elif index % 4 == 1:
+            numbers[key] = values[key] = index + 0.25
+        elif index % 4 == 2:
+            booleans[key], values[key] = 0, False
+        else:
+            extra[key] = values[key] = {"nested": [index, None]}
+    rows = [
+        row(strings={**strings, "removed": "old"}),
+        row(version=2, strings=strings, numbers=numbers, booleans=booleans,
+            extra=json.dumps(extra)),
+    ]
+    keys = ["missing", *reversed(values), "removed", "missing"]
+    assert execute(engine, rows, keys) == expected(**values)

--- a/futureagi/tracer/tests/test_trace_indexed_coordinate_reads.py
+++ b/futureagi/tracer/tests/test_trace_indexed_coordinate_reads.py
@@ -85,7 +85,7 @@ def test_coordinate_seed_cannot_filter_versions_values_roots_or_child_time(
         "latest_filter",
     ):
         assert forbidden not in coordinates
-    assert "SELECT DISTINCT observation_type, service_name," in coordinates
+    assert "SELECT observation_type, service_name," in coordinates
     assert "toStartOfHour(start_time), trace_id" in coordinates
     assert "project_id = %(project_id)s" in coordinates
     assert "trace_id IN %(candidate_trace_ids)s" in coordinates
@@ -95,7 +95,7 @@ def test_coordinate_seed_cannot_filter_versions_values_roots_or_child_time(
             {"trace_id": "two", "root_span_id": "other-root"},
         ]
     )
-    assert "SELECT DISTINCT observation_type, service_name," in sql
+    assert "SELECT observation_type, service_name," in sql
     assert (
         "GROUP BY observation_type, service_name, toStartOfHour(start_time), trace_id, id"
         in sql
@@ -172,7 +172,7 @@ def test_json_uses_same_complete_prefix_and_exact_typed_classifier(
         [{"trace_id": "one", "root_span_id": "not-authoritative"}]
     )
     assert "JSON" in sql
-    assert "SELECT DISTINCT observation_type, service_name," in sql
+    assert "SELECT observation_type, service_name," in sql
     assert (
         "GROUP BY observation_type, service_name, toStartOfHour(start_time), trace_id, id"
         in sql

--- a/futureagi/tracer/tests/test_trace_root_physical_replay.py
+++ b/futureagi/tracer/tests/test_trace_root_physical_replay.py
@@ -208,7 +208,16 @@ def values_where(sql):
     return re.sub(r"'(?:\\.|[^'\\])*'|\b(?:SELECT|PREWHERE|WHERE)\b|[()]", token, sql)
 
 
-def execute(engine, builder, rows, sql_and_params, *, tag_rows=None, join_use_nulls=0):
+def execute(
+    engine,
+    builder,
+    rows,
+    sql_and_params,
+    *,
+    tag_rows=None,
+    join_use_nulls=0,
+    row_source=None,
+):
     """Execute actual generated SQL on inline values, explicitly matching UTC storage.
 
     PREWHERE becomes WHERE because values() is not MergeTree. This is semantic
@@ -249,6 +258,9 @@ def execute(engine, builder, rows, sql_and_params, *, tag_rows=None, join_use_nu
     sql, bindings = sql_and_params
     sql = values_where(without_query_settings(sql))
     sql = sql % escape_params(bindings, context)
+    # The inline fixture already opens WITH. Merge generated candidate CTEs
+    # into that list instead of producing two adjacent WITH clauses.
+    sql = re.sub(r"^\s*WITH\b", ",", sql, count=1)
     traces_relation = """
         SELECT toUUID('11111111-1111-4111-8111-111111111111') AS project_id,
             'trace' AS id, '[]' AS tags, toUInt64(1) AS _version, toUInt8(0) AS is_deleted
@@ -262,6 +274,7 @@ def execute(engine, builder, rows, sql_and_params, *, tag_rows=None, join_use_nu
                 'project_id UUID, id UUID, tags String, _version UInt64, is_deleted UInt8',
                 {tag_bindings["rows"][1:-1]})
         """
+    source = row_source or f"values({params['columns']}, {params['rows'][1:-1]})"
     fixture = f"""WITH spans AS (
         SELECT *, 'trace-name' AS trace_name, 'ok' AS status,
             CAST(NULL AS Nullable(DateTime64(6, 'UTC'))) AS end_time,
@@ -272,10 +285,10 @@ def execute(engine, builder, rows, sql_and_params, *, tag_rows=None, join_use_nu
             map('company_id', 'company') AS attrs_string,
             map('duration', 2.0) AS attrs_number, map('flag', toUInt8(1)) AS attrs_bool,
             '{{}}' AS attributes_extra, map('source', 'fixture') AS metadata
-        FROM values({params["columns"]}, {params["rows"][1:-1]})
+        FROM {source}
     ), traces AS ({traces_relation})
     {sql} SETTINGS max_threads=1, max_memory_usage=536870912,
-        join_use_nulls={int(join_use_nulls)}
+        join_use_nulls={int(join_use_nulls)}, output_format_json_quote_64bit_integers=0
     """
     result = [
         json.loads(line)
@@ -558,8 +571,10 @@ def test_legacy_keeps_four_part_contract(cls):
 
 
 class InlineAnalytics:
-    def __init__(self, engine, builder, rows, *, drift=False):
+    def __init__(self, engine, builder, rows, *, drift=False, row_source=None):
+        assert not (drift and row_source is not None)
         self.engine, self.builder, self.rows, self.drift = engine, builder, rows, drift
+        self.row_source = row_source
         self.calls = []
 
     def execute_ch_query(self, query, params, **kwargs):
@@ -569,7 +584,9 @@ class InlineAnalytics:
         rows = self.rows
         if self.drift and params.get("page_hydration_physical_keys"):
             rows = [*rows, {**rows[0], "_version": rows[0]["_version"] + 1}]
-        result = execute(self.engine, self.builder, rows, (query, params))
+        result = execute(
+            self.engine, self.builder, rows, (query, params), row_source=self.row_source
+        )
         return QueryResult(result, len(result), "clickhouse", 1.0)
 
 

--- a/futureagi/tracer/tests/test_trace_slice_prefix_batching.py
+++ b/futureagi/tracer/tests/test_trace_slice_prefix_batching.py
@@ -1,0 +1,315 @@
+"""Ordered-slice batching must change acquisition cost, never public membership."""
+
+from datetime import timedelta
+
+import pytest
+
+from tracer.selectors.trace_filter_reads import read_bounded_filter_page
+from tracer.services.clickhouse.read_budget import ReadDeadlineExceeded
+from tracer.tests.test_bounded_trace_filter_reads import (
+    END,
+    _CursorPageFillIdentityHydrationFakeBuilder,
+    _FakeBuilder,
+    _IdentityHydrationFakeExecutor,
+    _time_filter,
+)
+
+
+class SliceBuilder(_CursorPageFillIdentityHydrationFakeBuilder):
+    build_filter_ordered_seed_page = _FakeBuilder.build_filter_seed_page
+
+    @staticmethod
+    def recommended_filter_cursor_seed_batch_size():
+        return 200
+
+    @staticmethod
+    def recommended_filter_initial_slice_width():
+        return timedelta(hours=1)
+
+    recommended_filter_max_slice_width = recommended_filter_initial_slice_width
+
+
+class TraceTransport(_IdentityHydrationFakeExecutor):
+    def execute_ch_query(self, *args, **kwargs):
+        result = super().execute_ch_query(*args, **kwargs)
+        for row in result.data:
+            row["trace_id"] = row["id"]
+        return result
+
+
+def fixture(days, rejected):
+    rows = [
+        {
+            "id": f"trace-{index:04d}",
+            "trace_id": f"trace-{index:04d}",
+            "root_span_id": f"root-{index:04d}",
+            "start_time": END
+            - timedelta(minutes=20 if index < rejected else 80, microseconds=index),
+        }
+        for index in range(rejected + 200)
+    ]
+    return SliceBuilder(
+        rows=rows,
+        match_rows=rows[rejected:],
+        start=END - timedelta(days=days),
+        end=END,
+        key_field="trace_id",
+        recommended_batch_size=200,
+    )
+
+
+def page(builder, transport, **kwargs):
+    return read_bounded_filter_page(
+        builder=builder,
+        analytics=transport,
+        filters=[_time_filter(builder.start, builder.end)],
+        key_field="trace_id",
+        page_number=0,
+        page_size=25,
+        deadline_ms=30_000,
+        bounded_continuation=True,
+        include_incomplete_rows=True,
+        **kwargs,
+    )
+
+
+def classifier_sizes(transport):
+    return [
+        len(params["candidate_ids"])
+        for query, params in transport.calls
+        if query == "match_identity"
+    ]
+
+
+@pytest.mark.parametrize("days", [7, 30, 365])
+@pytest.mark.parametrize("rejected", [0, 50, 238, 438])
+def test_new_dense_slice_closes_with50_after_sparse_tail(days, rejected):
+    builder = fixture(days, rejected)
+    transport = TraceTransport(builder)
+    result = page(builder, transport)
+    assert result.complete and result.has_more
+    assert result.rows == builder.match_rows[:25]
+    assert classifier_sizes(transport)[-1] == 50
+    if rejected >= 200:
+        # Split only the first full batch of an interval; repeated sparse
+        # batches in that same interval retain the original 200-ID sizing.
+        assert classifier_sizes(transport)[:2] == [50, 150]
+    if rejected == 438:
+        assert classifier_sizes(transport) == [50, 150, 200, 38, 50]
+
+
+def test_slice_prefix_pages_do_not_skip_unclassified_suffix():
+    builder = fixture(7, 438)
+    # This fake deliberately has no empty-time discovery; keep its final
+    # exhaustion proof finite, separate from the long-window prefix cases.
+    builder.start = END - timedelta(hours=2)
+    seen, cursor = [], {}
+    for _ in range(8):
+        result = page(builder, TraceTransport(builder), **cursor)
+        assert result.complete
+        seen.extend(result.rows)
+        cursor = {
+            "cursor_start_time": result.rows[-1]["start_time"],
+            "cursor_order_token": result.rows[-1]["trace_id"],
+        }
+    assert seen == builder.match_rows
+    assert len({row["trace_id"] for row in seen}) == 200
+
+
+def test_slice_prefix_corrected_order_requires_remaining_classification():
+    builder = fixture(7, 0)
+    builder.match_rows = [dict(row) for row in builder.match_rows]
+    for row in builder.match_rows[:50]:
+        row["start_time"] -= timedelta(minutes=30)
+    transport = TraceTransport(builder)
+    result = page(builder, transport)
+    expected = sorted(
+        builder.match_rows,
+        key=lambda row: (row["start_time"], row["trace_id"]),
+        reverse=True,
+    )
+    assert result.complete and result.has_more and result.rows == expected[:25]
+    assert classifier_sizes(transport) == [50, 150]
+
+
+@pytest.mark.parametrize("corrected", [False, True])
+def test_failed_slice_remainder_replays_unpublished_matches(corrected):
+    builder = fixture(7, 0)
+    builder.match_rows = [dict(row) for row in builder.match_rows]
+    if corrected:
+        for row in builder.match_rows[:50]:
+            row["start_time"] -= timedelta(minutes=30)
+    else:
+        builder.match_rows = builder.match_rows[40:]
+
+    class FailRemainder(TraceTransport):
+        def execute_ch_query(self, query, params, **kwargs):
+            if query == "match_identity" and classifier_sizes(self):
+                raise ReadDeadlineExceeded("local fixture remainder failure")
+            return super().execute_ch_query(query, params, **kwargs)
+
+    failed = page(builder, FailRemainder(builder))
+    assert not failed.complete and not failed.rows
+    assert failed.error_code == "read_budget_exceeded"
+    resumed = page(
+        builder,
+        TraceTransport(builder),
+        continuation_slice_start=failed.continuation_slice_start,
+        continuation_slice_end=failed.continuation_slice_end,
+        continuation_before_start_time=failed.continuation_before_start_time,
+        continuation_before_id=failed.continuation_before_id,
+    )
+    fresh = page(builder, TraceTransport(builder))
+    assert resumed.complete and resumed.rows == fresh.rows and resumed.has_more
+
+
+def test_empty_slice_prefix_still_classifies_every_candidate():
+    builder = fixture(7, 438)
+    builder.start = END - timedelta(hours=2)
+    builder.match_rows = []
+    transport = TraceTransport(builder)
+    result = page(builder, transport)
+    classified = [
+        candidate
+        for query, params in transport.calls
+        if query == "match_identity"
+        for candidate in params["candidate_ids"]
+    ]
+    assert result.complete and not result.rows and not result.has_more
+    assert classified == [row["id"] for row in builder.rows]
+
+
+@pytest.mark.parametrize("days", [7, 30, 365])
+@pytest.mark.parametrize("application_policy", [True, False])
+@pytest.mark.parametrize("dense_minutes", [140, 260])
+@pytest.mark.parametrize(
+    "operation,value",
+    [
+        ("in", ["company"]),
+        ("not_in", ["absent"]),
+        ("contains", "comp"),
+        ("not_contains", "absent"),
+    ],
+)
+def test_native_slice_prefix_rejects_tombstones_then_replays_dense_prefix(
+    days, application_policy, dense_minutes, operation, value
+):
+    from tracer.services.clickhouse.v2.query_builders.trace_list import (
+        TraceListQueryBuilderV2,
+    )
+    from tracer.tests.test_trace_root_physical_replay import (
+        NOW,
+        PROJECT,
+        InlineAnalytics,
+        execute,
+        make_builder,
+        physical_row,
+    )
+
+    engine = pytest.importorskip("chdb")
+    filters = make_builder(days=days).filters + [
+        {
+            "column_id": "company_id",
+            "filter_config": {
+                "col_type": "SPAN_ATTRIBUTE",
+                "filter_type": "text",
+                "filter_op": operation,
+                "filter_value": value,
+                **(
+                    {"attribute_value_types": ["string"]}
+                    if isinstance(value, list)
+                    else {}
+                ),
+            },
+        }
+    ]
+    builder = TraceListQueryBuilderV2(project_id=PROJECT, filters=filters, page_size=25)
+    assert builder.recommended_filter_classify_batch_size() == 200
+    assert builder.recommended_filter_cursor_seed_batch_size() == 200
+    rows = []
+    for index in range(488):
+        row = physical_row(
+            trace_id=f"trace-{index:04d}",
+            start_time=NOW
+            - timedelta(
+                minutes=20 if index < 50 else 80 if index < 288 else dense_minutes,
+                microseconds=index,
+            ),
+        )
+        rows.append(row)
+        if index < 288:
+            rows.append({**row, "_version": 3, "is_deleted": 1})
+
+    class NativeTransport(InlineAnalytics):
+        supports_bounded_speculative_reads = not application_policy
+
+    # Generate the same 776 physical versions without repeating a large VALUES
+    # literal in every expanded query CTE. This changes only fixture encoding.
+    row_source = f"""(
+        SELECT toUUID('{PROJECT}') AS project_id, 'SPAN' AS observation_type,
+            'svc' AS service_name,
+            concat('trace-', leftPad(toString(number), 4, '0')) AS trace_id,
+            'root' AS id,
+            toDateTime64('{NOW.replace(tzinfo=None).isoformat(sep=" ")}', 6, 'UTC')
+                - toIntervalMinute(multiIf(number < 50, 20, number < 288, 80, {dense_minutes}))
+                - toIntervalMicrosecond(number) AS start_time,
+            version AS _version, toUInt8(version = 3) AS is_deleted,
+            '' AS parent_span_id, CAST('new-input', 'Nullable(String)') AS input,
+            CAST(NULL, 'Nullable(String)') AS output,
+            CAST(NULL, 'Nullable(UUID)') AS project_version_id, 'new-name' AS name
+        FROM numbers(488)
+        ARRAY JOIN if(number < 288, [toUInt64(2), toUInt64(3)], [toUInt64(2)]) AS version
+    )"""
+    physical = execute(
+        engine,
+        builder,
+        rows,
+        ("SELECT " + ", ".join(rows[0]) + " FROM spans", {}),
+        row_source=row_source,
+    )
+    for row in physical:
+        row["_version"] = int(row["_version"])
+    def identity(row):
+        return row["trace_id"], row["_version"]
+
+    assert sorted(physical, key=identity) == sorted(rows, key=identity)
+    transport = NativeTransport(engine, builder, rows, row_source=row_source)
+    result = read_bounded_filter_page(
+        builder=builder,
+        analytics=transport,
+        filters=filters,
+        key_field="trace_id",
+        page_number=0,
+        page_size=25,
+        deadline_ms=30_000,
+        bounded_continuation=True,
+        include_incomplete_rows=True,
+        root_time_discovery=True,
+        carry_continuation_slice_width=True,
+        # Bind the initial one-hour acquisition interval explicitly so these
+        # cases test the same slice boundary across positive/negative operators.
+        # The request and exact child-history replay still cover all `days`.
+        continuation_slice_start=(NOW - timedelta(hours=1)).replace(tzinfo=None),
+        continuation_slice_end=NOW.replace(tzinfo=None),
+    )
+    assert result.complete and result.has_more
+    assert [row["trace_id"] for row in result.rows] == [
+        f"trace-{index:04d}" for index in range(288, 313)
+    ]
+    for row in result.rows:
+        assert str(row["project_id"]) == PROJECT
+        assert row["root_span_id"] == "root"
+        assert row["_root_version"] == 2 and row["_root_service_name"] == "svc"
+    batches = [
+        len(params["candidate_trace_ids"])
+        for _, params, *_ in transport.calls
+        if "candidate_trace_ids" in params
+    ]
+    # Only a new slice resets the density check: at 140 minutes the dense
+    # population shares the second, two-hour slice with the rejected roots.
+    # Speculative discovery may choose different boundaries in bounded mode;
+    # its result proof and batch ceiling are still checked. The real uncapped
+    # application path additionally proves the expected sizing transition.
+    assert all(0 < width <= 200 for width in batches)
+    if application_policy:
+        assert batches[-1] == (50 if dense_minutes == 260 else 200)

--- a/futureagi/tracer/tests/test_voice_long_text_candidate_seed.py
+++ b/futureagi/tracer/tests/test_voice_long_text_candidate_seed.py
@@ -12,6 +12,8 @@ from tracer.services.clickhouse.v2.query_builders.voice_call_list import (
 )
 from tracer.tests.test_trace_root_physical_replay import (
     complete_root_row,
+    execute,
+    physical_row,
 )
 
 pytestmark = pytest.mark.unit
@@ -181,3 +183,92 @@ def test_voice_filters_without_exhaustive_long_text_witness_keep_existing_plan(
 )
 def test_voice_internal_and_sampled_consumers_keep_existing_plan(mode):
     assert not voice_builder(**mode).supports_filter_candidate_seed_page()
+
+
+@pytest.fixture(scope="module")
+def engine():
+    return pytest.importorskip("chdb")
+
+
+@pytest.mark.parametrize("days", [7, 30, 365])
+@pytest.mark.parametrize(
+    "operation", ["equals", "in", "contains", "starts_with", "ends_with"]
+)
+@pytest.mark.parametrize("latest_state", ["matching", "changed", "removed", "deleted"])
+def test_voice_long_text_seed_is_rechecked_against_latest_child_state(
+    engine, days, operation, latest_state
+):
+    """A raw historical text hit is not proof of current voice membership.
+
+    The child intentionally predates every root window. Acquisition must not
+    exclude it by time, and classification must reject its removed/changed or
+    tombstoned latest value. Execute both generated statements, not SQL strings
+    that have been replaced with hand-written predicates.
+    """
+    builder = voice_builder(
+        days=days,
+        operation=operation,
+        values=VALUES if operation == "in" else VALUES[0],
+    )
+    root_start = END - timedelta(days=1)
+    child_start = END - timedelta(days=400)
+    rows = [
+        physical_row(
+            observation_type="conversation",
+            start_time=root_start,
+        ),
+        physical_row(
+            id="child",
+            parent_span_id="root",
+            start_time=child_start,
+            _version=1,
+        ),
+        physical_row(
+            id="child",
+            parent_span_id="root",
+            start_time=child_start,
+            _version=2,
+            is_deleted=int(latest_state == "deleted"),
+        ),
+    ]
+
+    class AttributeFixture:
+        def query(self, sql, fmt):
+            latest_value = (
+                VALUES[0] if latest_state in {"matching", "deleted"} else "changed"
+            )
+            latest_map = (
+                "map('unrelated', 'value')"
+                if latest_state == "removed"
+                else f"map('call.recording.url', '{latest_value}')"
+            )
+            attributes = (
+                "if(id = 'child', "
+                f"if(_version = 1, map('call.recording.url', '{VALUES[0]}'), {latest_map}), "
+                "map('unrelated', 'root')) AS attrs_string"
+            )
+            return engine.query(
+                sql.replace("map('company_id', 'company') AS attrs_string", attributes),
+                fmt,
+            )
+
+    fixture = AttributeFixture()
+    start, end = builder.parse_time_range(builder.filters)
+    candidates = execute(
+        fixture,
+        builder,
+        rows,
+        builder.build_filter_candidate_seed_page(
+            slice_start=start, slice_end=end, limit=25
+        ),
+    )
+    assert [row["trace_id"] for row in candidates] == ["trace"]
+    matched = execute(
+        fixture,
+        builder,
+        rows,
+        builder.build_filter_identity_match_query_from_seed_rows(candidates),
+    )
+    assert [row["trace_id"] for row in matched] == (
+        ["trace"] if latest_state == "matching" else []
+    )


### PR DESCRIPTION
Trace hydration and scored-span mapping can conflate physical replacement keys or retain an obsolete version after a timestamp correction. This change resolves the complete physical key before applying mutable predicates, reads only requested attribute values, and reuses the smaller first classifier batch at each ordered slice. Coordinate discovery filters trace IDs before reading project UUIDs and keeps all historical versions available to the final classifier. Its redundant DISTINCT is removed because the surrounding IN already deduplicates coordinate tuples.

An append-only schema migration adds the stricter trace-ID Bloom index definition. Existing data parts require a separately managed historical build; this PR does not perform that build.

Validation for the latest query cleanup, using real Django imports and the existing runtime:

```text
115 passed in 8.47s
```

These are executed cases from test_trace_indexed_coordinate_reads.py and test_raw_filter_integration_guards.py, including their existing parameterization, not a count of newly added test functions. A local ClickHouse 25.3.14.14 fixture also produced identical coordinate sets and complete latest-root metadata with and without DISTINCT, before and after replacement merges. It covers corrected/deleted roots, changed/removed child values, tombstones, typed values and complete physical identities. The owned fixture was removed. Whitespace checks passed. Ruff was unavailable in the existing runtime for this cleanup, so no fresh Ruff result is claimed.

The latest dev integration separately passed all 52 cases in test_ch25_apply_schema_replicated.py. Earlier physical-replay and CI results remain evidence for their original revisions; current-head CI must finish after this update.

Performance remains unqualified for the deployed API and UI. Removing DISTINCT enabled a proposed projection in the local experiment, but this PR adds no projection, and the experiment did not show consistent elapsed-time improvement. Without that projection, local row and byte reads were unchanged. These local checks do not establish the production latency target.

AI use: Codex drafted the implementation, tests, and PR text; separate Codex agents reviewed the changes.

E2E: exempt (backend-internal)

Stack position 2/6. Base: fix/TH-7247-review-04-grid-lifecycle. Merge the parent first, then retarget and recheck this PR against dev. Review order: #2640 → #2637 → #2638 → #2639 → #2641 → #2642. #2643 is independent and targets dev.
