### PR TITLE
fix(frontend): correct heigth typo to height in CompareDrawer chips

### DIFF
--- a/frontend/src/sections/project-detail/CompareDrawer/CompareSection.jsx
+++ b/frontend/src/sections/project-detail/CompareDrawer/CompareSection.jsx
@@ -219,7 +219,7 @@ const CompareSection = ({
                   fontSize: "12px",
                   fontWeight: "400",
                   lineHeight: "18px",
-                  heigth: "22px",
+                  height: "22px",
                   borderRadius: "8px",
                   padding: "6px 0px",
                 }}
@@ -250,7 +250,7 @@ const CompareSection = ({
                   fontWeight: "400",
                   lineHeight: "18px",
                   borderRadius: "8px",
-                  heigth: "22px",
+                  height: "22px",
                   padding: "6px 0px",
                 }}
               />


### PR DESCRIPTION
## Summary

Two chips in the Compare drawer (`CompareSection.jsx`) had `heigth` instead of `height` in their MUI `sx` prop. CSS silently ignores unknown properties, so both chips rendered at MUI's default small-chip height instead of the intended 22 px, making them visually inconsistent with the rest of the drawer.

## Linked issues

Closes #2633
Linear:

## AI use

AI use: Claude Code located both occurrences and applied the two-character fix; I reviewed the diff to confirm no other properties were changed.

## Type of change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📖 Documentation only
- [ ] 🧹 Chore / refactor (no user-visible change)
- [ ] 🚀 Performance improvement
- [ ] 🧪 Test-only change

## E2E coverage

E2E: exempt (cosmetic)

---

## 1) What changes were done

**A. Fixed `heigth` → `height` typo in CompareSection.jsx (lines 222 and 253 on `dev`)**

- Total Cost chip and Latency chip in the Compare drawer now apply `height: "22px"` correctly instead of the silently-dropped `heigth` value.
- No logic change — pure spelling correction.

---

## 2) Why the changes were done

- **Product/UX:** Both chips were rendering at MUI's default chip height instead of the intended 22 px, making them visually shorter than the surrounding styled elements in the drawer.
- **Technical:** CSS ignores unrecognised property names without any error, so the bug was invisible at runtime unless you inspected the computed styles in devtools.

---

## 3) Tests written + scenarios each covers

No automated tests — this is a two-character CSS property name correction. The fix is verifiable by opening the Compare drawer and inspecting the computed height of both chips (should be 22 px).

```
n/a — cosmetic spelling fix, no unit test applicable
```

---

## 4) How to run / test

### UI steps (manual)

1. Start the stack and open a project that has at least two versions to compare.
2. Open the Compare drawer.
3. Inspect the Total Cost and Latency chips in browser devtools — computed height should now be 22 px (previously it defaulted to MUI's internal chip height).

---

## 5) Screenshots / recordings

Before: both chips render at MUI default small-chip height (~24px with default padding).
After: chips honour the `height: "22px"` constraint.

---

## 6) Edge cases & considerations

- **Same file uses `height` correctly in four other places** — confirmed none of those were accidentally affected.
- **No other files** in the codebase contain the `heigth` misspelling (verified with grep).

---

## Checklist

- [x] My code follows the style guide
- [x] No automated test needed — cosmetic spelling fix
- [x] No hardcoded secrets, URLs, or PII
- [x] PR title follows Conventional Commits
- [x] Change is limited to the exact two occurrences reported in the issue

🤖 Generated with [Claude Code](https://claude.com/claude-code)