### PR TITLE
fix(frontend): correct heigth typo to height in Compare drawer chips

### DIFF
--- a/frontend/src/sections/project-detail/CompareDrawer/CompareSection.jsx
+++ b/frontend/src/sections/project-detail/CompareDrawer/CompareSection.jsx
@@ -219,7 +219,7 @@ const CompareSection = ({
                   fontSize: "12px",
                   fontWeight: "400",
                   lineHeight: "18px",
-                  heigth: "22px",
+                  height: "22px",
                   borderRadius: "8px",
                   padding: "6px 0px",
                 }}
@@ -250,7 +250,7 @@ const CompareSection = ({
                   fontWeight: "400",
                   lineHeight: "18px",
                   borderRadius: "8px",
-                  heigth: "22px",
+                  height: "22px",
                   padding: "6px 0px",
                 }}
               />


### PR DESCRIPTION
## Summary

The Total Cost and Latency chips in the project Compare drawer set `heigth: "22px"` (misspelled) in their `sx` styles instead of `height`. `heigth` is not a recognized CSS/MUI property, so it's silently dropped and both chips render at MUI's default small-chip height instead of the intended 22px. The same file spells `height` correctly five other times, confirming the intent.

## Linked issues

Closes #2633
Linear:

## AI use

AI use: Claude Code found the typo, applied the two-line fix, and verified it against `upstream/dev` under my direction and review.

## Type of change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## E2E coverage

E2E: exempt (cosmetic — a two-property style typo, no route/table/selector change)

## Changes

- `frontend/src/sections/project-detail/CompareDrawer/CompareSection.jsx` line 222
- `frontend/src/sections/project-detail/CompareDrawer/CompareSection.jsx` line 253

## Verification

- Repo-wide search for `heigth` (excluding this fix) now returns zero results in `frontend/`
- Pure string correction; no behavior changes beyond the two chips rendering at the intended 22px height
- Matches the precedent of #1967 / PR #2140 (same class of CSS-property typo, same minimal-diff treatment)

## Checklist

- [x] My code follows the style guide
- [ ] I've added tests that prove my fix is effective — not applicable; this file has zero existing test coverage and the accepted precedent for this exact typo class (#1967 / PR #2140) also shipped without a new test
- [x] No hardcoded secrets, URLs, or PII
- [ ] I've signed the CLA — please advise if this is required before review
- [x] PR title follows Conventional Commits
