### PR TITLE
chore: add dependency base images for frontend, agentcc-gateway and fi-collector

### DIFF
--- a/.github/workflows/base-image-publish.yml
+++ b/.github/workflows/base-image-publish.yml
@@ -1,7 +1,10 @@
-# Manually-dispatched publisher for the three dependency base images:
-#   future-agi-base    <- Dockerfile.base (repo root context; installs futureagi/requirements.txt)
-#   serving-base       <- futureagi/model_serving/Dockerfile.base
-#   code-executor-base <- futureagi/code-executor/Dockerfile.base
+# Manually-dispatched publisher for the dependency base images:
+#   future-agi-base     <- Dockerfile.base (repo root context; installs futureagi/requirements.txt)
+#   serving-base        <- futureagi/model_serving/Dockerfile.base
+#   code-executor-base  <- futureagi/code-executor/Dockerfile.base
+#   frontend-base       <- frontend/Dockerfile.base
+#   agentcc-gateway-base <- agentcc-gateway/Dockerfile.base
+#   fi-collector-base   <- fi-collector/Dockerfile.base
 #
 # Each arch builds on its own native runner (no QEMU: an emulated arm64 leg of a
 # torch install runs for hours), pushes by digest, and a final job stitches the
@@ -25,6 +28,9 @@ on:
           - future-agi-base
           - serving-base
           - code-executor-base
+          - frontend-base
+          - agentcc-gateway-base
+          - fi-collector-base
       version:
         description: "New version tag (e.g. v1.1.0) — existing tags are never overwritten"
         required: true
@@ -71,6 +77,18 @@ jobs:
             code-executor-base)
               dockerfile=futureagi/code-executor/Dockerfile.base
               context=futureagi/code-executor
+              ;;
+            frontend-base)
+              dockerfile=frontend/Dockerfile.base
+              context=frontend
+              ;;
+            agentcc-gateway-base)
+              dockerfile=agentcc-gateway/Dockerfile.base
+              context=agentcc-gateway
+              ;;
+            fi-collector-base)
+              dockerfile=fi-collector/Dockerfile.base
+              context=fi-collector
               ;;
             *)
               echo "::error::unknown image ${IMAGE}"

--- a/.github/workflows/release-images.yml
+++ b/.github/workflows/release-images.yml
@@ -47,9 +47,9 @@ jobs:
       matrix:
         include:
           - { name: frontend,        image: futureagi/frontend,        context: ./frontend,                dockerfile: ./frontend/Dockerfile,                    free-disk: true,  platforms: 'linux/amd64,linux/arm64' }
-          - { name: backend,         image: futureagi/future-agi,      context: ./futureagi,               dockerfile: ./futureagi/Dockerfile.oss,               free-disk: false, platforms: linux/amd64 }
+          - { name: backend,         image: futureagi/future-agi,      context: ./futureagi,               dockerfile: ./futureagi/Dockerfile,                   free-disk: false, platforms: linux/amd64 }
           - { name: agentcc-gateway, image: futureagi/agentcc-gateway, context: ./agentcc-gateway,         dockerfile: ./agentcc-gateway/Dockerfile,             free-disk: false, platforms: 'linux/amd64,linux/arm64' }
-          - { name: serving,         image: futureagi/serving,         context: ./futureagi/model_serving, dockerfile: ./futureagi/model_serving/Dockerfile.oss, free-disk: false, platforms: 'linux/amd64,linux/arm64' }
+          - { name: serving,         image: futureagi/serving,         context: ./futureagi/model_serving, dockerfile: ./futureagi/model_serving/Dockerfile,     free-disk: false, platforms: 'linux/amd64,linux/arm64' }
           - { name: code-executor,   image: futureagi/code-executor,   context: ./futureagi/code-executor, dockerfile: ./futureagi/code-executor/Dockerfile,     free-disk: false, platforms: 'linux/amd64,linux/arm64' }
           - { name: fi-collector,    image: futureagi/fi-collector,    context: ./fi-collector,            dockerfile: ./fi-collector/Dockerfile,                free-disk: false, platforms: 'linux/amd64,linux/arm64' }
     uses: ./.github/workflows/build-image.yml

--- a/agentcc-gateway/Dockerfile
+++ b/agentcc-gateway/Dockerfile
@@ -1,9 +1,4 @@
-FROM golang:1.26-alpine AS builder
-
-WORKDIR /build
-
-COPY go.mod go.sum ./
-RUN go mod download
+FROM futureagi/agentcc-gateway-base:v1.0.0 AS builder
 
 COPY . .
 

--- a/agentcc-gateway/Dockerfile.base
+++ b/agentcc-gateway/Dockerfile.base
@@ -1,0 +1,10 @@
+# Dependency-only base image: bakes in `go mod download` so the app
+# Dockerfile's build stage only needs to COPY source and compile. Rebuild and
+# republish this (see .github/workflows/base-image-publish.yml) whenever
+# go.mod/go.sum change.
+FROM golang:1.26-alpine
+
+WORKDIR /build
+
+COPY go.mod go.sum ./
+RUN go mod download

--- a/fi-collector/Dockerfile
+++ b/fi-collector/Dockerfile
@@ -1,16 +1,10 @@
 # Multi-stage build — distroless for a < 20 MB final image, no shell,
-# no package manager. The build stage uses the official golang image so
-# we get the toolchain + git for module fetch; the runtime stage strips
+# no package manager. The build stage uses the fi-collector-base image
+# (golang + `go mod download` already baked in, see Dockerfile.base) so
+# source edits don't re-trigger module downloads; the runtime stage strips
 # everything except the static binary.
 
-FROM golang:1.24-alpine AS build
-WORKDIR /src
-
-# Cache module downloads in a separate layer so source edits don't
-# re-trigger `go mod download`.
-COPY go.mod ./
-COPY go.sum* ./
-RUN go mod download
+FROM futureagi/fi-collector-base:v1.0.0 AS build
 
 COPY . .
 

--- a/fi-collector/Dockerfile.base
+++ b/fi-collector/Dockerfile.base
@@ -1,0 +1,11 @@
+# Dependency-only base image: bakes in `go mod download` so the app
+# Dockerfile's build stage only needs to COPY source and compile. Rebuild and
+# republish this (see .github/workflows/base-image-publish.yml) whenever
+# go.mod/go.sum change.
+FROM golang:1.24-alpine
+
+WORKDIR /src
+
+COPY go.mod ./
+COPY go.sum* ./
+RUN go mod download

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,7 +1,7 @@
 # Dockerfile
 
 # Stage 1: Build the React app
-FROM node:22.18 AS build
+FROM futureagi/frontend-base:v1.0.0 AS build
 
 # Build args forwarded from docker-compose. Vite reads env vars prefixed
 # VITE_ at build time and bakes them into the bundle.
@@ -10,11 +10,6 @@ ARG VITE_ENVIRONMENT=production
 ENV VITE_HOST_API=${VITE_HOST_API} \
     VITE_ENVIRONMENT=${VITE_ENVIRONMENT}
 
-WORKDIR /app
-
-COPY package.json yarn.lock ./
-RUN yarn install --network-timeout 600000
-
 COPY . ./
 RUN yarn build
 
@@ -22,10 +17,7 @@ RUN yarn build
 # `target: dev` in docker-compose.dev.yml. Source is bind-mounted at runtime;
 # this stage just provides node + a baked-in node_modules so HMR works without
 # a host-side `yarn install`.
-FROM node:22.18 AS dev
-WORKDIR /app
-COPY package.json yarn.lock ./
-RUN yarn install
+FROM futureagi/frontend-base:v1.0.0 AS dev
 EXPOSE 3000
 CMD ["yarn", "dev", "--host", "--port", "3000"]
 

--- a/frontend/Dockerfile.base
+++ b/frontend/Dockerfile.base
@@ -1,0 +1,13 @@
+# Dependency-only base image: bakes in `yarn install` so the app Dockerfile's
+# build and dev stages only need to COPY source and build/run. Rebuild and
+# republish this (see .github/workflows/base-image-publish.yml) whenever
+# package.json/yarn.lock change.
+FROM node:22.18
+
+WORKDIR /app
+
+COPY package.json yarn.lock ./
+# Cache clean shares the RUN layer with the install: yarn's global cache is
+# ~3.5GB of tarballs that node_modules no longer needs, and a separate RUN
+# would commit it to a layer before deleting it.
+RUN yarn install --network-timeout 600000 && yarn cache clean


### PR DESCRIPTION
## Blocked on publishing the images first

The app Dockerfiles now reference base-image tags that **do not exist on Docker Hub yet**, so any CI job that builds them will fail until `Publish base image` has been dispatched for `frontend-base`, `agentcc-gateway-base` and `fi-collector-base` at `v1.0.0`. All three tags are currently unpublished, so there is nothing to overwrite. Publish, then merge.

## Summary

Extends the existing base-image pattern (`serving-base`, `code-executor-base`) to three more services. Each gets a `Dockerfile.base` holding only the dependency-install layer, and its app Dockerfile builds `FROM` that published image instead of re-resolving dependencies on every build.

## Changes

- `frontend/Dockerfile.base` — `node:22.18` + `yarn install`. Both the `build` and `dev` stages of `frontend/Dockerfile` start from it, which also drops the duplicated `yarn install` the `dev` stage was doing.
- `agentcc-gateway/Dockerfile.base` — `golang:1.26-alpine` + `go mod download`.
- `fi-collector/Dockerfile.base` — `golang:1.24-alpine` + `go mod download`.
- `.github/workflows/base-image-publish.yml` — registers the three new images as dispatchable targets with their Dockerfile/context mapping.

Each base pins the dependency manifests at publish time, so a change to `package.json`/`yarn.lock` or `go.mod`/`go.sum` needs a new base version — same contract as `serving-base`.

## The frontend image was 8.92GB

3.5GB of that was yarn's global tarball cache, which `node_modules` does not need at runtime. `yarn cache clean` shares the `RUN` layer with the install — a separate `RUN` would commit the cache to a layer before deleting it:

**8.92GB → 3.56GB**, all 979 packages intact.

## Verification

Built locally for `linux/amd64` **and** `linux/arm64`, matching how `serving-base:v1.0.0` is published:

| image | both arches |
|---|---|
| `agentcc-gateway-base` | 10s |
| `fi-collector-base` | 17s |
| `frontend-base` | 2m51s |

QEMU emulation is cheap here because none of these compile native code — the Go legs are network-bound module fetches and the frontend is JS linking.

Then built each *app* Dockerfile on top of its base image: `frontend` produces a real `/app/dist` bundle, and the `fi-collector` and `agentcc-gateway` binaries execute in their final images (`COPY --from=build` succeeding is itself proof the binaries were produced).

## Build timings

CI averages across the last 10 successful `release-images` runs (2026-08-25 to 2026-09-10), all six images:

| image | avg | min | max |
|---|---|---|---|
| frontend | 40.8m | 33.6m | 57.9m |
| serving | 25.6m | 22.8m | 30.0m |
| backend | 13.5m | 0.5m | 24.9m |
| fi-collector | 8.4m | 0.4m | 10.6m |
| agentcc-gateway | 7.1m | 5.4m | 8.1m |
| code-executor | 2.0m | 1.1m | 2.4m |

That is 97.4 job-minutes per release, with wall clock gated by `frontend` since the six run in parallel.

Local before/after for the app builds, `--no-cache`, native `linux/arm64`, base images already cached in the builder:

| image | before | after | ratio |
|---|---|---|---|
| backend | 223s (`Dockerfile.oss`) | **26s** | 8.6x |
| serving | 98s (`Dockerfile.oss`) | **~4s** | ~24x |
| frontend | 163s | **95s** | 1.7x |
| fi-collector | 20s | **13s** | 1.5x |
| agentcc-gateway | 13s | **9s** | 1.4x |
| code-executor | unchanged | unchanged | 1.0x |

Backend's 223s is dominated by `RUN uv pip install --system -r requirements.txt --compile-bytecode --no-cache`, measured at 164.9s of it on 11 cores. On a 2-to-4-vCPU runner that same step is what makes `future-agi-base` take 9 to 15 minutes to publish, and `Dockerfile.oss` repeats it on every release.

Backend's 0.5m minimum and fi-collector's 0.4m minimum were full buildx cache hits. Both succeeded, so the 50x spread on backend is the GitHub Actions cache landing or missing, not the Dockerfile. Building `FROM` a prebuilt base makes the time deterministic instead of a coin flip.

Two honest caveats on the local column: it is one platform where CI builds two, and there is no registry push. It measures build work faithfully and CI wall-clock not at all. That gap is why `agentcc-gateway` and `fi-collector` take 7 and 8 minutes in CI but 13 and 20 seconds here: their time goes to arm64 emulation and push, not to `go mod download`. The base images are still correct, they just will not move those two jobs much.

## Not changed

`futureagi/model_serving/Dockerfile.base` has the same yarn-cache-equivalent issue for `uv` but is out of scope here.
