### PR TITLE
fix(alerts): scoring-eval alerts measure the score, not a label

### DIFF
--- a/e2e/FLOWS.md
+++ b/e2e/FLOWS.md
@@ -32,6 +32,30 @@
 - the header button carries the window spanning every fire
 - the monitor’s span-type filter travels in the link and renders as a chip
 
+### ALERT-E2E-002 — a scoring-eval alert measures the score while a labelled eval alerts on a chosen label
+
+**Goal:** A user sets up an alert on a scoring evaluation and it measures the score itself, while a labelled evaluation still alerts on a chosen label  
+**Spec:** `flows/alerts/scoring-eval-alert.spec.ts:26`  
+**Tags:** —
+
+**User steps:**
+
+1. seed a scoring eval (with labels) and a choices eval on a new project
+2. create an alert on the scoring eval with no chosen label
+3. try to create an alert on the scoring eval with a label
+4. try to create an alert on the choices eval with no label
+5. create an alert on the choices eval with a valid label
+6. open the alerts list and read each alert’s Alert Type
+
+**Backend state verified:**
+
+- scoring-eval alert with no label is created (POST /tracer/user-alerts/ 201)
+- scoring-eval alert with a label is rejected: must be empty for evals without predefined choices
+- choices-eval alert with no label is rejected: required for evals with predefined choices
+- choices-eval alert with a valid label is created
+- PG tracer_useralertmonitor: the scoring monitor’s threshold_metric_value is NULL, the choices monitor’s is the label, both org-scoped
+- alerts list shows the scoring alert’s Alert Type as the bare eval name and the choices alert’s as "name (label)"
+
 ## auth
 
 ### AUTH-E2E-001 — user signs in with email and password

--- a/e2e/flows/alerts/scoring-eval-alert.spec.ts
+++ b/e2e/flows/alerts/scoring-eval-alert.spec.ts
@@ -1,0 +1,225 @@
+import { test, expect } from '../../lib/fixtures';
+import { flowAnnotation } from '../../lib/flow-meta';
+
+// Endpoints pinned off frontend/src/utils/axios.js (endpoints.project.*):
+//   createEvalTemplateV2, createEvalTaskConfig, createMonitor.
+const PROJECT_PATH = '/tracer/project/';
+const EVAL_TEMPLATE_PATH = '/model-hub/eval-templates/create-v2/';
+const EVAL_CONFIG_PATH = '/tracer/custom-eval-config/';
+const MONITOR_PATH = '/tracer/user-alerts/';
+
+// The alerts list route (frontend/src/routes/sections/dashboard.jsx:1281). The
+// list is org-wide and searchable by alert name (Actions.jsx:88 placeholder).
+const ALERTS_URL = '/dashboard/alerts';
+
+// Browser-side wait. Two name searches at UI_READY back to back can approach the
+// 120s per-test default, so the test raises its own ceiling below.
+const UI_READY = 60_000;
+
+// Serializer-side messages the eval-alert validator returns
+// (futureagi/tracer/serializers/monitor.py:100-123). A score eval measures the
+// mean score, so a stored choice is rejected; a choices/pass-fail eval requires
+// one.
+const MSG_MUST_BE_EMPTY = 'must be empty for evals without predefined choices';
+const MSG_REQUIRED = 'required for evals with predefined choices';
+
+test(
+  'ALERT-E2E-002: a scoring-eval alert measures the score while a labelled eval alerts on a chosen label',
+  {
+    tag: ['@flow'],
+    annotation: flowAnnotation({
+      id: 'ALERT-E2E-002',
+      area: 'alerts',
+      userGoal:
+        'A user sets up an alert on a scoring evaluation and it measures the score itself, while a labelled evaluation still alerts on a chosen label',
+      steps: [
+        'seed a scoring eval (with labels) and a choices eval on a new project',
+        'create an alert on the scoring eval with no chosen label',
+        'try to create an alert on the scoring eval with a label',
+        'try to create an alert on the choices eval with no label',
+        'create an alert on the choices eval with a valid label',
+        'open the alerts list and read each alert’s Alert Type',
+      ],
+      backendChecks: [
+        'scoring-eval alert with no label is created (POST /tracer/user-alerts/ 201)',
+        'scoring-eval alert with a label is rejected: must be empty for evals without predefined choices',
+        'choices-eval alert with no label is rejected: required for evals with predefined choices',
+        'choices-eval alert with a valid label is created',
+        'PG tracer_useralertmonitor: the scoring monitor’s threshold_metric_value is NULL, the choices monitor’s is the label, both org-scoped',
+        'alerts list shows the scoring alert’s Alert Type as the bare eval name and the choices alert’s as "name (label)"',
+      ],
+    }),
+  },
+  async ({ page, actor, probe }, testInfo) => {
+    // Only UI_READY waits, but two sequential name searches can reach ~120s
+    // alongside seeding; give this test its own ceiling.
+    test.setTimeout(180_000);
+
+    const stamp = `${testInfo.workerIndex}-${Date.now().toString(36)}`;
+    const scoreEvalName = `e2e-eval-score-${stamp}`;
+    const choiceEvalName = `e2e-eval-choice-${stamp}`;
+    const scoreAlertName = `e2e-alert-score-${stamp}`;
+    const choiceAlertName = `e2e-alert-choice-${stamp}`;
+    const CHOICE_LABEL = 'frequently';
+
+    const seeded = await test.step(
+      'seed: a project with a scoring eval (labelled) and a choices eval',
+      async () => {
+        // ProjectSerializer requires model_type (futureagi/tracer/models/project.py).
+        const project = await actor.api.post<{ result: { project_id: string } }>(
+          PROJECT_PATH,
+          {
+            name: `e2e-alert-proj-${stamp}`,
+            trace_type: 'observe',
+            model_type: 'GenerativeLLM',
+          },
+        );
+        const projectId = project.result.project_id;
+
+        // create-v2 maps output_type -> config.output: 'percentage' -> "score",
+        // 'deterministic' -> "choices"; choice_scores becomes the template's
+        // choices list (futureagi/model_hub/views/separate_evals.py:2974-3037).
+        // So the scoring template lands as output="score" WITH labels — the
+        // exact TH-7788 shape.
+        const mkTemplate = async (
+          name: string,
+          outputType: 'percentage' | 'deterministic',
+        ) =>
+          (
+            await actor.api.post<{ result: { id: string } }>(EVAL_TEMPLATE_PATH, {
+              name,
+              eval_type: 'llm',
+              instructions: 'Rate the response. {{input}}',
+              model: 'turing_large',
+              output_type: outputType,
+              pass_threshold: 0.5,
+              choice_scores:
+                outputType === 'percentage'
+                  ? { Complete: 1.0, Partial: 0.5, Incomplete: 0.0 }
+                  : { never: 0.0, occasionally: 0.3, frequently: 0.7, always: 1.0 },
+            })
+          ).result.id;
+
+        // CustomEvalConfigSerializer (futureagi/tracer/serializers/custom_eval_config.py).
+        // The alert's Alert Type text is this config's name (get_metric_name).
+        const mkConfig = async (templateId: string, name: string) =>
+          (
+            await actor.api.post<{ result: { id: string } }>(EVAL_CONFIG_PATH, {
+              eval_template: templateId,
+              name,
+              project: projectId,
+              config: {},
+              mapping: {},
+              filters: {},
+              error_localizer: false,
+            })
+          ).result.id;
+
+        const scoreTpl = await mkTemplate(scoreEvalName, 'percentage');
+        const choiceTpl = await mkTemplate(choiceEvalName, 'deterministic');
+        const scoreCfgId = await mkConfig(scoreTpl, scoreEvalName);
+        const choiceCfgId = await mkConfig(choiceTpl, choiceEvalName);
+        return { projectId, scoreCfgId, choiceCfgId };
+      },
+    );
+    await testInfo.attach('seeded', {
+      body: JSON.stringify({ ...seeded, scoreAlertName, choiceAlertName }),
+      contentType: 'application/json',
+    });
+
+    // Wire body from UserAlertMonitorSerializer; values mirror a monitor created
+    // through the UI (threshold_type "static", numeric critical<warning).
+    const monitorBody = (name: string, metric: string, tmv?: string) => ({
+      name,
+      project: seeded.projectId,
+      metric_type: 'evaluation_metrics',
+      metric,
+      threshold_type: 'static',
+      threshold_operator: 'less_than',
+      critical_threshold_value: 0.4,
+      warning_threshold_value: 0.6,
+      alert_frequency: 5,
+      notification_emails: ['oncall@example.com'],
+      filters: {},
+      ...(tmv ? { threshold_metric_value: tmv } : {}),
+    });
+
+    await test.step('API: a scoring-eval alert is created with no chosen label', async () => {
+      await actor.api.post(MONITOR_PATH, monitorBody(scoreAlertName, seeded.scoreCfgId));
+    });
+
+    await test.step('API: a scoring-eval alert with a label is rejected', async () => {
+      await expect(
+        actor.api.post(
+          MONITOR_PATH,
+          monitorBody(`${scoreAlertName}-bad`, seeded.scoreCfgId, 'Incomplete'),
+        ),
+      ).rejects.toThrow(new RegExp(MSG_MUST_BE_EMPTY));
+    });
+
+    await test.step('API: a choices-eval alert with no label is rejected', async () => {
+      await expect(
+        actor.api.post(
+          MONITOR_PATH,
+          monitorBody(`${choiceAlertName}-bad`, seeded.choiceCfgId),
+        ),
+      ).rejects.toThrow(new RegExp(MSG_REQUIRED));
+    });
+
+    await test.step('API: a choices-eval alert is created with a valid label', async () => {
+      await actor.api.post(
+        MONITOR_PATH,
+        monitorBody(choiceAlertName, seeded.choiceCfgId, CHOICE_LABEL),
+      );
+    });
+
+    await test.step('storage: the scoring monitor stores no choice, the choices monitor stores the label', async () => {
+      const rows = await probe.pg<{
+        name: string;
+        threshold_metric_value: string | null;
+      }>(
+        `SELECT name, threshold_metric_value FROM tracer_useralertmonitor
+         WHERE name IN ($1, $2) AND organization_id = $3 AND deleted = false
+         ORDER BY name`,
+        [choiceAlertName, scoreAlertName, actor.organizationId],
+      );
+      // ORDER BY name: 'e2e-alert-choice-…' sorts before 'e2e-alert-score-…'.
+      expect(rows).toHaveLength(2);
+      expect(rows[0].name).toBe(choiceAlertName);
+      expect(rows[0].threshold_metric_value).toBe(CHOICE_LABEL);
+      expect(rows[1].name).toBe(scoreAlertName);
+      expect(rows[1].threshold_metric_value).toBeNull();
+    });
+
+    await test.step('UI: the alerts list shows the score alert bare and the choices alert suffixed', async () => {
+      await page.goto(ALERTS_URL, { waitUntil: 'domcontentloaded' });
+      await expect(page).toHaveURL(/\/dashboard\/alerts/, { timeout: UI_READY });
+
+      const search = page.getByPlaceholder('Search').first();
+      const alertTypeOf = (alertName: string) =>
+        page
+          .locator('.MuiDataGrid-row', {
+            has: page.locator(`[data-alert-row-name="${alertName}"]`),
+          })
+          .locator('[data-field="metricType"]');
+
+      await search.fill(scoreAlertName);
+      await expect(
+        page.locator(`[data-alert-row-name="${scoreAlertName}"]`),
+      ).toBeVisible({ timeout: UI_READY });
+      // Bare eval name, no " (label)" suffix — the TH-7788 display fix.
+      await expect(alertTypeOf(scoreAlertName)).toHaveText(scoreEvalName, {
+        timeout: UI_READY,
+      });
+
+      await search.fill(choiceAlertName);
+      await expect(
+        page.locator(`[data-alert-row-name="${choiceAlertName}"]`),
+      ).toBeVisible({ timeout: UI_READY });
+      await expect(alertTypeOf(choiceAlertName)).toHaveText(
+        `${choiceEvalName} (${CHOICE_LABEL})`,
+        { timeout: UI_READY },
+      );
+    });
+  },
+);

--- a/frontend/src/sections/projects/Alerts/__tests__/alert-choice-field-visibility.test.jsx
+++ b/frontend/src/sections/projects/Alerts/__tests__/alert-choice-field-visibility.test.jsx
@@ -184,4 +184,82 @@ describe("Choice field visibility depends on the eval's output type", () => {
     expect(body).not.toHaveProperty("threshold_metric_value");
     expect(body).toHaveProperty("metric", scoreEvalWithLabels.id);
   });
+
+  it("keeps a saved choice when the eval picker has not resolved the eval", async () => {
+    // baseSavedAlert is a Pass/Fail eval hydrated with threshold_metric_value
+    // "Passed". The picker mock resolves to [] here, the same shape it has
+    // while the get_eval_names query is in flight, 503s, or the eval simply
+    // has no ClickHouse rows yet — selectedEval is then undefined, and the
+    // saved choice must not be dropped from the submit payload on that basis
+    // alone.
+    const detail = {
+      ...baseSavedAlert,
+      threshold_type: "percentage_change",
+      critical_threshold_value: 0,
+      filters: {},
+    };
+
+    vi.spyOn(axios, "get").mockImplementation(() =>
+      Promise.resolve({ data: { result: [] } }),
+    );
+
+    useAlertStore.setState({
+      openSheetView: detail.id,
+      selectedProject: detail.project,
+    });
+    useAlertSheetStore.setState({
+      alertRuleDetails: null,
+      gridRef: { current: null },
+    });
+
+    renderWithRouter(
+      <QueryClientProvider
+        client={
+          new QueryClient({ defaultOptions: { queries: { retry: false } } })
+        }
+      >
+        <SnackbarProvider>
+          <AlertSettingsForm
+            onThresholdTypeChange={vi.fn()}
+            setThresholdOperator={vi.fn()}
+            setWarningValue={vi.fn()}
+            setCriticalValue={vi.fn()}
+            setFormIsDirty={vi.fn()}
+            onPayloadChange={vi.fn()}
+          />
+        </SnackbarProvider>
+      </QueryClientProvider>,
+    );
+
+    act(() => {
+      useAlertSheetStore.setState({
+        alertRuleDetails: normalizeAlertDetail(detail),
+      });
+    });
+
+    // The picker resolved to [] so there is no option to resolve the eval's
+    // name from — the metric field falls back to displaying the raw id.
+    // That is the signal that hydration has settled with an unresolved eval.
+    await waitFor(() =>
+      expect(screen.getByDisplayValue(detail.metric)).toBeInTheDocument(),
+    );
+
+    const patch = vi
+      .spyOn(axios, "patch")
+      .mockResolvedValue({ data: { result: "ok" } });
+
+    await act(async () => {
+      fireEvent.click(
+        document.querySelector('[data-alert-form-submit="update"]'),
+      );
+    });
+
+    await waitFor(() => expect(patch).toHaveBeenCalled());
+    const body = patch.mock.calls.at(-1)[1];
+    expect(body).toHaveProperty(
+      "threshold_metric_value",
+      detail.threshold_metric_value,
+    );
+    expect(body).toHaveProperty("metric", detail.metric);
+  });
 });

--- a/frontend/src/sections/projects/Alerts/__tests__/alert-choice-field-visibility.test.jsx
+++ b/frontend/src/sections/projects/Alerts/__tests__/alert-choice-field-visibility.test.jsx
@@ -263,3 +263,117 @@ describe("Choice field visibility depends on the eval's output type", () => {
     expect(body).toHaveProperty("metric", detail.metric);
   });
 });
+
+// The alert preview graph is enabled through onPayloadChange's second argument.
+// A "Pass/Fail" or "choices" eval's graph endpoint requires the chosen label,
+// so the preview must not be enabled until a choice is set — otherwise it fires
+// and the backend returns 400. A "score" eval needs no choice and previews as
+// soon as the metric is chosen.
+describe("Choice-thresholded evals gate the preview graph on a chosen label", () => {
+  const CHOICES_EVAL = {
+    id: "eval-2",
+    name: "Politeness",
+    output_type: "choices",
+    choices: ["never", "occasionally", "frequently", "always"],
+  };
+  const SCORE_EVAL = {
+    id: "eval-3",
+    name: "Coherence",
+    output_type: "score",
+    choices: null,
+  };
+
+  const renderDirtiedAlert = async (evaluation, thresholdMetricValue) => {
+    // savedAlert carries valid thresholds (less_than, 5 < 12), so the only
+    // variable under test is whether a choice is present.
+    const detail = {
+      ...baseSavedAlert,
+      metric: evaluation.id,
+      metric_name: evaluation.name,
+      threshold_metric_value: thresholdMetricValue,
+      filters: {},
+    };
+
+    vi.spyOn(axios, "get").mockImplementation((url) =>
+      Promise.resolve({
+        data: {
+          result: url === endpoints.project.getTraceEvals() ? [evaluation] : [],
+        },
+      }),
+    );
+
+    useAlertStore.setState({
+      openSheetView: detail.id,
+      selectedProject: detail.project,
+    });
+    useAlertSheetStore.setState({
+      alertRuleDetails: null,
+      gridRef: { current: null },
+    });
+
+    const payloadCalls = [];
+    const onPayloadChange = vi.fn((payload, enabled) =>
+      payloadCalls.push({ payload, enabled }),
+    );
+
+    renderWithRouter(
+      <QueryClientProvider
+        client={
+          new QueryClient({ defaultOptions: { queries: { retry: false } } })
+        }
+      >
+        <SnackbarProvider>
+          <AlertSettingsForm
+            onThresholdTypeChange={vi.fn()}
+            setThresholdOperator={vi.fn()}
+            setWarningValue={vi.fn()}
+            setCriticalValue={vi.fn()}
+            setFormIsDirty={vi.fn()}
+            onPayloadChange={onPayloadChange}
+          />
+        </SnackbarProvider>
+      </QueryClientProvider>,
+    );
+
+    act(() => {
+      useAlertSheetStore.setState({
+        alertRuleDetails: normalizeAlertDetail(detail),
+      });
+    });
+
+    await waitFor(() =>
+      expect(screen.getByDisplayValue(evaluation.name)).toBeInTheDocument(),
+    );
+
+    // isQueryEnabled requires the edited form to be dirty; a name edit dirties
+    // it without touching the choice under test.
+    const nameInput = document.querySelector('[data-alert-field="name"]');
+    act(() => {
+      fireEvent.change(nameInput, { target: { value: "Edited alert name" } });
+    });
+
+    return payloadCalls;
+  };
+
+  const lastEnabled = (calls) =>
+    calls.length ? calls[calls.length - 1].enabled : undefined;
+
+  it("enables the preview once a choices eval has a chosen label (edit mode)", async () => {
+    const calls = await renderDirtiedAlert(CHOICES_EVAL, "frequently");
+    await waitFor(() => expect(lastEnabled(calls)).toBe(true));
+  });
+
+  it("keeps the preview disabled for a choices eval with no chosen label", async () => {
+    const calls = await renderDirtiedAlert(CHOICES_EVAL, "");
+    // Every gating field is debounced 300ms; wait comfortably past that so a
+    // would-be enable (the pre-fix behaviour, which enabled as soon as the
+    // metric was set) has had time to fire before we assert it never did.
+    await new Promise((resolve) => setTimeout(resolve, 900));
+    expect(calls.some(({ enabled }) => enabled === true)).toBe(false);
+  });
+
+  it("enables the preview for a score eval without a choice (no regression)", async () => {
+    const calls = await renderDirtiedAlert(SCORE_EVAL, "");
+    await waitFor(() => expect(lastEnabled(calls)).toBe(true));
+  });
+});

--- a/frontend/src/sections/projects/Alerts/__tests__/alert-choice-field-visibility.test.jsx
+++ b/frontend/src/sections/projects/Alerts/__tests__/alert-choice-field-visibility.test.jsx
@@ -377,3 +377,88 @@ describe("Choice-thresholded evals gate the preview graph on a chosen label", ()
     await waitFor(() => expect(lastEnabled(calls)).toBe(true));
   });
 });
+
+// Saving an edit changes the alert's server-side graph, but the details-page
+// graph query is keyed only on the alert id + date window, so its cache goes
+// stale after a threshold_type/config change. The update must invalidate
+// ["alert-graph"] so the saved graph refetches immediately instead of waiting
+// on the 10s poll.
+describe("Saving an alert refreshes the details-page graph", () => {
+  it("invalidates the alert-graph query on update success", async () => {
+    const evaluation = {
+      id: "eval-1",
+      name: "Groundedness",
+      output_type: "Pass/Fail",
+      choices: ["Passed", "Failed"],
+    };
+    const detail = {
+      ...baseSavedAlert,
+      metric: evaluation.id,
+      metric_name: evaluation.name,
+      threshold_metric_value: "Passed",
+      filters: {},
+    };
+
+    vi.spyOn(axios, "get").mockImplementation((url) =>
+      Promise.resolve({
+        data: {
+          result: url === endpoints.project.getTraceEvals() ? [evaluation] : [],
+        },
+      }),
+    );
+
+    useAlertStore.setState({
+      openSheetView: detail.id,
+      selectedProject: detail.project,
+    });
+    useAlertSheetStore.setState({
+      alertRuleDetails: null,
+      gridRef: { current: null },
+    });
+
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+    const invalidate = vi.spyOn(queryClient, "invalidateQueries");
+
+    renderWithRouter(
+      <QueryClientProvider client={queryClient}>
+        <SnackbarProvider>
+          <AlertSettingsForm
+            onThresholdTypeChange={vi.fn()}
+            setThresholdOperator={vi.fn()}
+            setWarningValue={vi.fn()}
+            setCriticalValue={vi.fn()}
+            setFormIsDirty={vi.fn()}
+            onPayloadChange={vi.fn()}
+          />
+        </SnackbarProvider>
+      </QueryClientProvider>,
+    );
+
+    act(() => {
+      useAlertSheetStore.setState({
+        alertRuleDetails: normalizeAlertDetail(detail),
+      });
+    });
+
+    await waitFor(() =>
+      expect(screen.getByDisplayValue(evaluation.name)).toBeInTheDocument(),
+    );
+
+    const patch = vi
+      .spyOn(axios, "patch")
+      .mockResolvedValue({ data: { result: "ok" } });
+
+    await act(async () => {
+      fireEvent.click(
+        document.querySelector('[data-alert-form-submit="update"]'),
+      );
+    });
+
+    await waitFor(() => expect(patch).toHaveBeenCalled());
+    await waitFor(() =>
+      expect(invalidate).toHaveBeenCalledWith({ queryKey: ["alert-graph"] }),
+    );
+  });
+});

--- a/frontend/src/sections/projects/Alerts/__tests__/alert-choice-field-visibility.test.jsx
+++ b/frontend/src/sections/projects/Alerts/__tests__/alert-choice-field-visibility.test.jsx
@@ -1,7 +1,13 @@
 import React from "react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { act, renderWithRouter, screen, waitFor } from "src/utils/test-utils";
+import {
+  act,
+  fireEvent,
+  renderWithRouter,
+  screen,
+  waitFor,
+} from "src/utils/test-utils";
 
 import { SnackbarProvider } from "notistack";
 import axios, { endpoints } from "src/utils/axios";
@@ -152,4 +158,30 @@ describe("Choice field visibility depends on the eval's output type", () => {
       }
     },
   );
+
+  it("does not resend a hydrated stale choice for a score eval on submit", async () => {
+    const scoreEvalWithLabels = {
+      id: "eval-4",
+      name: "Helpfulness",
+      output_type: "score",
+      choices: ["Complete", "Partial", "Incomplete"],
+    };
+
+    await openAlertForEditing(scoreEvalWithLabels, "Incomplete");
+
+    const patch = vi
+      .spyOn(axios, "patch")
+      .mockResolvedValue({ data: { result: "ok" } });
+
+    await act(async () => {
+      fireEvent.click(
+        document.querySelector('[data-alert-form-submit="update"]'),
+      );
+    });
+
+    await waitFor(() => expect(patch).toHaveBeenCalled());
+    const body = patch.mock.calls.at(-1)[1];
+    expect(body).not.toHaveProperty("threshold_metric_value");
+    expect(body).toHaveProperty("metric", scoreEvalWithLabels.id);
+  });
 });

--- a/frontend/src/sections/projects/Alerts/__tests__/alert-choice-field-visibility.test.jsx
+++ b/frontend/src/sections/projects/Alerts/__tests__/alert-choice-field-visibility.test.jsx
@@ -1,0 +1,155 @@
+import React from "react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { act, renderWithRouter, screen, waitFor } from "src/utils/test-utils";
+
+import { SnackbarProvider } from "notistack";
+import axios, { endpoints } from "src/utils/axios";
+import { normalizeAlertDetail } from "../common";
+import AlertSettingsForm from "../components/AlertSettingsForm";
+import { savedAlert as baseSavedAlert } from "./fixtures";
+import { resetAlertStoreState, useAlertStore } from "../store/useAlertStore";
+import {
+  resetAlertSheetStoreState,
+  useAlertSheetStore,
+} from "../store/useAlertSheetStore";
+
+// A "Pass/Fail" or "choices" eval alerts on the share of rows with a given
+// label, so the form must offer a Choice picker. A "score" eval alerts on
+// the mean score instead, even when it happens to carry `choices` — the
+// picker must not appear for it.
+const cases = [
+  {
+    name: "Pass/Fail eval",
+    evaluation: {
+      id: "eval-1",
+      name: "Groundedness",
+      output_type: "Pass/Fail",
+      choices: ["Passed", "Failed"],
+    },
+    thresholdMetricValue: "Passed",
+    expectChoice: true,
+  },
+  {
+    name: "choices eval",
+    evaluation: {
+      id: "eval-2",
+      name: "Politeness",
+      output_type: "choices",
+      choices: ["never", "occasionally", "frequently", "always"],
+    },
+    thresholdMetricValue: "never",
+    expectChoice: true,
+  },
+  {
+    name: "score eval with no choices",
+    evaluation: {
+      id: "eval-3",
+      name: "Coherence",
+      output_type: "score",
+      choices: null,
+    },
+    thresholdMetricValue: "",
+    expectChoice: false,
+  },
+  {
+    name: "score eval that still carries choices",
+    evaluation: {
+      id: "eval-4",
+      name: "Helpfulness",
+      output_type: "score",
+      choices: ["Complete", "Partial", "Incomplete"],
+    },
+    thresholdMetricValue: "",
+    expectChoice: false,
+  },
+];
+
+const openAlertForEditing = async (evaluation, thresholdMetricValue) => {
+  const detail = {
+    ...baseSavedAlert,
+    metric: evaluation.id,
+    metric_name: evaluation.name,
+    threshold_type: "percentage_change",
+    threshold_metric_value: thresholdMetricValue,
+    critical_threshold_value: 0,
+    filters: {},
+  };
+
+  vi.spyOn(axios, "get").mockImplementation((url) =>
+    Promise.resolve({
+      data: {
+        result: url === endpoints.project.getTraceEvals() ? [evaluation] : [],
+      },
+    }),
+  );
+
+  useAlertStore.setState({
+    openSheetView: detail.id,
+    selectedProject: detail.project,
+  });
+  useAlertSheetStore.setState({
+    alertRuleDetails: null,
+    gridRef: { current: null },
+  });
+
+  renderWithRouter(
+    <QueryClientProvider
+      client={
+        new QueryClient({ defaultOptions: { queries: { retry: false } } })
+      }
+    >
+      <SnackbarProvider>
+        <AlertSettingsForm
+          onThresholdTypeChange={vi.fn()}
+          setThresholdOperator={vi.fn()}
+          setWarningValue={vi.fn()}
+          setCriticalValue={vi.fn()}
+          setFormIsDirty={vi.fn()}
+          onPayloadChange={vi.fn()}
+        />
+      </SnackbarProvider>
+    </QueryClientProvider>,
+  );
+
+  // The sheet mounts before the alert request resolves, so the saved alert
+  // reaches the form only after the form already exists.
+  act(() => {
+    useAlertSheetStore.setState({
+      alertRuleDetails: normalizeAlertDetail(detail),
+    });
+  });
+
+  // Wait for the evaluations list to load and the metric field to hydrate
+  // with the matching eval's name — only then has selectedMetricOptions had
+  // a chance to be computed from the real (loaded) evaluation shape.
+  await waitFor(() =>
+    expect(screen.getByDisplayValue(evaluation.name)).toBeInTheDocument(),
+  );
+};
+
+describe("Choice field visibility depends on the eval's output type", () => {
+  beforeEach(() => {
+    resetAlertStoreState();
+    resetAlertSheetStoreState();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    resetAlertStoreState();
+    resetAlertSheetStoreState();
+  });
+
+  it.each(cases)(
+    "$name: Choice label is $expectChoice",
+    async ({ evaluation, thresholdMetricValue, expectChoice }) => {
+      await openAlertForEditing(evaluation, thresholdMetricValue);
+
+      if (expectChoice) {
+        expect(screen.getAllByLabelText("Choice").length).toBeGreaterThan(0);
+      } else {
+        expect(screen.queryAllByLabelText("Choice")).toHaveLength(0);
+      }
+    },
+  );
+});

--- a/frontend/src/sections/projects/Alerts/__tests__/alert-filter-hydration.test.jsx
+++ b/frontend/src/sections/projects/Alerts/__tests__/alert-filter-hydration.test.jsx
@@ -202,7 +202,12 @@ const savedAlert = {
 };
 
 const evaluations = [
-  { id: "eval-1", name: "Groundedness", choices: ["Passed", "Failed"] },
+  {
+    id: "eval-1",
+    name: "Groundedness",
+    output_type: "Pass/Fail",
+    choices: ["Passed", "Failed"],
+  },
 ];
 
 const labelFor = (options, value) =>

--- a/frontend/src/sections/projects/Alerts/__tests__/eval-choice-threshold.test.js
+++ b/frontend/src/sections/projects/Alerts/__tests__/eval-choice-threshold.test.js
@@ -3,26 +3,36 @@ import { evalUsesChoiceThreshold } from "../common";
 
 describe("evalUsesChoiceThreshold", () => {
   it("is true for a Pass/Fail eval", () => {
-    expect(evalUsesChoiceThreshold({
-      output_type: "Pass/Fail", choices: ["Passed", "Failed"],
-    })).toBe(true);
+    expect(
+      evalUsesChoiceThreshold({
+        output_type: "Pass/Fail",
+        choices: ["Passed", "Failed"],
+      }),
+    ).toBe(true);
   });
 
   it("is true for a choices eval", () => {
-    expect(evalUsesChoiceThreshold({
-      output_type: "choices", choices: ["never", "always"],
-    })).toBe(true);
+    expect(
+      evalUsesChoiceThreshold({
+        output_type: "choices",
+        choices: ["never", "always"],
+      }),
+    ).toBe(true);
   });
 
   it("is false for a scoring eval that has labels", () => {
-    expect(evalUsesChoiceThreshold({
-      output_type: "score", choices: ["Complete", "Partial", "Incomplete"],
-    })).toBe(false);
+    expect(
+      evalUsesChoiceThreshold({
+        output_type: "score",
+        choices: ["Complete", "Partial", "Incomplete"],
+      }),
+    ).toBe(false);
   });
 
   it("is false for a scoring eval with no labels", () => {
-    expect(evalUsesChoiceThreshold({ output_type: "score", choices: null }))
-      .toBe(false);
+    expect(
+      evalUsesChoiceThreshold({ output_type: "score", choices: null }),
+    ).toBe(false);
   });
 
   it("is false for an unknown or missing output type", () => {

--- a/frontend/src/sections/projects/Alerts/__tests__/eval-choice-threshold.test.js
+++ b/frontend/src/sections/projects/Alerts/__tests__/eval-choice-threshold.test.js
@@ -1,0 +1,32 @@
+import { describe, it, expect } from "vitest";
+import { evalUsesChoiceThreshold } from "../common";
+
+describe("evalUsesChoiceThreshold", () => {
+  it("is true for a Pass/Fail eval", () => {
+    expect(evalUsesChoiceThreshold({
+      output_type: "Pass/Fail", choices: ["Passed", "Failed"],
+    })).toBe(true);
+  });
+
+  it("is true for a choices eval", () => {
+    expect(evalUsesChoiceThreshold({
+      output_type: "choices", choices: ["never", "always"],
+    })).toBe(true);
+  });
+
+  it("is false for a scoring eval that has labels", () => {
+    expect(evalUsesChoiceThreshold({
+      output_type: "score", choices: ["Complete", "Partial", "Incomplete"],
+    })).toBe(false);
+  });
+
+  it("is false for a scoring eval with no labels", () => {
+    expect(evalUsesChoiceThreshold({ output_type: "score", choices: null }))
+      .toBe(false);
+  });
+
+  it("is false for an unknown or missing output type", () => {
+    expect(evalUsesChoiceThreshold({ choices: ["a"] })).toBe(false);
+    expect(evalUsesChoiceThreshold(undefined)).toBe(false);
+  });
+});

--- a/frontend/src/sections/projects/Alerts/common.js
+++ b/frontend/src/sections/projects/Alerts/common.js
@@ -930,3 +930,13 @@ export const ISSUE_FILTER_FIELDS = [
     choiceLabels: { critical: "Critical", warning: "Warning" },
   },
 ];
+
+// Output types whose alert metric is the share of one chosen label. A Scoring
+// eval may also carry labels, but its metric is the mean score, so it must not
+// offer a choice.
+export const CHOICE_THRESHOLD_OUTPUT_TYPES = ["Pass/Fail", "choices"];
+
+export const evalUsesChoiceThreshold = (evaluation) =>
+  CHOICE_THRESHOLD_OUTPUT_TYPES.includes(evaluation?.output_type) &&
+  Array.isArray(evaluation?.choices) &&
+  evaluation.choices.length > 0;

--- a/frontend/src/sections/projects/Alerts/components/AlertSettingsForm.jsx
+++ b/frontend/src/sections/projects/Alerts/components/AlertSettingsForm.jsx
@@ -359,9 +359,10 @@ export default function AlertSettingsForm({
       }),
       ...(data?.metric_type === "evaluation_metrics" && {
         metric: data?.metric,
-        ...(data?.threshold_metric_value && {
-          threshold_metric_value: data?.threshold_metric_value,
-        }),
+        ...(data?.threshold_metric_value &&
+          selectedMetricOptions?.length > 0 && {
+            threshold_metric_value: data?.threshold_metric_value,
+          }),
       }),
       ...notificationPayload,
       ...(data?.threshold_type === "percentage_change" && {

--- a/frontend/src/sections/projects/Alerts/components/AlertSettingsForm.jsx
+++ b/frontend/src/sections/projects/Alerts/components/AlertSettingsForm.jsx
@@ -155,11 +155,13 @@ export default function AlertSettingsForm({
     enabled: Boolean(observeId && metricType === "evaluation_metrics"),
   });
 
+  const selectedEval = useMemo(
+    () => expandedEvaluations?.find((evaluation) => evaluation?.id === metric),
+    [expandedEvaluations, metric],
+  );
+
   const selectedMetricOptions = useMemo(() => {
     if (expandedEvaluations?.length > 0 && metric) {
-      const selectedEval = expandedEvaluations.find(
-        (evaluation) => evaluation?.id === metric,
-      );
       if (!evalUsesChoiceThreshold(selectedEval)) return [];
       return (
         selectedEval?.choices?.map((choice) => ({
@@ -169,7 +171,7 @@ export default function AlertSettingsForm({
       );
     }
     return [];
-  }, [expandedEvaluations, metric]);
+  }, [expandedEvaluations, metric, selectedEval]);
 
   const queryPayload = useMemo(() => {
     const { observation_type, span_attributes_filters } =
@@ -360,7 +362,7 @@ export default function AlertSettingsForm({
       ...(data?.metric_type === "evaluation_metrics" && {
         metric: data?.metric,
         ...(data?.threshold_metric_value &&
-          selectedMetricOptions?.length > 0 && {
+          !(selectedEval && !evalUsesChoiceThreshold(selectedEval)) && {
             threshold_metric_value: data?.threshold_metric_value,
           }),
       }),

--- a/frontend/src/sections/projects/Alerts/components/AlertSettingsForm.jsx
+++ b/frontend/src/sections/projects/Alerts/components/AlertSettingsForm.jsx
@@ -17,6 +17,7 @@ import {
   timeOptions,
   alertDefinitionOptions,
   convertFiltersToPayload,
+  evalUsesChoiceThreshold,
   isSpanAttrFilterValid,
 } from "../common";
 import { FormSearchSelectFieldControl } from "src/components/FromSearchSelectField";
@@ -159,6 +160,7 @@ export default function AlertSettingsForm({
       const selectedEval = expandedEvaluations.find(
         (evaluation) => evaluation?.id === metric,
       );
+      if (!evalUsesChoiceThreshold(selectedEval)) return [];
       return (
         selectedEval?.choices?.map((choice) => ({
           label: choice,

--- a/frontend/src/sections/projects/Alerts/components/AlertSettingsForm.jsx
+++ b/frontend/src/sections/projects/Alerts/components/AlertSettingsForm.jsx
@@ -22,7 +22,7 @@ import {
 } from "../common";
 import { FormSearchSelectFieldControl } from "src/components/FromSearchSelectField";
 import AlertFilterBar from "./AlertFilterBar";
-import { useMutation, useQuery } from "@tanstack/react-query";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import axios, { endpoints } from "src/utils/axios";
 import RadioField from "src/components/RadioField/RadioField";
 import { ShowComponent } from "src/components/show";
@@ -62,6 +62,7 @@ export default function AlertSettingsForm({
 
   const { alertRuleDetails, refreshGrid: refreshIssues } = useAlertSheetView();
   const { currentOrganizationId } = useOrganization();
+  const queryClient = useQueryClient();
   const observeId = selectedProject || alertRuleDetails?.project || null;
 
   const buildFormValues = useCallback(
@@ -325,6 +326,10 @@ export default function AlertSettingsForm({
       handleCloseCreateAlert();
       refreshGrid();
       refreshIssues();
+      // The details-page graph is keyed only on the alert id + date window, so
+      // a threshold_type or config change leaves its cache stale until the 10s
+      // poll happens to refetch. Invalidate it so the saved graph updates now.
+      queryClient.invalidateQueries({ queryKey: ["alert-graph"] });
     },
   });
 

--- a/frontend/src/sections/projects/Alerts/components/AlertSettingsForm.jsx
+++ b/frontend/src/sections/projects/Alerts/components/AlertSettingsForm.jsx
@@ -237,7 +237,13 @@ export default function AlertSettingsForm({
       debouncedWarning &&
       debouncedFrequency &&
       !hasErrors &&
-      (debouncedMetricType === "evaluation_metrics" ? debouncedMetric : true);
+      (debouncedMetricType === "evaluation_metrics"
+        ? debouncedMetric &&
+          // A choice-thresholded eval's graph requires the chosen label; firing
+          // the preview before it is set 400s. Score evals need no choice.
+          (!evalUsesChoiceThreshold(selectedEval) ||
+            debouncedThresHoldMetricValue)
+        : true);
 
     const isThresholdValid = (() => {
       if (debouncedOperator === "less_than") {
@@ -261,6 +267,8 @@ export default function AlertSettingsForm({
     debouncedWarning,
     debouncedFrequency,
     debouncedMetric,
+    debouncedThresHoldMetricValue,
+    selectedEval,
     errors,
     openSheetView,
     isDirty,

--- a/futureagi/ai_tools/tools/tracing/create_alert_monitor.py
+++ b/futureagi/ai_tools/tools/tracing/create_alert_monitor.py
@@ -193,6 +193,7 @@ class CreateAlertMonitorTool(BaseTool):
                     error_code="VALIDATION_ERROR",
                 )
             from tracer.models.custom_eval_config import CustomEvalConfig
+            from tracer.utils.monitor import uses_choice_threshold
 
             try:
                 custom_eval_config = CustomEvalConfig.objects.get(
@@ -206,8 +207,7 @@ class CreateAlertMonitorTool(BaseTool):
 
             choices = (
                 custom_eval_config.eval_template.choices
-                if custom_eval_config.eval_template
-                and custom_eval_config.eval_template.choices
+                if uses_choice_threshold(custom_eval_config.eval_template)
                 else None
             )
             if choices:

--- a/futureagi/tracer/serializers/monitor.py
+++ b/futureagi/tracer/serializers/monitor.py
@@ -61,7 +61,9 @@ class UserAlertMonitorSerializer(serializers.ModelSerializer):
                 )
                 if eval_config:
                     metric_name = eval_config.name
-                    if obj.threshold_metric_value:
+                    if obj.threshold_metric_value and _uses_choice_threshold(
+                        eval_config.eval_template
+                    ):
                         metric_name += f" ({obj.threshold_metric_value})"
                     return metric_name
                 return "Invalid Eval"
@@ -492,7 +494,9 @@ class UserAlertMonitorDetailSerializer(serializers.ModelSerializer):
                 )
                 if eval_config:
                     metric_name = eval_config.name
-                    if obj.threshold_metric_value:
+                    if obj.threshold_metric_value and _uses_choice_threshold(
+                        eval_config.eval_template
+                    ):
                         metric_name += f" ({obj.threshold_metric_value})"
                     return metric_name
                 return "Invalid Eval"

--- a/futureagi/tracer/serializers/monitor.py
+++ b/futureagi/tracer/serializers/monitor.py
@@ -3,7 +3,7 @@ import json
 from rest_framework import serializers
 
 from accounts.serializers.user import UserSerializer
-from tracer.models.custom_eval_config import CustomEvalConfig
+from tracer.models.custom_eval_config import CustomEvalConfig, EvalOutputType
 from tracer.models.monitor import (
     AlertTypeChoices,
     MonitorMetricTypeChoices,
@@ -20,6 +20,19 @@ from tracer.serializers.filters import (
 )
 
 OBSERVATION_SPAN_TYPES = [t[0] for t in ObservationSpan.OBSERVATION_SPAN_TYPES]
+
+
+def _uses_choice_threshold(eval_template) -> bool:
+    """True when the eval's alert metric is the share of one chosen label.
+
+    A scoring eval may also carry labels, but its metric is the mean score, so
+    the stored choice is neither validated nor displayed for it.
+    """
+    output_type = (eval_template.config or {}).get("output") if eval_template else None
+    return output_type in (
+        EvalOutputType.PASS_FAIL.value,
+        EvalOutputType.CHOICES.value,
+    )
 
 
 class UserAlertMonitorSerializer(serializers.ModelSerializer):
@@ -97,10 +110,10 @@ class UserAlertMonitorSerializer(serializers.ModelSerializer):
                     {"metric": f"Invalid metric format for '{metric}'."}
                 )
 
+            eval_template = custom_eval_config.eval_template
             choices = (
-                custom_eval_config.eval_template.choices
-                if custom_eval_config.eval_template
-                and custom_eval_config.eval_template.choices
+                eval_template.choices
+                if _uses_choice_threshold(eval_template) and eval_template.choices
                 else None
             )
             if choices:

--- a/futureagi/tracer/serializers/monitor.py
+++ b/futureagi/tracer/serializers/monitor.py
@@ -3,7 +3,7 @@ import json
 from rest_framework import serializers
 
 from accounts.serializers.user import UserSerializer
-from tracer.models.custom_eval_config import CustomEvalConfig, EvalOutputType
+from tracer.models.custom_eval_config import CustomEvalConfig
 from tracer.models.monitor import (
     AlertTypeChoices,
     MonitorMetricTypeChoices,
@@ -18,21 +18,9 @@ from tracer.serializers.filters import (
     filter_list_field,
     filter_list_query_param_field,
 )
+from tracer.utils.monitor import uses_choice_threshold
 
 OBSERVATION_SPAN_TYPES = [t[0] for t in ObservationSpan.OBSERVATION_SPAN_TYPES]
-
-
-def _uses_choice_threshold(eval_template) -> bool:
-    """True when the eval's alert metric is the share of one chosen label.
-
-    A scoring eval may also carry labels, but its metric is the mean score, so
-    the stored choice is neither validated nor displayed for it.
-    """
-    output_type = (eval_template.config or {}).get("output") if eval_template else None
-    return output_type in (
-        EvalOutputType.PASS_FAIL.value,
-        EvalOutputType.CHOICES.value,
-    )
 
 
 class UserAlertMonitorSerializer(serializers.ModelSerializer):
@@ -61,7 +49,7 @@ class UserAlertMonitorSerializer(serializers.ModelSerializer):
                 )
                 if eval_config:
                     metric_name = eval_config.name
-                    if obj.threshold_metric_value and _uses_choice_threshold(
+                    if obj.threshold_metric_value and uses_choice_threshold(
                         eval_config.eval_template
                     ):
                         metric_name += f" ({obj.threshold_metric_value})"
@@ -114,9 +102,7 @@ class UserAlertMonitorSerializer(serializers.ModelSerializer):
 
             eval_template = custom_eval_config.eval_template
             choices = (
-                eval_template.choices
-                if _uses_choice_threshold(eval_template) and eval_template.choices
-                else None
+                eval_template.choices if uses_choice_threshold(eval_template) else None
             )
             if choices:
                 if threshold_metric_value is None:
@@ -494,7 +480,7 @@ class UserAlertMonitorDetailSerializer(serializers.ModelSerializer):
                 )
                 if eval_config:
                     metric_name = eval_config.name
-                    if obj.threshold_metric_value and _uses_choice_threshold(
+                    if obj.threshold_metric_value and uses_choice_threshold(
                         eval_config.eval_template
                     ):
                         metric_name += f" ({obj.threshold_metric_value})"

--- a/futureagi/tracer/tests/test_monitor.py
+++ b/futureagi/tracer/tests/test_monitor.py
@@ -555,7 +555,7 @@ class TestUserAlertMonitorListAPI:
             mapping={"input": "input", "output": "output"},
             filters={},
         )
-        UserAlertMonitor.objects.create(
+        monitor = UserAlertMonitor.objects.create(
             organization=organization,
             workspace=workspace,
             project=observe_project,
@@ -580,6 +580,10 @@ class TestUserAlertMonitorListAPI:
         assert len(rows) == 1
         rendered = rows[0]["metric_type"]
         assert rendered == eval_config.name
+
+        response = auth_client.get(f"/tracer/user-alerts/{monitor.id}/details/")
+        assert response.status_code == status.HTTP_200_OK
+        assert get_result(response)["metric_name"] == eval_config.name
 
     def test_list_monitors_choices_eval_keeps_choice_suffix(
         self, auth_client, organization, workspace, observe_project

--- a/futureagi/tracer/tests/test_monitor.py
+++ b/futureagi/tracer/tests/test_monitor.py
@@ -533,6 +533,101 @@ class TestUserAlertMonitorListAPI:
         )
         assert response.status_code == status.HTTP_200_OK
 
+    def test_list_monitors_score_eval_hides_stale_choice_suffix(
+        self, auth_client, organization, workspace, observe_project
+    ):
+        """A monitor saved before this branch may still carry a stored
+        threshold_metric_value on a score-typed eval. The Alert Type column
+        must not render that stale value as a suffix."""
+        template = EvalTemplate.objects.create(
+            name=f"Score Eval {uuid.uuid4().hex[:8]}",
+            description="A test evaluation template",
+            organization=organization,
+            workspace=workspace,
+            config={"output": "score"},
+            choices=["Complete", "Partial", "Incomplete"],
+        )
+        eval_config = CustomEvalConfig.objects.create(
+            name=f"Score Eval Config {uuid.uuid4().hex[:8]}",
+            project=observe_project,
+            eval_template=template,
+            config={"threshold": 0.8},
+            mapping={"input": "input", "output": "output"},
+            filters={},
+        )
+        UserAlertMonitor.objects.create(
+            organization=organization,
+            workspace=workspace,
+            project=observe_project,
+            name="Stale Score Alert",
+            metric_type="evaluation_metrics",
+            metric=str(eval_config.id),
+            threshold_metric_value="Incomplete",
+            threshold_operator="greater_than",
+            threshold_type="static",
+            critical_threshold_value=0.15,
+            alert_frequency=60,
+        )
+
+        response = auth_client.get(
+            "/tracer/user-alerts/list_monitors/",
+            {"project_id": str(observe_project.id)},
+        )
+        assert response.status_code == status.HTTP_200_OK
+
+        data = get_result(response)
+        rows = [row for row in data["table"] if row["name"] == "Stale Score Alert"]
+        assert len(rows) == 1
+        rendered = rows[0]["metric_type"]
+        assert rendered == eval_config.name
+
+    def test_list_monitors_choices_eval_keeps_choice_suffix(
+        self, auth_client, organization, workspace, observe_project
+    ):
+        """A monitor on a choices-typed eval keeps its stored choice in the
+        Alert Type column."""
+        template = EvalTemplate.objects.create(
+            name=f"Choices Eval {uuid.uuid4().hex[:8]}",
+            description="A test evaluation template",
+            organization=organization,
+            workspace=workspace,
+            config={"output": "choices"},
+            choices=["Complete", "Partial", "Incomplete"],
+        )
+        eval_config = CustomEvalConfig.objects.create(
+            name=f"Choices Eval Config {uuid.uuid4().hex[:8]}",
+            project=observe_project,
+            eval_template=template,
+            config={"threshold": 0.8},
+            mapping={"input": "input", "output": "output"},
+            filters={},
+        )
+        UserAlertMonitor.objects.create(
+            organization=organization,
+            workspace=workspace,
+            project=observe_project,
+            name="Choices Alert",
+            metric_type="evaluation_metrics",
+            metric=str(eval_config.id),
+            threshold_metric_value="Incomplete",
+            threshold_operator="greater_than",
+            threshold_type="static",
+            critical_threshold_value=0.15,
+            alert_frequency=60,
+        )
+
+        response = auth_client.get(
+            "/tracer/user-alerts/list_monitors/",
+            {"project_id": str(observe_project.id)},
+        )
+        assert response.status_code == status.HTTP_200_OK
+
+        data = get_result(response)
+        rows = [row for row in data["table"] if row["name"] == "Choices Alert"]
+        assert len(rows) == 1
+        rendered = rows[0]["metric_type"]
+        assert rendered == f"{eval_config.name} (Incomplete)"
+
 
 @pytest.mark.integration
 @pytest.mark.api
@@ -591,6 +686,48 @@ class TestUserAlertMonitorDetailsAPI:
         response = auth_client.get(f"/tracer/user-alerts/{other_monitor.id}/details/")
 
         assert response.status_code == status.HTTP_404_NOT_FOUND
+
+    def test_get_details_pass_fail_eval_keeps_choice_suffix(
+        self, auth_client, organization, workspace, observe_project
+    ):
+        """A monitor on a Pass/Fail-typed eval keeps its stored choice in the
+        detail sheet's rendered metric name."""
+        template = EvalTemplate.objects.create(
+            name=f"Pass Fail Eval {uuid.uuid4().hex[:8]}",
+            description="A test evaluation template",
+            organization=organization,
+            workspace=workspace,
+            config={"output": "Pass/Fail"},
+            choices=["Passed", "Failed"],
+        )
+        eval_config = CustomEvalConfig.objects.create(
+            name=f"Pass Fail Eval Config {uuid.uuid4().hex[:8]}",
+            project=observe_project,
+            eval_template=template,
+            config={"threshold": 0.8},
+            mapping={"input": "input", "output": "output"},
+            filters={},
+        )
+        monitor = UserAlertMonitor.objects.create(
+            organization=organization,
+            workspace=workspace,
+            project=observe_project,
+            name="Pass Fail Alert",
+            metric_type="evaluation_metrics",
+            metric=str(eval_config.id),
+            threshold_metric_value="Passed",
+            threshold_operator="greater_than",
+            threshold_type="static",
+            critical_threshold_value=0.15,
+            alert_frequency=60,
+        )
+
+        response = auth_client.get(f"/tracer/user-alerts/{monitor.id}/details/")
+        assert response.status_code == status.HTTP_200_OK
+
+        data = get_result(response)
+        rendered = data["metric_name"]
+        assert rendered == f"{eval_config.name} (Passed)"
 
 
 @pytest.mark.integration

--- a/futureagi/tracer/tests/test_monitor.py
+++ b/futureagi/tracer/tests/test_monitor.py
@@ -1111,6 +1111,52 @@ class TestUserAlertMonitorDuplicateAPI:
             name="Cross Workspace Copy"
         ).exists()
 
+    def test_duplicate_drops_stale_choice_on_score_eval(
+        self, auth_client, organization, workspace, observe_project
+    ):
+        """A monitor saved before this branch may still carry a stored
+        threshold_metric_value on a score-typed eval. Duplicating it must not
+        copy that stale value onto the new row."""
+        template = EvalTemplate.objects.create(
+            name=f"Score Eval {uuid.uuid4().hex[:8]}",
+            description="A test evaluation template",
+            organization=organization,
+            workspace=workspace,
+            config={"output": "score"},
+            choices=["Complete", "Partial", "Incomplete"],
+        )
+        eval_config = CustomEvalConfig.objects.create(
+            name=f"Score Eval Config {uuid.uuid4().hex[:8]}",
+            project=observe_project,
+            eval_template=template,
+            config={"threshold": 0.8},
+            mapping={"input": "input", "output": "output"},
+            filters={},
+        )
+        monitor = UserAlertMonitor.objects.create(
+            organization=organization,
+            workspace=workspace,
+            project=observe_project,
+            name="Stale Score Alert",
+            metric_type="evaluation_metrics",
+            metric=str(eval_config.id),
+            threshold_metric_value="Incomplete",
+            threshold_operator="greater_than",
+            threshold_type="static",
+            critical_threshold_value=0.15,
+            alert_frequency=60,
+        )
+
+        response = auth_client.post(
+            "/tracer/user-alerts/duplicate/",
+            {"id": str(monitor.id), "name": "Stale Score Alert Copy"},
+            format="json",
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        copied_monitor = UserAlertMonitor.objects.get(name="Stale Score Alert Copy")
+        assert copied_monitor.threshold_metric_value is None
+
 
 @pytest.mark.integration
 @pytest.mark.api

--- a/futureagi/tracer/tests/test_monitor.py
+++ b/futureagi/tracer/tests/test_monitor.py
@@ -345,7 +345,6 @@ class TestUserAlertMonitorCreateAPI:
                 "name": "Score Eval Alert No Choice",
                 "metric_type": "evaluation_metrics",
                 "metric": str(eval_config.id),
-                "threshold_metric_value": None,
                 "threshold_operator": "greater_than",
                 "threshold_type": "static",
                 "critical_threshold_value": 0.15,
@@ -355,9 +354,8 @@ class TestUserAlertMonitorCreateAPI:
         )
 
         assert response.status_code == status.HTTP_200_OK
-        assert UserAlertMonitor.objects.filter(
-            name="Score Eval Alert No Choice"
-        ).exists()
+        monitor = UserAlertMonitor.objects.get(name="Score Eval Alert No Choice")
+        assert monitor.threshold_metric_value is None
 
     def test_create_pass_fail_eval_choice(
         self, auth_client, organization, workspace, observe_project
@@ -537,8 +535,9 @@ class TestUserAlertMonitorListAPI:
         self, auth_client, organization, workspace, observe_project
     ):
         """A monitor saved before this branch may still carry a stored
-        threshold_metric_value on a score-typed eval. The Alert Type column
-        must not render that stale value as a suffix."""
+        threshold_metric_value on a score-typed eval. Neither the alerts
+        list's Alert Type column nor the detail sheet's metric_name must
+        render that stale value as a suffix."""
         template = EvalTemplate.objects.create(
             name=f"Score Eval {uuid.uuid4().hex[:8]}",
             description="A test evaluation template",

--- a/futureagi/tracer/tests/test_monitor.py
+++ b/futureagi/tracer/tests/test_monitor.py
@@ -12,6 +12,8 @@ from rest_framework import status
 from accounts.models.user import User
 from accounts.models.workspace import Workspace
 from model_hub.models.ai_model import AIModel
+from model_hub.models.evals_metric import EvalTemplate
+from tracer.models.custom_eval_config import CustomEvalConfig
 from tracer.models.monitor import UserAlertMonitor, UserAlertMonitorLog
 from tracer.models.project import Project
 
@@ -262,6 +264,220 @@ class TestUserAlertMonitorCreateAPI:
         )
 
         assert response.status_code == status.HTTP_400_BAD_REQUEST
+
+    def _create_eval_config(
+        self, organization, workspace, observe_project, output_type, choices
+    ):
+        """Build an EvalTemplate + CustomEvalConfig pinned to observe_project.
+
+        Alert creation only accepts an `observe`-typed project, so the eval
+        config must live on `observe_project`, not the `experiment`-typed
+        `project` fixture used elsewhere in conftest.py.
+        """
+        template = EvalTemplate.objects.create(
+            name=f"Test Eval Template {uuid.uuid4().hex[:8]}",
+            description="A test evaluation template",
+            organization=organization,
+            workspace=workspace,
+            config={"output": output_type},
+            choices=choices,
+        )
+        return CustomEvalConfig.objects.create(
+            name=f"Test Custom Eval {uuid.uuid4().hex[:8]}",
+            project=observe_project,
+            eval_template=template,
+            config={"threshold": 0.8},
+            mapping={"input": "input", "output": "output"},
+            filters={},
+        )
+
+    def test_create_score_eval_with_choice_rejected(
+        self, auth_client, organization, workspace, observe_project
+    ):
+        """A score-typed eval carries labels but its metric is the mean score,
+        so a stored choice must be rejected."""
+        eval_config = self._create_eval_config(
+            organization,
+            workspace,
+            observe_project,
+            "score",
+            ["Complete", "Partial", "Incomplete"],
+        )
+
+        response = auth_client.post(
+            "/tracer/user-alerts/",
+            {
+                "project": str(observe_project.id),
+                "name": "Score Eval Alert",
+                "metric_type": "evaluation_metrics",
+                "metric": str(eval_config.id),
+                "threshold_metric_value": "Incomplete",
+                "threshold_operator": "greater_than",
+                "threshold_type": "static",
+                "critical_threshold_value": 0.15,
+                "alert_frequency": 60,
+            },
+            format="json",
+        )
+
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert "must be empty for evals without predefined choices" in str(
+            response.json()
+        )
+
+    def test_create_score_eval_without_choice_succeeds(
+        self, auth_client, organization, workspace, observe_project
+    ):
+        """The frontend no longer sends threshold_metric_value for score evals;
+        that must be accepted even when the template carries labels."""
+        eval_config = self._create_eval_config(
+            organization,
+            workspace,
+            observe_project,
+            "score",
+            ["Complete", "Partial", "Incomplete"],
+        )
+
+        response = auth_client.post(
+            "/tracer/user-alerts/",
+            {
+                "project": str(observe_project.id),
+                "name": "Score Eval Alert No Choice",
+                "metric_type": "evaluation_metrics",
+                "metric": str(eval_config.id),
+                "threshold_metric_value": None,
+                "threshold_operator": "greater_than",
+                "threshold_type": "static",
+                "critical_threshold_value": 0.15,
+                "alert_frequency": 60,
+            },
+            format="json",
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        assert UserAlertMonitor.objects.filter(
+            name="Score Eval Alert No Choice"
+        ).exists()
+
+    def test_create_pass_fail_eval_choice(
+        self, auth_client, organization, workspace, observe_project
+    ):
+        eval_config = self._create_eval_config(
+            organization,
+            workspace,
+            observe_project,
+            "Pass/Fail",
+            ["Passed", "Failed"],
+        )
+
+        response = auth_client.post(
+            "/tracer/user-alerts/",
+            {
+                "project": str(observe_project.id),
+                "name": "Pass Fail Eval Alert",
+                "metric_type": "evaluation_metrics",
+                "metric": str(eval_config.id),
+                "threshold_metric_value": "Passed",
+                "threshold_operator": "greater_than",
+                "threshold_type": "static",
+                "critical_threshold_value": 0.15,
+                "alert_frequency": 60,
+            },
+            format="json",
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        assert UserAlertMonitor.objects.filter(name="Pass Fail Eval Alert").exists()
+
+    def test_create_pass_fail_eval_invalid_choice_rejected(
+        self, auth_client, organization, workspace, observe_project
+    ):
+        eval_config = self._create_eval_config(
+            organization,
+            workspace,
+            observe_project,
+            "Pass/Fail",
+            ["Passed", "Failed"],
+        )
+
+        response = auth_client.post(
+            "/tracer/user-alerts/",
+            {
+                "project": str(observe_project.id),
+                "name": "Pass Fail Eval Alert Invalid",
+                "metric_type": "evaluation_metrics",
+                "metric": str(eval_config.id),
+                "threshold_metric_value": "Maybe",
+                "threshold_operator": "greater_than",
+                "threshold_type": "static",
+                "critical_threshold_value": 0.15,
+                "alert_frequency": 60,
+            },
+            format="json",
+        )
+
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert "is not valid" in str(response.json())
+
+    def test_create_choices_eval_valid_choice(
+        self, auth_client, organization, workspace, observe_project
+    ):
+        eval_config = self._create_eval_config(
+            organization,
+            workspace,
+            observe_project,
+            "choices",
+            ["never", "occasionally", "frequently", "always"],
+        )
+
+        response = auth_client.post(
+            "/tracer/user-alerts/",
+            {
+                "project": str(observe_project.id),
+                "name": "Choices Eval Alert",
+                "metric_type": "evaluation_metrics",
+                "metric": str(eval_config.id),
+                "threshold_metric_value": "frequently",
+                "threshold_operator": "greater_than",
+                "threshold_type": "static",
+                "critical_threshold_value": 0.15,
+                "alert_frequency": 60,
+            },
+            format="json",
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        assert UserAlertMonitor.objects.filter(name="Choices Eval Alert").exists()
+
+    def test_create_choices_eval_without_choice_rejected(
+        self, auth_client, organization, workspace, observe_project
+    ):
+        eval_config = self._create_eval_config(
+            organization,
+            workspace,
+            observe_project,
+            "choices",
+            ["never", "occasionally", "frequently", "always"],
+        )
+
+        response = auth_client.post(
+            "/tracer/user-alerts/",
+            {
+                "project": str(observe_project.id),
+                "name": "Choices Eval Alert No Choice",
+                "metric_type": "evaluation_metrics",
+                "metric": str(eval_config.id),
+                "threshold_metric_value": None,
+                "threshold_operator": "greater_than",
+                "threshold_type": "static",
+                "critical_threshold_value": 0.15,
+                "alert_frequency": 60,
+            },
+            format="json",
+        )
+
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert "required for evals with predefined choices" in str(response.json())
 
 
 @pytest.mark.integration

--- a/futureagi/tracer/utils/monitor.py
+++ b/futureagi/tracer/utils/monitor.py
@@ -42,6 +42,21 @@ _EVAL_OUTPUT_TYPE_MAP = {
 }
 
 
+def uses_choice_threshold(eval_template) -> bool:
+    """True when the eval's alert metric is the share of one chosen label.
+
+    A scoring eval may also carry labels, but its metric is the mean score, so
+    a stored choice is neither validated, displayed, nor copied for it.
+    """
+    if eval_template is None:
+        return False
+    output_type = (eval_template.config or {}).get("output")
+    return output_type in (
+        EvalOutputType.PASS_FAIL.value,
+        EvalOutputType.CHOICES.value,
+    ) and bool(eval_template.choices)
+
+
 class MonitorConfigError(Exception):
     """Monitor misconfiguration (e.g. deleted eval config); not retryable."""
 

--- a/futureagi/tracer/views/monitor.py
+++ b/futureagi/tracer/views/monitor.py
@@ -46,7 +46,7 @@ from tracer.serializers.monitor import (
     UserAlertMonitorSerializer,
 )
 from tracer.utils.helper import get_sort_query
-from tracer.utils.monitor import MonitorConfigError
+from tracer.utils.monitor import MonitorConfigError, uses_choice_threshold
 from tracer.utils.monitor_graphs import (
     MONITOR_GRAPH_METADATA_PG_TIMEOUT_CAP_MS,
     MonitorGraphUnavailable,
@@ -628,6 +628,23 @@ class UserAlertMonitorView(BaseModelViewSetMixinWithUserOrg, ModelViewSet):
                 {"name": f"An alert with the name '{new_name}' already exists."}
             )
 
+        threshold_metric_value = monitor.threshold_metric_value
+        if (
+            monitor.metric_type == MonitorMetricTypeChoices.EVALUATION_METRICS.value
+            and monitor.metric
+        ):
+            eval_config = (
+                CustomEvalConfig.objects.filter(
+                    id=monitor.metric,
+                    project=monitor.project,
+                    deleted=False,
+                )
+                .select_related("eval_template")
+                .first()
+            )
+            if eval_config and not uses_choice_threshold(eval_config.eval_template):
+                threshold_metric_value = None
+
         duplicated_monitor = UserAlertMonitor.objects.create(
             organization=org,
             workspace=monitor.workspace,
@@ -638,7 +655,7 @@ class UserAlertMonitorView(BaseModelViewSetMixinWithUserOrg, ModelViewSet):
             metric=monitor.metric,
             threshold_operator=monitor.threshold_operator,
             threshold_type=monitor.threshold_type,
-            threshold_metric_value=monitor.threshold_metric_value,
+            threshold_metric_value=threshold_metric_value,
             critical_threshold_value=monitor.critical_threshold_value,
             warning_threshold_value=monitor.warning_threshold_value,
             alert_frequency=monitor.alert_frequency,


### PR DESCRIPTION
## What & why

Closes TH-7788. An alert on a **scoring** evaluation that happens to carry labels was configured through a Choices-style UI (pick a label, alert on its %) while the backend scored it numerically — so the alert silently measured `avg(output_float)` and ignored the label, and `synthesis-quality-completeness` (Whatfix) never fired.

Per Chintan's ruling, a scoring eval's alert measures the **average score**; only Pass/Fail and Choices evals alert on a chosen label. The decision now comes from the eval's **output type**, not from "does the template have labels".

## Changes

**One rule, shared everywhere** — `uses_choice_threshold(eval_template)` in `tracer/utils/monitor.py`, with a case-for-case JS twin `evalUsesChoiceThreshold` in `Alerts/common.js`.

- **Frontend** (`AlertSettingsForm.jsx`): the Choice field renders only for choice-thresholded evals; a hydrated stale choice isn't re-sent when the eval is a scoring one; the saved choice is kept when the eval picker hasn't resolved (avoids regressing Pass/Fail edits).
- **Serializer** (`serializers/monitor.py`): create/update validates the choice against the output type (a scoring eval rejects a choice; a labelled eval requires one), and the alerts-list + detail displays only append `(label)` for choice-thresholded evals.
- **AI tool + duplicate view**: the same rule now gates `create_alert_monitor.py` and the alert-duplicate flow, so neither mints or copies a stale choice.

**Two adjacent fixes pulled in (scope note):** these are real bugs found while testing, slightly beyond the ticket's stated scope —

- the alert **preview graph** no longer fires (and 400s) for a Pass/Fail/Choices eval before a label is chosen;
- the **details-page graph** now refreshes immediately after a threshold_type change instead of waiting on the 10s poll.

## Verification

- **FE:** the Alerts vitest suite is green (85 tests), each new case shown RED before the fix.
- **BE:** `TestUserAlertMonitorCreateAPI` / `ListAPI` / `DetailsAPI` / `DuplicateAPI` green on a clean test DB.
- **Pipeline:** ran the real `_process_monitor` firing path against seeded data — a scoring-eval alert fires on `avg(output_float)` (0.7958), a choices alert on the label share, a pass/fail alert on the Failed share; healthy vs fired decisions all correct.
- **E2E:** ALERT-E2E-002 (below) green against the branch, red against the old code at the exact bug, with per-check anchor perturbations.

## Recording of the fixes

https://github.com/user-attachments/assets/05a670d0-ab6c-4422-8f4a-7dd3b71f60d6

## Coordination

PR #2497 (TH-7789) also touches `AlertSettingsForm.jsx` and `alert-filter-hydration.test.jsx` — sequence the merges.

E2E: new ALERT-E2E-002
