### PR TITLE
fix(tracer): custom-model cost was 1000x too high

### DIFF
--- a/futureagi/tracer/tests/test_custom_model_cost_calculation.py
+++ b/futureagi/tracer/tests/test_custom_model_cost_calculation.py
@@ -1,0 +1,75 @@
+"""
+Regression tests for calculate_cost_from_tokens with custom-model pricing.
+
+The custom-model settings UI collects "Input/Output Token Cost Per Million
+Tokens" and stores it unchanged (model_hub/views/custom_model.py). The cost
+calculation must therefore divide by 1_000_000, not 1_000 — see
+https://github.com/future-agi/future-agi/issues/2634.
+"""
+
+import pytest
+from django.core.cache import cache
+
+from accounts.models.organization import Organization
+from accounts.models.user import User
+from accounts.models.workspace import Workspace
+from model_hub.models.custom_models import CustomAIModel
+from tracer.utils.otel import calculate_cost_from_tokens
+
+
+@pytest.mark.django_db
+class TestCustomModelCostCalculation:
+    def setup_method(self):
+        cache.clear()
+        self.organization = Organization.objects.create(name="Cost Test Org")
+        self.user = User.objects.create_user(
+            email="cost-test@example.com", password="password123"
+        )
+        self.workspace = Workspace.objects.create(
+            name="Cost Test Workspace",
+            organization=self.organization,
+            created_by=self.user,
+        )
+        self.custom_model = CustomAIModel.objects.create(
+            user_model_id="my-custom-llm",
+            provider="openai",
+            input_token_cost=2.50,
+            output_token_cost=10.00,
+            organization=self.organization,
+            workspace=self.workspace,
+            user=self.user,
+            key_config={"key": "test-api-key"},
+        )
+
+    def teardown_method(self):
+        cache.clear()
+
+    def test_custom_model_cost_uses_per_million_token_pricing(self):
+        """1M prompt tokens at $2.50/1M input must cost $2.50, not $2500."""
+        cost = calculate_cost_from_tokens(
+            prompt_tokens=1_000_000,
+            completion_tokens=0,
+            model="my-custom-llm",
+            organization_id=str(self.organization.id),
+        )
+        assert cost == pytest.approx(2.50)
+
+    def test_custom_model_cost_combines_prompt_and_completion(self):
+        cost = calculate_cost_from_tokens(
+            prompt_tokens=1_000_000,
+            completion_tokens=1_000_000,
+            model="my-custom-llm",
+            organization_id=str(self.organization.id),
+        )
+        assert cost == pytest.approx(2.50 + 10.00)
+
+    def test_custom_model_cost_scales_linearly_below_a_million_tokens(self):
+        """1000 tokens at $2.50/1M input should cost a fraction of a cent, not
+        the pre-fix $0.0025 (which was itself 1000x the correct $0.0000025)."""
+        cost = calculate_cost_from_tokens(
+            prompt_tokens=1_000,
+            completion_tokens=0,
+            model="my-custom-llm",
+            organization_id=str(self.organization.id),
+        )
+        assert cost == pytest.approx(2.50 * 1_000 / 1_000_000)

--- a/futureagi/tracer/utils/otel.py
+++ b/futureagi/tracer/utils/otel.py
@@ -22,6 +22,7 @@ from model_hub.models.choices import StatusType
 from model_hub.models.custom_models import CustomAIModel
 from model_hub.models.evals_metric import EvalTemplate
 from model_hub.utils.eval_mapping import require_mapping_paths
+from tfc.constants.api_calls import APICallStatusChoices, APICallTypeChoices
 from tfc.utils.storage import upload_audio_to_s3, upload_image_to_s3, upload_video_to_s3
 from tracer.models.custom_eval_config import CustomEvalConfig
 from tracer.models.observation_span import ObservationSpan, UserIdType
@@ -36,7 +37,7 @@ from tracer.utils.semantic_conventions import (
     detect_semconv,
     get_attribute,
 )
-from tfc.constants.api_calls import APICallStatusChoices, APICallTypeChoices
+
 try:
     from ee.usage.utils.usage_entries import log_and_deduct_cost_for_resource_request
 except ImportError:
@@ -1798,11 +1799,14 @@ def calculate_cost_from_tokens(
                 if custom_pricing.get("not_found"):
                     cost = 0
                 else:
+                    # input_cost/output_cost are entered in the UI as price per
+                    # million tokens ("Input/Output Token Cost Per Million
+                    # Tokens"); scale by 1_000_000 to match that unit.
                     prompt_tokens_cost_usd_dollar = prompt_tokens * (
-                        custom_pricing["input_cost"] / 1000
+                        custom_pricing["input_cost"] / 1_000_000
                     )
                     completion_tokens_cost_usd_dollar = completion_tokens * (
-                        custom_pricing["output_cost"] / 1000
+                        custom_pricing["output_cost"] / 1_000_000
                     )
                     cost = (
                         prompt_tokens_cost_usd_dollar


### PR DESCRIPTION
## Summary

Custom-model costs were computed 1000x too high. The settings UI collects "Input/Output Token Cost Per Million Tokens", the value is stored unchanged, but `calculate_cost_from_tokens` (`tracer/utils/otel.py`) divided it by `1_000` instead of `1_000_000`. Entering a realistic $2.50/1M-input price produced $2,500.00 for 1M prompt tokens instead of $2.50. This affects every span/trace cost figure, cost graph, and cost aggregation for custom models (built-in models go through `litellm.cost_per_token()` and were unaffected).

## Linked issues

Closes #2634
Linear:

## AI use

AI use: Claude Code (Anthropic) did the investigation, wrote the fix and the regression tests, and ran them against a local Postgres/ClickHouse/Redis test stack (details in section 3) under my direction and review. I verified the root cause by reading the UI field labels/payload path and the consuming function, and confirmed the tests fail against the pre-fix code and pass against the fix (both outputs pasted below).

## Type of change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📖 Documentation only
- [ ] 🧹 Chore / refactor (no user-visible change)
- [ ] 🚀 Performance improvement
- [ ] 🧪 Test-only change

## E2E coverage

E2E: exempt (backend-internal — pure cost-calculation arithmetic, no route/table/selector change; covered by the new backend regression tests)

---

## 1) What changes were done

**A. Fix the cost divisor**

- `tracer/utils/otel.py`, `calculate_cost_from_tokens`: custom-model `input_cost`/`output_cost` are now divided by `1_000_000` instead of `1_000`, matching the unit the settings UI collects ("Input/Output Token Cost Per Million Tokens", `frontend/src/pages/dashboard/settings/helper.js`).
- Added a comment explaining the unit, since nothing in the surrounding code stated it and that's exactly how the bug happened.

**B. Regression tests**

- New `tracer/tests/test_custom_model_cost_calculation.py` covering the exact scenario from the issue, plus combined input+output cost and sub-million-token linear scaling.

## 2) Why the changes were done

- **Product/UX:** users configuring a custom model's pricing were seeing cost figures 1000x their real spend across span/trace cost columns, cost graphs, and cost aggregations — a correctness bug with direct billing/reporting impact.
- **Technical:** the UI, payload, and storage path all pass the value through unchanged (verified end to end: `AddCustomModal.jsx` → `model_hub/views/custom_model.py` → `CustomAIModel.input_token_cost`/`output_token_cost`), so the only place the unit could be reconciled is the one place it's consumed for arithmetic — the divisor in `calculate_cost_from_tokens`.
- **Architecture:** no schema or API surface change; this is a pure arithmetic fix at the single consumption site.

## 3) Tests written + scenarios each covers

**`tracer/tests/test_custom_model_cost_calculation.py`** — verifies `calculate_cost_from_tokens` applies per-million-token pricing correctly for a `CustomAIModel`

- `test_custom_model_cost_uses_per_million_token_pricing` — 1,000,000 prompt tokens at $2.50/1M input must cost $2.50, not $2,500
- `test_custom_model_cost_combines_prompt_and_completion` — prompt + completion costs sum correctly at 1M tokens each
- `test_custom_model_cost_scales_linearly_below_a_million_tokens` — 1,000 tokens costs a linear fraction of the per-million price

Real pasted output, against the fix (all three pass):

```
$ .venv/bin/python -m pytest tracer/tests/test_custom_model_cost_calculation.py -v
============================= test session starts ==============================
platform darwin -- Python 3.11.16, pytest-9.1.1, pluggy-1.6.0
django: version: 5.1.8, settings: tfc.settings.test (from env)
collected 3 items

tracer/tests/test_custom_model_cost_calculation.py::TestCustomModelCostCalculation::test_custom_model_cost_uses_per_million_token_pricing PASSED [ 33%]
tracer/tests/test_custom_model_cost_calculation.py::TestCustomModelCostCalculation::test_custom_model_cost_combines_prompt_and_completion PASSED [ 66%]
tracer/tests/test_custom_model_cost_calculation.py::TestCustomModelCostCalculation::test_custom_model_cost_scales_linearly_below_a_million_tokens PASSED [100%]

============================== 3 passed in 1.12s ===============================
```

And, to confirm these aren't tautological, the same three against the pre-fix `/ 1000` code (all three fail with exactly the predicted 1000x factor):

```
FAILED ...test_custom_model_cost_uses_per_million_token_pricing - assert 2500.0 == 2.5 ± 2.5e-06
FAILED ...test_custom_model_cost_combines_prompt_and_completion - assert 12500.0 == 12.5 ± 1.2e-05
FAILED ...test_custom_model_cost_scales_linearly_below_a_million_tokens - assert 2.5 == 0.0025 ± 2.5e-09
============================== 3 failed in 1.25s ===============================
```

## 4) How to run / test

Ran via `bin/test up` (docker-compose test services) + a manually created Python 3.11 venv, then `pytest` directly against those services (`DJANGO_SETTINGS_MODULE=tfc.settings.test`, `DATABASE_URL`/`REDIS_URL`/`CH_*` pointed at the compose sidecars) rather than the `bin/test` wrapper script. `bin/test`'s own migration step hit `manage.py migrate` being blocked by the `STARTUP_DB_MUTATION_MODE` guard (`model_hub/apps.py`); ran with `STARTUP_DB_MUTATION_MODE=operator SERVICE_TYPE=bootstrap` instead, which is a one-shot bootstrap pattern the app itself documents in its error message, not a workaround.

Two environment snags along the way, in case they're useful independent of this PR (I did not open new issues for these — both look like the same root cause already tracked in #2393 "requirements-test.txt cannot run the test suite"):
- `requirements-test.txt` has no `pytest`/`pytest-django`/etc — installed the versions pinned in `pyproject.toml`'s dev group instead.
- `requirements.txt` pins `cuda-bindings`/`nvidia-*`/`triton` (Linux/CUDA-only, no macOS wheels) and conflicts with `requirements-test.txt` on `anthropic` (0.55.0 vs 0.56.0) — stripped the CUDA-only pins and let the test file's pin win for a local macOS venv.

```bash
cd futureagi
python3.11 -m venv .venv && .venv/bin/pip install -r <CUDA/triton-stripped requirements.txt> -r <same for requirements-test.txt>
.venv/bin/pip install "pytest>=8.4.1" "pytest-django>=4.11.1" "pytest-mock>=3.14.1"   # not in requirements-test.txt

bin/test up   # starts the docker-compose test services only

export DJANGO_SETTINGS_MODULE=tfc.settings.test
export DATABASE_URL=postgres://test_user:test_password@localhost:15432/test_tfc
export REDIS_URL=redis://localhost:16379/0
export CH_HOST=localhost CH_DATABASE=test_tfc
export CH25_HOST=localhost CH25_HTTP_PORT=18123 CH25_DATABASE=test_tfc
export MINIO_ENDPOINT=localhost:19005 MINIO_ACCESS_KEY=minioadmin MINIO_SECRET_KEY=minioadmin
export DEBUG=1 TEST=1
STARTUP_DB_MUTATION_MODE=operator SERVICE_TYPE=bootstrap .venv/bin/python manage.py migrate --noinput

.venv/bin/python -m pytest tracer/tests/test_custom_model_cost_calculation.py -v
```

### UI steps (manual)

Not exercised in a browser — this is a pure backend arithmetic fix with no UI change; the regression tests above exercise the exact code path the UI's configured pricing flows through.

---

## 6) Edge cases & considerations

- **Zero-cost pricing:** unaffected — `0 / 1_000_000 == 0`, same as before.
- **Built-in (non-custom) models:** unaffected — they resolve through `litellm.cost_per_token()`, a separate branch untouched by this change.
- **Already-computed/stored costs on existing spans:** this fix only changes cost calculated for *newly ingested* spans going forward; it does not backfill historical `ObservationSpan.cost` values that were already persisted 1000x high. Flagging this in case a backfill is wanted — happy to scope that separately if so, but kept this PR to the single-cause fix per the "one logical change" guidance.
- **Pricing cache (`custom_model_pricing:*`, 24h TTL, never invalidated):** a related but separate bug — filed as #2635, deliberately not touched here to keep this PR to one fix.

## 7) Pre-existing issues (NOT introduced by this PR)

None observed in the scope touched by this change.

## 8) Architectural / important decisions

- **Fixed the backend divisor rather than the UI copy:** the UI labels ("...Per Million Tokens") and placeholders appear consistently in both `getModelFields` and `getCustomModelFields`, and the value is stored as typed with no conversion — so the UI's stated unit is the source of truth, and the single consuming arithmetic site is the one place that disagreed with it.

## Checklist

- [x] My code follows the style guide
- [x] I've added tests that prove my fix is effective (and confirmed they fail against the pre-fix code)
- [x] Backend tests pass locally (via `pytest` against `bin/test up` services — see section 4 for why not the `bin/test` wrapper directly)
- [ ] `yarn test:run` passes locally (frontend) — no frontend changes in this PR
- [ ] `yarn contracts:check` passes if API surface changed — no API surface change
- [ ] I've updated the documentation where relevant — no user-facing docs reference this arithmetic
- [x] No hardcoded secrets, URLs, or PII
- [ ] I've signed the CLA — please advise if this is required before review
- [x] PR title follows Conventional Commits
- [ ] Linear issue is linked and updated with status — no Linear access; GitHub issue #2634 linked above
