### PR TITLE
hotfix(accounts): fix Marketplace runtime errors that escaped review [TH-7731]

### DIFF
--- a/futureagi/accounts/gcp_marketplace_events.py
+++ b/futureagi/accounts/gcp_marketplace_events.py
@@ -438,7 +438,7 @@ def handle_entitlement_deleted(payload: dict) -> None:
         organization_id=row.organization_id
     ).first()
     continues = subscription is not None and (
-        subscription.is_marketplace_billed()
+        subscription.is_marketplace_billed
         or subscription.plan != PlanChoices.FREE
         or bool(subscription.stripe_subscription_id)
     )

--- a/futureagi/accounts/gcp_marketplace_usage.py
+++ b/futureagi/accounts/gcp_marketplace_usage.py
@@ -796,10 +796,10 @@ def _reconcile_entitlement(entitlement, period: str) -> list[dict]:
         # After the allowance, because that is what we report: the raw
         # total would flag every org by its own allowance. None means no
         # usage row, so zero, not skip -- skipping hides an over-report.
-        ledger_total = _billable_total(entitlement, dimension, period, plan)
-        ledger_total = (ledger_total or Decimal(0)).to_integral_value(
-            rounding=ROUND_FLOOR
-        )
+        billable = _billable_total(entitlement, dimension, period, plan)
+        ledger_total = billable or Decimal(0)
+        if dimension not in settings.GCP_MARKETPLACE_FLOAT_DIMENSIONS:
+            ledger_total = ledger_total.to_integral_value(rounding=ROUND_FLOOR)
 
         reported = GCPMarketplaceUsageCheckpoint.objects.filter(
             entitlement=entitlement,

--- a/futureagi/accounts/gcp_marketplace_utils.py
+++ b/futureagi/accounts/gcp_marketplace_utils.py
@@ -492,7 +492,7 @@ def process_signup(onboarding_token: str, email: str, full_name: str) -> User:
         )
         organization.name = full_name or organization.name
         organization.display_name = full_name or organization.display_name
-        organization.save(update_fields=["name", "display_name", "updated_at"])
+        organization.save(update_fields=["name", "display_name"])
 
     process_post_registration(user.id, generated_password)
     _finish_signup(gcp_account, onboarding_token)

--- a/futureagi/accounts/services/gcp_procurement.py
+++ b/futureagi/accounts/services/gcp_procurement.py
@@ -186,14 +186,16 @@ class GCPProcurementService:
         )
 
     def approve_entitlement(
-        self, entitlement_id: str, entitlement_migrated: bool = False
+        self, entitlement_id: str, migrated_from_entitlement_id: str | None = None
     ) -> dict:
         logger.info(
             "gcp_marketplace_entitlement_approve", entitlement_id=entitlement_id
         )
         body: dict = {}
-        if entitlement_migrated:
-            body["entitlementMigrated"] = True
+        if migrated_from_entitlement_id:
+            body["entitlementMigrated"] = self.entitlement_name(
+                migrated_from_entitlement_id
+            )
         return self._write(
             self.client.providers()
             .entitlements()
@@ -275,7 +277,7 @@ class GCPProcurementService:
             "pageToken": page_token,
         }
         if account_id:
-            kwargs["filter"] = f"account={self.account_name(account_id)}"
+            kwargs["filter"] = f"account={account_id}"
         return self._read(self.client.providers().entitlements().list(**kwargs))
 
     def iter_entitlements(self, account_id: str | None = None):


### PR DESCRIPTION
> Hotfix of #2674 cherry-picked onto main so production can redeploy without waiting for the dev promotion. Same commit, same diff.

## Summary

Fixes four runtime errors in the GCP Marketplace integration that static review and the (absent) test suite did not catch. The first one blocks every Marketplace sign-up on production, form and Google OAuth alike, with a 400 `validation_error` reading `The following fields do not exist in this model, are m2m fields, or are non-concrete fields: updated_at`. The second crashes the `ENTITLEMENT_DELETED` handler. The remaining two correct API payloads on paths that have no caller yet.

## Why the changes are done — what is the problem

### Reproduce on dev / main today (before this PR)

1. Subscribe to the Future AGI listing in the Google Cloud console and follow the redirect to `/auth/jwt/register?onboarding_gcp_token=...`.
2. Submit the form with any email and name, or click Continue with Google.
3. The sign-up endpoint returns 400 with the `updated_at` message above. The transaction rolls back, Google never receives the account approval, and the customer is stuck on a broken form.

### Where it breaks — BE

`process_signup` renames the org after creating the owner and saves with `update_fields=["name", "display_name", "updated_at"]`. `Organization` is a plain `models.Model` with only `created_at`; it does not extend `BaseModel`, which is where `updated_at` lives. Django rejects the save at runtime, inside the `transaction.atomic()` block, so the User and membership roll back too.

`handle_entitlement_deleted` calls `subscription.is_marketplace_billed()`, but `OrganizationSubscription.is_marketplace_billed` is a `@property`. Every `ENTITLEMENT_DELETED` event for an org with a subscription row raised `TypeError: 'bool' object is not callable` inside `process_event`, rolled back the dedupe row and redelivered until the poison guard dropped it.

## What changed

### futureagi/accounts/gcp_marketplace_utils.py

Dropped `updated_at` from the `Organization.save(update_fields=...)` call. The two remaining fields are concrete on the model. This fixes both sign-up routes, since the form view and the SSO resolver share this function.

### futureagi/accounts/gcp_marketplace_events.py

`is_marketplace_billed` is read as a property, matching every other caller in `billing_api.py`, `stripe_service.py` and `ee/cloud/billing/usage.py`.

### futureagi/accounts/gcp_marketplace_usage.py

The daily reconcile floored the ledger total for every dimension, but `_add_window` floors only integer dimensions. For `storage` and `voice_sim_minutes` the reported checkpoints sum to the exact fractional total, so any fractional usage logged a false `gcp_marketplace_usage_discrepancy` every day. Reconcile now floors only dimensions outside `GCP_MARKETPLACE_FLOAT_DIMENSIONS`, matching the reporting path.

### futureagi/accounts/services/gcp_procurement.py

- `approve_entitlement` sent `entitlementMigrated: true`. The Procurement API defines the field as a string holding the migrated entitlement's resource name (`providers/{p}/entitlements/{e}`). The parameter is now `migrated_from_entitlement_id` and the body carries the resource name. Both current callers pass only the entitlement id, so behaviour is unchanged today.
- `list_entitlements` filtered on the full account resource name unquoted. The API expects the bare account id (`account=E-1234-...`) and rejects unquoted slashes. No current caller passes `account_id`.

Both API shapes were compared against the `cloudcommerceprocurement.v1.json` discovery document bundled in the installed `google-api-python-client`.

## Tests included — what each scenario covers

No automated tests exist for the Marketplace code and none are added here. Manual test plan:

- [ ] Fresh Marketplace purchase, submit the register form with email and name: sign-up returns 200, the org is renamed, the account and entitlement are approved on the Google side.
- [ ] Same flow via Continue with Google on the register page: same result.
- [ ] Publish an `ENTITLEMENT_DELETED` message for an org with a subscription row: the handler completes and the dedupe row persists.
- [ ] Org with fractional storage usage: the daily reconcile logs no discrepancy for `storage`.

## Commands to run tests

```sh
# cwd: futureagi
uvx ruff check --select F,B,E9 accounts/gcp_marketplace_utils.py accounts/gcp_marketplace_events.py accounts/gcp_marketplace_usage.py accounts/services/gcp_procurement.py
```

### Local verification results

```
All checks passed!
```

Every `update_fields` list, ORM lookup, related name, choice value and cross-module call in the Marketplace modules was verified against its definition. `makemigrations --check --dry-run` under `django.setup()` reports no changes.

## Backwards compatibility

No schema change, no migration. Semantics:

| Caller | Impact |
|---|---|
| Sign-up form and SSO resolver | Now succeed. Payloads and responses unchanged. |
| `ENTITLEMENT_DELETED` handler | Now completes instead of raising. |
| Daily usage reconcile | Fewer false discrepancy logs for float dimensions. |
| `approve_entitlement(entitlement_id)` | Unchanged for both current callers. The optional second argument changed type from bool to str; no caller used it. |
| `list_entitlements(account_id=...)` | Unchanged; no current caller. |

## Manual verification (UI)

1. Open the Marketplace listing, subscribe, complete the redirect to the register page.
2. Submit the form. Confirm the success toast and that the org appears on the payg plan in Settings.
3. Confirm the pricing page shows the plan-change lock reason.

## Type of change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📖 Documentation
- [ ] 🧹 Chore / refactor
- [ ] 🚀 Performance
- [ ] 🧪 Test-only

## Checklist

- [x] Follows the style guide, lint passes
- [ ] Tests added (none exist for this module)
- [x] No secrets, URLs or PII

## Backout / rollback

Revert the single commit. Nothing in it touches the database.

## Linear

Fixes TH-7731
