### PR TITLE
fix(startup): run migrations on hosted pod boot by default

### DIFF
--- a/futureagi/entrypoint.sh
+++ b/futureagi/entrypoint.sh
@@ -10,10 +10,11 @@ ENV_PROJECT_ROOT=${ENV_PROJECT_ROOT:-/app/backend}
 # Fast startup mode - skip non-essential checks for faster local dev
 FAST_STARTUP=${FAST_STARTUP:-false}
 
-# Hosted application startup is mutation-free by default. Production schema or
-# data bootstrap must run as a dedicated one-shot operator job using both
-# SERVICE_TYPE=bootstrap and STARTUP_DB_MUTATION_MODE=operator. Development and
-# self-hosted compose retain the existing default startup behavior.
+# Startup runs migrations by default everywhere, including hosted deployments.
+# A pod opts out of DB mutations by exporting the literal value "true" in
+# NO_STARTUP_DB_MUTATIONS (read-only test pods, mutation-free replicas). A
+# dedicated one-shot job can still bootstrap via SERVICE_TYPE=bootstrap and
+# STARTUP_DB_MUTATION_MODE=operator.
 CLOUD_STARTUP=false
 case "$ENV_TYPE" in
     "prod"|"production"|"staging"|"PROD"|"PRODUCTION"|"STAGING") CLOUD_STARTUP=true ;;
@@ -37,13 +38,7 @@ if [ "$CLOUD_STARTUP" = "true" ] && [ "$SERVICE_TYPE" = "bootstrap" ] && [ "$STA
 fi
 
 if [ "${NO_STARTUP_DB_MUTATIONS+x}" != "x" ]; then
-    if [ "$OPERATOR_BOOTSTRAP" = "true" ]; then
-        NO_STARTUP_DB_MUTATIONS=false
-    elif [ "$CLOUD_STARTUP" = "true" ]; then
-        NO_STARTUP_DB_MUTATIONS=true
-    else
-        NO_STARTUP_DB_MUTATIONS=false
-    fi
+    NO_STARTUP_DB_MUTATIONS=false
 fi
 case "$NO_STARTUP_DB_MUTATIONS" in
     "true"|"false") ;;
@@ -56,13 +51,6 @@ esac
 if [ "$OPERATOR_BOOTSTRAP" = "true" ] && [ "$NO_STARTUP_DB_MUTATIONS" != "false" ]; then
     echo "ERROR: operator bootstrap requires NO_STARTUP_DB_MUTATIONS=false"
     exit 64
-fi
-
-if [ "$CLOUD_STARTUP" = "true" ] && [ "$NO_STARTUP_DB_MUTATIONS" = "false" ]; then
-    if [ "$OPERATOR_BOOTSTRAP" != "true" ]; then
-        echo "ERROR: hosted database mutations require SERVICE_TYPE=bootstrap and STARTUP_DB_MUTATION_MODE=operator"
-        exit 64
-    fi
 fi
 
 if [ "$CLOUD_STARTUP" = "true" ] && [ "$SERVICE_TYPE" = "bootstrap" ] && [ "$OPERATOR_BOOTSTRAP" != "true" ]; then

--- a/futureagi/model_hub/apps.py
+++ b/futureagi/model_hub/apps.py
@@ -30,9 +30,6 @@ STARTUP_SAFE_MANAGEMENT_COMMANDS = frozenset(
     }
 )
 
-HOSTED_ENV_TYPES = frozenset({"prod", "production", "staging"})
-HOSTED_DEPLOYMENTS = frozenset({"US", "EU", "DEV"})
-
 # Application processes are never schema/bootstrap runners. A one-shot operator
 # job may run one of these explicit management commands, but it does not enable
 # mutation hooks during AppConfig initialization.
@@ -71,15 +68,6 @@ def startup_db_mutations_disabled() -> bool:
     if value is not None and value not in {"true", "false"}:
         raise RuntimeError("NO_STARTUP_DB_MUTATIONS must be exactly 'true' or 'false'")
     return True
-
-
-def hosted_startup_environment() -> bool:
-    """Return whether this process belongs to a hosted deployment."""
-
-    return (
-        os.getenv("ENV_TYPE", "").strip().lower() in HOSTED_ENV_TYPES
-        or os.getenv("CLOUD_DEPLOYMENT", "").strip().upper() in HOSTED_DEPLOYMENTS
-    )
 
 
 def _management_command(argv: list[str]) -> str | None:
@@ -132,9 +120,10 @@ def operator_startup_mutation_authorized(argv: list[str]) -> bool:
 def explicit_management_mutation_authorized(argv: list[str]) -> bool:
     """Authorize one allowlisted explicit command, never an AppConfig hook.
 
-    Hosted deployments require the dedicated operator/bootstrap pair. Local
-    and self-hosted entrypoints preserve their documented migration workflow
-    only when they explicitly export ``NO_STARTUP_DB_MUTATIONS=false``.
+    Every entrypoint — local, self-hosted, and hosted pods alike — runs its
+    documented migration workflow when it explicitly exports
+    ``NO_STARTUP_DB_MUTATIONS=false``. The dedicated operator/bootstrap pair
+    remains valid for one-shot jobs.
     """
 
     command = _management_command(argv)
@@ -142,10 +131,7 @@ def explicit_management_mutation_authorized(argv: list[str]) -> bool:
         return False
     if operator_startup_mutation_authorized(argv):
         return True
-    return (
-        os.getenv("NO_STARTUP_DB_MUTATIONS") == "false"
-        and not hosted_startup_environment()
-    )
+    return os.getenv("NO_STARTUP_DB_MUTATIONS") == "false"
 
 
 def guarded_management_command(argv: list[str]) -> str | None:

--- a/futureagi/model_hub/tests/test_clickhouse_cache_warm.py
+++ b/futureagi/model_hub/tests/test_clickhouse_cache_warm.py
@@ -104,9 +104,18 @@ def test_local_entrypoint_authorizes_explicit_database_commands(monkeypatch, com
 
 
 @pytest.mark.parametrize("env_type", ["prod", "production", "staging"])
-def test_hosted_backend_cannot_use_local_explicit_database_mode(monkeypatch, env_type):
+def test_hosted_backend_authorizes_explicit_database_mode(monkeypatch, env_type):
     monkeypatch.setenv("ENV_TYPE", env_type)
     monkeypatch.setenv("NO_STARTUP_DB_MUTATIONS", "false")
+
+    assert explicit_management_mutation_authorized(["manage.py", "migrate"]) is True
+
+
+@pytest.mark.parametrize("env_type", ["prod", "production"])
+def test_hosted_backend_without_explicit_opt_in_stays_mutation_free(
+    monkeypatch, env_type
+):
+    monkeypatch.setenv("ENV_TYPE", env_type)
 
     assert explicit_management_mutation_authorized(["manage.py", "migrate"]) is False
 

--- a/futureagi/tfc/tests/test_entrypoint_mutation_guard.py
+++ b/futureagi/tfc/tests/test_entrypoint_mutation_guard.py
@@ -9,7 +9,7 @@ ENTRYPOINT = Path(__file__).resolve().parents[2] / "entrypoint.sh"
 
 def _guard_source() -> str:
     source = ENTRYPOINT.read_text()
-    start = source.index("# Hosted application startup is mutation-free by default.")
+    start = source.index("# Startup runs migrations by default everywhere,")
     end = source.index("# Disable bytecode compilation")
     return source[start:end]
 
@@ -84,37 +84,37 @@ def test_entrypoint_guard_rejects_ambiguous_values(value):
 
 
 @pytest.mark.parametrize("env_type", ["prod", "production", "staging"])
-def test_entrypoint_hosted_startup_defaults_to_mutation_free(env_type):
+def test_entrypoint_hosted_startup_defaults_to_running_migrations(env_type):
     completed = _run_guard(None, env_type=env_type)
 
     assert completed.returncode == 0
-    assert completed.stdout.endswith("true:false:disabled")
+    assert completed.stdout.endswith("false:false:disabled")
 
 
 @pytest.mark.parametrize("cloud_deployment", ["US", "EU", "DEV"])
-def test_entrypoint_cloud_deployment_defaults_to_mutation_free(cloud_deployment):
+def test_entrypoint_cloud_deployment_defaults_to_running_migrations(cloud_deployment):
     completed = _run_guard(None, cloud_deployment=cloud_deployment)
 
     assert completed.returncode == 0
-    assert completed.stdout.endswith("true:false:disabled")
+    assert completed.stdout.endswith("false:false:disabled")
 
 
 @pytest.mark.parametrize(
-    ("service_type", "mutation_mode"),
-    [("backend", "disabled"), ("backend", "operator"), ("bootstrap", "disabled")],
+    ("mutation_mode", "expected"),
+    [(None, "false:false:disabled"), ("disabled", "false:false:disabled")],
 )
-def test_entrypoint_hosted_false_requires_dedicated_operator_job(
-    service_type, mutation_mode
+def test_entrypoint_hosted_backend_mutations_allowed_without_operator_job(
+    mutation_mode, expected
 ):
     completed = _run_guard(
         "false",
         env_type="production",
-        service_type=service_type,
+        service_type="backend",
         mutation_mode=mutation_mode,
     )
 
-    assert completed.returncode == 64
-    assert "hosted database mutations require" in completed.stdout
+    assert completed.returncode == 0
+    assert completed.stdout.endswith(expected)
 
 
 def test_entrypoint_hosted_operator_bootstrap_is_explicitly_allowed():
@@ -232,7 +232,7 @@ def test_entrypoint_guard_defaults_by_environment_without_loose_expansion():
 
     assert "NO_STARTUP_DB_MUTATIONS:-true" not in source
     assert "CLOUD_STARTUP" in _guard_source()
-    assert "NO_STARTUP_DB_MUTATIONS=true" in _guard_source()
+    assert "NO_STARTUP_DB_MUTATIONS=true" not in _guard_source()
     assert "NO_STARTUP_DB_MUTATIONS=false" in _guard_source()
 
 


### PR DESCRIPTION
Closes TH-7906

## Problem

Since `5fec819a3` (author `RedTeam <rt@example.com>`, landed via #2381), hosted pods (`ENV_TYPE=prod/staging` or `CLOUD_DEPLOYMENT=US/EU/DEV`) default `NO_STARTUP_DB_MUTATIONS=true`, and the entrypoint hard-errors (`exit 64`) if a non-bootstrap pod tries to enable mutations. The intended replacement — a one-shot `SERVICE_TYPE=bootstrap` operator Job — was never added to the Helm charts.

Net effect on US prod: **helm upgrades stopped applying Django migrations entirely** (and Temporal schedule registration). The `django_migrations` ledger is frozen and the `gcp_marketplace_*` tables from `ee/usage/0009` are missing.

## Change

Restore the pre-gate behavior: every pod boot runs `createcachetable` + `migrate` (backend), exactly as before, while keeping `NO_STARTUP_DB_MUTATIONS=true` as an explicit opt-out (used by `bin/test`, read-only QA pods, compose read-only services).

- **`futureagi/entrypoint.sh`** — default `NO_STARTUP_DB_MUTATIONS=false` for every service type; drop the guard that forced hosted mutations through a bootstrap operator job. The operator/bootstrap path itself is unchanged and still available.
- **`futureagi/model_hub/apps.py`** — the in-process `AppConfig.ready()` gate now authorizes the allowlisted explicit commands (`migrate`, `createcachetable`, `register_temporal_schedules`, …) on hosted deployments too when `NO_STARTUP_DB_MUTATIONS=false` is exported (previously it raised `RuntimeError` on any hosted `migrate` outside a bootstrap job, which would have crash-looped pods even with the entrypoint fixed). Deleted the now-unused `hosted_startup_environment` helper. `manage.py shell` and all non-allowlisted commands remain blocked on hosted pods.
- Updated the guard tests that pinned the hosted mutation-free defaults (`test_entrypoint_mutation_guard.py`, `test_clickhouse_cache_warm.py`); 95 tests pass locally.

## Deploy notes (operational, not part of this PR)

- Known trade-off: this reinstates the multi-replica migrate race on boot (the 2026-07-21 CrashLoop incident with `CREATE INDEX CONCURRENTLY` migrations). Accepted explicitly in favor of never silently skipping migrations.
- First rollout to US prod will apply a ~6-week migration backlog — plan to run `manage.py migrate` once from a single pod before rolling all replicas.
- **Do not roll the resulting image to EU** until its ~66-migration backlog is handled deliberately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TEcwLpvuUNEFWg7UgxZnke
