### PR TITLE
ci(release): bump propertyCatalog image tags and verify none are left behind

### DIFF
--- a/.github/workflows/release-images.yml
+++ b/.github/workflows/release-images.yml
@@ -171,8 +171,36 @@ jobs:
           # decommissioned AWS deployment and is intentionally left untouched.
           # shellcheck disable=SC2086
           bump eu/gcp/deployment/values.yaml  $COMMON_PATHS .fiCollector.image.tag
+          # US-only: the property catalog runtime pins its collector image to
+          # fiCollector and its lifecycle writer to backend, and
+          # property-catalog-validation.yaml fails the render when either drifts.
           # shellcheck disable=SC2086
-          bump us/gcp/deployment/values.yaml  $COMMON_PATHS .fiCollector.image.tag
+          bump us/gcp/deployment/values.yaml  $COMMON_PATHS .fiCollector.image.tag \
+            .propertyCatalog.image.tag .propertyCatalog.lifecycle.image.tag
+      - name: Verify no platform image was left behind
+        env:
+          VERSION: ${{ needs.guard.outputs.version }}
+        run: |
+          set -eu
+          # The path list above bumps what it is told to. This asserts the result:
+          # every image in the platform release lane must now carry $VERSION. A tag
+          # added to a values file but not to the path list is caught here instead
+          # of reaching a release PR. future-agi-simulation-runner is deliberately
+          # excluded — it rides its own version lane.
+          expr='[.. | select(tag == "!!map" and has("repository") and has("tag"))
+                    | select(.repository | test("futureagi/(future-agi-ee|fi-collector|agentcc-gateway|code-executor|serving)$"))
+                    | select(.tag != strenv(VERSION))
+                    | .repository + " = " + (.tag|tostring)] | .[]'
+          rc=0
+          for f in eu/gcp/deployment/values.yaml us/gcp/deployment/values.yaml; do
+            stale=$(yq -r "$expr" "$f")
+            if [ -n "$stale" ]; then
+              echo "::error::$f has platform images not bumped to ${VERSION}:"
+              echo "$stale"
+              rc=1
+            fi
+          done
+          exit $rc
       - name: Open bump PR
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}


### PR DESCRIPTION
## Summary

The v1.37.0 bump ([deployment#326](https://github.com/future-agi/deployment/pull/326)) moved twelve image tags per region but left two on `v1.36.1` — both nested under `propertyCatalog` in `us/gcp/deployment/values.yaml`:

| Path | Contract |
|---|---|
| `.propertyCatalog.image.tag` | must match `.fiCollector.image.tag` |
| `.propertyCatalog.lifecycle.image.tag` | must match `.backend.image.tag` |

`property-catalog-validation.yaml` enforces both equalities, so the US chart stopped rendering entirely and the release could not be deployed:

```
execution error at (application/templates/property-catalog-validation.yaml:113:4):
propertyCatalog collector requires the exact runtime image repository and tag
```

[deployment#327](https://github.com/future-agi/deployment/pull/327) fixed the two lines by hand. This fixes the automation so it stops recurring.

## Why the bot missed them

Every path in `COMMON_PATHS` sits at `<component>.image.tag`. These two are one level deeper, so the list never reached them.

## Changes

**1. Pass both paths to the `us/gcp` bump.** They're US-only — EU has no `propertyCatalog` block.

**2. Add a post-bump assertion.** `bump()` already fails when a listed path has *gone missing* ("path list is stale, refusing partial bump"), but the opposite direction was unguarded: a tag added to a values file and never added to the path list is silently skipped. That's exactly what happened here. The new step asserts every image in the platform release lane carries the new version, so the next one is caught in the release job instead of in a deploy.

`future-agi-simulation-runner` is deliberately excluded — it rides its own version lane (pinned at `v1.29.0`), as are third-party images (`nginx`, `rabbitmq`, `flower`, `busybox`).

## Testing

Replayed the real `v1.36.1` → `v1.37.0` bump against the actual values files at `becc190` (the pre-bump state), using the same yq v4.44.3 the job installs.

**New path list — passes:**
```
=== guard step, verbatim ===
GUARD EXIT=0  (0 = clean)

us: v1.37.0
eu: v1.37.0
helm template us/gcp/deployment ... → RENDER OK
```

**Old path list — the new check catches #326:**
```
::error::us/gcp/deployment/values.yaml has platform images not bumped to v1.37.0:
  .../futureagi/fi-collector = v1.36.1
  .../futureagi/future-agi-ee = v1.36.1
GUARD EXIT=1
```

EU is clean in both runs, confirming the check doesn't false-positive on the region without a `propertyCatalog` block, on the pinned simulation runner, or on third-party images.

## Note

`dev` currently carries an identical copy of this workflow (same blob SHA), so it'll pick this up on the next main→dev sync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
