### PR TITLE
fix(agent-playground): show node execution list [agent]

### DIFF
--- a/frontend/src/sections/agent-playground/AgentBuilder/RunAgentPanel/CustomTreeNode.jsx
+++ b/frontend/src/sections/agent-playground/AgentBuilder/RunAgentPanel/CustomTreeNode.jsx
@@ -116,73 +116,76 @@ export const CustomTreeNode = ({
               flexShrink: 0,
             }}
           >
-            {/* Duration */}
-            <Box
-              component="span"
-              sx={{
-                display: "flex",
-                flexDirection: "row",
-                alignItems: "center",
-                gap: 0.5,
-              }}
-            >
-              <SvgColor
+            {duration != null && (
+              <Box
+                component="span"
                 sx={{
-                  height: 12,
-                  width: 12,
-                  bgcolor: "text.disabled",
+                  display: "flex",
+                  flexDirection: "row",
+                  alignItems: "center",
+                  gap: 0.5,
                 }}
-                src="/assets/icons/navbar/ic_new_clock.svg"
-              />
-              <Typography color="text.disabled" typography={"s3"}>
-                {formatMs(duration ?? 0)}
-              </Typography>
-            </Box>
-            {/* Tokens */}
-            <Box
-              component="span"
-              sx={{
-                display: "flex",
-                flexDirection: "row",
-                alignItems: "center",
-                gap: 0.5,
-              }}
-            >
-              <SvgColor
+              >
+                <SvgColor
+                  sx={{
+                    height: 12,
+                    width: 12,
+                    bgcolor: "text.disabled",
+                  }}
+                  src="/assets/icons/navbar/ic_new_clock.svg"
+                />
+                <Typography color="text.disabled" typography={"s3"}>
+                  {formatMs(duration)}
+                </Typography>
+              </Box>
+            )}
+            {tokens != null && (
+              <Box
+                component="span"
                 sx={{
-                  height: 12,
-                  width: 12,
-                  bgcolor: "text.disabled",
+                  display: "flex",
+                  flexDirection: "row",
+                  alignItems: "center",
+                  gap: 0.5,
                 }}
-                src="/assets/icons/ic_tokens.svg"
-              />
-              <Typography color="text.disabled" typography={"s3"}>
-                {(tokens ?? 0).toLocaleString()}
-              </Typography>
-            </Box>
+              >
+                <SvgColor
+                  sx={{
+                    height: 12,
+                    width: 12,
+                    bgcolor: "text.disabled",
+                  }}
+                  src="/assets/icons/ic_tokens.svg"
+                />
+                <Typography color="text.disabled" typography={"s3"}>
+                  {tokens.toLocaleString()}
+                </Typography>
+              </Box>
+            )}
 
-            {/* Cost */}
-            <Box
-              component="span"
-              sx={{
-                display: "flex",
-                flexDirection: "row",
-                alignItems: "center",
-                gap: 0.5,
-              }}
-            >
-              <SvgColor
+            {cost != null && (
+              <Box
+                component="span"
                 sx={{
-                  height: 12,
-                  width: 12,
-                  bgcolor: "text.disabled",
+                  display: "flex",
+                  flexDirection: "row",
+                  alignItems: "center",
+                  gap: 0.5,
                 }}
-                src="/assets/icons/components/ic_cost.svg"
-              />
-              <Typography color="text.disabled" typography={"s3"}>
-                {(cost ?? 0).toFixed(4)}
-              </Typography>
-            </Box>
+              >
+                <SvgColor
+                  sx={{
+                    height: 12,
+                    width: 12,
+                    bgcolor: "text.disabled",
+                  }}
+                  src="/assets/icons/components/ic_cost.svg"
+                />
+                <Typography color="text.disabled" typography={"s3"}>
+                  {cost.toFixed(4)}
+                </Typography>
+              </Box>
+            )}
           </Box>
         </Box>
       </Stack>

--- a/frontend/src/sections/agent-playground/AgentBuilder/RunAgentPanel/NodeOutputListView.jsx
+++ b/frontend/src/sections/agent-playground/AgentBuilder/RunAgentPanel/NodeOutputListView.jsx
@@ -8,6 +8,14 @@ import { useState, useMemo } from "react";
 import { TreeView } from "../../../../TreeView";
 import { CustomTreeNode } from "./CustomTreeNode";
 
+const filterNodeTree = (nodes, query) =>
+  nodes.reduce((matches, node) => {
+    const children = filterNodeTree(node.children || [], query);
+    if (node.name.toLowerCase().includes(query) || children.length > 0)
+      matches.push({ ...node, children });
+    return matches;
+  }, []);
+
 export default function NodeOutputListView({
   showTitle = true,
   showSearch = true,
@@ -19,9 +27,7 @@ export default function NodeOutputListView({
   const [searchQuery, setSearchQuery] = useState("");
   const filteredNodes = useMemo(() => {
     if (!nodes?.length) return [];
-    return nodes.filter((node) =>
-      (node?.name ?? "").toLowerCase().includes(searchQuery.toLowerCase()),
-    );
+    return filterNodeTree(nodes, searchQuery.trim().toLowerCase());
   }, [nodes, searchQuery]);
   return (
     <Box

--- a/frontend/src/sections/agent-playground/AgentBuilder/RunAgentPanel/RunAgentPanel.jsx
+++ b/frontend/src/sections/agent-playground/AgentBuilder/RunAgentPanel/RunAgentPanel.jsx
@@ -1,11 +1,19 @@
 import { Box } from "@mui/material";
-import React, { useCallback, useRef, useState, useEffect } from "react";
+import React, {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 import PropTypes from "prop-types";
 import { AgentGraph } from "src/components/AgentGraph";
 import { START_ID, END_ID } from "src/components/AgentGraph/layoutUtils";
 import useResolvedExecution from "../../hooks/useResolvedExecution";
 import { useWorkflowRunStoreShallow } from "../../store";
 import NodeOutputDetail from "./NodeOutputDetail";
+import NodeOutputListView from "./NodeOutputListView";
+import { buildNodeOutputTree } from "./common";
 import ResizablePanels from "src/components/resizablePanels/ResizablePanels";
 import PanelErrorBoundary from "../../components/PanelErrorBoundary";
 
@@ -22,6 +30,10 @@ export default function RunAgentPanel({
   const [isResizing, setIsResizing] = useState(false);
   const isRunning = useWorkflowRunStoreShallow((s) => s.isRunning);
   const [selectedNodeId, setSelectedNodeId] = useState(null);
+  const nodeOutputTree = useMemo(
+    () => buildNodeOutputTree(executionData?.nodes),
+    [executionData?.nodes],
+  );
 
   // Reset selected node when a new execution starts
   useEffect(() => {
@@ -148,26 +160,41 @@ export default function RunAgentPanel({
         }}
       />
       <ResizablePanels
-        initialLeftWidth={50}
+        initialLeftWidth={25}
         minLeftWidth={15}
-        maxLeftWidth={80}
+        maxLeftWidth={40}
         leftPanel={
-          <AgentGraph
-            executionData={executionData}
-            onNodeClick={handleGraphNodeClick}
+          <NodeOutputListView
+            currentAgent={executionData?.agent}
+            nodes={nodeOutputTree}
             selectedNodeId={selectedNodeId}
+            onNodeSelect={setSelectedNodeId}
           />
         }
         rightPanel={
-          <PanelErrorBoundary
-            name="NodeOutputDetail"
-            onRetry={() => setSelectedNodeId(null)}
-          >
-            <NodeOutputDetail
-              executionId={resolvedExecutionId}
-              nodeExecutionId={selectedNodeExecutionId}
-            />
-          </PanelErrorBoundary>
+          <ResizablePanels
+            initialLeftWidth={50}
+            minLeftWidth={20}
+            maxLeftWidth={80}
+            leftPanel={
+              <AgentGraph
+                executionData={executionData}
+                onNodeClick={handleGraphNodeClick}
+                selectedNodeId={selectedNodeId}
+              />
+            }
+            rightPanel={
+              <PanelErrorBoundary
+                name="NodeOutputDetail"
+                onRetry={() => setSelectedNodeId(null)}
+              >
+                <NodeOutputDetail
+                  executionId={resolvedExecutionId}
+                  nodeExecutionId={selectedNodeExecutionId}
+                />
+              </PanelErrorBoundary>
+            }
+          />
         }
       />
     </Box>

--- a/frontend/src/sections/agent-playground/AgentBuilder/RunAgentPanel/__tests__/CustomTreeNode.test.jsx
+++ b/frontend/src/sections/agent-playground/AgentBuilder/RunAgentPanel/__tests__/CustomTreeNode.test.jsx
@@ -1,0 +1,47 @@
+import { describe, expect, it, vi } from "vitest";
+import { render, screen } from "src/utils/test-utils";
+import { CustomTreeNode } from "../CustomTreeNode";
+
+const renderNode = (node) =>
+  render(
+    <CustomTreeNode
+      node={node}
+      depth={0}
+      isSelected={false}
+      isExpanded={false}
+      hasChildren={false}
+      onSelect={vi.fn()}
+      onToggle={vi.fn()}
+    />,
+  );
+
+describe("CustomTreeNode", () => {
+  it("renders duration while omitting unavailable token and cost values", () => {
+    renderNode({
+      id: "node-1",
+      name: "Generate answer",
+      type: "llm_prompt",
+      duration: 1250,
+    });
+
+    expect(screen.getByText("Generate answer")).toBeInTheDocument();
+    expect(screen.getByText("1.25s")).toBeInTheDocument();
+    expect(screen.queryByText("0")).not.toBeInTheDocument();
+    expect(screen.queryByText("0.0000")).not.toBeInTheDocument();
+  });
+
+  it("renders zero metrics when they were explicitly supplied", () => {
+    renderNode({
+      id: "node-1",
+      name: "Generate answer",
+      type: "llm_prompt",
+      duration: 0,
+      tokens: 0,
+      cost: 0,
+    });
+
+    expect(screen.getByText("0ms")).toBeInTheDocument();
+    expect(screen.getByText("0.0000")).toBeInTheDocument();
+    expect(screen.getByText("0")).toBeInTheDocument();
+  });
+});

--- a/frontend/src/sections/agent-playground/AgentBuilder/RunAgentPanel/__tests__/NodeOutputListView.test.jsx
+++ b/frontend/src/sections/agent-playground/AgentBuilder/RunAgentPanel/__tests__/NodeOutputListView.test.jsx
@@ -1,0 +1,52 @@
+import { describe, expect, it, vi } from "vitest";
+import userEvent from "@testing-library/user-event";
+import { render, screen } from "src/utils/test-utils";
+import NodeOutputListView from "../NodeOutputListView";
+
+const nodes = [
+  {
+    id: "agent",
+    name: "Nested agent",
+    type: "agent",
+    children: [
+      {
+        id: "agent__prompt",
+        name: "Generate answer",
+        type: "llm_prompt",
+        duration: 500,
+        children: [],
+      },
+    ],
+  },
+];
+
+describe("NodeOutputListView", () => {
+  it("selects rows and filters nested executions by name", async () => {
+    const onNodeSelect = vi.fn();
+    const user = userEvent.setup();
+    render(
+      <NodeOutputListView
+        nodes={nodes}
+        selectedNodeId={null}
+        onNodeSelect={onNodeSelect}
+      />,
+    );
+
+    await user.click(screen.getByText("Generate answer"));
+    expect(onNodeSelect).toHaveBeenCalledWith("agent__prompt");
+
+    await user.type(screen.getByPlaceholderText("Search"), "generate");
+    expect(screen.getByText("Generate answer")).toBeInTheDocument();
+    expect(screen.getByText("Nested agent")).toBeInTheDocument();
+
+    await user.clear(screen.getByPlaceholderText("Search"));
+    await user.type(screen.getByPlaceholderText("Search"), "missing");
+    expect(screen.getByText("No matching nodes")).toBeInTheDocument();
+  });
+
+  it("uses the existing empty state when no nodes executed", () => {
+    render(<NodeOutputListView nodes={[]} onNodeSelect={vi.fn()} />);
+
+    expect(screen.getByText("No nodes to display")).toBeInTheDocument();
+  });
+});

--- a/frontend/src/sections/agent-playground/AgentBuilder/RunAgentPanel/__tests__/common.test.js
+++ b/frontend/src/sections/agent-playground/AgentBuilder/RunAgentPanel/__tests__/common.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { getNodeConfig } from "../common";
+import { buildNodeOutputTree, getNodeConfig } from "../common";
 
 describe("getNodeConfig", () => {
   it("returns prompt config for 'llm_prompt' type", () => {
@@ -28,5 +28,72 @@ describe("getNodeConfig", () => {
   it("returns default config for undefined type", () => {
     const config = getNodeConfig(undefined);
     expect(config.color).toBe("text.secondary");
+  });
+});
+
+describe("buildNodeOutputTree", () => {
+  it("maps executed node fields and converts seconds to milliseconds", () => {
+    const result = buildNodeOutputTree([
+      {
+        id: "prompt",
+        name: "Fallback name",
+        node_execution: {
+          node_name: "Generate answer",
+          node_type: "llm_prompt",
+          duration_seconds: 1.25,
+        },
+      },
+    ]);
+
+    expect(result).toEqual([
+      {
+        id: "prompt",
+        name: "Generate answer",
+        type: "llm_prompt",
+        duration: 1250,
+        children: [],
+      },
+    ]);
+  });
+
+  it("omits nodes that did not execute and prefixes subgraph child ids", () => {
+    const result = buildNodeOutputTree([
+      { id: "skipped", name: "Skipped" },
+      {
+        id: "agent",
+        name: "Nested agent",
+        subGraph: {
+          nodes: [
+            {
+              id: "inner",
+              nodeExecution: {
+                node_name: "Inner prompt",
+                node_type: "llm_prompt",
+                duration_seconds: 0.5,
+              },
+            },
+          ],
+        },
+      },
+    ]);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe("agent");
+    expect(result[0].children[0]).toMatchObject({
+      id: "agent__inner",
+      name: "Inner prompt",
+      duration: 500,
+    });
+  });
+
+  it("includes cost and token metrics only when the API supplies them", () => {
+    const [node] = buildNodeOutputTree([
+      {
+        id: "prompt",
+        nodeExecution: { cost: 0, tokens: 0 },
+      },
+    ]);
+
+    expect(node).toMatchObject({ cost: 0, tokens: 0 });
   });
 });

--- a/frontend/src/sections/agent-playground/AgentBuilder/RunAgentPanel/common.js
+++ b/frontend/src/sections/agent-playground/AgentBuilder/RunAgentPanel/common.js
@@ -22,3 +22,27 @@ const NODE_TYPE_CONFIG = {
 export const getNodeConfig = (type) => {
   return NODE_TYPE_CONFIG[type] || NODE_TYPE_CONFIG.default;
 };
+
+const getExecution = (node) => node?.nodeExecution || node?.node_execution;
+
+export const buildNodeOutputTree = (nodes = [], parentId = null) =>
+  nodes.reduce((result, node) => {
+    const execution = getExecution(node);
+    const id = parentId ? `${parentId}__${node.id}` : node.id;
+    const children = buildNodeOutputTree(node?.subGraph?.nodes || [], id);
+
+    if (!execution && children.length === 0) return result;
+
+    result.push({
+      id,
+      name: execution?.node_name || node.name || "Unnamed node",
+      type: execution?.node_type || (node?.subGraph ? "agent" : node.type),
+      ...(execution?.duration_seconds != null && {
+        duration: execution.duration_seconds * 1000,
+      }),
+      ...(execution?.cost != null && { cost: execution.cost }),
+      ...(execution?.tokens != null && { tokens: execution.tokens }),
+      children,
+    });
+    return result;
+  }, []);


### PR DESCRIPTION
## Summary

The agent playground run panel now displays its existing searchable node-execution list alongside the graph and detail pane. Execution records are mapped to the tree row shape, graph/list selection stays synchronized, nested node IDs match the graph, and unavailable cost/token metrics are omitted instead of appearing as misleading zeroes.

## Linked issues

Closes #2663
Linear: N/A

## AI use

AI use: Pi assisted with repository search, implementation, and tests; I directed the scope and reviewed the final diff and validation output.

## Type of change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📖 Documentation only
- [ ] 🧹 Chore / refactor
- [ ] 🚀 Performance improvement
- [ ] 🧪 Test-only change

## E2E coverage

E2E: exempt (harness-gap: no authenticated agent-playground run-panel fixture flow)

---

## 1) What changes were done

**A. Node execution overview**

- Wired `NodeOutputListView` into `RunAgentPanel` beside the graph and detail pane using nested resizable panels.
- Added a focused adapter from API execution records to the existing tree row model, including nested subgraph IDs and seconds-to-milliseconds conversion.
- Made search retain matching nested nodes and their ancestors.

**B. Accurate metadata**

- Rows display duration from `duration_seconds`.
- Cost and token metrics render only when supplied by the API, including legitimate zero values.

## 2) Why the changes were done

- **Product/UX:** Users can scan, search, compare, and select every executed node without clicking around the graph one node at a time.
- **Technical:** Reusing the shipped list/tree components avoids a second execution-navigation implementation and keeps selection IDs shared with the graph.

## 3) Tests written + scenarios each covers

**`RunAgentPanel/__tests__/common.test.js`**

- Maps snake/camel execution shapes, duration, nested IDs, omitted nodes, and optional metrics.

**`RunAgentPanel/__tests__/CustomTreeNode.test.jsx`**

- Omits absent metrics and preserves explicitly supplied zero values.

**`RunAgentPanel/__tests__/NodeOutputListView.test.jsx`**

- Covers row selection, nested search, ancestor retention, no-match feedback, and the existing empty state.

```text
Test Files  3 passed (3)
Tests       12 passed (12)
Duration    7.20s
```

## 4) How to run / test

```bash
cd frontend
vitest run src/sections/agent-playground/AgentBuilder/RunAgentPanel/__tests__
eslint src/sections/agent-playground/AgentBuilder/RunAgentPanel
```

### UI steps

1. Run an agent with several nodes in Agent Playground.
2. Verify the run panel shows the execution list, graph, and detail pane.
3. Select a list row and a graph node; verify both surfaces and the detail pane remain synchronized.
4. Search for a nested node and resize both panel dividers.

## 5) Screenshots / recordings

Not included; local authenticated stack data was unavailable.

## 6) Edge cases & considerations

- Nodes without execution records are omitted; an entirely empty run uses the existing empty state.
- Nested IDs use the graph's `parent__child` convention.
- Missing cost/token values are omitted, while supplied zeroes remain visible.

## 7) Pre-existing issues (NOT introduced by this PR)

- The complete frontend Vitest run exceeded a 20-minute local timeout. The affected focused suite passes.
- Full frontend ESLint passes with 426 existing warnings and zero errors; changed-file ESLint is clean.

## 8) Architectural / important decisions

- **Adapter at the panel boundary:** Keeps API-specific names and units out of generic tree presentation components.
- **Nested resizable panels:** Preserves existing graph/detail behavior while adding the list as a peer surface.

## Checklist

- [x] My code follows the style guide
- [x] I've added tests that prove my fix is effective
- [ ] `yarn test:run` passes locally (full run timed out; focused affected suite passes)
- [x] Contracts are unchanged
- [x] Documentation is not required
- [x] No hardcoded secrets, URLs, or PII
- [ ] CLA bot pending
- [x] PR title follows Conventional Commits
- [x] Linear issue: N/A
