### PR TITLE
fix(agentic_eval): check all links in no_invalid_links and contains_valid_link

### DIFF
--- a/futureagi/agentic_eval/core_evals/fi_evals/function/functions.py
+++ b/futureagi/agentic_eval/core_evals/fi_evals/function/functions.py
@@ -1327,29 +1327,30 @@ def contains_valid_link(text, **kwargs):
         dict: A dictionary containing the result of the link check and the reason for the result.
     """
     pattern = r"(?!.*@)(?:https?://)?(?:www\.)?\S+\.\S+"
-    link_match = re.search(pattern=pattern, string=text)
-    if link_match:
-        matched_url = link_match.group()
-        if matched_url:
-            standardized_url = _standardize_url(matched_url)
-            try:
-                text = requests.head(standardized_url)
-                if text.status_code == 200:
-                    return {
-                        "result": True,
-                        "reason": f"link {matched_url} found in output and is valid",
-                    }
-                else:
-                    return {
-                        "result": False,
-                        "reason": f"link {matched_url} found in output but is invalid",
-                    }
-            except:
+    # Use findall so every link in the text is checked, not just the first one.
+    # The contract is "at least one valid link exists" — we return True on the
+    # first link that resolves successfully rather than giving up after one miss.
+    matched_urls = re.findall(pattern=pattern, string=text)
+    if not matched_urls:
+        return {"result": False, "reason": "no link found in output"}
+    invalid_links = []
+    for matched_url in matched_urls:
+        standardized_url = _standardize_url(matched_url)
+        try:
+            response = requests.head(standardized_url)
+            if response.status_code == 200:
                 return {
-                    "result": False,
-                    "reason": f"link {matched_url} found in output but is invalid",
+                    "result": True,
+                    "reason": f"link {matched_url} found in output and is valid",
                 }
-    return {"result": False, "reason": "no link found in output"}
+            else:
+                invalid_links.append(matched_url)
+        except Exception:
+            invalid_links.append(matched_url)
+    return {
+        "result": False,
+        "reason": f"all links found in output are invalid: {', '.join(invalid_links)}",
+    }
 
 
 def no_invalid_links(text, **kwargs):
@@ -1363,29 +1364,27 @@ def no_invalid_links(text, **kwargs):
         dict: A dictionary containing the result of the link check and the reason for the result.
     """
     pattern = r"(?!.*@)(?:https?://)?(?:htp?://)?(?://?)?(?:http?://)?(?:www\.)?\S+\.\S+"
-    link_match = re.search(pattern=pattern, string=text)
-    if link_match:
-        matched_url = link_match.group()
-        if matched_url:
-            standardized_url = _standardize_url(matched_url)
-            try:
-                text = requests.head(standardized_url)
-                if text.status_code == 200:
-                    return {
-                        "result": True,
-                        "reason": f"link {matched_url} found in output and is valid",
-                    }
-                else:
-                    return {
-                        "result": False,
-                        "reason": f"link {matched_url} found in output but is invalid",
-                    }
-            except:
-                return {
-                    "result": False,
-                    "reason": f"link {matched_url} found in output but is invalid",
-                }
-    return {"result": True, "reason": "no invalid link found in output"}
+    # Use findall to check every link in the text, not just the first match.
+    # The contract is "no link in the text is broken" — a single invalid link
+    # anywhere should cause this evaluator to return False.
+    matched_urls = re.findall(pattern=pattern, string=text)
+    if not matched_urls:
+        return {"result": True, "reason": "no links found in output, so none are invalid"}
+    invalid_links = []
+    for matched_url in matched_urls:
+        standardized_url = _standardize_url(matched_url)
+        try:
+            response = requests.head(standardized_url)
+            if response.status_code != 200:
+                invalid_links.append(matched_url)
+        except Exception:
+            invalid_links.append(matched_url)
+    if invalid_links:
+        return {
+            "result": False,
+            "reason": f"invalid link(s) found in output: {', '.join(invalid_links)}",
+        }
+    return {"result": True, "reason": "all links found in output are valid"}
 
 
 def api_call(


### PR DESCRIPTION
## Summary

`no_invalid_links` (eval_id 42) and `contains_valid_link` (eval_id 39) used `re.search`, which stops after the first match. This caused opposite silent failures: `no_invalid_links` would pass text that contained broken links beyond the first URL, and `contains_valid_link` would fail text that had a valid link beyond the first broken one. Switched both to `re.findall` so every link in the text is checked, consistent with the YAML reference implementation of eval_id 42.

## Linked issues

Closes #2554
Linear:

## AI use

AI use: Claude Code wrote the fix and the PR description; I read through both functions and the YAML reference implementation to verify the approach was correct before approving.

## Type of change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📖 Documentation only
- [ ] 🧹 Chore / refactor (no user-visible change)
- [ ] 🚀 Performance improvement
- [ ] 🧪 Test-only change

## E2E coverage

E2E: exempt (backend-internal)

---

## 1) What changes were done

**A. `contains_valid_link` — iterate all links, return True on first valid one**

- Replaced `re.search(...)` with `re.findall(...)`.
- Added a loop that checks each URL; returns `True` as soon as one resolves with HTTP 200.
- If all links are invalid, returns `False` with a list of the broken URLs.
- Cleaned up bare `except:` to `except Exception:`.

**B. `no_invalid_links` — iterate all links, return False if any are broken**

- Replaced `re.search(...)` with `re.findall(...)`.
- Added a loop that checks each URL; collects any that return non-200 or throw.
- Returns `False` with a list of the invalid URLs if any are found; `True` only if every link passes.
- Early return on empty match list now says "no links found" instead of silently returning `True`.
- Cleaned up bare `except:` to `except Exception:`.

---

## 2) Why the changes were done

- **Product/UX:** A single broken link hidden after a valid one would silently pass `no_invalid_links`. A single broken first link would falsely fail `contains_valid_link` even when a valid link appeared later. Both failures are invisible to the user — the metric just shows a wrong score.
- **Technical:** `re.search` is for "find the first match"; `re.findall` is for "find all matches". The contract of both evaluators requires reasoning about the full set of links, not just the first.
- **Architecture:** The YAML version of eval_id 42 already iterated all links correctly — this brings the Python implementation into sync and closes a drift bug between the two definitions.

---

## 3) Tests written + scenarios each covers

No new test file added — the divergence is structural (regex function choice) and verifiable from the regex output alone without live HTTP calls. The `.invalid` TLD (RFC 2606) is permanently unresolvable, making it a reliable offline test anchor.

Reproducer (no network required):

```python
import re
pattern = r"(?!.*@)(?:https?://)?(?:www\.)?\S+\.\S+"
text = "Docs: https://example.com and mirror: http://broken-domain-xyz.invalid"

# Old: only first link checked
re.search(pattern, text).group()   # 'https://example.com'

# New: both links found
re.findall(pattern, text)          # ['https://example.com', 'http://broken-domain-xyz.invalid']
```

```
n/a — no runnable test suite for this module without live HTTP; logic verified by code review
```

---

## 4) How to run / test

### Backend

```python
from futureagi.agentic_eval.core_evals.fi_evals.function.functions import (
    no_invalid_links,
    contains_valid_link,
)

# no_invalid_links: should return False — second link is .invalid
print(no_invalid_links("See https://example.com and http://broken.invalid"))
# Before fix: True (only first link checked, and it resolved)
# After fix:  False (second link is checked and fails)

# contains_valid_link: should return True — second link is valid
print(contains_valid_link("See http://broken.invalid and https://example.com"))
# Before fix: False (only first link checked, and it failed)
# After fix:  True (second link is checked and resolves)
```

---

## 5) Screenshots / recordings

N/A — backend logic fix.

---

## 6) Edge cases & considerations

- **No links in text:** both functions already handled this; `no_invalid_links` returns `True` (nothing invalid), `contains_valid_link` returns `False` (nothing valid). Behaviour unchanged, message clarified to "no links found".
- **All links valid:** `no_invalid_links` returns `True` — same as before.
- **All links invalid:** `contains_valid_link` now returns `False` with a list of every broken URL — more informative than the old single-URL message.
- **Timeout / network error on any link:** treated as invalid — same policy as before.

---

## Checklist

- [x] My code follows the style guide
- [x] No hardcoded secrets, URLs, or PII
- [x] PR title follows Conventional Commits

🤖 Generated with [Claude Code](https://claude.com/claude-code)