### PR TITLE
test: [6/6] Add read-only Voice replay coverage [agent]

### DIFF
--- a/scripts/qa/observe_candidate_hydration.py
+++ b/scripts/qa/observe_candidate_hydration.py
@@ -23,6 +23,106 @@ CONTENT_KEYS = (
 )
 
 
+def hydrate_voice_page(reader, builder, payload):
+    """Read every selected Voice root's raw content under the existing guards.
+
+    Reuse the public physical-identity builders, finite batches and memory-only
+    split policy. Provider formatting and relational enrichments remain a
+    separate gate; this diagnostic cannot claim a complete public request.
+    """
+    if payload.get("query_complete") is not True:
+        return payload
+    from django.conf import settings
+    from tracer.services.clickhouse.read_budget import ReadDeadlineExceeded
+
+    rows = [dict(row) for row in payload.get("table", [])]
+    # Validate the complete page before any batch, including cross-batch
+    # duplicates and project escape. Never silently truncate identities.
+    identities = builder.content_root_identities_for_rows(rows) if rows else []
+    if len(set(identities)) != len(rows):
+        raise replay.ReplayError("REPLAY_DUPLICATE_VOICE_ROOT_IDENTITY")
+    phases, hydrated = [], []
+    attempts = 0
+
+    def hydrate_batch(batch):
+        nonlocal attempts
+        if attempts >= settings.VOICE_CONTENT_MAX_QUERY_ATTEMPTS:
+            raise ReadDeadlineExceeded("voice content hydration query budget exceeded")
+        remaining = reader.remaining_read_ms()
+        if remaining < 25:
+            raise ReadDeadlineExceeded("voice content hydration read deadline exceeded")
+        batch_identities = builder.content_root_identities_for_rows(batch)
+        sql, params = builder.build_content_query(
+            [identity[2] for identity in batch_identities],
+            root_identities=batch_identities,
+        )
+        if not sql:
+            raise replay.ReplayError("REPLAY_REQUIRED_HYDRATION_QUERY_MISSING")
+        attempts += 1
+        try:
+            content = reader.execute_ch_query(
+                sql,
+                params,
+                timeout_ms=min(remaining, settings.VOICE_CONTENT_MIN_REMAINING_MS),
+                settings={
+                    "max_result_rows": len(batch_identities),
+                    "result_overflow_mode": "throw",
+                },
+            ).data
+        except Exception as exc:
+            if getattr(exc, "code", None) != 241 or len(batch) == 1:
+                raise
+            midpoint = len(batch) // 2
+            return hydrate_batch(batch[:midpoint]) + hydrate_batch(batch[midpoint:])
+        if not builder.content_root_rows_match(batch, content):
+            raise replay.ReplayError("REPLAY_CONTENT_IDENTITY_OR_VERSION_DRIFT")
+        required = {
+            "provider",
+            "span_attributes",
+            "attrs_string",
+            "attrs_number",
+            "attrs_bool",
+        }
+        if any(not required <= row.keys() for row in content):
+            raise replay.ReplayError("REPLAY_VOICE_CONTENT_FIELDS_MISSING")
+        phases.append({"name": "content", "rows": len(content)})
+        return content
+
+    for start in range(0, len(rows), settings.VOICE_CONTENT_MAX_BATCH_SIZE):
+        hydrated.extend(
+            hydrate_batch(rows[start : start + settings.VOICE_CONTENT_MAX_BATCH_SIZE])
+        )
+    if rows and not builder.content_root_rows_match(rows, hydrated):
+        raise replay.ReplayError("REPLAY_CONTENT_IDENTITY_OR_VERSION_DRIFT")
+    content_by_identity = {
+        builder.bounded_filter_page_hydration_identity(row): row for row in hydrated
+    }
+    for row, identity in zip(rows, identities):
+        content = content_by_identity[identity]
+        # Preserve actual NULLs, long values and all fields returned by the
+        # public content builder. Only that builder excludes bulky call_logs.
+        row.update(content)
+    return {
+        **payload,
+        "table": rows,
+        "hydration_phases": phases,
+        "query_layer_coverage": {
+            "contract": "CH25_voice_physical_root_content.v1",
+            "selection": True,
+            "content": True,
+            "execution": "serial_read_only_candidate_diagnostic_guards",
+            "omitted_public_phases": [
+                "provider_attribute_normalization_and_formatting",
+                "eval_query_and_cell_enrichment",
+                "annotation_query_and_cell_enrichment",
+                "PG_configuration",
+                "HTTP_serializer_and_transport",
+            ],
+            "full_public_request": False,
+        },
+    }
+
+
 def hydrate_session_queries(reader, builder, payload, *, remaining_ms):
     """Time all three real Session hydration builders on either selector route.
 

--- a/scripts/qa/replay_observe_queries_readonly.py
+++ b/scripts/qa/replay_observe_queries_readonly.py
@@ -29,6 +29,9 @@ from uuid import UUID, uuid4
 import replay_observe_filters as replay
 
 ROOT = Path(__file__).resolve().parents[2]
+VOICE_LIST_PATH = "/tracer/trace/list_voice_calls/"
+NATIVE_LISTS = {**replay.LISTS, "voice_calls": VOICE_LIST_PATH}
+NATIVE_SURFACES = (*replay.SURFACES, "voice_calls")
 
 
 @contextmanager
@@ -125,6 +128,7 @@ def candidate_runtime_profile():
                 "EXACT_GRAPH_",
                 "USER_LIST_",
                 "DASHBOARD_",
+                "VOICE_CONTENT_",
                 "CLICKHOUSE_APPLICATION_READ_",
             )
         )
@@ -205,7 +209,7 @@ def qualification_summary(plan, rows, fingerprint):
             op_keys.add("BLOCKED_OR_UNRESOLVED/" + case.get("variant", "UNKNOWN"))
         counters += [operators[key] for key in op_keys]
         list_result_kind = None
-        if (row and case["surface"] in replay.LISTS
+        if (row and case["surface"] in NATIVE_LISTS
                 and status == "COMPLETE_UNVERIFIED" and row.get("complete") is True):
             cardinality = row.get("result_rows")
             list_result_kind = (
@@ -829,8 +833,10 @@ class CandidateQueries:
             }
         try:
             req = case["request"]
-            filters = normalize_filters(req)
             surface = case["surface"]
+            # Voice uses its public request serializer in entity_list, including
+            # filters supplied either as JSON query text or a read-POST body.
+            filters = [] if surface == "voice_calls" else normalize_filters(req)
             with self.metadata.metadata_io() if self.metadata else nullcontext():
                 if surface in replay.GRAPHS:
                     payload = self.graph(reader, case, filters)
@@ -1186,16 +1192,41 @@ class CandidateQueries:
         from tracer.services.clickhouse.v2.query_builders.session_list import (
             SessionListQueryBuilderV2,
         )
+        from tracer.services.clickhouse.v2.query_builders.voice_call_list import (
+            VoiceCallListQueryBuilderV2,
+        )
         from observe_candidate_hydration import hydrate_session_queries
 
         surface = case["surface"]
+        if surface not in NATIVE_LISTS or surface.startswith("users_"):
+            raise replay.ReplayError("REPLAY_LIST_SURFACE_UNSUPPORTED")
         entity = (
-            "sessions"
-            if "sessions" in surface
-            else "spans"
-            if "spans" in surface
-            else "traces"
+            "voice_calls" if surface == "voice_calls" else surface.rsplit("_", 1)[-1]
         )
+        voice_request = None
+        if entity == "voice_calls":
+            from tracer.serializers.trace import TraceVoiceCallListQuerySerializer
+
+            request = case["request"]
+            data = (
+                request.get("body")
+                if request.get("method") == "POST"
+                else request.get("params")
+            )
+            serializer = TraceVoiceCallListQuerySerializer(data=data)
+            serializer.is_valid(raise_exception=True)
+            voice_request = serializer.validated_data
+            if (
+                request.get("method") not in {"GET", "POST"}
+                or request.get("path") != VOICE_LIST_PATH
+                or str(voice_request["project_id"]) != self.plan["scope"]["project_id"]
+                or voice_request["page_size"] != request["target_rows"]
+                or voice_request["page"] != 1
+                or voice_request.get("cursor")
+                or not voice_request["cursor_mode"]
+            ):
+                raise replay.ReplayError("REPLAY_VOICE_FIRST_PAGE_WORKLOAD_MISMATCH")
+            filters = voice_request["filters"]
         candidate_deadline = time.monotonic() + (
             settings.INTERACTIVE_ANALYTICS_DEFAULT_WALL_MS / 1000
         )
@@ -1219,6 +1250,7 @@ class CandidateQueries:
             "traces": TraceListQueryBuilderV2,
             "spans": SpanListQueryBuilderV2,
             "sessions": SessionListQueryBuilderV2,
+            "voice_calls": VoiceCallListQueryBuilderV2,
         }[entity]
         page_size = case["request"]["target_rows"]
         builder_kwargs = {
@@ -1227,8 +1259,12 @@ class CandidateQueries:
             "page_number": 0,
             "page_size": page_size,
         }
-        if entity != "traces":
+        if entity in {"spans", "sessions"}:
             builder_kwargs["bounded_internal_scan"] = True
+        if voice_request is not None:
+            builder_kwargs["remove_simulation_calls"] = voice_request[
+                "remove_simulation_calls"
+            ]
         if self.metadata:
             builder_kwargs.update(
                 self.metadata.builder_kwargs(self.plan["scope"]["project_id"])
@@ -1248,7 +1284,12 @@ class CandidateQueries:
                 "table": chosen,
                 "has_more": len(candidates) > page_size,
             }, remaining_ms=session_timeout_ms)
-        key = {"traces": "trace_id", "spans": "id", "sessions": "session_id"}[entity]
+        key = {
+            "traces": "trace_id",
+            "voice_calls": "trace_id",
+            "spans": "id",
+            "sessions": "session_id",
+        }[entity]
 
         def read_page(state):
             options = {}
@@ -1273,7 +1314,7 @@ class CandidateQueries:
                 ),
                 include_incomplete_rows=True,
                 bounded_continuation=True,
-                carry_continuation_slice_width=entity == "traces",
+                carry_continuation_slice_width=entity in {"traces", "voice_calls"},
                 root_time_discovery=bool(
                     entity == "traces"
                     and not state.get("continuation_before_start_time")
@@ -1298,6 +1339,10 @@ class CandidateQueries:
                 reader, builder, payload, entity=entity, request=case["request"],
                 timing=getattr(reader, "local_phase", None),
             )
+        if entity == "voice_calls":
+            from observe_candidate_hydration import hydrate_voice_page
+
+            payload = hydrate_voice_page(reader, builder, payload)
         return payload
 
     def resolve_session_user_filters(self, reader, filters, remaining_ms):
@@ -1366,7 +1411,7 @@ def main():
         help="Scoped real PG metadata capture, not a query-result fixture",
     )
     parser.add_argument("--ledger", required=True)
-    parser.add_argument("--surface", choices=replay.SURFACES)
+    parser.add_argument("--surface", choices=NATIVE_SURFACES)
     parser.add_argument("--period", choices=("7D", "30D", "12M"))
     parser.add_argument("--attribute")
     parser.add_argument("--variant")

--- a/scripts/qa/test_observe_voice_replay.py
+++ b/scripts/qa/test_observe_voice_replay.py
@@ -1,0 +1,431 @@
+"""Voice replay on real SELECT-only inline fixtures; no configured DB/DDL.
+
+Native tests exercise generated selection and content SQL, not HTTP or deployed
+performance. Explicit transport fixtures below only verify failure contracts.
+"""
+
+from datetime import timedelta
+import json
+import time
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+import observe_candidate_hydration as hydration
+import replay_observe_filters as replay
+import replay_observe_queries_readonly as queries
+
+
+@pytest.fixture(scope="module", autouse=True)
+def candidate_runtime():
+    from django.apps import apps
+    import probe_long_text_index_contract_readonly as setup
+
+    if not apps.ready:
+        setup.initialize()
+
+
+@pytest.fixture
+def voice():
+    from tracer.services.clickhouse.v2.query_builders.voice_call_list import (
+        VoiceCallListQueryBuilderV2,
+    )
+    from tracer.tests import test_voice_physical_replay as fixture
+
+    return VoiceCallListQueryBuilderV2, fixture
+
+
+def request_case(fixture, *, days=7, filters=(), page_size=2, **params):
+    window = {
+        "column_id": "created_at",
+        "filter_config": {
+            "col_type": "SYSTEM_METRIC",
+            "filter_type": "datetime",
+            "filter_op": "between",
+            "filter_value": [
+                (fixture.NOW - timedelta(days=days)).isoformat(),
+                fixture.NOW.isoformat(),
+            ],
+        },
+    }
+    return {
+        "surface": "voice_calls",
+        "request": {
+            "method": "GET",
+            "path": queries.VOICE_LIST_PATH,
+            "target_rows": page_size,
+            "params": {
+                "project_id": fixture.PROJECT,
+                "page_size": page_size,
+                "page": 1,
+                "cursor_mode": True,
+                "filters": json.dumps([window, *filters]),
+                **params,
+            },
+        },
+    }
+
+
+def attribute(key, value, kind="text"):
+    return {
+        "column_id": key,
+        "filter_config": {
+            "col_type": "SPAN_ATTRIBUTE",
+            "filter_type": kind,
+            "filter_op": "equals",
+            "filter_value": value,
+        },
+    }
+
+
+def adapter_for(fixture):
+    return queries.CandidateQueries(
+        SimpleNamespace(relational_metadata=None),
+        {"scope": {"project_id": fixture.PROJECT}},
+        [fixture.PROJECT],
+    )
+
+
+class NativeReader:
+    supports_bounded_speculative_reads = False
+
+    def __init__(self, engine, fixture, rows):
+        self.engine, self.fixture, self.rows = engine, fixture, rows
+        self.calls = []
+
+    def remaining_read_ms(self):
+        return 60_000
+
+    def close(self):
+        pass
+
+    def execute_ch_query(self, sql, params, **kwargs):
+        from tracer.services.clickhouse.query_service import QueryResult
+
+        queries.validate_select(sql, params, [self.fixture.PROJECT])
+        self.calls.append((sql, params, kwargs))
+        rows = self.fixture.execute_voice(self.engine, None, self.rows, (sql, params))
+        return QueryResult(rows, len(rows), "clickhouse", 1.0)
+
+
+@pytest.mark.parametrize("days", [7, 30, 365])
+@pytest.mark.parametrize("kind", ["string", "number", "long-string"])
+@pytest.mark.parametrize("has_match", [True, False])
+def test_native_adapter_selects_and_hydrates_typed_voice_roots(
+    voice, days, kind, has_match
+):
+    engine = pytest.importorskip("chdb")
+    _, fixture = voice
+    long_value = "recording-" + "x" * 1001
+    leaves = {
+        "string": attribute("current", "value" if has_match else "absent"),
+        "number": attribute("duration", 2 if has_match else 999, "number"),
+        "long-string": attribute("recording", long_value if has_match else "z" * 1001),
+    }
+
+    class ContentFixture:
+        def query(self, sql, fmt):
+            return engine.query(
+                sql.replace(
+                    "map('current', 'value')",
+                    f"map('current', 'value', 'recording', '{long_value}')",
+                ),
+                fmt,
+            )
+
+    case = request_case(fixture, days=days, filters=[leaves[kind]])
+    rows = [
+        fixture.physical_row(
+            trace_id=f"call-{index}",
+            id=f"root-{index}",
+            observation_type="conversation",
+            start_time=fixture.NOW - timedelta(minutes=index + 1),
+        )
+        for index in range(3)
+    ]
+    reader = NativeReader(ContentFixture(), fixture, rows)
+    payload = adapter_for(fixture).entity_list(
+        reader, case, queries.normalize_filters(case["request"])
+    )
+    assert payload["query_complete"] and payload["query_exact"]
+    assert [row["trace_id"] for row in payload["table"]] == (
+        ["call-0", "call-1"] if has_match else []
+    )
+    content_calls = [
+        call for call in reader.calls if "content_root_identities" in call[1]
+    ]
+    assert len(content_calls) == int(has_match)
+    assert payload["query_layer_coverage"]["content"]
+    assert not payload["query_layer_coverage"]["full_public_request"]
+    for row in payload["table"]:
+        assert row["provider"] is None
+        assert row["attrs_string"]["recording"] == long_value
+        assert row["attrs_number"]["duration"] == 2
+        assert row["attrs_bool"]["flag"] == 1
+        assert json.loads(row["span_attributes"]) == {"current": True}
+        assert "call_logs" not in row["attrs_string"]
+
+
+@pytest.mark.parametrize("method", ["GET", "POST"])
+def test_native_full_run_routes_voice_without_promoting_fixture_timing(voice, method):
+    engine = pytest.importorskip("chdb")
+    _, fixture = voice
+    reader = NativeReader(
+        engine, fixture, [fixture.physical_row(observation_type="conversation")]
+    )
+    reader.deadline = time.monotonic() + 60
+    adapter = adapter_for(fixture)
+    adapter.args = SimpleNamespace(
+        relational_metadata=None, safety_seconds=60, verify_trace_ids=False
+    )
+    case = {
+        **request_case(fixture),
+        "id": "voice-native-fixture",
+        "blocked": None,
+        "period": "7D",
+        "target_ms": 5000,
+    }
+    if method == "POST":
+        request = case["request"]
+        request["method"] = "POST"
+        request["body"] = request.pop("params")
+        request["body"]["filters"] = json.loads(request["body"]["filters"])
+    with patch.object(queries, "ReadOnlyExecutor", return_value=reader):
+        result = adapter.run(case)
+    assert result["status"] == "COMPLETE_UNVERIFIED"
+    assert result["surface"] == "voice_calls" and result["result_rows"] == 1
+    assert (
+        result["query_layer_coverage"]["contract"]
+        == "CH25_voice_physical_root_content.v1"
+    )
+    assert not result["http_e2e"] and not result["ui_e2e"]
+    assert result["correctness"] == "UNVERIFIED"
+    assert any("content_root_identities" in params for _, params, _ in reader.calls)
+    # values() fixture timings, including QueryResult's synthetic 1ms, are
+    # functional evidence only. No production latency assertion is made.
+
+
+def test_native_voice_content_batches_and_rejects_latest_version_drift(voice):
+    engine = pytest.importorskip("chdb")
+    builder_cls, fixture = voice
+    builder = fixture.make_builder(builder_cls)
+    selected = [
+        fixture.voice_root(trace_id=f"call-{index}", root_span_id=f"root-{index}")
+        for index in range(3)
+    ]
+    rows = [
+        fixture.physical_row(
+            trace_id=row["trace_id"],
+            id=row["root_span_id"],
+            observation_type="conversation",
+        )
+        for row in selected
+    ]
+    reader = NativeReader(engine, fixture, rows)
+    with patch("django.conf.settings.VOICE_CONTENT_MAX_BATCH_SIZE", 2):
+        payload = hydration.hydrate_voice_page(
+            reader, builder, {"query_complete": True, "table": selected}
+        )
+    assert [phase["rows"] for phase in payload["hydration_phases"]] == [2, 1]
+    assert [
+        len(params["content_root_identities"]) for _, params, _ in reader.calls
+    ] == [2, 1]
+    assert [row["trace_id"] for row in payload["table"]] == [
+        row["trace_id"] for row in selected
+    ]
+    reader = NativeReader(engine, fixture, [*rows, {**rows[0], "_version": 3}])
+    with pytest.raises(replay.ReplayError, match="IDENTITY_OR_VERSION_DRIFT"):
+        hydration.hydrate_voice_page(
+            reader, builder, {"query_complete": True, "table": selected}
+        )
+
+
+class TransportFixture:
+    """Supplementary failure/dispatch fixture, never native SQL evidence."""
+
+    def __init__(self, response):
+        self.response, self.calls = response, []
+
+    def remaining_read_ms(self):
+        return 60_000
+
+    def execute_ch_query(self, sql, params, **kwargs):
+        self.calls.append((sql, params, kwargs))
+        return SimpleNamespace(data=self.response(params))
+
+
+def test_voice_dispatch_uses_public_normalization_and_metadata(voice):
+    builder_cls, fixture = voice
+    adapter = adapter_for(fixture)
+    metadata = {"annotation_label_ids": ["label"], "eval_filter_metadata": {"eval": {}}}
+    adapter.metadata = SimpleNamespace(builder_kwargs=lambda _: metadata)
+    for flag, expected in (
+        ("false", False),
+        ("0", False),
+        ("true", True),
+        (True, True),
+    ):
+        case = request_case(fixture, remove_simulation_calls=flag)
+        seen = {}
+
+        def collect(read_page, builder, key, target, remaining):
+            seen.update(builder=builder, key=key, target=target)
+            return {"query_complete": True, "table": []}
+
+        with patch.object(queries, "collect_selector_page", side_effect=collect):
+            adapter.entity_list(TransportFixture(None), case, [])
+        assert isinstance(seen["builder"], builder_cls)
+        assert seen["key"] == "trace_id" and seen["target"] == 2
+        assert not seen["builder"]._bounded_internal_scan
+        assert seen["builder"].remove_simulation_calls is expected
+        assert seen["builder"].annotation_label_ids == ["label"]
+        assert seen["builder"].eval_filter_metadata == {"eval": {}}
+
+
+@pytest.mark.parametrize(
+    "change",
+    [
+        {"page": 2, "cursor_mode": False},
+        {"cursor_mode": False},
+        {"page_size": 3},
+        {"project_id": "22222222-2222-4222-8222-222222222222"},
+    ],
+)
+def test_voice_does_not_silently_replay_different_workload(voice, change):
+    _, fixture = voice
+    case = request_case(fixture)
+    case["request"]["params"].update(change)
+    reader = TransportFixture(None)
+    with pytest.raises(
+        replay.ReplayError, match="REPLAY_VOICE_FIRST_PAGE_WORKLOAD_MISMATCH"
+    ):
+        adapter_for(fixture).entity_list(reader, case, [])
+    assert not reader.calls
+
+
+@pytest.mark.parametrize(
+    "params,error_key",
+    [
+        ({"remove_simulation_calls": "invalid-boolean"}, "remove_simulation_calls"),
+        ({"page": 2}, "cursor_mode"),
+    ],
+)
+def test_invalid_voice_serializer_input_is_rejected_before_queries(
+    voice, params, error_key
+):
+    from rest_framework.exceptions import ValidationError
+
+    _, fixture = voice
+    reader = TransportFixture(None)
+    case = request_case(fixture, **params)
+    with pytest.raises(ValidationError) as error:
+        adapter_for(fixture).entity_list(reader, case, [])
+    assert set(error.value.detail) == {error_key}
+    assert error.value.detail[error_key][0].code == "invalid"
+    assert not reader.calls
+
+
+def test_missing_duplicate_foreign_content_and_duplicate_selection_fail_closed(voice):
+    builder_cls, fixture = voice
+    builder, row = fixture.make_builder(builder_cls), fixture.voice_root()
+    for content in (
+        [],
+        [row, row],
+        [{**row, "_root_version": 3}],
+        [{**row, "_root_service_name": "foreign"}],
+        [{**row, "project_id": "22222222-2222-4222-8222-222222222222"}],
+    ):
+        with pytest.raises(replay.ReplayError, match="IDENTITY_OR_VERSION_DRIFT"):
+            hydration.hydrate_voice_page(
+                TransportFixture(lambda _: content),
+                builder,
+                {"query_complete": True, "table": [row]},
+            )
+    reader = TransportFixture(None)
+    with pytest.raises(replay.ReplayError, match="DUPLICATE_VOICE_ROOT"):
+        hydration.hydrate_voice_page(
+            reader, builder, {"query_complete": True, "table": [row, row]}
+        )
+    assert not reader.calls
+    with pytest.raises(replay.ReplayError, match="VOICE_CONTENT_FIELDS_MISSING"):
+        hydration.hydrate_voice_page(
+            TransportFixture(lambda _: [row]),
+            builder,
+            {"query_complete": True, "table": [row]},
+        )
+
+
+def test_memory_split_requires_every_identity_and_does_not_retry_other_failures(voice):
+    from clickhouse_driver.errors import ServerException
+    from tracer.tests.test_trace_root_physical_replay import content_identity_row
+
+    builder_cls, fixture = voice
+    builder = fixture.make_builder(builder_cls)
+    rows = [
+        fixture.voice_root(trace_id=f"call-{i}", root_span_id=f"root-{i}")
+        for i in range(2)
+    ]
+
+    def response(params):
+        identities = params["content_root_identities"]
+        if len(identities) > 1:
+            raise ServerException("synthetic memory failure", code=241)
+        return [
+            {
+                **content_identity_row(identity),
+                "provider": None,
+                "span_attributes": "{}",
+                "attrs_string": {},
+                "attrs_number": {},
+                "attrs_bool": {},
+            }
+            for identity in identities
+        ]
+
+    reader = TransportFixture(response)
+    result = hydration.hydrate_voice_page(
+        reader, builder, {"query_complete": True, "table": rows}
+    )
+    assert len(reader.calls) == 3 and len(result["table"]) == 2
+    from tracer.services.clickhouse.read_budget import ReadDeadlineExceeded
+
+    reader = TransportFixture(response)
+    with patch("django.conf.settings.VOICE_CONTENT_MAX_QUERY_ATTEMPTS", 1):
+        with pytest.raises(ReadDeadlineExceeded, match="query budget exceeded"):
+            hydration.hydrate_voice_page(
+                reader, builder, {"query_complete": True, "table": rows}
+            )
+    assert len(reader.calls) == 1
+    for code in (159, 386):
+
+        def fail(_):
+            raise ServerException("synthetic failure", code=code)
+
+        reader = TransportFixture(fail)
+        with pytest.raises(ServerException):
+            hydration.hydrate_voice_page(
+                reader, builder, {"query_complete": True, "table": rows}
+            )
+        assert len(reader.calls) == 1
+
+
+def test_incomplete_and_empty_voice_pages_do_not_read_content(voice):
+    builder_cls, fixture = voice
+    for complete, rows in ((False, [fixture.voice_root()]), (True, [])):
+        reader = TransportFixture(None)
+        result = hydration.hydrate_voice_page(
+            reader,
+            fixture.make_builder(builder_cls),
+            {"query_complete": complete, "table": rows},
+        )
+        assert result["query_complete"] is complete
+        assert not reader.calls
+
+
+def test_unknown_list_surface_cannot_fall_back_to_trace(voice):
+    _, fixture = voice
+    with pytest.raises(replay.ReplayError, match="SURFACE_UNSUPPORTED"):
+        adapter_for(fixture).entity_list(
+            TransportFixture(None), {"surface": "voices"}, []
+        )


### PR DESCRIPTION
The read-only Observe replay harness could not execute the public Voice list query path. Add an explicit Voice workload that validates the public GET/POST request contract, reuses the Voice selector, and hydrates the selected physical root versions with the existing bounded content builder.

Read-only limits, scope checks, and exact physical identity checks remain enforced. The receipt explicitly excludes provider formatting, PostgreSQL configuration, evaluation/annotation enrichment, and HTTP transport. It cannot report full public-request qualification.

Validation: local SELECT-only ClickHouse 25.3.14.14 inline-fixture and QA harness regressions passed 189 tests and 112 subtests. Ruff and whitespace checks passed. These verify SQL semantics and adapter contracts; deployed Voice HTTP/UI performance remains untested. The repository backend workflow does not run for this child base or scripts/qa-only changes.

AI-assisted implementation with independent code review. The validation above is retained evidence from before this stack reorder. Runtime changes are preserved; CI for the restacked head is pending.

Stack position 6/6; base is the dashboard preview PR #2641. Review and merge in the order below; retarget and recheck each descendant after its parent merges.

Review order:
1. [fix: [1/6] Fix cancelled grid reads and cursor continuation [agent]](https://github.com/future-agi/future-agi/pull/2640)
2. [fix: [2/6] Preserve latest physical state in Trace reads [agent]](https://github.com/future-agi/future-agi/pull/2637)
3. [fix: [3/6] Reduce exact Users replay work [agent]](https://github.com/future-agi/future-agi/pull/2638)
4. [fix: [4/6] Use complete exact graph snapshots [agent]](https://github.com/future-agi/future-agi/pull/2639)
5. [fix: [5/6] Preserve dashboard previews while exact reads finish [agent]](https://github.com/future-agi/future-agi/pull/2641)
6. [test: [6/6] Add read-only Voice replay coverage [agent]](https://github.com/future-agi/future-agi/pull/2642)

[#2643](https://github.com/future-agi/future-agi/pull/2643) is independent and targets `dev`.
