### PR TITLE
fix: resolve session list identity filters

### DIFF
--- a/futureagi/tracer/serializers/filters.py
+++ b/futureagi/tracer/serializers/filters.py
@@ -916,6 +916,31 @@ class SessionFilterItemField(FilterItemField):
     allow_session_numeric_membership = True
 
 
+_SESSION_ID_COLUMNS = {"session", "session_id", "trace_session_id"}
+_SESSION_ID_OPERATORS = {
+    "equals",
+    "not_equals",
+    "in",
+    "not_in",
+    "is_null",
+    "is_not_null",
+}
+
+
+class _SessionFilterListMixin:
+    """Drop unsupported session-identity leaves without rejecting the page."""
+
+    def to_internal_value(self, data):
+        values = super().to_internal_value(data)
+        return [
+            value
+            for value in values
+            if value.get("column_id") not in _SESSION_ID_COLUMNS
+            or (value.get("filter_config") or {}).get("filter_op")
+            in _SESSION_ID_OPERATORS
+        ]
+
+
 class FilterListField(serializers.ListField):
     """List wrapper that carries the exact filter-item OpenAPI shape.
 
@@ -939,7 +964,7 @@ class FilterListField(serializers.ListField):
         return validated
 
 
-class SessionFilterListField(FilterListField):
+class SessionFilterListField(_SessionFilterListMixin, FilterListField):
     """Session-only filter list; all other surfaces retain the FE contract."""
 
     child = SessionFilterItemField()
@@ -965,7 +990,7 @@ class BoundedFilterListField(FilterListField):
         return value
 
 
-class SessionBoundedFilterListField(BoundedFilterListField):
+class SessionBoundedFilterListField(_SessionFilterListMixin, BoundedFilterListField):
     """Bounded session-only filter list with numeric aggregate membership."""
 
     child = SessionFilterItemField()

--- a/futureagi/tracer/services/clickhouse/query_builders/filters.py
+++ b/futureagi/tracer/services/clickhouse/query_builders/filters.py
@@ -1714,6 +1714,27 @@ class ClickHouseFilterBuilder:
         curated ``end_users`` RMT, then map to end_user_id on spans."""
 
         if filter_op in NO_VALUE_OPS:
+            if enduser_column == "user_id_type":
+                dimension_op = "IS NULL" if filter_op == "is_null" else "IS NOT NULL"
+                dimension_ids = self._enduser_dimension_id_subquery(
+                    f"user_id_type {dimension_op}"
+                )
+                candidate_filter = self._candidate_trace_filter()
+                project_filter = self._strict_span_project_filter()
+                nil_user = (
+                    "end_user_id = toUUID('00000000-0000-0000-0000-000000000000') OR "
+                    if filter_op == "is_null"
+                    else ""
+                )
+                return (
+                    f"trace_id IN ("
+                    f"SELECT trace_id FROM {self.table} "
+                    f"WHERE ({nil_user}end_user_id IN ({dimension_ids})) "
+                    f"AND _peerdb_is_deleted = 0{self._span_membership_date_filter()}"
+                    f"{project_filter}"
+                    f"{candidate_filter})"
+                )
+
             comparison_op = "=" if filter_op == "is_null" else "!="
             candidate_filter = self._candidate_trace_filter()
             project_filter = self._strict_span_project_filter()

--- a/futureagi/tracer/services/clickhouse/query_builders/session_list.py
+++ b/futureagi/tracer/services/clickhouse/query_builders/session_list.py
@@ -451,7 +451,12 @@ class SessionListQueryBuilder(BaseQueryBuilder):
         )
         self._bounded_has_eval_values(has_eval_filters)
 
-        allowed_keys = {"annotator", "has_annotation", "my_annotations"}
+        allowed_keys = {
+            "annotator",
+            "has_annotation",
+            "my_annotations",
+            "user_id_type",
+        }
         allowed_types = {"ANNOTATION", "EVAL_METRIC"}
         for item in generic_filters:
             column_id = item.get("column_id") or item.get("columnId")
@@ -3108,7 +3113,8 @@ class SessionListQueryBuilder(BaseQueryBuilder):
     # them here). These must NOT flow into `ClickHouseFilterBuilder.translate()`
     # — they are resolved through the id-remap on a wrapped layer instead (see
     # `_build_resolved_user_clause` / P3b step1.5), so a cross-cutover straddler
-    # unifies. `user` is the FilterBuilder alias for `end_user_id`.
+    # unifies. The request view translates the public `user` alias from a
+    # readable user_id into this builder's UUID membership contract.
     _ENDUSER_ID_FILTER_COLS = frozenset({"end_user_id", "user"})
     _SESSION_ID_FILTER_COLS = SESSION_ID_FILTER_COLS
 

--- a/futureagi/tracer/services/clickhouse/v2/end_user_dict_reader.py
+++ b/futureagi/tracer/services/clickhouse/v2/end_user_dict_reader.py
@@ -270,6 +270,72 @@ def resolve_end_user_fields(
     return out
 
 
+def resolve_end_user_ids_by_user_ids(
+    user_ids: Iterable[object],
+    *,
+    project_id: object | None = None,
+    organization_id: object | None = None,
+    timeout_ms: int | None = None,
+    settings: dict | None = None,
+) -> dict[str, list[str]]:
+    """Batch-resolve external user IDs to scoped curated end-user UUIDs."""
+    if project_id is None and organization_id is None:
+        raise ValueError(
+            "resolve_end_user_ids_by_user_ids requires project_id and/or "
+            "organization_id (an unscoped reverse lookup would cross tenants)"
+        )
+    values = tuple(dict.fromkeys(str(value) for value in user_ids if value))
+    if not values:
+        return {}
+    if timeout_ms is not None and timeout_ms <= 0:
+        raise ValueError("timeout_ms must be positive")
+
+    client = _get_client()
+    if timeout_ms is not None:
+        from tracer.services.clickhouse.read_budget import ReadDeadlineExceeded
+        from tracer.services.clickhouse.server_readonly import (
+            ServerEnforcedReadOnlyNativeClient,
+        )
+
+        if isinstance(client, ServerEnforcedReadOnlyNativeClient):
+            raise ReadDeadlineExceeded(
+                "server-locked end-user lookup cannot enforce request deadline"
+            )
+
+    conds = ["user_id IN %(uids)s", "is_deleted = 0"]
+    params: dict[str, object] = {"uids": values}
+    if project_id is not None:
+        conds.append("project_id = %(pid)s")
+        params["pid"] = str(project_id)
+    if organization_id is not None:
+        conds.append("organization_id = %(oid)s")
+        params["oid"] = str(organization_id)
+
+    try:
+        result = client.query(
+            (
+                "SELECT user_id, toString(end_user_id) "
+                f"FROM end_users FINAL WHERE {' AND '.join(conds)}"
+            ),
+            parameters=params,
+            settings=application_read_settings(
+                {**current_settings(), **(settings or {})},
+                timeout_ms=timeout_ms,
+            ),
+        )
+    except Exception:
+        _reset_client()
+        raise
+
+    resolved = {value: [] for value in values}
+    for user_id, end_user_id in result.result_rows:
+        if user_id in resolved and end_user_id:
+            resolved[user_id].append(str(end_user_id))
+    for user_id, ids in resolved.items():
+        resolved[user_id] = list(dict.fromkeys(ids))
+    return resolved
+
+
 def resolve_end_user_ids_by_user_id(
     user_id: object,
     *,

--- a/futureagi/tracer/services/clickhouse/v2/trace_session_dict_reader.py
+++ b/futureagi/tracer/services/clickhouse/v2/trace_session_dict_reader.py
@@ -81,6 +81,7 @@ from __future__ import annotations
 
 import threading
 from collections.abc import Iterable
+from uuid import UUID
 
 import structlog
 
@@ -280,6 +281,91 @@ def resolve_external_session_ids(
         # to None — matches the old back-fill that read NULL straight off PG.
         out[row[0]] = row[1] or None
     return out
+
+
+def resolve_session_filter_values(
+    values: Iterable[object],
+    *,
+    project_ids: Iterable[object],
+    deadline: ReadDeadline | None = None,
+    settings: dict | None = None,
+) -> dict[str, list[str]]:
+    """Resolve session filter values to scoped, remap-survivor UUIDs.
+
+    A filter value may be either the internal ``trace_session_id`` returned as
+    an option value or the arbitrary ``external_session_id`` sent by the SDK.
+    UUID-shaped external IDs are checked through both lanes. Unknown values map
+    to an empty list; callers apply inclusive/negated empty-set semantics.
+    """
+    raw_values = tuple(dict.fromkeys(str(value) for value in values if value))
+    scoped_project_ids = tuple(
+        dict.fromkeys(str(project_id) for project_id in project_ids if project_id)
+    )
+    if not raw_values or not scoped_project_ids:
+        return {value: [] for value in raw_values}
+
+    uuid_values: list[str] = []
+    for value in raw_values:
+        try:
+            uuid_values.append(str(UUID(value)))
+        except ValueError:
+            continue
+
+    resolved_uuid_values = _resolve_existing_ids(uuid_values)
+    target_ids = tuple(dict.fromkeys(resolved_uuid_values.values()))
+    resolved = resolved_id_expr("ts.trace_session_id", "session_filter_remap")
+    remap_join = remap_left_join(
+        "ts.trace_session_id",
+        _SESSION_REMAP,
+        "session_filter_remap",
+    )
+    target_clause = f" OR {resolved} IN %(target_ids)s" if target_ids else ""
+    query_kwargs = {
+        "parameters": {
+            "project_ids": scoped_project_ids,
+            "external_ids": raw_values,
+            "target_ids": target_ids,
+        },
+        "settings": application_read_settings(
+            {**current_settings(), **(settings or {})},
+            timeout_ms=(deadline.remaining_ms() if deadline is not None else None),
+        ),
+    }
+
+    client = _get_client()
+    try:
+        result = client.query(
+            (
+                f"SELECT DISTINCT toString({resolved}), ts.external_session_id "
+                f"FROM {_SESSIONS_TABLE} AS ts FINAL "
+                f"{remap_join} "
+                f"WHERE ts.project_id IN %(project_ids)s "
+                f"AND ts.is_deleted = 0 "
+                f"AND (ts.external_session_id IN %(external_ids)s"
+                f"{target_clause})"
+            ),
+            **query_kwargs,
+        )
+    except Exception:
+        _reset_client()
+        raise
+
+    matches = {value: [] for value in raw_values}
+    inputs_by_target: dict[str, list[str]] = {}
+    for input_id, target_id in resolved_uuid_values.items():
+        inputs_by_target.setdefault(target_id, []).append(input_id)
+
+    for resolved_id, external_id in result.result_rows:
+        resolved_id = str(resolved_id)
+        external_id = str(external_id)
+        if external_id in matches:
+            matches[external_id].append(resolved_id)
+        for input_id in inputs_by_target.get(resolved_id, []):
+            matches[input_id].append(resolved_id)
+
+    for value, ids in matches.items():
+        matches[value] = list(dict.fromkeys(ids))
+    return matches
 
 
 def _resolve_existing_ids(trace_session_ids: Iterable[object]) -> dict[str, str]:

--- a/futureagi/tracer/services/user_filter_capabilities.py
+++ b/futureagi/tracer/services/user_filter_capabilities.py
@@ -22,7 +22,7 @@ def is_native_user_id_filter(item):
     its own predicate compiler unchanged instead of becoming account scope.
     Call after public filter normalization/validation.
     """
-    if item.get("column_id") != "user_id":
+    if item.get("column_id") not in {"user", "user_id"}:
         return False
     cfg = item.get("filter_config") or {}
     family = str(cfg.get("col_type") or "").upper()

--- a/futureagi/tracer/tests/test_filter_serializer_contracts.py
+++ b/futureagi/tracer/tests/test_filter_serializer_contracts.py
@@ -87,6 +87,18 @@ def _session_numeric_membership_filter(
     }
 
 
+def _session_id_filter(filter_value, filter_op="in", column_id="session"):
+    return {
+        "column_id": column_id,
+        "filter_config": {
+            "col_type": "SYSTEM_METRIC",
+            "filter_type": "text",
+            "filter_op": filter_op,
+            "filter_value": filter_value,
+        },
+    }
+
+
 class TestFilterSerializerContracts:
     @pytest.mark.parametrize(
         "serializer_class",
@@ -451,6 +463,106 @@ class TestFilterSerializerContracts:
         ]
         assert serializer.validated_data["page_size"] == 75
         assert serializer.validated_data["bookmarked"] is True
+
+    @pytest.mark.parametrize(
+        "serializer_class",
+        [TraceSessionListQuerySerializer, TraceSessionRetrieveQuerySerializer],
+    )
+    @pytest.mark.parametrize("column_id", ["session", "session_id", "trace_session_id"])
+    def test_session_queries_preserve_external_session_ids(
+        self, serializer_class, column_id
+    ):
+        serializer = serializer_class(
+            data={
+                "filters": json.dumps(
+                    [
+                        _session_id_filter(
+                            ["external-session", "missing-session"],
+                            column_id=column_id,
+                        )
+                    ]
+                )
+            }
+        )
+
+        assert serializer.is_valid(), serializer.errors
+        assert serializer.validated_data["filters"][0]["filter_config"][
+            "filter_value"
+        ] == ["external-session", "missing-session"]
+
+    def test_session_graph_preserves_external_session_ids(self):
+        serializer = TraceSessionGraphDataRequestSerializer(
+            data={
+                "project_id": "1372e742-a10b-4d98-9ca4-31ef4d67115f",
+                "req_data_config": {
+                    "id": "session_count",
+                    "type": "SYSTEM_METRIC",
+                },
+                "filters": [_session_id_filter(["external-session"])],
+            }
+        )
+
+        assert serializer.is_valid(), serializer.errors
+        assert serializer.validated_data["filters"][0]["filter_config"][
+            "filter_value"
+        ] == ["external-session"]
+
+    @pytest.mark.parametrize(
+        "serializer_class",
+        [
+            TraceSessionListQuerySerializer,
+            TraceSessionRetrieveQuerySerializer,
+            TraceSessionGraphDataRequestSerializer,
+        ],
+    )
+    @pytest.mark.parametrize("filter_op", ["contains", "not_contains", "starts_with"])
+    def test_session_queries_drop_non_identity_operators(
+        self, serializer_class, filter_op
+    ):
+        filters = [
+            _session_id_filter("session", filter_op),
+            _session_id_filter(["external-session"], column_id="session_id"),
+        ]
+        data = {"filters": json.dumps(filters)}
+        if serializer_class is TraceSessionGraphDataRequestSerializer:
+            data = {
+                "project_id": "1372e742-a10b-4d98-9ca4-31ef4d67115f",
+                "req_data_config": {
+                    "id": "session_count",
+                    "type": "SYSTEM_METRIC",
+                },
+                "filters": filters,
+            }
+        serializer = serializer_class(data=data)
+
+        assert serializer.is_valid(), serializer.errors
+        assert serializer.validated_data["filters"] == [filters[1]]
+
+    @pytest.mark.parametrize(
+        "serializer_class",
+        [
+            TraceSessionListQuerySerializer,
+            TraceSessionRetrieveQuerySerializer,
+            TraceSessionGraphDataRequestSerializer,
+        ],
+    )
+    @pytest.mark.parametrize("filter_op", ["is_null", "is_not_null"])
+    def test_session_queries_accept_identity_null_operators(
+        self, serializer_class, filter_op
+    ):
+        data = {"filters": json.dumps([_session_id_filter(None, filter_op)])}
+        if serializer_class is TraceSessionGraphDataRequestSerializer:
+            data = {
+                "project_id": "1372e742-a10b-4d98-9ca4-31ef4d67115f",
+                "req_data_config": {
+                    "id": "session_count",
+                    "type": "SYSTEM_METRIC",
+                },
+                "filters": [_session_id_filter(None, filter_op)],
+            }
+        serializer = serializer_class(data=data)
+
+        assert serializer.is_valid(), serializer.errors
 
     def test_session_list_query_rejects_legacy_query_and_filter_aliases(self):
         serializer = TraceSessionListQuerySerializer(

--- a/futureagi/tracer/tests/test_list_sessions_org_scope.py
+++ b/futureagi/tracer/tests/test_list_sessions_org_scope.py
@@ -19,6 +19,7 @@ These tests pin:
 """
 
 import uuid
+from copy import deepcopy
 from types import SimpleNamespace
 from unittest import mock
 
@@ -104,6 +105,150 @@ class TestListSessionsClickHouseOrgScope:
             return_value=[],
         )
 
+    def test_session_filter_resolves_external_id_and_drops_unknown_value(self):
+        from tracer.services.clickhouse.query_builders.session_filters import (
+            build_session_id_filter_clause,
+        )
+        from tracer.views.trace_session import _resolve_session_identity_filters
+
+        session_id = str(uuid.uuid4())
+        filters = [
+            {
+                "column_id": "session",
+                "filter_config": {
+                    "filter_type": "text",
+                    "filter_op": "in",
+                    "filter_value": ["customer-session", "missing-session"],
+                    "col_type": "SYSTEM_METRIC",
+                },
+            }
+        ]
+
+        with mock.patch(
+            "tracer.services.clickhouse.v2.trace_session_dict_reader.resolve_session_filter_values",
+            return_value={
+                "customer-session": [session_id],
+                "missing-session": [],
+            },
+        ) as resolve_mock:
+            resolved = _resolve_session_identity_filters(
+                filters,
+                project_ids=[uuid.uuid4()],
+            )
+
+        resolve_mock.assert_called_once()
+        assert resolved[0]["filter_config"]["filter_value"] == [session_id]
+        params = {}
+        assert (
+            build_session_id_filter_clause(
+                resolved,
+                params,
+                session_col="trace_session_id",
+                param_prefix="session_",
+            )
+            == "trace_session_id IN %(session_1)s"
+        )
+        assert params == {"session_1": (session_id,)}
+
+    def test_unresolved_negated_session_filter_is_a_noop(self):
+        from tracer.services.clickhouse.query_builders.session_filters import (
+            build_session_id_filter_clause,
+        )
+        from tracer.views.trace_session import _resolve_session_identity_filters
+
+        filters = [
+            {
+                "column_id": "session_id",
+                "filter_config": {
+                    "filter_type": "text",
+                    "filter_op": "not_in",
+                    "filter_value": ["missing-session"],
+                    "col_type": "SYSTEM_METRIC",
+                },
+            }
+        ]
+        with mock.patch(
+            "tracer.services.clickhouse.v2.trace_session_dict_reader.resolve_session_filter_values",
+            return_value={"missing-session": []},
+        ):
+            resolved = _resolve_session_identity_filters(
+                filters,
+                project_ids=[uuid.uuid4()],
+            )
+
+        assert resolved[0]["filter_config"]["filter_value"] == []
+        assert (
+            build_session_id_filter_clause(
+                resolved,
+                {},
+                session_col="trace_session_id",
+                param_prefix="session_",
+            )
+            == "1 = 1"
+        )
+
+    def test_session_resolution_batches_leaves_without_mutating_input(self):
+        from tracer.views.trace_session import _resolve_session_identity_filters
+
+        first_id = str(uuid.uuid4())
+        second_id = str(uuid.uuid4())
+        project_ids = [uuid.uuid4(), uuid.uuid4()]
+        filters = [
+            {
+                "column_id": "created_at",
+                "filter_config": {
+                    "filter_type": "datetime",
+                    "filter_op": "between",
+                    "filter_value": ["2026-09-01", "2026-09-02"],
+                },
+            },
+            {
+                "column_id": "session",
+                "filter_config": {
+                    "filter_type": "text",
+                    "filter_op": "equals",
+                    "filter_value": "external-one",
+                },
+            },
+            {
+                "column_id": "session_id",
+                "filter_config": {
+                    "filter_type": "text",
+                    "filter_op": "not_equals",
+                    "filter_value": ["external-two"],
+                },
+            },
+            {
+                "column_id": "trace_session_id",
+                "filter_config": {
+                    "filter_type": "text",
+                    "filter_op": "is_null",
+                },
+            },
+        ]
+        original = deepcopy(filters)
+
+        with mock.patch(
+            "tracer.services.clickhouse.v2.trace_session_dict_reader.resolve_session_filter_values",
+            return_value={
+                "external-one": [first_id, first_id],
+                "external-two": [second_id],
+            },
+        ) as resolve_mock:
+            resolved = _resolve_session_identity_filters(
+                filters,
+                project_ids=project_ids,
+            )
+
+        resolve_mock.assert_called_once()
+        assert resolve_mock.call_args.args[0] == ["external-one", "external-two"]
+        assert resolve_mock.call_args.kwargs["project_ids"] == project_ids
+        assert filters == original
+        assert resolved[0] == original[0]
+        assert resolved[1]["filter_config"]["filter_value"] == [first_id]
+        assert resolved[2]["filter_config"]["filter_value"] == [second_id]
+        assert resolved[3] == original[3]
+
     def test_runs_without_nameerror_when_user_id_set_org_scope(self):
         """Repro of TH-5092: ``org`` was undefined when ``user_id`` was set.
 
@@ -119,8 +264,8 @@ class TestListSessionsClickHouseOrgScope:
         eu_ids = [str(uuid.uuid4())]
         with (
             mock.patch(
-                "tracer.views.trace_session._resolve_end_user_ids_for_user_id",
-                return_value=(eu_ids, None),
+                "tracer.views.trace_session._resolve_end_user_ids_for_user_ids",
+                return_value=({"user-eve": eu_ids}, None),
             ),
             self._patch_session_name_lookup(),
         ):
@@ -161,8 +306,8 @@ class TestListSessionsClickHouseOrgScope:
 
         with (
             mock.patch(
-                "tracer.views.trace_session._resolve_end_user_ids_for_user_id",
-                return_value=(eu_ids, None),
+                "tracer.views.trace_session._resolve_end_user_ids_for_user_ids",
+                return_value=({"user-eve": eu_ids}, None),
             ),
             self._patch_session_name_lookup(),
             mock.patch(
@@ -229,8 +374,8 @@ class TestListSessionsClickHouseOrgScope:
 
         with (
             mock.patch(
-                "tracer.views.trace_session._resolve_end_user_ids_for_user_id",
-                side_effect=[([alice_id], None), ([bob_id], None)],
+                "tracer.views.trace_session._resolve_end_user_ids_for_user_ids",
+                return_value=({"alice": [alice_id], "bob": [bob_id]}, None),
             ) as resolve_mock,
             self._patch_session_name_lookup(),
             self._patch_annotation_labels(),
@@ -248,7 +393,8 @@ class TestListSessionsClickHouseOrgScope:
                 validated_data=self._make_validated_data(filters=filters),
             )
 
-        assert [c.args[0] for c in resolve_mock.call_args_list] == ["alice", "bob"]
+        resolve_mock.assert_called_once()
+        assert resolve_mock.call_args.args[0] == ["alice", "bob"]
         synthetic = [
             f for f in captured["filters"] if f.get("column_id") == "end_user_id"
         ]
@@ -256,6 +402,360 @@ class TestListSessionsClickHouseOrgScope:
         cfg = synthetic[0]["filter_config"]
         assert cfg["filter_op"] == "in"
         assert cfg["filter_value"] == [alice_id, bob_id]
+
+    def test_user_filter_alias_drops_unresolved_values(self):
+        from tracer.services.clickhouse.v2.query_builders.session_list import (
+            SessionListQueryBuilderV2 as RealBuilder,
+        )
+
+        view = self._make_view()
+        request = self._make_request()
+        analytics = self._patch_analytics()
+        captured = {}
+        user_id = str(uuid.uuid4())
+
+        def _capture_builder(*args, **kwargs):
+            captured["filters"] = list(kwargs.get("filters") or [])
+            return RealBuilder(*args, **kwargs)
+
+        filters = [
+            {
+                "column_id": "user",
+                "filter_config": {
+                    "filter_type": "text",
+                    "filter_op": "in",
+                    "filter_value": ["user_carol", "us"],
+                    "col_type": "SYSTEM_METRIC",
+                },
+            }
+        ]
+
+        with (
+            mock.patch(
+                "tracer.views.trace_session._resolve_end_user_ids_for_user_ids",
+                return_value=({"user_carol": [user_id], "us": []}, None),
+            ) as resolve_mock,
+            self._patch_session_name_lookup(),
+            self._patch_annotation_labels(),
+            mock.patch(
+                "tracer.views.trace_session.SessionListQueryBuilderV2",
+                side_effect=_capture_builder,
+                wraps=RealBuilder,
+            ),
+        ):
+            view._list_sessions_clickhouse(
+                request,
+                project_id=uuid.uuid4(),
+                project=None,
+                analytics=analytics,
+                validated_data=self._make_validated_data(filters=filters),
+            )
+
+        resolve_mock.assert_called_once()
+        assert resolve_mock.call_args.args[0] == ["user_carol", "us"]
+        synthetic = [
+            item
+            for item in captured["filters"]
+            if item.get("column_id") == "end_user_id"
+        ]
+        assert len(synthetic) == 1
+        assert synthetic[0]["filter_config"]["filter_value"] == [user_id]
+
+    @pytest.mark.parametrize("column_id", ["user", "user_id"])
+    @pytest.mark.parametrize(
+        "filter_op,filter_value,expected_op",
+        [
+            ("equals", "alice", "in"),
+            ("in", ["alice"], "in"),
+            ("not_equals", "alice", "not_in"),
+            ("not_in", ["alice"], "not_in"),
+            ("is_null", None, "is_null"),
+            ("is_not_null", None, "is_not_null"),
+        ],
+    )
+    def test_session_list_user_filter_operator_matrix(
+        self,
+        column_id,
+        filter_op,
+        filter_value,
+        expected_op,
+    ):
+        from tracer.services.clickhouse.v2.query_builders.session_list import (
+            SessionListQueryBuilderV2 as RealBuilder,
+        )
+
+        view = self._make_view()
+        request = self._make_request()
+        analytics = self._patch_analytics()
+        captured = {}
+        alice_id = str(uuid.uuid4())
+
+        def _capture_builder(*args, **kwargs):
+            captured["filters"] = list(kwargs.get("filters") or [])
+            return RealBuilder(*args, **kwargs)
+
+        config = {
+            "filter_type": "text",
+            "filter_op": filter_op,
+            "col_type": "SYSTEM_METRIC",
+        }
+        if filter_value is not None:
+            config["filter_value"] = filter_value
+        filters = [
+            {
+                "column_id": column_id,
+                "property_id": f"system_attribute:sessions:{column_id}",
+                "filter_config": config,
+            }
+        ]
+
+        with (
+            mock.patch(
+                "tracer.views.trace_session._resolve_end_user_ids_for_user_ids",
+                return_value=({"alice": [alice_id]}, None),
+            ) as resolve_mock,
+            self._patch_session_name_lookup(),
+            self._patch_annotation_labels(),
+            mock.patch(
+                "tracer.views.trace_session.SessionListQueryBuilderV2",
+                side_effect=_capture_builder,
+                wraps=RealBuilder,
+            ),
+        ):
+            view._list_sessions_clickhouse(
+                request,
+                project_id=uuid.uuid4(),
+                project=None,
+                analytics=analytics,
+                validated_data=self._make_validated_data(filters=filters),
+            )
+
+        synthetic = [
+            item
+            for item in captured["filters"]
+            if item.get("column_id") == "end_user_id"
+        ]
+        assert len(synthetic) == 1
+        resolved_config = synthetic[0]["filter_config"]
+        assert resolved_config["filter_op"] == expected_op
+        if filter_op in {"is_null", "is_not_null"}:
+            resolve_mock.assert_not_called()
+            assert "filter_value" not in resolved_config
+        else:
+            resolve_mock.assert_called_once()
+            assert resolve_mock.call_args.args[0] == ["alice"]
+            assert resolved_config["filter_value"] == [alice_id]
+
+    def test_user_filter_leaves_are_batched_but_remain_independent(self):
+        from tracer.services.clickhouse.v2.query_builders.session_list import (
+            SessionListQueryBuilderV2 as RealBuilder,
+        )
+
+        view = self._make_view()
+        request = self._make_request()
+        analytics = self._patch_analytics()
+        captured = {}
+        alice_id = str(uuid.uuid4())
+
+        def _capture_builder(*args, **kwargs):
+            captured["filters"] = list(kwargs.get("filters") or [])
+            return RealBuilder(*args, **kwargs)
+
+        filters = [
+            {
+                "column_id": "user_id",
+                "filter_config": {
+                    "filter_type": "text",
+                    "filter_op": "in",
+                    "filter_value": ["alice"],
+                    "col_type": "SYSTEM_METRIC",
+                },
+            },
+            {
+                "column_id": "user",
+                "filter_config": {
+                    "filter_type": "text",
+                    "filter_op": "in",
+                    "filter_value": ["missing"],
+                    "col_type": "SYSTEM_METRIC",
+                },
+            },
+            {
+                "column_id": "user_id",
+                "filter_config": {
+                    "filter_type": "text",
+                    "filter_op": "not_in",
+                    "filter_value": ["missing"],
+                    "col_type": "SYSTEM_METRIC",
+                },
+            },
+        ]
+
+        with (
+            mock.patch(
+                "tracer.views.trace_session._resolve_end_user_ids_for_user_ids",
+                return_value=({"alice": [alice_id], "missing": []}, None),
+            ) as resolve_mock,
+            self._patch_session_name_lookup(),
+            self._patch_annotation_labels(),
+            mock.patch(
+                "tracer.views.trace_session.SessionListQueryBuilderV2",
+                side_effect=_capture_builder,
+                wraps=RealBuilder,
+            ),
+        ):
+            view._list_sessions_clickhouse(
+                request,
+                project_id=uuid.uuid4(),
+                project=None,
+                analytics=analytics,
+                validated_data=self._make_validated_data(filters=filters),
+            )
+
+        resolve_mock.assert_called_once()
+        assert resolve_mock.call_args.args[0] == ["alice", "missing", "missing"]
+        synthetic = [
+            item
+            for item in captured["filters"]
+            if item.get("column_id") == "end_user_id"
+        ]
+        assert [item["filter_config"]["filter_op"] for item in synthetic] == [
+            "in",
+            "in",
+        ]
+        assert synthetic[0]["filter_config"]["filter_value"] == [alice_id]
+        assert synthetic[1]["filter_config"]["filter_value"] == [
+            "00000000-0000-0000-0000-000000000000"
+        ]
+
+    @pytest.mark.parametrize(
+        "families",
+        [
+            ("session", "user"),
+            ("session", "user_id_type"),
+            ("user", "user_id_type"),
+            ("session", "user", "user_id_type"),
+        ],
+        ids=[
+            "session-user",
+            "session-user-type",
+            "user-user-type",
+            "session-user-user-type",
+        ],
+    )
+    @pytest.mark.parametrize(
+        "session_column", ["session", "session_id", "trace_session_id"]
+    )
+    @pytest.mark.parametrize("user_column", ["user", "user_id"])
+    @pytest.mark.parametrize("profile", ["inclusive", "negated-null"])
+    def test_session_list_identity_filter_combination_matrix(
+        self,
+        families,
+        session_column,
+        user_column,
+        profile,
+    ):
+        from tracer.services.clickhouse.v2.query_builders.session_list import (
+            SessionListQueryBuilderV2 as RealBuilder,
+        )
+
+        view = self._make_view()
+        request = self._make_request()
+        analytics = self._patch_analytics()
+        captured = {}
+        session_id = str(uuid.uuid4())
+        user_id = str(uuid.uuid4())
+        filters = []
+        if "session" in families:
+            filters.append(
+                {
+                    "column_id": session_column,
+                    "property_id": "system_attribute:sessions:session",
+                    "filter_config": {
+                        "filter_type": "text",
+                        "filter_op": "in" if profile == "inclusive" else "not_in",
+                        "filter_value": ["external-session"],
+                        "col_type": "SYSTEM_METRIC",
+                    },
+                }
+            )
+        if "user" in families:
+            filters.append(
+                {
+                    "column_id": user_column,
+                    "property_id": "system_attribute:sessions:user",
+                    "filter_config": {
+                        "filter_type": "text",
+                        "filter_op": "in" if profile == "inclusive" else "not_in",
+                        "filter_value": ["alice"],
+                        "col_type": "SYSTEM_METRIC",
+                    },
+                }
+            )
+        if "user_id_type" in families:
+            type_config = {
+                "filter_type": "text",
+                "filter_op": "in" if profile == "inclusive" else "is_null",
+                "col_type": "SYSTEM_METRIC",
+            }
+            if profile == "inclusive":
+                type_config["filter_value"] = ["email"]
+            filters.append(
+                {
+                    "column_id": "user_id_type",
+                    "property_id": "system_attribute:sessions:user_id_type",
+                    "filter_config": type_config,
+                }
+            )
+
+        def _capture_builder(*args, **kwargs):
+            captured["filters"] = list(kwargs.get("filters") or [])
+            return RealBuilder(*args, **kwargs)
+
+        with (
+            mock.patch(
+                "tracer.services.clickhouse.v2.trace_session_dict_reader.resolve_session_filter_values",
+                return_value={"external-session": [session_id]},
+            ) as session_resolve_mock,
+            mock.patch(
+                "tracer.views.trace_session._resolve_end_user_ids_for_user_ids",
+                return_value=({"alice": [user_id]}, None),
+            ) as user_resolve_mock,
+            self._patch_session_name_lookup(),
+            self._patch_annotation_labels(),
+            mock.patch(
+                "tracer.views.trace_session.SessionListQueryBuilderV2",
+                side_effect=_capture_builder,
+                wraps=RealBuilder,
+            ),
+        ):
+            view._list_sessions_clickhouse(
+                request,
+                project_id=uuid.uuid4(),
+                project=None,
+                analytics=analytics,
+                validated_data=self._make_validated_data(filters=filters),
+            )
+
+        by_column = {
+            item["column_id"]: item["filter_config"]
+            for item in captured["filters"]
+            if item.get("column_id") in {session_column, "end_user_id", "user_id_type"}
+        }
+        if "session" in families:
+            session_resolve_mock.assert_called_once()
+            assert by_column[session_column]["filter_value"] == [session_id]
+        else:
+            session_resolve_mock.assert_not_called()
+        if "user" in families:
+            user_resolve_mock.assert_called_once()
+            assert by_column["end_user_id"]["filter_value"] == [user_id]
+        else:
+            user_resolve_mock.assert_not_called()
+        if "user_id_type" in families:
+            assert by_column["user_id_type"]["filter_op"] == (
+                "in" if profile == "inclusive" else "is_null"
+            )
 
     def test_user_id_filter_preserves_negated_operator(self):
         from tracer.services.clickhouse.v2.query_builders.session_list import (
@@ -286,8 +786,8 @@ class TestListSessionsClickHouseOrgScope:
 
         with (
             mock.patch(
-                "tracer.views.trace_session._resolve_end_user_ids_for_user_id",
-                return_value=([alice_id], None),
+                "tracer.views.trace_session._resolve_end_user_ids_for_user_ids",
+                return_value=({"alice": [alice_id]}, None),
             ),
             self._patch_session_name_lookup(),
             self._patch_annotation_labels(),
@@ -339,7 +839,7 @@ class TestListSessionsClickHouseOrgScope:
 
         with (
             mock.patch(
-                "tracer.views.trace_session._resolve_end_user_ids_for_user_id"
+                "tracer.views.trace_session._resolve_end_user_ids_for_user_ids"
             ) as resolve_mock,
             self._patch_session_name_lookup(),
             self._patch_annotation_labels(),
@@ -395,8 +895,8 @@ class TestListSessionsClickHouseOrgScope:
         }
         with (
             mock.patch(
-                "tracer.views.trace_session._resolve_end_user_ids_for_user_id",
-                return_value=(eu_ids, display),
+                "tracer.views.trace_session._resolve_end_user_ids_for_user_ids",
+                return_value=({"user-eve": eu_ids}, display),
             ) as resolve_mock,
             self._patch_session_name_lookup(),
             mock.patch.object(view, "_fetch_end_user_info", return_value={}),

--- a/futureagi/tracer/tests/test_observe_filter_matrix_native.py
+++ b/futureagi/tracer/tests/test_observe_filter_matrix_native.py
@@ -11,6 +11,11 @@ import pytest
 from rest_framework.exceptions import ValidationError
 
 from tracer.serializers.trace import UsersQuerySerializer
+from tracer.serializers.trace_session import (
+    TraceSessionGraphDataRequestSerializer,
+    TraceSessionListQuerySerializer,
+    TraceSessionRetrieveQuerySerializer,
+)
 from tracer.services.clickhouse import exact_graph_reads as graph
 from tracer.services.clickhouse.query_builders.base import BaseQueryBuilder
 from tracer.services.clickhouse.query_builders.filters import EvalFilterMetadata
@@ -39,6 +44,78 @@ NATIVE_CASES = tuple(
     for surface in ("traces", "sessions", "users")
     for item in INVENTORY["eval_configurations"]
 )
+SESSION_IDENTITY_COLUMNS = ("session", "session_id", "trace_session_id")
+SESSION_IDENTITY_SUPPORTED_OPS = frozenset(
+    {"equals", "not_equals", "in", "not_in", "is_null", "is_not_null"}
+)
+SESSION_IDENTITY_OPERATOR_CASES = tuple(
+    (column_id, filter_op, filter_op in SESSION_IDENTITY_SUPPORTED_OPS)
+    for column_id in SESSION_IDENTITY_COLUMNS
+    for filter_op in (
+        "equals",
+        "not_equals",
+        "in",
+        "not_in",
+        "contains",
+        "not_contains",
+        "starts_with",
+        "ends_with",
+        "is_null",
+        "is_not_null",
+    )
+)
+SESSION_IDENTITY_SERIALIZERS = (
+    TraceSessionListQuerySerializer,
+    TraceSessionRetrieveQuerySerializer,
+    TraceSessionGraphDataRequestSerializer,
+)
+
+
+@pytest.mark.parametrize(
+    "serializer_class",
+    SESSION_IDENTITY_SERIALIZERS,
+    ids=lambda serializer_class: serializer_class.__name__,
+)
+@pytest.mark.parametrize(
+    "column_id,filter_op,supported",
+    SESSION_IDENTITY_OPERATOR_CASES,
+    ids=lambda case: str(case),
+)
+def test_session_identity_operator_matrix(
+    serializer_class,
+    column_id,
+    filter_op,
+    supported,
+):
+    if filter_op in {"is_null", "is_not_null"}:
+        filter_value = None
+    elif filter_op in {"in", "not_in"}:
+        filter_value = ["external-session", "missing-session"]
+    else:
+        filter_value = "external-session"
+    leaf = {
+        "column_id": column_id,
+        "filter_config": {
+            "col_type": "SYSTEM_METRIC",
+            "filter_type": "text",
+            "filter_op": filter_op,
+            "filter_value": filter_value,
+        },
+    }
+    if serializer_class is TraceSessionGraphDataRequestSerializer:
+        data = {
+            "project_id": PROJECT,
+            "req_data_config": {"id": "session_count", "type": "SYSTEM_METRIC"},
+            "filters": [leaf],
+        }
+    else:
+        data = {"filters": json.dumps([leaf])}
+
+    serializer = serializer_class(data=data)
+
+    assert serializer.is_valid(), serializer.errors
+    expected = [leaf] if supported else []
+    assert serializer.validated_data["filters"] == expected
 
 
 def _compile(surface, filters, days):

--- a/futureagi/tracer/tests/test_session_analytics_v2.py
+++ b/futureagi/tracer/tests/test_session_analytics_v2.py
@@ -165,7 +165,7 @@ def navigation_context_call():
     with mock.patch("tracer.services.clickhouse.v2.query_service.V2AnalyticsQueryService", return_value=service), \
          mock.patch("tracer.views.trace_session._project_queryset_for_request", return_value=projects), \
          mock.patch("tracer.views.trace_session._bounded_session_list_postgres_reads"),          mock.patch("tracer.views.trace_session.EndUser.objects.filter") as display_users, \
-         mock.patch("tracer.services.clickhouse.v2.end_user_dict_reader.resolve_end_user_ids_by_user_id", return_value=[USER_ID]) as users, \
+         mock.patch("tracer.services.clickhouse.v2.end_user_dict_reader.resolve_end_user_ids_by_user_ids", return_value={"public-user": [USER_ID]}) as users, \
          mock.patch.object(SessionAnalyticsQueryBuilderV2, "build_session_navigation_query", side_effect=AssertionError("context cannot use legacy navigation")) as legacy:
         display_users.return_value.filter.return_value = display_users.return_value
         display_users.return_value.values.return_value.first.return_value = None
@@ -279,12 +279,19 @@ def test_context_user_leaves_remain_and_and_custom_user_id_is_not_resolved(navig
         "col_type": "SPAN_ATTRIBUTE", "filter_type": "number",
         "filter_op": "greater_than", "filter_value": 2,
     }})
-    users.side_effect = lambda value, **_: {
-        "public-user": [USER_ID], "second-user": [OTHER_PROJECT_ID], "excluded-user": [],
-    }[value]
+    users.side_effect = lambda values, **_: {
+        value: {
+            "public-user": [USER_ID], "second-user": [OTHER_PROJECT_ID],
+            "excluded-user": [],
+        }[value]
+        for value in values
+    }
     assert call(context) == (OTHER_PROJECT_ID, None)
     query, params = service.execute_ch_query.call_args.args
-    assert users.call_count == 3
+    users.assert_called_once()
+    assert set(users.call_args.args[0]) == {
+        "public-user", "second-user", "excluded-user",
+    }
     assert "matching_scalar_sessions" in query
     assert "user_id" in params.values()
     assert (USER_ID,) in params.values() and (OTHER_PROJECT_ID,) in params.values()

--- a/futureagi/tracer/tests/test_session_list_bounded_view.py
+++ b/futureagi/tracer/tests/test_session_list_bounded_view.py
@@ -153,11 +153,14 @@ def _session_handler_resolved_filters(filters, *, user_id=None, org_scope=False)
     display_rows.values.return_value.first.return_value = None
     with (
         mock.patch(
-            "tracer.services.clickhouse.v2.end_user_dict_reader.resolve_end_user_ids_by_user_id",
-            side_effect=lambda value, **kwargs: {
-                "user-a": [str(uuid.UUID(int=1))],
-                "user-b": [str(uuid.UUID(int=2))],
-            }.get(value, []),
+            "tracer.services.clickhouse.v2.end_user_dict_reader.resolve_end_user_ids_by_user_ids",
+            side_effect=lambda values, **kwargs: {
+                value: {
+                    "user-a": [str(uuid.UUID(int=1))],
+                    "user-b": [str(uuid.UUID(int=2))],
+                }.get(value, [])
+                for value in values
+            },
         ) as resolve,
         mock.patch(
             "tracer.views.trace_session.EndUser.objects.filter",
@@ -180,15 +183,12 @@ def _session_handler_resolved_filters(filters, *, user_id=None, org_scope=False)
             validated_data=serializer.validated_data,
             org_project_ids=project_ids,
         )
-    for call in resolve.call_args_list:
-        assert call.kwargs["organization_id"] == request.organization.id
-        assert call.kwargs["project_id"] == (None if org_scope else project_id)
-        assert call.kwargs["timeout_ms"] > 0
-        assert call.kwargs["settings"] is not None
-    # Repeated leaves remain separate, but reuse the same tenant-scoped lookup.
-    assert len(resolve.call_args_list) == len(
-        {call.args[0] for call in resolve.call_args_list}
-    )
+    resolve.assert_called_once()
+    call = resolve.call_args
+    assert call.kwargs["organization_id"] == request.organization.id
+    assert call.kwargs["project_id"] == (None if org_scope else project_id)
+    assert call.kwargs["timeout_ms"] > 0
+    assert call.kwargs["settings"] is not None
     if display_rows.filter.called:
         display_rows.filter.assert_any_call(organization=request.organization)
         if org_scope:
@@ -373,8 +373,8 @@ def test_session_handler_native_user_checks_each_operator(unsupported_first):
     analytics = mock.MagicMock()
     with (
         mock.patch(
-            "tracer.services.clickhouse.v2.end_user_dict_reader.resolve_end_user_ids_by_user_id",
-            return_value=[],
+            "tracer.services.clickhouse.v2.end_user_dict_reader.resolve_end_user_ids_by_user_ids",
+            return_value={},
         ),
         mock.patch(
             "tracer.views.trace_session.SessionListQueryBuilderV2",

--- a/futureagi/tracer/tests/test_session_user_candidate_reads.py
+++ b/futureagi/tracer/tests/test_session_user_candidate_reads.py
@@ -442,9 +442,7 @@ def test_raw_new_session_seed_classifier_expands_group_and_keeps_all_filters():
     assert "latest_attr_exists_1 AND" in match_sql
     assert "countIf(latest_attr_exists_0 AND" in match_sql
     assert "countIf(latest_attr_exists_1 AND" in match_sql
-    assert (
-        "AND countIf(is_root) > 0" in match_sql
-    )
+    assert "AND countIf(is_root) > 0" in match_sql
     assert match_params["candidate_filter_session_id_array"] == [new_session_id]
     assert match_params["latest_filter_param_0"] == "rejected"
     assert match_params["latest_filter_param_1"] == "us"
@@ -1061,6 +1059,261 @@ def test_session_has_annotation_uses_only_candidate_session_trace_ids():
         "GROUP BY session_id"
     )
     assert params["candidate_filter_session_ids"] == (candidate_session_id,)
+
+
+@pytest.mark.unit
+def test_session_user_id_type_uses_finite_end_user_relation():
+    now = datetime(2026, 7, 31, 12, 0)
+    candidate_session_id = str(uuid.uuid4())
+    builder = SessionListQueryBuilderV2(
+        project_id=str(uuid.uuid4()),
+        filters=[
+            *_window(now),
+            {
+                "column_id": "user_id_type",
+                "filter_config": {
+                    "col_type": "SYSTEM_METRIC",
+                    "filter_type": "text",
+                    "filter_op": "in",
+                    "filter_value": ["email"],
+                },
+            },
+        ],
+        bounded_internal_scan=True,
+    )
+
+    sql, params = builder.build_filter_match_query([candidate_session_id])
+
+    assert builder.supports_bounded_filter_scan() is True
+    assert builder.bounded_filter_degraded_error_code() is None
+    assert "candidate_relational_trace_ids AS" in sql
+    assert "FROM end_users AS eu FINAL" in sql
+    assert "SELECT trace_id FROM candidate_relational_trace_ids" in sql
+    assert "%(session_relational_trace_ids)s" not in sql
+    assert params["session_relational_0_col_1"] == ("email",)
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    ("filter_op", "dimension_predicate", "includes_unassigned_users"),
+    [
+        ("is_null", "user_id_type IS NULL", True),
+        ("is_not_null", "user_id_type IS NOT NULL", False),
+    ],
+)
+def test_session_user_id_type_null_operators_use_end_user_dimension(
+    filter_op, dimension_predicate, includes_unassigned_users
+):
+    now = datetime(2026, 7, 31, 12, 0)
+    builder = SessionListQueryBuilderV2(
+        project_id=str(uuid.uuid4()),
+        filters=[
+            *_window(now),
+            {
+                "column_id": "user_id_type",
+                "filter_config": {
+                    "col_type": "SYSTEM_METRIC",
+                    "filter_type": "text",
+                    "filter_op": filter_op,
+                },
+            },
+        ],
+        bounded_internal_scan=True,
+    )
+
+    sql, _ = builder.build_filter_match_query([str(uuid.uuid4())])
+
+    assert builder.supports_bounded_filter_scan() is True
+    assert "FROM end_users AS eu FINAL" in sql
+    assert dimension_predicate in sql
+    nil_user_predicate = "end_user_id = toUUID('00000000-0000-0000-0000-000000000000')"
+    assert (nil_user_predicate in sql) is includes_unassigned_users
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "filter_op",
+    [
+        "equals",
+        "not_equals",
+        "in",
+        "not_in",
+        "contains",
+        "not_contains",
+        "starts_with",
+        "ends_with",
+        "is_null",
+        "is_not_null",
+    ],
+)
+def test_session_user_id_type_operator_matrix_uses_end_user_dimension(filter_op):
+    now = datetime(2026, 7, 31, 12, 0)
+    config = {
+        "col_type": "SYSTEM_METRIC",
+        "filter_type": "text",
+        "filter_op": filter_op,
+    }
+    if filter_op in {"in", "not_in"}:
+        config["filter_value"] = ["email", "phone"]
+    elif filter_op not in {"is_null", "is_not_null"}:
+        config["filter_value"] = "email"
+    builder = SessionListQueryBuilderV2(
+        project_id=str(uuid.uuid4()),
+        filters=[
+            *_window(now),
+            {
+                "column_id": "user_id_type",
+                "filter_config": config,
+            },
+        ],
+        bounded_internal_scan=True,
+    )
+
+    sql, _ = builder.build_filter_match_query([str(uuid.uuid4())])
+
+    assert builder.supports_bounded_filter_scan() is True
+    assert builder.bounded_filter_degraded_error_code() is None
+    assert "FROM end_users AS eu FINAL" in sql
+    assert "candidate_relational_trace_ids AS" in sql
+
+
+@pytest.mark.unit
+def test_session_filter_value_resolution_keeps_external_and_internal_matches(
+    monkeypatch,
+):
+    from tracer.services.clickhouse.v2 import trace_session_dict_reader as reader
+
+    project_id = str(uuid.uuid4())
+    external_id = "customer-session"
+    missing_id = "missing-session"
+    internal_id = str(uuid.uuid4())
+    survivor_id = str(uuid.uuid4())
+    client = mock.MagicMock()
+    client.query.return_value = SimpleNamespace(
+        result_rows=[(survivor_id, external_id)]
+    )
+    monkeypatch.setattr(reader, "_get_client", lambda: client)
+    monkeypatch.setattr(
+        reader,
+        "_resolve_existing_ids",
+        lambda values: {internal_id: survivor_id} if internal_id in values else {},
+    )
+
+    resolved = reader.resolve_session_filter_values(
+        [external_id, missing_id, internal_id],
+        project_ids=[project_id],
+    )
+
+    assert resolved == {
+        external_id: [survivor_id],
+        missing_id: [],
+        internal_id: [survivor_id],
+    }
+    params = client.query.call_args.kwargs["parameters"]
+    assert params["project_ids"] == (project_id,)
+    assert params["external_ids"] == (external_id, missing_id, internal_id)
+    assert params["target_ids"] == (survivor_id,)
+
+
+@pytest.mark.unit
+def test_uuid_shaped_session_value_is_checked_as_internal_and_external(monkeypatch):
+    from tracer.services.clickhouse.v2 import trace_session_dict_reader as reader
+
+    value = str(uuid.uuid4())
+    internal_survivor = str(uuid.uuid4())
+    external_survivor = str(uuid.uuid4())
+    project_id = str(uuid.uuid4())
+    client = mock.MagicMock()
+    client.query.return_value = SimpleNamespace(
+        result_rows=[
+            (internal_survivor, "different-external-id"),
+            (external_survivor, value),
+        ]
+    )
+    monkeypatch.setattr(reader, "_get_client", lambda: client)
+    monkeypatch.setattr(
+        reader,
+        "_resolve_existing_ids",
+        lambda values: {value: internal_survivor},
+    )
+
+    resolved = reader.resolve_session_filter_values(
+        [value],
+        project_ids=[project_id],
+    )
+
+    assert resolved == {value: [internal_survivor, external_survivor]}
+    params = client.query.call_args.kwargs["parameters"]
+    assert params["external_ids"] == (value,)
+    assert params["target_ids"] == (internal_survivor,)
+
+
+@pytest.mark.unit
+def test_multi_user_filter_resolution_uses_one_clickhouse_query(monkeypatch):
+    from tracer.services.clickhouse.v2 import end_user_dict_reader as reader
+
+    alice_id = str(uuid.uuid4())
+    bob_id = str(uuid.uuid4())
+    project_id = str(uuid.uuid4())
+    client = mock.MagicMock()
+    client.query.return_value = SimpleNamespace(
+        result_rows=[("alice", alice_id), ("bob", bob_id)]
+    )
+    monkeypatch.setattr(reader, "_get_client", lambda: client)
+
+    resolved = reader.resolve_end_user_ids_by_user_ids(
+        ["alice", "bob", "alice"],
+        project_id=project_id,
+    )
+
+    assert resolved == {"alice": [alice_id], "bob": [bob_id]}
+    client.query.assert_called_once()
+    params = client.query.call_args.kwargs["parameters"]
+    assert params["uids"] == ("alice", "bob")
+    assert params["pid"] == project_id
+
+
+@pytest.mark.unit
+def test_multi_user_filter_resolution_requires_tenant_scope():
+    from tracer.services.clickhouse.v2.end_user_dict_reader import (
+        resolve_end_user_ids_by_user_ids,
+    )
+
+    with pytest.raises(ValueError, match="unscoped reverse lookup"):
+        resolve_end_user_ids_by_user_ids(["alice"])
+
+
+@pytest.mark.unit
+def test_multi_user_filter_resolution_preserves_all_curated_ids(monkeypatch):
+    from tracer.services.clickhouse.v2 import end_user_dict_reader as reader
+
+    first_id = str(uuid.uuid4())
+    second_id = str(uuid.uuid4())
+    organization_id = str(uuid.uuid4())
+    client = mock.MagicMock()
+    client.query.return_value = SimpleNamespace(
+        result_rows=[
+            ("alice", first_id),
+            ("alice", first_id),
+            ("alice", second_id),
+            ("unrequested", str(uuid.uuid4())),
+        ]
+    )
+    monkeypatch.setattr(reader, "_get_client", lambda: client)
+
+    resolved = reader.resolve_end_user_ids_by_user_ids(
+        ["alice", "missing"],
+        organization_id=organization_id,
+    )
+
+    assert resolved == {
+        "alice": [first_id, second_id],
+        "missing": [],
+    }
+    params = client.query.call_args.kwargs["parameters"]
+    assert params["uids"] == ("alice", "missing")
+    assert params["oid"] == organization_id
+    assert "pid" not in params
 
 
 @pytest.mark.unit

--- a/futureagi/tracer/tests/test_trace_session.py
+++ b/futureagi/tracer/tests/test_trace_session.py
@@ -596,6 +596,11 @@ class TestTraceSessionGraphAPI:
                 "tracer.views.trace_session.fetch_session_graph_ch",
                 return_value=graph,
             ) as graph_read,
+            mock.patch(
+                "tracer.services.clickhouse.v2.trace_session_dict_reader."
+                "resolve_session_filter_values",
+                return_value={session_id: [session_id]},
+            ) as resolve_session,
             mock.patch.object(Trace, "objects") as pg_trace_manager,
         ):
             response = auth_client.post(
@@ -644,6 +649,7 @@ class TestTraceSessionGraphAPI:
         filters = graph_read.call_args.kwargs["filters"]
         assert filters[-1]["column_id"] == "session"
         assert filters[-1]["filter_config"]["filter_value"] == [session_id]
+        resolve_session.assert_called_once()
         pg_trace_manager.assert_not_called()
 
     def test_session_system_graph_dispatches_exact_snapshot(self):
@@ -2865,8 +2871,8 @@ class TestTraceSessionUserIdFilterValidation:
             ]
         )
         with mock.patch(
-            "tracer.views.trace_session._resolve_end_user_ids_for_user_id",
-            return_value=([], None),
+            "tracer.views.trace_session._resolve_end_user_ids_for_user_ids",
+            return_value=({"alice": []}, None),
         ):
             response = auth_client.get(
                 "/tracer/trace-session/list_sessions/",

--- a/futureagi/tracer/tests/test_users_filter_capabilities.py
+++ b/futureagi/tracer/tests/test_users_filter_capabilities.py
@@ -60,6 +60,25 @@ def test_registry_native_user_resolution_keeps_legacy_label_semantics():
     )
 
 
+def test_native_user_resolution_accepts_session_user_alias():
+    from tracer.services.user_filter_capabilities import is_native_user_id_filter
+
+    assert is_native_user_id_filter(
+        {
+            "column_id": "user",
+            "property_id": "system_attribute:traces:user",
+            "filter_config": {"col_type": "SYSTEM_METRIC"},
+        }
+    )
+    assert not is_native_user_id_filter(
+        {
+            "column_id": "user",
+            "property_id": "custom_attribute:user",
+            "filter_config": {"col_type": "SPAN_ATTRIBUTE"},
+        }
+    )
+
+
 UNSUPPORTED = (
     "dataset",
     "eval_source",

--- a/futureagi/tracer/views/trace_session.py
+++ b/futureagi/tracer/views/trace_session.py
@@ -1,5 +1,6 @@
 import json
 from collections import defaultdict
+from collections.abc import Callable
 from concurrent.futures import ThreadPoolExecutor
 from concurrent.futures import TimeoutError as FuturesTimeoutError
 from contextlib import contextmanager
@@ -118,6 +119,9 @@ from tracer.services.clickhouse.query_builders.eval_status import (
 )
 from tracer.services.clickhouse.query_builders.latest_filter_predicates import (
     UnsupportedFilterShapeError,
+)
+from tracer.services.clickhouse.query_builders.session_filters import (
+    SESSION_ID_FILTER_COLS,
 )
 from tracer.services.clickhouse.read_budget import (
     ReadDeadline,
@@ -680,40 +684,30 @@ def _resolve_ch_session_fields(request, trace_session_id):
     return session_fields
 
 
-def _resolve_end_user_ids_for_user_id(
-    user_id,
+def _resolve_end_user_ids_for_user_ids(
+    user_ids,
     *,
     org,
     org_scope,
     project_id,
+    display_user_id=None,
     deadline: ReadDeadline | None = None,
 ):
-    """Resolve a string ``user_id`` to the set of CH ``end_user`` UUIDs.
-
-    The CH ``spans`` table keys users by the UUID ``end_user_id``, not the
-    string ``user_id``, so a string filter must be reverse-resolved. Prefers
-    the curated CH ``end_users`` dimension (state-robust across the P3b id
-    cutover). ClickHouse is authoritative; an empty CH result stays empty and a
-    CH failure propagates instead of consulting the stale PostgreSQL mirror.
-
-    Returns ``(ids, display_row)`` where ``display_row`` is the first matched
-    PG row's display fields (``user_id``/``user_id_type``/``user_id_hash``) or
-    ``None`` — used to label the single-user (cross-project) detail page.
-    """
+    """Batch-resolve user labels and optionally load one display record."""
     from tracer.services.clickhouse.v2.end_user_dict_reader import (
-        resolve_end_user_ids_by_user_id,
+        resolve_end_user_ids_by_user_ids,
     )
 
-    timeout_ms = (
-        deadline.remaining_ms(SESSION_LIST_ENRICHMENT_TIMEOUT_MS)
-        if deadline is not None
-        else None
-    )
-    ids = resolve_end_user_ids_by_user_id(
-        user_id,
+    values = tuple(dict.fromkeys(str(value) for value in user_ids if value))
+    resolved = resolve_end_user_ids_by_user_ids(
+        values,
         organization_id=org.id if org else None,
         project_id=(project_id if (not org_scope and project_id) else None),
-        timeout_ms=timeout_ms,
+        timeout_ms=(
+            deadline.remaining_ms(SESSION_LIST_ENRICHMENT_TIMEOUT_MS)
+            if deadline is not None
+            else None
+        ),
         settings=(
             _session_read_settings(max_result_rows=10_000)
             if deadline is not None
@@ -722,11 +716,8 @@ def _resolve_end_user_ids_for_user_id(
     )
 
     display_row = None
-    if ids:
-        # This finite metadata read labels the single-user detail view only; it
-        # never decides ClickHouse membership. Missing/stale PG metadata simply
-        # leaves the CH-derived row labels to page enrichment below.
-        end_user_qs = EndUser.objects.filter(user_id=user_id)
+    if display_user_id and resolved.get(str(display_user_id)):
+        end_user_qs = EndUser.objects.filter(user_id=display_user_id)
         if org:
             end_user_qs = end_user_qs.filter(organization=org)
         if not org_scope and project_id:
@@ -734,7 +725,66 @@ def _resolve_end_user_ids_for_user_id(
         display_row = end_user_qs.values(
             "id", "user_id", "user_id_type", "user_id_hash"
         ).first()
-    return ids, display_row
+    return resolved, display_row
+
+
+def _resolve_session_identity_filters(
+    filters,
+    *,
+    project_ids,
+    deadline: ReadDeadline | None = None,
+    deadline_factory: Callable[[], ReadDeadline] | None = None,
+):
+    """Resolve public session labels/IDs to scoped survivor UUID filters."""
+    raw_values = []
+    for item in filters:
+        column_id, config = FilterEngine._normalize_filter_params(item)
+        if column_id not in SESSION_ID_FILTER_COLS:
+            continue
+        filter_op = config.get("filter_op")
+        if filter_op in {"is_null", "is_not_null"}:
+            continue
+        value = config.get("filter_value")
+        values = value if isinstance(value, list) else [value]
+        raw_values.extend(entry for entry in values if entry not in (None, ""))
+
+    if not raw_values:
+        return list(filters)
+
+    if deadline is None and deadline_factory is not None:
+        deadline = deadline_factory()
+
+    from tracer.services.clickhouse.v2.trace_session_dict_reader import (
+        resolve_session_filter_values,
+    )
+
+    resolved = resolve_session_filter_values(
+        raw_values,
+        project_ids=project_ids,
+        deadline=deadline,
+        settings=_session_read_settings(max_result_rows=10_000),
+    )
+    output = []
+    for item in filters:
+        column_id, config = FilterEngine._normalize_filter_params(item)
+        if column_id not in SESSION_ID_FILTER_COLS or config.get("filter_op") in {
+            "is_null",
+            "is_not_null",
+        }:
+            output.append(item)
+            continue
+
+        raw_value = config.get("filter_value")
+        values = raw_value if isinstance(raw_value, list) else [raw_value]
+        resolved_ids = []
+        for value in values:
+            resolved_ids.extend(resolved.get(str(value), []))
+        normalized_item = dict(item)
+        normalized_config = dict(config)
+        normalized_config["filter_value"] = list(dict.fromkeys(resolved_ids))
+        normalized_item["filter_config"] = normalized_config
+        output.append(normalized_item)
+    return output
 
 
 def _soft_delete_trace_session_tree(trace_sessions):
@@ -1086,6 +1136,14 @@ class TraceSessionView(BaseModelViewSetMixin, ModelViewSet):
         page_size = query_data["page_size"]
         page_start = page_number * page_size
         read_deadline = ReadDeadline.start(SESSION_LIST_WALL_DEADLINE_MS)
+        query_data = {
+            **query_data,
+            "filters": _resolve_session_identity_filters(
+                query_data.get("filters", []),
+                project_ids=[project_id],
+                deadline=read_deadline,
+            ),
+        }
 
         # P3b step1.5: resolve the session's canonical ID and expand it to
         # all group member IDs (old + new). Use IN (...) instead of the heavy
@@ -1658,9 +1716,16 @@ class TraceSessionView(BaseModelViewSetMixin, ModelViewSet):
                         )
                     )
 
+            filters = _resolve_session_identity_filters(
+                body["filters"],
+                project_ids=[project_id],
+                deadline_factory=lambda: ReadDeadline.start(
+                    graph_action_remaining_ms(deadline)
+                ),
+            )
             filters = bind_request_my_annotations_principal(
                 request,
-                body["filters"],
+                filters,
             )
             filters = graph_execution_filters(filters)
             try:
@@ -2808,7 +2873,11 @@ class TraceSessionView(BaseModelViewSetMixin, ModelViewSet):
         # (request is a param here; the helper is pure getattr, no query). Needed
         # by the user_id → end_user_id resolution below.
         org = _get_request_organization(request)
-        filters = list(validated_data.get("filters", []) or [])
+        filters = _resolve_session_identity_filters(
+            validated_data.get("filters", []) or [],
+            project_ids=(org_project_ids or [project_id]),
+            deadline=read_deadline,
+        )
         attested_filters = list(filters)
         sort_params = validated_data.get("sort_params", [])
         page_number = validated_data.get("page_number", 0)
@@ -2833,13 +2902,13 @@ class TraceSessionView(BaseModelViewSetMixin, ModelViewSet):
         if user_id_qp:
             user_filters.insert(0, {"filter_op": "in", "filter_value": str(user_id_qp)})
 
-        # The existing tenant-scoped resolver yields curated IDs; the builder
-        # binds each synthetic leaf to its id-remap-resolved end_user_id column.
+        # Resolve all user labels in one tenant-scoped lookup, then preserve
+        # each original leaf as an independent synthetic end_user_id filter.
         _NULL_USER_OPS = {"is_null", "is_not_null"}
         _NEGATED_USER_OPS = {"not_in", "not_equals"}
         _SUPPORTED_USER_OPS = _NULL_USER_OPS | _NEGATED_USER_OPS | {"in", "equals"}
-        resolved_users = {}
-        end_user_display = None
+        prepared_user_filters = []
+        all_user_values = []
         for _cfg in user_filters:
             user_id_op = _cfg.get("filter_op") or "in"
             if user_id_op not in _SUPPORTED_USER_OPS:
@@ -2847,41 +2916,43 @@ class TraceSessionView(BaseModelViewSetMixin, ModelViewSet):
                     f"Unsupported operator '{user_id_op}' for user_id filter. "
                     f"Supported: {sorted(_SUPPORTED_USER_OPS)}"
                 )
+            values = []
+            if user_id_op not in _NULL_USER_OPS:
+                raw_values = _cfg.get("filter_value")
+                if not isinstance(raw_values, list):
+                    raw_values = [raw_values]
+                values = [str(value) for value in raw_values if value not in (None, "")]
+                if not values:
+                    continue
+                all_user_values.extend(values)
+            prepared_user_filters.append((user_id_op, values))
+
+        resolved_by_user, end_user_display = ({}, None)
+        if all_user_values:
+            resolved_by_user, end_user_display = _resolve_end_user_ids_for_user_ids(
+                all_user_values,
+                org=org,
+                org_scope=org_scope,
+                project_id=project_id,
+                display_user_id=user_id_qp,
+                deadline=read_deadline,
+            )
+
+        for user_id_op, user_id_values in prepared_user_filters:
             resolved_config = {
                 "col_type": "SYSTEM_METRIC",
                 "filter_type": "text",
                 "filter_op": user_id_op,
             }
             if user_id_op not in _NULL_USER_OPS:
-                _values = _cfg.get("filter_value")
-                if not isinstance(_values, list):
-                    _values = [_values]
-                _values = [str(v) for v in _values if v not in (None, "")]
-                if not _values:
-                    continue
                 _ids: list[str] = []
-                for _uv in dict.fromkeys(_values):
-                    if _uv not in resolved_users:
-                        resolved_users[_uv] = _resolve_end_user_ids_for_user_id(
-                            _uv,
-                            org=org,
-                            org_scope=org_scope,
-                            project_id=project_id,
-                            deadline=read_deadline,
-                        )
-                    _resolved, _display = resolved_users[_uv]
-                    _ids.extend(_resolved)
-                    # Only the query-param user labels the displayed rows.
-                    if (
-                        _display is not None
-                        and end_user_display is None
-                        and user_id_qp is not None
-                        and _uv == str(user_id_qp)
-                    ):
-                        end_user_display = _display
+                for _uv in dict.fromkeys(user_id_values):
+                    _ids.extend(resolved_by_user.get(_uv, []))
+                _ids = list(dict.fromkeys(_ids))
                 _out_op = "not_in" if user_id_op in _NEGATED_USER_OPS else "in"
-                # Unknown positive sets match nothing; unknown negative sets
-                # add no restriction, without discarding any other AND leaf.
+                # An unresolved value-set means "no such user". For inclusive
+                # ops that is an empty result (NIL sentinel matches nothing);
+                # for negated ops it is a no-op (everything matches).
                 if not _ids:
                     if _out_op == "not_in":
                         continue


### PR DESCRIPTION
## Summary

Session-list filters now resolve readable session and user identifiers to their project- or organization-scoped UUIDs before ClickHouse query compilation. Unknown values are removed safely, preventing malformed UUID predicates and HTTP 400 responses while preserving inclusive, negated, null, and combined-filter behavior.

Fixed TH-6063
Closes TH-6063

## Type of change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## E2E coverage

E2E: exempt (backend-internal)

---

## 1) What changes were done

**A. Session identity resolution**

- Resolves external SDK session IDs and internal session UUIDs within the authorized project scope.
- Supports `session`, `session_id`, and `trace_session_id` aliases consistently.
- Drops unsupported partial-text session identity filters without rejecting the request.

**B. User identity resolution**

- Resolves readable `user` and `user_id` values in one scoped batch lookup.
- Handles `user_id_type` through the bounded end-user dimension, including null semantics.

**C. Safe empty-set behavior**

- Unknown inclusive values produce no matches.
- Unknown negated values produce no additional restriction.
- Combined identity filters retain independent AND semantics.

## 2) Why the changes were done

- **Product/UX:** Invalid or unknown readable filter values no longer cause the sessions page to fail with HTTP 400.
- **Technical:** ClickHouse UUID predicates now receive canonical UUIDs only, after tenant-scoped resolution.
- **Architecture:** Resolution stays at the view boundary; query builders retain an internal UUID membership contract.

## 3) Tests written + scenarios each covers

- Serializer contract and native filter matrices cover aliases, operators, nulls, and all session API surfaces.
- Session-list view matrices cover session, user, and user-type filters independently and in combinations.
- Dictionary-reader tests cover scoped batch resolution, unknown values, UUID-shaped external IDs, deduplication, and tenant isolation.
- Existing list, graph, navigation, analytics, and bounded-query tests were updated to the batch resolver contract.

```text
Changed tracer tests: 1,052 passed, 12 skipped, 17 deselected
Focused list/navigation/graph tests: 184 passed, 9 skipped, 17 deselected
Full tracer suite comparison: 0 introduced failures or errors; all 196 added tests passed
```

## 4) How to run / test

```bash
cd futureagi
bin/test tracer
```

## 5) Screenshots / recordings

Not applicable; this is a backend-only change with no visual UI changes.

## 6) Edge cases & considerations

- UUID-shaped external session IDs are checked as both public and internal identifiers.
- Unknown values cannot reach ClickHouse UUID predicates.
- Null filters bypass value lookup.
- Resolution is constrained to authorized project or organization scope.
- Child graph deadlines are created lazily so requests without identity resolution retain their existing deadline budget.

## 7) Pre-existing issues (NOT introduced by this PR)

The full tracer suite has the same 75 failures and 9 errors on both `origin/dev` and this branch. JUnit comparison found zero newly failing or erroring test node IDs.

Contract verification reached schema generation under Python 3.11 but could not replace the checked-in schema because the local environment lacks the licensed routes. No generated contracts changed.

## 8) Architectural / important decisions

- Resolve public identities once at the authorized API boundary instead of adding external-ID behavior to every downstream UUID query builder.
- Preserve logical filter semantics by removing unknown values from leaves rather than dropping valid inclusive leaves or rejecting the complete request.

## Checklist

- [x] Code follows the style guide
- [x] Behavioral tests prove the fix
- [x] Full backend suite was compared with the base branch
- [x] No frontend changes are required
- [x] No hardcoded secrets, URLs, or PII
- [x] PR title follows Conventional Commits
