### PR TITLE
fix(repo): pin LF for shell scripts so the stack boots on Windows

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,35 @@
+# Line-ending policy.
+#
+# Git for Windows ships with core.autocrlf=true, which rewrites text files to
+# CRLF on checkout. Every script below either runs inside a Linux container or
+# is executed by a POSIX shell, and CRLF breaks them: the shebang line parses
+# but the next line carries a trailing \r, so `set -eu` is read as `set -eu\r`
+# and the shell aborts with "illegal option". Pinning eol=lf makes the checkout
+# match the blob regardless of the contributor's autocrlf setting.
+#
+# Two ways this bites today:
+#   • Scripts bind-mounted into containers (scripts/property_catalog_oss/*.sh
+#     into property-catalog-*-bootstrap) fail at run time.
+#   • entrypoint.sh is COPYed into the backend image and invoked as
+#     ENTRYPOINT ["bash", "./entrypoint.sh"], so an image built on Windows
+#     fails to start at all.
+
+*.sh            text eol=lf
+
+# Shell scripts without a .sh extension — bin/install is the documented
+# self-host entry point and futureagi/bin/temporal-worker is exec'd inside the
+# container on the production path.
+bin/e2e                             text eol=lf
+bin/install                         text eol=lf
+bin/property-catalog-backfill       text eol=lf
+bin/uninstall                       text eol=lf
+futureagi/bin/temporal-worker       text eol=lf
+futureagi/bin/test                  text eol=lf
+
+# Container and SQL inputs read by Linux tooling.
+Dockerfile*     text eol=lf
+*.sql           text eol=lf
+
+# PowerShell is the Windows-native path and keeps CRLF. Listed after bin/*
+# entries so it wins for bin/install.ps1 and bin/property-catalog-backfill.ps1.
+*.ps1           text eol=crlf


### PR DESCRIPTION
## Summary

Git for Windows defaults to `core.autocrlf=true` and nothing in the repo overrides it, so every shell script arrives CRLF on a Windows checkout. Anything a Linux shell then executes fails — the shebang parses, the next line carries a trailing `\r`, and the shell aborts. The bind-mounted property-catalog bootstrap exits 2 and the catalog never initialises; separately, `entrypoint.sh` is COPYed into the backend image, so an image built on Windows cannot start at all. The blobs were always correct — only the checkout was wrong. This adds a `.gitattributes` pinning `eol=lf` for scripts that run under a POSIX shell, while leaving the Windows-native `.ps1` installers on CRLF.

## Linked issues

Closes #2656
Linear: n/a (outside contributor)

## AI use

AI use: Claude Code diagnosed the failure, wrote the `.gitattributes`, and ran the verification; I directed the scope, decided which file patterns were in and out, and confirmed each result. The command output below is real, from my Windows machine.

## Type of change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📖 Documentation only
- [ ] 🧹 Chore / refactor (no user-visible change)
- [ ] 🚀 Performance improvement
- [ ] 🧪 Test-only change

## E2E coverage

E2E: exempt (tooling: one `.gitattributes` file; no application code changed)

---

## 1) What changes were done

**A. `.gitattributes` (new, the only file in this PR)**

- `*.sh text eol=lf` — covers the 22 `.sh` files in the repo.
- Six shell scripts have no extension and would be missed by `*.sh`, so they are listed individually: `bin/e2e`, `bin/install`, `bin/property-catalog-backfill`, `bin/uninstall`, `futureagi/bin/temporal-worker`, `futureagi/bin/test`. `bin/install` is the documented self-host entry point and `futureagi/bin/temporal-worker` is `exec`'d inside the container on the production path.
- `Dockerfile* text eol=lf` and `*.sql text eol=lf` — the `v2/schema` `.sql` files are mounted at `/property-catalog-schema` and read by name inside the bootstrap container.
- `*.ps1 text eol=crlf`, listed last so it wins for `bin/install.ps1` and `bin/property-catalog-backfill.ps1` and the Windows-native path is unaffected.

No application code, no compose changes, no behaviour change on Linux or macOS.

---

## 2) Why the changes were done

- **Product/UX:** a Windows contributor following the README today gets a stack whose property catalog never initialises, with an error (`set: line 2: illegal option -`) that gives no hint the cause is their Git config. This is a first-run blocker, not a slowdown.
- **Technical:** the repo already stores LF — verified with `git show HEAD:<path> | file -`. The defect is purely in checkout, so the fix belongs in checkout config rather than in the scripts or the Dockerfiles. `eol=lf` makes the working tree match the blob regardless of the contributor's `core.autocrlf`.
- **Technical (scope):** an explicit file list was chosen over a blanket `* text=auto` so the change cannot renormalise unrelated files. Confirmed no binary file matches any pattern here.
- **Architecture:** on Linux and macOS `core.autocrlf` defaults to `input`/`false`, so files are already LF and every rule is a no-op. The blast radius is Windows checkouts only.

---

## 3) Tests written + scenarios each covers

No unit tests. This PR adds a single Git configuration file and contains no application code to assert against — `bin/test` and `yarn test:run` are unaffected by it. Verification is empirical; all four checks are real output from a Windows machine with `core.autocrlf=true`.

**Check 1 — the rules resolve as intended**

```
$ git check-attr text eol -- \
    futureagi/scripts/property_catalog_oss/bootstrap_clickhouse.sh \
    futureagi/entrypoint.sh bin/install futureagi/bin/temporal-worker \
    bin/install.ps1 Dockerfile

futureagi/scripts/property_catalog_oss/bootstrap_clickhouse.sh: eol: lf
futureagi/entrypoint.sh: eol: lf
bin/install: eol: lf
futureagi/bin/temporal-worker: eol: lf
bin/install.ps1: eol: crlf
Dockerfile: eol: lf
```

**Check 2 — re-checkout actually changes the bytes**

```
BEFORE:
POSIX shell script, ASCII text executable, with CRLF line terminators
#!/bin/sh^M$
set -eu^M$

AFTER (rm + git checkout --, autocrlf still true):
POSIX shell script, ASCII text executable
#!/bin/sh$
set -eu$
```

**Check 3 — the failing container now succeeds.** This is the actual bug, end to end, with no manual workaround:

```
$ docker compose up -d property-catalog-clickhouse-bootstrap
$ docker inspect futureagi-property-catalog-clickhouse-bootstrap-1 \
    --format '{{.State.Status}} exit={{.State.ExitCode}}'
exited exit=0

$ docker logs futureagi-property-catalog-clickhouse-bootstrap-1
OSS property catalog ClickHouse bootstrap complete: property_catalog_dev_oss
```

Before the fix, on the same machine, the same container:

```
/bootstrap/bootstrap_clickhouse.sh: set: line 2: illegal option -
exited exit=2
```

**Check 4 — a fresh clone gets it right.** Cloning with `core.autocrlf=true` still set:

```
futureagi/scripts/property_catalog_oss/bootstrap_clickhouse.sh   LF
futureagi/scripts/property_catalog_oss/bootstrap_postgres.sh     LF
futureagi/entrypoint.sh                                          LF
bin/install                                                      LF
futureagi/bin/temporal-worker                                    LF
Dockerfile                                                       LF
bin/install.ps1                                                  CRLF   <- correctly preserved
```

**Backend and frontend suites:** not run. This diff contains no Python, JS, or API surface, so neither suite exercises it. Happy to run them if you'd like it on the record.

---

## 4) How to run / test

Reproduce the bug on `dev`, then confirm the fix on this branch. Requires Windows with Git's default `core.autocrlf=true`.

```bash
# 1. On dev — the checkout disagrees with the blob
file -b futureagi/scripts/property_catalog_oss/bootstrap_clickhouse.sh
# -> ... with CRLF line terminators
git show HEAD:futureagi/scripts/property_catalog_oss/bootstrap_clickhouse.sh | file -
# -> ... (no CRLF; the repo is correct)

# 2. Watch it fail
cp .env.example .env
docker compose up -d property-catalog-clickhouse-bootstrap
docker inspect futureagi-property-catalog-clickhouse-bootstrap-1 --format '{{.State.ExitCode}}'
# -> 2

# 3. On this branch, force the filters to apply to an existing clone
git checkout -- .
file -b futureagi/scripts/property_catalog_oss/bootstrap_clickhouse.sh
# -> no CRLF

# 4. Watch it pass
docker compose up -d property-catalog-clickhouse-bootstrap
docker inspect futureagi-property-catalog-clickhouse-bootstrap-1 --format '{{.State.ExitCode}}'
# -> 0
```

On Linux or macOS every rule here is a no-op, so there is nothing to verify beyond the stack behaving as before.

### UI steps (manual)

Not applicable — no user-facing surface changes.

---

## 5) Screenshots / recordings

Not applicable — no UI change. All verification is terminal output, included inline in §3 so the values are greppable rather than trapped in an image.

---

## 6) Edge cases & considerations

- **Existing clones need a refresh.** `.gitattributes` only applies at checkout, so contributors who already have the repo will still have CRLF files until they run `git checkout -- .` or clone fresh. Nothing breaks in the meantime — they are simply no better off than before. Happy to add a line to CONTRIBUTING if you'd like it documented there.
- **`.ps1` ordering is load-bearing.** `bin/install.ps1` and `bin/property-catalog-backfill.ps1` sit under `bin/`, so the `*.ps1 text eol=crlf` line must come last to win. Verified it does — check 4 shows `bin/install.ps1` still CRLF after a fresh clone.
- **No binary files affected.** Checked every path matching `*.sh`, `Dockerfile*`, `*.sql`, `*.ps1`; none are binary, so there is no corruption risk from the `text` attribute.
- **No-op on Linux/macOS.** `core.autocrlf` defaults to `input`/`false` there, so files are already LF.
- **Not version-specific.** The repo has never had a `.gitattributes`, so this reproduces on every commit in its history, not just current `dev`.
- **Deliberately narrow.** `* text=auto` would have been the broader idiom but risks renormalising unrelated files; see §8.

---

## 7) Pre-existing issues (NOT introduced by this PR)

**Four SVGs are stored with CRLF in the repo.** `git add --renormalize .` wants to convert `frontend/public/assets/icons/custom/mp3.svg`, `.../custom/trash.svg`, `.../navbar/ic_dash_tasks.svg`, and `frontend/public/icons/fileIcons/default.svg`. Unrelated to this bug and deliberately excluded to keep the diff to one file. Worth its own issue if anyone cares — happy to raise it.

---

## 8) Architectural / important decisions

- **Explicit file list over `* text=auto`:** the blanket idiom is more common, but it would renormalise every text file in the repo and produce a diff far larger than the bug warrants — including the four SVGs above. Listing the patterns that actually run under a Linux shell keeps the change reviewable and its blast radius provable.
- **Extensionless scripts listed individually:** `*.sh` alone would have silently missed `bin/install` and `futureagi/bin/temporal-worker`, which are the two most consequential — one is the documented install path, the other is `exec`'d inside the container.
- **`Dockerfile*` and `*.sql` included despite not being the reported symptom:** both are consumed by Linux tooling from the checkout, so they share the root cause. Leaving them out would fix the reported instance and leave the next one to be rediscovered.
- **`.ps1` kept on CRLF rather than normalised to LF:** those are the Windows-native installers and there is no reason to change their current behaviour in a PR about Linux containers.

---

## Checklist

- [x] My code follows the [style guide](../CONTRIBUTING.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works — *no application code changed; four empirical checks in §3 instead*
- [ ] `bin/test` passes locally (backend) — *not run; no backend code touched*
- [ ] `yarn test:run` passes locally (frontend) — *not run; no frontend code touched*
- [x] `yarn contracts:check` passes if API surface changed — *n/a, no API surface change*
- [ ] I've updated the documentation where relevant — *not updated; see §6 re: a possible CONTRIBUTING note about existing clones*
- [x] No hardcoded secrets, URLs, or PII
- [x] I've signed the [CLA](../CONTRIBUTING.md#contributor-license-agreement-cla)
- [x] PR title follows Conventional Commits
- [ ] Linear issue is linked and updated with status — *n/a, outside contributor*