### PR TITLE
fix: [5/6] Preserve dashboard previews while exact reads finish [agent]

### DIFF
--- a/frontend/src/sections/dashboards/WidgetChart.jsx
+++ b/frontend/src/sections/dashboards/WidgetChart.jsx
@@ -27,7 +27,6 @@ import WidgetPieCharts from "./WidgetPieCharts";
 import { toTimeRangePayload } from "./dashboardDateRange";
 import {
   AGGREGATION_POLLING_PAUSED_MESSAGE,
-  AGGREGATION_REQUEST_TIMEOUT_MS,
   AGGREGATION_PREPARING_MESSAGE,
   QUERY_FAILED_RETRY_MESSAGE,
   createAggregationPollController,
@@ -262,7 +261,6 @@ export default function WidgetChart({
     previousRefreshRequestRef.current = refreshRequestId;
     let active = true;
     let pollTimer = null;
-    let requestTimer = null;
     let requestController = null;
     let requestGeneration = 0;
     const pollingController = createAggregationPollController();
@@ -275,10 +273,6 @@ export default function WidgetChart({
       if (pollTimer !== null) {
         window.clearTimeout(pollTimer);
         pollTimer = null;
-      }
-      if (requestTimer !== null) {
-        window.clearTimeout(requestTimer);
-        requestTimer = null;
       }
       requestController?.abort();
       requestController = null;
@@ -322,7 +316,6 @@ export default function WidgetChart({
       requestController?.abort();
       const controller = new AbortController();
       requestController = controller;
-      if (requestTimer !== null) window.clearTimeout(requestTimer);
 
       const handleQueuedTransportFailure = () => {
         const exhausted = !pollingController.recordFailure();
@@ -336,31 +329,11 @@ export default function WidgetChart({
         else schedulePoll();
       };
 
-      requestTimer = window.setTimeout(() => {
-        if (!active || settled || generation !== requestGeneration) return;
-        requestGeneration += 1;
-        requestTimer = null;
-        controller.abort();
-        if (refreshWasQueued) {
-          handleQueuedTransportFailure();
-          return;
-        }
-        setLatestOutcome({
-          signature: querySignature,
-          unavailable: true,
-          retryUnavailable: true,
-          pollingPaused: false,
-        });
-        settle(null, false);
-      }, AGGREGATION_REQUEST_TIMEOUT_MS);
-
+      // Exact reads can outlive a browser deadline. Their controller remains
+      // owned by this widget scope and is cancelled on replacement or unmount.
       const acceptResponse = () => {
         if (!active || settled || generation !== requestGeneration)
           return false;
-        if (requestTimer !== null) {
-          window.clearTimeout(requestTimer);
-          requestTimer = null;
-        }
         if (requestController === controller) requestController = null;
         return true;
       };
@@ -451,7 +424,6 @@ export default function WidgetChart({
       active = false;
       requestGeneration += 1;
       if (pollTimer !== null) window.clearTimeout(pollTimer);
-      if (requestTimer !== null) window.clearTimeout(requestTimer);
       requestController?.abort();
     };
   }, [

--- a/frontend/src/sections/dashboards/WidgetEditorView.jsx
+++ b/frontend/src/sections/dashboards/WidgetEditorView.jsx
@@ -99,7 +99,6 @@ import {
   fromAxisConfigPayload,
   getAggColumnLabel,
   getAutoDecimals,
-  getExactDashboardResult,
   getDashboardMetricSeriesState,
   getPlottedChartSeries,
   getSeriesScalar,
@@ -113,10 +112,7 @@ import {
 } from "./widgetUtils";
 import {
   AGGREGATION_PREPARING_MESSAGE,
-  createAggregationPollController,
   getFilterValueReadMessage,
-  getAggregationRefreshState,
-  getExactAggregationReadState,
 } from "src/utils/queryReadState";
 import {
   AGGREGATION_OPTIONS,
@@ -133,11 +129,9 @@ import {
   getWidgetEditorLoadState,
   getWidgetPreviewState,
   shouldBlockWidgetPreviewForFailure,
-  WIDGET_PREVIEW_MAX_WAIT_MS,
 } from "./widgetEditorState";
-import { INTERACTIVE_REQUEST_TIMEOUT_MS } from "src/config/runtime_limits";
+import { useWidgetPreviewReads } from "./useWidgetPreviewReads";
 
-const WIDGET_PREVIEW_REQUEST_TIMEOUT_MS = INTERACTIVE_REQUEST_TIMEOUT_MS;
 
 const escapeCsvField = (field) => {
   const str = String(field ?? "");
@@ -2157,14 +2151,7 @@ export default function WidgetEditorView() {
   const mutateDashboardQuery = queryMutation.mutate;
   const resetDashboardQuery = queryMutation.reset;
   const { data: simulationAgents = [] } = useSimulationAgents();
-  const [lastExactPreview, setLastExactPreview] = useState(null);
-  const currentPreviewSignatureRef = useRef("");
-  const previewPollTimerRef = useRef(null);
-  const previewRequestControllerRef = useRef(null);
-  const previewRequestTimerRef = useRef(null);
-  const previewGenerationRef = useRef(0);
-  const [isPreviewRefreshing, setIsPreviewRefreshing] = useState(false);
-  const [previewFailed, setPreviewFailed] = useState(false);
+
 
   // Build a map: agent_definition_id → observability project for cross-source correlation
   const simAgentObsMap = useMemo(() => {
@@ -2924,166 +2911,8 @@ export default function WidgetEditorView() {
 
   const previewQueryConfig = buildQueryConfig();
   const previewQuerySignature = JSON.stringify(previewQueryConfig);
-  currentPreviewSignatureRef.current = previewQuerySignature;
-
-  useEffect(() => {
-    previewGenerationRef.current += 1;
-    previewRequestControllerRef.current?.abort();
-    previewRequestControllerRef.current = null;
-    clearTimeout(previewRequestTimerRef.current);
-    previewRequestTimerRef.current = null;
-    clearTimeout(previewPollTimerRef.current);
-    previewPollTimerRef.current = null;
-    setIsPreviewRefreshing(false);
-    setPreviewFailed(false);
-  }, [previewQuerySignature]);
-
-  useEffect(
-    () => () => {
-      previewGenerationRef.current += 1;
-      previewRequestControllerRef.current?.abort();
-      previewRequestControllerRef.current = null;
-      clearTimeout(previewRequestTimerRef.current);
-      clearTimeout(previewPollTimerRef.current);
-    },
-    [],
-  );
-
-  const runPreviewQuery = useCallback(
-    (queryConfig, { refresh = false } = {}) => {
-      const signature = JSON.stringify(queryConfig);
-      const generation = previewGenerationRef.current + 1;
-      previewGenerationRef.current = generation;
-      clearTimeout(previewPollTimerRef.current);
-      previewPollTimerRef.current = null;
-      const pollingController = createAggregationPollController();
-      // Include the first preview request in the same sub-ten-second action
-      // budget as any pending-response polls. Retry creates a fresh controller.
-      pollingController.start();
-      pollingController.recordAttempt();
-      let refreshWasQueued = false;
-      setPreviewFailed(false);
-
-      const isCurrent = () =>
-        previewGenerationRef.current === generation &&
-        currentPreviewSignatureRef.current === signature;
-
-      const schedulePoll = () => {
-        if (!isCurrent() || previewPollTimerRef.current !== null) return;
-        pollingController.start();
-        const delay = pollingController.nextDelay();
-        if (delay === false) {
-          setIsPreviewRefreshing(false);
-          setPreviewFailed(true);
-          return;
-        }
-        previewPollTimerRef.current = window.setTimeout(() => {
-          previewPollTimerRef.current = null;
-          pollingController.recordAttempt();
-          execute(false);
-        }, delay);
-      };
-
-      const execute = (forceRefresh) => {
-        previewRequestControllerRef.current?.abort();
-        clearTimeout(previewRequestTimerRef.current);
-        const requestController = new AbortController();
-        previewRequestControllerRef.current = requestController;
-        const finishAttempt = () => {
-          clearTimeout(previewRequestTimerRef.current);
-          previewRequestTimerRef.current = null;
-          if (previewRequestControllerRef.current === requestController) {
-            previewRequestControllerRef.current = null;
-          }
-        };
-        const requestTimeoutMs = pollingController.remainingMs(
-          WIDGET_PREVIEW_REQUEST_TIMEOUT_MS,
-        );
-        previewRequestTimerRef.current = window.setTimeout(() => {
-          if (
-            !isCurrent() ||
-            previewRequestControllerRef.current !== requestController
-          ) {
-            return;
-          }
-          finishAttempt();
-          previewGenerationRef.current = generation + 1;
-          requestController.abort();
-          setIsPreviewRefreshing(false);
-          setPreviewFailed(true);
-        }, requestTimeoutMs);
-        mutateDashboardQuery(
-          {
-            queryConfig,
-            refresh: forceRefresh,
-            signal: requestController.signal,
-          },
-          {
-            onSuccess: (response) => {
-              finishAttempt();
-              if (!isCurrent()) return;
-
-              const exactResult = getExactDashboardResult(response);
-              const { isRefreshing, refreshFailed } =
-                getAggregationRefreshState(response);
-              const readState = getExactAggregationReadState(response);
-              const responsePreviewState = getWidgetPreviewState(
-                response?.data?.result,
-                { isSuccess: true },
-              );
-              pollingController.recordSuccess();
-              if (exactResult) {
-                setLastExactPreview({ signature, result: exactResult });
-                setPreviewFailed(false);
-              }
-              if (
-                isRefreshing &&
-                !refreshFailed &&
-                (exactResult || readState === "pending")
-              ) {
-                refreshWasQueued = true;
-                setIsPreviewRefreshing(true);
-                schedulePoll();
-                return;
-              }
-              if (
-                !refreshFailed &&
-                !exactResult &&
-                responsePreviewState === "preparing"
-              ) {
-                refreshWasQueued = true;
-                setIsPreviewRefreshing(true);
-                schedulePoll();
-                return;
-              }
-              setIsPreviewRefreshing(false);
-              if (
-                !exactResult &&
-                (refreshFailed ||
-                  responsePreviewState === "failed" ||
-                  readState !== "complete")
-              ) {
-                setPreviewFailed(true);
-              }
-            },
-            onError: () => {
-              finishAttempt();
-              if (!isCurrent()) return;
-              if (refreshWasQueued && pollingController.recordFailure()) {
-                schedulePoll();
-                return;
-              }
-              setIsPreviewRefreshing(false);
-              setPreviewFailed(true);
-            },
-          },
-        );
-      };
-
-      execute(refresh);
-    },
-    [mutateDashboardQuery],
-  );
+  const { previewPollingPaused, lastExactPreview, isPreviewRefreshing, previewFailed, setPreviewFailed, runPreviewQuery } =
+    useWidgetPreviewReads(mutateDashboardQuery, previewQuerySignature);
 
   // Auto-preview when config changes (debounced)
   const previewTimerRef = useRef(null);
@@ -4039,36 +3868,25 @@ export default function WidgetEditorView() {
     queryMutation,
   );
   const previewPreparing =
+    !previewPollingPaused &&
     !previewFailed &&
     canPreview &&
     !activeExactPreview &&
     (queryMutation.isPending ||
       isPreviewRefreshing ||
       serverPreviewState === "preparing");
-  const previewActivity = previewPreparing && !activeExactPreview;
   const previewFailureBlocksRendering = shouldBlockWidgetPreviewForFailure({
     previewFailed,
     hasExactPreview: Boolean(activeExactPreview),
   });
 
-  useEffect(() => {
-    if (!previewActivity) return undefined;
-    const timer = setTimeout(() => {
-      previewGenerationRef.current += 1;
-      clearTimeout(previewPollTimerRef.current);
-      previewPollTimerRef.current = null;
-      setIsPreviewRefreshing(false);
-      setPreviewFailed(true);
-    }, WIDGET_PREVIEW_MAX_WAIT_MS);
-    return () => clearTimeout(timer);
-  }, [previewActivity]);
-
   const retryPreview = useCallback(() => {
     setPreviewFailed(false);
     runPreviewQuery(buildQueryConfig(), { refresh: true });
-  }, [buildQueryConfig, runPreviewQuery]);
+  }, [buildQueryConfig, runPreviewQuery, setPreviewFailed]);
 
   const previewLoading =
+    !previewPollingPaused &&
     !previewFailed &&
     ((queryMutation.isPending && !activeExactPreview) ||
       (isEditing && isDashboardLoading) ||
@@ -4766,6 +4584,9 @@ export default function WidgetEditorView() {
               overflow: "hidden",
             }}
           >
+            {previewPollingPaused && (
+              <Box sx={{ p: 2 }}><WidgetPreviewStatus state="paused" onRetry={retryPreview} /></Box>
+            )}
             {/* Bar chart — horizontal bars (left) + search/checkboxes (right) */}
             {isHorizontal && (previewLoading || previewPreparing) && (
               <Box
@@ -4790,6 +4611,7 @@ export default function WidgetEditorView() {
               !previewLoading &&
               !previewPreparing &&
               !previewFailureBlocksRendering &&
+              !previewPollingPaused &&
               previewSeries.length === 0 && (
                 <Box
                   sx={{
@@ -5179,7 +5001,7 @@ export default function WidgetEditorView() {
                   overflow: "hidden",
                 }}
               >
-                {previewLoading || previewPreparing ? (
+                {previewPollingPaused && !activeExactPreview ? null : previewLoading || previewPreparing ? (
                   <WidgetPreviewStatus
                     state={previewPreparing ? "preparing" : "loading"}
                   />

--- a/frontend/src/sections/dashboards/__tests__/WidgetChart.test.jsx
+++ b/frontend/src/sections/dashboards/__tests__/WidgetChart.test.jsx
@@ -5,7 +5,6 @@ import WidgetChart from "../WidgetChart";
 import {
   AGGREGATION_POLL_MAX_ATTEMPTS,
   AGGREGATION_POLLING_PAUSED_MESSAGE,
-  AGGREGATION_REQUEST_TIMEOUT_MS,
 } from "src/utils/queryReadState";
 import WidgetPieCharts from "../WidgetPieCharts";
 import { NO_DATA_FOR_RANGE_MESSAGE } from "../constants";
@@ -467,35 +466,20 @@ describe("WidgetChart — queued exact refresh", () => {
     );
   });
 
-  it("leaves a cold spinner after the component deadline even when the mutation adapter stays pending", async () => {
+  it("keeps a cold exact read pending until its slow complete response", async () => {
     vi.useFakeTimers();
     h.query.isPending = true;
     h.query.mutate.mockImplementation(() => {});
     const onQuerySettled = vi.fn();
-
-    render(
-      <WidgetChart
-        widget={baseWidget}
-        dashboardId="dashboard-1"
-        globalDateRange={null}
-        onQuerySettled={onQuerySettled}
-      />,
-    );
-
+    render(<WidgetChart widget={baseWidget} dashboardId="dashboard-1" globalDateRange={null} onQuerySettled={onQuerySettled} />);
     expect(screen.getByRole("progressbar")).toBeInTheDocument();
-
-    await act(async () =>
-      vi.advanceTimersByTimeAsync(AGGREGATION_REQUEST_TIMEOUT_MS),
-    );
-
-    expect(screen.queryByRole("progressbar")).not.toBeInTheDocument();
-    expect(
-      screen.getByText("We couldn't load this data. Please retry in a moment."),
-    ).toBeInTheDocument();
-    expect(onQuerySettled).toHaveBeenCalledOnce();
-    expect(onQuerySettled).toHaveBeenCalledWith(
-      expect.objectContaining({ exact: false, updatedAt: null }),
-    );
+    await act(async () => vi.advanceTimersByTimeAsync(120_000));
+    expect(screen.getByRole("progressbar")).toBeInTheDocument();
+    expect(onQuerySettled).not.toHaveBeenCalled();
+    expect(h.query.mutate.mock.calls[0][0].signal.aborted).toBe(false);
+    act(() => h.query.mutate.mock.calls[0][1].onSuccess(queryResult([{ timestamp: "2026-07-09T00:00:00Z", value: 24 }])));
+    expect(screen.getByTestId("apex-line")).toBeInTheDocument();
+    expect(onQuerySettled).toHaveBeenCalledWith(expect.objectContaining({ exact: true }));
   });
 
   it("keeps cached exact data, stops at the finite budget, and resumes on explicit refresh", async () => {
@@ -617,79 +601,37 @@ describe("WidgetChart — queued exact refresh", () => {
     );
   });
 
-  it("times out an unresolved request while preserving the previous exact snapshot", async () => {
+  it("preserves cached exact data during a slow read and accepts its completion", async () => {
     vi.useFakeTimers();
-    const cachedResponse = queryResult([
-      { timestamp: "2026-07-09T00:00:00Z", value: 12 },
-    ]);
-    const onQuerySettled = vi.fn();
-    h.query.data = cachedResponse;
+    h.query.data = queryResult([{ timestamp: "2026-07-09T00:00:00Z", value: 12 }]);
     h.query.mutate.mockImplementation(() => {});
-
-    render(
-      <WidgetChart
-        widget={baseWidget}
-        dashboardId="dashboard-1"
-        globalDateRange={null}
-        onQuerySettled={onQuerySettled}
-      />,
-    );
-
-    expect(h.query.mutate).toHaveBeenCalledOnce();
+    const onQuerySettled = vi.fn();
+    render(<WidgetChart widget={baseWidget} dashboardId="dashboard-1" globalDateRange={null} onQuerySettled={onQuerySettled} />);
     const requestSignal = h.query.mutate.mock.calls[0][0].signal;
+    await act(async () => vi.advanceTimersByTimeAsync(120_000));
+    expect(screen.getByTestId("apex-line")).toBeInTheDocument();
+    expect(screen.queryByText("We couldn't load this data. Please retry in a moment.")).not.toBeInTheDocument();
     expect(requestSignal.aborted).toBe(false);
-    expect(screen.getByTestId("apex-line")).toBeInTheDocument();
     expect(onQuerySettled).not.toHaveBeenCalled();
-
-    await act(async () =>
-      vi.advanceTimersByTimeAsync(AGGREGATION_REQUEST_TIMEOUT_MS),
-    );
-
-    expect(screen.getByTestId("apex-line")).toBeInTheDocument();
-    expect(
-      screen.getByText("We couldn't load this data. Please retry in a moment."),
-    ).toBeInTheDocument();
-    expect(onQuerySettled).toHaveBeenCalledOnce();
-    expect(onQuerySettled).toHaveBeenCalledWith(
-      expect.objectContaining({ exact: false, updatedAt: null }),
-    );
-    expect(requestSignal.aborted).toBe(true);
-
-    await act(async () =>
-      vi.advanceTimersByTimeAsync(AGGREGATION_REQUEST_TIMEOUT_MS * 2),
-    );
     expect(h.query.mutate).toHaveBeenCalledOnce();
+    act(() => h.query.mutate.mock.calls[0][1].onSuccess(queryResult([{ timestamp: "2026-07-09T00:00:00Z", value: 24 }])));
     expect(onQuerySettled).toHaveBeenCalledOnce();
+    expect(onQuerySettled).toHaveBeenCalledWith(expect.objectContaining({ exact: true }));
   });
 
-  it("aborts a cold hung request and leaves a finite retry state", async () => {
+  it("aborts a pending read on unmount and ignores a late exact response", async () => {
     vi.useFakeTimers();
     const onQuerySettled = vi.fn();
     h.query.mutate.mockImplementation(() => {});
-
-    render(
-      <WidgetChart
-        widget={baseWidget}
-        dashboardId="dashboard-1"
-        globalDateRange={null}
-        onQuerySettled={onQuerySettled}
-      />,
-    );
-
+    const view = render(<WidgetChart widget={baseWidget} dashboardId="dashboard-1" globalDateRange={null} onQuerySettled={onQuerySettled} />);
     const requestSignal = h.query.mutate.mock.calls[0][0].signal;
+    await act(async () => vi.advanceTimersByTimeAsync(120_000));
     expect(requestSignal.aborted).toBe(false);
     expect(screen.getByText(PREPARING_MESSAGE)).toBeInTheDocument();
-
-    await act(async () =>
-      vi.advanceTimersByTimeAsync(AGGREGATION_REQUEST_TIMEOUT_MS),
-    );
-
+    view.unmount();
     expect(requestSignal.aborted).toBe(true);
-    expect(screen.queryByText(PREPARING_MESSAGE)).not.toBeInTheDocument();
-    expect(
-      screen.getByText("We couldn't load this data. Please retry in a moment."),
-    ).toBeInTheDocument();
-    expect(onQuerySettled).toHaveBeenCalledOnce();
+    act(() => h.query.mutate.mock.calls[0][1].onSuccess(queryResult([{ timestamp: "2026-07-09T00:00:00Z", value: 24 }])));
+    expect(onQuerySettled).not.toHaveBeenCalled();
   });
 
   it("aborts an obsolete request and ignores its late response after the query scope changes", () => {

--- a/frontend/src/sections/dashboards/__tests__/WidgetEditorView.preview.test.jsx
+++ b/frontend/src/sections/dashboards/__tests__/WidgetEditorView.preview.test.jsx
@@ -1,0 +1,165 @@
+import React from "react";
+import { act, fireEvent, render, screen } from "src/utils/test-utils";
+import { afterEach, describe, expect, it, vi } from "vitest";
+const h = vi.hoisted(() => ({
+  mutate: vi.fn(),
+  reset: vi.fn(),
+  chartType: "line",
+}));
+const catalog = {
+  metrics: [],
+  categoryCounts: {},
+  categoryCountsExact: true,
+  isLoading: false,
+};
+const dashboard = () => ({
+  id: "dashboard-1",
+  name: "Fixture dashboard",
+  widgets: [
+    {
+      id: "widget-1",
+      name: "Fixture widget",
+      query_config: {
+        time_range: { preset: "7D" },
+        granularity: "day",
+        metrics: [
+          {
+            name: "latency",
+            display_name: "Latency",
+            type: "system_metric",
+            source: "traces",
+            aggregation: "avg",
+          },
+        ],
+      },
+      chart_config: { chart_type: h.chartType },
+    },
+  ],
+});
+vi.mock("react-router-dom", async (original) => ({
+  ...(await original()),
+  useParams: () => ({ dashboardId: "dashboard-1", widgetId: "widget-1" }),
+}));
+vi.mock("src/hooks/useDashboards", () => ({
+  useDashboardDetail: () => ({ data: dashboard(), isLoading: false }),
+  useDashboardQuery: () => ({
+    mutate: h.mutate,
+    reset: h.reset,
+    isIdle: false,
+    isPending: false,
+  }),
+  useCreateWidget: () => ({}),
+  useUpdateWidget: () => ({}),
+  useDeleteWidget: () => ({}),
+  useSimulationAgents: () => ({ data: [] }),
+  usePropertyCatalog: () => catalog,
+  useLegacyDashboardMetricsPaginated: () => catalog,
+  isPropertyCatalogNotReadyError: () => false,
+}));
+vi.mock("src/contexts/WorkspaceContext", () => ({
+  useWorkspace: () => ({ currentWorkspaceId: "workspace-1" }),
+}));
+vi.mock("../hooks/useCanEditDashboard", () => ({
+  default: () => ({ canDelete: false, isReadOnly: false }),
+}));
+vi.mock("src/components/snackbar", () => ({
+  useSnackbar: () => ({ enqueueSnackbar: vi.fn() }),
+}));
+vi.mock("src/components/iconify", () => ({ default: () => null }));
+vi.mock("src/components/filter-value-label", () => ({
+  default: () => null,
+  useResolvedFilterOptions: () => ({ options: [] }),
+}));
+vi.mock("src/sections/projects/LLMTracing/useCursorAttributeInventory", () => ({
+  attributeInventoryKey: (x) => x,
+  useLegacyCursorAttributeInventory: () => ({
+    filteredAttributes: [],
+    inventoryControlProps: {},
+  }),
+}));
+vi.mock("react-apexcharts", () => ({
+  default: () => <div data-testid="editor-chart" />,
+}));
+import WidgetEditorView from "../WidgetEditorView";
+const pending = {
+  data: {
+    result: {
+      metrics: [],
+      query_complete: false,
+      query_status: "pending",
+      query_sampled: false,
+      query_refreshing: true,
+    },
+  },
+};
+const exact = {
+  data: {
+    result: {
+      query_complete: true,
+      query_status: "complete",
+      query_sampled: false,
+      metrics: [
+        {
+          name: "latency",
+          aggregation: "avg",
+          query_complete: true,
+          query_status: "complete",
+          query_sampled: false,
+          series: [
+            {
+              name: "total",
+              data: [{ timestamp: "2026-07-09T00:00:00Z", value: 24 }],
+            },
+          ],
+        },
+      ],
+    },
+  },
+};
+afterEach(() => {
+  vi.useRealTimers();
+  vi.clearAllMocks();
+});
+describe("full dashboard editor preview wiring", () => {
+  it.each(["line", "bar"])(
+    "renders a polling pause and resumes the exact %s preview",
+    async (chartType) => {
+      vi.useFakeTimers();
+      h.chartType = chartType;
+      h.mutate.mockImplementation((_request, options) =>
+        options.onSuccess(pending),
+      );
+      const view = render(<WidgetEditorView />);
+      await act(async () => vi.advanceTimersByTimeAsync(500_000));
+      expect(h.mutate).toHaveBeenCalled();
+      expect(
+        screen.getByRole("button", { name: "Continue" }),
+      ).toBeInTheDocument();
+      expect(
+        screen.queryByText(/Data could not be prepared/i),
+      ).not.toBeInTheDocument();
+      expect(screen.queryByText(/Preparing data/)).not.toBeInTheDocument();
+      h.mutate.mockImplementation((_request, options) =>
+        options.onSuccess(exact),
+      );
+      fireEvent.click(screen.getByRole("button", { name: "Continue" }));
+      expect(
+        screen.queryByRole("button", { name: "Continue" }),
+      ).not.toBeInTheDocument();
+      if (chartType === "line")
+        expect(screen.getByTestId("editor-chart")).toBeInTheDocument();
+      else expect(view.container).toHaveTextContent("24");
+    },
+  );
+  it("cancels its debounced preview read when the editor unmounts", async () => {
+    vi.useFakeTimers();
+    h.mutate.mockImplementation(() => {});
+    const view = render(<WidgetEditorView />);
+    await act(async () => vi.advanceTimersByTimeAsync(500));
+    expect(h.mutate).toHaveBeenCalledOnce();
+    const request = h.mutate.mock.calls[0][0];
+    expect(request.signal.aborted).toBe(false);
+    view.unmount();
+    expect(request.signal.aborted).toBe(true);
+  });
+});

--- a/frontend/src/sections/dashboards/__tests__/useWidgetPreviewReads.test.jsx
+++ b/frontend/src/sections/dashboards/__tests__/useWidgetPreviewReads.test.jsx
@@ -1,0 +1,117 @@
+import { act, renderHook } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { useWidgetPreviewReads } from "../useWidgetPreviewReads";
+const config = { metrics: [{ name: "Latency", aggregation: "avg" }] };
+const signature = JSON.stringify(config);
+const exact = (value) => ({
+  data: {
+    result: {
+      query_complete: true,
+      query_status: "complete",
+      query_sampled: false,
+      metrics: [
+        {
+          name: "Latency",
+          aggregation: "avg",
+          query_complete: true,
+          query_status: "complete",
+          query_sampled: false,
+          series: [
+            {
+              name: "total",
+              data: [{ timestamp: "2026-07-09T00:00:00Z", value }],
+            },
+          ],
+        },
+      ],
+    },
+  },
+});
+afterEach(() => vi.useRealTimers());
+describe("widget editor exact read lifecycle", () => {
+  it("accepts an exact result after a slow read without a browser timeout failure", async () => {
+    vi.useFakeTimers();
+    const mutate = vi.fn();
+    const { result } = renderHook(() =>
+      useWidgetPreviewReads(mutate, signature),
+    );
+    act(() => result.current.runPreviewQuery(config));
+    await act(async () => vi.advanceTimersByTimeAsync(120_000));
+    expect(result.current.previewFailed).toBe(false);
+    expect(mutate.mock.calls[0][0].signal.aborted).toBe(false);
+    act(() => mutate.mock.calls[0][1].onSuccess(exact(12)));
+    expect(result.current.lastExactPreview?.result).toEqual(
+      exact(12).data.result,
+    );
+  });
+  it("aborts on scope change and prevents a late old result from replacing the new result", () => {
+    const mutate = vi.fn();
+    const next = { metrics: [{ name: "Cost", aggregation: "sum" }] };
+    const { result, rerender } = renderHook(
+      ({ scope }) => useWidgetPreviewReads(mutate, scope),
+      { initialProps: { scope: signature } },
+    );
+    act(() => result.current.runPreviewQuery(config));
+    rerender({ scope: JSON.stringify(next) });
+    expect(mutate.mock.calls[0][0].signal.aborted).toBe(true);
+    act(() => result.current.runPreviewQuery(next));
+    act(() => mutate.mock.calls[1][1].onSuccess(exact(24)));
+    act(() => mutate.mock.calls[0][1].onSuccess(exact(999)));
+    expect(result.current.lastExactPreview?.signature).toBe(
+      JSON.stringify(next),
+    );
+    expect(result.current.lastExactPreview?.result).toEqual(
+      exact(24).data.result,
+    );
+  });
+  it("preserves the exact snapshot during a slow refresh and aborts on unmount", async () => {
+    vi.useFakeTimers();
+    const mutate = vi.fn();
+    const { result, unmount } = renderHook(() =>
+      useWidgetPreviewReads(mutate, signature),
+    );
+    act(() => result.current.runPreviewQuery(config));
+    act(() => mutate.mock.calls[0][1].onSuccess(exact(12)));
+    act(() => result.current.runPreviewQuery(config, { refresh: true }));
+    await act(async () => vi.advanceTimersByTimeAsync(120_000));
+    expect(result.current.previewFailed).toBe(false);
+    expect(result.current.lastExactPreview?.result).toEqual(
+      exact(12).data.result,
+    );
+    expect(mutate.mock.calls[1][0].signal.aborted).toBe(false);
+    unmount();
+    expect(mutate.mock.calls[1][0].signal.aborted).toBe(true);
+  });
+});
+
+it("pauses polling a pending exact job without a query failure and continues explicitly", async () => {
+  vi.useFakeTimers();
+  const pending = {
+    data: {
+      result: {
+        metrics: [],
+        query_complete: false,
+        query_status: "pending",
+        query_sampled: false,
+        query_refreshing: true,
+      },
+    },
+  };
+  const mutate = vi.fn((_request, options) => options.onSuccess(pending));
+  const { result } = renderHook(() => useWidgetPreviewReads(mutate, signature));
+  act(() => result.current.runPreviewQuery(config));
+  await act(async () => vi.advanceTimersByTimeAsync(500_000));
+  expect(result.current.previewPollingPaused).toBe(true);
+  expect(result.current.previewFailed).toBe(false);
+  const count = mutate.mock.calls.length;
+  await act(async () => vi.advanceTimersByTimeAsync(500_000));
+  expect(mutate).toHaveBeenCalledTimes(count);
+  mutate.mockImplementation((_request, options) =>
+    options.onSuccess(exact(24)),
+  );
+  act(() => result.current.runPreviewQuery(config, { refresh: true }));
+  expect(result.current.previewPollingPaused).toBe(false);
+  expect(result.current.lastExactPreview?.result).toEqual(
+    exact(24).data.result,
+  );
+});

--- a/frontend/src/sections/dashboards/__tests__/widgetEditorStatus.test.jsx
+++ b/frontend/src/sections/dashboards/__tests__/widgetEditorStatus.test.jsx
@@ -127,3 +127,12 @@ describe("exact widget preview states", () => {
     expect(retry).toHaveBeenCalledOnce();
   });
 });
+
+it("renders a neutral continuation for a pending preview whose polling paused", () => {
+  const resume = vi.fn();
+  render(<WidgetPreviewStatus state="paused" onRetry={resume} />);
+  expect(screen.queryByText(/could not be prepared/i)).not.toBeInTheDocument();
+  expect(screen.queryByRole("progressbar")).not.toBeInTheDocument();
+  fireEvent.click(screen.getByRole("button", { name: "Continue" }));
+  expect(resume).toHaveBeenCalledOnce();
+});

--- a/frontend/src/sections/dashboards/useWidgetPreviewReads.js
+++ b/frontend/src/sections/dashboards/useWidgetPreviewReads.js
@@ -1,0 +1,175 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import {
+  createAggregationPollController,
+  getAggregationRefreshState,
+  getExactAggregationReadState,
+} from "src/utils/queryReadState";
+import { getExactDashboardResult } from "./widgetUtils";
+import { getWidgetPreviewState } from "./widgetEditorState";
+
+export function useWidgetPreviewReads(
+  mutateDashboardQuery,
+  previewQuerySignature,
+) {
+  const [lastExactPreview, setLastExactPreview] = useState(null);
+  const currentPreviewSignatureRef = useRef("");
+  const previewPollTimerRef = useRef(null);
+  const previewRequestControllerRef = useRef(null);
+  const previewGenerationRef = useRef(0);
+  const [isPreviewRefreshing, setIsPreviewRefreshing] = useState(false);
+  const [previewFailed, setPreviewFailed] = useState(false);
+  const [previewPollingPaused, setPreviewPollingPaused] = useState(false);
+  currentPreviewSignatureRef.current = previewQuerySignature;
+
+  useEffect(() => {
+    previewGenerationRef.current += 1;
+    previewRequestControllerRef.current?.abort();
+    previewRequestControllerRef.current = null;
+    clearTimeout(previewPollTimerRef.current);
+    previewPollTimerRef.current = null;
+    setIsPreviewRefreshing(false);
+    setPreviewFailed(false);
+    setPreviewPollingPaused(false);
+  }, [previewQuerySignature]);
+
+  useEffect(
+    () => () => {
+      previewGenerationRef.current += 1;
+      previewRequestControllerRef.current?.abort();
+      previewRequestControllerRef.current = null;
+      clearTimeout(previewPollTimerRef.current);
+    },
+    [],
+  );
+
+  const runPreviewQuery = useCallback(
+    (queryConfig, { refresh = false } = {}) => {
+      const signature = JSON.stringify(queryConfig);
+      const generation = previewGenerationRef.current + 1;
+      previewGenerationRef.current = generation;
+      clearTimeout(previewPollTimerRef.current);
+      previewPollTimerRef.current = null;
+      const pollingController = createAggregationPollController();
+      // Polling pending snapshots has its own budget. Exact HTTP reads stay
+      // active until completion, replacement, or unmount.
+      pollingController.start();
+      pollingController.recordAttempt();
+      let refreshWasQueued = false;
+      setPreviewFailed(false);
+      setPreviewPollingPaused(false);
+
+      const isCurrent = () =>
+        previewGenerationRef.current === generation &&
+        currentPreviewSignatureRef.current === signature;
+
+      const schedulePoll = () => {
+        if (!isCurrent() || previewPollTimerRef.current !== null) return;
+        pollingController.start();
+        const delay = pollingController.nextDelay();
+        if (delay === false) {
+          const paused =
+            pollingController.getTerminationReason() === "poll_budget";
+          setIsPreviewRefreshing(false);
+          setPreviewPollingPaused(paused);
+          setPreviewFailed(!paused);
+          return;
+        }
+        previewPollTimerRef.current = window.setTimeout(() => {
+          previewPollTimerRef.current = null;
+          pollingController.recordAttempt();
+          execute(false);
+        }, delay);
+      };
+
+      const execute = (forceRefresh) => {
+        previewRequestControllerRef.current?.abort();
+        const requestController = new AbortController();
+        previewRequestControllerRef.current = requestController;
+        const finishAttempt = () => {
+          if (previewRequestControllerRef.current === requestController) {
+            previewRequestControllerRef.current = null;
+          }
+        };
+        mutateDashboardQuery(
+          {
+            queryConfig,
+            refresh: forceRefresh,
+            signal: requestController.signal,
+          },
+          {
+            onSuccess: (response) => {
+              finishAttempt();
+              if (!isCurrent()) return;
+
+              const exactResult = getExactDashboardResult(response);
+              const { isRefreshing, refreshFailed } =
+                getAggregationRefreshState(response);
+              const readState = getExactAggregationReadState(response);
+              const responsePreviewState = getWidgetPreviewState(
+                response?.data?.result,
+                { isSuccess: true },
+              );
+              pollingController.recordSuccess();
+              if (exactResult) {
+                setLastExactPreview({ signature, result: exactResult });
+                setPreviewFailed(false);
+                setPreviewPollingPaused(false);
+              }
+              if (
+                isRefreshing &&
+                !refreshFailed &&
+                (exactResult || readState === "pending")
+              ) {
+                refreshWasQueued = true;
+                setIsPreviewRefreshing(true);
+                schedulePoll();
+                return;
+              }
+              if (
+                !refreshFailed &&
+                !exactResult &&
+                responsePreviewState === "preparing"
+              ) {
+                refreshWasQueued = true;
+                setIsPreviewRefreshing(true);
+                schedulePoll();
+                return;
+              }
+              setIsPreviewRefreshing(false);
+              if (
+                !exactResult &&
+                (refreshFailed ||
+                  responsePreviewState === "failed" ||
+                  readState !== "complete")
+              ) {
+                setPreviewFailed(true);
+              }
+            },
+            onError: () => {
+              finishAttempt();
+              if (!isCurrent()) return;
+              if (refreshWasQueued && pollingController.recordFailure()) {
+                schedulePoll();
+                return;
+              }
+              setIsPreviewRefreshing(false);
+              setPreviewFailed(true);
+            },
+          },
+        );
+      };
+
+      execute(refresh);
+    },
+    [mutateDashboardQuery],
+  );
+
+  return {
+    previewPollingPaused,
+    lastExactPreview,
+    isPreviewRefreshing,
+    previewFailed,
+    setPreviewFailed,
+    runPreviewQuery,
+  };
+}

--- a/frontend/src/sections/dashboards/widgetEditorStatus.jsx
+++ b/frontend/src/sections/dashboards/widgetEditorStatus.jsx
@@ -9,6 +9,8 @@ import {
   Typography,
 } from "@mui/material";
 
+import { AGGREGATION_POLLING_PAUSED_MESSAGE } from "src/utils/queryReadState";
+
 export function WidgetPreviewStatus({ state, onRetry }) {
   if (state === "loading") {
     return <CircularProgress size={24} aria-label="Loading preview" />;
@@ -21,6 +23,20 @@ export function WidgetPreviewStatus({ state, onRetry }) {
           Preparing data…
         </Typography>
       </Stack>
+    );
+  }
+  if (state === "paused") {
+    return (
+      <Alert
+        severity="info"
+        action={
+          <Button color="inherit" size="small" onClick={onRetry}>
+            Continue
+          </Button>
+        }
+      >
+        {AGGREGATION_POLLING_PAUSED_MESSAGE}
+      </Alert>
     );
   }
   if (state === "failed") {
@@ -41,7 +57,7 @@ export function WidgetPreviewStatus({ state, onRetry }) {
 }
 
 WidgetPreviewStatus.propTypes = {
-  state: PropTypes.oneOf(["loading", "preparing", "failed", "ready"])
+  state: PropTypes.oneOf(["loading", "preparing", "paused", "failed", "ready"])
     .isRequired,
   onRetry: PropTypes.func,
 };


### PR DESCRIPTION
Dashboard previews could discard useful cached results or show a terminal failure when a browser timer or polling budget expired. Preserve exact previews, keep cancellation and stale-response protection, and expose a neutral Continue state when polling pauses. Extract shared preview ownership into a hook and remove the duplicate editor effect logic.

Validation: prior dashboard suite passed 235 tests, plus three full WidgetEditorView render cases covering line/bar pending-to-complete transitions and unmount cancellation. Stacked files match the tested working files.

Production currently shows “Data could not be prepared” on the reported cost widget. Its backend cause and the 5s target remain unresolved. These local changes are not deployed and are not a production performance fix.

The validation above is retained evidence from before this stack reorder. Runtime changes are preserved; CI for the restacked head is pending.

Stack position 5/6. Base: `fix/TH-7247-review-03-exact-graphs`. Review and merge in the order below; retarget and recheck each descendant after its parent merges.

AI-assisted implementation. Backend/E2E CI does not run against child PR bases; reported local tests are not deployed performance qualification.

Review order:
1. [fix: [1/6] Fix cancelled grid reads and cursor continuation [agent]](https://github.com/future-agi/future-agi/pull/2640)
2. [fix: [2/6] Preserve latest physical state in Trace reads [agent]](https://github.com/future-agi/future-agi/pull/2637)
3. [fix: [3/6] Reduce exact Users replay work [agent]](https://github.com/future-agi/future-agi/pull/2638)
4. [fix: [4/6] Use complete exact graph snapshots [agent]](https://github.com/future-agi/future-agi/pull/2639)
5. [fix: [5/6] Preserve dashboard previews while exact reads finish [agent]](https://github.com/future-agi/future-agi/pull/2641)
6. [test: [6/6] Add read-only Voice replay coverage [agent]](https://github.com/future-agi/future-agi/pull/2642)

[#2643](https://github.com/future-agi/future-agi/pull/2643) is independent and targets `dev`.
