### PR TITLE
fix: [3/6] Reduce exact Users replay work [agent]

### DIFF
--- a/futureagi/tracer/services/clickhouse/query_builders/user_list.py
+++ b/futureagi/tracer/services/clickhouse/query_builders/user_list.py
@@ -426,7 +426,7 @@ class UserListQueryBuilder(BaseQueryBuilder):
         return " AND ".join(clauses), params
 
     def _positive_scalar_user_witness(self) -> tuple[str, dict[str, Any]]:
-        """Reuse the compiler's complete numeric witness; decline all other shapes."""
+        """Reuse complete numeric or ordinary text witnesses for group acquisition."""
         from tracer.services.clickhouse.query_builders.latest_filter_predicates import (
             compile_trace_filter_plans,
         )
@@ -439,6 +439,10 @@ class UserListQueryBuilder(BaseQueryBuilder):
                 self._is_date_filter(item)
                 or self._is_relation_filter(item)
                 or self._is_output_filter(item)
+                or (
+                    item.get("column_id") == "eval_score"
+                    and self._filter_col_type(item) != "SPAN_ATTRIBUTE"
+                )
             ):
                 continue
             config = dict(item.get("filter_config") or item.get("filterConfig") or {})
@@ -452,11 +456,30 @@ class UserListQueryBuilder(BaseQueryBuilder):
                 continue
             plan = plans[0]
             witness = plan.raw_graph_value_witness_predicate or ""
+            raw_values = config.get("filter_value", config.get("filterValue"))
+            values = raw_values if isinstance(raw_values, list) else [raw_values]
+            # Users canonicalizes boolean/JSON-looking text and uses Python's
+            # Unicode lower(). Do not narrow those domains with a raw string
+            # comparison. Unsupported shapes keep the complete existing path.
+            plain_text = (
+                (config.get("filter_type") or config.get("filterType")) in {"text", "string"}
+                and (config.get("filter_op") or config.get("filterOp")) in {"equals", "in"}
+                and bool(values)
+                and all(
+                    isinstance(value, str)
+                    and value
+                    and value.isascii()
+                    and value.strip().lower() not in {"true", "false"}
+                    and not value.strip().startswith(("{", "["))
+                    for value in values
+                )
+            )
+            numeric_witness = "span_attr_num[" in witness and "span_attr_str" not in witness
+            text_witness = plain_text and "span_attr_str[" in witness and "span_attr_num" not in witness
             if (
                 plan.scope == "any"
                 and not plan.exclude_group_matches
-                and "span_attr_num[" in witness
-                and "span_attr_str" not in witness
+                and (numeric_witness or text_witness)
                 and "span_attr_bool" not in witness
                 and "JSONExtract" not in witness
             ):
@@ -731,7 +754,15 @@ class UserListQueryBuilder(BaseQueryBuilder):
             """
         else:
             embedded_session_projection = "toUInt64(0) AS num_sessions,"
-        usage_ctes = f"""
+        # With scalar acquisition, the final INNER JOIN already applies this
+        # dimension membership. Repeating it here expands the witness/dimension
+        # CTE branch again. Keep it for unseeded reads to bound aggregation.
+        usage_user_filter = "" if scalar_ctes else f"""
+          AND {resolved_latest_eu} IN (
+              SELECT end_user_id FROM filtered_end_users
+          )
+        """
+        identity_acquisition_cte = f"""
     candidate_span_identities AS (
         SELECT DISTINCT
             project_id,
@@ -747,6 +778,39 @@ class UserListQueryBuilder(BaseQueryBuilder):
           AND start_time < fromUnixTimestamp64Micro(%(user_window_end_us)s, 'UTC')
           {candidate_span_filter}
     ),
+        """ if candidate_span_filter else ""
+        # Without a user/scalar seed, every latest row in the exact window
+        # witnesses its own identity. Replay the intersecting immutable hours
+        # directly instead of constructing the same identity population twice.
+        # Seeded reads must retain the identity set: end_user_id is mutable.
+        replay_identity_filter = """
+          AND (
+              project_id,
+              observation_type,
+              service_name,
+              toStartOfHour(start_time),
+              trace_id,
+              id
+          ) IN (
+              SELECT
+                  project_id,
+                  observation_type,
+                  service_name,
+                  identity_hour,
+                  trace_id,
+                  id
+              FROM candidate_span_identities
+          )
+        """ if candidate_span_filter else """
+          AND toStartOfHour(start_time) >= toStartOfHour(
+              fromUnixTimestamp64Micro(%(user_window_start_us)s, 'UTC')
+          )
+          AND toStartOfHour(start_time) < fromUnixTimestamp64Micro(
+              %(user_window_end_us)s, 'UTC'
+          )
+        """
+        usage_ctes = f"""
+    {identity_acquisition_cte}
     latest_candidate_spans AS (
         SELECT
             project_id,
@@ -767,23 +831,7 @@ class UserListQueryBuilder(BaseQueryBuilder):
         FROM spans
         PREWHERE {self._project_predicate("spans")}
           AND toDate(start_time) BETWEEN toDate(%(start_date)s) AND toDate(%(end_date)s)
-          AND (
-              project_id,
-              observation_type,
-              service_name,
-              toStartOfHour(start_time),
-              trace_id,
-              id
-          ) IN (
-              SELECT
-                  project_id,
-                  observation_type,
-                  service_name,
-                  identity_hour,
-                  trace_id,
-                  id
-              FROM candidate_span_identities
-          )
+          {replay_identity_filter}
         GROUP BY
             project_id,
             observation_type,
@@ -808,9 +856,7 @@ class UserListQueryBuilder(BaseQueryBuilder):
         WHERE latest_is_deleted = 0
           AND latest_start_time >= fromUnixTimestamp64Micro(%(user_window_start_us)s, 'UTC')
           AND latest_start_time < fromUnixTimestamp64Micro(%(user_window_end_us)s, 'UTC')
-          AND {resolved_latest_eu} IN (
-              SELECT end_user_id FROM filtered_end_users
-          )
+          {usage_user_filter}
         GROUP BY end_user_id
     )
         """
@@ -1233,92 +1279,32 @@ class UserListQueryBuilder(BaseQueryBuilder):
 
         if not end_user_ids:
             return "", {}
-        start_date, end_date = self.parse_time_range(self.filters)
-        params: dict[str, Any] = {
-            "candidate_end_user_ids": tuple(str(value) for value in end_user_ids),
-            "start_date": start_date,
-            "end_date": end_date,
-        }
-        if self.project_ids:
-            params["project_ids"] = tuple(self.project_ids)
-        else:
-            params["project_id"] = self.project_id
-
-        # Page hydration runs only after a finite user page is selected. Building
-        # the global remap window here made this read exceed the 256 MiB
-        # production ceiling on large remap tables. Expand only the consolidation
-        # groups touched by the page ids.
-        eu_map, finite_map_params = self._finite_end_user_map(
-            candidate_param="candidate_end_user_ids"
+        prefix, params = self._finite_user_activity_ctes(
+            end_user_ids,
+            [
+                "argMax(tuple(trace_session_id), _version).1 AS latest_trace_session_id",
+                "argMax(status, _version) AS latest_status",
+                "argMax(tuple(end_time), _version).1 AS latest_end_time",
+                "argMax(latency_ms, _version) AS latest_latency_ms",
+            ],
+            include_sessions=True,
         )
-        params.update(finite_map_params)
-        ts_map = survivor_map_subquery("trace_session_id_remap")
         resolved_latest_eu = resolved_id_expr("latest_end_user_id", "span_eu_remap")
         resolved_latest_session = resolved_id_expr(
             "latest_trace_session_id", "span_ts_remap"
         )
 
         query = f"""
-        WITH
-        eu_survivor_map AS ({eu_map}),
-        ts_survivor_map AS ({ts_map}),
-        expanded_candidate_user_ids AS (
-            SELECT any_id AS end_user_id
-            FROM eu_survivor_map
-            WHERE survivor_id IN %(candidate_end_user_ids)s
-            UNION DISTINCT
-            SELECT end_user_id
-            FROM end_users FINAL
-            WHERE end_user_id IN %(candidate_end_user_ids)s
-        ),
-        candidate_span_identities AS (
-            SELECT DISTINCT
-                project_id,
-                trace_id,
-                id,
-                start_time
-            FROM spans
-            PREWHERE {self._project_predicate("spans")}
-              AND toDate(start_time) BETWEEN toDate(%(start_date)s) AND toDate(%(end_date)s)
-              AND start_time >= %(start_date)s
-              AND start_time < %(end_date)s
-              AND end_user_id IN (
-                  SELECT end_user_id FROM expanded_candidate_user_ids
-              )
-        ),
-        latest_candidate_spans AS (
-            SELECT
-                project_id,
-                trace_id,
-                id,
-                start_time,
-                argMax(tuple(end_user_id), _version).1 AS latest_end_user_id,
-                argMax(tuple(trace_session_id), _version).1 AS latest_trace_session_id,
-                argMax(observation_type, _version) AS latest_observation_type,
-                argMax(status, _version) AS latest_status,
-                argMax(tuple(end_time), _version).1 AS latest_end_time,
-                argMax(latency_ms, _version) AS latest_latency_ms,
-                argMax(is_deleted, _version) AS latest_is_deleted
-            FROM spans
-            PREWHERE {self._project_predicate("spans")}
-              AND toDate(start_time) BETWEEN toDate(%(start_date)s) AND toDate(%(end_date)s)
-              AND start_time >= %(start_date)s
-              AND start_time < %(end_date)s
-              AND (project_id, trace_id, id, start_time) IN (
-                  SELECT project_id, trace_id, id, start_time
-                  FROM candidate_span_identities
-              )
-            GROUP BY project_id, trace_id, id, start_time
-        ),
+        {prefix},
         resolved_candidate_spans AS (
             SELECT
                 {resolved_latest_eu} AS end_user_id,
                 {resolved_latest_session} AS trace_session_id,
                 trace_id,
-                start_time,
+                latest_start_time AS start_time,
                 latest_end_time AS end_time,
                 latest_latency_ms AS latency_ms,
-                latest_observation_type AS observation_type,
+                observation_type,
                 latest_status AS status
             FROM latest_candidate_spans
             LEFT JOIN eu_survivor_map AS span_eu_remap
@@ -1326,6 +1312,8 @@ class UserListQueryBuilder(BaseQueryBuilder):
             LEFT JOIN ts_survivor_map AS span_ts_remap
                 ON latest_trace_session_id = span_ts_remap.any_id
             WHERE latest_is_deleted = 0
+              AND latest_start_time >= fromUnixTimestamp64Micro(%(user_window_start_us)s, 'UTC')
+              AND latest_start_time < fromUnixTimestamp64Micro(%(user_window_end_us)s, 'UTC')
               AND {resolved_latest_eu} IN %(candidate_end_user_ids)s
         ),
         extra_metrics AS (

--- a/futureagi/tracer/tests/test_session_native_conjunction_replay.py
+++ b/futureagi/tracer/tests/test_session_native_conjunction_replay.py
@@ -1,0 +1,132 @@
+"""Execute Session conjunctions across distinct traces using SELECT-only fixtures."""
+
+import json
+from datetime import timedelta
+
+import pytest
+from clickhouse_driver.util.escape import escape_params
+
+from tracer.services.clickhouse.v2.query_builders.session_list import (
+    SessionListQueryBuilderV2,
+)
+from tracer.tests.test_session_entity_filter_membership import (
+    END,
+    PROJECT,
+    SESSION,
+    _filter,
+)
+from tracer.tests.test_users_attribute_physical_replay import (
+    CONTEXT,
+    values_where,
+    without_query_settings,
+)
+
+
+def run(rows, filters, days=7):
+    engine = pytest.importorskip("chdb")
+    builder = SessionListQueryBuilderV2(
+        project_id=PROJECT,
+        filters=[
+            _filter(
+                "created_at",
+                [(END - timedelta(days=days)).isoformat(), END.isoformat()],
+                kind="datetime",
+                operation="between",
+                source="SYSTEM_METRIC",
+            ),
+            *filters,
+        ],
+        bounded_internal_scan=True,
+    )
+    sql, params = builder.build_filter_match_query([SESSION])
+    schema = "project_id UUID, observation_type String, service_name String, trace_id String, id String, start_time DateTime64(6,'UTC'), trace_session_id Nullable(UUID), parent_span_id Nullable(String), _version UInt64, is_deleted UInt8, string_keys Array(String), string_values Array(String), number_keys Array(String), number_values Array(Float64), bool_keys Array(String), bool_values Array(UInt8)"
+    data = []
+    for index, kind, key, value, version, deleted in rows:
+        text = {key: value} if kind == "text" and value is not None else {}
+        number = {key: value} if kind == "number" and value is not None else {}
+        boolean = {key: value} if kind == "boolean" and value is not None else {}
+        data.append(
+            (
+                PROJECT,
+                "SPAN",
+                "svc",
+                f"trace-{index}",
+                f"span-{index}",
+                (END - timedelta(hours=1)).isoformat(sep=" "),
+                SESSION,
+                None,
+                version,
+                deleted,
+                list(text),
+                list(text.values()),
+                list(number),
+                list(number.values()),
+                list(boolean),
+                list(boolean.values()),
+            )
+        )
+    literals = escape_params({"schema": schema, "rows": tuple(data)}, CONTEXT)
+    rendered = without_query_settings(sql) % escape_params(params, CONTEXT)
+    rendered = rendered.replace(
+        "trace_session_id_remap FINAL", "trace_session_id_remap"
+    )
+    prefix = f"""WITH spans AS (SELECT *, mapFromArrays(string_keys,string_values) AS attrs_string,mapFromArrays(number_keys,number_values) AS attrs_number,mapFromArrays(bool_keys,bool_values) AS attrs_bool,'{{}}' AS attributes_extra, start_time AS end_time, 0. AS cost,toInt32(0) AS total_tokens,toInt32(0) AS prompt_tokens,toInt32(0) AS completion_tokens FROM values({literals["schema"]},{literals["rows"][1:-1]})),trace_session_id_remap AS (SELECT toUUID('00000000-0000-0000-0000-000000000000') AS old_id,old_id AS new_id WHERE 0),"""
+    return [
+        json.loads(line)
+        for line in str(
+            engine.query(values_where(prefix + rendered.lstrip()[4:]), "JSONEachRow")
+        ).splitlines()
+        if line
+    ]
+
+
+@pytest.mark.parametrize("days", [7, 30, 365])
+@pytest.mark.parametrize("width", [2, 5, 10])
+def test_session_conjunction_rejects_each_stale_leaf(days, width):
+    # Each leaf belongs to a different trace of one session. The session must
+    # satisfy all leaves, even though no individual trace satisfies them all.
+    kinds = [("text", "Alpha"), ("number", 7), ("boolean", True)]
+    rows = []
+    filters = []
+    for index in range(width):
+        kind, value = kinds[index % len(kinds)]
+        key = f"property_{index}"
+        rows.append((index, kind, key, value, 1, 0))
+        filters.append(_filter(key, value, kind=kind))
+    assert [row["session_id"] for row in run(rows, filters, days)] == [SESSION]
+    for index, kind, key, value, _, _ in rows:
+        # Removing only one latest leaf must reject the session. Its old
+        # matching physical version deliberately remains in the input.
+        assert not run([*rows, (index, kind, key, None, 2, 0)], filters, days)
+        # A latest tombstone must also hide the old matching leaf.
+        assert not run([*rows, (index, kind, key, value, 2, 1)], filters, days)
+
+
+@pytest.mark.parametrize("days", [7, 30, 365])
+@pytest.mark.parametrize("width", [2, 5, 10])
+def test_session_negative_conjunction_uses_all_latest_traces(days, width):
+    # Negative membership excludes the whole session if any latest live trace
+    # violates a leaf; unrelated traces with missing keys cannot make it pass.
+    cases = [
+        ("text", "Allowed", "not_contains", "forbidden", "FORBIDDEN value"),
+        ("number", 7, "not_in", [9, 11], 9),
+        ("boolean", None, "is_null", None, True),
+    ]
+    rows, filters, forbidden_values = [], [], []
+    for index in range(width):
+        kind, value, operation, operand, forbidden = cases[index % len(cases)]
+        key = f"negative_property_{index}"
+        rows.append((index, kind, key, value, 1, 0))
+        filters.append(_filter(key, operand, kind=kind, operation=operation))
+        forbidden_values.append(forbidden)
+    assert [row["session_id"] for row in run(rows, filters, days)] == [SESSION]
+    for original, forbidden in zip(rows, forbidden_values, strict=True):
+        index, kind, key, value, _, _ = original
+        violation = (index, kind, key, forbidden, 2, 0)
+        assert not run([*rows, violation], filters, days)
+        # An older violation must not exclude a corrected latest version.
+        restored = (index, kind, key, value, 3, 0)
+        assert [
+            row["session_id"]
+            for row in run([*rows, violation, restored], filters, days)
+        ] == [SESSION]

--- a/futureagi/tracer/tests/test_session_user_candidate_reads.py
+++ b/futureagi/tracer/tests/test_session_user_candidate_reads.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
+import json
 import os
+import re
 import time
 import uuid
 from datetime import UTC, datetime, timedelta
@@ -10,12 +12,14 @@ from types import SimpleNamespace
 from unittest import mock
 
 import pytest
+from clickhouse_driver.util.escape import escape_params
 from django.conf import settings as django_settings
 from django.test import override_settings
 
 from tracer.selectors.trace_filter_reads import read_bounded_filter_page
 from tracer.services.clickhouse.query_builders.user_list import (
     UnsupportedBoundedUserListQuery,
+    UserListQueryBuilder,
 )
 from tracer.services.clickhouse.v2.query_builders.session_list import (
     SessionListQueryBuilderV2,
@@ -105,10 +109,233 @@ def test_user_default_page_replays_latest_state_before_pagination():
     assert params["limit"] == 25
     assert params["offset"] == 50
     assert "argMax(is_deleted, _version) AS latest_is_deleted" in metrics_sql
-    assert "(project_id, trace_id, id, start_time) IN" in metrics_sql
+    compact_metrics_sql = " ".join(metrics_sql.split())
+    assert (
+        "GROUP BY project_id, observation_type, service_name, identity_hour, trace_id, id"
+        in compact_metrics_sql
+    )
+    assert (
+        "( project_id, observation_type, service_name, toStartOfHour(start_time), trace_id, id ) IN"
+        in compact_metrics_sql
+    )
+    latest_scan = metrics_sql.split("latest_candidate_spans AS (", 1)[1].split(
+        "GROUP BY", 1
+    )[0]
+    assert "argMax(start_time, _version) AS latest_start_time" in latest_scan
+    assert "start_time >=" not in latest_scan
+    assert "start_time <" not in latest_scan
+    assert "end_user_id IN" not in latest_scan
+    assert "latest_is_deleted = 0" not in latest_scan
+    resolved = metrics_sql.split("resolved_candidate_spans AS (", 1)[1].split(
+        "extra_metrics AS (", 1
+    )[0]
+    assert "latest_start_time AS start_time" in resolved
+    assert "latest_is_deleted = 0" in resolved
+    assert "latest_start_time >= fromUnixTimestamp64Micro(" in resolved
+    assert "latest_start_time < fromUnixTimestamp64Micro(" in resolved
+    assert "IN %(candidate_end_user_ids)s" in resolved
     assert "eu_survivor_map" in metrics_sql
     assert "ts_survivor_map" in metrics_sql
+    assert "candidate_session_ids AS" in metrics_sql
+    assert "WHERE new_id IN (SELECT new_id FROM touched_session_groups)" in metrics_sql
+    assert "OVER (PARTITION BY new_id)" not in metrics_sql
     assert len(metrics_params["candidate_end_user_ids"]) == 1
+    assert set(re.findall(r"%\((\w+)\)s", metrics_sql)) <= metrics_params.keys()
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "builder_class", [UserListQueryBuilder, UserListQueryBuilderV2]
+)
+@pytest.mark.parametrize("workspace", [False, True])
+def test_user_page_metrics_preserves_combined_query_and_empty_page_contract(
+    builder_class, workspace
+):
+    project_id, user_id = str(uuid.uuid4()), str(uuid.uuid4())
+    builder = builder_class(
+        organization_id=str(uuid.uuid4()),
+        **({"project_ids": [project_id]} if workspace else {"project_id": project_id}),
+        filters=_window(datetime(2026, 8, 1, 10, tzinfo=UTC)),
+        limit=25,
+        offset=50,
+    )
+    combined_sql, combined_params = builder.build()
+    original_params = dict(combined_params)
+    assert builder.build_page_metrics_query([]) == ("", {})
+    sql, params = builder.build_page_metrics_query([user_id])
+    assert params["candidate_end_user_ids"] == (user_id,)
+    assert params["project_ids" if workspace else "project_id"] == (
+        (project_id,) if workspace else project_id
+    )
+    assert set(re.findall(r"%\((\w+)\)s", sql)) <= params.keys()
+    assert builder.params == original_params
+    assert builder.build() == (combined_sql, original_params)
+
+
+def _inline_user_metric_rows(sql, params, span_rows, user_id, session_id):
+    """Execute only SELECTs over inline spans and already-latest dimension rows.
+
+    VALUES has no PREWHERE/FINAL: preserve predicates with the existing clause
+    lowering helper and remove FINAL only from the fixed dimension fixtures.
+    The offline runner can route chdb.query to its read-only native CH25 adapter.
+    """
+    chdb = pytest.importorskip("chdb", reason="isolated native fixture engine required")
+    from tracer.tests.test_session_exact_latest_cursor import _values_where
+
+    context = SimpleNamespace(server_info=SimpleNamespace(get_timezone=lambda: "UTC"))
+    rendered = sql % escape_params(params, context)
+    rendered = re.sub(
+        r"\b(end_users|end_user_id_remap|trace_session_id_remap)\s+FINAL\b",
+        r"\1",
+        rendered,
+    )
+    columns = """project_id UUID, observation_type String, service_name String,
+        start_time DateTime64(6, 'UTC'), trace_id String, id String,
+        end_user_id Nullable(UUID), trace_session_id Nullable(UUID),
+        _version UInt64, is_deleted UInt8, status String, latency_ms Int32,
+        end_time Nullable(DateTime64(6, 'UTC'))"""
+    literals = escape_params(
+        {
+            "columns": columns,
+            "rows": tuple(span_rows),
+            "user_id": user_id,
+            "session_id": session_id,
+            "raw_user_id": str(uuid.UUID(int=20)),
+            "raw_session_id": str(uuid.UUID(int=30)),
+        },
+        context,
+    )
+    assert rendered.lstrip().startswith("WITH")
+    rendered = f"""
+        WITH spans AS (
+            SELECT * FROM values({literals["columns"]}, {literals["rows"][1:-1]})
+        ), end_users AS (
+            SELECT toUUID({literals["user_id"]}) AS end_user_id
+        ), end_user_id_remap AS (
+            SELECT toUUID({literals["user_id"]}) AS old_id,
+                toUUID({literals["raw_user_id"]}) AS new_id
+        ), trace_session_id_remap AS (
+            SELECT toUUID({literals["session_id"]}) AS old_id,
+                toUUID({literals["raw_session_id"]}) AS new_id
+        ), {rendered.lstrip()[4:]}
+    """
+    result = str(chdb.query(_values_where(rendered), "JSONEachRow"))
+    rows = [json.loads(line) for line in result.splitlines() if line]
+    # JSON transports UInt64 as strings; the application native driver uses ints.
+    for row in rows:
+        for field in row:
+            if field.startswith("num_"):
+                row[field] = int(row[field])
+    return rows
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    ("case", "expected_calls"),
+    [
+        ("timestamp_correction", 1),
+        ("timestamp_corrected_tombstone", 0),
+        ("distinct_service_identity", 2),
+        ("correction_outside_window_same_hour", 0),
+    ],
+)
+def test_user_page_metrics_exact_physical_replay_inline(case, expected_calls):
+    project_id, user_id, session_id = (str(uuid.UUID(int=i)) for i in (1, 2, 3))
+    start = datetime(2026, 8, 1, 10, 0)
+    end = start + timedelta(minutes=30)
+    at = start + timedelta(minutes=10)
+    latest_at = (
+        end + timedelta(minutes=1)
+        if case == "correction_outside_window_same_hour"
+        else at + timedelta(microseconds=1)
+    )
+    if case == "distinct_service_identity":
+        latest_at = at
+
+    def row(version, moment, service, deleted):
+        # escape_params(datetime) truncates microseconds; explicit strings retain
+        # the storage correction that this regression must distinguish.
+        return (
+            project_id,
+            "llm",
+            service,
+            moment.isoformat(sep=" ", timespec="microseconds"),
+            "trace",
+            "span",
+            str(uuid.UUID(int=20)),
+            str(uuid.UUID(int=30)),
+            version,
+            deleted,
+            "ERROR",
+            1000,
+            (moment + timedelta(seconds=1)).isoformat(sep=" ", timespec="microseconds"),
+        )
+
+    span_rows = [
+        row(1, at, "a", 0),
+        row(
+            2,
+            latest_at,
+            "b" if case == "distinct_service_identity" else "a",
+            int(case == "timestamp_corrected_tombstone"),
+        ),
+    ]
+    builder = UserListQueryBuilderV2(
+        organization_id=str(uuid.UUID(int=4)),
+        project_id=project_id,
+        filters=[
+            {
+                "column_id": "created_at",
+                "filter_config": {
+                    "filter_type": "datetime",
+                    "filter_op": "between",
+                    "filter_value": [start.isoformat(), end.isoformat()],
+                },
+            }
+        ],
+    )
+    expected = (
+        [
+            {
+                "end_user_id": user_id,
+                "num_sessions": 1,
+                "avg_session_duration": 1.0,
+                "avg_trace_latency": 1000.0,
+                "num_llm_calls": expected_calls,
+                "num_guardrails_triggered": 0,
+                "num_active_days": 1,
+                "num_traces_with_errors": 1,
+            }
+        ]
+        if expected_calls
+        else []
+    )
+    sql, params = builder.build_page_metrics_query([user_id])
+    assert (
+        _inline_user_metric_rows(sql, params, span_rows, user_id, session_id)
+        == expected
+    )
+
+    # Exercise the current manager's requested-metric path on the same source
+    # rows and compare both APIs with explicit expected rows, including aliases.
+    metric_keys = {
+        "num_sessions",
+        "avg_session_duration",
+        "avg_trace_latency",
+        "num_llm_calls",
+        "num_guardrails_triggered",
+        "num_active_days",
+        "num_traces_with_errors",
+    }
+    requested = {}
+    for sql, params, _fields in builder.build_requested_page_metric_queries(
+        [user_id], metric_keys
+    ):
+        for result in _inline_user_metric_rows(
+            sql, params, span_rows, user_id, session_id
+        ):
+            requested.setdefault(result["end_user_id"], {}).update(result)
+    assert list(requested.values()) == expected
 
 
 @pytest.mark.unit
@@ -442,9 +669,7 @@ def test_raw_new_session_seed_classifier_expands_group_and_keeps_all_filters():
     assert "latest_attr_exists_1 AND" in match_sql
     assert "countIf(latest_attr_exists_0 AND" in match_sql
     assert "countIf(latest_attr_exists_1 AND" in match_sql
-    assert (
-        "AND countIf(is_root) > 0" in match_sql
-    )
+    assert "AND countIf(is_root) > 0" in match_sql
     assert match_params["candidate_filter_session_id_array"] == [new_session_id]
     assert match_params["latest_filter_param_0"] == "rejected"
     assert match_params["latest_filter_param_1"] == "us"

--- a/futureagi/tracer/tests/test_user_latest_window_replay.py
+++ b/futureagi/tracer/tests/test_user_latest_window_replay.py
@@ -47,7 +47,9 @@ def builder(workspace=False):
     )
 
 
-def assert_window_replay(sql, params, latest_cte="latest_candidate_spans"):
+def assert_window_replay(
+    sql, params, latest_cte="latest_candidate_spans", *, unseeded=False
+):
     latest = cte(sql, latest_cte)
     scan = latest.split("PREWHERE", 1)[1].split("GROUP BY", 1)[0]
     # Exact mutable timestamp predicates belong after version collapse. The
@@ -57,7 +59,12 @@ def assert_window_replay(sql, params, latest_cte="latest_candidate_spans"):
     assert "latest_is_deleted = 0" not in scan
     assert "end_user_id IN" not in scan
     assert "toStartOfHour(start_time)" in scan
-    assert "candidate_span_identities" in scan
+    if unseeded:
+        assert "candidate_span_identities" not in sql
+        assert "toStartOfHour(start_time) >= toStartOfHour(" in scan
+        assert "toStartOfHour(start_time) < fromUnixTimestamp64Micro(" in scan
+    else:
+        assert "candidate_span_identities" in scan
     assert "argMax(start_time, _version) AS latest_start_time" in latest
     assert "latest_start_time >= fromUnixTimestamp64Micro(" in sql
     assert "latest_start_time < fromUnixTimestamp64Micro(" in sql

--- a/futureagi/tracer/tests/test_users_attribute_physical_replay.py
+++ b/futureagi/tracer/tests/test_users_attribute_physical_replay.py
@@ -1,0 +1,449 @@
+"""Users typed hydration on constant fixtures, never server tables or DDL.
+
+Execute the real builder and compare every result with independent physical-key
+replacement. This is semantic evidence, not production latency qualification.
+"""
+
+import json
+import math
+from datetime import datetime, timedelta
+from types import SimpleNamespace
+from unittest.mock import patch
+from uuid import UUID
+
+import pytest
+from clickhouse_driver.util.escape import escape_params
+
+from tracer.services.clickhouse.server_readonly import without_query_settings
+from tracer.services.users_list_manager import (
+    UsersListManager,
+    _users_attr_enrichment_query,
+)
+from tracer.tests.test_trace_root_physical_replay import values_where
+from tracer.tests.test_user_latest_window_replay import cte
+
+pytestmark = pytest.mark.unit
+PROJECT, OTHER, FOREIGN, USER, ALIAS, NEW, UNMAPPED = (
+    str(UUID(int=i)) for i in (101, 102, 103, 110, 140, 150, 170)
+)
+START = datetime(2026, 8, 1, 12, 15, 0, 123456)
+REMAP = {USER: USER, ALIAS: USER, NEW: USER}
+CONTEXT = SimpleNamespace(server_info=SimpleNamespace(get_timezone=lambda: "UTC"))
+LONG = "雪 %_\\' quoted text " * 400
+KEYS = (
+    "tag",
+    "long",
+    "flag",
+    "zero",
+    "empty",
+    "null",
+    "array",
+    "object",
+    "mixed",
+    "cleared",
+    "deleted",
+    "reassigned",
+    "outside",
+    "absent",
+)
+
+
+def span(identity, **changes):
+    return {
+        "project_id": PROJECT,
+        "observation_type": "SPAN",
+        "service_name": "svc",
+        "trace_id": "trace",
+        "id": identity,
+        "start_time": START,
+        "_version": 1,
+        "is_deleted": 0,
+        "end_user_id": ALIAS,
+        "attributes_extra": {},
+        "attrs_string": {},
+        "attrs_number": {},
+        "attrs_bool": {},
+        **changes,
+    }
+
+
+def cohort(days):
+    end = START + timedelta(days=days)
+    rows = [
+        span(
+            "live",
+            attrs_string={"tag": "first", "long": LONG, "empty": ""},
+            attrs_number={"zero": 0},
+            attrs_bool={"flag": 0},
+            attributes_extra={
+                "null": None,
+                "array": [1, "1", True],
+                "object": {"a": "b"},
+            },
+        ),
+        span("another", end_user_id=NEW, attrs_string={"tag": "second"}),
+        span("unmapped", end_user_id=UNMAPPED, attrs_string={"tag": "unmapped"}),
+        span("live", project_id=OTHER, attrs_string={"tag": "other-project"}),
+        span("live", project_id=FOREIGN, attrs_string={"tag": "foreign"}),
+        span("live", service_name="other", attrs_string={"tag": "other-service"}),
+        span("live", observation_type="EVENT", attrs_string={"tag": "other-kind"}),
+        span("live", trace_id="other", attrs_string={"tag": "other-trace"}),
+        span(
+            "live",
+            start_time=START + timedelta(hours=1),
+            attrs_string={"tag": "other-hour"},
+        ),
+        span("at-end", start_time=end, attrs_string={"outside": "exclusive-end"}),
+        span(
+            "near-end",
+            start_time=end - timedelta(microseconds=1),
+            attrs_string={"tag": "last-microsecond"},
+        ),
+        span("moved-in", start_time=START - timedelta(microseconds=1)),
+        span("moved-in", _version=2, attrs_string={"tag": "moved-in"}),
+        span("null-user", end_user_id=None, attrs_string={"tag": "no-user"}),
+    ]
+    for key, changes in (
+        ("cleared", {"attrs_string": {}}),
+        ("deleted", {"is_deleted": 1}),
+        ("reassigned", {"end_user_id": str(UUID(int=999))}),
+        ("outside", {"start_time": START - timedelta(microseconds=1)}),
+    ):
+        old = span(key, attrs_string={key: "obsolete"})
+        rows.extend([old, {**old, "_version": 2, **changes}])
+    for i, changes in enumerate(
+        (
+            {"attrs_string": {"mixed": "7"}},
+            {"attrs_number": {"mixed": 7}},
+            {"attrs_bool": {"mixed": 1}, "attrs_number": {"mixed": 9}},
+            {"attributes_extra": {"mixed": [7]}, "attrs_bool": {"mixed": 1}},
+            {"attributes_extra": {"mixed": None}, "attrs_string": {"mixed": "shadow"}},
+            {"attrs_number": {"mixed": float("inf")}},
+            {"attrs_number": {"mixed": float("nan")}},
+        )
+    ):
+        rows.append(span(f"mixed-{i}", **changes))
+    # Identical duplicate versions are safe; conflicting equal versions have
+    # no uniquely defined physical winner and are deliberately not invented.
+    rows.append(dict(rows[0]))
+    return rows
+
+
+def canonical(value):
+    return json.dumps(value, sort_keys=True, ensure_ascii=False, separators=(",", ":"))
+
+
+def expected(rows, keys, projects, days):
+    latest = {}
+    for row in rows:
+        physical_key = tuple(
+            row[k]
+            for k in (
+                "project_id",
+                "observation_type",
+                "service_name",
+                "trace_id",
+                "id",
+            )
+        ) + (row["start_time"].replace(minute=0, second=0, microsecond=0),)
+        if (
+            physical_key not in latest
+            or row["_version"] > latest[physical_key]["_version"]
+        ):
+            latest[physical_key] = row
+    result = {}
+    for row in latest.values():
+        user = REMAP.get(row["end_user_id"], row["end_user_id"])
+        if (
+            row["project_id"] not in projects
+            or row["is_deleted"]
+            or user not in (USER, UNMAPPED)
+            or not START <= row["start_time"] < START + timedelta(days=days)
+        ):
+            continue
+        for key in keys:
+            for storage, kind in (
+                ("attributes_extra", "json"),
+                ("attrs_bool", "boolean"),
+                ("attrs_number", "number"),
+                ("attrs_string", "string"),
+            ):
+                values = row[storage] or {}
+                if key not in values:
+                    continue
+                value = values[key]
+                if kind == "boolean":
+                    value = bool(value)
+                elif kind == "number":
+                    value = None if not math.isfinite(value) else value
+                result.setdefault((user, key), set()).add((kind, canonical(value)))
+                break
+    return result
+
+
+def execute(
+    rows,
+    keys,
+    *,
+    days=7,
+    workspace=False,
+    finite=True,
+    join_use_nulls=0,
+    query_factory=_users_attr_enrichment_query,
+    compiled=None,
+):
+    engine = pytest.importorskip("chdb")
+    sql, params = query_factory(
+        **({"project_ids": [PROJECT, OTHER]} if workspace else {"project_id": PROJECT}),
+        attribute_keys=keys,
+        start_date=START,
+        end_date=START + timedelta(days=days),
+        candidate_end_user_id_map=REMAP if finite else None,
+    )
+    params.update(
+        eu_ids=(USER, UNMAPPED),
+        eu_scan_ids=(*REMAP, UNMAPPED) if finite else (USER, UNMAPPED),
+    )
+    if compiled is not None:
+        sql, params = compiled
+    columns = """project_id UUID, observation_type String, service_name String,
+        trace_id String, id String, start_time DateTime64(6, 'UTC'), _version UInt64,
+        is_deleted UInt8, end_user_id Nullable(UUID), attributes_extra Nullable(String),
+        string_keys Array(String), string_value_indices Array(UInt32),
+        number_keys Array(String), number_values Array(Float64),
+        bool_keys Array(String), bool_values Array(UInt8)"""
+    encoded = []
+    # Encode repeated strings once, keeping the exact long values without a
+    # multi-megabyte VALUES statement or an increased parser/memory limit.
+    string_pool = list(
+        dict.fromkeys(value for row in rows for value in row["attrs_string"].values())
+    )
+    string_indices = {value: index + 1 for index, value in enumerate(string_pool)}
+    for row in rows:
+        values = [
+            row[k]
+            for k in (
+                "project_id",
+                "observation_type",
+                "service_name",
+                "trace_id",
+                "id",
+            )
+        ]
+        values += [
+            row["start_time"].isoformat(sep=" "),
+            row["_version"],
+            row["is_deleted"],
+            row["end_user_id"],
+            None
+            if row["attributes_extra"] is None
+            else canonical(row["attributes_extra"]),
+        ]
+        for storage in ("attrs_string", "attrs_number", "attrs_bool"):
+            stored_values = list(row[storage].values())
+            if storage == "attrs_string":
+                stored_values = [string_indices[value] for value in stored_values]
+            values.extend([list(row[storage]), stored_values])
+        encoded.append(tuple(values))
+    literals = escape_params(
+        {
+            "columns": columns,
+            "rows": tuple(encoded),
+            "remaps": ((USER, NEW), (ALIAS, NEW)),
+            "string_pool": string_pool,
+        },
+        CONTEXT,
+    )
+    rendered = without_query_settings(sql) % escape_params(params, CONTEXT)
+    # Dimension fixtures already contain their latest rows; only this fixed
+    # fixture's FINAL is removed. Preserve every predicate when lowering PREWHERE.
+    rendered = rendered.replace("end_user_id_remap FINAL", "end_user_id_remap")
+    assert rendered.lstrip().startswith("WITH")
+    rendered = f"""WITH {literals["string_pool"]} AS fixture_string_pool, spans AS (
+        SELECT *, mapFromArrays(string_keys,
+            arrayMap(i -> fixture_string_pool[i], string_value_indices)) AS attrs_string,
+            mapFromArrays(number_keys, number_values) AS attrs_number,
+            mapFromArrays(bool_keys, bool_values) AS attrs_bool
+        FROM values({literals["columns"]}, {literals["rows"][1:-1]})
+    ), end_user_id_remap AS (
+        SELECT * FROM values('old_id UUID, new_id UUID', {literals["remaps"][1:-1]})
+    ), {rendered.lstrip()[4:]}
+    SETTINGS join_use_nulls={join_use_nulls}, max_threads=1,
+        max_execution_time=5, max_memory_usage=268435456
+    """
+    try:
+        result = engine.query(values_where(rendered), "JSONEachRow")
+    except RuntimeError as exc:
+        # Native client errors otherwise echo the entire long-string fixture.
+        raise RuntimeError(str(exc).split("(query:", 1)[0][:1500]) from None
+    return [json.loads(line) for line in str(result).splitlines() if line]
+
+
+def decoded(rows):
+    result = {
+        (row["end_user_id"], row["attribute_key"]): {
+            (kind, canonical(json.loads(value)))
+            for kind, value in row["attribute_typed_values"]
+        }
+        for row in rows
+    }
+    assert len(result) == len(rows), "one output per user/key"
+    return result
+
+
+def test_requested_keys_keep_full_physical_replay_and_post_collapse_visibility():
+    sql, params = _users_attr_enrichment_query(
+        project_id=PROJECT, attribute_keys=["tag", "tag", "long"]
+    )
+    latest = cte(sql, "latest_candidate_attribute_values")
+    group = latest.split("GROUP BY", 1)[1]
+    for column in (
+        "project_id",
+        "observation_type",
+        "service_name",
+        "identity_hour",
+        "trace_id",
+        "id",
+    ):
+        assert column in group
+    scan = latest.split("PREWHERE", 1)[1].split("GROUP BY", 1)[0]
+    assert "candidate_span_identities" in scan
+    assert "is_deleted = 0" not in scan and "end_user_id IN" not in scan
+    assert "latest_is_deleted = 0" in sql
+    assert "GROUP BY end_user_id, attribute_key" in sql
+    assert params["requested_attribute_keys"] == ["tag", "long"]
+
+
+def test_duplicate_single_key_is_bound_once():
+    sql, params = _users_attr_enrichment_query(
+        project_id=PROJECT, attribute_keys=["long", "long"]
+    )
+    assert "%(requested_attribute_keys)s" in sql and "'long'" not in sql
+    assert params["requested_attribute_keys"] == ["long"]
+
+
+@pytest.mark.parametrize("days", [7, 30, 365])
+@pytest.mark.parametrize("key", KEYS)
+def test_each_single_typed_key_replays_exactly(key, days):
+    rows = cohort(days)
+    assert decoded(execute(rows, [key], days=days)) == expected(
+        rows, [key], [PROJECT], days
+    )
+
+
+@pytest.mark.parametrize("days", [7, 30, 365])
+@pytest.mark.parametrize("workspace", [False, True])
+@pytest.mark.parametrize("finite", [False, True])
+@pytest.mark.parametrize("join_use_nulls", [0, 1])
+def test_typed_replay_matches_full_physical_truth(
+    days, workspace, finite, join_use_nulls
+):
+    rows = cohort(days)
+    actual = execute(
+        rows,
+        KEYS,
+        days=days,
+        workspace=workspace,
+        finite=finite,
+        join_use_nulls=join_use_nulls,
+    )
+    assert decoded(actual) == expected(
+        rows, KEYS, [PROJECT, OTHER] if workspace else [PROJECT], days
+    )
+
+
+@pytest.mark.parametrize("key_count", [1, 4, 10])
+def test_requested_key_width_keeps_sparse_and_removed_values(key_count):
+    keys = [f"key-{i}" for i in range(key_count)]
+    rows = [
+        span("dense", attrs_string=dict.fromkeys(keys, LONG)),
+        span("sparse", attrs_string={keys[-1]: "sparse"}),
+        span("removed", attrs_string=dict.fromkeys(keys, "obsolete")),
+        span("removed", _version=2),
+        span("null-extra", attributes_extra=None, attrs_string={keys[0]: "fallback"}),
+    ]
+    assert decoded(execute(rows, keys)) == expected(rows, keys, [PROJECT], 7)
+
+
+def test_actual_collector_preserves_mixed_values_and_missing_keys():
+    rows = cohort(7)
+    manager = UsersListManager(
+        organization_id=PROJECT,
+        allowed_project_ids=[PROJECT],
+        project_id=PROJECT,
+        requested_columns=[],
+        attribute_keys=list(KEYS),
+    )
+    calls = []
+
+    def read(sql, params, **kwargs):
+        calls.append(params["requested_attribute_keys"])
+        return SimpleNamespace(
+            data=execute(
+                rows, params["requested_attribute_keys"], compiled=(sql, params)
+            )
+        )
+
+    with patch("tracer.services.users_list_manager.V2AnalyticsQueryService") as service:
+        service.return_value.execute_ch_query.side_effect = read
+        attrs = manager._read_span_attributes(
+            [{"end_user_id": USER}],
+            None,
+            start_date=START,
+            end_date=START + timedelta(days=7),
+            candidate_scan_ids=list(REMAP),
+            candidate_end_user_id_map=REMAP,
+        )
+    assert [key for batch in calls for key in batch] == list(KEYS)
+    assert max(map(len, calls)) == 4  # Existing production batch size is unchanged.
+    assert attrs[USER]["long"] == LONG and attrs[USER]["empty"] == ""
+    assert attrs[USER]["zero"] == 0 and attrs[USER]["flag"] == "false"
+    assert attrs[USER]["null"] is None
+    assert {"cleared", "deleted", "reassigned", "outside", "absent"}.isdisjoint(
+        attrs[USER]
+    )
+
+
+def test_actual_collector_reads_all_250_long_keys_in_existing_batches():
+    keys = [f"key-{i}" for i in range(250)]
+    rows = [
+        span("dense", attrs_string=dict.fromkeys(keys, LONG)),
+        span("sparse", attrs_string={keys[-1]: "sparse"}),
+        span("removed", attrs_string=dict.fromkeys(keys, "obsolete")),
+        span("removed", _version=2),
+        span("null-extra", attributes_extra=None, attrs_string={keys[0]: "fallback"}),
+    ]
+    manager = UsersListManager(
+        organization_id=PROJECT,
+        allowed_project_ids=[PROJECT],
+        project_id=PROJECT,
+        requested_columns=[],
+        attribute_keys=keys,
+    )
+    calls, actual = [], []
+
+    def read(sql, params, **kwargs):
+        calls.append(params["requested_attribute_keys"])
+        result = execute(
+            rows, params["requested_attribute_keys"], compiled=(sql, params)
+        )
+        actual.extend(result)
+        return SimpleNamespace(data=result)
+
+    with patch("tracer.services.users_list_manager.V2AnalyticsQueryService") as service:
+        service.return_value.execute_ch_query.side_effect = read
+        attrs = manager._read_span_attributes(
+            [{"end_user_id": USER}],
+            None,
+            start_date=START,
+            end_date=START + timedelta(days=7),
+            candidate_scan_ids=list(REMAP),
+            candidate_end_user_id_map=REMAP,
+        )
+    assert len(calls) == 63 and max(map(len, calls)) == 4
+    assert [key for batch in calls for key in batch] == keys
+    assert decoded(actual) == expected(rows, keys, [PROJECT], 7)
+    assert set(attrs[USER]) == set(keys)
+    assert attrs[USER][keys[1]] == LONG
+    assert set(attrs[USER][keys[0]]) == {LONG, "fallback"}
+    assert set(attrs[USER][keys[-1]]) == {LONG, "sparse"}

--- a/futureagi/tracer/tests/test_users_exact_activity_cursor.py
+++ b/futureagi/tracer/tests/test_users_exact_activity_cursor.py
@@ -56,7 +56,7 @@ def test_exact_candidate_population_window_order_and_scope(workspace, days):
     )
     assert "span_user_rollup" not in sql
     assert "FROM spans AS sp FINAL" not in sql
-    assert_window_replay(sql, params)
+    assert_window_replay(sql, params, unseeded=True)
     assert "count() OVER()" not in sql
     assert params["limit"] == 26
     assert params["before_activity_us"] + 1 == params["user_window_end_us"]
@@ -118,7 +118,7 @@ def test_native_user_id_witness_is_after_latest_replay_before_candidate_limit(
     assert params["candidate_user_label_0"] == (
         ("guest-a",) if op == "equals" else ("guest-a", "guest-b")
     )
-    assert_window_replay(sql, params)
+    assert_window_replay(sql, params, unseeded=True)
 
 
 @pytest.mark.parametrize(
@@ -187,7 +187,7 @@ def test_scalar_witness_narrows_groups_not_activity_or_replacement(workspace):
         raw_filter("equals", 0),
         raw_filter("less_than", 1),
         raw_filter("equals", False, "boolean"),
-        raw_filter("equals", "1", "text"),
+        raw_filter("equals", "true", "text"),
         {
             "column_id": "total_cost",
             "filter_config": {

--- a/futureagi/tracer/tests/test_users_native_conjunction_replay.py
+++ b/futureagi/tracer/tests/test_users_native_conjunction_replay.py
@@ -1,0 +1,86 @@
+"""Native typed hydration plus real Users AND matching; SELECT fixtures only."""
+
+from copy import deepcopy
+from datetime import timedelta
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+from tracer.services.users_list_manager import UsersListManager
+from tracer.tests.test_user_attribute_native_key_collision import wire
+from tracer.tests.test_users_attribute_physical_replay import (
+    PROJECT,
+    REMAP,
+    START,
+    USER,
+    execute,
+    span,
+)
+
+pytestmark = pytest.mark.unit
+
+
+@pytest.mark.parametrize("days", [7, 30, 365])
+@pytest.mark.parametrize("width", [2, 5, 10])
+def test_native_typed_conjunction_requires_every_latest_property(days, width):
+    filters, physical_rows = [], []
+    for index in range(width):
+        key = f"compound_{index}"
+        kind, value, storage = (
+            ("text", "Alpha", "attrs_string"),
+            ("number", 7, "attrs_number"),
+            ("boolean", True, "attrs_bool"),
+        )[index % 3]
+        filters.append(wire(key, value, kind=kind))
+        # Properties on different spans of the same canonical user must AND
+        # together at user grain, not require a single span to contain them all.
+        physical_rows.append(span(f"span-{index}", **{storage: {key: value}}))
+
+    for cleared_index in [None, *range(width)]:
+        rows = deepcopy(physical_rows)
+        if cleared_index is not None:
+            # The old matching version remains physically present. The newest
+            # version clears only this leaf; every other leaf still matches.
+            cleared = deepcopy(rows[cleared_index])
+            cleared.update(_version=2, attrs_string={}, attrs_number={}, attrs_bool={})
+            rows.append(cleared)
+        manager = UsersListManager(
+            organization_id=PROJECT,
+            allowed_project_ids=[PROJECT],
+            project_id=PROJECT,
+            requested_columns=[],
+            filters=deepcopy(filters),
+        )
+        candidate = {"end_user_id": USER, "user_id": "fixture-user"}
+        batches = []
+
+        def read(sql, params, *, _rows=rows, _batches=batches, **_kwargs):
+            _batches.append(params["requested_attribute_keys"])
+            return SimpleNamespace(
+                data=execute(
+                    _rows,
+                    params["requested_attribute_keys"],
+                    days=days,
+                    compiled=(sql, params),
+                )
+            )
+
+        with patch(
+            "tracer.services.users_list_manager.V2AnalyticsQueryService"
+        ) as service:
+            service.return_value.execute_ch_query.side_effect = read
+            attrs = manager._read_span_attributes(
+                [candidate],
+                None,
+                start_date=START,
+                end_date=START + timedelta(days=days),
+                candidate_scan_ids=list(REMAP),
+                candidate_end_user_id_map=REMAP,
+            )
+        manager._apply_span_attributes([candidate], attrs)
+        assert manager._row_matches_filters(candidate) is (cleared_index is None)
+        assert {key for batch in batches for key in batch} == {
+            f"compound_{i}" for i in range(width)
+        }
+        assert max(map(len, batches)) <= 4

--- a/futureagi/tracer/tests/test_users_replay_certification.py
+++ b/futureagi/tracer/tests/test_users_replay_certification.py
@@ -1,0 +1,202 @@
+"""Real Users SQL generation with a fake transport; no database reads or writes."""
+
+import hashlib
+import json
+import time
+from datetime import UTC, datetime, timedelta
+from importlib import import_module
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import Mock, patch
+
+import pytest
+
+from tracer.services.clickhouse.v2.query_builders.user_list import (
+    UserListQueryBuilderV2,
+)
+from tracer.services.users_list_manager import UsersListManager
+
+PROJECT = "11111111-1111-4111-8111-111111111111"
+ORG = "22222222-2222-4222-8222-222222222222"
+USER = "33333333-3333-4333-8333-333333333333"
+OTHER = "44444444-4444-4444-8444-444444444444"
+
+
+@pytest.fixture(autouse=True)
+def replay_module(monkeypatch):
+    # Standard backend pytest does not add the standalone QA scripts to sys.path.
+    monkeypatch.syspath_prepend(str(Path(__file__).resolve().parents[3] / "scripts/qa"))
+    global replay
+    replay = import_module("replay_observe_queries_readonly")
+
+
+def fixture(*, days=7, kind="text", workspace=False, search=""):
+    end = datetime(2026, 8, 1, 12, tzinfo=UTC)
+    start = end - timedelta(days=days)
+    filters = [{"column_id": "created_at", "filter_config": {
+        "filter_type": "datetime", "filter_op": "between",
+        "filter_value": [start.isoformat(), end.isoformat()],
+    }}]
+    if kind is not None:
+        filters.append({"column_id": "fixture_attribute", "filter_config": {
+            "col_type": "SPAN_ATTRIBUTE", "filter_type": "text" if kind == "typed_text" else kind,
+            "filter_op": "greater_than" if kind == "number" else "in" if kind == "typed_text" else "equals",
+            "filter_value": 10 if kind == "number" else ["synthetic string"] if kind == "typed_text" else "synthetic string",
+            **({"attribute_value_types": ["string"]} if kind == "typed_text" else {}),
+        }})
+    params = {"page_size": 25, "cursor_mode": True, "filters": json.dumps(filters)}
+    if not workspace:
+        params["project_id"] = PROJECT
+    case = {"surface": "users_workspace" if workspace else "users_project",
+            "request": {"method": "GET", "path": "/tracer/users/",
+                        "target_rows": 25, "params": params},
+            "window": {"start": start.isoformat(), "end": end.isoformat()}}
+    manager = UsersListManager(organization_id=ORG, allowed_project_ids=[PROJECT],
+                               project_id=None if workspace else PROJECT,
+                               filters=replay.normalize_filters(case["request"]),
+                               search=search)
+    scope = {"organization_id": ORG, "project_id": PROJECT}
+    reader = object.__new__(replay.ReadOnlyExecutor)
+    reader.mode, reader.projects, reader.calls = "candidate", [PROJECT], []
+    reader._users_context = reader._users_certificate = None
+    reader._users_origin_expected = False
+    reader.prefix, reader.deadline = "offline-fixture", time.monotonic() + 60
+    reader.args = SimpleNamespace(threads=1, read_gib=1)
+    reader.client = SimpleNamespace(
+        execute=Mock(return_value=([(USER, PROJECT)],
+                                  [("end_user_id", "String"), ("project_id", "String")])),
+        last_query=SimpleNamespace(progress=SimpleNamespace(rows=1, bytes=32)),
+    )
+    builder = UserListQueryBuilderV2(organization_id=ORG, project_ids=[PROJECT],
+                                    filters=manager.filters, search=search)
+    sql, bindings = builder.build_dimension_candidate_query(
+        limit=65 if manager.attribute_exact_text_filters else 26,
+        window_start=start, window_end=end,
+    )
+    return reader, manager, case, scope, builder, sql, bindings
+
+
+def configure(items):
+    reader, manager, case, scope, *_ = items
+    reader._configure_users_remap(manager, case, scope, "synthetic-plan")
+    return reader
+
+
+@pytest.mark.parametrize("days", [7, 30, 365])
+@pytest.mark.parametrize("kind", [None, "text", "typed_text", "number"])
+@pytest.mark.parametrize("workspace", [False, True])
+def test_reviewed_origin_shapes_are_exactly_bound(days, kind, workspace):
+    items = fixture(days=days, kind=kind, workspace=workspace)
+    reader = configure(items)
+    sql, bindings = items[-2:]
+    digest = hashlib.sha256(sql.strip().rstrip(";").encode()).hexdigest()
+    assert replay._users_sources_current()
+    assert digest in replay._USERS_ORIGIN_SHAS
+    assert reader._users_context.origin_sql_sha256 == digest
+    assert reader._users_context.origin_row_limit == (65 if kind in {"text", "typed_text"} else 26)
+    assert reader._users_context.origin_bindings == replay.replay.digest(replay.safe_json(bindings))
+    reader.client.execute.assert_not_called()
+    reader.execute_ch_query(sql, bindings)
+    assert reader._users_certificate.ids == (USER,)
+    limits = reader.client.execute.call_args.kwargs["settings"]
+    assert limits["readonly"] == 2
+    assert 0 < limits["max_memory_usage"] <= 4 * 1024**3
+    assert limits["max_bytes_to_read"] == 1024**3
+    assert limits["max_result_rows"] == 100001
+    assert limits["read_overflow_mode"] == limits["result_overflow_mode"] == "throw"
+
+
+@pytest.mark.parametrize("change", ["search", "source", "project", "page_size", "cursor", "method"])
+def test_unreviewed_context_fails_before_transport(change, monkeypatch):
+    items = fixture(search="synthetic" if change == "search" else "")
+    reader, manager, case, *_ = items
+    if change == "source":
+        monkeypatch.setattr(replay, "_users_sources_current", lambda: False)
+    elif change == "project":
+        manager.scoped_project_ids = [OTHER]
+    elif change in {"page_size", "cursor"}:
+        case["request"]["params"][change] = 100 if change == "page_size" else "prior-page"
+    elif change == "method":
+        case["request"]["method"] = "POST"
+    with pytest.raises(replay.replay.ReplayError, match="USERS_REMAP_(CONTEXT|ORIGIN)_NOT_QUALIFIED"):
+        configure(items)
+    reader.client.execute.assert_not_called()
+
+
+@pytest.mark.parametrize("change", ["sql", "bindings", "source", "scope"])
+def test_origin_cannot_change_after_configuration(change, monkeypatch):
+    items = fixture()
+    reader = configure(items)
+    sql, bindings = items[-2:]
+    if change == "sql":
+        sql, bindings = fixture(kind="number")[-2:]
+    elif change == "bindings":
+        bindings = {**bindings, "limit": 27}
+    elif change == "source":
+        monkeypatch.setattr(replay, "_users_sources_current", lambda: False)
+    else:
+        reader.projects = [OTHER]
+    with pytest.raises(replay.replay.ReplayError, match="USERS_REMAP_"):
+        reader.execute_ch_query(sql, bindings)
+    reader.client.execute.assert_not_called()
+
+
+@pytest.mark.parametrize("kind", [None, "text", "typed_text", "number"])
+def test_actual_manager_initial_query_matches_approved_bindings(kind):
+    items = fixture(kind=kind)
+    reader = configure(items)
+
+    class TransportReached(BaseException):
+        pass
+
+    # Stop at the fake transport, after the real manager and guard agree.
+    reader.client.execute.side_effect = TransportReached
+    with patch("tracer.services.users_list_manager.V2AnalyticsQueryService", return_value=reader):
+        with pytest.raises(TransportReached):
+            items[1].list_cursor_payload(page_size=25)
+    reader.client.execute.assert_called_once()
+    assert reader.client.execute.call_args.args[1]["limit"] == (65 if kind in {"text", "typed_text"} else 26)
+
+
+@pytest.mark.parametrize("kind", [None, "text", "typed_text", "number"])
+def test_origin_result_may_not_exceed_its_exact_initial_bound(kind):
+    items = fixture(kind=kind)
+    reader = configure(items)
+    count = reader._users_context.origin_row_limit + 1
+    reader.client.execute.return_value = (
+        [(USER, PROJECT)] * count, [("end_user_id", "String"), ("project_id", "String")],
+    )
+    with pytest.raises(replay.replay.ReplayError, match="USERS_REMAP_ORIGIN_RESULT_INVALID"):
+        reader.execute_ch_query(*items[-2:])
+    assert reader._users_certificate is None
+
+
+@pytest.mark.parametrize("change", [None, "ids", "client", "origin", "scope"])
+def test_remap_is_finite_context_bound_and_single_use(change):
+    items = fixture()
+    reader = configure(items)
+    reader.execute_ch_query(*items[-2:])
+    remap_sql, params = items[4].build_dimension_survivor_query([USER])
+    reader.client.execute.reset_mock()
+    reader.client.execute.return_value = ([(USER, USER)], [("any_id", "String"), ("survivor_id", "String")])
+    if change == "ids":
+        params = {"dimension_candidate_ids": (OTHER,)}
+    elif change == "client":
+        reader.client = SimpleNamespace(execute=Mock())
+    elif change == "origin":
+        reader.calls[-1]["query_id"] = "another-origin"
+    elif change == "scope":
+        reader.projects = [OTHER]
+    if change:
+        with pytest.raises(replay.replay.ReplayError):
+            reader.execute_ch_query(remap_sql, params)
+        reader.client.execute.assert_not_called()
+        return
+    reader.execute_ch_query(remap_sql, params)
+    receipt = reader.calls[-1]["scope_certificate"]
+    assert receipt["origin_sql_sha256"] == reader._users_context.origin_sql_sha256
+    assert receipt["result_validated"] and receipt["candidate_count"] == 1
+    reader.client.execute.reset_mock()
+    with pytest.raises(replay.replay.ReplayError):
+        reader.execute_ch_query(remap_sql, params)
+    reader.client.execute.assert_not_called()

--- a/futureagi/tracer/tests/test_users_text_candidate_witness.py
+++ b/futureagi/tracer/tests/test_users_text_candidate_witness.py
@@ -1,0 +1,285 @@
+"""Exact candidate acquisition on native constant fixtures; no tables or DDL.
+
+Candidates may include stale witnesses. They must retain every possible match,
+and their activity metrics/order must use all latest live spans, not just matches.
+This is not production-performance or full Users API qualification.
+"""
+
+import json
+from datetime import UTC, datetime, timedelta
+from types import SimpleNamespace
+from uuid import UUID
+
+import pytest
+from clickhouse_driver.util.escape import escape_params
+
+from tracer.services.clickhouse.server_readonly import without_query_settings
+from tracer.services.clickhouse.v2.id_remap_sql import resolved_id_expr
+from tracer.services.clickhouse.v2.query_builders.user_list import (
+    UserListQueryBuilderV2,
+)
+from tracer.tests.test_trace_root_physical_replay import values_where
+from tracer.tests.test_user_latest_window_replay import assert_window_replay, cte
+
+PROJECT, FOREIGN = str(UUID(int=1001)), str(UUID(int=1002))
+START = datetime(2026, 8, 1, 12, 15, tzinfo=UTC)
+LONG = "long ASCII %_\\' text " * 100
+CONTEXT = SimpleNamespace(server_info=SimpleNamespace(get_timezone=lambda: "UTC"))
+
+
+def leaf(value, op="equals"):
+    picker = op == "typed_in"
+    return {
+        "column_id": "tag",
+        "filter_config": {
+            "col_type": "SPAN_ATTRIBUTE",
+            "filter_type": "text",
+            "filter_op": "in" if picker else op,
+            "filter_value": value,
+            **({"attribute_value_types": ["string"] * len(value)} if picker else {}),
+        },
+    }
+
+
+def builder(items, days=7):
+    return UserListQueryBuilderV2(
+        organization_id=PROJECT,
+        project_ids=[PROJECT],
+        filters=[
+            {
+                "column_id": "created_at",
+                "filter_config": {
+                    "filter_type": "datetime",
+                    "filter_op": "between",
+                    "filter_value": [
+                        START.isoformat(),
+                        (START + timedelta(days=days)).isoformat(),
+                    ],
+                },
+            },
+            *items,
+        ],
+    )
+
+
+@pytest.mark.parametrize(
+    "value,op",
+    [
+        ("123456", "equals"),
+        (LONG, "equals"),
+        (["Alpha", "Beta"], "in"),
+        (["123456"], "typed_in"),
+    ],
+    ids=["digit-string", "long-text", "multi-value", "picker"],
+)
+def test_plain_text_witness_prunes_groups_not_latest_activity(value, op):
+    sql, params = builder([leaf(value, op)]).build_dimension_candidate_query(limit=65)
+    assert "scalar_witness_identities AS" in sql
+    witness = cte(sql, "scalar_witness_identities")
+    assert "attrs_string" in witness
+    assert "LIMIT" not in witness and "is_deleted" not in witness
+    assert "attrs_string" not in cte(sql, "exact_usage")
+    assert "filtered_end_users" not in cte(sql, "exact_usage")
+    assert "INNER JOIN exact_usage AS xu ON xu.end_user_id = eu.end_user_id" in sql
+    assert_window_replay(sql, params)
+
+
+@pytest.mark.parametrize(
+    "value,op",
+    [
+        ("", "equals"),
+        ("true", "equals"),
+        (" FALSE ", "equals"),
+        ('{"a":1}', "equals"),
+        ("[1,2]", "equals"),
+        ("\u0130", "equals"),
+        ("value", "not_equals"),
+        (None, "is_null"),
+        ("value", "contains"),
+        (["safe", "true"], "in"),
+        (["true"], "typed_in"),
+    ],
+)
+def test_unproven_text_shapes_keep_existing_complete_path(value, op):
+    sql, _ = builder([leaf(value, op)]).build_dimension_candidate_query(limit=65)
+    assert "scalar_witness_identities AS" not in sql
+
+
+def population(needle):
+    rows = []
+
+    def add(
+        user,
+        identity,
+        *,
+        value=None,
+        minute=20,
+        version=1,
+        deleted=0,
+        cost=1,
+        service="svc",
+        project=PROJECT,
+    ):
+        rows.append(
+            (
+                project,
+                service,
+                "SPAN",
+                identity,
+                str(UUID(int=user)),
+                START.replace(minute=minute, tzinfo=None).isoformat(" "),
+                version,
+                deleted,
+                START.replace(minute=minute + 1, tzinfo=None).isoformat(" "),
+                cost,
+                [] if value is None else ["tag"],
+                [] if value is None else [value],
+            )
+        )
+
+    add(50, "matching-alias", value=needle, cost=2)
+    add(10, "later-unmatched", value="unrelated", minute=40, cost=7)
+    add(40, "reassigned", value=needle)
+    add(20, "reassigned", value=needle, version=2, cost=3)
+    add(40, "retained-old-user-activity", value="unrelated", cost=4)
+    add(30, "deleted", value=needle)
+    add(30, "deleted", value=needle, version=2, deleted=1)
+    add(60, "never-matched", value="unrelated")
+    add(70, "missing-string-key")
+    add(80, "moved-out", value=needle)
+    add(80, "moved-out", value=needle, version=2, minute=10)
+    add(100, "deleted", value=needle, service="different-service")
+    add(110, "foreign", value=needle, project=FOREIGN)
+    add(120, "field-removed", value=needle)
+    add(120, "field-removed", version=2)
+    add(130, "without-curated-user", value=needle)
+    return rows
+
+
+def execute(rows, items, *, days=7, before=None, limit=65, redundant_membership=False):
+    engine = pytest.importorskip("chdb")
+    sql, params = builder(items, days).build_dimension_candidate_query(
+        limit=limit,
+        before_first_seen=before[0] if before else None,
+        before_end_user_id=before[1] if before else None,
+    )
+    if redundant_membership:
+        # Restore the removed, redundant semijoin as a differential control.
+        # Both versions retain the authoritative final dimension INNER JOIN.
+        assert sql.count("WHERE latest_is_deleted = 0") == 1
+        sql = sql.replace(
+            "WHERE latest_is_deleted = 0",
+            "WHERE latest_is_deleted = 0 AND "
+            f"{resolved_id_expr('latest_end_user_id', 'span_eu_remap')} IN "
+            "(SELECT end_user_id FROM filtered_end_users)",
+        )
+    rendered = without_query_settings(sql) % escape_params(params, CONTEXT)
+    # These dimension fixtures have one current row per key. FINAL is unnecessary
+    # only for these constant CTEs; no span predicate or version replay is removed.
+    rendered = rendered.replace("end_users AS eu FINAL", "end_users AS eu")
+    rendered = rendered.replace("end_user_id_remap FINAL", "end_user_id_remap")
+    columns = (
+        "project_id UUID, service_name String, observation_type String, id String, "
+        "end_user_id Nullable(UUID), start_time DateTime64(6, 'UTC'), _version UInt64, "
+        "is_deleted UInt8, end_time DateTime64(6, 'UTC'), cost Float64, "
+        "fixture_keys Array(String), fixture_values Array(String)"
+    )
+    literals = escape_params(
+        {
+            "columns": columns,
+            "rows": tuple(rows),
+            "users": tuple(
+                (str(UUID(int=n)), FOREIGN if n == 110 else PROJECT)
+                for n in (10, 20, 30, 40, 50, 60, 70, 80, 100, 110, 120)
+            ),
+            "remaps": (
+                (str(UUID(int=10)), str(UUID(int=90))),
+                (str(UUID(int=50)), str(UUID(int=90))),
+            ),
+            "org": PROJECT,
+            "start": START.replace(tzinfo=None).isoformat(" "),
+        },
+        CONTEXT,
+    )
+    query = f"""WITH spans AS (
+        SELECT *, id AS trace_id, mapFromArrays(fixture_keys, fixture_values) AS attrs_string,
+            CAST(map(), 'Map(String, Float64)') AS attrs_number,
+            CAST(map(), 'Map(String, UInt8)') AS attrs_bool,
+            toUInt64(1) AS total_tokens, toUInt64(1) AS prompt_tokens,
+            toUInt64(0) AS completion_tokens
+        FROM values({literals["columns"]}, {literals["rows"][1:-1]})
+    ), end_users AS (
+        SELECT *, toUUID({literals["org"]}) AS organization_id,
+            toString(end_user_id) AS user_id, 'custom' AS user_id_type,
+            toUInt64(0) AS user_id_hash, toUInt8(0) AS is_deleted,
+            toDateTime64({literals["start"]}, 6, 'UTC') AS first_seen, first_seen AS version
+        FROM values('end_user_id UUID, project_id UUID', {literals["users"][1:-1]})
+    ), end_user_id_remap AS (
+        SELECT * FROM values('old_id UUID, new_id UUID', {literals["remaps"][1:-1]})
+    ), {rendered.lstrip()[4:]}
+    SETTINGS max_threads=1, max_execution_time=5, max_memory_usage=268435456
+    """
+    return [
+        json.loads(line)
+        for line in str(engine.query(values_where(query), "JSONEachRow")).splitlines()
+        if line
+    ]
+
+
+@pytest.mark.parametrize("days", [7, 30, 365])
+@pytest.mark.parametrize(
+    "needle,op",
+    [
+        ("123456", "equals"),
+        (LONG, "equals"),
+        ("Alpha", "in"),
+        ("\N{KELVIN SIGN}ey", "equals"),
+        ("\N{KELVIN SIGN}" * 10, "in"),
+        ("123456", "typed_in"),
+        (LONG, "typed_in"),
+    ],
+    ids=[
+        "digit-string",
+        "long-text",
+        "multi-value",
+        "kelvin",
+        "many-kelvins",
+        "picker",
+        "long-picker",
+    ],
+)
+def test_native_candidates_preserve_corrected_users_full_metrics_and_pagination(
+    days, needle, op
+):
+    rows = population(needle)
+    expected = (
+        [needle.lower()]
+        if op == "typed_in"
+        else [needle.lower(), "another"]
+        if op == "in"
+        else needle.lower()
+    )
+    item = leaf(expected, op)
+    actual = execute(rows, [item], days=days)
+    assert actual == execute(rows, [item], days=days, redundant_membership=True)
+    by_user = {row["end_user_id"]: row for row in actual}
+    # Removed-field and reassigned-old-user witnesses remain conservative; final
+    # membership is decided later. Never-matched users are safely pruned here.
+    assert set(by_user) == {str(UUID(int=n)) for n in (10, 20, 40, 100, 120)}
+    baseline = execute(rows, [], days=days)
+    assert actual == [row for row in baseline if row["end_user_id"] in by_user]
+    assert by_user[str(UUID(int=10))]["total_cost"] == 9
+    assert int(by_user[str(UUID(int=10))]["num_traces"]) == 2
+    assert by_user[str(UUID(int=20))]["total_cost"] == 3
+    assert by_user[str(UUID(int=40))]["total_cost"] == 4
+    paged, cursor = [], None
+    for _ in range(4):
+        page = execute(rows, [item], days=days, before=cursor, limit=2)
+        if not page:
+            break
+        paged.extend(page)
+        cursor = (
+            datetime.fromisoformat(page[-1]["last_active"]),
+            page[-1]["end_user_id"],
+        )
+    assert paged == actual

--- a/futureagi/tracer/tests/test_users_text_witness_cross_types.py
+++ b/futureagi/tracer/tests/test_users_text_witness_cross_types.py
@@ -1,0 +1,174 @@
+"""Offline Users seed/matcher contracts; synthetic typed rows, no SQL execution."""
+
+import json
+from copy import deepcopy
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+from tracer.services.users_list_manager import UsersListManager
+from tracer.tests.test_user_attribute_native_key_collision import PROJECT, UID, wire
+from tracer.tests.test_user_latest_window_replay import builder
+
+pytestmark = pytest.mark.unit
+
+
+def leaf(key, value=None, *, op="equals", types=None, **kwargs):
+    item = wire(key, value, **kwargs)
+    item["filter_config"]["filter_op"] = op
+    if types is not None:
+        item["filter_config"]["attribute_value_types"] = types
+    return item
+
+
+def witness(items):
+    query = builder()
+    query.filters = deepcopy(items)
+    return query._positive_scalar_user_witness()
+
+
+def collected(items, stored):
+    manager = UsersListManager(
+        organization_id=PROJECT,
+        allowed_project_ids=[PROJECT],
+        requested_columns=[],
+        filters=deepcopy(items),
+    )
+    row = {"end_user_id": UID, "user_id": "display", "bool_eval_pass_rate": 1}
+    data = [
+        {
+            "end_user_id": UID,
+            "attribute_key": key,
+            "attribute_typed_values": [
+                (kind, json.dumps(value)) for kind, value in values
+            ],
+        }
+        for key, values in stored.items()
+    ]
+    # Exercise the real collector and provenance cache; intercept the service
+    # before any query can reach a database. Relation membership is preclassified.
+    with patch("tracer.services.users_list_manager.V2AnalyticsQueryService") as service:
+        service.return_value.execute_ch_query.return_value = SimpleNamespace(data=data)
+        attrs = manager._read_span_attributes([row], None)
+    manager._apply_span_attributes([row], attrs)
+    manager._relation_matching_user_ids = {UID}
+    return manager, row
+
+
+@pytest.mark.parametrize(
+    "selected,kind",
+    [(7, "number"), (True, "boolean"), ("7", "number"), ("true", "boolean")],
+)
+def test_mixed_picker_cannot_drop_non_string_matches(selected, kind):
+    item = leaf("picker", ["Alpha", selected], op="in", types=["string", kind])
+    assert witness([item]) == ("", {})
+    actual = 7 if kind == "number" else True
+    for stored, expected in [
+        ([("string", "ALPHA")], True),
+        ([(kind, actual)], True),
+        ([("string", str(selected).lower())], False),
+        ([], False),
+    ]:
+        manager, row = collected([item], {"picker": stored})
+        assert manager._row_matches_filters(row) is expected
+        assert (
+            manager._attribute_value_types_by_user.get(UID, {}).get("picker", {})
+            or not stored
+        )
+        anchor = leaf("tag", "Alpha")
+        manager, row = collected(
+            [item, anchor], {"picker": stored, "tag": [("string", "ALPHA")]}
+        )
+        assert witness([item, anchor]) == witness([anchor])
+        assert manager._row_matches_filters(row) is expected
+
+
+COMPANIONS = {
+    "number": leaf("amount", 7, kind="number"),
+    "boolean": leaf("enabled", True, kind="boolean"),
+    "negative": leaf("state", "blocked", op="not_equals"),
+    "missing": leaf("absent", op="is_null"),
+    "json": leaf("payload", {"flag": True}, kind="map", op="contains"),
+    "annotation": leaf("tag", "approved", source="ANNOTATION"),
+    "eval": leaf("tag", "passed", source="EVAL_METRIC"),
+    "native": leaf("user_id", "display", source="SYSTEM_METRIC"),
+    "mixed": leaf(
+        "picker", ["other", 7, True], op="in", types=["string", "number", "boolean"]
+    ),
+}
+STORED = {
+    "tag": [("string", "ALPHA"), ("number", 999)],
+    "amount": [("number", 7)],
+    "enabled": [("boolean", True)],
+    "state": [("string", "allowed")],
+    "payload": [("json", {"flag": True})],
+    "picker": [("number", 7)],
+    "user_id": [("string", "raw-different")],
+}
+
+
+@pytest.mark.parametrize("op", ["equals", "in"])
+@pytest.mark.parametrize("width", [2, 5, 10])
+@pytest.mark.parametrize("family", list(COMPANIONS))
+def test_cross_property_and_membership_keeps_necessary_seed_superset(op, width, family):
+    names = [family, *(name for name in COMPANIONS if name != family)]
+    anchor = leaf("tag", "Alpha" if op == "equals" else ["Alpha", "Beta"], op=op)
+    items = [anchor, *(COMPANIONS[name] for name in names[: width - 1])]
+    original = deepcopy(items)
+    for ordered in (items, list(reversed(items))):
+        seed = witness(ordered)
+        assert seed[0]
+        selected = next(item for item in ordered if witness([item]) == seed)
+        assert selected["filter_config"]["col_type"] == "SPAN_ATTRIBUTE"
+        assert selected["filter_config"]["filter_op"] in {"equals", "in"}
+        manager, row = collected(ordered, STORED)
+        assert manager._row_matches_filters(row)
+        assert manager._attribute_value_matches(
+            row=row, key=selected["column_id"], config=selected["filter_config"]
+        )
+        # Every AND leaf is required, even though acquisition may use just one.
+        for item in ordered:
+            attrs = deepcopy(manager._attribute_values_by_user)
+            key, cfg = item["column_id"], item["filter_config"]
+            if cfg["col_type"] in {"ANNOTATION", "EVAL_METRIC"}:
+                manager._relation_matching_user_ids.clear()
+            elif cfg["col_type"] == "SYSTEM_METRIC":
+                row["user_id"] = "wrong"
+            elif cfg["filter_op"] == "is_null":
+                manager._attribute_values_by_user[UID][key] = "present"
+            else:
+                manager._attribute_values_by_user[UID].pop(key, None)
+            assert not manager._row_matches_filters(row), (family, width, item)
+            manager._attribute_values_by_user = attrs
+            manager._relation_matching_user_ids = {UID}
+            row["user_id"] = "display"
+    assert items == original
+
+
+@pytest.mark.parametrize(
+    "key,source,value",
+    [
+        ("tag", "ANNOTATION", "approved"),
+        ("tag", "EVAL_METRIC", "passed"),
+        ("user_id", "SYSTEM_METRIC", "display"),
+        ("eval_score", "SYSTEM_METRIC", "1"),
+    ],
+)
+@pytest.mark.parametrize("op", ["equals", "in"])
+def test_relation_and_native_matches_do_not_require_raw_text(key, source, value, op):
+    item = leaf(key, [value] if op == "in" else value, source=source, op=op)
+    manager, row = collected([item], {})
+    assert manager._row_matches_filters(row)
+    assert witness([item]) == ("", {})
+    anchor = leaf("tag", "Alpha")
+    assert witness([item, anchor]) == witness([anchor])
+
+
+@pytest.mark.parametrize("op", ["equals", "in"])
+def test_raw_eval_score_attribute_keeps_its_own_witness(op):
+    item = leaf("eval_score", ["Alpha"] if op == "in" else "Alpha", op=op)
+    assert witness([item])[0]
+    for stored, matches in [([], False), ([("string", "ALPHA")], True)]:
+        manager, row = collected([item], {"eval_score": stored})
+        assert manager._row_matches_filters(row) is matches

--- a/futureagi/tracer/tests/test_users_unseeded_hour_replay.py
+++ b/futureagi/tracer/tests/test_users_unseeded_hour_replay.py
@@ -1,0 +1,199 @@
+"""Unseeded Users replay on constant fixtures; no table creation or writes."""
+
+import json
+from datetime import UTC, datetime, timedelta
+
+import pytest
+from clickhouse_driver.util.escape import escape_params
+
+from tracer.services.clickhouse.v2.query_builders.user_list import (
+    UserListQueryBuilderV2,
+)
+from tracer.tests.test_users_attribute_physical_replay import (
+    CONTEXT,
+    values_where,
+    without_query_settings,
+)
+
+P = "11111111-1111-4111-8111-111111111111"
+U = "22222222-2222-4222-8222-222222222222"
+A = "33333333-3333-4333-8333-333333333333"
+R = "44444444-4444-4444-8444-444444444444"
+START = datetime(2026, 9, 1, 12, 15, tzinfo=UTC)
+
+
+def query(days, change, *, window_start=START, window_end=None):
+    builder = UserListQueryBuilderV2(organization_id=P, project_ids=[P], filters=[])
+    sql, params = builder.build_dimension_candidate_query(
+        limit=26,
+        window_start=window_start,
+        window_end=window_end or START + timedelta(days=days),
+    )
+    base = {
+        "project_id": P,
+        "observation_type": "SPAN",
+        "service_name": "service",
+        "trace_id": "trace",
+        "id": "span",
+        "start_time": START + timedelta(minutes=15),
+        "end_time": START + timedelta(minutes=16),
+        "end_user_id": U,
+        "_version": 1,
+        "cost": 1.25,
+        "total_tokens": 8,
+        "prompt_tokens": 3,
+        "completion_tokens": 5,
+        "is_deleted": 0,
+        "trace_session_id": None,
+    }
+    later = {**base, "_version": 2, **change}
+    types = "project_id UUID, observation_type String, service_name String, trace_id String, id String, start_time DateTime64(6, 'UTC'), end_time Nullable(DateTime64(6, 'UTC')), end_user_id Nullable(UUID), _version UInt64, cost Float64, total_tokens Int32, prompt_tokens Int32, completion_tokens Int32, is_deleted UInt8, trace_session_id Nullable(UUID)"
+
+    def encode(row):
+        return tuple(
+            v.replace(tzinfo=None).isoformat(sep=" ") if isinstance(v, datetime) else v
+            for v in row.values()
+        )
+
+    literals = escape_params(
+        {
+            "schema": types,
+            "rows": (encode(base), encode(later)),
+            "p": P,
+            "u": U,
+            "a": A,
+            "r": R,
+            "time": START.replace(tzinfo=None).isoformat(sep=" "),
+        },
+        CONTEXT,
+    )
+    prefix = f"""WITH spans AS (SELECT * FROM values({literals["schema"]},{literals["rows"][1:-1]})),
+end_users AS (SELECT toUUID({literals["p"]}) AS project_id,toUUID({literals["p"]}) AS organization_id,toUUID({literals["u"]}) AS end_user_id,'fixture-user' AS user_id,'custom' AS user_id_type,toUInt64(1) AS user_id_hash,toDateTime64({literals["time"]},6,'UTC') AS first_seen,first_seen AS version,toUInt8(0) AS is_deleted),
+end_user_id_remap AS (SELECT * FROM values('old_id UUID, new_id UUID',({literals["u"]},{literals["r"]}),({literals["a"]},{literals["r"]}))),"""
+
+    def render(text):
+        text = without_query_settings(text) % escape_params(params, CONTEXT)
+        text = text.replace("end_user_id_remap FINAL", "end_user_id_remap").replace(
+            "end_users AS eu FINAL", "end_users AS eu"
+        )
+        return values_where(prefix + text.lstrip()[4:])
+
+    return render(sql)
+
+
+@pytest.mark.parametrize("days", [7, 30, 365])
+@pytest.mark.parametrize(
+    "change, present",
+    [
+        ({}, True),
+        ({"end_user_id": A}, True),
+        ({"is_deleted": 1}, False),
+        ({"end_user_id": None}, False),
+        ({"end_time": None}, True),
+        ({"start_time": START - timedelta(minutes=5)}, False),
+        ({"service_name": "other", "is_deleted": 1}, True),
+        (
+            {"cost": 0, "total_tokens": 0, "prompt_tokens": 0, "completion_tokens": 0},
+            True,
+        ),
+    ],
+)
+def test_unseeded_users_latest_state(days, change, present):
+    engine = pytest.importorskip("chdb")
+    sql = query(days, change)
+    assert "candidate_span_identities" not in sql
+    rows = [
+        json.loads(line)
+        for line in str(engine.query(sql, "JSONEachRow")).splitlines()
+        if line
+    ]
+    assert len(rows) == int(present)
+    if present:
+        row = rows[0]
+        assert row["end_user_id"] == U
+        assert row["total_cost"] == change.get("cost", 1.25)
+        assert int(row["total_tokens"]) == change.get("total_tokens", 8)
+        assert int(row["num_traces"]) == 1
+        if "end_time" in change:
+            assert row["last_active"] is None
+
+
+@pytest.mark.parametrize("days", [7, 30, 365])
+@pytest.mark.parametrize(
+    "boundary",
+    ["start_same_hour", "start_previous_hour", "end_same_hour", "end_next_hour"],
+)
+@pytest.mark.parametrize("deleted", [0, 1])
+def test_unseeded_users_window_identity_boundaries(days, boundary, deleted):
+    engine = pytest.importorskip("chdb")
+    times = {
+        "start_same_hour": START - timedelta(minutes=5),
+        "start_previous_hour": START - timedelta(hours=1),
+        "end_same_hour": START + timedelta(days=days, minutes=5),
+        "end_next_hour": START + timedelta(days=days, hours=1),
+    }
+    sql = query(days, {"start_time": times[boundary], "is_deleted": deleted})
+    rows = [
+        json.loads(line)
+        for line in str(engine.query(sql, "JSONEachRow")).splitlines()
+        if line
+    ]
+    # A different hour is a different physical key; it cannot replace the
+    # original live row. Within its hour, a correction outside the window does.
+    assert len(rows) == (0 if boundary == "start_same_hour" else 1)
+    if rows:
+        assert rows[0]["total_cost"] == 1.25
+        assert rows[0]["end_user_id"] == U
+
+
+@pytest.mark.parametrize(
+    "lower,upper,correction,present",
+    [
+        (-1, 0, 0, False),
+        (0, 1, 0, True),
+        (1, 2, 0, False),
+        (1, 2, 1, True),
+        (0, 1, 1, False),
+        (-1, 0, -1, True),
+        (0, 1, -1, False),
+    ],
+)
+def test_unseeded_replay_keeps_microsecond_half_open_window(
+    lower, upper, correction, present
+):
+    engine = pytest.importorskip("chdb")
+    physical_start = START + timedelta(minutes=15)
+    sql = query(
+        7,
+        {"start_time": physical_start + timedelta(microseconds=correction)},
+        window_start=physical_start + timedelta(microseconds=lower),
+        window_end=physical_start + timedelta(microseconds=upper),
+    )
+    rows = [
+        json.loads(line)
+        for line in str(engine.query(sql, "JSONEachRow")).splitlines()
+        if line
+    ]
+    assert len(rows) == int(present)
+    if present:
+        assert rows[0]["total_cost"] == 1.25
+
+
+@pytest.mark.parametrize("deleted", [0, 1])
+def test_unseeded_replay_at_exact_hour_boundary(deleted):
+    engine = pytest.importorskip("chdb")
+    next_hour = START.replace(hour=13, minute=0)
+    sql = query(
+        7,
+        {"start_time": next_hour, "is_deleted": deleted},
+        window_start=next_hour,
+        window_end=next_hour + timedelta(microseconds=1),
+    )
+    rows = [
+        json.loads(line)
+        for line in str(engine.query(sql, "JSONEachRow")).splitlines()
+        if line
+    ]
+    assert len(rows) == (0 if deleted else 1)
+    if rows:
+        assert rows[0]["total_cost"] == 1.25

--- a/scripts/qa/replay_observe_queries_readonly.py
+++ b/scripts/qa/replay_observe_queries_readonly.py
@@ -138,6 +138,8 @@ def qualification_summary(plan, rows, fingerprint):
     """Account for the entire plan, not just successful or selected requests.
 
     First-page identity checks do not prove full rows, pagination or UI.
+    Empty lists do not prove positive-data coverage; graph buckets do not
+    establish that any source records matched the filter.
     Old-source results and duplicate attempts are never additional coverage.
     """
     current, historical = {}, 0
@@ -202,6 +204,14 @@ def qualification_summary(plan, rows, fingerprint):
             # No real typed seed/request must not disappear as zero coverage.
             op_keys.add("BLOCKED_OR_UNRESOLVED/" + case.get("variant", "UNKNOWN"))
         counters += [operators[key] for key in op_keys]
+        list_result_kind = None
+        if (row and case["surface"] in replay.LISTS
+                and status == "COMPLETE_UNVERIFIED" and row.get("complete") is True):
+            cardinality = row.get("result_rows")
+            list_result_kind = (
+                "rows_unknown" if type(cardinality) is not int or cardinality < 0
+                else "nonempty" if cardinality > 0 else "empty"
+            )
         for counts in counters:
             counts["planned"] += 1
             counts[status] += 1
@@ -214,6 +224,11 @@ def qualification_summary(plan, rows, fingerprint):
                     counts["identity_order_verified"] += 1
                 elif reference.get("status") == "ID_ORDER_MISMATCH":
                     counts["identity_order_mismatch"] += 1
+                if list_result_kind:
+                    counts[f"list_complete_{list_result_kind}"] += 1
+                    if (list_result_kind != "rows_unknown"
+                            and reference.get("status") == "ID_ORDER_MATCH"):
+                        counts[f"list_identity_order_verified_{list_result_kind}"] += 1
     return {
         "plan_id": plan["plan_id"],
         "source_sha256": fingerprint,
@@ -354,11 +369,25 @@ def diagnostic_read_settings(
     return limits
 
 
-_USERS_ORIGIN_SHA = "20d339691652b7d0120ae3b6b8d1dfaf2a859c778688f19cce0e74e66e944f1f"
+# Reviewed first-page SQL shapes, not a blanket exemption for Users queries.
+# Keep each run bound to its exact selected shape and parameters below.
+_USERS_ORIGIN_SHAS = frozenset({
+    # Direct immutable-hour replay for unseeded Users, with 48 native latest
+    # state/window cases. Seeded shapes below differ only in whitespace from
+    # their original reviewed shapes; candidate membership is unchanged.
+    "ba51ea62b5e2f3831b6d9d1e4ab345283c068af90f1795bb7b7082526cd4d4e5",  # direct unseeded
+    "7b8c40bf16c6d1a869f19c75d26304d755298c7016ac451233958599369f3f51",  # text equality
+    "40aca43c4986c4b67e5d8b99ae753c347c7101d29735d7edf9f3de139ef97c95",  # string picker
+    "6c104d494f91458151c8e8ac48000b655c2535f31a34bb6e13642cf4ee2badd5",  # numeric witness
+    "47bc881ae53416886c98e29bbfe7ad3c76ac1f5be2e85c28580453da25a80278",  # numeric > witness
+    "2d41d1e3c331f81153c381c9b749e63aceeeac7ed7cb3d02da98bdda51951533",  # no scalar witness
+    "b7d8c12ae5adefc8e9776a4241fd77139d6f80407a002c6a292b32ab730397a4",  # ordinary text equality
+    "84c58fe4e006998b9f7d09a3cff2ea62f4209ffa724528b6cf6ae9978ef31fb0",  # single string picker
+})
 _USERS_REMAP_SHA = "090df268267944b22e713077c59d4836e4046fadb60bfbb78116f3a43af46676"
 _USERS_SOURCE_PINS = {
     "tracer.services.users_list_manager": "b5da3657a94ab71710a8db384990e018269929e80c2f651cf8a25b02df3eb831",
-    "tracer.services.clickhouse.query_builders.user_list": "97c47542622bb599cb003d2e7c5dfcc6bcba0989aaef41e8c3461ed6d6435ba8",
+    "tracer.services.clickhouse.query_builders.user_list": "6d6f39cd0f5f65a0a71056e9006727113d5f4fa0da38131f67b3814831039093",
     "tracer.services.clickhouse.v2.query_builders.user_list": "d5024fe5a46b7cbdf2621d04dfd02027c17816f7250f84120c920a0dd3c9908e",
     "tracer.services.clickhouse.v2.id_remap_sql": "56903f382c0f8dc40099e5ebfda45a8ab853c0b8f7ec16b5712f9c11092fe24a",
 }
@@ -387,6 +416,8 @@ class _UsersRemapContext:
     authorized_projects: tuple[str, ...]
     origin_bindings: str
     binding: str
+    origin_sql_sha256: str
+    origin_row_limit: int
 
 
 @dataclass(frozen=True)
@@ -433,6 +464,7 @@ class ReadOnlyExecutor:
         return max(0, int((self.deadline - time.monotonic()) * 1000))
 
     def _configure_users_remap(self, manager, case, scope, plan_id):
+        from tracer.services import users_list_manager as users
         from tracer.services.clickhouse.v2.query_builders.user_list import UserListQueryBuilderV2
 
         self._users_context = self._users_certificate = None
@@ -450,22 +482,31 @@ class ReadOnlyExecutor:
                 or tuple(manager.scoped_project_ids) != projects
                 or not projects or len(set(projects)) != len(projects)
                 or not set(projects) <= set(self.projects)
+                or manager._attribute_witness_disabled
                 or replay.digest(safe_json(manager.filters)) != replay.digest(safe_json(normalize_filters(request)))
                 or not _users_sources_current()):
             raise replay.ReplayError("USERS_REMAP_CONTEXT_NOT_QUALIFIED")
         builder = UserListQueryBuilderV2(organization_id=manager.organization_id,
                                        project_ids=list(projects), filters=manager.filters,
                                        search=manager.search, empty_scope=manager.empty_scope)
+        # Mirror only the reviewed manager's initial batch, including lookahead.
+        # This finite identity bound is separate from the unchanged query caps.
+        origin_limit = 1 + (users.USER_LIST_ATTRIBUTE_WITNESS_BATCH_SIZE
+                            if manager.attribute_exact_text_filters
+                            else users.USER_LIST_CANDIDATE_BATCH_SIZE)
         sql, bindings = builder.build_dimension_candidate_query(
-            limit=26, window_start=replay.utc(case["window"]["start"]),
+            limit=origin_limit, window_start=replay.utc(case["window"]["start"]),
             window_end=replay.utc(case["window"]["end"]),
         )
-        if hashlib.sha256(sql.strip().rstrip(";").encode()).hexdigest() != _USERS_ORIGIN_SHA:
+        origin_sha = hashlib.sha256(sql.strip().rstrip(";").encode()).hexdigest()
+        if origin_sha not in _USERS_ORIGIN_SHAS:
             raise replay.ReplayError("USERS_REMAP_ORIGIN_NOT_QUALIFIED")
         self._users_context = _UsersRemapContext(
             tuple(_user_uuid(p) for p in projects), tuple(map(str, self.projects)),
             replay.digest(safe_json(bindings)),
             replay.digest({"case": case, "scope": scope, "plan_id": plan_id, "projects": projects}),
+            origin_sha,
+            origin_limit,
         )
         self._users_origin_expected = True
 
@@ -483,7 +524,8 @@ class ReadOnlyExecutor:
 
     def _users_result(self, result, *, origin, certificate, query_id):
         if origin:
-            if (result.row_count != len(result.data) or result.row_count > 26
+            if (result.row_count != len(result.data)
+                    or result.row_count > self._users_context.origin_row_limit
                     or len(result.columns) != len(set(result.columns))):
                 raise replay.ReplayError("USERS_REMAP_ORIGIN_RESULT_INVALID")
             try:
@@ -528,7 +570,7 @@ class ReadOnlyExecutor:
                 raise
             self._validate_users_remap(query, params, pending)
             sql, certified = query, pending
-        if origin and (hashlib.sha256(sql.encode()).hexdigest() != _USERS_ORIGIN_SHA
+        if origin and (hashlib.sha256(sql.encode()).hexdigest() != self._users_context.origin_sql_sha256
                        or replay.digest(safe_json(params)) != self._users_context.origin_bindings):
             raise replay.ReplayError("USERS_REMAP_ORIGIN_BINDINGS_CHANGED")
         remaining = self.remaining_read_ms()
@@ -563,7 +605,7 @@ class ReadOnlyExecutor:
             record["scope_certificate"] = {
                 "kind": "finite_users_remap_certificate.v1",
                 "origin_query_id": certified.origin_query_id,
-                "origin_sql_sha256": _USERS_ORIGIN_SHA,
+                "origin_sql_sha256": certified.context.origin_sql_sha256,
                 "source_sha256": replay.digest(_USERS_SOURCE_PINS),
                 "scope_binding_sha256": certified.context.binding,
                 "candidate_count": len(certified.ids), "candidate_ids_sha256": replay.digest(certified.ids),

--- a/scripts/qa/test_replay_observe_queries_readonly.py
+++ b/scripts/qa/test_replay_observe_queries_readonly.py
@@ -245,7 +245,9 @@ class UsersRemapCertificateTests(unittest.TestCase):
         project, user, foreign = (str(UUID(int=i)) for i in (1, 2, 3))
         reader = object.__new__(queries.ReadOnlyExecutor)
         reader.client, reader._users_certificate = object(), None
-        reader._users_context = queries._UsersRemapContext((project,), (project,), "bindings", "scope")
+        reader._users_context = queries._UsersRemapContext(
+            (project,), (project,), "bindings", "scope", "reviewed-origin-hash", 26
+        )
         origin = SimpleNamespace(row_count=1, columns=["end_user_id", "project_id"],
                                  data=[{"end_user_id": user, "project_id": project}])
         reader._users_result(origin, origin=True, certificate=None, query_id="actual-origin")
@@ -924,6 +926,41 @@ class OutcomeTests(unittest.TestCase):
             queries.qualification_summary(
                 {"plan_id": "other", "cases": cases}, rows, "current"
             )
+
+    def test_empty_list_or_bucket_results_cannot_prove_positive_list_coverage(self):
+        examples = [
+            ("traces", True, 25, "COMPLETE_UNVERIFIED"),
+            ("sessions", True, 0, "COMPLETE_UNVERIFIED"),
+            ("users_project", True, None, "COMPLETE_UNVERIFIED"),
+            ("traces", True, True, "COMPLETE_UNVERIFIED"),
+            ("traces", False, 25, "INCOMPLETE"),
+            ("traces", True, 25, "INEXACT"),
+            ("trace_graph", True, 365, "COMPLETE_UNVERIFIED"),
+        ]
+        cases, rows = [], []
+        for i, (surface, complete, count, status) in enumerate(examples):
+            cases.append({"id": str(i), "surface": surface, "period": "7D",
+                          "attributes": ["field"], "blocked": None})
+            rows.append({"case_id": str(i), "plan_id": "plan",
+                         "source_sha256": "current", "complete": complete,
+                         "result_rows": count, "status": status, "latency_met": True,
+                         "independent_reference": {"status": "ID_ORDER_MATCH"}})
+        plan = {"plan_id": "plan", "cases": cases}
+        summary = queries.qualification_summary(plan, rows, "current")
+        for counts in (summary["totals"], summary["by_attribute"]["field"]):
+            self.assertEqual(counts["list_complete_nonempty"], 1)
+            self.assertEqual(counts["list_complete_empty"], 1)
+            self.assertEqual(counts["list_complete_rows_unknown"], 2)
+            self.assertEqual(counts["list_identity_order_verified_nonempty"], 1)
+            self.assertEqual(counts["list_identity_order_verified_empty"], 1)
+        self.assertNotIn("list_complete_nonempty", summary["by_surface_period"]["trace_graph/7D"])
+        # A later failed attempt supersedes a prior positive match; attempts
+        # are not additional case coverage, and stale source rows do not count.
+        rows += [{**rows[0], "status": "ERROR", "complete": False},
+                 {**rows[0], "source_sha256": "old"}]
+        summary = queries.qualification_summary(plan, rows, "current")
+        self.assertEqual(summary["totals"].get("list_complete_nonempty", 0), 0)
+        self.assertEqual(summary["qualification"], "NOT_QUALIFIED")
 
     def test_completed_identity_mismatch_is_visible_even_if_fast(self):
         plan = {


### PR DESCRIPTION
Unseeded Users acquisition repeated physical-identity discovery before latest-state aggregation. Prune by immutable storage hours while retaining exact winner-time and live-membership checks; keep finite seeded replay intact. Update the read-only QA certificates for the reviewed query shapes without loosening their memory, time or scan guards.

Validation: prior native hour-boundary, replacement and typed conjunction tests passed; the reviewed QA guard suite passed 86 tests. Stacked files match the tested working files.

Production Users latency is unresolved: a guarded acquisition still hit its 30s diagnostic limit. Do not interpret the local fixture improvement as a production speed qualification.

The validation above is retained evidence from before this stack reorder. Runtime changes are preserved; CI for the restacked head is pending.

Stack position 3/6. Base: `fix/TH-7247-review-01-trace-reads`. Review and merge in the order below; retarget and recheck each descendant after its parent merges.

AI-assisted implementation. Backend/E2E CI does not run against child PR bases; reported local tests are not deployed performance qualification.

Review order:
1. [fix: [1/6] Fix cancelled grid reads and cursor continuation [agent]](https://github.com/future-agi/future-agi/pull/2640)
2. [fix: [2/6] Preserve latest physical state in Trace reads [agent]](https://github.com/future-agi/future-agi/pull/2637)
3. [fix: [3/6] Reduce exact Users replay work [agent]](https://github.com/future-agi/future-agi/pull/2638)
4. [fix: [4/6] Use complete exact graph snapshots [agent]](https://github.com/future-agi/future-agi/pull/2639)
5. [fix: [5/6] Preserve dashboard previews while exact reads finish [agent]](https://github.com/future-agi/future-agi/pull/2641)
6. [test: [6/6] Add read-only Voice replay coverage [agent]](https://github.com/future-agi/future-agi/pull/2642)

[#2643](https://github.com/future-agi/future-agi/pull/2643) is independent and targets `dev`.
