### PR TITLE
feat(simulate): bring the Retell dev-branch follow-ups to the hosted-bundle branch

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -87,6 +87,54 @@ SYSTEM_VOICE_PROVIDER=
 VAPI_API_KEY=
 VAPI_API_BASE_URL=
 VAPI_PHONE_NUMBER_ID=
+
+# ---- Hosted voice simulation runner (worker-simulation-runner) ----
+# The runner reads these from its own process environment and refuses a run
+# per missing name. Verify the runner's EFFECTIVE environment before rollout,
+# without helm or docker (a shared .env is not it: other services may carry
+# keys the runner must not see):
+#   docker exec <runner-container> env > runner.env
+#   scripts/verify-simulation-runner-deployment.sh --env-only \
+#     --runner-env-file runner.env --voice-transports sip_outbound
+# Always, for any hosted voice run:
+#   LIVEKIT_URL / LIVEKIT_API_KEY / LIVEKIT_API_SECRET — the LiveKit project the
+#     simulator joins; must be the same project that owns the trunk below.
+#   INTERNAL_API_SECRET — fleet-wide bearer the SDK child uses to report results
+#     back to the backend (see simulate/authentication.py).
+#   ALK_RUNNER_API_URL — backend URL the child reports to (Compose and the
+#     chart set it; only a hand-built environment needs it here). The check
+#     also accepts FI_BASE_URL in its place.
+# sip_outbound (the platform dials the customer's agent):
+#   LIVEKIT_OUTBOUND_TRUNK_ID — LiveKit SIP trunk the simulator dials out on.
+#   PSTN_CALLER_NUMBER — E.164 number provisioned on that trunk; the call's
+#     caller id.
+# sip_inbound_retell (the customer's Retell agent dials our leased number):
+#   ALK_SIM_SLOT_LEASE_SCRIPT — path, inside the runner, to the LiveKit infra
+#     repo's lease_sim_slot.py that leases a pool number + room per run.
+#   SIM_SLOT_LEASE_STORE — where that script records active leases. Its own
+#     default is a per-container path, so replicas would not see each other's
+#     leases; point every runner at one shared location.
+# Optional — leave unset for the default; an assigned-but-empty value is
+# refused by the check because the worker fails at import on it:
+#   HOSTED_RUNNER_PARENT_SLACK_SECONDS — seconds the workflow timeout and the
+#     number lease exceed the child's own run budget (unset = 600).
+#   HOSTED_RUNNER_LEASED_ROOM_REUSE — false/0/no rolls back to one room per
+#     row (unset = true).
+# Never on the runner: FI_API_KEY / FI_SECRET_KEY. The SDK submitter prefers
+#   the org key pair over the internal bearer, and ingestion then authenticates
+#   the wrong org. HOSTED_RUNNER_MAX_DURATION_SECONDS is retired: no code reads it.
+LIVEKIT_URL=
+LIVEKIT_API_KEY=
+LIVEKIT_API_SECRET=
+INTERNAL_API_SECRET=
+LIVEKIT_OUTBOUND_TRUNK_ID=
+PSTN_CALLER_NUMBER=
+# Set the next two together, only for the Retell-originator path: an empty
+# SIM_SLOT_LEASE_STORE with the script set resolves to the working directory.
+# ALK_SIM_SLOT_LEASE_SCRIPT=
+# SIM_SLOT_LEASE_STORE=
+# HOSTED_RUNNER_PARENT_SLACK_SECONDS=600
+# HOSTED_RUNNER_LEASED_ROOM_REUSE=true
 MAILGUN_API_KEY=
 MAILGUN_SENDER_DOMAIN=
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -373,6 +373,11 @@ services:
       ALK_SIM_SLOT_LEASE_SCRIPT: ${ALK_SIM_SLOT_LEASE_SCRIPT:-}
       TEMPORAL_MAX_CONCURRENT_ACTIVITIES: ${ALK_RUNNER_MAX_CONCURRENCY:-4}
       TEMPORAL_MAX_CONCURRENT_WORKFLOW_TASKS: ${TEMPORAL_SIMRUNNER_MAX_WORKFLOWS:-8}
+      # A stop must let a phone call in flight finish: the worker drains for
+      # this long, and stop_grace_period below must exceed it, or Docker
+      # force-kills the child mid-call and the leased number stays taken until
+      # its TTL. Raise both together for long phone runs (the prod chart: 4200).
+      TEMPORAL_GRACEFUL_SHUTDOWN_TIMEOUT: ${SIMULATION_RUNNER_GRACEFUL_SHUTDOWN_TIMEOUT:-300}
       # Absolute so the SDK child (runs from a mkdtemp cwd) resolves the key.
       GOOGLE_APPLICATION_CREDENTIALS: /app/backend/Vertex_AI_Creds.json
       # gemini-3.1 is 404 in regional endpoints; only served on `global`.
@@ -385,6 +390,7 @@ services:
       # (_voice_simulator_config): English -> Deepgram aura-2-andromeda-en,
       # other/unknown -> streaming Gemini (multilingual). Set
       # SIMULATOR_TTS_PROVIDER / SIMULATOR_TTS_MODEL here to force one engine.
+    stop_grace_period: ${SIMULATION_RUNNER_STOP_GRACE_PERIOD:-330s}
     volumes:
       # Runner image lacks the key (only the backend image has it); mount it.
       - ${GOOGLE_APPLICATION_CREDENTIALS:-/dev/null}:/app/backend/Vertex_AI_Creds.json:ro

--- a/futureagi/simulate/tests/test_alk_simulate_ingestion.py
+++ b/futureagi/simulate/tests/test_alk_simulate_ingestion.py
@@ -1007,6 +1007,77 @@ class TestResultIngest:
         assert cmd.get("total_tokens") == 1500
         assert cmd.get("input_tokens") is None
 
+    def test_retell_result_resolves_speaker_roles_through_the_retell_maps(
+        self, auth_client, run_test
+    ):
+        """A hosted Retell result stores provider_call_data['retell']; the transcript
+        the UI renders must resolve through the Retell maps, not fall back to VAPI
+        with an unknown-provider error. Direction defaults to outbound."""
+        from simulate.serializers.test_execution import (
+            CallExecutionDetailSerializer,
+        )
+        from simulate.utils.speaker_roles import SpeakerRoleResolver
+        from tracer.models.observability_provider import ProviderChoices
+
+        _, call_ids = _start_and_batch(auth_client, run_test)
+        call_id = call_ids[0]
+        resp = auth_client.patch(
+            f"{ALK_BASE}/call-executions/{call_id}/result/",
+            {
+                "status": "completed",
+                "transcript": _transcript_payload(),
+                "provider_call_data": {"retell": {"call_id": "call_abc"}},
+            },
+            format="json",
+        )
+        assert resp.status_code == 200, resp.content
+        call = CallExecution.objects.get(id=call_id)
+        assert (
+            SpeakerRoleResolver.detect_provider(call.provider_call_data)
+            == ProviderChoices.RETELL
+        )
+        with patch("simulate.utils.speaker_roles.logger") as resolver_log:
+            rows = CallExecutionDetailSerializer(
+                context={"detail_mode": True}
+            ).get_transcript(call)
+        resolver_log.error.assert_not_called()
+        # Outbound: the tested agent speaks as "assistant", the simulator as "user".
+        assert [row["speaker_role"] for row in rows] == ["user", "assistant", "user"]
+
+    def test_retell_inbound_result_swaps_speaker_roles(self, auth_client, run_test):
+        """Same hosted Retell result, inbound direction: the simulator placed the
+        call, so the raw 'assistant' turns are the simulator and 'user' turns are
+        the tested agent. The Retell inbound map must do the swap."""
+        from simulate.serializers.test_execution import (
+            CallExecutionDetailSerializer,
+        )
+
+        _, call_ids = _start_and_batch(auth_client, run_test)
+        call_id = call_ids[0]
+        resp = auth_client.patch(
+            f"{ALK_BASE}/call-executions/{call_id}/result/",
+            {
+                "status": "completed",
+                "transcript": _transcript_payload(),
+                "provider_call_data": {"retell": {"call_id": "call_abc"}},
+            },
+            format="json",
+        )
+        assert resp.status_code == 200, resp.content
+        call = CallExecution.objects.get(id=call_id)
+        call.call_metadata = {**(call.call_metadata or {}), "call_direction": "inbound"}
+        call.save(update_fields=["call_metadata"])
+        with patch("simulate.utils.speaker_roles.logger") as resolver_log:
+            rows = CallExecutionDetailSerializer(
+                context={"detail_mode": True}
+            ).get_transcript(call)
+        resolver_log.error.assert_not_called()
+        assert [row["speaker_role"] for row in rows] == [
+            "assistant",
+            "user",
+            "assistant",
+        ]
+
     def test_reingest_preserves_csat(self, auth_client, run_test):
         _, call_ids = _start_and_batch(auth_client, run_test)
         call_id = call_ids[0]

--- a/scripts/verify-simulation-runner-deployment.sh
+++ b/scripts/verify-simulation-runner-deployment.sh
@@ -513,6 +513,24 @@ runner_value() {
     ' "$values_file"
 }
 
+# Compose renders durations as 5m30s / 1h10m / 45s; the stop grace must be
+# compared in seconds against the worker's drain timeout.
+compose_duration_seconds() {
+    local text=$1 total=0 num unit
+    while [[ "$text" =~ ^([0-9]+)([hms]) ]]; do
+        num=${BASH_REMATCH[1]}
+        unit=${BASH_REMATCH[2]}
+        case "$unit" in
+            h) total=$((total + num * 3600)) ;;
+            m) total=$((total + num * 60)) ;;
+            s) total=$((total + num)) ;;
+        esac
+        text=${text#"${BASH_REMATCH[0]}"}
+    done
+    [[ -z "$text" ]] || return 1
+    printf '%s' "$total"
+}
+
 assert_integer_at_least() {
     local value=$1
     local minimum=$2
@@ -572,6 +590,17 @@ compose_workflow_concurrency=$(compose_field_value TEMPORAL_MAX_CONCURRENT_WORKF
 [[ "$compose_child_concurrency" == "$compose_activity_concurrency" ]] || \
     die "Compose runner concurrency caps differ"
 [[ "$compose_workflow_concurrency" == 8 ]] || die "Compose runner workflow-task concurrency default is not 8"
+# A stop that lands during a phone call must outlast the worker's drain, or
+# Docker force-kills the child mid-call and the leased number stays taken.
+compose_drain_seconds=$(compose_field_value TEMPORAL_GRACEFUL_SHUTDOWN_TIMEOUT "$compose_runner_render")
+compose_stop_grace=$(compose_field_value stop_grace_period "$compose_runner_render")
+[[ "$compose_drain_seconds" =~ ^[0-9]+$ ]] || \
+    die "Compose runner does not set an integer TEMPORAL_GRACEFUL_SHUTDOWN_TIMEOUT"
+[[ -n "$compose_stop_grace" ]] || die "Compose runner does not set stop_grace_period"
+compose_stop_grace_seconds=$(compose_duration_seconds "$compose_stop_grace") || \
+    die "Compose runner stop_grace_period is not a duration: $compose_stop_grace"
+((compose_stop_grace_seconds > compose_drain_seconds)) || \
+    die "Compose runner stop_grace_period must exceed TEMPORAL_GRACEFUL_SHUTDOWN_TIMEOUT"
 if [[ "$explicit_compose_set" == true ]]; then
     echo "Compose configuration (caller-specified set): OK"
 else

--- a/scripts/verify-simulation-runner-deployment.sh
+++ b/scripts/verify-simulation-runner-deployment.sh
@@ -16,9 +16,36 @@ Options:
   --release NAME           Helm release name used for rendering
   --namespace NAME         Helm namespace used for rendering
   --runner-tag TAG         Override the runner image tag for rendering (latest is rejected)
+  --runner-env-file PATH   KEY=VALUE file holding the runner worker's EFFECTIVE
+                           environment, e.g. `docker exec <runner> env > file` or
+                           the rendered Secret. Not a shared .env: other services
+                           may legitimately carry keys the runner must not see.
+                           Repeat for layered files; later files win. Names are
+                           checked, values are never printed.
+  --voice-transports LIST  Comma-separated hosted voice transports the deployment
+                           must serve: sip_outbound (we dial the agent),
+                           sip_inbound_retell (the Retell agent dials our leased
+                           number). Adds that transport's required settings.
+  --env-only               Run only the runner environment contract check; skips
+                           the Compose and Helm renders (no docker/helm needed).
   -h, --help               Show this help
 
 Environment overrides use the SIMULATION_RUNNER_* prefix with the same names.
+
+Runner environment contract (what the hosted voice runner refuses without).
+Every problem is reported together; a value of only whitespace counts as missing.
+  always            LIVEKIT_URL LIVEKIT_API_KEY LIVEKIT_API_SECRET INTERNAL_API_SECRET
+                    and ALK_RUNNER_API_URL (or FI_BASE_URL) for result ingestion
+  sip_outbound      LIVEKIT_OUTBOUND_TRUNK_ID PSTN_CALLER_NUMBER (E.164)
+  sip_inbound_retell ALK_SIM_SLOT_LEASE_SCRIPT SIM_SLOT_LEASE_STORE
+  must be unset     FI_API_KEY FI_SECRET_KEY (the SDK submitter prefers them over
+                    the internal bearer and ingestion then authenticates the wrong
+                    org), HOSTED_RUNNER_MAX_DURATION_SECONDS (retired)
+  optional          HOSTED_RUNNER_PARENT_SLACK_SECONDS (integer, default 600),
+                    HOSTED_RUNNER_LEASED_ROOM_REUSE (default true). Assigned-but-
+                    empty is refused: int("") kills the worker at import.
+  glued lines       a value containing one of these names followed by "=" is two
+                    assignments joined by an append with no trailing newline.
 USAGE
 }
 
@@ -39,6 +66,12 @@ fi
 helm_release=${SIMULATION_RUNNER_HELM_RELEASE:-simulation-runner-preflight}
 helm_namespace=${SIMULATION_RUNNER_HELM_NAMESPACE:-default}
 runner_tag=${SIMULATION_RUNNER_IMAGE_TAG:-preflight-only}
+runner_env_files=()
+if [[ -n "${SIMULATION_RUNNER_RUNNER_ENV_FILE:-}" ]]; then
+    runner_env_files=("$SIMULATION_RUNNER_RUNNER_ENV_FILE")
+fi
+voice_transports=${SIMULATION_RUNNER_VOICE_TRANSPORTS:-}
+env_only=false
 
 while (($#)); do
     case "$1" in
@@ -75,6 +108,21 @@ while (($#)); do
             runner_tag=$2
             shift 2
             ;;
+        --runner-env-file)
+            (($# >= 2)) || die "--runner-env-file requires a path"
+            [[ -n "$2" ]] || die "--runner-env-file requires a non-empty path"
+            runner_env_files+=("$2")
+            shift 2
+            ;;
+        --voice-transports)
+            (($# >= 2)) || die "--voice-transports requires a list"
+            voice_transports=$2
+            shift 2
+            ;;
+        --env-only)
+            env_only=true
+            shift
+            ;;
         -h|--help)
             usage
             exit 0
@@ -98,10 +146,221 @@ if ((${#compose_files[@]} == 0)); then
 fi
 
 [[ -d "$repo_root" ]] || die "repository root does not exist: $repo_root"
-[[ -d "$deployment_root" ]] || die "deployment root does not exist: $deployment_root"
-for compose_file in "${compose_files[@]}"; do
-    [[ -f "$compose_file" ]] || die "Compose file does not exist: $compose_file"
-done
+if ((${#runner_env_files[@]} == 0)); then
+    [[ "$env_only" != true ]] || die "--env-only requires at least one --runner-env-file"
+    [[ -z "$voice_transports" ]] || \
+        die "--voice-transports names a contract to check but no --runner-env-file" \
+            "was given"
+fi
+if [[ "$env_only" != true ]]; then
+    [[ -d "$deployment_root" ]] || die "deployment root does not exist: $deployment_root"
+    for compose_file in "${compose_files[@]}"; do
+        [[ -f "$compose_file" ]] || die "Compose file does not exist: $compose_file"
+    done
+fi
+
+# ---- Runner environment contract -------------------------------------------
+# The hosted voice runner reads these from its process environment and refuses
+# one run per missing name. Check them here, once, before anything is rolled
+# out, and report every problem together. Only names are ever printed; values
+# stay in this process. Plain file scans, no bash-4 features: this must run
+# from a stock macOS bash 3.2 too.
+
+contract_failures=()
+
+contract_fail() {
+    contract_failures+=("$*")
+}
+
+runner_env_file_exists() {
+    local file
+    for file in "${runner_env_files[@]}"; do
+        [[ -f "$file" ]] || die "runner env file does not exist: $file"
+    done
+}
+
+strip_ws() {
+    local value=$1
+    value=${value#"${value%%[![:space:]]*}"}
+    value=${value%"${value##*[![:space:]]}"}
+    printf '%s' "$value"
+}
+
+# Last assignment across the files wins, matching dotenv/Compose semantics.
+# Whitespace around the value and then surrounding quotes are dropped the way
+# the builder's strip does, so a value of spaces counts as missing here as it
+# does there. The raw form is the value verbatim: the input is the runner's
+# effective environment, which the builder hands to the kit untouched, and the
+# kit's E.164 rule must hold on exactly that.
+runner_env_value() {
+    local name=$1
+    local raw=${2:-}
+    local file line value found=""
+    for file in "${runner_env_files[@]}"; do
+        while IFS= read -r line || [[ -n "$line" ]]; do
+            line=${line%$'\r'}
+            [[ "$line" == "$name="* ]] || continue
+            value=${line#*=}
+            if [[ -z "$raw" ]]; then
+                value=$(strip_ws "$value")
+                if [[ "$value" =~ ^\"(.*)\"$ || "$value" =~ ^\'(.*)\'$ ]]; then
+                    value=$(strip_ws "${BASH_REMATCH[1]}")
+                fi
+            fi
+            found=$value
+        done <"$file"
+    done
+    printf '%s' "$found"
+}
+
+runner_env_set() {
+    [[ -n "$(runner_env_value "$1")" ]]
+}
+
+# True when any file carries a NAME= line, even an empty one. An optional
+# setting that is assigned but empty is not "absent": int("") kills the worker
+# at import and an empty boolean silently reads as false.
+runner_env_assigned() {
+    local name=$1
+    local file
+    for file in "${runner_env_files[@]}"; do
+        grep -q "^$name=" "$file" && return 0
+    done
+    return 1
+}
+
+# A value that contains one of this contract's exact names followed by "=" is
+# two lines glued together by an append onto a file with no trailing newline;
+# both settings are then wrong and the failure surfaces one run later. Exact
+# names only: a prefix pattern would refuse a URL query like ?LIVEKIT_URL_HINT=.
+contract_names='LIVEKIT_URL|LIVEKIT_API_KEY|LIVEKIT_API_SECRET|LIVEKIT_OUTBOUND_TRUNK_ID'
+contract_names+='|INTERNAL_API_SECRET|ALK_RUNNER_API_URL|FI_BASE_URL|PSTN_CALLER_NUMBER'
+contract_names+='|ALK_SIM_SLOT_LEASE_SCRIPT|SIM_SLOT_LEASE_STORE'
+contract_names+='|HOSTED_RUNNER_PARENT_SLACK_SECONDS|HOSTED_RUNNER_LEASED_ROOM_REUSE'
+contract_names+='|HOSTED_RUNNER_MAX_DURATION_SECONDS|FI_API_KEY|FI_SECRET_KEY'
+glued_pattern="($contract_names)="
+
+check_runner_env_not_glued() {
+    local file line value lineno
+    for file in "${runner_env_files[@]}"; do
+        lineno=0
+        while IFS= read -r line || [[ -n "$line" ]]; do
+            lineno=$((lineno + 1))
+            line=${line%$'\r'}
+            [[ "$line" =~ ^[A-Za-z_][A-Za-z0-9_]*= ]] || continue
+            value=${line#*=}
+            if [[ "$value" =~ $glued_pattern ]]; then
+                contract_fail "$file line $lineno looks like two assignments glued on one line" \
+                    "(missing newline before the next KEY=)"
+            fi
+        done <"$file"
+    done
+}
+
+check_runner_env_present() {
+    local scope=$1
+    shift
+    local missing=()
+    local name
+    for name in "$@"; do
+        runner_env_set "$name" || missing+=("$name")
+    done
+    ((${#missing[@]} == 0)) || \
+        contract_fail "missing for $scope: ${missing[*]}"
+}
+
+check_runner_env_absent() {
+    local reason=$1
+    shift
+    local present=()
+    local name
+    for name in "$@"; do
+        runner_env_set "$name" && present+=("$name")
+    done
+    ((${#present[@]} == 0)) || \
+        contract_fail "must be unset: ${present[*]} ($reason)"
+}
+
+verify_runner_env() {
+    local transport value
+    runner_env_file_exists
+    check_runner_env_not_glued
+    check_runner_env_present "hosted voice runs" \
+        LIVEKIT_URL LIVEKIT_API_KEY LIVEKIT_API_SECRET INTERNAL_API_SECRET
+    # The child reports results to one of these; without either, nothing lands.
+    runner_env_set ALK_RUNNER_API_URL || runner_env_set FI_BASE_URL || \
+        contract_fail "missing for result ingestion: ALK_RUNNER_API_URL (or FI_BASE_URL)"
+    local transports=()
+    IFS=', ' read -r -a transports <<<"$voice_transports"
+    for transport in "${transports[@]+"${transports[@]}"}"; do
+        transport=${transport// /}
+        case "$transport" in
+            "")
+                ;;
+            sip_outbound)
+                check_runner_env_present "sip_outbound (we dial the agent)" \
+                    LIVEKIT_OUTBOUND_TRUNK_ID PSTN_CALLER_NUMBER
+                value=$(runner_env_value PSTN_CALLER_NUMBER raw)
+                # The kit's transport model rejects anything but E.164 at hydration,
+                # on the value as handed over: stray whitespace fails it there too.
+                if [[ -n "$value" && ! "$value" =~ ^\+[1-9][0-9]{6,14}$ ]]; then
+                    contract_fail "PSTN_CALLER_NUMBER is not E.164 (+ then 7-15 digits;" \
+                        "no spaces or quotes, exactly as the runner env holds it)"
+                fi
+                ;;
+            sip_inbound_retell)
+                check_runner_env_present \
+                    "sip_inbound_retell (the Retell agent dials our leased number)" \
+                    ALK_SIM_SLOT_LEASE_SCRIPT SIM_SLOT_LEASE_STORE
+                ;;
+            *)
+                contract_fail "unknown voice transport: $transport" \
+                    "(expected sip_outbound, sip_inbound_retell)"
+                ;;
+        esac
+    done
+    local key_pair_reason="the SDK submitter prefers the org key pair over the"
+    key_pair_reason+=" internal bearer, so ingestion authenticates the wrong org"
+    check_runner_env_absent "$key_pair_reason" FI_API_KEY FI_SECRET_KEY
+    check_runner_env_absent \
+        "retired: the run budget is the child's own deadline" \
+        HOSTED_RUNNER_MAX_DURATION_SECONDS
+    if runner_env_assigned HOSTED_RUNNER_PARENT_SLACK_SECONDS; then
+        value=$(runner_env_value HOSTED_RUNNER_PARENT_SLACK_SECONDS)
+        [[ "$value" =~ ^\+?[0-9]+$ ]] || \
+            contract_fail "HOSTED_RUNNER_PARENT_SLACK_SECONDS must be a non-negative integer" \
+                "(an empty assignment kills the worker at import)"
+    fi
+    if runner_env_assigned HOSTED_RUNNER_LEASED_ROOM_REUSE; then
+        value=$(runner_env_value HOSTED_RUNNER_LEASED_ROOM_REUSE)
+        # The code lowercases and treats true/1/yes as on and anything else as
+        # off, so a typo silently disables reuse; only the explicit spellings pass.
+        case "$(printf '%s' "$value" | tr '[:upper:]' '[:lower:]')" in
+            true|1|yes|false|0|no) ;;
+            *)
+                contract_fail "HOSTED_RUNNER_LEASED_ROOM_REUSE must be true/1/yes or false/0/no" \
+                    "(anything else reads as false; empty is refused)"
+                ;;
+        esac
+    fi
+    if ((${#contract_failures[@]} > 0)); then
+        local failure
+        for failure in "${contract_failures[@]}"; do
+            echo "ERROR: runner env contract: $failure" >&2
+        done
+        exit 1
+    fi
+    echo "Runner environment contract (${#runner_env_files[@]} file(s);" \
+        "transports: ${voice_transports:-none}): OK"
+}
+
+if ((${#runner_env_files[@]} > 0)); then
+    verify_runner_env
+fi
+if [[ "$env_only" == true ]]; then
+    echo "Simulation-runner deployment preflight (env only): PASS"
+    exit 0
+fi
 
 command -v helm >/dev/null 2>&1 || die "helm is required"
 helm_command=(helm)


### PR DESCRIPTION
## Summary

Cherry-picks the three follow-up commits from the dev-targeted Retell PR (#2602) onto this branch so both lines carry the same runner contract and test coverage: the hosted-path speaker-role tests, the runner's environment contract in the deployment preflight and `.env.example`, and the runner's stop grace period. The Retell speaker maps themselves were already here from #2557; that pick therefore only adds the two hosted tests.

## Linked issues

Closes #
Linear:

## AI use

AI use: Claude Code did the cherry-picks and verification under the author's direction; the commits are the author's from #2602.

## Type of change

- [x] ✨ New feature (non-breaking change which adds functionality)

## E2E coverage

E2E: exempt (harness-gap: no simulate flows exist yet; hosted phone runs need Retell and a leased trunk number that are not-in-stack)

---

## 1) What changes were done

- `simulate/tests/test_alk_simulate_ingestion.py`: two hosted-path tests in `TestResultIngest` that ingest a Retell result through the ALK endpoint and render it through the detail serializer; both fail without the Retell speaker maps.
- `scripts/verify-simulation-runner-deployment.sh` + `.env.example`: the runner environment contract (`--runner-env-file`, `--voice-transports sip_outbound,sip_inbound_retell`, `--env-only`), and a compose-stage assertion that the runner's stop grace exceeds its drain timeout.
- `docker-compose.yml`: the runner sets `TEMPORAL_GRACEFUL_SHUTDOWN_TIMEOUT` (default 300) and `stop_grace_period` (default 330s), both overridable, so a stop mid-call drains instead of force-killing the child and orphaning a leased number.

All three applied without conflicts; the tree has one definition of each speaker map and one copy of each test.

## 2) How it was tested

- Contract check: 24 permutations on macOS system bash 3.2 on the dev-side commit; the three-case smoke repeated three times on this tree, stable, zero planted values in output.
- Compose render on this branch (with placeholders for the dev overlay's required variables): runner shows `TEMPORAL_GRACEFUL_SHUTDOWN_TIMEOUT: "300"` and `stop_grace_period: 5m30s`.
- The hosted tests could NOT be run on this base, see below; they passed on the dev base (71 passed with the resolver suite).

## 3) Finding on this branch (pre-existing, blocks every DB test here)

`futureagi/tracer/migrations` has two leaf nodes: `0097_observabilityprovider_poll_state` (from #2556, merged into this branch on 2026-09-05) and `0098_observabilityprovider_poll_state` (the renumbered copy that came in with the dev merge on 2026-09-08). Django refuses to set up any test database on this branch: "Conflicting migrations detected; multiple leaf nodes". Both add the same column, so a plain merge migration is not enough: a database that already applied 0097 (the dev box) will fail 0098 on the existing column, and one that applied 0098 (anything from dev) must not re-run 0097. Repair belongs to whoever owns the branch's migration state; the author of both migrations is me and I can supply the fix on request. Not addressed in this PR on purpose.

Companion dev PR: https://github.com/future-agi/future-agi/pull/2602