### PR TITLE
fix(agentic_eval): fix Spearman rho for tied ranks and constant inputs

### DIFF
--- a/futureagi/agentic_eval/core_evals/fi_evals/function/functions.py
+++ b/futureagi/agentic_eval/core_evals/fi_evals/function/functions.py
@@ -3613,8 +3613,26 @@ def calculate_spearman_correlation(output, expected, **kwargs):
         return ranks
 
     rx, ry = _rank(x), _rank(y)
-    d_sq = sum((rxi - ryi) ** 2 for rxi, ryi in zip(rx, ry))
-    rho = 1 - (6 * d_sq) / (n * (n ** 2 - 1))
+
+    # Compute rho as Pearson's r over the rank vectors rather than the 1-6Σd²/n(n²-1)
+    # shortcut. The shortcut is only algebraically equivalent when both rank vectors
+    # are permutations of 1..n with no ties. When _rank produces midranks for tied
+    # values the shortcut gives wrong results; Pearson's r over the ranks is always
+    # correct regardless of ties.
+    rx_mean = sum(rx) / n
+    ry_mean = sum(ry) / n
+    cov = sum((rxi - rx_mean) * (ryi - ry_mean) for rxi, ryi in zip(rx, ry))
+    var_x = sum((rxi - rx_mean) ** 2 for rxi in rx)
+    var_y = sum((ryi - ry_mean) ** 2 for ryi in ry)
+
+    # Guard against constant inputs (zero variance → correlation is undefined).
+    # Returning 0.5 (the neutral midpoint of the normalised [0,1] range) is the
+    # least surprising value; it signals "no information" rather than a false
+    # perfect or perfect-negative correlation.
+    if var_x == 0 or var_y == 0:
+        return {"result": 0.5, "reason": "Spearman rho=undefined (constant input), normalized=0.5"}
+
+    rho = cov / (var_x * var_y) ** 0.5
     score = (rho + 1) / 2
     return {"result": score, "reason": f"Spearman rho={rho:.4f}, normalized={score:.4f}"}
 


### PR DESCRIPTION
## Summary

`calculate_spearman_correlation` produced wrong rho values whenever the input contained tied values, and misreported constant inputs as strong correlations. The root cause: it correctly assigned midranks to ties but then used the `1 − 6Σd²/n(n²−1)` shortcut, which is only algebraically valid when both rank vectors are strict permutations of 1..n (no ties). Replaced the shortcut with Pearson's r computed directly over the rank vectors, which handles midranks correctly by definition. Also added a zero-variance guard so constant inputs return a neutral 0.5 instead of a false perfect or moderate correlation.

## Linked issues

Closes #2569
Linear:

## AI use

AI use: Claude Code wrote the Pearson-over-ranks replacement and the zero-variance guard; I cross-checked the results against the scipy reference values from the issue's reproduction table before approving.

## Type of change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📖 Documentation only
- [ ] 🧹 Chore / refactor (no user-visible change)
- [ ] 🚀 Performance improvement
- [ ] 🧪 Test-only change

## E2E coverage

E2E: exempt (backend-internal)

---

## 1) What changes were done

**A. Replace d² shortcut with Pearson's r over rank vectors**

The shortcut `rho = 1 - (6 * d_sq) / (n * (n**2 - 1))` is replaced with:

```python
rx_mean = sum(rx) / n
ry_mean = sum(ry) / n
cov  = sum((rxi - rx_mean) * (ryi - ry_mean) for rxi, ryi in zip(rx, ry))
var_x = sum((rxi - rx_mean) ** 2 for rxi in rx)
var_y = sum((ryi - ry_mean) ** 2 for ryi in ry)
rho  = cov / (var_x * var_y) ** 0.5
```

This is mathematically equivalent to the shortcut when there are no ties, and correct for midranks too.

**B. Zero-variance guard**

Added a check for `var_x == 0 or var_y == 0` (constant input) before the division. Returns `result: 0.5` with a clear reason string explaining the input was constant and rho is undefined.

---

## 2) Why the changes were done

- **Product/UX:** Spearman rho is typically run on Likert-scale LLM-judge outputs (1–5 or 1–10) where ties are the norm. The error was up to 0.46 rho units on the examples in the issue — well outside any acceptable tolerance. A constant predictor (model emitting the same value every row) was being reported as a moderate positive correlation instead of "no information".
- **Technical:** The d² shortcut is an algebraic simplification that holds only when both rank vectors sum to n(n+1)/2 and have no repeated values. Midranks break that invariant. Pearson's r over the raw rank values is the general definition of Spearman's rho and works for all inputs.
- **Architecture:** The `_rank` helper already produced correct midranks. Only the final rho formula was wrong. No change to the ranking logic itself.

---

## 3) Tests written + scenarios each covers

Reproducer from the issue (no external dependencies):

```python
from futureagi.agentic_eval.core_evals.fi_evals.function.functions import calculate_spearman_correlation

# Tied ranks — previously wrong by up to 0.46 rho units
print(calculate_spearman_correlation([1, 1, 2, 3], [1, 2, 2, 3]))
# Before: rho=0.8500, score=0.9250
# After:  rho=0.8333, score=0.9167  (matches scipy.stats.spearmanr)

print(calculate_spearman_correlation([1, 1, 1, 1, 2], [5, 4, 3, 2, 1]))
# Before: rho=-0.2500, score=0.3750
# After:  rho=-0.7071, score=0.1464  (matches scipy.stats.spearmanr)

# Constant prediction — now returns neutral 0.5
print(calculate_spearman_correlation([3, 3, 3, 3], [1, 2, 3, 4]))
# Before: rho=0.5, score=0.75  (false moderate correlation)
# After:  result=0.5, "Spearman rho=undefined (constant input)"
```

```
n/a — no runnable test suite for this module without additional setup
```

---

## 4) How to run / test

### Backend

Run the reproducer above and compare against `scipy.stats.spearmanr` for the tied-rank cases.

---

## 5) Screenshots / recordings

N/A — backend arithmetic fix.

---

## 6) Edge cases & considerations

- **No ties (clean permutations):** Pearson's r over ranks gives the same result as the d² shortcut — no regression.
- **Both inputs constant:** `var_x == 0` and `var_y == 0` — returns 0.5. Prevents division by zero and avoids the false rho=1.0 from the old code.
- **One input constant:** `var_x == 0` or `var_y == 0` — same guard, returns 0.5. Previously reported as rho=0.5/score=0.75, falsely suggesting a moderate positive correlation.
- **All ties in one vector, variation in the other:** handled correctly by the Pearson formula — produces rho=0 (no monotone relationship can be assessed), normalised to 0.5.
- **n < 2:** already guarded at the top of the function — unchanged.

---

## Checklist

- [x] My code follows the style guide
- [x] No hardcoded secrets, URLs, or PII
- [x] PR title follows Conventional Commits

🤖 Generated with [Claude Code](https://claude.com/claude-code)