### PR TITLE
fix(tracing): replay session users by physical span identity [agent]

### DIFF
--- a/futureagi/tracer/tests/test_session_end_user_physical_replay.py
+++ b/futureagi/tracer/tests/test_session_end_user_physical_replay.py
@@ -1,0 +1,231 @@
+"""Session user labels from actual helper SQL over constant ClickHouse rows.
+
+These fixtures exercise canonicalization, physical replay and output rekeying.
+Only the curated dictionary transport is mocked; no tables or DDL are needed.
+Equal-version or final-order ties may choose either coherent winner.
+"""
+
+import json
+from datetime import datetime, timedelta
+from types import SimpleNamespace
+
+import pytest
+from clickhouse_driver.util.escape import escape_params
+
+from tracer.services.clickhouse.v2 import end_user_dict_reader
+from tracer.views.trace_session import TraceSessionView
+
+pytestmark = pytest.mark.unit
+PROJECT = "11111111-1111-4111-8111-111111111111"
+OTHER = "22222222-2222-4222-8222-222222222222"
+SESSION = "10000000-0000-4000-8000-000000000001"
+ALIAS = "10000000-0000-4000-8000-000000000002"
+NEW = "10000000-0000-4000-8000-000000000003"
+USER = "20000000-0000-4000-8000-000000000001"
+OTHER_USER = "20000000-0000-4000-8000-000000000002"
+NIL = "00000000-0000-0000-0000-000000000000"
+AT = datetime(2026, 8, 1, 12)
+CONTEXT = SimpleNamespace(server_info=SimpleNamespace(get_timezone=lambda: "UTC"))
+
+
+def row(**changes):
+    return {
+        "project_id": PROJECT,
+        "observation_type": "SPAN",
+        "service_name": "service",
+        "trace_id": "trace",
+        "id": "child",
+        "start_time": AT + timedelta(minutes=10),
+        "trace_session_id": SESSION,
+        "end_user_id": USER,
+        "_version": 1,
+        "is_deleted": 0,
+    } | changes
+
+
+@pytest.fixture(scope="module")
+def engine():
+    return pytest.importorskip("chdb", reason="optional constant-fixture engine")
+
+
+def read(engine, monkeypatch, rows, *, ids=(SESSION,), remaps=(), reverse=False):
+    rows = list(reversed(rows)) if reverse else rows
+    schema = (
+        "project_id UUID, observation_type String, service_name String, "
+        "trace_id String, id String, start_time DateTime64(6,'UTC'), "
+        "trace_session_id Nullable(UUID), end_user_id Nullable(UUID), "
+        "_version UInt64, is_deleted UInt8"
+    )
+    values = tuple(
+        tuple(
+            r[key].isoformat(sep=" ") if key == "start_time" else r[key]
+            for key in row()
+        )
+        for r in rows
+    )
+    literals = escape_params(
+        {"schema": schema, "rows": values, "remaps": remaps}, CONTEXT
+    )
+    remap_source = (
+        f"SELECT * FROM values('old_id UUID, new_id UUID', {literals['remaps'][1:-1]})"
+        if remaps
+        else f"SELECT toUUID('{NIL}') AS old_id, old_id AS new_id WHERE 0"
+    )
+    prefix = (
+        f"WITH spans AS (SELECT * FROM values({literals['schema']}, {literals['rows'][1:-1]})), "
+        f"trace_session_id_remap AS ({remap_source})"
+    )
+    calls = []
+
+    def execute(query, params, **_kwargs):
+        calls.append(query)
+        # VALUES has no PREWHERE/FINAL; preserve all predicates and aggregates.
+        query = query.replace("PREWHERE", "WHERE").replace(
+            "trace_session_id_remap FINAL", "trace_session_id_remap"
+        )
+        query = query.lstrip()
+        query = "," + query[4:] if query.startswith("WITH") else " " + query
+        sql = prefix + query % escape_params(params, CONTEXT)
+        sql += (
+            " SETTINGS max_threads=1, max_execution_time=5, "
+            "max_memory_usage=134217728, max_result_rows=100, "
+            "max_result_bytes=1048576, result_overflow_mode='throw', "
+            f"join_use_nulls={int(reverse)}"
+        )
+        return SimpleNamespace(
+            data=[
+                json.loads(line)
+                for line in str(engine.query(sql, "JSONEachRow")).splitlines()
+                if line
+            ]
+        )
+
+    def curated_fields(user_ids, **_kwargs):
+        assert user_ids and NIL not in user_ids and None not in user_ids
+        return {
+            user_id: {
+                "user_id": user_id,
+                "user_id_type": "custom",
+                "user_id_hash": 0,
+            }
+            for user_id in user_ids
+        }
+
+    monkeypatch.setattr(end_user_dict_reader, "resolve_end_user_fields", curated_fields)
+    result = TraceSessionView._fetch_end_user_info(
+        ids, SimpleNamespace(execute_ch_query=execute), [PROJECT]
+    )
+    assert len(calls) == 2  # Existing canonicalization, then the actual helper replay.
+    return {session: fields["user_id"] for session, fields in result.items()}
+
+
+@pytest.mark.parametrize("reverse", [False, True])
+@pytest.mark.parametrize(
+    "latest",
+    [
+        {"is_deleted": 1},
+        {"end_user_id": None},
+        {"end_user_id": NIL},
+        {"trace_session_id": ALIAS},
+        {"trace_session_id": None},
+    ],
+)
+def test_corrected_timestamp_does_not_resurrect_user(
+    engine, monkeypatch, reverse, latest
+):
+    rows = [row(start_time=AT + timedelta(minutes=50)), row(_version=2, **latest)]
+    assert read(engine, monkeypatch, rows, reverse=reverse) == {}
+
+
+@pytest.mark.parametrize("reverse", [False, True])
+def test_user_order_uses_corrected_winning_time(engine, monkeypatch, reverse):
+    rows = [
+        row(start_time=AT + timedelta(minutes=50)),
+        row(_version=2),
+        row(
+            id="other-child",
+            start_time=AT + timedelta(minutes=30),
+            end_user_id=OTHER_USER,
+        ),
+    ]
+    assert read(engine, monkeypatch, rows, reverse=reverse) == {SESSION: OTHER_USER}
+
+
+@pytest.mark.parametrize("reverse", [False, True])
+@pytest.mark.parametrize(
+    "identity",
+    [
+        {"service_name": "other"},
+        {"observation_type": "LLM"},
+        {"start_time": AT + timedelta(hours=1)},
+        {"project_id": OTHER},
+    ],
+)
+def test_tombstone_cannot_delete_another_physical_key(
+    engine, monkeypatch, reverse, identity
+):
+    assert read(
+        engine,
+        monkeypatch,
+        [row(), row(_version=2, is_deleted=1, **identity)],
+        reverse=reverse,
+    ) == {SESSION: USER}
+
+
+def test_latest_user_reassignment_and_all_history_child(engine, monkeypatch):
+    old = datetime(2010, 1, 1)
+    rows = [
+        row(start_time=old),
+        row(start_time=old, _version=2, end_user_id=OTHER_USER),
+        row(id="root", end_user_id=None),
+    ]
+    assert read(engine, monkeypatch, rows) == {SESSION: OTHER_USER}
+
+
+@pytest.mark.parametrize("reverse", [False, True])
+def test_session_aliases_rekey_one_canonical_label(engine, monkeypatch, reverse):
+    rows = [
+        row(),
+        row(
+            id="new-child",
+            trace_session_id=NEW,
+            end_user_id=OTHER_USER,
+            start_time=AT + timedelta(minutes=20),
+        ),
+    ]
+    ids = (SESSION, ALIAS, NEW)
+    assert read(
+        engine,
+        monkeypatch,
+        rows,
+        ids=ids,
+        remaps=((SESSION, NEW), (ALIAS, NEW)),
+        reverse=reverse,
+    ) == dict.fromkeys(ids, OTHER_USER)
+
+
+@pytest.mark.parametrize("reverse", [False, True])
+@pytest.mark.parametrize(
+    "other",
+    [
+        {"is_deleted": 1, "start_time": AT + timedelta(minutes=20)},
+        {"end_user_id": None},
+    ],
+)
+def test_equal_version_tie_keeps_one_coherent_tuple(
+    engine, monkeypatch, reverse, other
+):
+    rows = [row(_version=2), row(_version=2, trace_session_id=ALIAS, **other)]
+    assert read(engine, monkeypatch, rows, ids=(SESSION, ALIAS), reverse=reverse) in (
+        {},
+        {SESSION: USER},
+    )
+
+
+@pytest.mark.parametrize("reverse", [False, True])
+def test_final_order_tie_retains_existing_choice(engine, monkeypatch, reverse):
+    rows = [row(), row(service_name="other", end_user_id=OTHER_USER)]
+    assert read(engine, monkeypatch, rows, reverse=reverse) in (
+        {SESSION: USER},
+        {SESSION: OTHER_USER},
+    )

--- a/futureagi/tracer/views/trace_session.py
+++ b/futureagi/tracer/views/trace_session.py
@@ -2411,37 +2411,12 @@ class TraceSessionView(BaseModelViewSetMixin, ModelViewSet):
         project_ids=None,
         deadline: ReadDeadline | None = None,
     ):
-        """Fetch curated end-user fields for a session page from CH — PRIMARY
-        ``_list_sessions_clickhouse`` path ONLY (the PG-fallback branch uses
-        ``_fetch_end_user_info_pg`` so it degrades gracefully on a CH outage).
+        """Fetch curated user labels for each canonical session across all history.
 
-        CH-derived-dimensions cutover (DESIGN §4.3 / §5.2). The old read
-        traversed the PG ``ObservationSpan.end_user`` FK into ``tracer_enduser``
-        (``end_user__user_id``/``__user_id_type``/``__user_id_hash``). That FK
-        and table retire at P4, so the read now restructures:
-
-          1. Resolve the per-session ``end_user_id`` from the CH ``spans`` table
-             — ``argMaxIf(end_user_id, start_time, <has-user>)`` over the
-             session's spans that carry an end user (``end_user_id``
-             non-null/non-NIL). The ordering key is ``start_time``, which MATCHES
-             the old PG read exactly: ``_fetch_end_user_info_pg`` does
-             ``end_user__isnull=False`` then ``DISTINCT ON(trace__session_id)
-             ORDER BY trace__session_id, -start_time`` — i.e. the LATEST span
-             with a user, the same max-``start_time`` pick.
-             NOTE — the only residual delta is the tie-break among spans sharing
-             the EXACT same max ``start_time`` but DIFFERENT end users: PG
-             ``DISTINCT ON`` (single ``-start_time`` order) and CH ``argMaxIf``
-             both pick an arbitrary one, not guaranteed to be the same row. This
-             bites only multi-user sessions with start_time ties; sessions are
-             single-user in practice. If it ever matters, make the order total
-             on both sides (e.g. argMax over a ``(start_time, id)`` tuple).
-          2. Batch-resolve ``{end_user_id -> {user_id, user_id_type,
-             user_id_hash}}`` from ``end_users_dict`` (the curated labels), with
-             the FK-faithful NULL/'' normalization the reader documents.
-
-        Returns ``{session_id -> {user_id, user_id_type, user_id_hash}}``; a
-        session with no end-user span is simply absent (caller defaults to a
-        ``{}`` record → all-None fields), matching the old left-join miss.
+        Replay each physical span's latest version, then select the latest live
+        user-bearing span by ``(start_time, trace_id, id)`` across session aliases.
+        Resolve curated fields and re-key them to the caller's session IDs;
+        sessions without a qualifying user are absent from the result.
         """
         from tracer.services.clickhouse.v2.end_user_dict_reader import (
             resolve_end_user_fields,
@@ -2509,11 +2484,15 @@ class TraceSessionView(BaseModelViewSetMixin, ModelViewSet):
         ts_map = bounded_survivor_map_subquery(
             "trace_session_id_remap", candidate_param="session_ids"
         )
+        # Replay the complete CH25 replacement key, including its indexed
+        # type/service/hour prefix. Exact timestamps and user/session values
+        # can change within that key; take them from one coherent winner.
         eu_by_session_q = f"""
             WITH
             ts_survivor_map AS ({ts_map}),
             candidate_span_identities AS (
-                SELECT DISTINCT project_id, trace_id, id, start_time
+                SELECT DISTINCT project_id, observation_type, service_name,
+                    toStartOfHour(start_time) AS start_hour, trace_id, id
                 FROM spans
                 PREWHERE 1 = 1
                   {proj_clause}
@@ -2531,25 +2510,29 @@ class TraceSessionView(BaseModelViewSetMixin, ModelViewSet):
                     project_id,
                     trace_id,
                     id,
-                    start_time,
-                    argMax(tuple(trace_session_id), _version).1
-                        AS latest_trace_session_id,
-                    argMax(tuple(end_user_id), _version).1 AS latest_end_user_id,
-                    argMax(is_deleted, _version) AS latest_is_deleted
+                    argMax(tuple(start_time, trace_session_id,
+                        end_user_id, is_deleted), _version) AS latest_span,
+                    latest_span.1 AS latest_start_time,
+                    latest_span.2 AS latest_trace_session_id,
+                    latest_span.3 AS latest_end_user_id,
+                    latest_span.4 AS latest_is_deleted
                 FROM spans
                 PREWHERE 1 = 1
                   {proj_clause}
-                  AND (project_id, trace_id, id, start_time) IN (
-                      SELECT project_id, trace_id, id, start_time
+                  AND (project_id, observation_type, service_name,
+                       toStartOfHour(start_time), trace_id, id) IN (
+                      SELECT project_id, observation_type, service_name,
+                          start_hour, trace_id, id
                       FROM candidate_span_identities
                   )
-                GROUP BY project_id, trace_id, id, start_time
+                GROUP BY project_id, observation_type, service_name,
+                         toStartOfHour(start_time), trace_id, id
             ),
             resolved_candidate_spans AS (
                 SELECT
                     {ts_resolved} AS session_id,
                     latest_end_user_id AS end_user_id,
-                    start_time,
+                    latest_start_time AS start_time,
                     trace_id,
                     id
                 FROM latest_candidate_spans


### PR DESCRIPTION
## Summary

Sessions can retain a removed user after a span timestamp is corrected, or lose a valid user when different services reuse a span ID. Replay session-user spans by the complete physical replacement key and select the timestamp, session, user, and deletion flag from one latest-version tuple. This also lets the replay use the indexed type/service/hour prefix.

This is an independent follow-up to #2381, based on `dev`. It does not depend on the six-PR optimization stack. The change is confined to the session label helper and its regression tests; the obsolete cutover explanation is shortened.

## Linked issues

TH-7247.

AI use: Codex drafted the implementation, tests, and PR text; a separate Codex agent reviewed the code and execution evidence.

E2E: exempt (backend-internal)

## Tests and validation

`test_session_end_user_physical_replay.py` executes the actual helper's canonicalization and replay queries over native constant rows. The curated dictionary transport is mocked.

- `test_corrected_timestamp_does_not_resurrect_user`: corrected timestamps with tombstones, NULL/NIL users, or reassigned/removed sessions.
- `test_user_order_uses_corrected_winning_time`: user ordering follows the winning timestamp.
- `test_tombstone_cannot_delete_another_physical_key`: project, type, service, and hour boundaries.
- `test_latest_user_reassignment_and_all_history_child`: reassigned users and older child spans remain in scope.
- `test_session_aliases_rekey_one_canonical_label`: many aliases return the canonical label under each caller ID.
- `test_equal_version_tie_keeps_one_coherent_tuple`: tied versions cannot combine unrelated fields.
- `test_final_order_tie_retains_existing_choice`: preserve the existing permitted tie outcomes.

Focused isolated runtime using ClickHouse 25.3.14.14:

```text
142 passed, 3 deselected in 9.07s
```

This includes all 29 new cases. After the final fixture-type cleanup, the new cases were rerun:

```text
29 passed in 6.59s
```

The three excluded integration cases require database fixture setup; the full `bin/test` stack was not run locally. Against the unchanged `dev` helper, the same 29 new cases produce:

```text
16 failed, 13 passed in 8.80s
```

Ruff and diff checks pass. The retained helper SQL matches the measured candidate modulo whitespace.

To run the new cases with the repository test environment, install optional `chdb` into that test Python environment, then run `bin/test tracer/tests/test_session_end_user_physical_replay.py -v` from `futureagi`. Without `chdb`, these native cases skip.

## Performance evidence and limits

One read-only comparison over the same 25-session page returned identical rekeyed user IDs. The span-label query took 2,322.23ms versus 4,071.49ms, and read 962,927,805 versus 1,728,689,967 bytes. The candidate ran first under unchanged diagnostic guards.

This measures one query stage, not the full helper, API, or browser page. Dictionary lookup, page selection, serialization, and rendering remain outside that comparison. The separate diagnostic project-witness prerequisite is excluded from both query timings. Full-page performance and repeated cold/warm behavior are still unqualified.

## Behavior preserved

All-history child/root eligibility, bounded session remapping, project scope, post-winner deletion and membership checks, curated labels, and caller-ID rekeying are preserved. Equal-version and final-order ties retain their existing unspecified choice. No schema or data changes are included.
