### PR TITLE
Design polish: simulate-v2 prototype (clipped text, verdict-first results, missing states)

### DIFF
--- a/frontend/src/routes/sections/dashboard.jsx
+++ b/frontend/src/routes/sections/dashboard.jsx
@@ -1412,6 +1412,14 @@ export const dashboardRoutes = (
               element: <Navigate to="/dashboard/simulate/environments" replace />,
             },
             {
+              /* The global runs list moved onto the My Environments tab, but
+                 the paths.simulate.simulationRuns constant still points here.
+                 Redirect stale links/bookmarks instead of hitting the catch-all
+                 404. */
+              path: "runs",
+              element: <Navigate to="/dashboard/simulate/environments" replace />,
+            },
+            {
               /* Twin detail page still lives — post-provisioning UX. */
               path: "twins/:envId",
               element: <SimTwinDetail />,

--- a/frontend/src/sections/simulate-v2/DESIGN_POLISH_WORKLOG.md
+++ b/frontend/src/sections/simulate-v2/DESIGN_POLISH_WORKLOG.md
@@ -11,13 +11,19 @@ Design system anchors:
   `SectionCard`, `EmptyState`, `PersonaBadge`, `DomainChip`, `VERDICT_TONE`, `STATUS_META`.
 
 ## Workstreams (priority order)
-- [ ] A. Data/number + color coherence — reconcile pass-rate labels across run screens; one pass/warn/fail scale; drop ad-hoc peach/pink tints.
-- [ ] B. Clipped text / overflow — Scenarios table columns; Interface (RL) code block.
-- [ ] C. Lead with the verdict — Traces rows; live-run task titles (persona first).
-- [ ] D. Missing states & flows — one not-found component; twin routes; orphaned /simulate/runs; empty states.
-- [ ] E. Chart craft & compare — Simulations summary deltas + "1 runs" grammar + hide chart when n<3.
-- [ ] F. Cut self-narrating prose — connect screens, list-page H1 subtitles, workspace headers, button labels.
-- [ ] G. Chrome/overlay — Overview CTA consolidation; content bottom padding so FABs don't collide.
+- [~] A. Data/number + color coherence — Traces "not measured" cells now show "—" (no phantom score); CSAT alarm reserved for 1-2; VERDICT_TONE gained an amber `error`. Deeper cross-screen count reconciliation (40 vs 50 scenarios; agent v1 vs "no agent"; gate "cleared to ship" vs run failures) left for dev — it spans mock selectors.
+- [x] B. Clipped text / overflow — Scenarios table (fixed layout + colgroup); Interface code (pre-wrap).
+- [x] C. Lead with the verdict — Traces rows lead with Verdict + specific scenario name + summary.
+- [x] D. Missing states & flows — shared EmptyState with a real exit on twin-detail / twin-connect / use-template; /simulate/runs redirect.
+- [~] E. Chart craft & compare — "1 runs" grammar + misleading copy fixed; trend chart held until >=3 runs. Per-column deltas: the baseline-delta feature already exists on baseline-select; auto-defaulting it is a follow-up (don't destabilise baseline UX).
+- [~] F. Cut self-narrating prose — fixed the re-prove banner casing/length; entry-card affordance. Broad prose trim left partial (brand voice is deliberate; trimmed only clear dupes).
+- [ ] G. Chrome/overlay — Overview CTA consolidation + FAB overlap: recommended for dev (touches global layout / shared toolbar).
+
+## Follow-ups recommended for dev (higher-risk / cross-cutting)
+- One source of truth for counts + statuses (40/50 scenarios; agent-attached; release gate vs run verdict).
+- Collapse the 3-tier workspace header to 2; single primary CTA; disabled "Run simulation" needs a reason.
+- FAB + avatar overlap on right-aligned content (global layout).
+- Traces trailing grader columns still overflow right; cap numeric widths / column reorder.
 
 ## Rules
 - Only commit simulate-v2 design files (+ shared primitives/routes as needed). NEVER commit the
@@ -27,3 +33,10 @@ Design system anchors:
 
 ## Log
 - (start) branch cut; design system read; worklog created.
+- Commit 1: clipped-text fix (Scenarios fixed table layout; Interface pre-wrap).
+- Commit 2: lead run rows with verdict; CSAT alarm 1-2; error tone; summary grammar/copy + chart gate.
+- Commit 3: graceful shared not-found states + /simulate/runs redirect + PropTypes.
+- Commit 4: Traces name/summary lead; grader "—" for not-measured; drop vertical grid; banner casing.
+- Commit 5: chart held to >=3 runs; self-improve "up to N%" neutral; amber (not red) measurement-fix card.
+- Commit 6: entry-card violet hover + persistent arrow affordance.
+- Verified each screen via Playwright capture; two Fable critic passes drove the priorities.

--- a/frontend/src/sections/simulate-v2/DESIGN_POLISH_WORKLOG.md
+++ b/frontend/src/sections/simulate-v2/DESIGN_POLISH_WORKLOG.md
@@ -1,0 +1,29 @@
+# Simulate Studio v2 — design polish worklog
+
+Branch: `feat/sim-studio-v2-design-polish` (cut from `feat/simulation-studio-v2`).
+Goal: raise design quality + fill missing states/flows, grounded in the existing FutureAGI
+design system (theme palette + `components/primitives.jsx`). Fable used as design critic.
+
+Design system anchors:
+- Brand primary `#7857FC`; semantic `success #5ACE6D`, `warning #F5E65F`/icon `#8C3F08`,
+  `error #DB2F2D`, `info #2F7CF7`. Grey scale has a violet bias.
+- Reuse primitives: `Verdict`, `StatusChip`, `StatusDot`, `ScorePill`, `MetricTile`,
+  `SectionCard`, `EmptyState`, `PersonaBadge`, `DomainChip`, `VERDICT_TONE`, `STATUS_META`.
+
+## Workstreams (priority order)
+- [ ] A. Data/number + color coherence — reconcile pass-rate labels across run screens; one pass/warn/fail scale; drop ad-hoc peach/pink tints.
+- [ ] B. Clipped text / overflow — Scenarios table columns; Interface (RL) code block.
+- [ ] C. Lead with the verdict — Traces rows; live-run task titles (persona first).
+- [ ] D. Missing states & flows — one not-found component; twin routes; orphaned /simulate/runs; empty states.
+- [ ] E. Chart craft & compare — Simulations summary deltas + "1 runs" grammar + hide chart when n<3.
+- [ ] F. Cut self-narrating prose — connect screens, list-page H1 subtitles, workspace headers, button labels.
+- [ ] G. Chrome/overlay — Overview CTA consolidation; content bottom padding so FABs don't collide.
+
+## Rules
+- Only commit simulate-v2 design files (+ shared primitives/routes as needed). NEVER commit the
+  dev-only auth stub (`auth-provider.jsx`) or fast-play (`useRunPlayer.js`) — kept uncommitted.
+- Match existing code idioms. No new deps. Run lint after edits.
+- Verify each screen visually (Playwright capture) before/after; Fable critic on the changed screens.
+
+## Log
+- (start) branch cut; design system read; worklog created.

--- a/frontend/src/sections/simulate-v2/_mock/runStream.js
+++ b/frontend/src/sections/simulate-v2/_mock/runStream.js
@@ -446,6 +446,12 @@ export function buildRun({
     return {
       id: sc.id,
       callLog,
+      /* Carry the scenario's own name + human summary so the traces table can
+         lead each row with the specific scenario (matching the Scenarios tab)
+         instead of the goal template, which repeats across every row in a
+         group. */
+      name: sc.name,
+      summary: sc.summary,
       title: sc.title,
       task: sc.task,
       persona: sc.persona,

--- a/frontend/src/sections/simulate-v2/components/primitives.jsx
+++ b/frontend/src/sections/simulate-v2/components/primitives.jsx
@@ -144,6 +144,10 @@ export const VERDICT_TONE = {
   passed:  { color: "#5AA47B", label: "Passed" },
   failed:  { color: "#C2603F", label: "Failed" },
   flaky:   { color: "#B98A3C", label: "Flaky" },
+  /* Infra fell over before the agent could be judged — deliberately amber,
+     not red: this is our failure, not the agent's, and it never counts against
+     the agent's score. */
+  error:   { color: "#C67A2E", label: "Errored" },
   unmeasured: { color: "#9AA0A6", label: "Not measured" },
   missing: { color: "#9AA0A6", label: "Not run" },
 };

--- a/frontend/src/sections/simulate-v2/environments/StartEnvironment.jsx
+++ b/frontend/src/sections/simulate-v2/environments/StartEnvironment.jsx
@@ -240,7 +240,8 @@ function HeroCard({ icon, title, tag, description, chips, moreLabel, selected, o
           : "background.paper",
         transition: "border-color .12s ease, background-color .12s ease",
         "&:hover": {
-          borderColor: (th) => selected ? undefined : (th.palette.mode === "dark" ? alpha(th.palette.text.primary, 0.32) : th.palette.text.disabled),
+          borderColor: (th) => selected ? undefined : alpha(th.palette.primary.main, 0.55),
+          bgcolor: (th) => selected ? undefined : alpha(th.palette.primary.main, th.palette.mode === "dark" ? 0.08 : 0.035),
         },
       }}
     >
@@ -368,11 +369,27 @@ function OptionCard({ option, selected, onClick }) {
           ? alpha(th.palette.text.primary, th.palette.mode === "dark" ? 0.06 : 0.03)
           : "background.paper",
         transition: "border-color .12s ease, background-color .12s ease",
+        /* A clearer, on-brand affordance: these are the pick-your-on-ramp
+           cards, so hover pulls the violet accent and the corner arrow leans
+           in — the static card no longer reads as a passive tile. */
         "&:hover": {
-          borderColor: (th) => selected ? undefined : (th.palette.mode === "dark" ? alpha(th.palette.text.primary, 0.32) : th.palette.text.disabled),
+          borderColor: (th) => selected ? undefined : alpha(th.palette.primary.main, 0.55),
+          bgcolor: (th) => selected ? undefined : alpha(th.palette.primary.main, th.palette.mode === "dark" ? 0.08 : 0.035),
+          "& .opt-arrow": { opacity: 1, transform: "translateX(2px)", color: "primary.main" },
         },
       }}
     >
+      {!selected && (
+        <Iconify
+          className="opt-arrow"
+          icon="solar:arrow-right-linear"
+          width={16}
+          sx={{
+            position: "absolute", top: 12, right: 12, color: "text.disabled", opacity: 0.45,
+            transition: "opacity .12s ease, transform .12s ease, color .12s ease",
+          }}
+        />
+      )}
       <Stack direction="row" alignItems="center" spacing={1.25}>
         <Box
           sx={{

--- a/frontend/src/sections/simulate-v2/environments/TwinConnectPage.jsx
+++ b/frontend/src/sections/simulate-v2/environments/TwinConnectPage.jsx
@@ -1,3 +1,4 @@
+import PropTypes from "prop-types";
 import { useMemo, useState, useEffect } from "react";
 import { useNavigate, useParams } from "react-router-dom";
 import { Helmet } from "react-helmet-async";
@@ -53,7 +54,20 @@ export default function TwinConnectPage() {
   if (!env) {
     return (
       <Box sx={{ p: 4 }}>
-        <EmptyState icon="solar:danger-triangle-linear" title="Environment not found" body="It may have been renamed or deleted." />
+        <EmptyState
+          icon="solar:box-minimalistic-linear"
+          title="This environment isn't here"
+          body="It may have been deleted, or the link is from an older version."
+          action={
+            <Button
+              variant="contained" color="primary" size="small"
+              startIcon={<Iconify icon="solar:alt-arrow-left-linear" width={16} />}
+              onClick={() => navigate(paths.dashboard.simulate.environments)}
+            >
+              Back to environments
+            </Button>
+          }
+        />
       </Box>
     );
   }
@@ -232,3 +246,4 @@ function Line({ label, value }) {
     </Stack>
   );
 }
+Line.propTypes = { label: PropTypes.node, value: PropTypes.node };

--- a/frontend/src/sections/simulate-v2/environments/UseTemplate.jsx
+++ b/frontend/src/sections/simulate-v2/environments/UseTemplate.jsx
@@ -164,7 +164,20 @@ export default function UseTemplate() {
   if (!env) {
     return (
       <Box sx={{ p: 3 }}>
-        <EmptyState icon="solar:danger-triangle-linear" title="Template not found" body="It may have been renamed." />
+        <EmptyState
+          icon="solar:widget-4-linear"
+          title="This template isn't here"
+          body="It may have been renamed, or the link is from an older version. Browse the full catalog to pick another."
+          action={
+            <Button
+              variant="contained" color="primary" size="small"
+              startIcon={<Iconify icon="solar:alt-arrow-left-linear" width={16} />}
+              onClick={() => navigate(paths.dashboard.simulate.environments)}
+            >
+              Browse environments
+            </Button>
+          }
+        />
       </Box>
     );
   }

--- a/frontend/src/sections/simulate-v2/run/RunsSummary.jsx
+++ b/frontend/src/sections/simulate-v2/run/RunsSummary.jsx
@@ -318,11 +318,11 @@ export default function RunsSummary({ env, envState, onGo, onStart }) {
           bgcolor: "background.paper", overflow: "hidden",
         }}
       >
-        {/* A trend needs at least two points. With one run the line was two
-            dots on a stem across an empty axis — it read as a broken chart, so
-            the whole chart region (grader picker, legend, line) waits for a
-            second run and the table below carries the single run on its own. */}
-        {summaries.length > 1 && (<>
+        {/* A two-point line across the full width was flat noise ("we have a
+            chart component"); the table reads a 2-run comparison better than a
+            line does. Hold the trend until a third run gives it a shape — until
+            then the runs table below carries the comparison. */}
+        {summaries.length >= 3 && (<>
         {/*
           Its own row rather than the card's action slot. Seven graders make
           both the selector's summary and the legend long, and in the header

--- a/frontend/src/sections/simulate-v2/run/RunsSummary.jsx
+++ b/frontend/src/sections/simulate-v2/run/RunsSummary.jsx
@@ -269,9 +269,9 @@ export default function RunsSummary({ env, envState, onGo, onStart }) {
               acceptable is a subtitle that keeps promising "the same scenarios"
               while one of the rows below covered three of them. */}
           <Typography sx={{ typography: "s1", color: "text.secondary" }}>
-            {summaries.length} runs
+            {summaries.length} {summaries.length === 1 ? "run" : "runs"}
             {full.length === summaries.length
-              ? `. The same ${envState.scenarios.length} scenarios every time, so what changed is the agent. 3 samples per scenario.`
+              ? `. The same ${envState.scenarios.length} scenarios every time — compare two runs to see what moved. 3 samples per scenario.`
               : `. ${full.length} over the full ${envState.scenarios.length} scenarios, ${summaries.length - full.length} over a subset. 3 samples per scenario.`}
             {trials.length > 0 && ` · ${trials.length} self-improvement trial${trials.length === 1 ? "" : "s"} live under their parent run`}
           </Typography>
@@ -318,6 +318,11 @@ export default function RunsSummary({ env, envState, onGo, onStart }) {
           bgcolor: "background.paper", overflow: "hidden",
         }}
       >
+        {/* A trend needs at least two points. With one run the line was two
+            dots on a stem across an empty axis — it read as a broken chart, so
+            the whole chart region (grader picker, legend, line) waits for a
+            second run and the table below carries the single run on its own. */}
+        {summaries.length > 1 && (<>
         {/*
           Its own row rather than the card's action slot. Seven graders make
           both the selector's summary and the legend long, and in the header
@@ -466,6 +471,7 @@ export default function RunsSummary({ env, envState, onGo, onStart }) {
             }}
           />
         </Box>
+        </>)}
 
         {/* ── did the fix do what it was projected to do ── */}
       {expectation && verified && (

--- a/frontend/src/sections/simulate-v2/run/TraceTable.jsx
+++ b/frontend/src/sections/simulate-v2/run/TraceTable.jsx
@@ -492,7 +492,9 @@ export default function TraceTable({
         const measured = t.status !== "unmeasured" && t.status !== "error";
         return (
           <TableCell key={e.id} sx={{ ...bodyCell, p: 0, position: "relative" }} onClick={() => onOpen(t)}>
-            {r && measured ? <Score result={r} /> : <Box sx={{ p: 2, typography: "s2", color: "text.disabled" }}>—</Box>}
+            {r && measured
+              ? <Score result={r} />
+              : <Box sx={{ p: 2, display: "grid", placeItems: "center", typography: "s2", fontWeight: 600, color: "text.disabled" }}>—</Box>}
           </TableCell>
         );
       })}

--- a/frontend/src/sections/simulate-v2/run/TraceTable.jsx
+++ b/frontend/src/sections/simulate-v2/run/TraceTable.jsx
@@ -8,6 +8,7 @@ import {
 import Iconify from "src/components/iconify";
 import { interpolateColorBasedOnScore } from "src/utils/utils";
 import { subTasksFor } from "../_mock/contract";
+import { Verdict } from "../components/primitives";
 
 /**
  * The traces, as a table with optional grouping.
@@ -43,7 +44,10 @@ const latencyOf = (t) => 280 + (hash(t.id) % 320);
   the highlight stays rare and meaningful.
 */
 const METRIC_THRESHOLDS = {
-  csat:    { direction: "lowIsBad",  bad: 4 },
+  /* Only genuinely low satisfaction is an alarm. CSAT runs ~1-6 here, so a
+     4 is a good result — flagging it red next to a "Passed" verdict read as a
+     contradiction. Reserve the red triangle for 1-2. */
+  csat:    { direction: "lowIsBad",  bad: 2 },
   turns:   { direction: "highIsBad", bad: 12 },
   latency: { direction: "highIsBad", bad: 550 },
   tokens:  { direction: "highIsBad", bad: 6000 },
@@ -440,14 +444,15 @@ export default function TraceTable({
 
       {show("callDetails") && (
         <TableCell sx={bodyCell} onClick={() => onOpen(t)}>
-          <Typography sx={{ typography: "s2", fontWeight: 500 }}>
-            {t.status === "failed" ? "Failed" : t.status === "error" ? "Errored" : "Completed"}
+          {/* Lead with the verdict, not the lifecycle status: a reader
+              scanning results wants "did it pass" first, and every passed
+              row used to read a grey "Completed" that buried the answer. */}
+          <Verdict status={t.status} passes={t.passes} repeats={t.repeats} />
+          <Typography noWrap sx={{ typography: "s3", color: "text.secondary", fontWeight: 600, mt: 0.375 }}>
+            {t.name || t.title || t.id}
           </Typography>
-          <Typography sx={{ typography: "s3", color: "text.subtitle" }}>
-            Duration : {((t.durationMs || 0) / 1000).toFixed(1)}s
-          </Typography>
-          <Typography sx={{ typography: "s3", color: "text.subtitle" }}>
-            {t.id}
+          <Typography noWrap sx={{ typography: "s3", color: "text.subtitle" }}>
+            {((t.durationMs || 0) / 1000).toFixed(1)}s · {t.id}
           </Typography>
         </TableCell>
       )}

--- a/frontend/src/sections/simulate-v2/run/TraceTable.jsx
+++ b/frontend/src/sections/simulate-v2/run/TraceTable.jsx
@@ -334,22 +334,21 @@ export default function TraceTable({
     return arr;
   }, [tasks, groupBy, env]);
 
+  /* Row separators only — the vertical grid lines that used to border every
+     cell made a dense results table read as a spreadsheet from a decade ago. */
   const headCell = {
     typography: "s2", fontWeight: 500, color: "text.secondary",
     whiteSpace: "nowrap", bgcolor: "background.paper", height: 44, py: 0,
     borderBottom: "1px solid", borderColor: "divider",
-    "&:not(:first-of-type)": { borderLeft: "1px solid", borderColor: "divider" },
   };
   const num = {
     verticalAlign: "top", py: 1.5,
     typography: "s2", color: "text.secondary", fontVariantNumeric: "tabular-nums",
     borderBottom: "1px solid", borderColor: "divider",
-    "&:not(:first-of-type)": { borderLeft: "1px solid", borderColor: "divider" },
   };
   const bodyCell = {
     verticalAlign: "top", py: 1.5,
     borderBottom: "1px solid", borderColor: "divider",
-    "&:not(:first-of-type)": { borderLeft: "1px solid", borderColor: "divider" },
   };
   const checkCell = {
     width: 48, p: 0, pl: 1.25, verticalAlign: "middle",
@@ -446,13 +445,20 @@ export default function TraceTable({
         <TableCell sx={bodyCell} onClick={() => onOpen(t)}>
           {/* Lead with the verdict, not the lifecycle status: a reader
               scanning results wants "did it pass" first, and every passed
-              row used to read a grey "Completed" that buried the answer. */}
+              row used to read a grey "Completed" that buried the answer.
+              Then the specific scenario name (not the goal template, which
+              repeats down the group), its human summary, then duration. */}
           <Verdict status={t.status} passes={t.passes} repeats={t.repeats} />
           <Typography noWrap sx={{ typography: "s3", color: "text.secondary", fontWeight: 600, mt: 0.375 }}>
             {t.name || t.title || t.id}
           </Typography>
-          <Typography noWrap sx={{ typography: "s3", color: "text.subtitle" }}>
-            {((t.durationMs || 0) / 1000).toFixed(1)}s · {t.id}
+          {(t.summary || t.title) && (
+            <Typography noWrap sx={{ typography: "s3", color: "text.subtitle" }}>
+              {t.summary || t.title}
+            </Typography>
+          )}
+          <Typography noWrap sx={{ typography: "s3", color: "text.disabled" }}>
+            {((t.durationMs || 0) / 1000).toFixed(1)}s
           </Typography>
         </TableCell>
       )}
@@ -480,9 +486,13 @@ export default function TraceTable({
 
       {showEvals && evals.map((e) => {
         const r = t.evalResults?.find((x) => x.id === e.id);
+        /* A task with no verdict (infra never let it be judged) must not show a
+           grader score — a "Not measured" row that reads "Passed 81" is the
+           contradiction reviewers notice first. */
+        const measured = t.status !== "unmeasured" && t.status !== "error";
         return (
           <TableCell key={e.id} sx={{ ...bodyCell, p: 0, position: "relative" }} onClick={() => onOpen(t)}>
-            {r ? <Score result={r} /> : <Box sx={{ p: 2, typography: "s2", color: "text.disabled" }}>—</Box>}
+            {r && measured ? <Score result={r} /> : <Box sx={{ p: 2, typography: "s2", color: "text.disabled" }}>—</Box>}
           </TableCell>
         );
       })}

--- a/frontend/src/sections/simulate-v2/run/fixmyagent/DiagnosisPane.jsx
+++ b/frontend/src/sections/simulate-v2/run/fixmyagent/DiagnosisPane.jsx
@@ -253,10 +253,16 @@ export default function DiagnosisPane({
                 <Typography sx={{ typography: "s3", color: "text.subtitle", mb: 1 }}>
                   These change the environment, not the agent — and no prompt edit substitutes for them.
                 </Typography>
+                {/* Amber, not red: these are measurement fixes to apply, not
+                    errors. A red border read as "something is broken here". */}
                 <Stack
                   spacing={0}
                   divider={<Box sx={{ borderBottom: "1px solid", borderColor: "divider" }} />}
-                  sx={{ border: "1px solid", borderColor: alpha("#DC2626", 0.3), borderRadius: 1 }}
+                  sx={{
+                    border: "1px solid", borderColor: "divider",
+                    borderLeft: "3px solid", borderLeftColor: alpha("#CA8A04", 0.8),
+                    borderRadius: 1,
+                  }}
                 >
                   {checks.map((c) => (
                     <Box key={c.id} sx={{ p: 1.75 }}>
@@ -464,10 +470,12 @@ export default function DiagnosisPane({
                 <Typography sx={{ typography: "s3", color: "text.subtitle" }}>
                   With {included.length} included
                 </Typography>
+                {/* A projection, not a promise — 'up to', and neutral, because a
+                    green 100% reads as an outcome the run already reached. */}
                 <Typography
-                  sx={{ typography: "s1", fontWeight: 700, color: "#16A34A", fontVariantNumeric: "tabular-nums" }}
+                  sx={{ typography: "s1", fontWeight: 700, color: "text.primary", fontVariantNumeric: "tabular-nums" }}
                 >
-                  {projected}%
+                  up to {projected}%
                 </Typography>
               </Box>
               <Box flex={1} />

--- a/frontend/src/sections/simulate-v2/twins/TwinDetail.jsx
+++ b/frontend/src/sections/simulate-v2/twins/TwinDetail.jsx
@@ -19,6 +19,7 @@ import SalesforceSandboxMock from "./SalesforceSandboxMock";
 import GenericSandboxMock from "./GenericSandboxMock";
 import TwinControlsDrawer from "./TwinControlsDrawer";
 import { OpenApiDialog, OpenSurfaceDialog } from "./TwinSandboxDialogs";
+import { EmptyState } from "../components/primitives";
 
 const SANDBOX_MOCKS = {
   slack: SlackSandboxMock,
@@ -92,19 +93,21 @@ export default function TwinDetail() {
 
   if (!env || !backing) {
     return (
-      <Box sx={{ p: 4 }}>
-        <Typography sx={{ typography: "s1", fontWeight: 700 }}>
-          Clone environment not found
-        </Typography>
-        <Typography sx={{ typography: "s2", color: "text.subtitle", mb: 2 }}>
-          It may have been deleted, or the URL is stale.
-        </Typography>
-        <Button
-          variant="outlined" size="small"
-          onClick={() => navigate(paths.dashboard.simulate.twins)}
-        >
-          Back to Clones
-        </Button>
+      <Box sx={{ display: "grid", placeItems: "center", minHeight: "60vh", p: 4 }}>
+        <EmptyState
+          icon="solar:box-minimalistic-linear"
+          title="This environment isn't here"
+          body="It may have been deleted, or the link is from an older version. Your environments are all in one place."
+          action={
+            <Button
+              variant="contained" color="primary" size="small"
+              startIcon={<Iconify icon="solar:alt-arrow-left-linear" width={16} />}
+              onClick={() => navigate(paths.dashboard.simulate.environments)}
+            >
+              Back to environments
+            </Button>
+          }
+        />
       </Box>
     );
   }

--- a/frontend/src/sections/simulate-v2/workspace/RlPanel.jsx
+++ b/frontend/src/sections/simulate-v2/workspace/RlPanel.jsx
@@ -93,11 +93,11 @@ export default function RlPanel({ env, envState, patch }) {
                 component="pre"
                 sx={{
                   m: 0, pl: 2.5, pr: 6, py: 2,
-                  /* Wrap instead of hiding overflow: these are short config /
-                     loop snippets, so a wrapped line reads better than a
-                     hidden horizontal scroll with no affordance. pr leaves
-                     room for the copy button so it never sits on the code. */
-                  whiteSpace: "pre-wrap", wordBreak: "break-word",
+                  /* Real code: keep lines intact and scroll horizontally.
+                     Soft-wrapping a Python comment spilled "being trained"
+                     onto its own column-0 line, which read as a statement.
+                     pr keeps the copy button clear of the code. */
+                  whiteSpace: "pre", overflowX: "auto",
                   typography: "s2", fontFamily: "ui-monospace, SFMono-Regular, Menlo, monospace",
                   color: "text.secondary", lineHeight: 1.7,
                 }}
@@ -246,7 +246,7 @@ export default function RlPanel({ env, envState, patch }) {
         <Box
           component="pre"
           sx={{
-            m: 0, px: 2.5, py: 2, whiteSpace: "pre-wrap", wordBreak: "break-word",
+            m: 0, px: 2.5, py: 2, whiteSpace: "pre", overflowX: "auto",
             borderTop: "1px solid", borderColor: "divider", bgcolor: "background.neutral",
             typography: "s3", fontFamily: "ui-monospace, SFMono-Regular, Menlo, monospace",
             color: "text.subtitle", lineHeight: 1.7,

--- a/frontend/src/sections/simulate-v2/workspace/RlPanel.jsx
+++ b/frontend/src/sections/simulate-v2/workspace/RlPanel.jsx
@@ -92,7 +92,12 @@ export default function RlPanel({ env, envState, patch }) {
               <Box
                 component="pre"
                 sx={{
-                  m: 0, px: 2.5, py: 2, overflowX: "auto",
+                  m: 0, pl: 2.5, pr: 6, py: 2,
+                  /* Wrap instead of hiding overflow: these are short config /
+                     loop snippets, so a wrapped line reads better than a
+                     hidden horizontal scroll with no affordance. pr leaves
+                     room for the copy button so it never sits on the code. */
+                  whiteSpace: "pre-wrap", wordBreak: "break-word",
                   typography: "s2", fontFamily: "ui-monospace, SFMono-Regular, Menlo, monospace",
                   color: "text.secondary", lineHeight: 1.7,
                 }}
@@ -241,7 +246,7 @@ export default function RlPanel({ env, envState, patch }) {
         <Box
           component="pre"
           sx={{
-            m: 0, px: 2.5, py: 2, overflowX: "auto",
+            m: 0, px: 2.5, py: 2, whiteSpace: "pre-wrap", wordBreak: "break-word",
             borderTop: "1px solid", borderColor: "divider", bgcolor: "background.neutral",
             typography: "s3", fontFamily: "ui-monospace, SFMono-Regular, Menlo, monospace",
             color: "text.subtitle", lineHeight: 1.7,

--- a/frontend/src/sections/simulate-v2/workspace/ScenariosStep.jsx
+++ b/frontend/src/sections/simulate-v2/workspace/ScenariosStep.jsx
@@ -212,9 +212,9 @@ export default function ScenariosStep({ env, envState, patch, buildMode }) {
                 : edited.length === stale.length ? " after being edited" : ""}
             </Typography>
             <Typography sx={{ typography: "s2", color: "text.secondary" }}>
-              This environment is on {proofStatus(stale[0], env, envState).current}.{" "}
-              {staleReasons.map((r) => INVALIDATING[r]).join("; ")}. They will still run and still
-              report a number — the number is just no longer standing on a proof.
+              This environment moved to {proofStatus(stale[0], env, envState).current} —{" "}
+              {staleReasons.map((r) => INVALIDATING[r]).join("; ")}. They still run and still report a
+              number; it just isn&apos;t standing on a proof yet.
             </Typography>
           </Box>
           <Button

--- a/frontend/src/sections/simulate-v2/workspace/scenarios/ScenarioTable.jsx
+++ b/frontend/src/sections/simulate-v2/workspace/scenarios/ScenarioTable.jsx
@@ -89,9 +89,23 @@ export default function ScenarioTable({ rows, groups, env, onEdit, onRemove }) {
   ];
   let counter = 0;
 
+  /*
+    Fixed layout + an explicit colgroup: with table-layout:auto the cell
+    maxWidths were advisory, so `noWrap` bodies grew the column and clipped
+    mid-glyph at the viewport edge instead of ellipsising inside their cell.
+    Pinning each column's width makes every truncation land in-cell.
+    Widths sum to 1534 (== minWidth) so the last column can't be squeezed.
+  */
+  const colWidths = [44, 44, 260, 180, 240, 300, 150, 220, 96];
+
   return (
     <Box sx={{ overflowX: "auto" }}>
-      <Table size="small" sx={{ minWidth: 1400 }}>
+      <Table size="small" sx={{ minWidth: 1534, tableLayout: "fixed" }}>
+        <colgroup>
+          {colWidths.map((w, i) => (
+            <col key={i} style={{ width: w }} />
+          ))}
+        </colgroup>
         <TableHead>
           <TableRow>
             {columns.map((h, i) => {
@@ -414,14 +428,14 @@ function SubTasksCell({ subTasks }) {
     <TruncTooltip title={fullList}>
       <Stack spacing={0.375}>
         {list.slice(0, 3).map((st, i) => (
-          <Stack key={st.id} direction="row" spacing={0.75} alignItems="flex-start">
+          <Stack key={st.id} direction="row" spacing={0.75} alignItems="flex-start" sx={{ minWidth: 0 }}>
             <Typography sx={{
               typography: "s3", color: "text.subtitle",
               fontVariantNumeric: "tabular-nums", flexShrink: 0, mt: "1px",
             }}>
               {i + 1}.
             </Typography>
-            <Typography noWrap sx={{ typography: "s3", color: "text.secondary", minWidth: 0 }}>
+            <Typography noWrap sx={{ typography: "s3", color: "text.secondary", flex: 1, minWidth: 0 }}>
               {st.label}
             </Typography>
           </Stack>

--- a/frontend/src/sections/simulate-v2/workspace/scenarios/ScenarioTable.jsx
+++ b/frontend/src/sections/simulate-v2/workspace/scenarios/ScenarioTable.jsx
@@ -426,16 +426,19 @@ function SubTasksCell({ subTasks }) {
   const fullList = list.map((st, i) => `${i + 1}. ${st.label}`).join("\n");
   return (
     <TruncTooltip title={fullList}>
-      <Stack spacing={0.375}>
+      <Stack spacing={0.375} sx={{ width: "100%", minWidth: 0 }}>
         {list.slice(0, 3).map((st, i) => (
-          <Stack key={st.id} direction="row" spacing={0.75} alignItems="flex-start" sx={{ minWidth: 0 }}>
+          <Stack key={st.id} direction="row" spacing={0.75} alignItems="flex-start" sx={{ minWidth: 0, width: "100%" }}>
             <Typography sx={{
               typography: "s3", color: "text.subtitle",
               fontVariantNumeric: "tabular-nums", flexShrink: 0, mt: "1px",
             }}>
               {i + 1}.
             </Typography>
-            <Typography noWrap sx={{ typography: "s3", color: "text.secondary", flex: 1, minWidth: 0 }}>
+            {/* Explicit maxWidth (the Sub-tasks colgroup width minus the number
+                + padding) so the ellipsis triggers reliably — nested flex inside
+                a table cell wasn't giving noWrap a width to truncate against. */}
+            <Typography noWrap sx={{ typography: "s3", color: "text.secondary", flex: 1, minWidth: 0, maxWidth: 228 }}>
               {st.label}
             </Typography>
           </Stack>


### PR DESCRIPTION
## Summary

Design-polish pass on the simulate-v2 (Simulation Studio) prototype: stop text clipping on the Scenarios table and the Interface code block, make run-result rows lead with the verdict, correct contradictory / over-claimed states (a not-measured scenario shows `—` and is excluded from the score; the fix projection reads "up to N%" instead of a green 100%), give the twin / template not-found screens a real exit, redirect the orphaned `/simulate/runs` path, and tidy the entry cards. Frontend-only; the module is mock/localStorage-driven, so nothing here touches the backend.

## Linked issues

Closes #
Linear: project "Simulation for text and voice agents". Follow-ups filed from this work: TH-7915, TH-7916, TH-7917, TH-7918.

## AI use

AI use: Claude Code (Opus) produced most of this change — the code edits and this description — working under my direction in a screenshot-based design-critic loop. I reviewed every diff, ran the app locally against each screen before/after, and ran `eslint` (0 errors) on the changed files. Two local-only dev helpers used to review the prototype without a backend (`VITE_SIM_AUTH_STUB`, `VITE_SIM_FASTPLAY`) are deliberately NOT committed to this branch.

## Type of change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] 🧹 Chore / refactor (design polish, no API change)

## E2E coverage

E2E: exempt (not-in-stack)

The simulate-v2 module is a frontend-only prototype backed by a reducer + localStorage, with no backend and no flows in the E2E harness yet — the coverage classifier reports `Areas with no flows yet: simulate`. This PR is design polish within that prototype, so there is no real-stack flow to add or update.

---

## 1) What changes were done

**A. Text no longer clips.** The Scenarios table uses a fixed layout + colgroup so sub-task / persona / situation cells ellipsise in-cell instead of clipping mid-glyph at the viewport; the Interface code block scrolls horizontally instead of soft-wrapping Python comments onto fake column-0 lines.

**B. Run results lead with the verdict.** Traces rows lead with the `Passed / Failed / Errored` verdict (+ sample count) and the specific scenario name, not a grey lifecycle "Completed" and a repeated goal. Vertical grid lines removed. A not-measured / errored row shows `—` in grader columns (never a phantom score) and CSAT reserves its red alarm for 1–2.

**C. Honest self-improve semantics.** The projected pass rate reads "up to N%" in neutral text (not a green 100% that looked already-achieved); the measurement-fix card uses an amber accent, not a red "error" border.

**D. Missing states / flows.** Twin-detail, twin-connect and use-template render the shared `EmptyState` with a neutral icon and a real "Back to environments" action; the orphaned `paths.simulate.simulationRuns` (`/simulate/runs`) redirects instead of hitting the catch-all 404.

**E. Runs summary.** Fixed "1 run" grammar, dropped the misleading "what changed is the agent" copy, and held the trend chart until there are ≥3 runs (a 2-point flat line was noise).

**F. Entry cards.** Connect / hero cards pull the violet accent on hover and connect cards carry a persistent corner arrow.

## 2) Verification

- `eslint` — 0 errors across all changed files.
- Ran the running app against every changed screen (mock prototype, no backend) and captured before/after; two Fable critic passes drove the priorities and a regression round fixed the two issues they caught.
- Full log + rationale: `frontend/src/sections/simulate-v2/DESIGN_POLISH_WORKLOG.md`.
