### PR TITLE
fix: [4/6] Use complete exact graph snapshots [agent]

### DIFF
--- a/frontend/src/sections/projects/LLMTracing/GraphSection/GraphSection.jsx
+++ b/frontend/src/sections/projects/LLMTracing/GraphSection/GraphSection.jsx
@@ -34,7 +34,6 @@ import { FILTER_FOR_HAS_EVAL, toBackendFilters } from "../common";
 import { buildDefaultDateEntry } from "./graphFilterUtils";
 import {
   AGGREGATION_POLLING_PAUSED_MESSAGE,
-  AGGREGATION_REQUEST_TIMEOUT_MS,
   GRAPH_LOADING_MESSAGE,
   QUERY_FAILED_RETRY_MESSAGE,
   createAggregationPollController,
@@ -211,20 +210,15 @@ const GraphSection = ({
         setAggregationPollingPaused(false);
       }
 
-      // Start the action clock before the first HTTP read. Pending-response
-      // polling consumes this same sub-ten-second budget; an explicit Refresh
-      // resets it through resetAggregationBudget().
+      // Bound polling of pending responses separately. A valid exact HTTP
+      // read may finish later; scope changes and unmount still cancel it.
       pollingControllerRef.current.start();
       pollingControllerRef.current.recordAttempt();
       const generation = requestGenerationRef.current;
       return awaitAggregationRequestWithDeadline(request, {
-        timeoutMs: pollingControllerRef.current.remainingMs(
-          AGGREGATION_REQUEST_TIMEOUT_MS,
-        ),
+        timeoutMs: Infinity,
         signal,
         isCurrent: () => generation === requestGenerationRef.current,
-        onTimeout: () =>
-          pollingControllerRef.current.terminate("action_deadline"),
       });
     },
     [],

--- a/frontend/src/sections/projects/LLMTracing/GraphSection/PrimaryGraph.jsx
+++ b/frontend/src/sections/projects/LLMTracing/GraphSection/PrimaryGraph.jsx
@@ -57,7 +57,6 @@ import { toBackendFilters } from "../common";
 import { combineGraphFilters } from "./graphFilterUtils";
 import {
   AGGREGATION_POLLING_PAUSED_MESSAGE,
-  AGGREGATION_REQUEST_TIMEOUT_MS,
   GRAPH_LOADING_MESSAGE,
   QUERY_FAILED_RETRY_MESSAGE,
   createAggregationPollController,
@@ -595,19 +594,15 @@ const PrimaryGraph = ({
         setAggregationPollingPaused(false);
       }
 
-      // The first HTTP read and any pending-response polls share one visible
-      // action wall. The user-facing Refresh path resets this controller.
+      // Bound polling of pending responses separately. A valid exact HTTP
+      // read may finish later; scope changes and unmount still cancel it.
       pollingControllerRef.current.start();
       pollingControllerRef.current.recordAttempt();
       const generation = requestGenerationRef.current;
       return awaitAggregationRequestWithDeadline(request, {
-        timeoutMs: pollingControllerRef.current.remainingMs(
-          AGGREGATION_REQUEST_TIMEOUT_MS,
-        ),
+        timeoutMs: Infinity,
         signal,
         isCurrent: () => generation === requestGenerationRef.current,
-        onTimeout: () =>
-          pollingControllerRef.current.terminate("action_deadline"),
       });
     },
     [],

--- a/frontend/src/sections/projects/LLMTracing/GraphSection/__tests__/GraphSection.test.jsx
+++ b/frontend/src/sections/projects/LLMTracing/GraphSection/__tests__/GraphSection.test.jsx
@@ -6,7 +6,6 @@ import axios from "src/utils/axios";
 import {
   AGGREGATION_POLL_MAX_ATTEMPTS,
   AGGREGATION_POLLING_PAUSED_MESSAGE,
-  AGGREGATION_REQUEST_TIMEOUT_MS,
   GRAPH_LOADING_MESSAGE,
   QUERY_FAILED_RETRY_MESSAGE,
 } from "src/utils/queryReadState";
@@ -583,7 +582,7 @@ describe("GraphSection exact graph boundary", () => {
     },
   );
 
-  it("bounds a never-resolving transport, ignores its late response, and restarts on refresh", async () => {
+  it("accepts a slow exact read and supports a later explicit refresh", async () => {
     vi.useFakeTimers();
     let resolveLateRequest;
     axios.post.mockImplementationOnce(
@@ -604,11 +603,11 @@ describe("GraphSection exact graph boundary", () => {
     ).not.toBeInTheDocument();
 
     await act(async () =>
-      vi.advanceTimersByTimeAsync(AGGREGATION_REQUEST_TIMEOUT_MS),
+      vi.advanceTimersByTimeAsync(120_000),
     );
     expect(
-      screen.getByText("We couldn't load this data. Please retry in a moment."),
-    ).toBeInTheDocument();
+      screen.queryByText("We couldn't load this data. Please retry in a moment."),
+    ).not.toBeInTheDocument();
     expect(axios.post).toHaveBeenCalledOnce();
 
     resolveLateRequest({
@@ -629,7 +628,7 @@ describe("GraphSection exact graph boundary", () => {
       },
     });
     await act(async () => vi.advanceTimersByTimeAsync(0));
-    expect(screen.queryByTestId("apex-chart")).not.toBeInTheDocument();
+    expect(screen.getByTestId("apex-chart")).toHaveAttribute("data-primary-first-y", "999");
 
     axios.post.mockResolvedValueOnce({
       data: {

--- a/frontend/src/sections/projects/LLMTracing/GraphSection/__tests__/PrimaryGraph.test.jsx
+++ b/frontend/src/sections/projects/LLMTracing/GraphSection/__tests__/PrimaryGraph.test.jsx
@@ -6,7 +6,6 @@ import axios from "src/utils/axios";
 import {
   AGGREGATION_POLL_MAX_ATTEMPTS,
   AGGREGATION_POLLING_PAUSED_MESSAGE,
-  AGGREGATION_REQUEST_TIMEOUT_MS,
   GRAPH_LOADING_MESSAGE,
   QUERY_FAILED_RETRY_MESSAGE,
 } from "src/utils/queryReadState";
@@ -1141,7 +1140,7 @@ describe("PrimaryGraph", () => {
     );
   });
 
-  it("bounds a never-resolving refresh, preserves exact data, and ignores its late response", async () => {
+  it("preserves exact data during a slow refresh and accepts its complete response", async () => {
     vi.useFakeTimers();
     const exactResponse = {
       data: {
@@ -1186,15 +1185,15 @@ describe("PrimaryGraph", () => {
     expect(screen.getByTestId("apex-chart")).toBeInTheDocument();
 
     await act(async () =>
-      vi.advanceTimersByTimeAsync(AGGREGATION_REQUEST_TIMEOUT_MS),
+      vi.advanceTimersByTimeAsync(120_000),
     );
     expect(screen.getByTestId("apex-chart")).toBeInTheDocument();
     expect(
-      screen.getByText("We couldn't load this data. Please retry in a moment."),
-    ).toBeInTheDocument();
-    const boundedRequestCount = axios.post.mock.calls.length;
-    expect(boundedRequestCount).toBe(2);
-    expect(refreshSignal.aborted).toBe(true);
+      screen.queryByText("We couldn't load this data. Please retry in a moment."),
+    ).not.toBeInTheDocument();
+    const requestCount = axios.post.mock.calls.length;
+    expect(requestCount).toBe(2);
+    expect(refreshSignal.aborted).toBe(false);
 
     resolveLateRefresh({
       data: {
@@ -1215,10 +1214,10 @@ describe("PrimaryGraph", () => {
     });
     await act(async () => vi.advanceTimersByTimeAsync(0));
 
-    expect(axios.post).toHaveBeenCalledTimes(boundedRequestCount);
+    expect(axios.post).toHaveBeenCalledTimes(requestCount);
     expect(screen.getByTestId("apex-chart")).toHaveAttribute(
       "data-primary-first-y",
-      "12",
+      "999",
     );
 
     axios.post.mockResolvedValueOnce({
@@ -1253,7 +1252,7 @@ describe("PrimaryGraph", () => {
     ).not.toBeInTheDocument();
   });
 
-  it("starts a fresh transport budget when the graph query changes", async () => {
+  it("cancels a slow read when the graph query changes", async () => {
     vi.useFakeTimers();
     axios.post.mockImplementationOnce(() => new Promise(() => {}));
     const queryClient = new QueryClient({
@@ -1270,11 +1269,13 @@ describe("PrimaryGraph", () => {
     await act(async () => vi.advanceTimersByTimeAsync(10));
 
     await act(async () =>
-      vi.advanceTimersByTimeAsync(AGGREGATION_REQUEST_TIMEOUT_MS),
+      vi.advanceTimersByTimeAsync(120_000),
     );
     expect(
-      screen.getByText("We couldn't load this data. Please retry in a moment."),
-    ).toBeInTheDocument();
+      screen.queryByText("We couldn't load this data. Please retry in a moment."),
+    ).not.toBeInTheDocument();
+    const oldSignal = axios.post.mock.calls[0][2].signal;
+    expect(oldSignal.aborted).toBe(false);
 
     axios.post.mockResolvedValueOnce({
       data: {
@@ -1304,6 +1305,7 @@ describe("PrimaryGraph", () => {
     await act(async () => vi.advanceTimersByTimeAsync(10));
 
     expect(axios.post).toHaveBeenCalledTimes(2);
+    expect(oldSignal.aborted).toBe(true);
     expect(screen.getByTestId("apex-chart")).toHaveAttribute(
       "data-primary-first-y",
       "36",

--- a/futureagi/tracer/services/clickhouse/exact_graph_reads.py
+++ b/futureagi/tracer/services/clickhouse/exact_graph_reads.py
@@ -19,6 +19,7 @@ import json
 from collections import defaultdict
 from collections.abc import Callable
 from concurrent.futures import ThreadPoolExecutor, as_completed
+from contextvars import copy_context
 from copy import deepcopy
 from dataclasses import dataclass
 from datetime import datetime, timedelta
@@ -36,6 +37,7 @@ from model_hub.models.choices import AnnotationTypeChoices
 from model_hub.models.score import Score
 from tracer.models.custom_eval_config import CustomEvalConfig
 from tracer.services.annotation_label_source import AnnotationScoreReadUnavailable
+from tracer.services.clickhouse.application_read_policy import is_application_read
 from tracer.services.clickhouse.eval_logger_table import eval_logger_source
 from tracer.services.clickhouse.query_builders import TimeSeriesQueryBuilder
 from tracer.services.clickhouse.query_builders.agent_graph import (
@@ -407,7 +409,7 @@ def _metadata(
     rows_returned: int,
 ) -> dict[str, Any]:
     elapsed_ms = max(monotonic() - started, 0.0) * 1000
-    if elapsed_ms >= EXACT_GRAPH_QUERY_TIMEOUT_MS:
+    if not is_application_read() and elapsed_ms >= EXACT_GRAPH_QUERY_TIMEOUT_MS:
         raise ExactGraphReadError("exact graph refresh deadline exceeded")
     metadata = {
         "query_complete": True,
@@ -424,13 +426,19 @@ def _remaining_exact_graph_timeout_ms(
     started: float,
     statement_ceiling_ms: int | None = None,
 ) -> int:
-    """Return the time left on one authoritative exact-refresh wall.
+    """Keep a shared wall for diagnostics and a compatibility hint for app reads.
 
-    Background readers do builder, relation, database, formatting, and
-    publication work under one reviewed graph budget. A later statement may
-    consume only the remaining portion; it never receives a fresh
-    per-statement grant.
+    Application query services ignore the timeout hint. Their complete results
+    must remain publishable regardless of elapsed builder or database time.
     """
+    if statement_ceiling_ms is not None and statement_ceiling_ms <= 0:
+        raise ValueError("exact graph statement timeout must be positive")
+    if is_application_read():
+        return int(
+            EXACT_GRAPH_QUERY_TIMEOUT_MS
+            if statement_ceiling_ms is None
+            else statement_ceiling_ms
+        )
 
     elapsed_ms = max(monotonic() - started, 0.0) * 1000
     # Floor the remaining duration, rather than subtracting a floored elapsed
@@ -440,8 +448,6 @@ def _remaining_exact_graph_timeout_ms(
         raise ExactGraphReadError("exact graph refresh bounded deadline exceeded")
     if statement_ceiling_ms is None:
         return remaining_ms
-    if statement_ceiling_ms <= 0:
-        raise ValueError("exact graph statement timeout must be positive")
     return min(int(statement_ceiling_ms), remaining_ms)
 
 
@@ -837,6 +843,7 @@ def _enumerate_authoritative_anchor_trace_ids(
         ) as executor:
             futures = [
                 executor.submit(
+                    copy_context().run,
                     scan_adaptive_lane,
                     lane_start,
                     lane_end,
@@ -1004,6 +1011,7 @@ def _enumerate_authoritative_anchor_trace_ids(
             ) as executor:
                 futures = [
                     executor.submit(
+                        copy_context().run,
                         scan_adaptive_lane,
                         lane_start,
                         lane_end,

--- a/futureagi/tracer/services/clickhouse/graph_action_deadline.py
+++ b/futureagi/tracer/services/clickhouse/graph_action_deadline.py
@@ -1,4 +1,4 @@
-"""One request-owned wall deadline for latency-critical Observe graph actions."""
+"""Application graph admission and explicit diagnostic deadline handling."""
 
 from __future__ import annotations
 
@@ -26,10 +26,23 @@ class GraphActionUnavailable(RuntimeError):
     """A graph action exhausted its wall or could not complete a read."""
 
 
-def start_graph_action_deadline() -> ReadDeadline:
-    """Start the single wall clock before any graph-action database read."""
+class ApplicationGraphReadDeadline(ReadDeadline):
+    """Track elapsed time without rejecting an application graph request.
 
-    return ReadDeadline.start(GRAPH_ACTION_WALL_DEADLINE_MS)
+    Legacy call sites require a positive timeout argument. Return that hint
+    without subtracting elapsed time; application transports own their read
+    policy and do not enforce this diagnostic compatibility value.
+    """
+
+    def remaining_ms(self, cap_ms: int | None = None, *, floor_ms: int = 25) -> int:
+        if cap_ms is not None and cap_ms <= 0:
+            raise ValueError("read timeout cap must be positive")
+        return self.total_ms if cap_ms is None else int(cap_ms)
+
+
+def start_graph_action_deadline() -> ReadDeadline:
+    """Start elapsed-time tracking without an application admission cutoff."""
+    return ApplicationGraphReadDeadline.start(GRAPH_ACTION_WALL_DEADLINE_MS)
 
 
 def graph_action_remaining_ms(
@@ -38,7 +51,7 @@ def graph_action_remaining_ms(
     *,
     floor_ms: int = 1,
 ) -> int:
-    """Return only the action's remaining wall, mapped to its public boundary."""
+    """Resolve an application compatibility hint or a diagnostic remaining wall."""
 
     try:
         return deadline.remaining_ms(cap_ms, floor_ms=floor_ms)
@@ -56,7 +69,7 @@ def bounded_graph_action_request(
     *,
     resource: str,
 ) -> Callable[[Callable[..., Any]], Callable[..., Any]]:
-    """Start the graph wall before validation and finish after validation."""
+    """Track the graph request across validation and preserve its response."""
 
     def decorate(view_method):
         @wraps(view_method)

--- a/futureagi/tracer/services/clickhouse/graph_dispatch.py
+++ b/futureagi/tracer/services/clickhouse/graph_dispatch.py
@@ -25,12 +25,7 @@ from tracer.services.clickhouse.bounded_graph_reads import (
 )
 from tracer.services.clickhouse.eval_logger_table import eval_logger_source
 from tracer.services.clickhouse.exact_graph_reads import (
-    ExactGraphReadError,
     _annotation_label_ids_for_filters,
-    read_exact_all_system_metrics,
-    read_exact_annotation_graph,
-    read_exact_eval_graph,
-    read_exact_user_system_graph,
 )
 from tracer.services.clickhouse.query_builders import (
     TimeSeriesQueryBuilder,
@@ -1355,139 +1350,42 @@ def fetch_system_metric_graph_ch(
     organization_id: str | None = None,
     workspace_id: str | None = None,
 ) -> dict[str, Any]:
-    """Read an unfiltered rollup or an exact synchronous filtered graph."""
+    """Read or schedule a complete latest-state Trace/Span graph snapshot."""
 
     project_id = _validated_project_id(project_id)
     filters = list(filters or [])
     normalized_observe_type = str(observe_type or "trace").strip().lower()
     if normalized_observe_type not in {"trace", "span"}:
         raise ValueError("observe_type must be trace or span")
-    if not _active_filters(filters):
-        if not bool(getattr(analytics, "supports_per_query_read_settings", True)):
-            return degraded_graph_response(
-                str(metric_id or ""),
-                BoundedGraphReadError("query_failed", retryable=True),
-                provenance="server_read_policy_unavailable",
-            )
-        return _fetch_rollup_system_metric_graph(
-            analytics=analytics,
-            project_id=project_id,
-            filters=filters,
-            interval=interval,
-            metric_id=str(metric_id or ""),
-            observe_type=normalized_observe_type,
-            timeout_ms=timeout_ms,
-        )
+    if int(timeout_ms) <= 0:
+        raise ValueError("graph timeout must be positive")
     bounded_time_range = BaseQueryBuilder.analyze_bounded_datetime_filters(
-        filters,
-        strict=True,
+        filters, strict=True,
     )
     if bounded_time_range.empty:
+        # An empty interval is provably exact and requires no database read.
         return _fetch_direct_raw_system_metric_graph(
-            analytics=analytics,
-            project_id=project_id,
-            filters=filters,
-            interval=interval,
-            metric_id=str(metric_id or ""),
-            observe_type=normalized_observe_type,
-            timeout_ms=timeout_ms,
+            analytics=analytics, project_id=project_id, filters=filters,
+            interval=interval, metric_id=str(metric_id or ""),
+            observe_type=normalized_observe_type, timeout_ms=timeout_ms,
         )
-    # Observe charts are interactive. Compile all filters into one raw physical
-    # spans scan and fold trace membership in ClickHouse, instead of running the
-    # serial candidate/classifier/replay reader. A cache-only probe prevents a
-    # running heavy refresh from being duplicated by every browser poll. True
-    # cold misses still try the direct path first; only a proven read-budget
-    # failure is handed to the existing deduplicated background worker.
-    identity = {
-        "project_id": project_id,
-        "filters": filters,
-        "interval": interval,
-        "metric_id": str(metric_id or ""),
-        "observe_type": normalized_observe_type,
-    }
-    pending_payload = _pending_graph_payload(str(metric_id or ""))
-    cached = _read_or_refresh_exact_graph(
+    return _read_or_refresh_exact_graph(
         namespace="observe-system-graph",
-        identity=dict(identity),
-        refresh=False,
-        pending_payload=pending_payload,
+        identity={
+            "project_id": project_id,
+            "filters": filters,
+            "interval": interval,
+            "metric_id": str(metric_id or ""),
+            "observe_type": normalized_observe_type,
+            # Older snapshots counted raw physical versions. They must never
+            # satisfy a latest-state request, including during refresh.
+            "payload_version": 2,
+        },
+        refresh=bool(refresh),
+        pending_payload=_pending_graph_payload(str(metric_id or "")),
         organization_id=organization_id,
         workspace_id=workspace_id,
-        schedule_on_miss=False,
     )
-    if (
-        isinstance(cached, dict)
-        and cached.get("query_status") == "complete"
-        and graph_payload_is_publishable(cached, allow_sampled=False)
-    ):
-        if refresh and organization_id:
-            return _read_or_refresh_exact_graph(
-                namespace="observe-system-graph",
-                identity=dict(identity),
-                refresh=True,
-                pending_payload=pending_payload,
-                organization_id=organization_id,
-                workspace_id=workspace_id,
-            )
-        return cached
-    if isinstance(cached, dict) and cached.get("query_refreshing") is True:
-        return cached
-    if refresh and organization_id:
-        return _read_or_refresh_exact_graph(
-            namespace="observe-system-graph",
-            identity=dict(identity),
-            refresh=True,
-            pending_payload=pending_payload,
-            organization_id=organization_id,
-            workspace_id=workspace_id,
-        )
-
-    interactive_deadline_ms = min(
-        int(timeout_ms),
-        GRAPH_INTERACTIVE_QUERY_TIMEOUT_MS,
-    )
-    if interactive_deadline_ms <= 0:
-        raise ValueError("graph timeout must be positive")
-    bounded_analytics = _DeadlineBoundGraphAnalytics(
-        analytics,
-        ReadDeadline.start(interactive_deadline_ms),
-    )
-    try:
-        response = _fetch_direct_raw_system_metric_graph(
-            analytics=bounded_analytics,
-            project_id=project_id,
-            filters=filters,
-            interval=interval,
-            metric_id=str(metric_id or ""),
-            observe_type=normalized_observe_type,
-            timeout_ms=interactive_deadline_ms,
-        )
-        return response
-    except ExactGraphReadError as exc:
-        degraded = degraded_graph_response(
-            str(metric_id or ""), exc, provenance="bounded_candidates"
-        )
-    except Exception as exc:
-        if not (is_read_budget_error(exc) or is_clickhouse_query_error(exc)):
-            raise
-        degraded = degraded_graph_response(
-            str(metric_id or ""), exc, provenance="bounded_candidates"
-        )
-    if organization_id:
-        try:
-            return _read_or_refresh_exact_graph(
-                namespace="observe-system-graph",
-                identity=dict(identity),
-                refresh=True,
-                pending_payload=pending_payload,
-                organization_id=organization_id,
-                workspace_id=workspace_id,
-            )
-        except Exception:
-            # The direct failure is already sanitized. Cache/worker transport
-            # availability must not turn it into a raw API exception.
-            return degraded
-    return degraded
 
 
 def fetch_agent_graph_ch(
@@ -1540,58 +1438,32 @@ def fetch_all_system_metrics_ch(
     organization_id: str | None = None,
     workspace_id: str | None = None,
 ) -> dict[str, Any]:
-    """Read the complete exact project-chart metric bundle synchronously."""
+    """Read or schedule the complete exact project-chart metric bundle."""
 
-    del refresh, organization_id, workspace_id
     project_id = _validated_project_id(project_id)
-    filters = list(filters or [])
-    interactive_deadline_ms = min(
-        int(timeout_ms),
-        GRAPH_INTERACTIVE_QUERY_TIMEOUT_MS,
-    )
-    if interactive_deadline_ms <= 0:
+    if int(timeout_ms) <= 0:
         raise ValueError("graph timeout must be positive")
-    bounded_analytics = _DeadlineBoundGraphAnalytics(
-        analytics,
-        ReadDeadline.start(interactive_deadline_ms),
-    )
-    try:
-        response = read_exact_all_system_metrics(
-            analytics=bounded_analytics,
-            project_id=project_id,
-            filters=filters,
-            interval=interval,
-        )
-        response.update(
-            {
-                "query_provenance": "exact_snapshot",
-                "query_exact": True,
-            }
-        )
-        return response
-    except ExactGraphReadError as exc:
-        degraded = degraded_graph_response(
-            "",
-            exc,
-            provenance="exact_snapshot",
-        )
-    except Exception as exc:
-        if not (is_read_budget_error(exc) or is_clickhouse_query_error(exc)):
-            raise
-        degraded = degraded_graph_response(
-            "",
-            exc,
-            provenance="exact_snapshot",
-        )
-    return {
-        **{
+    return _read_or_refresh_exact_graph(
+        namespace="observe-all-system-graphs",
+        identity={
+            "project_id": project_id,
+            "filters": list(filters or []),
+            "interval": interval,
+        },
+        refresh=bool(refresh),
+        pending_payload={
             "latency": [],
             "tokens": [],
             "cost": [],
             "traffic": [],
+            "query_complete": False,
+            "query_status": "pending",
+            "query_sampled": False,
+            "query_refreshing": True,
         },
-        **{key: value for key, value in degraded.items() if key.startswith("query_")},
-    }
+        organization_id=organization_id,
+        workspace_id=workspace_id,
+    )
 
 
 def fetch_user_system_metric_graph_ch(
@@ -1606,51 +1478,24 @@ def fetch_user_system_metric_graph_ch(
     organization_id: str | None = None,
     workspace_id: str | None = None,
 ) -> dict[str, Any]:
-    """Read one complete exact user-grain graph snapshot synchronously."""
-
-    del refresh, organization_id, workspace_id
+    """Return a complete snapshot or the state of its exact background refresh."""
     project_id = _validated_project_id(project_id)
-    filters = list(filters or [])
-    interactive_deadline_ms = min(
-        int(timeout_ms),
-        GRAPH_INTERACTIVE_QUERY_TIMEOUT_MS,
-    )
-    if interactive_deadline_ms <= 0:
+    if int(timeout_ms) <= 0:
         raise ValueError("graph timeout must be positive")
-    bounded_analytics = _DeadlineBoundGraphAnalytics(
-        analytics,
-        ReadDeadline.start(interactive_deadline_ms),
-    )
     normalized_metric_id = str(metric_id or "")
-    try:
-        response = read_exact_user_system_graph(
-            analytics=bounded_analytics,
-            project_id=project_id,
-            filters=filters,
-            interval=interval,
-            metric_id=normalized_metric_id,
-        )
-        response.update(
-            {
-                "query_provenance": "exact_snapshot",
-                "query_exact": True,
-            }
-        )
-        return enforce_exact_graph_data_contract(response)
-    except ExactGraphReadError as exc:
-        return degraded_graph_response(
-            normalized_metric_id,
-            exc,
-            provenance="exact_snapshot",
-        )
-    except Exception as exc:
-        if not (is_read_budget_error(exc) or is_clickhouse_query_error(exc)):
-            raise
-        return degraded_graph_response(
-            normalized_metric_id,
-            exc,
-            provenance="exact_snapshot",
-        )
+    return _read_or_refresh_exact_graph(
+        namespace="observe-user-system-graph",
+        identity={
+            "project_id": project_id,
+            "filters": list(filters or []),
+            "interval": interval,
+            "metric_id": normalized_metric_id,
+        },
+        refresh=bool(refresh),
+        pending_payload=_pending_graph_payload(normalized_metric_id),
+        organization_id=organization_id,
+        workspace_id=workspace_id,
+    )
 
 
 def normalize_eval_graph_output_type(req_data_config: dict[str, Any]) -> str:
@@ -1947,45 +1792,23 @@ def fetch_eval_graph_ch(
     normalized_aggregation_context = str(aggregation_context or "trace").strip().lower()
     if normalized_aggregation_context not in {"trace", "session", "user"}:
         raise ValueError("unsupported eval graph aggregation context")
-    del refresh, organization_id, workspace_id
-    interactive_deadline_ms = min(
-        int(timeout_ms),
-        GRAPH_INTERACTIVE_QUERY_TIMEOUT_MS,
-    )
-    if interactive_deadline_ms <= 0:
+    if int(timeout_ms) <= 0:
         raise ValueError("graph timeout must be positive")
-    bounded_analytics = _DeadlineBoundGraphAnalytics(
-        analytics,
-        ReadDeadline.start(interactive_deadline_ms),
+    return _read_or_refresh_exact_graph(
+        namespace="observe-eval-graph",
+        identity={
+            "project_id": project_id,
+            "filters": filters,
+            "interval": interval,
+            "req_data_config": dict(req_data_config),
+            "observe_type": normalized_observe_type,
+            "aggregation_context": normalized_aggregation_context,
+        },
+        refresh=bool(refresh),
+        pending_payload=_pending_graph_payload(str(req_data_config.get("id") or "")),
+        organization_id=organization_id,
+        workspace_id=workspace_id,
     )
-    try:
-        response = read_exact_eval_graph(
-            analytics=bounded_analytics,
-            project_id=project_id,
-            filters=filters,
-            interval=interval,
-            req_data_config=req_data_config,
-            observe_type=normalized_observe_type,
-            aggregation_context=normalized_aggregation_context,
-        )
-    except ExactGraphReadError as exc:
-        return degraded_graph_response(
-            str(req_data_config.get("id") or ""),
-            exc,
-            provenance="exact_snapshot",
-        )
-    except Exception as exc:
-        if not (is_read_budget_error(exc) or is_clickhouse_query_error(exc)):
-            raise
-        return degraded_graph_response(
-            str(req_data_config.get("id") or ""),
-            exc,
-            provenance="exact_snapshot",
-        )
-    if not isinstance(response, dict):
-        raise ExactGraphReadError("eval graph returned an invalid payload")
-    response.update({"query_provenance": "exact_snapshot", "query_exact": True})
-    return enforce_exact_graph_data_contract(response)
 
 
 def fetch_eval_chart_series_ch(
@@ -2256,35 +2079,23 @@ def fetch_annotation_graph_ch(
     normalized_aggregation_context = str(aggregation_context or "trace").strip().lower()
     if normalized_aggregation_context not in {"trace", "session", "user"}:
         raise ValueError("unsupported annotation graph aggregation context")
-    del refresh, organization_id, workspace_id
-    interactive_deadline_ms = min(
-        int(timeout_ms),
-        GRAPH_INTERACTIVE_QUERY_TIMEOUT_MS,
-    )
-    if interactive_deadline_ms <= 0:
+    if int(timeout_ms) <= 0:
         raise ValueError("graph timeout must be positive")
-    bounded_analytics = _DeadlineBoundGraphAnalytics(
-        analytics,
-        ReadDeadline.start(interactive_deadline_ms),
+    return _read_or_refresh_exact_graph(
+        namespace="observe-annotation-graph",
+        identity={
+            "project_id": project_id,
+            "filters": filters,
+            "interval": interval,
+            "req_data_config": dict(req_data_config),
+            "observe_type": normalized_observe_type,
+            "aggregation_context": normalized_aggregation_context,
+        },
+        refresh=bool(refresh),
+        pending_payload=_pending_graph_payload(str(req_data_config.get("id") or "")),
+        organization_id=organization_id,
+        workspace_id=workspace_id,
     )
-    try:
-        response = read_exact_annotation_graph(
-            analytics=bounded_analytics,
-            project_id=project_id,
-            filters=filters,
-            interval=interval,
-            req_data_config=req_data_config,
-            observe_type=normalized_observe_type,
-            aggregation_context=normalized_aggregation_context,
-        )
-    except ExactGraphReadError as exc:
-        return degraded_graph_response(label_id, exc, provenance="exact_snapshot")
-    except Exception as exc:
-        if not (is_read_budget_error(exc) or is_clickhouse_query_error(exc)):
-            raise
-        return degraded_graph_response(label_id, exc, provenance="exact_snapshot")
-    response.update({"query_provenance": "exact_snapshot", "query_exact": True})
-    return enforce_exact_graph_data_contract(response)
 
 
 __all__ = [

--- a/futureagi/tracer/services/clickhouse/session_graph.py
+++ b/futureagi/tracer/services/clickhouse/session_graph.py
@@ -705,7 +705,7 @@ def fetch_session_graph_ch(
     organization_id: str | None = None,
     workspace_id: str | None = None,
 ) -> dict[str, Any]:
-    """Dispatch rollups, bounded average-trace samples, or exact snapshots."""
+    """Dispatch all public Session graph metrics through exact snapshots."""
 
     if wall_deadline_ms <= 0:
         raise ValueError("session graph wall deadline must be positive")
@@ -716,54 +716,10 @@ def fetch_session_graph_ch(
     if metric_type == "SYSTEM_METRIC":
         if metric_id not in SESSION_SYSTEM_METRICS:
             raise ValueError("Unsupported session system metric")
-        if metric_id in _SESSION_ROLLUP_METRICS and _has_only_positive_window_filters(
-            filters
-        ):
-            if not bool(getattr(analytics, "supports_per_query_read_settings", True)):
-                return degraded_graph_response(
-                    metric_id,
-                    BoundedGraphReadError("query_failed", retryable=True),
-                    provenance="server_read_policy_unavailable",
-                )
-            started = monotonic()
-            deadline = ReadDeadline.start(
-                min(
-                    int(wall_deadline_ms),
-                    SESSION_GRAPH_INTERACTIVE_QUERY_TIMEOUT_MS,
-                )
-            )
-            return _fetch_rollup_system_metric_graph(
-                analytics=_DeadlineBoundAnalytics(analytics, deadline),
-                project_id=str(project_id),
-                filters=filters,
-                interval=interval,
-                metric_id=metric_id,
-                started=started,
-            )
-        if metric_id == "avg_traces_per_session" and _has_only_positive_window_filters(
-            filters
-        ):
-            started = monotonic()
-            deadline_ms = min(int(wall_deadline_ms), SESSION_GRAPH_WALL_DEADLINE_MS)
-            response = _fetch_system_metric_graph(
-                analytics=_DeadlineBoundAnalytics(
-                    analytics,
-                    ReadDeadline.start(deadline_ms),
-                ),
-                project_id=str(project_id),
-                filters=filters,
-                interval=interval,
-                metric_id=metric_id,
-                started=started,
-                deadline_ms=deadline_ms,
-            )
-            response.update(
-                {
-                    "query_exact": False,
-                    "query_provenance": "bounded_candidates",
-                }
-            )
-            return response
+        # Time-only requests require the same exact latest-session population
+        # as attribute-filtered requests. Rollups and bounded candidates cannot
+        # replace that population merely because no property leaf is present.
+        # The existing snapshot reader owns pending/cache/refresh behavior.
         identity = {
             "project_id": str(project_id),
             "filters": filters,

--- a/futureagi/tracer/tasks/exact_aggregation.py
+++ b/futureagi/tracer/tasks/exact_aggregation.py
@@ -17,6 +17,7 @@ from typing import Any
 import structlog
 
 from tfc.temporal import temporal_activity
+from tracer.services.clickhouse.application_read_policy import application_read_context
 from tracer.services.exact_aggregation_cache import (
     EXACT_AGGREGATION_ACTIVITY_TIMEOUT_SECONDS,
     EXACT_AGGREGATION_SCHEDULE_TO_START_TIMEOUT_SECONDS,
@@ -116,22 +117,18 @@ def _exact_observe_analytics() -> Iterator[Any]:
 
 
 def _observe_payload(namespace: str, identity: dict[str, Any]) -> Any:
-    from django.conf import settings
-
     from tracer.services.clickhouse.exact_graph_reads import (
         read_exact_agent_graph,
         read_exact_all_system_metrics,
         read_exact_annotation_graph,
         read_exact_eval_graph,
         read_exact_session_system_graph,
+        read_exact_system_graph,
         read_exact_user_system_graph,
-    )
-    from tracer.services.clickhouse.graph_dispatch import (
-        _fetch_direct_raw_system_metric_graph,
     )
 
     _reauthorize_exact_observe_project(identity)
-    with _exact_observe_analytics() as analytics:
+    with application_read_context(), _exact_observe_analytics() as analytics:
         if namespace == "observe-agent-graph":
             return read_exact_agent_graph(
                 analytics=analytics,
@@ -145,11 +142,10 @@ def _observe_payload(namespace: str, identity: dict[str, Any]) -> Any:
             "interval": str(identity["interval"]),
         }
         if namespace == "observe-system-graph":
-            return _fetch_direct_raw_system_metric_graph(
+            return read_exact_system_graph(
                 **common,
                 metric_id=str(identity.get("metric_id") or ""),
                 observe_type=str(identity.get("observe_type") or "trace"),
-                timeout_ms=int(settings.GRAPH_BACKGROUND_WALL_MS),
             )
         if namespace == "observe-all-system-graphs":
             return read_exact_all_system_metrics(**common)

--- a/futureagi/tracer/tests/test_bounded_graph_reads.py
+++ b/futureagi/tracer/tests/test_bounded_graph_reads.py
@@ -3731,12 +3731,6 @@ def test_public_graph_wrappers_use_exact_snapshot_without_inline_reads(
     ("fetch_name", "reader_name", "expected_exact", "expected_provenance"),
     [
         (
-            "fetch_system_metric_graph_ch",
-            "_fetch_direct_raw_system_metric_graph",
-            False,
-            "bounded_candidates",
-        ),
-        (
             "fetch_user_system_metric_graph_ch",
             "read_exact_user_system_graph",
             True,
@@ -3756,7 +3750,7 @@ def test_public_graph_wrappers_use_exact_snapshot_without_inline_reads(
         ),
     ],
 )
-def test_public_primary_graph_wrappers_use_inline_reads(
+def test_public_entity_and_decoration_graph_wrappers_use_exact_snapshots(
     monkeypatch,
     fetch_name,
     reader_name,
@@ -3765,19 +3759,15 @@ def test_public_primary_graph_wrappers_use_inline_reads(
 ):
     calls = []
 
-    def direct_reader(**kwargs):
-        calls.append(kwargs)
+    def snapshot(namespace, identity, **options):
+        calls.append(identity)
         return {
-            "metric_name": "metric",
-            "data": [],
-            "query_complete": True,
-            "query_status": "complete",
-            "query_sampled": False,
-            "query_exact": expected_exact,
+            "metric_name": "metric", "data": [],
+            "query_complete": True, "query_status": "complete",
+            "query_sampled": False, "query_exact": expected_exact,
             "query_provenance": expected_provenance,
         }
-
-    monkeypatch.setattr(graph_dispatch, reader_name, direct_reader)
+    monkeypatch.setattr(graph_dispatch, "read_or_schedule_exact_snapshot", snapshot)
     filters = [_date_filter(), _attribute_filter("final_status", "Rejected")]
     common = {
         "analytics": object(),
@@ -3785,13 +3775,7 @@ def test_public_primary_graph_wrappers_use_inline_reads(
         "filters": filters,
         "interval": "hour",
     }
-    if fetch_name == "fetch_system_metric_graph_ch":
-        response = graph_dispatch.fetch_system_metric_graph_ch(
-            **common,
-            metric_id="latency",
-            observe_type="trace",
-        )
-    elif fetch_name == "fetch_user_system_metric_graph_ch":
+    if fetch_name == "fetch_user_system_metric_graph_ch":
         response = graph_dispatch.fetch_user_system_metric_graph_ch(
             **common,
             metric_id="active_users",
@@ -3825,44 +3809,29 @@ def test_public_primary_graph_wrappers_use_inline_reads(
 
 
 @pytest.mark.unit
-def test_all_system_metrics_wrapper_uses_one_inline_exact_snapshot_read(monkeypatch):
+def test_all_system_metrics_wrapper_preserves_exact_snapshot(monkeypatch):
+    expected = {
+        "latency": [], "tokens": [], "cost": [], "traffic": [],
+        "query_complete": True, "query_status": "complete",
+        "query_sampled": False, "query_exact": True,
+        "query_provenance": "exact_snapshot",
+    }
     calls = []
-
-    def direct_reader(**kwargs):
-        calls.append(kwargs)
-        return {
-            "latency": [],
-            "tokens": [],
-            "cost": [],
-            "traffic": [],
-            "query_complete": True,
-            "query_status": "complete",
-            "query_sampled": False,
-        }
-
-    monkeypatch.setattr(
-        graph_dispatch,
-        "read_exact_all_system_metrics",
-        direct_reader,
-    )
+    def snapshot(namespace, identity, **options):
+        calls.append((namespace, identity, options))
+        return expected
+    monkeypatch.setattr(graph_dispatch, "read_or_schedule_exact_snapshot", snapshot)
     filters = [_date_filter(), _attribute_filter("final_status", "Rejected")]
-
-    response = graph_dispatch.fetch_all_system_metrics_ch(
-        analytics=object(),
-        project_id=PROJECT_ID,
-        filters=filters,
-        interval="hour",
+    result = graph_dispatch.fetch_all_system_metrics_ch(
+        analytics=object(), project_id=PROJECT_ID, filters=filters, interval="hour",
     )
-
+    assert result is expected
     assert len(calls) == 1
-    assert calls[0]["project_id"] == PROJECT_ID
-    assert calls[0]["filters"] == filters
-    assert calls[0]["interval"] == "hour"
-    assert response["query_status"] == "complete"
-    assert response["query_complete"] is True
-    assert response["query_sampled"] is False
-    assert response["query_exact"] is True
-    assert response["query_provenance"] == "exact_snapshot"
+    namespace, identity, _ = calls[0]
+    assert namespace == "observe-all-system-graphs"
+    assert identity["project_id"] == PROJECT_ID
+    assert identity["filters"] == filters
+    assert identity["interval"] == "hour"
 
 
 @pytest.mark.unit

--- a/futureagi/tracer/tests/test_chart_bundle_exact_routing.py
+++ b/futureagi/tracer/tests/test_chart_bundle_exact_routing.py
@@ -1,0 +1,61 @@
+"""Public chart bundles preserve exact snapshot state and trusted scope."""
+
+from datetime import datetime, timedelta
+from unittest.mock import Mock
+
+import pytest
+
+from tracer.services.clickhouse import graph_dispatch
+from tracer.services.clickhouse.v2 import query_service
+from tracer.utils.graphs_optimized import get_all_system_metrics
+
+
+@pytest.mark.parametrize("days", [7, 30, 365])
+@pytest.mark.parametrize("refresh", [False, True])
+def test_chart_bundle_returns_pending_without_inline_query(monkeypatch, days, refresh):
+    end = datetime(2026, 9, 5)
+    filters = [
+        {
+            "column_id": "created_at",
+            "filter_config": {
+                "filter_type": "datetime",
+                "filter_op": "between",
+                "filter_value": [
+                    (end - timedelta(days=days)).isoformat(),
+                    end.isoformat(),
+                ],
+            },
+        }
+    ]
+    analytics = Mock()
+    monkeypatch.setattr(query_service, "V2AnalyticsQueryService", lambda: analytics)
+    calls = []
+
+    def schedule(namespace, identity, **options):
+        calls.append((namespace, identity, options))
+        return options["pending_payload"]
+
+    monkeypatch.setattr(graph_dispatch, "read_or_schedule_exact_snapshot", schedule)
+    result = get_all_system_metrics(
+        interval="day",
+        filters=filters,
+        property="average",
+        system_metric_filters={"project_id": "00000000-0000-4000-8000-000000000001"},
+        refresh=refresh,
+        organization_id="organization",
+        workspace_id="workspace",
+    )
+    assert len(calls) == 1
+    namespace, identity, options = calls[0]
+    assert namespace == "observe-all-system-graphs"
+    assert identity["filters"] == filters
+    assert identity["organization_id"] == "organization"
+    assert identity["workspace_id"] == "workspace"
+    assert options["refresh"] is refresh
+    assert result["query_status"] == "pending"
+    assert result["query_complete"] is False
+    assert result["query_sampled"] is False
+    assert result["query_refreshing"] is True
+    assert graph_dispatch.graph_payload_is_publishable(result, allow_sampled=False)
+    assert all(result[key] == [] for key in ("latency", "tokens", "cost", "traffic"))
+    analytics.execute_ch_query.assert_not_called()

--- a/futureagi/tracer/tests/test_exact_aggregation_contract.py
+++ b/futureagi/tracer/tests/test_exact_aggregation_contract.py
@@ -6228,48 +6228,27 @@ def test_exact_graph_budget_failure_does_not_publish_or_split_contribution_batch
 
 
 @pytest.mark.unit
-def test_public_filtered_graph_runs_direct_raw_reader_inline_without_scheduling():
+def test_public_filtered_graph_schedules_complete_latest_state_snapshot():
     from tracer.services.clickhouse import graph_dispatch
-
-    cache.clear()
 
     start = datetime(2026, 8, 1, 0, 0)
     end = datetime(2026, 8, 8, 0, 0)
-    exact_calls = []
-
-    def direct_read(**kwargs):
-        exact_calls.append(kwargs)
-        return {
-            "metric_name": "traffic",
-            "data": [],
-            "query_complete": True,
-            "query_status": "complete",
-            "query_sampled": False,
-            "query_exact": False,
-            "query_provenance": "bounded_candidates",
-        }
-
+    expected = {"data": [], "query_status": "pending", "query_complete": False}
     with patch.object(
-        graph_dispatch,
-        "_fetch_direct_raw_system_metric_graph",
-        side_effect=direct_read,
-    ):
+        graph_dispatch, "read_or_schedule_exact_snapshot", return_value=expected,
+    ) as schedule:
         result = graph_dispatch.fetch_system_metric_graph_ch(
-            analytics=object(),
-            project_id="11111111-1111-4111-8111-111111111111",
-            filters=_exact_multi_filters(start, end),
-            interval="day",
-            metric_id="traffic",
-            observe_type="trace",
-            timeout_ms=30_000,
+            analytics=object(), project_id="11111111-1111-4111-8111-111111111111",
+            filters=_exact_multi_filters(start, end), interval="day",
+            metric_id="traffic", observe_type="trace", timeout_ms=30_000,
         )
-
-    assert result["query_status"] == "complete"
-    assert result["query_complete"] is True
-    assert result["query_sampled"] is False
-    assert result["query_exact"] is False
-    assert result["query_provenance"] == "bounded_candidates"
-    assert exact_calls[0]["filters"] == _exact_multi_filters(start, end)
+    assert result is expected
+    schedule.assert_called_once()
+    namespace, identity = schedule.call_args.args
+    assert namespace == "observe-system-graph"
+    assert identity["filters"] == _exact_multi_filters(start, end)
+    assert identity["payload_version"] == 2
+    assert schedule.call_args.kwargs["pending_payload"]["query_sampled"] is False
 
 
 @pytest.mark.unit
@@ -7692,7 +7671,7 @@ def test_exact_annotation_graph_supports_combined_structured_filters(
         ("annotation", "read_exact_annotation_graph"),
     ],
 )
-def test_session_eval_annotation_direct_reader_keeps_session_context(
+def test_session_eval_annotation_snapshot_keeps_session_context(
     monkeypatch,
     metric_type,
     reader_name,
@@ -7701,8 +7680,8 @@ def test_session_eval_annotation_direct_reader_keeps_session_context(
 
     captured = {}
 
-    def direct_reader(**kwargs):
-        captured.update(kwargs)
+    def snapshot(namespace, identity, **options):
+        captured.update(identity)
         return {
             "metric_name": "metric",
             "data": [],
@@ -7713,8 +7692,8 @@ def test_session_eval_annotation_direct_reader_keeps_session_context(
 
     monkeypatch.setattr(
         graph_dispatch,
-        reader_name,
-        direct_reader,
+        "read_or_schedule_exact_snapshot",
+        snapshot,
     )
     common = {
         "analytics": object(),
@@ -7743,7 +7722,7 @@ def test_session_eval_annotation_direct_reader_keeps_session_context(
         ("annotation", "read_exact_annotation_graph"),
     ],
 )
-def test_user_eval_annotation_direct_reader_keeps_user_context(
+def test_user_eval_annotation_snapshot_keeps_user_context(
     monkeypatch,
     metric_type,
     reader_name,
@@ -7752,8 +7731,8 @@ def test_user_eval_annotation_direct_reader_keeps_user_context(
 
     captured = {}
 
-    def direct_reader(**kwargs):
-        captured.update(kwargs)
+    def snapshot(namespace, identity, **options):
+        captured.update(identity)
         return {
             "metric_name": "metric",
             "data": [],
@@ -7764,8 +7743,8 @@ def test_user_eval_annotation_direct_reader_keeps_user_context(
 
     monkeypatch.setattr(
         graph_dispatch,
-        reader_name,
-        direct_reader,
+        "read_or_schedule_exact_snapshot",
+        snapshot,
     )
     common = {
         "analytics": object(),

--- a/futureagi/tracer/tests/test_exact_graph_anchor_partition.py
+++ b/futureagi/tracer/tests/test_exact_graph_anchor_partition.py
@@ -476,7 +476,9 @@ def test_exact_graph_raw_candidate_page_stays_finite_and_keyset_ordered():
     )
 
     assert (
-        _builder(_system_filter()).exact_graph_candidate_witness_replays_global_membership()
+        _builder(
+            _system_filter()
+        ).exact_graph_candidate_witness_replays_global_membership()
         is False
     )
 
@@ -509,9 +511,7 @@ def test_exact_graph_candidate_reports_only_deployed_value_indexes(
         )
     )
 
-    assert (
-        builder.exact_graph_candidate_witness_has_deployed_value_index() is expected
-    )
+    assert builder.exact_graph_candidate_witness_has_deployed_value_index() is expected
 
 
 @pytest.mark.unit
@@ -1398,10 +1398,16 @@ def test_authoritative_anchor_orchestrator_grows_across_sparse_year(monkeypatch)
 
 
 @pytest.mark.unit
+@pytest.mark.parametrize("application_mode", [False, True])
 def test_authoritative_anchor_orchestrator_runs_two_disjoint_partitions_in_parallel(
     monkeypatch,
+    application_mode,
 ):
     from tracer.services.clickhouse import exact_graph_reads as exact_module
+    from tracer.services.clickhouse.application_read_policy import (
+        application_read_context,
+        is_application_read,
+    )
 
     monkeypatch.setattr(exact_module, "EXACT_GRAPH_TRACE_ANCHOR_MAX_WORKERS", 2)
 
@@ -1425,6 +1431,7 @@ def test_authoritative_anchor_orchestrator_runs_two_disjoint_partitions_in_paral
     class Analytics:
         @staticmethod
         def execute_ch_query(query: str, params: dict[str, Any], **kwargs: Any):
+            assert is_application_read() is application_mode
             del params, kwargs
             if query == "bounds":
                 return SimpleNamespace(
@@ -1452,13 +1459,14 @@ def test_authoritative_anchor_orchestrator_runs_two_disjoint_partitions_in_paral
                 )
             raise AssertionError(f"unexpected fake query: {query}")
 
-    result = exact_module._enumerate_authoritative_anchor_trace_ids(
-        analytics=Analytics(),
-        builder=builder,
-        request_start=WINDOW_START,
-        request_end=WINDOW_END,
-        started=monotonic(),
-    )
+    with application_read_context(application_mode):
+        result = exact_module._enumerate_authoritative_anchor_trace_ids(
+            analytics=Analytics(),
+            builder=builder,
+            request_start=WINDOW_START,
+            request_end=WINDOW_END,
+            started=monotonic(),
+        )
 
     assert result == (["trace-00", "trace-02"], 4, 5)
     assert {(call[0], call[1]) for call in builder.partition_calls} == {

--- a/futureagi/tracer/tests/test_exact_graph_application_deadline.py
+++ b/futureagi/tracer/tests/test_exact_graph_application_deadline.py
@@ -1,0 +1,63 @@
+"""Application graph completion must not fail a diagnostic publication wall."""
+
+from datetime import datetime, timedelta
+from types import SimpleNamespace
+
+import pytest
+
+from tracer.services.clickhouse import exact_graph_reads as graph
+from tracer.services.clickhouse.application_read_policy import (
+    application_read_context,
+    is_application_read,
+)
+
+
+@pytest.mark.parametrize("days", [7, 30, 365])
+def test_completed_application_graph_survives_slow_query_and_publication(
+    monkeypatch, days
+):
+    clock = [0.0]
+    monkeypatch.setattr(graph, "monotonic", lambda: clock[0])
+    calls = []
+
+    def execute(query, params, **options):
+        assert is_application_read()
+        calls.append(options)
+        clock[0] = graph.EXACT_GRAPH_QUERY_TIMEOUT_MS / 1000 + 60
+        return SimpleNamespace(data=[], columns=[])
+
+    end = datetime(2026, 9, 5)
+    filters = [
+        {
+            "column_id": "created_at",
+            "filter_config": {
+                "filter_type": "datetime",
+                "filter_op": "between",
+                "filter_value": [
+                    (end - timedelta(days=days)).isoformat(),
+                    end.isoformat(),
+                ],
+            },
+        }
+    ]
+    with application_read_context():
+        result = graph.read_exact_session_system_graph(
+            analytics=SimpleNamespace(execute_ch_query=execute),
+            project_id="00000000-0000-4000-8000-000000000001",
+            filters=filters,
+            interval="day",
+            metric_id="traffic",
+        )
+        assert graph._remaining_exact_graph_timeout_ms(0, 1234) == 1234
+        with pytest.raises(ValueError):
+            graph._remaining_exact_graph_timeout_ms(0, 0)
+    assert not is_application_read()
+    assert len(calls) == 1
+    assert result["query_complete"] is True
+    assert result["query_sampled"] is False
+    assert result["query_elapsed_ms"] > graph.EXACT_GRAPH_QUERY_TIMEOUT_MS
+    # The same elapsed time still invalidates a bounded diagnostic read.
+    with pytest.raises(graph.ExactGraphReadError):
+        graph._remaining_exact_graph_timeout_ms(0)
+    with pytest.raises(graph.ExactGraphReadError):
+        graph._metadata(started=0, query_count=1, rows_returned=0)

--- a/futureagi/tracer/tests/test_exact_query_identity.py
+++ b/futureagi/tracer/tests/test_exact_query_identity.py
@@ -176,48 +176,31 @@ def test_no_filter_poll_at_a_later_time_reuses_the_original_frozen_job(monkeypat
 
 
 @pytest.mark.unit
-def test_filtered_system_graph_uses_inline_raw_reader_without_snapshot(
-    monkeypatch,
-):
+def test_filtered_system_graph_uses_exact_snapshot(monkeypatch):
     from tracer.services.clickhouse import graph_dispatch
 
-    direct_calls = []
-
-    def direct_read(**kwargs):
-        direct_calls.append(kwargs)
-        return {
-            "metric_name": "latency",
-            "data": [],
-            "query_complete": True,
-            "query_status": "complete",
-            "query_sampled": False,
-            "query_exact": False,
-            "query_provenance": "bounded_candidates",
-        }
-
-    monkeypatch.setattr(
-        graph_dispatch,
-        "_fetch_direct_raw_system_metric_graph",
-        direct_read,
-    )
+    calls = []
+    expected = {"query_status": "pending", "query_complete": False, "data": []}
+    def schedule(namespace, identity, **options):
+        calls.append((namespace, identity, options))
+        return expected
+    monkeypatch.setattr(graph_dispatch, "read_or_schedule_exact_snapshot", schedule)
+    def reject_raw(**kwargs):
+        raise AssertionError("raw physical versions cannot supply an exact graph")
+    monkeypatch.setattr(graph_dispatch, "_fetch_direct_raw_system_metric_graph", reject_raw)
     result = graph_dispatch.fetch_system_metric_graph_ch(
-        analytics=object(),
-        project_id=PROJECT_ID,
-        filters=[_attribute_filter()],
-        interval="day",
-        metric_id="latency",
-        observe_type="span",
+        analytics=object(), project_id=PROJECT_ID, filters=[_attribute_filter()],
+        interval="day", metric_id="latency", observe_type="span",
     )
-
-    assert result["query_status"] == "complete"
-    assert result["query_complete"] is True
-    assert result["query_sampled"] is False
-    assert result["query_exact"] is False
-    assert result["query_provenance"] == "bounded_candidates"
-    assert len(direct_calls) == 1
-    assert direct_calls[0]["project_id"] == PROJECT_ID
-    assert direct_calls[0]["filters"] == [_attribute_filter()]
-    assert direct_calls[0]["observe_type"] == "span"
+    assert result is expected
+    assert len(calls) == 1
+    namespace, identity, options = calls[0]
+    assert namespace == "observe-system-graph"
+    assert identity["project_id"] == PROJECT_ID
+    assert identity["filters"] == [_attribute_filter()]
+    assert identity["observe_type"] == "span"
+    assert identity["payload_version"] == 2
+    assert options["schedule_on_miss"] is True
 
 
 @pytest.mark.unit

--- a/futureagi/tracer/tests/test_graph_application_admission.py
+++ b/futureagi/tracer/tests/test_graph_application_admission.py
@@ -1,0 +1,60 @@
+"""Public graph admission survives elapsed time; diagnostic budgets still expire."""
+
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+import pytest
+
+from tracer.services.clickhouse import graph_action_deadline as graph
+from tracer.services.clickhouse import read_budget
+
+
+@pytest.mark.parametrize("elapsed_seconds", [30, 300, 3600])
+def test_application_graph_admission_does_not_expire(monkeypatch, elapsed_seconds):
+    clock = [0.0]
+    monkeypatch.setattr(read_budget.time, "monotonic", lambda: clock[0])
+    deadline = graph.start_graph_action_deadline()
+    clock[0] = elapsed_seconds
+    assert graph.graph_action_remaining_ms(deadline) > 0
+    assert graph.graph_action_remaining_ms(deadline, 1234) == 1234
+    with pytest.raises(ValueError):
+        graph.graph_action_remaining_ms(deadline, 0)
+    diagnostic = read_budget.ReadDeadline(started=0, total_ms=500)
+    with pytest.raises(graph.GraphActionUnavailable):
+        graph.graph_action_remaining_ms(diagnostic)
+
+
+def test_public_wrapper_keeps_slow_valid_request_publishable(monkeypatch):
+    clock = [0.0]
+    monkeypatch.setattr(read_budget.time, "monotonic", lambda: clock[0])
+    pending = {"query_status": "pending", "query_complete": False}
+    view = SimpleNamespace(_gm=SimpleNamespace(custom_error_response=Mock()))
+
+    @graph.bounded_graph_action_request(resource="test")
+    def action(view, request, *, _graph_action_deadline):
+        clock[0] = 3600
+        assert graph.graph_action_remaining_ms(_graph_action_deadline) > 0
+        return pending
+
+    assert action(view, object()) is pending
+    view._gm.custom_error_response.assert_not_called()
+
+
+@pytest.mark.parametrize("outer", [False, True])
+def test_slow_application_ownership_scope_restores_postgres_policy(monkeypatch, outer):
+    from tracer.tests.test_postgres_application_read_policy import FakePostgres
+
+    pg = FakePostgres(outer=outer)
+    clock = [0.0]
+    monkeypatch.setattr(read_budget.time, "monotonic", lambda: clock[0])
+    monkeypatch.setattr(graph, "connection", pg)
+    monkeypatch.setattr(graph.transaction, "atomic", pg.atomic)
+    deadline = graph.start_graph_action_deadline()
+    with graph.graph_action_postgres_budget(deadline):
+        pg.execute("SELECT first")
+        clock[0] = 3600
+        pg.execute("SELECT second")
+    assert pg.query_timeouts == ["0", "0"]
+    assert pg.timeout == "750ms"
+    assert pg.in_atomic_block is outer
+    assert not pg.wrappers

--- a/futureagi/tracer/tests/test_graph_eval_config_deadline.py
+++ b/futureagi/tracer/tests/test_graph_eval_config_deadline.py
@@ -1,4 +1,8 @@
-"""Offline ownership/PG-control contracts; no database or wall-time benchmark."""
+"""Offline ownership/PG-control contracts; no database or wall-time benchmark.
+
+Bounded adapters here exercise diagnostic opt-in reads. Public application
+snapshot routing and pending state are covered by the graph routing suites.
+"""
 
 from contextlib import contextmanager
 from functools import partial
@@ -294,7 +298,7 @@ def test_public_user_eval_expired_wall_does_not_start_ownership_lookup(monkeypat
     "budget_ms,elapsed_ms",
     [(500, 250), (5_000, 4_750), (9_500, 9_250), (9_500, 0)],
 )
-def test_public_request_checks_do_not_become_owned_metadata_statement_caps(
+def test_diagnostic_request_checks_do_not_become_owned_metadata_statement_caps(
     install, monkeypatch, budget_ms, elapsed_ms
 ):
     from tracer.services.clickhouse import graph_dispatch as dispatch
@@ -317,13 +321,14 @@ def test_public_request_checks_do_not_become_owned_metadata_statement_caps(
 
     monkeypatch.setattr(graph, "_user_filter_clauses", expensive_clauses)
     analytics = RecordingAnalytics()
-    result = dispatch.fetch_user_system_metric_graph_ch(
-        analytics=analytics,
+    result = graph.read_exact_user_system_graph(
+        analytics=dispatch._DeadlineBoundGraphAnalytics(
+            analytics, read_budget.ReadDeadline.start(budget_ms)
+        ),
         project_id=PROJECT,
         filters=eval_filters(),
         interval="day",
         metric_id="active_users",
-        timeout_ms=budget_ms,
     )
     assert pg.config_query_timeout == 0
     assert result["query_complete"] is True
@@ -337,7 +342,7 @@ def test_public_request_checks_do_not_become_owned_metadata_statement_caps(
 
 @pytest.mark.parametrize("outer", [False, True])
 @pytest.mark.parametrize("phase", ["before-lookup", "after-install", "after-select"])
-def test_public_expiry_skips_or_discards_ownership_without_background_grant(
+def test_diagnostic_expiry_skips_or_discards_ownership_without_background_grant(
     install, monkeypatch, outer, phase
 ):
     from tracer.services.clickhouse import graph_dispatch as dispatch
@@ -366,16 +371,16 @@ def test_public_expiry_skips_or_discards_ownership_without_background_grant(
 
     monkeypatch.setattr(graph, "_user_filter_clauses", expensive_clauses)
     analytics = RecordingAnalytics()
-    result = dispatch.fetch_user_system_metric_graph_ch(
-        analytics=analytics,
-        project_id=PROJECT,
-        filters=eval_filters(),
-        interval="day",
-        metric_id="active_users",
-        timeout_ms=500,
-    )
-    assert result["query_complete"] is False
-    assert result["query_error_code"] == "read_budget_exceeded"
+    with pytest.raises((graph.ExactGraphReadError, read_budget.ReadDeadlineExceeded)):
+        graph.read_exact_user_system_graph(
+            analytics=dispatch._DeadlineBoundGraphAnalytics(
+                analytics, read_budget.ReadDeadline.start(500)
+            ),
+            project_id=PROJECT,
+            filters=eval_filters(),
+            interval="day",
+            metric_id="active_users",
+        )
     assert analytics.calls == []
     assert pg.timeout == "8s" and pg.in_atomic_block is outer
     assert pg.wrappers == []
@@ -426,7 +431,7 @@ def test_adapter_remaining_read_ms_does_not_restart_request(monkeypatch):
 
 
 @pytest.mark.parametrize("surface", ["eval", "annotation"])
-def test_public_entity_graph_forwards_original_wall_to_each_owned_lookup(
+def test_diagnostic_entity_graph_forwards_original_wall_to_each_owned_lookup(
     install, monkeypatch, surface
 ):
     from tracer.services.clickhouse import graph_dispatch as dispatch
@@ -488,19 +493,20 @@ def test_public_entity_graph_forwards_original_wall_to_each_owned_lookup(
     )
     analytics = RecordingAnalytics()
     fetch = (
-        dispatch.fetch_eval_graph_ch
+        graph.read_exact_eval_graph
         if surface == "eval"
-        else dispatch.fetch_annotation_graph_ch
+        else graph.read_exact_annotation_graph
     )
     result = fetch(
-        analytics=analytics,
+        analytics=dispatch._DeadlineBoundGraphAnalytics(
+            analytics, read_budget.ReadDeadline.start(500)
+        ),
         project_id=PROJECT,
         filters=eval_filters(),
         interval="day",
         req_data_config={"id": CONFIG, "output_type": "float"},
         observe_type="trace",
         aggregation_context="user",
-        timeout_ms=500,
     )
     assert result["query_complete"] is True
     expected = [0] if surface == "eval" else [0, 0]

--- a/futureagi/tracer/tests/test_graph_public_source_routing.py
+++ b/futureagi/tracer/tests/test_graph_public_source_routing.py
@@ -132,8 +132,16 @@ class RecordingAnalytics:
         return SimpleNamespace(data=[], columns=COLUMNS, query_time_ms=1)
 
 
-def direct(filters, observe_type):
+def direct(monkeypatch, filters, observe_type):
     analytics = RecordingAnalytics()
+    scheduled = []
+
+    def schedule(namespace, identity, **options):
+        assert namespace == "observe-system-graph"
+        scheduled.append(identity)
+        return options["pending_payload"]
+
+    monkeypatch.setattr(dispatch, "read_or_schedule_exact_snapshot", schedule)
     result = dispatch.fetch_system_metric_graph_ch(
         analytics=analytics,
         project_id=PROJECT,
@@ -142,9 +150,44 @@ def direct(filters, observe_type):
         metric_id="traffic",
         observe_type=observe_type,
     )
+    assert result["query_status"] == "pending"
+    assert analytics.calls == []
+    assert len(scheduled) == 1
+    identity = scheduled[0]
+    compiled = []
+
+    def enumerate_ids(**kwargs):
+        builder = TraceListQueryBuilderV2(
+            project_id=PROJECT,
+            filters=kwargs["filters"],
+            bounded_internal_scan=True,
+            bounded_identity_only=True,
+            bounded_bulk_scan=True,
+            bounded_include_filter_witnesses=False,
+            bounded_global_span_witnesses=True,
+        )
+        query, params = builder.build_filter_identity_match_query_from_seed_rows(
+            [{"trace_id": "trace-1", "start_time": END - timedelta(hours=1)}]
+        )
+        assert "latest_is_deleted = 0" in query
+        compiled.append((query, params, {}))
+        return ["trace-1"], 1, 1
+
+    monkeypatch.setattr(exact, "_enumerate_exact_trace_ids", enumerate_ids)
+    result = exact.read_exact_system_graph(
+        analytics=analytics,
+        project_id=identity["project_id"],
+        filters=identity["filters"],
+        interval=identity["interval"],
+        metric_id=identity["metric_id"],
+        observe_type=identity["observe_type"],
+    )
     assert result["query_complete"] is True
-    assert len(analytics.calls) == 1
-    return analytics.calls[0]
+    if observe_type == "trace":
+        assert len(compiled) == 1
+        return compiled
+    assert analytics.calls
+    return analytics.calls
 
 
 @pytest.mark.parametrize("key", RAW_NAMES)
@@ -158,19 +201,22 @@ def direct(filters, observe_type):
 )
 @pytest.mark.parametrize("observe_type", ["trace", "span"])
 def test_public_dispatch_raw_alias_compiles_map_not_native_relation(
+    monkeypatch,
     key,
     kind,
     value,
     column,
     observe_type,
 ):
-    query, params, _ = direct([window(), leaf(key, value, kind=kind)], observe_type)
-    assert f"{column}['{key}']" in query
-    assert "FROM spans" in query
-    assert "tracer_eval_logger" not in query
-    assert "model_hub_score" not in query
-    assert "FROM end_users" not in query
-    assert "spans_hourly_rollup" not in query
+    calls = direct(monkeypatch, [window(), leaf(key, value, kind=kind)], observe_type)
+    for query, params, _ in calls:
+        assert column in query
+        assert key in params.values() or f"{column}['{key}']" in query
+        assert "FROM spans" in query
+        assert "tracer_eval_logger" not in query
+        assert "model_hub_score" not in query
+        assert "FROM end_users" not in query
+        assert "spans_hourly_rollup" not in query
 
 
 @pytest.mark.parametrize("key", ["created_at", "start_time"])
@@ -180,15 +226,17 @@ def test_public_dispatch_raw_alias_compiles_map_not_native_relation(
 )
 @pytest.mark.parametrize("observe_type", ["trace", "span"])
 def test_public_dispatch_raw_date_is_not_date_only_rollup(
-    key, days, op, value, observe_type
+    monkeypatch, key, days, op, value, observe_type
 ):
-    query, params, _ = direct([window(days), leaf(key, value, op=op)], observe_type)
-    assert "spans_hourly_rollup" not in query
-    assert f"mapContains(attrs_string, '{key}')" in query
-    if op != "is_null":
-        assert f"attrs_string['{key}']" in query
-    assert params["start_date"] == END - timedelta(days=days)
-    assert params["end_date"] == END
+    calls = direct(monkeypatch, [window(days), leaf(key, value, op=op)], observe_type)
+    for query, params, _ in calls:
+        assert "spans_hourly_rollup" not in query
+        assert "mapContains" in query and "attrs_string" in query
+        assert key in params.values() or f"'{key}'" in query
+        if op != "is_null":
+            assert "attrs_string[" in query
+        assert params["start_date"] == END - timedelta(days=days)
+        assert params["end_date"] == END
 
 
 @pytest.mark.parametrize("key", ["created_at", "start_time"])

--- a/futureagi/tracer/tests/test_graph_rollup_fast_path.py
+++ b/futureagi/tracer/tests/test_graph_rollup_fast_path.py
@@ -13,6 +13,97 @@ from tracer.services.clickhouse.session_graph import fetch_session_graph_ch
 PROJECT_ID = "22222222-2222-4222-8222-222222222222"
 
 
+def _assert_exact_route(
+    monkeypatch,
+    *,
+    surface="trace",
+    filters=None,
+    interval="day",
+    refresh=False,
+    payload=None,
+    analytics=None,
+):
+    from tracer.services.clickhouse import session_graph
+
+    analytics = analytics if analytics is not None else mock.Mock()
+    filters = list(filters or [])
+    payload = (
+        payload
+        if payload is not None
+        else {
+            "metric_name": "latency",
+            "data": [],
+            "query_status": "pending",
+            "query_complete": False,
+            "query_sampled": False,
+            "query_refreshing": True,
+        }
+    )
+    schedule = mock.Mock(return_value=payload)
+    owner = session_graph if surface == "session" else graph_dispatch
+    monkeypatch.setattr(owner, "read_or_schedule_exact_snapshot", schedule)
+    raw = mock.Mock(
+        side_effect=AssertionError("public graphs must not read raw versions")
+    )
+    monkeypatch.setattr(graph_dispatch, "_fetch_direct_raw_system_metric_graph", raw)
+    common = {
+        "analytics": analytics,
+        "project_id": PROJECT_ID,
+        "filters": filters,
+        "interval": interval,
+        "refresh": refresh,
+        "organization_id": "organization",
+        "workspace_id": "workspace",
+    }
+    if surface == "session":
+        result = fetch_session_graph_ch(
+            **common, req_data_config={"type": "SYSTEM_METRIC", "id": "latency"}
+        )
+    else:
+        result = graph_dispatch.fetch_system_metric_graph_ch(
+            **common, metric_id="latency", observe_type=surface
+        )
+    assert result is payload
+    schedule.assert_called_once()
+    namespace, identity = schedule.call_args.args
+    assert namespace == (
+        "observe-session-system-graph"
+        if surface == "session"
+        else "observe-system-graph"
+    )
+    assert identity["filters"] == filters and identity["interval"] == interval
+    assert identity["organization_id"] == "organization"
+    assert identity["workspace_id"] == "workspace"
+    assert schedule.call_args.kwargs["refresh"] is refresh
+    analytics.execute_ch_query.assert_not_called()
+    raw.assert_not_called()
+    return schedule
+
+
+def _legacy_rollup(
+    *, surface="trace", analytics, filters, interval="day", metric_id="latency"
+):
+    # Retain low-level rollup diagnostics without routing public exact reads here.
+    from time import monotonic
+
+    from tracer.services.clickhouse import session_graph
+
+    common = {
+        "analytics": analytics,
+        "project_id": PROJECT_ID,
+        "filters": filters,
+        "interval": interval,
+        "metric_id": metric_id,
+    }
+    if surface == "session":
+        return session_graph._fetch_rollup_system_metric_graph(
+            **common, started=monotonic()
+        )
+    return graph_dispatch._fetch_rollup_system_metric_graph(
+        **common, observe_type="trace", timeout_ms=30000
+    )
+
+
 def _date_filter(start: str, end: str) -> dict:
     return {
         "column_id": "created_at",
@@ -108,7 +199,7 @@ FILTER_SHAPES = [
         *[([_date_filter(start, end)], interval) for start, end, interval in WINDOWS],
     ],
 )
-def test_trace_primary_date_only_uses_one_interactive_rollup_query(
+def test_legacy_trace_primary_date_only_uses_one_interactive_rollup_query(
     monkeypatch, filters, interval
 ):
     analytics = mock.Mock()
@@ -143,13 +234,11 @@ def test_trace_primary_date_only_uses_one_interactive_rollup_query(
         exact_read,
     )
 
-    response = graph_dispatch.fetch_system_metric_graph_ch(
+    response = _legacy_rollup(
         analytics=analytics,
-        project_id=PROJECT_ID,
         filters=filters,
         interval=interval,
         metric_id="latency",
-        observe_type="trace",
     )
 
     exact_read.assert_not_called()
@@ -188,144 +277,52 @@ def test_trace_primary_date_only_uses_one_interactive_rollup_query(
 
 @pytest.mark.unit
 @pytest.mark.parametrize("observe_type", ["trace", "span"])
-def test_date_only_rollup_fails_closed_when_query_settings_are_locked(observe_type):
+def test_time_only_graph_schedules_worker_with_own_read_policy(
+    monkeypatch, observe_type
+):
     analytics = mock.Mock()
     analytics.supports_per_query_read_settings = False
-
-    response = graph_dispatch.fetch_system_metric_graph_ch(
-        analytics=analytics,
-        project_id=PROJECT_ID,
-        filters=[],
-        interval="day",
-        metric_id="latency",
-        observe_type=observe_type,
-    )
-
-    analytics.execute_ch_query.assert_not_called()
-    assert response["data"] == []
-    assert response["query_complete"] is False
-    assert response["query_status"] == "degraded"
-    assert response["query_error_code"] == "query_failed"
-    assert response["query_provenance"] == "server_read_policy_unavailable"
+    _assert_exact_route(monkeypatch, surface=observe_type, analytics=analytics)
 
 
 @pytest.mark.unit
-def test_session_date_only_rollup_fails_closed_when_query_settings_are_locked():
+def test_session_graph_schedules_worker_with_own_read_policy(monkeypatch):
     analytics = mock.Mock()
     analytics.supports_per_query_read_settings = False
-
-    response = fetch_session_graph_ch(
-        analytics=analytics,
-        project_id=PROJECT_ID,
-        filters=[],
-        interval="day",
-        req_data_config={"type": "SYSTEM_METRIC", "id": "latency"},
-    )
-
-    analytics.execute_ch_query.assert_not_called()
-    assert response["data"] == []
-    assert response["query_complete"] is False
-    assert response["query_status"] == "degraded"
-    assert response["query_error_code"] == "query_failed"
-    assert response["query_provenance"] == "server_read_policy_unavailable"
+    _assert_exact_route(monkeypatch, surface="session", analytics=analytics)
 
 
 @pytest.mark.unit
 @pytest.mark.parametrize(("start", "end", "interval"), WINDOWS)
 @pytest.mark.parametrize("row_filter", FILTER_SHAPES)
-def test_span_filtered_w1_w6_and_sparse_dense_eval_annotation_matrix_is_complete(
-    monkeypatch,
-    start,
-    end,
-    interval,
-    row_filter,
+def test_span_filter_matrix_schedules_exact_population(
+    monkeypatch, start, end, interval, row_filter
 ):
-    direct_read = mock.Mock(
-        return_value={
-            "metric_name": "latency",
-            "data": [{"timestamp": start, "value": 42, "primary_traffic": 1}],
-            "query_complete": True,
-            "query_status": "complete",
-            "query_sampled": False,
-            "query_exact": False,
-            "query_provenance": "bounded_candidates",
-        }
-    )
-    monkeypatch.setattr(
-        graph_dispatch,
-        "_fetch_direct_raw_system_metric_graph",
-        direct_read,
-    )
-
-    response = graph_dispatch.fetch_system_metric_graph_ch(
-        analytics=mock.Mock(),
-        project_id=PROJECT_ID,
+    _assert_exact_route(
+        monkeypatch,
+        surface="span",
         filters=[_date_filter(start, end), row_filter],
         interval=interval,
-        metric_id="latency",
-        observe_type="span",
     )
-
-    assert response["query_complete"] is True
-    assert response["query_status"] == "complete"
-    assert response["query_sampled"] is False
-    assert response["query_exact"] is False
-    assert response["query_provenance"] == "bounded_candidates"
-    assert response["data"][0]["value"] == 42
-    assert graph_dispatch.graph_payload_is_publishable(response, allow_sampled=False)
-    direct_read.assert_called_once()
-    assert direct_read.call_args.kwargs["filters"][-1] == row_filter
-    assert direct_read.call_args.kwargs["observe_type"] == "span"
 
 
 @pytest.mark.unit
-def test_trace_filtered_system_graph_uses_direct_raw_reader(
-    monkeypatch,
-):
-    analytics = mock.Mock()
-    direct_payload = {
+def test_trace_graph_preserves_last_complete_exact_snapshot(monkeypatch):
+    payload = {
         "metric_name": "latency",
         "data": [
-            {
-                "timestamp": "2026-08-01T00:00:00",
-                "value": 12,
-                "primary_traffic": 1,
-            }
+            {"timestamp": "2026-08-01T00:00:00", "value": 12, "primary_traffic": 1}
         ],
         "query_complete": True,
         "query_status": "complete",
         "query_sampled": False,
-        "query_exact": False,
-        "query_provenance": "bounded_candidates",
+        "query_exact": True,
+        "query_provenance": "exact_snapshot",
+        "query_refreshing": True,
     }
-    direct_read = mock.Mock(return_value=direct_payload)
-    monkeypatch.setattr(
-        graph_dispatch,
-        "_fetch_direct_raw_system_metric_graph",
-        direct_read,
+    _assert_exact_route(
+        monkeypatch, filters=[_attribute_filter()], payload=payload, refresh=True
     )
-    filters = [
-        _date_filter("2026-08-01T00:00:00Z", "2026-08-12T00:00:00Z"),
-        _attribute_filter(),
-    ]
-
-    response = graph_dispatch.fetch_system_metric_graph_ch(
-        analytics=analytics,
-        project_id=PROJECT_ID,
-        filters=filters,
-        interval="day",
-        metric_id="latency",
-        observe_type="trace",
-    )
-
-    assert response["data"] == direct_payload["data"]
-    assert response["query_exact"] is False
-    assert response["query_provenance"] == "bounded_candidates"
-    direct_read.assert_called_once()
-    assert direct_read.call_args.kwargs["project_id"] == PROJECT_ID
-    assert direct_read.call_args.kwargs["filters"] == filters
-    assert direct_read.call_args.kwargs["metric_id"] == "latency"
-    assert direct_read.call_args.kwargs["observe_type"] == "trace"
 
 
 def _empty_graph_query_result():
@@ -561,100 +558,26 @@ def test_negative_and_span_graph_filters_never_use_trace_seed(monkeypatch):
 
 
 @pytest.mark.unit
-def test_filtered_raw_graph_statement_uses_one_interactive_deadline(
-    monkeypatch,
-):
-    analytics = mock.Mock()
-    analytics.execute_ch_query.return_value = mock.Mock(data=[], columns=[])
-    deadline = mock.Mock()
-    deadline.remaining_ms.return_value = 9_300
-    observed_analytics = []
-
-    def direct_read(*, analytics, **_kwargs):
-        observed_analytics.append(analytics)
-        analytics.execute_ch_query(
-            "SELECT raw aggregation",
-            {},
-            timeout_ms=60_000,
-            settings={"max_rows_to_read": 1, "max_threads": 8},
-        )
-        return {
-            "metric_name": "latency",
-            "data": [],
-            "query_complete": True,
-            "query_status": "complete",
-            "query_sampled": False,
-            "query_exact": False,
-            "query_provenance": "bounded_candidates",
-        }
-
-    deadline_start = mock.Mock(return_value=deadline)
+def test_filtered_graph_does_not_start_interactive_statement_deadline(monkeypatch):
+    deadline_start = mock.Mock(side_effect=AssertionError("no synchronous graph read"))
     monkeypatch.setattr(graph_dispatch.ReadDeadline, "start", deadline_start)
-    monkeypatch.setattr(
-        graph_dispatch,
-        "_fetch_direct_raw_system_metric_graph",
-        direct_read,
-    )
-
-    response = graph_dispatch.fetch_system_metric_graph_ch(
-        analytics=analytics,
-        project_id=PROJECT_ID,
-        filters=[_attribute_filter()],
-        interval="day",
-        metric_id="latency",
-        observe_type="trace",
-    )
-
-    assert response["query_status"] == "complete"
-    deadline_start.assert_called_once_with(
-        django_settings.INTERACTIVE_ANALYTICS_DEFAULT_WALL_MS
-    )
-    assert len(observed_analytics) == 1
-    assert deadline.remaining_ms.call_count == 1
-    assert [
-        call.kwargs["timeout_ms"] for call in analytics.execute_ch_query.call_args_list
-    ] == [9_300]
-    for call in analytics.execute_ch_query.call_args_list:
-        read_settings = call.kwargs["settings"]
-        assert "max_rows_to_read" not in read_settings
-        assert (
-            read_settings["max_threads"]
-            == django_settings.DASHBOARD_TRACE_READ_MAX_THREADS
-        )
-        assert (
-            read_settings["max_memory_usage"]
-            == django_settings.OBSERVABILITY_LIST_MAX_MEMORY_BYTES
-        )
+    _assert_exact_route(monkeypatch, filters=[_attribute_filter()])
+    deadline_start.assert_not_called()
 
 
 @pytest.mark.unit
-def test_filtered_graph_raw_budget_failure_fails_closed_without_sample(
-    monkeypatch,
-):
-    direct_read = mock.Mock(
-        side_effect=graph_dispatch.ExactGraphReadError("exact graph deadline exceeded")
+def test_filtered_graph_preserves_failed_snapshot_without_sample_fallback(monkeypatch):
+    payload = {
+        "metric_name": "latency",
+        "data": [],
+        "query_complete": False,
+        "query_status": "failed",
+        "query_sampled": False,
+        "query_error_code": "query_failed",
+    }
+    _assert_exact_route(
+        monkeypatch, surface="span", filters=[_attribute_filter()], payload=payload
     )
-    monkeypatch.setattr(
-        graph_dispatch,
-        "_fetch_direct_raw_system_metric_graph",
-        direct_read,
-    )
-
-    response = graph_dispatch.fetch_system_metric_graph_ch(
-        analytics=mock.Mock(),
-        project_id=PROJECT_ID,
-        filters=[_attribute_filter()],
-        interval="month",
-        metric_id="traffic",
-        observe_type="span",
-    )
-
-    assert response["data"] == []
-    assert response["query_status"] == "degraded"
-    assert response["query_sampled"] is False
-    assert response["query_exact"] is False
-    assert response["query_provenance"] == "bounded_candidates"
-    direct_read.assert_called_once()
 
 
 @pytest.mark.unit
@@ -693,61 +616,14 @@ def test_filtered_graph_poll_does_not_duplicate_running_background_read(monkeypa
     assert response == pending
     direct_read.assert_not_called()
     assert cache_probe.call_count == 1
-    assert cache_probe.call_args.kwargs["schedule_on_miss"] is False
+    assert cache_probe.call_args.kwargs["schedule_on_miss"] is True
 
 
 @pytest.mark.unit
-def test_filtered_graph_budget_failure_schedules_one_heavy_read(monkeypatch):
-    pending = {
-        "metric_name": "latency",
-        "data": [],
-        "query_complete": False,
-        "query_status": "pending",
-        "query_sampled": False,
-        "query_refreshing": True,
-    }
-    cache_calls = []
-
-    def cache_read(*args, **kwargs):
-        cache_calls.append((args, kwargs))
-        if kwargs.get("schedule_on_miss") is False:
-            return {**pending, "query_refreshing": False}
-        return pending
-
-    monkeypatch.setattr(
-        graph_dispatch,
-        "read_or_schedule_exact_snapshot",
-        cache_read,
-    )
-    monkeypatch.setattr(
-        graph_dispatch,
-        "_fetch_direct_raw_system_metric_graph",
-        mock.Mock(
-            side_effect=graph_dispatch.ExactGraphReadError(
-                "exact graph deadline exceeded"
-            )
-        ),
-    )
-
-    response = graph_dispatch.fetch_system_metric_graph_ch(
-        analytics=mock.Mock(),
-        project_id=PROJECT_ID,
-        filters=[_attribute_filter()],
-        interval="day",
-        metric_id="latency",
-        observe_type="trace",
-        organization_id="33333333-3333-4333-8333-333333333333",
-        workspace_id="44444444-4444-4444-8444-444444444444",
-    )
-
-    assert response == pending
-    assert len(cache_calls) == 2
-    assert cache_calls[0][1]["schedule_on_miss"] is False
-    assert cache_calls[1][1]["schedule_on_miss"] is True
-    assert cache_calls[1][1]["refresh"] is True
-    assert cache_calls[1][0][1]["organization_id"] == (
-        "33333333-3333-4333-8333-333333333333"
-    )
+def test_filtered_graph_cold_miss_schedules_one_exact_read(monkeypatch):
+    schedule = _assert_exact_route(monkeypatch, filters=[_attribute_filter()])
+    assert schedule.call_args.kwargs["schedule_on_miss"] is True
+    assert schedule.call_args.kwargs["refresh"] is False
 
 
 @pytest.mark.unit
@@ -777,16 +653,13 @@ def test_exact_graph_forces_weekly_buckets_only_beyond_three_months(
 
 
 @pytest.mark.unit
-def test_filtered_graph_programming_defect_is_not_disguised_as_degraded(
-    monkeypatch,
-):
-    direct_read = mock.Mock(side_effect=AssertionError("malformed candidate row"))
+def test_filtered_graph_dispatch_defect_is_not_disguised_as_degraded(monkeypatch):
     monkeypatch.setattr(
         graph_dispatch,
-        "_fetch_direct_raw_system_metric_graph",
-        direct_read,
+        "read_or_schedule_exact_snapshot",
+        mock.Mock(side_effect=AssertionError("malformed snapshot")),
     )
-    with pytest.raises(AssertionError, match="malformed candidate row"):
+    with pytest.raises(AssertionError, match="malformed snapshot"):
         graph_dispatch.fetch_system_metric_graph_ch(
             analytics=mock.Mock(),
             project_id=PROJECT_ID,
@@ -798,7 +671,9 @@ def test_filtered_graph_programming_defect_is_not_disguised_as_degraded(
 
 
 @pytest.mark.unit
-def test_trace_rollup_failure_propagates_without_exact_or_raw_fallback(monkeypatch):
+def test_legacy_trace_rollup_failure_propagates_without_exact_or_raw_fallback(
+    monkeypatch,
+):
     analytics = mock.Mock()
     failure = NetworkError("private ClickHouse details")
     analytics.execute_ch_query.side_effect = failure
@@ -810,9 +685,8 @@ def test_trace_rollup_failure_propagates_without_exact_or_raw_fallback(monkeypat
     )
 
     with pytest.raises(NetworkError) as raised:
-        graph_dispatch.fetch_system_metric_graph_ch(
+        _legacy_rollup(
             analytics=analytics,
-            project_id=PROJECT_ID,
             filters=[
                 _date_filter(
                     "2026-08-01T00:00:00Z",
@@ -829,7 +703,9 @@ def test_trace_rollup_failure_propagates_without_exact_or_raw_fallback(monkeypat
 
 
 @pytest.mark.unit
-def test_session_rollup_failure_propagates_without_exact_or_raw_fallback(monkeypatch):
+def test_legacy_session_rollup_failure_propagates_without_exact_or_raw_fallback(
+    monkeypatch,
+):
     analytics = mock.Mock()
     failure = NetworkError("private ClickHouse details")
     analytics.execute_ch_query.side_effect = failure
@@ -840,9 +716,9 @@ def test_session_rollup_failure_propagates_without_exact_or_raw_fallback(monkeyp
     )
 
     with pytest.raises(NetworkError) as raised:
-        fetch_session_graph_ch(
+        _legacy_rollup(
+            surface="session",
             analytics=analytics,
-            project_id=PROJECT_ID,
             filters=[
                 _date_filter(
                     "2026-08-01T00:00:00Z",
@@ -850,7 +726,7 @@ def test_session_rollup_failure_propagates_without_exact_or_raw_fallback(monkeyp
                 )
             ],
             interval="day",
-            req_data_config={"id": "session_count", "type": "SYSTEM_METRIC"},
+            metric_id="session_count",
         )
 
     assert raised.value is failure
@@ -862,7 +738,7 @@ def test_session_rollup_failure_propagates_without_exact_or_raw_fallback(monkeyp
 
 @pytest.mark.unit
 @pytest.mark.parametrize("surface", ["trace", "session"])
-def test_rollup_schema_drift_fails_closed_instead_of_publishing_zero(
+def test_legacy_rollup_schema_drift_fails_closed_instead_of_publishing_zero(
     monkeypatch, surface
 ):
     analytics = mock.Mock()
@@ -879,9 +755,8 @@ def test_rollup_schema_drift_fails_closed_instead_of_publishing_zero(
         )
 
         def invoke():
-            return graph_dispatch.fetch_system_metric_graph_ch(
+            return _legacy_rollup(
                 analytics=analytics,
-                project_id=PROJECT_ID,
                 filters=[
                     _date_filter(
                         "2026-08-01T00:00:00Z",
@@ -898,9 +773,9 @@ def test_rollup_schema_drift_fails_closed_instead_of_publishing_zero(
         )
 
         def invoke():
-            return fetch_session_graph_ch(
+            return _legacy_rollup(
+                surface="session",
                 analytics=analytics,
-                project_id=PROJECT_ID,
                 filters=[
                     _date_filter(
                         "2026-08-01T00:00:00Z",
@@ -908,7 +783,7 @@ def test_rollup_schema_drift_fails_closed_instead_of_publishing_zero(
                     )
                 ],
                 interval="day",
-                req_data_config={"id": "session_count", "type": "SYSTEM_METRIC"},
+                metric_id="session_count",
             )
 
     with pytest.raises(graph_dispatch.BoundedGraphReadError) as raised:

--- a/futureagi/tracer/tests/test_public_charts_direct_write.py
+++ b/futureagi/tracer/tests/test_public_charts_direct_write.py
@@ -47,13 +47,14 @@ FINAL_STATUS_FILTER = {
 
 
 @pytest.mark.unit
-def test_public_chart_routes_have_no_full_window_latest_spans_collapse():
+def test_public_chart_routes_schedule_exact_background_population():
     source = inspect.getsource(graph_dispatch.fetch_all_system_metrics_ch)
     assert "WITH latest_spans AS" not in source
     assert "ORDER BY _version DESC" not in source
-    assert "read_exact_all_system_metrics" in source
-    assert "_DeadlineBoundGraphAnalytics" in source
-    assert "_read_or_refresh_exact_graph" not in source
+    assert "read_exact_all_system_metrics" not in source
+    assert "_DeadlineBoundGraphAnalytics" not in source
+    assert "_read_or_refresh_exact_graph" in source
+    assert "observe-all-system-graphs" in source
     assert "read_graph_candidates" not in source
 
 

--- a/futureagi/tracer/tests/test_remaining_graph_exact_routing.py
+++ b/futureagi/tracer/tests/test_remaining_graph_exact_routing.py
@@ -1,0 +1,89 @@
+"""User, Eval and Annotation graphs retain scope across exact refresh routing."""
+
+from datetime import datetime, timedelta
+from unittest.mock import Mock
+
+import pytest
+
+from tracer.services.clickhouse import graph_dispatch as graph
+
+
+@pytest.mark.parametrize("kind", ["user", "eval", "annotation"])
+@pytest.mark.parametrize("days", [7, 30, 365])
+@pytest.mark.parametrize("grain", ["trace", "session", "user"])
+@pytest.mark.parametrize("refresh", [False, True])
+def test_exact_graph_route_preserves_request(monkeypatch, kind, days, grain, refresh):
+    end = datetime(2026, 9, 5)
+    filters = [
+        {
+            "column_id": "created_at",
+            "filter_config": {
+                "filter_type": "datetime",
+                "filter_op": "between",
+                "filter_value": [
+                    (end - timedelta(days=days)).isoformat(),
+                    end.isoformat(),
+                ],
+            },
+        },
+        {
+            "column_id": "company_id",
+            "filter_config": {
+                "col_type": "SPAN_ATTRIBUTE",
+                "filter_type": "text",
+                "filter_op": "equals",
+                "filter_value": ["12345678", "87654321"],
+            },
+        },
+    ]
+    calls = []
+
+    def schedule(namespace, identity, **options):
+        calls.append((namespace, identity, options))
+        return options["pending_payload"]
+
+    monkeypatch.setattr(graph, "read_or_schedule_exact_snapshot", schedule)
+    analytics = Mock()
+    common = {
+        "analytics": analytics,
+        "project_id": "00000000-0000-4000-8000-000000000001",
+        "filters": filters,
+        "interval": "day",
+        "refresh": refresh,
+        "organization_id": "org",
+        "workspace_id": "workspace",
+    }
+    config = {"id": "score-id", "output_type": "SCORE", "aggregation": "average"}
+    if kind == "user":
+        result = graph.fetch_user_system_metric_graph_ch(
+            **common, metric_id="active_users"
+        )
+        namespace = "observe-user-system-graph"
+    else:
+        result = getattr(graph, f"fetch_{kind}_graph_ch")(
+            **common,
+            req_data_config=config,
+            observe_type="span",
+            aggregation_context=grain,
+        )
+        namespace = f"observe-{kind}-graph"
+    assert len(calls) == 1
+    actual_namespace, identity, options = calls[0]
+    assert actual_namespace == namespace
+    assert identity["filters"] == filters
+    assert identity["project_id"] == common["project_id"]
+    assert identity["interval"] == "day"
+    assert identity["organization_id"] == "org"
+    assert identity["workspace_id"] == "workspace"
+    assert options["refresh"] is refresh
+    if kind != "user":
+        assert identity["req_data_config"] == config
+        assert identity["aggregation_context"] == grain
+        assert identity["observe_type"] == "span"
+    else:
+        assert identity["metric_id"] == "active_users"
+    assert result["query_complete"] is False
+    assert result["query_status"] == "pending"
+    assert result["query_sampled"] is False
+    assert graph.graph_payload_is_publishable(result, allow_sampled=False)
+    analytics.execute_ch_query.assert_not_called()

--- a/futureagi/tracer/tests/test_session_graph_exact_routing.py
+++ b/futureagi/tracer/tests/test_session_graph_exact_routing.py
@@ -1,0 +1,60 @@
+"""Public Session graphs must not silently switch to non-exact time-only reads."""
+
+from datetime import datetime, timedelta
+from unittest.mock import Mock
+
+import pytest
+
+from tracer.services.clickhouse import session_graph
+
+
+@pytest.mark.parametrize("days", [7, 30, 365])
+@pytest.mark.parametrize("metric_id", sorted(session_graph.SESSION_SYSTEM_METRICS))
+def test_time_only_session_metrics_schedule_exact_population(
+    monkeypatch, days, metric_id
+):
+    end = datetime(2026, 9, 5)
+    filters = [
+        {
+            "column_id": "created_at",
+            "filter_config": {
+                "filter_type": "datetime",
+                "filter_op": "between",
+                "filter_value": [
+                    (end - timedelta(days=days)).isoformat(),
+                    end.isoformat(),
+                ],
+            },
+        }
+    ]
+    expected = {"query_status": "pending", "query_complete": False, "data": []}
+    schedule = Mock(return_value=expected)
+    monkeypatch.setattr(session_graph, "read_or_schedule_exact_snapshot", schedule)
+    analytics = Mock()
+    result = session_graph.fetch_session_graph_ch(
+        analytics=analytics,
+        project_id="00000000-0000-4000-8000-000000000001",
+        filters=filters,
+        interval="day",
+        req_data_config={"type": "SYSTEM_METRIC", "id": metric_id},
+        organization_id="organization",
+        workspace_id="workspace",
+        refresh=True,
+    )
+    assert result is expected
+    schedule.assert_called_once()
+    namespace, identity = schedule.call_args.args
+    assert namespace == "observe-session-system-graph"
+    assert identity == {
+        "project_id": "00000000-0000-4000-8000-000000000001",
+        "filters": filters,
+        "interval": "day",
+        "metric_id": metric_id,
+        "organization_id": "organization",
+        "workspace_id": "workspace",
+    }
+    assert schedule.call_args.kwargs["refresh"] is True
+    pending = schedule.call_args.kwargs["pending_payload"]
+    assert pending["query_complete"] is False
+    assert pending["query_sampled"] is False
+    analytics.execute_ch_query.assert_not_called()

--- a/futureagi/tracer/tests/test_session_graph_native_conjunction.py
+++ b/futureagi/tracer/tests/test_session_graph_native_conjunction.py
@@ -1,0 +1,160 @@
+"""Native Session graph/list membership parity on SELECT-only constant fixtures.
+
+The graph root source uses an explicit six-key argMax fixture to emulate FINAL.
+This verifies generated membership SQL, not physical MergeTree FINAL execution,
+production storage performance, cache dispatch, or graph bucket formatting.
+"""
+
+import json
+from datetime import timedelta
+
+import pytest
+from clickhouse_driver.util.escape import escape_params
+
+from tracer.services.clickhouse.v2.query_builders.session_list import (
+    SessionListQueryBuilderV2,
+)
+from tracer.tests.test_session_entity_filter_membership import (
+    END,
+    PROJECT,
+    SESSION,
+    _filter,
+)
+from tracer.tests.test_users_attribute_physical_replay import (
+    CONTEXT,
+    values_where,
+    without_query_settings,
+)
+
+
+def run(rows, filters, days=7):
+    engine = pytest.importorskip("chdb")
+    builder = SessionListQueryBuilderV2(
+        project_id=PROJECT,
+        filters=[
+            _filter(
+                "created_at",
+                [(END - timedelta(days=days)).isoformat(), END.isoformat()],
+                kind="datetime",
+                operation="between",
+                source="SYSTEM_METRIC",
+            ),
+            *filters,
+        ],
+        bounded_internal_scan=True,
+    )
+    from tracer.services.clickhouse.exact_graph_reads import (
+        _session_aggregate_source_sql,
+    )
+
+    source, params = _session_aggregate_source_sql(
+        project_id=PROJECT,
+        filters=builder.filters,
+        start_date=END - timedelta(days=days),
+        end_date=END,
+        include_trace_ids=False,
+        anchor_by_session_start=True,
+        use_scalar_witness=True,
+    )
+    sql = "SELECT session_id FROM (" + source + ")"
+    schema = "project_id UUID, observation_type String, service_name String, trace_id String, id String, start_time DateTime64(6,'UTC'), trace_session_id Nullable(UUID), parent_span_id Nullable(String), _version UInt64, is_deleted UInt8, string_keys Array(String), string_values Array(String), number_keys Array(String), number_values Array(Float64), bool_keys Array(String), bool_values Array(UInt8)"
+    data = []
+    for index, kind, key, value, version, deleted in rows:
+        text = {key: value} if kind == "text" and value is not None else {}
+        number = {key: value} if kind == "number" and value is not None else {}
+        boolean = {key: value} if kind == "boolean" and value is not None else {}
+        data.append(
+            (
+                PROJECT,
+                "SPAN",
+                "svc",
+                f"trace-{index}",
+                f"span-{index}",
+                (END - timedelta(hours=1)).isoformat(sep=" "),
+                SESSION,
+                None,
+                version,
+                deleted,
+                list(text),
+                list(text.values()),
+                list(number),
+                list(number.values()),
+                list(boolean),
+                list(boolean.values()),
+            )
+        )
+    literals = escape_params({"schema": schema, "rows": tuple(data)}, CONTEXT)
+    rendered = without_query_settings(sql) % escape_params(params, CONTEXT)
+    rendered = rendered.replace("spans FINAL", "latest_spans")
+    rendered = rendered.replace(
+        "trace_session_id_remap FINAL", "trace_session_id_remap"
+    )
+    prefix = f"""WITH spans AS (SELECT *, mapFromArrays(string_keys,string_values) AS attrs_string,mapFromArrays(number_keys,number_values) AS attrs_number,mapFromArrays(bool_keys,bool_values) AS attrs_bool,'{{}}' AS attributes_extra, start_time AS end_time, 0. AS latency_ms, 'UNSET' AS status, 0. AS cost,toInt32(0) AS total_tokens,toInt32(0) AS prompt_tokens,toInt32(0) AS completion_tokens FROM values({literals["schema"]},{literals["rows"][1:-1]})),trace_session_id_remap AS (SELECT toUUID('00000000-0000-0000-0000-000000000000') AS old_id,old_id AS new_id WHERE 0),"""
+    fields = [
+        "project_id",
+        "observation_type",
+        "service_name",
+        "trace_id",
+        "id",
+        "start_time",
+        "trace_session_id",
+        "parent_span_id",
+        "_version",
+        "is_deleted",
+        "end_time",
+        "latency_ms",
+        "cost",
+        "total_tokens",
+        "prompt_tokens",
+        "completion_tokens",
+        "status",
+    ]
+    packed = ",".join("raw." + name for name in fields)
+    projected = ",".join(f"w.{i} AS {name}" for i, name in enumerate(fields, 1))
+    prefix += f"latest_spans AS (SELECT argMax(tuple({packed}),raw._version) AS w,{projected} FROM spans AS raw GROUP BY raw.project_id,raw.observation_type,raw.service_name,toStartOfHour(raw.start_time),raw.trace_id,raw.id),"
+    # Graph SQL has an outer SELECT, so append the fixture CTEs before it.
+    return [
+        json.loads(line)
+        for line in str(
+            engine.query(values_where(prefix[:-1] + " " + rendered), "JSONEachRow")
+        ).splitlines()
+        if line
+    ]
+
+
+@pytest.mark.parametrize("days", [7, 30, 365])
+@pytest.mark.parametrize("width", [2, 5, 10])
+@pytest.mark.parametrize("negative", [False, True])
+def test_session_graph_list_conjunction_parity(days, width, negative):
+    from tracer.tests.test_session_native_conjunction_replay import run as run_list
+
+    cases = (
+        [
+            ("text", "Allowed", "not_contains", "forbidden", "FORBIDDEN value"),
+            ("number", 7, "not_in", [9, 11], 9),
+            ("boolean", None, "is_null", None, True),
+        ]
+        if negative
+        else [
+            ("text", "Alpha", "equals", "Alpha", None),
+            ("number", 7, "equals", 7, None),
+            ("boolean", True, "equals", True, None),
+        ]
+    )
+    rows, filters, invalid_values = [], [], []
+    for index in range(width):
+        kind, value, operation, operand, invalid = cases[index % len(cases)]
+        key = f"property_{index}"
+        rows.append((index, kind, key, value, 1, 0))
+        filters.append(_filter(key, operand, kind=kind, operation=operation))
+        invalid_values.append(invalid)
+
+    def assert_membership(physical_rows, expected):
+        graph_ids = [row["session_id"] for row in run(physical_rows, filters, days)]
+        list_ids = [row["session_id"] for row in run_list(physical_rows, filters, days)]
+        assert graph_ids == list_ids == expected
+
+    assert_membership(rows, [SESSION])
+    for original, invalid in zip(rows, invalid_values, strict=True):
+        index, kind, key, _, _, _ = original
+        assert_membership([*rows, (index, kind, key, invalid, 2, 0)], [])

--- a/futureagi/tracer/tests/test_system_graph_exact_routing.py
+++ b/futureagi/tracer/tests/test_system_graph_exact_routing.py
@@ -1,0 +1,130 @@
+"""Trace/Span graph dispatch must use latest-state readers, not raw versions."""
+
+from contextlib import contextmanager
+from datetime import datetime, timedelta
+from unittest.mock import Mock
+
+import pytest
+
+from tracer.services.clickhouse import exact_graph_reads, graph_dispatch
+from tracer.services.clickhouse.application_read_policy import is_application_read
+from tracer.services.exact_aggregation_cache import snapshot_cache_key
+from tracer.tasks import exact_aggregation
+
+PROJECT = "00000000-0000-4000-8000-000000000001"
+
+
+@pytest.mark.parametrize("observe_type", ["trace", "span"])
+@pytest.mark.parametrize("days", [7, 30, 365])
+@pytest.mark.parametrize("with_property", [False, True])
+def test_system_graph_schedules_latest_state(
+    monkeypatch, observe_type, days, with_property
+):
+    end = datetime(2026, 9, 5)
+    filters = [
+        {
+            "column_id": "created_at",
+            "filter_config": {
+                "filter_type": "datetime",
+                "filter_op": "between",
+                "filter_value": [
+                    (end - timedelta(days=days)).isoformat(),
+                    end.isoformat(),
+                ],
+            },
+        }
+    ]
+    if with_property:
+        filters.append(
+            {
+                "column_id": "company_id",
+                "filter_config": {
+                    "col_type": "SPAN_ATTRIBUTE",
+                    "filter_type": "text",
+                    "filter_op": "in",
+                    "filter_value": ["one", "two"],
+                    "attribute_value_types": ["string", "string"],
+                },
+            }
+        )
+    expected = {"data": [], "query_status": "pending", "query_complete": False}
+    schedule = Mock(return_value=expected)
+    monkeypatch.setattr(graph_dispatch, "read_or_schedule_exact_snapshot", schedule)
+    analytics = Mock()
+    result = graph_dispatch.fetch_system_metric_graph_ch(
+        analytics=analytics,
+        project_id=PROJECT,
+        filters=filters,
+        interval="day",
+        metric_id="traffic",
+        observe_type=observe_type,
+        organization_id="organization",
+        workspace_id="workspace",
+        refresh=True,
+    )
+    assert result is expected
+    schedule.assert_called_once()
+    namespace, identity = schedule.call_args.args
+    assert namespace == "observe-system-graph"
+    assert identity["filters"] == filters
+    assert identity["observe_type"] == observe_type
+    assert identity["organization_id"] == "organization"
+    assert identity["workspace_id"] == "workspace"
+    assert identity["payload_version"] == 2
+    legacy = {k: v for k, v in identity.items() if k != "payload_version"}
+    assert snapshot_cache_key(namespace, identity) != snapshot_cache_key(
+        namespace, legacy
+    )
+    assert schedule.call_args.kwargs["refresh"] is True
+    assert schedule.call_args.kwargs["pending_payload"]["query_complete"] is False
+    analytics.execute_ch_query.assert_not_called()
+
+
+@pytest.mark.parametrize("observe_type", ["trace", "span"])
+def test_system_worker_uses_exact_reader_after_reauthorization(
+    monkeypatch, observe_type
+):
+    events = []
+    analytics = object()
+
+    @contextmanager
+    def service():
+        events.append("connect")
+        yield analytics
+
+    expected = {"query_complete": True, "query_exact": True}
+
+    def reader(**kwargs):
+        assert is_application_read()
+        events.append("read")
+        assert kwargs["analytics"] is analytics
+        assert kwargs["observe_type"] == observe_type
+        assert kwargs["project_id"] == PROJECT
+        return expected
+
+    monkeypatch.setattr(
+        exact_aggregation,
+        "_reauthorize_exact_observe_project",
+        lambda _: events.append("authorize"),
+    )
+    monkeypatch.setattr(exact_aggregation, "_exact_observe_analytics", service)
+    monkeypatch.setattr(exact_graph_reads, "read_exact_system_graph", reader)
+    raw = Mock(side_effect=AssertionError("raw physical versions must not be used"))
+    monkeypatch.setattr(graph_dispatch, "_fetch_direct_raw_system_metric_graph", raw)
+    assert (
+        exact_aggregation._observe_payload(
+            "observe-system-graph",
+            {
+                "project_id": PROJECT,
+                "filters": [],
+                "interval": "day",
+                "metric_id": "traffic",
+                "observe_type": observe_type,
+                "payload_version": 2,
+            },
+        )
+        is expected
+    )
+    assert not is_application_read()
+    assert events == ["authorize", "connect", "read"]
+    raw.assert_not_called()

--- a/futureagi/tracer/tests/test_trace_session.py
+++ b/futureagi/tracer/tests/test_trace_session.py
@@ -20,7 +20,6 @@ from tracer.models.trace import Trace
 from tracer.models.trace_session import TraceSession, TraceSessionOverlay
 from tracer.services.clickhouse.bounded_graph_reads import (
     BoundedGraphReadError,
-    GraphCandidateSample,
 )
 from tracer.services.clickhouse.filter_value_reads import FilterValueRead
 from tracer.services.clickhouse.read_budget import ReadDeadlineExceeded
@@ -711,155 +710,89 @@ class TestTraceSessionGraphAPI:
             "avg_duration",
         ],
     )
-    def test_session_system_graph_dispatches_date_only_metrics_to_rollup(
-        self, metric_id
-    ):
-        project_id = str(uuid.uuid4())
+    def test_session_system_graph_dispatches_date_only_metrics_to_exact_snapshot(self, metric_id):
         analytics = mock.Mock()
-        analytics.execute_ch_query.return_value = mock.Mock(
-            data=[], columns=SESSION_ROLLUP_RESULT_COLUMNS
-        )
-
-        with mock.patch(
-            "tracer.services.clickhouse.session_graph.read_or_schedule_exact_snapshot",
-        ) as exact_read:
-            graph = fetch_session_graph_ch(
-                analytics=analytics,
-                project_id=project_id,
-                filters=[],
-                interval="day",
-                req_data_config={"id": metric_id, "type": "SYSTEM_METRIC"},
-            )
-
-        assert graph["metric_name"] == metric_id
-        assert graph["query_complete"] is True
-        assert graph["query_status"] == "complete"
-        assert graph["query_sampled"] is False
-        assert graph["query_exact"] is False
-        assert graph["query_provenance"] == "materialized_rollup"
-        exact_read.assert_not_called()
-        query_call = analytics.execute_ch_query.call_args
-        assert "FROM spans_per_session AS sps" in query_call.args[0]
-        assert "FROM spans\n" not in query_call.args[0]
-        assert "trace_session_id_remap" not in query_call.args[0]
-        assert (
-            0
-            < query_call.kwargs["timeout_ms"]
-            <= django_settings.INTERACTIVE_ANALYTICS_DEFAULT_WALL_MS
-        )
-        assert query_call.kwargs["settings"]["max_threads"] == 4
-        assert "max_rows_to_read" not in query_call.kwargs["settings"]
-
-    def test_session_avg_traces_uses_bounded_candidates_without_pending(self):
-        project_id = str(uuid.uuid4())
-        analytics = mock.Mock()
-        start = datetime(2026, 8, 1)
-        sample = GraphCandidateSample(
-            rows=(
-                {
-                    "trace_id": "trace-1",
-                    "trace_session_id": "session-1",
-                    "start_time": start + timedelta(hours=1),
-                },
-            ),
-            query_complete=True,
-            query_status="complete",
-            query_error_code=None,
-            window_start=start,
-            window_end=start + timedelta(days=1),
-            elapsed_ms=5,
-            query_count=1,
-            rows_returned=1,
-            result_payload_bytes=100,
-            total_rows_lower_bound=1,
-        )
-        analytics.execute_ch_query.return_value = mock.Mock(data=[])
-
+        expected = {
+            "metric_name": metric_id, "data": [],
+            "query_status": "complete", "query_complete": True,
+            "query_sampled": False,
+        }
         with (
             mock.patch(
-                "tracer.services.clickhouse.session_graph.read_or_schedule_exact_snapshot"
+                "tracer.services.clickhouse.session_graph.read_or_schedule_exact_snapshot",
+                return_value=expected,
             ) as exact_read,
             mock.patch(
-                "tracer.services.clickhouse.session_graph.read_graph_candidates",
-                return_value=sample,
+                "tracer.services.clickhouse.session_graph.read_graph_candidates"
             ) as candidate_read,
         ):
             graph = fetch_session_graph_ch(
-                analytics=analytics,
-                project_id=project_id,
-                filters=[],
+                analytics=analytics, project_id=str(uuid.uuid4()), filters=[],
                 interval="day",
-                req_data_config={
-                    "id": "avg_traces_per_session",
-                    "type": "SYSTEM_METRIC",
-                },
+                req_data_config={"id": metric_id, "type": "SYSTEM_METRIC"},
             )
+        assert graph is expected
+        exact_read.assert_called_once()
+        assert exact_read.call_args.args[0] == "observe-session-system-graph"
+        assert exact_read.call_args.args[1]["metric_id"] == metric_id
+        candidate_read.assert_not_called()
+        analytics.execute_ch_query.assert_not_called()
 
-        assert graph["query_status"] == "complete"
-        assert graph["query_exact"] is False
-        assert graph["query_provenance"] == "bounded_candidates"
-        assert graph["data"][0]["value"] == 1
-        assert "query_refreshing" not in graph
-        exact_read.assert_not_called()
-        assert (
-            candidate_read.call_args.kwargs["deadline_ms"]
-            == django_settings.INTERACTIVE_ANALYTICS_DEFAULT_WALL_MS
-        )
-
-    def test_session_avg_traces_budget_failure_preserves_sample_progress(self):
-        start = datetime(2025, 8, 12)
-        sample = GraphCandidateSample(
-            rows=(
-                {
-                    "trace_id": "trace-1",
-                    "trace_session_id": "session-1",
-                    "start_time": start,
-                },
-            ),
-            query_complete=False,
-            query_status="degraded",
-            query_error_code="read_budget_exceeded",
-            window_start=start,
-            window_end=start + timedelta(days=365),
-            elapsed_ms=9_475,
-            query_count=3,
-            rows_returned=4,
-            result_payload_bytes=400,
-            total_rows_lower_bound=4,
-            sampling_strategy="time_stratified_latest_state",
-            sampling_strata=8,
-            sampling_strata_completed=3,
-        )
-
+    def test_session_avg_traces_uses_exact_snapshot(self):
+        analytics = mock.Mock()
+        expected = {
+            "metric_name": "avg_traces_per_session", "data": [],
+            "query_status": "complete", "query_complete": True,
+            "query_sampled": False,
+        }
         with (
             mock.patch(
-                "tracer.services.clickhouse.session_graph.read_graph_candidates",
-                return_value=sample,
-            ),
-            mock.patch(
-                "tracer.services.clickhouse.session_graph.read_or_schedule_exact_snapshot"
+                "tracer.services.clickhouse.session_graph.read_or_schedule_exact_snapshot",
+                return_value=expected,
             ) as exact_read,
+            mock.patch(
+                "tracer.services.clickhouse.session_graph.read_graph_candidates"
+            ) as candidate_read,
         ):
             graph = fetch_session_graph_ch(
-                analytics=mock.Mock(),
-                project_id=str(uuid.uuid4()),
-                filters=[],
-                interval="month",
-                req_data_config={
-                    "id": "avg_traces_per_session",
-                    "type": "SYSTEM_METRIC",
-                },
+                analytics=analytics, project_id=str(uuid.uuid4()), filters=[],
+                interval="day",
+                req_data_config={"id": "avg_traces_per_session", "type": "SYSTEM_METRIC"},
             )
+        assert graph is expected
+        exact_read.assert_called_once()
+        assert exact_read.call_args.args[0] == "observe-session-system-graph"
+        assert exact_read.call_args.args[1]["metric_id"] == "avg_traces_per_session"
+        candidate_read.assert_not_called()
+        analytics.execute_ch_query.assert_not_called()
 
-        assert graph["data"] == []
-        assert graph["query_status"] == "degraded"
-        assert graph["query_error_code"] == "read_budget_exceeded"
-        assert graph["query_sampling_strata"] == 8
-        assert graph["query_sampling_strata_completed"] == 3
-        assert graph["query_exact"] is False
-        assert graph["query_provenance"] == "bounded_candidates"
-        assert "query_refreshing" not in graph
-        exact_read.assert_not_called()
+    def test_session_avg_traces_pending_never_publishes_sample(self):
+        analytics = mock.Mock()
+        expected = {
+            "metric_name": "avg_traces_per_session", "data": [],
+            "query_status": "pending", "query_complete": False,
+            "query_sampled": False,
+        }
+        with (
+            mock.patch(
+                "tracer.services.clickhouse.session_graph.read_or_schedule_exact_snapshot",
+                return_value=expected,
+            ) as exact_read,
+            mock.patch(
+                "tracer.services.clickhouse.session_graph.read_graph_candidates"
+            ) as candidate_read,
+        ):
+            graph = fetch_session_graph_ch(
+                analytics=analytics, project_id=str(uuid.uuid4()), filters=[],
+                interval="day",
+                req_data_config={"id": "avg_traces_per_session", "type": "SYSTEM_METRIC"},
+            )
+        assert graph is expected
+        exact_read.assert_called_once()
+        assert exact_read.call_args.args[0] == "observe-session-system-graph"
+        assert exact_read.call_args.args[1]["metric_id"] == "avg_traces_per_session"
+        candidate_read.assert_not_called()
+        analytics.execute_ch_query.assert_not_called()
 
     def test_session_system_candidate_sql_replays_v2_updates_and_tombstones(self):
         builder = TraceListQueryBuilderV2(
@@ -997,30 +930,31 @@ class TestTraceSessionGraphAPI:
 
     def test_session_date_only_graph_does_not_read_bounded_candidates(self):
         analytics = mock.Mock()
-        analytics.execute_ch_query.return_value = mock.Mock(
-            data=[], columns=SESSION_ROLLUP_RESULT_COLUMNS
-        )
-
+        expected = {
+            "metric_name": "session_count", "data": [],
+            "query_status": "pending", "query_complete": False,
+            "query_sampled": False,
+        }
         with (
             mock.patch(
-                "tracer.services.clickhouse.session_graph.read_or_schedule_exact_snapshot"
+                "tracer.services.clickhouse.session_graph.read_or_schedule_exact_snapshot",
+                return_value=expected,
             ) as exact_read,
             mock.patch(
                 "tracer.services.clickhouse.session_graph.read_graph_candidates"
             ) as candidate_read,
         ):
             graph = fetch_session_graph_ch(
-                analytics=analytics,
-                project_id=str(uuid.uuid4()),
-                filters=[],
+                analytics=analytics, project_id=str(uuid.uuid4()), filters=[],
                 interval="day",
                 req_data_config={"id": "session_count", "type": "SYSTEM_METRIC"},
             )
-
-        assert graph["query_provenance"] == "materialized_rollup"
-        exact_read.assert_not_called()
+        assert graph is expected
+        exact_read.assert_called_once()
+        assert exact_read.call_args.args[0] == "observe-session-system-graph"
+        assert exact_read.call_args.args[1]["metric_id"] == "session_count"
         candidate_read.assert_not_called()
-        analytics.execute_ch_query.assert_called_once()
+        analytics.execute_ch_query.assert_not_called()
 
     def test_session_system_graph_forwards_explicit_refresh(self):
         analytics = mock.Mock()

--- a/futureagi/tracer/utils/graphs_optimized.py
+++ b/futureagi/tracer/utils/graphs_optimized.py
@@ -438,7 +438,7 @@ def _read_direct_system_metrics(
     organization_id: str | None = None,
     workspace_id: str | None = None,
 ) -> dict[str, list[dict[str, Any]]]:
-    """Execute the direct-write system-metric builder on the CH25 service."""
+    """Read or schedule the exact CH25 system-metric snapshot."""
     try:
         from tracer.services.clickhouse.graph_dispatch import (
             fetch_all_system_metrics_ch,
@@ -481,7 +481,7 @@ def get_all_system_metrics(
     organization_id: str | None = None,
     workspace_id: str | None = None,
 ) -> dict:
-    """Read latency, token, cost, and traffic series in one CH25 query."""
+    """Return latency, token, cost, and traffic series from one exact snapshot."""
     del property
 
     project_id = system_metric_filters.get("project_id")


### PR DESCRIPTION
Cold graph paths mixed raw-version or rollup reads with interactive deadlines, and some paths discarded refresh or tenant scope. Route Trace, Span, Session, User, Eval, Annotation and bundled system charts through the existing exact snapshot workers. Preserve pending state, trusted scope and latest-state membership. Application graph reads retain completion after elapsed time; bounded diagnostic reads remain available. Remove superseded public routing branches.

Validation: 581 graph routing/source/ownership tests and 101 admission/PostgreSQL/view tests passed. Parallel-worker context tests passed. Frontend graph tests passed in the existing offline run; stacked files are byte-identical.

This changes cold-read behavior to pending while a worker computes a complete snapshot. Worker availability, real API/browser completion and the 5s target remain unqualified. Keep draft until those gates are resolved.

The local validation above remains evidence from before this stack reorder. Latest `dev` at `41b8cf75f` is integrated through the parent stack; this PR's own patch is unchanged. At current head `beb44f07c`, the [Frontend Feature pipeline](https://github.com/future-agi/future-agi/actions/runs/34347595497) passed 7 tests and skipped 4,982, with type and build checks passing. This is name-filtered frontend coverage, not the full component or backend suite. Worker behavior, deployed API/browser completion and the 5s target remain unqualified. The stack parent's admission blocker remains separate from these checks.

Stack position 4/6. Base: `fix/TH-7247-review-02-users-reads`. Review and merge in the order below; retarget and recheck each descendant after its parent merges.

AI-assisted implementation. Backend/E2E CI does not run against child PR bases; reported local tests are not deployed performance qualification.

Review order:
1. [fix: [1/6] Fix cancelled grid reads and cursor continuation [agent]](https://github.com/future-agi/future-agi/pull/2640)
2. [fix: [2/6] Preserve latest physical state in Trace reads [agent]](https://github.com/future-agi/future-agi/pull/2637)
3. [fix: [3/6] Reduce exact Users replay work [agent]](https://github.com/future-agi/future-agi/pull/2638)
4. [fix: [4/6] Use complete exact graph snapshots [agent]](https://github.com/future-agi/future-agi/pull/2639)
5. [fix: [5/6] Preserve dashboard previews while exact reads finish [agent]](https://github.com/future-agi/future-agi/pull/2641)
6. [test: [6/6] Add read-only Voice replay coverage [agent]](https://github.com/future-agi/future-agi/pull/2642)

[#2643](https://github.com/future-agi/future-agi/pull/2643) is independent and targets `dev`.
