### PR TITLE
test(accounts): add GCP Marketplace test suite [TH-7731]

### DIFF
--- a/futureagi/accounts/tests/gcp_marketplace/conftest.py
+++ b/futureagi/accounts/tests/gcp_marketplace/conftest.py
@@ -1,0 +1,81 @@
+from decimal import Decimal
+from unittest.mock import patch
+
+import pytest
+from django.utils import timezone
+
+from accounts.models.gcp_marketplace import (
+    GCPMarketplaceAccount,
+    GCPMarketplaceAccountState,
+    GCPMarketplaceEntitlement,
+    GCPMarketplaceEntitlementState,
+)
+from accounts.tests.gcp_marketplace.support import (
+    ACCOUNT_ID,
+    CREATE_TIME,
+    ENTITLEMENT_ID,
+    UPDATE_TIME,
+    USAGE_REPORTING_ID,
+    FakeProcurement,
+    google_time,
+    remote_entitlement,
+)
+
+
+@pytest.fixture
+def procurement():
+    """Replace the Procurement singleton everywhere the handlers reach it."""
+    fake = FakeProcurement()
+    with (
+        patch("accounts.gcp_marketplace_events.gcp_procurement", fake),
+        patch("accounts.gcp_marketplace_utils.gcp_procurement", fake),
+    ):
+        yield fake
+
+
+@pytest.fixture
+def free_tier(db):
+    from ee.usage.models.usage import SubscriptionTier, SubscriptionTierChoices
+
+    tier, _ = SubscriptionTier.objects.get_or_create(
+        name=SubscriptionTierChoices.FREE.value,
+        defaults={"wallet_refill_amount": Decimal("0")},
+    )
+    return tier
+
+
+@pytest.fixture
+def subscription(organization, free_tier):
+    """The organization's subscription, on the free plan and card billing."""
+    from ee.usage.models.usage import OrganizationSubscription
+
+    return OrganizationSubscription.objects.create(
+        organization=organization, subscription_tier=free_tier
+    )
+
+
+@pytest.fixture
+def gcp_account(db, organization):
+    """An account whose customer has completed sign-up."""
+    return GCPMarketplaceAccount.objects.create(
+        procurement_account_id=ACCOUNT_ID,
+        organization=organization,
+        state=GCPMarketplaceAccountState.ACTIVE,
+        approved_at=timezone.now(),
+    )
+
+
+@pytest.fixture
+def entitlement(gcp_account):
+    """A live payg entitlement, as after ENTITLEMENT_ACTIVE."""
+    return GCPMarketplaceEntitlement.objects.create(
+        entitlement_id=ENTITLEMENT_ID,
+        account=gcp_account,
+        organization=gcp_account.organization,
+        plan_id="payg",
+        status=GCPMarketplaceEntitlementState.ACTIVE,
+        usage_reporting_id=USAGE_REPORTING_ID,
+        effective_at=google_time(CREATE_TIME),
+        google_update_time=google_time(UPDATE_TIME),
+        raw_payload=remote_entitlement(state="ENTITLEMENT_ACTIVE"),
+    )

--- a/futureagi/accounts/tests/gcp_marketplace/support.py
+++ b/futureagi/accounts/tests/gcp_marketplace/support.py
@@ -1,0 +1,185 @@
+"""Fakes and payload builders shared by the GCP Marketplace suite.
+
+Google is never called. The Procurement and Service Control singletons are
+replaced by fakes that keep the real resource-name helpers and record every
+write, so tests assert on what would have been sent.
+
+Payload shapes follow what the production subscription actually delivered:
+the events of one purchase share an eventId, cancellations carry their own,
+and a Procurement GET returns the full resource, not the event body.
+"""
+
+from unittest.mock import MagicMock
+
+from django.utils.dateparse import parse_datetime
+
+from accounts.services.gcp_procurement import SIGNUP_APPROVAL
+from accounts.services.gcp_service_control import ReportOutcome
+
+PROVIDER_ID = "futureagiprimary"
+PRODUCT = "futureagi.endpoints.futureagiprimary.cloud.goog"
+ACCOUNT_ID = "1557400d-2c70-4abb-adf4-e5111a6a9393"
+ENTITLEMENT_ID = "a8ad2d7f-4475-4bc2-886b-15bdd3ddb102"
+USAGE_REPORTING_ID = "project_number:69718560399"
+CREATE_TIME = "2026-09-09T15:40:00.568941Z"
+UPDATE_TIME = "2026-09-09T15:40:03.439363Z"
+PURCHASE_EVENT_ID = "CREATE_ENTITLEMENT-344268f5-c72e-4570-91a1-e1045965cc1d"
+
+REQUESTED = "ENTITLEMENT_ACTIVATION_REQUESTED"
+
+
+def google_time(value: str):
+    return parse_datetime(value)
+
+
+def remote_entitlement(
+    entitlement_id: str = ENTITLEMENT_ID,
+    *,
+    state: str = REQUESTED,
+    plan: str = "payg",
+    account_id: str = ACCOUNT_ID,
+    update_time: str = UPDATE_TIME,
+    usage_reporting_id: str = USAGE_REPORTING_ID,
+    **extra,
+) -> dict:
+    """A Procurement `entitlements.get` response."""
+    payload = {
+        "name": f"providers/{PROVIDER_ID}/entitlements/{entitlement_id}",
+        "account": f"providers/{PROVIDER_ID}/accounts/{account_id}",
+        "provider": PROVIDER_ID,
+        "product": PRODUCT,
+        "productExternalName": PRODUCT,
+        "plan": plan,
+        "state": state,
+        "createTime": CREATE_TIME,
+        "updateTime": update_time,
+        "usageReportingId": usage_reporting_id,
+        "orderId": entitlement_id,
+        "offer": (
+            f"projects/641933367818/services/{PRODUCT}/standardOffers/"
+            "84d66619-5945-4905-a63e-1dd495185dbb"
+        ),
+    }
+    payload.update(extra)
+    return payload
+
+
+def remote_account(
+    account_id: str = ACCOUNT_ID,
+    *,
+    state: str = "ACCOUNT_ACTIVE",
+    signup_pending: bool = True,
+) -> dict:
+    """A Procurement `accounts.get` response."""
+    return {
+        "name": f"providers/{PROVIDER_ID}/accounts/{account_id}",
+        "provider": PROVIDER_ID,
+        "state": state,
+        "approvals": [
+            {
+                "name": SIGNUP_APPROVAL,
+                "state": "PENDING" if signup_pending else "APPROVED",
+                "updateTime": CREATE_TIME,
+            }
+        ],
+        "createTime": CREATE_TIME,
+        "updateTime": CREATE_TIME,
+    }
+
+
+def event(
+    event_type: str,
+    *,
+    entitlement_id: str | None = None,
+    account_id: str | None = None,
+    event_id: str = PURCHASE_EVENT_ID,
+) -> dict:
+    """A Pub/Sub message body as Google publishes it."""
+    payload = {"eventId": event_id, "eventType": event_type, "providerId": PROVIDER_ID}
+    if entitlement_id:
+        payload["entitlement"] = {"id": entitlement_id, "updateTime": UPDATE_TIME}
+    if account_id:
+        payload["account"] = {"id": account_id, "updateTime": CREATE_TIME}
+    return payload
+
+
+class FakeProcurement:
+    """Stands in for the `gcp_procurement` singleton.
+
+    Reads return whatever the test assigns; writes are MagicMocks so tests
+    assert on the exact call. The name helpers are real: handlers depend on
+    `bare_id` to link accounts and the fake must agree with production.
+    """
+
+    provider_id = PROVIDER_ID
+
+    def __init__(self):
+        self.get_entitlement = MagicMock(return_value=remote_entitlement())
+        self.get_account = MagicMock(return_value=remote_account())
+        self.approve_account = MagicMock(return_value={})
+        self.approve_entitlement = MagicMock(return_value={})
+        self.approve_plan_change = MagicMock(return_value={})
+        self.reject_entitlement = MagicMock(return_value={})
+        self.list_entitlements = MagicMock(return_value={"entitlements": []})
+        self.iter_entitlements = MagicMock(side_effect=lambda **kwargs: iter(()))
+
+    @staticmethod
+    def bare_id(resource_name: str) -> str:
+        return (resource_name or "").rsplit("/", 1)[-1]
+
+    def account_name(self, account_id: str) -> str:
+        return f"providers/{PROVIDER_ID}/accounts/{account_id}"
+
+    def entitlement_name(self, entitlement_id: str) -> str:
+        return f"providers/{PROVIDER_ID}/entitlements/{entitlement_id}"
+
+    @staticmethod
+    def pending_approval(account: dict, approval_name: str = SIGNUP_APPROVAL) -> bool:
+        for approval in account.get("approvals") or []:
+            if approval.get("name") == approval_name:
+                return approval.get("state") == "PENDING"
+        return False
+
+
+class FakeServiceControl:
+    """Stands in for the `gcp_service_control` singleton.
+
+    `build_operation` mirrors the production shape so tests can read the
+    consumer id, metric names and values off what `report` received.
+    """
+
+    def __init__(self):
+        self.check = MagicMock(return_value=[])
+        self.report = MagicMock(return_value=ReportOutcome())
+        self.is_definitive_failure = MagicMock(return_value=False)
+
+    def metric_name(self, metric_id: str) -> str:
+        return f"{PRODUCT}/{metric_id}"
+
+    def build_operation(
+        self,
+        consumer_id: str,
+        operation_id: str,
+        start_time: str,
+        end_time: str,
+        metric_values: dict[str, tuple[float, bool]],
+        operation_name: str = "usage_report",
+    ) -> dict:
+        return {
+            "operationId": operation_id,
+            "operationName": operation_name,
+            "consumerId": consumer_id,
+            "startTime": start_time,
+            "endTime": end_time,
+            "metricValueSets": [
+                {
+                    "metricName": self.metric_name(metric_id),
+                    "metricValues": [
+                        {"doubleValue": float(value)}
+                        if is_float
+                        else {"int64Value": str(int(value))}
+                    ],
+                }
+                for metric_id, (value, is_float) in metric_values.items()
+            ],
+        }

--- a/futureagi/accounts/tests/gcp_marketplace/test_activities.py
+++ b/futureagi/accounts/tests/gcp_marketplace/test_activities.py
@@ -1,0 +1,240 @@
+"""The Pub/Sub consumer activity and its schedules.
+
+The subscriber client is faked so the ack decisions can be asserted per
+message: handled and unparseable messages are acked, a failing one is left
+for redelivery until the poison window passes.
+"""
+
+import json
+from datetime import timedelta
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+from django.core.cache import cache
+from django.test import override_settings
+from django.utils import timezone
+
+from accounts.tests.gcp_marketplace.support import ENTITLEMENT_ID, event
+from tfc.temporal.marketplace.activities import (
+    ACK_DEADLINE_SECONDS,
+    POISON_AFTER,
+    _clear_failures,
+    _drain_sync,
+    _failure_key,
+    _is_configured,
+    _is_poison,
+    drain_gcp_marketplace_events_activity,
+)
+from tfc.temporal.marketplace.types import DrainResult
+
+pytestmark = [pytest.mark.unit]
+
+CONFIGURED = override_settings(
+    GCP_MARKETPLACE_PROJECT_ID="futureagiprimary",
+    GCP_MARKETPLACE_PUBSUB_SUBSCRIPTION="marketplace-events",
+)
+UNCONFIGURED = override_settings(
+    GCP_MARKETPLACE_PROJECT_ID="", GCP_MARKETPLACE_PUBSUB_SUBSCRIPTION=""
+)
+SUBSCRIPTION_PATH = "projects/futureagiprimary/subscriptions/marketplace-events"
+
+
+@pytest.fixture(autouse=True)
+def clean_cache():
+    cache.clear()
+    yield
+    cache.clear()
+
+
+def message(ack_id: str, body) -> SimpleNamespace:
+    data = body if isinstance(body, bytes) else json.dumps(body).encode()
+    return SimpleNamespace(ack_id=ack_id, message=SimpleNamespace(data=data))
+
+
+@pytest.fixture
+def subscriber():
+    fake = MagicMock()
+    fake.subscription_path.return_value = SUBSCRIPTION_PATH
+    fake.pull.return_value = SimpleNamespace(received_messages=[])
+    with patch("google.cloud.pubsub_v1.SubscriberClient", return_value=fake):
+        yield fake
+
+
+@pytest.fixture
+def process_event():
+    with patch("accounts.gcp_marketplace_events.process_event") as mocked:
+        yield mocked
+
+
+def creation(event_id="CREATE_ENTITLEMENT-1"):
+    return event(
+        "ENTITLEMENT_CREATION_REQUESTED",
+        entitlement_id=ENTITLEMENT_ID,
+        event_id=event_id,
+    )
+
+
+class TestConfiguration:
+    @CONFIGURED
+    def test_configured_when_project_and_subscription_are_set(self):
+        assert _is_configured() is True
+
+    @UNCONFIGURED
+    def test_not_configured_without_them(self):
+        assert _is_configured() is False
+
+    @override_settings(
+        GCP_MARKETPLACE_PROJECT_ID="p", GCP_MARKETPLACE_PUBSUB_SUBSCRIPTION=""
+    )
+    def test_not_configured_with_only_a_project(self):
+        assert _is_configured() is False
+
+    async def test_activity_is_a_no_op_outside_cloud(self, settings):
+        settings.GCP_MARKETPLACE_PROJECT_ID = ""
+        settings.GCP_MARKETPLACE_PUBSUB_SUBSCRIPTION = ""
+
+        assert await drain_gcp_marketplace_events_activity() == DrainResult(
+            events_processed=0, had_events=False
+        )
+
+
+class TestPoisonGuard:
+    def test_failure_key_needs_an_event_id(self):
+        assert _failure_key({"eventType": "ENTITLEMENT_ACTIVE"}) is None
+        assert _failure_key(creation("E-1")).endswith("E-1")
+
+    @pytest.mark.xfail(
+        strict=True,
+        reason=(
+            "Google reuses one eventId across the events of a purchase, so one "
+            "failing handler counts against the others sharing the id. Fixed on "
+            "fix/th-7731-marketplace-event-dedupe."
+        ),
+    )
+    def test_failure_key_tells_event_types_apart(self):
+        payload = creation("SHARED")
+        sibling = event(
+            "ENTITLEMENT_OFFER_ACCEPTED",
+            entitlement_id=ENTITLEMENT_ID,
+            event_id="SHARED",
+        )
+
+        assert _failure_key(payload) != _failure_key(sibling)
+
+    def test_first_failures_are_retried(self):
+        payload = creation()
+
+        assert _is_poison(payload) is False
+        assert _is_poison(payload) is False
+        assert cache.get(_failure_key(payload))["count"] == 2
+
+    def test_dropped_after_failing_for_the_whole_window(self):
+        payload = creation()
+        first = timezone.now() - POISON_AFTER - timedelta(minutes=1)
+        cache.set(_failure_key(payload), {"first": first.isoformat(), "count": 40})
+
+        assert _is_poison(payload) is True
+        assert cache.get(_failure_key(payload)) is None
+
+    def test_success_clears_the_record(self):
+        payload = creation()
+        _is_poison(payload)
+
+        _clear_failures(payload)
+
+        assert cache.get(_failure_key(payload)) is None
+
+    def test_message_without_an_id_is_dropped_at_once(self):
+        assert _is_poison({"eventType": "ENTITLEMENT_ACTIVE"}) is True
+
+
+@pytest.mark.django_db
+class TestDrain:
+    @pytest.fixture(autouse=True)
+    def configured(self, settings):
+        settings.GCP_MARKETPLACE_PROJECT_ID = "futureagiprimary"
+        settings.GCP_MARKETPLACE_PUBSUB_SUBSCRIPTION = "marketplace-events"
+
+    def test_empty_pull_acks_nothing(self, subscriber, process_event):
+        assert _drain_sync(MagicMock()) == {"events_processed": 0, "had_events": False}
+
+        subscriber.acknowledge.assert_not_called()
+        process_event.assert_not_called()
+
+    def test_acks_handled_and_unparseable_and_keeps_the_failed_one(
+        self, subscriber, process_event
+    ):
+        subscriber.pull.return_value = SimpleNamespace(
+            received_messages=[
+                message("ack-ok", creation("E-ok")),
+                message("ack-bad", creation("E-bad")),
+                message("ack-garbage", b"not json"),
+            ]
+        )
+        process_event.side_effect = lambda payload: (
+            (_ for _ in ()).throw(RuntimeError("procurement down"))
+            if payload["eventId"] == "E-bad"
+            else True
+        )
+        heartbeat = MagicMock()
+
+        result = _drain_sync(heartbeat)
+
+        assert result == {"events_processed": 2, "had_events": True}
+        subscriber.modify_ack_deadline.assert_called_once_with(
+            request={
+                "subscription": SUBSCRIPTION_PATH,
+                "ack_ids": ["ack-ok", "ack-bad", "ack-garbage"],
+                "ack_deadline_seconds": ACK_DEADLINE_SECONDS,
+            },
+            timeout=30,
+        )
+        subscriber.acknowledge.assert_called_once()
+        assert subscriber.acknowledge.call_args.kwargs["request"]["ack_ids"] == [
+            "ack-ok",
+            "ack-garbage",
+        ]
+        assert heartbeat.call_count == 3
+        assert cache.get(_failure_key(creation("E-bad")))["count"] == 1
+        assert cache.get(_failure_key(creation("E-ok"))) is None
+
+    def test_a_message_failing_for_a_day_is_finally_acked(
+        self, subscriber, process_event
+    ):
+        payload = creation("E-poison")
+        first = timezone.now() - POISON_AFTER - timedelta(minutes=1)
+        cache.set(_failure_key(payload), {"first": first.isoformat(), "count": 280})
+        subscriber.pull.return_value = SimpleNamespace(
+            received_messages=[message("ack-poison", payload)]
+        )
+        process_event.side_effect = RuntimeError("still broken")
+
+        result = _drain_sync(MagicMock())
+
+        assert result == {"events_processed": 1, "had_events": True}
+        assert subscriber.acknowledge.call_args.kwargs["request"]["ack_ids"] == [
+            "ack-poison"
+        ]
+
+
+class TestSchedules:
+    def test_four_marketplace_schedules_on_the_default_queue(self):
+        from tfc.temporal.schedules.marketplace import MARKETPLACE_SCHEDULES
+
+        by_id = {config.schedule_id: config for config in MARKETPLACE_SCHEDULES}
+        assert set(by_id) == {
+            "gcp-marketplace-consumer",
+            "gcp-marketplace-usage-report",
+            "gcp-marketplace-plan-reconcile",
+            "gcp-marketplace-usage-reconcile",
+        }
+        assert {config.queue for config in MARKETPLACE_SCHEDULES} == {"default"}
+        assert by_id["gcp-marketplace-consumer"].interval_seconds == 300
+
+    def test_marketplace_schedules_are_part_of_the_registered_set(self):
+        from tfc.temporal.schedules import ALL_SCHEDULES
+        from tfc.temporal.schedules.marketplace import MARKETPLACE_SCHEDULES
+
+        registered = {config.schedule_id for config in ALL_SCHEDULES}
+        assert {c.schedule_id for c in MARKETPLACE_SCHEDULES} <= registered

--- a/futureagi/accounts/tests/gcp_marketplace/test_events.py
+++ b/futureagi/accounts/tests/gcp_marketplace/test_events.py
@@ -1,0 +1,568 @@
+"""Pub/Sub lifecycle handlers.
+
+Every handler re-fetches Google and acts on the fetched state, so each test
+sets what Google would answer and asserts what changed locally and which
+Procurement writes went out.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from googleapiclient.errors import HttpError
+
+from accounts.gcp_marketplace_events import (
+    SECOND_ENTITLEMENT_REASON,
+    process_event,
+    reconcile_entitlement_plans,
+    sync_entitlement,
+)
+from accounts.models.gcp_marketplace import (
+    GCPMarketplaceAccountState,
+    GCPMarketplaceEntitlement,
+    GCPMarketplaceEntitlementState,
+    GCPMarketplaceProcessedEvent,
+)
+from accounts.tests.gcp_marketplace.support import (
+    ACCOUNT_ID,
+    ENTITLEMENT_ID,
+    UPDATE_TIME,
+    USAGE_REPORTING_ID,
+    event,
+    google_time,
+    remote_account,
+    remote_entitlement,
+)
+from ee.usage.models.usage import (
+    BillingIntervalChoices,
+    BillingMethodChoices,
+    OrganizationSubscription,
+    PlanChoices,
+)
+
+pytestmark = [pytest.mark.integration, pytest.mark.requires_ee, pytest.mark.django_db]
+
+ACTIVE = GCPMarketplaceEntitlementState.ACTIVE
+REQUESTED = GCPMarketplaceEntitlementState.ACTIVATION_REQUESTED
+CANCELLED = GCPMarketplaceEntitlementState.CANCELLED
+PENDING_CANCELLATION = GCPMarketplaceEntitlementState.PENDING_CANCELLATION
+PENDING_APPROVAL = GCPMarketplaceEntitlementState.PENDING_PLAN_CHANGE_APPROVAL
+
+FREE_ON_CARD = (
+    PlanChoices.FREE,
+    BillingIntervalChoices.MONTHLY,
+    BillingMethodChoices.CARD,
+)
+PAYG_ON_MARKETPLACE = (
+    PlanChoices.PAYG,
+    BillingIntervalChoices.MONTHLY,
+    BillingMethodChoices.GCP_MARKETPLACE,
+)
+
+SECOND_ID = "6450d107-8413-478d-be1b-142c5df5eb31"
+LATER = "2026-09-09T18:15:06.594210Z"
+
+
+def row(entitlement_id=ENTITLEMENT_ID):
+    return GCPMarketplaceEntitlement.objects.get(entitlement_id=entitlement_id)
+
+
+def plan_of(organization):
+    sub = OrganizationSubscription.objects.get(organization=organization)
+    return sub.plan, sub.billing_interval, sub.billing_method
+
+
+def put_on_marketplace(subscription):
+    subscription.plan = PlanChoices.PAYG
+    subscription.billing_method = BillingMethodChoices.GCP_MARKETPLACE
+    subscription.save()
+
+
+def http_error(status: int) -> HttpError:
+    return HttpError(resp=MagicMock(status=status, reason="x"), content=b"{}")
+
+
+class TestProcessEvent:
+    def test_handles_an_event_once_and_records_it(self, procurement, gcp_account):
+        payload = event("ACCOUNT_ACTIVE", account_id=ACCOUNT_ID)
+
+        assert process_event(payload) is True
+        assert process_event(payload) is False
+
+        assert procurement.get_account.call_count == 1
+        ledger = GCPMarketplaceProcessedEvent.objects.get()
+        assert ledger.event_type == "ACCOUNT_ACTIVE"
+        assert ledger.subject_id == ACCOUNT_ID
+
+    def test_unknown_type_is_acked_without_a_ledger_row(self, procurement):
+        payload = event("ENTITLEMENT_SOMETHING_NEW", entitlement_id=ENTITLEMENT_ID)
+
+        assert process_event(payload) is False
+        assert not GCPMarketplaceProcessedEvent.objects.exists()
+
+    def test_missing_event_id_is_acked(self, procurement):
+        payload = event("ACCOUNT_ACTIVE", account_id=ACCOUNT_ID)
+        del payload["eventId"]
+
+        assert process_event(payload) is False
+        procurement.get_account.assert_not_called()
+
+    def test_handler_failure_rolls_the_ledger_row_back(self, procurement, gcp_account):
+        procurement.get_account.side_effect = RuntimeError("procurement down")
+
+        with pytest.raises(RuntimeError):
+            process_event(event("ACCOUNT_ACTIVE", account_id=ACCOUNT_ID))
+
+        assert not GCPMarketplaceProcessedEvent.objects.exists()
+
+    @pytest.mark.xfail(
+        strict=True,
+        reason=(
+            "Google reuses one eventId across the events of a purchase and the "
+            "ledger keys on the id alone, so the second event is dropped as a "
+            "duplicate. Fixed on fix/th-7731-marketplace-event-dedupe."
+        ),
+    )
+    def test_events_of_one_purchase_share_an_event_id_and_are_all_handled(
+        self, procurement, gcp_account
+    ):
+        shared = "CREATE_ENTITLEMENT-9b443172-4b7e-4559-8e04-3b15b4222f0e"
+
+        first = process_event(
+            event("ACCOUNT_ACTIVE", account_id=ACCOUNT_ID, event_id=shared)
+        )
+        second = process_event(
+            event(
+                "ENTITLEMENT_CREATION_REQUESTED",
+                entitlement_id=ENTITLEMENT_ID,
+                event_id=shared,
+            )
+        )
+
+        assert (first, second) == (True, True)
+        procurement.approve_entitlement.assert_called_once_with(ENTITLEMENT_ID)
+
+
+class TestSyncEntitlement:
+    def test_mirrors_google_and_links_the_account(self, procurement, gcp_account):
+        synced = sync_entitlement(ENTITLEMENT_ID)
+
+        assert synced.account == gcp_account
+        assert synced.organization == gcp_account.organization
+        assert synced.plan_id == "payg"
+        assert synced.status == REQUESTED
+        assert synced.usage_reporting_id == USAGE_REPORTING_ID
+        assert synced.google_update_time == google_time(UPDATE_TIME)
+        assert synced.raw_payload["name"].endswith(ENTITLEMENT_ID)
+
+    def test_unknown_account_leaves_the_row_orphaned(self, procurement):
+        synced = sync_entitlement(ENTITLEMENT_ID)
+
+        assert synced.account is None
+        assert synced.organization is None
+
+    def test_state_older_than_stored_is_ignored(self, procurement, entitlement):
+        procurement.get_entitlement.return_value = remote_entitlement(
+            state=CANCELLED, update_time="2026-09-09T10:00:00Z"
+        )
+
+        assert sync_entitlement(ENTITLEMENT_ID) is None
+        assert row().status == ACTIVE
+
+
+class TestCreationRequested:
+    @staticmethod
+    def payload(entitlement_id=ENTITLEMENT_ID):
+        return event("ENTITLEMENT_CREATION_REQUESTED", entitlement_id=entitlement_id)
+
+    def test_approves_when_sign_up_already_approved_the_account(
+        self, procurement, gcp_account
+    ):
+        assert process_event(self.payload()) is True
+
+        procurement.approve_entitlement.assert_called_once_with(ENTITLEMENT_ID)
+        assert row().account == gcp_account
+
+    def test_holds_until_sign_up_approves_the_account(self, procurement, gcp_account):
+        gcp_account.approved_at = None
+        gcp_account.save(update_fields=["approved_at"])
+
+        process_event(self.payload())
+
+        procurement.approve_entitlement.assert_not_called()
+        assert row().status == REQUESTED
+
+    def test_holds_when_the_account_row_does_not_exist_yet(self, procurement):
+        process_event(self.payload())
+
+        procurement.approve_entitlement.assert_not_called()
+        assert row().account is None
+
+    def test_does_not_approve_again_after_a_lost_response(
+        self, procurement, gcp_account
+    ):
+        procurement.get_entitlement.return_value = remote_entitlement(state=ACTIVE)
+
+        process_event(self.payload())
+
+        procurement.approve_entitlement.assert_not_called()
+
+    def test_rejects_a_second_purchase_while_one_is_in_service(
+        self, procurement, entitlement
+    ):
+        procurement.get_entitlement.return_value = remote_entitlement(
+            SECOND_ID, state=REQUESTED, plan="scale-P1Y"
+        )
+
+        process_event(self.payload(SECOND_ID))
+
+        procurement.reject_entitlement.assert_called_once_with(
+            SECOND_ID, SECOND_ENTITLEMENT_REASON
+        )
+        procurement.approve_entitlement.assert_not_called()
+
+
+class TestEntitlementActive:
+    @staticmethod
+    def activate(procurement, **remote):
+        procurement.get_entitlement.return_value = remote_entitlement(
+            state=ACTIVE, **remote
+        )
+        return process_event(event("ENTITLEMENT_ACTIVE", entitlement_id=ENTITLEMENT_ID))
+
+    @pytest.mark.parametrize(
+        "plan_id, plan, interval",
+        [
+            ("payg", PlanChoices.PAYG, BillingIntervalChoices.MONTHLY),
+            ("scale", PlanChoices.SCALE, BillingIntervalChoices.MONTHLY),
+            ("scale-P1Y", PlanChoices.SCALE, BillingIntervalChoices.ANNUAL),
+            ("enterprise-P1Y", PlanChoices.ENTERPRISE, BillingIntervalChoices.ANNUAL),
+        ],
+    )
+    def test_applies_the_plan_and_moves_billing_to_the_marketplace(
+        self, procurement, gcp_account, subscription, plan_id, plan, interval
+    ):
+        self.activate(procurement, plan=plan_id)
+
+        assert plan_of(gcp_account.organization) == (
+            plan,
+            interval,
+            BillingMethodChoices.GCP_MARKETPLACE,
+        )
+        assert row().usage_reporting_id == USAGE_REPORTING_ID
+
+    def test_unmapped_plan_is_recorded_but_not_applied(
+        self, procurement, gcp_account, subscription
+    ):
+        assert self.activate(procurement, plan="legacy-gold") is True
+
+        assert plan_of(gcp_account.organization) == FREE_ON_CARD
+        assert row().plan_id == "legacy-gold"
+
+    def test_missing_usage_reporting_id_still_applies_the_plan(
+        self, procurement, gcp_account, subscription
+    ):
+        self.activate(procurement, usage_reporting_id="")
+
+        assert plan_of(gcp_account.organization) == PAYG_ON_MARKETPLACE
+        assert row().usage_reporting_id == ""
+
+
+class TestOfferAccepted:
+    @staticmethod
+    def accept(procurement, **remote):
+        procurement.get_entitlement.return_value = remote_entitlement(**remote)
+        return process_event(
+            event("ENTITLEMENT_OFFER_ACCEPTED", entitlement_id=ENTITLEMENT_ID)
+        )
+
+    def test_private_offer_on_a_live_entitlement_applies_its_plan(
+        self, procurement, gcp_account, subscription
+    ):
+        self.accept(procurement, state=ACTIVE, plan="enterprise-P1Y")
+
+        assert plan_of(gcp_account.organization) == (
+            PlanChoices.ENTERPRISE,
+            BillingIntervalChoices.ANNUAL,
+            BillingMethodChoices.GCP_MARKETPLACE,
+        )
+
+    @pytest.mark.xfail(
+        strict=True,
+        reason=(
+            "Standard offers publish ENTITLEMENT_OFFER_ACCEPTED at purchase, while "
+            "the entitlement still awaits approval, and the handler applies the "
+            "plan regardless of state. Fixed on fix/th-7731-marketplace-event-dedupe."
+        ),
+    )
+    def test_standard_offer_before_activation_does_not_apply_the_plan(
+        self, procurement, gcp_account, subscription
+    ):
+        self.accept(procurement, state=REQUESTED, plan="payg")
+
+        assert plan_of(gcp_account.organization) == FREE_ON_CARD
+        assert row().status == REQUESTED
+
+
+class TestPlanChange:
+    @staticmethod
+    def requested(procurement, **remote):
+        procurement.get_entitlement.return_value = remote_entitlement(**remote)
+        return process_event(
+            event("ENTITLEMENT_PLAN_CHANGE_REQUESTED", entitlement_id=ENTITLEMENT_ID)
+        )
+
+    def test_requested_change_is_approved_with_the_pending_plan(
+        self, procurement, entitlement
+    ):
+        self.requested(
+            procurement,
+            state=PENDING_APPROVAL,
+            newPendingPlan="scale-P1Y",
+            update_time=LATER,
+        )
+
+        procurement.approve_plan_change.assert_called_once_with(
+            ENTITLEMENT_ID, "scale-P1Y"
+        )
+        assert row().new_pending_plan == "scale-P1Y"
+
+    def test_request_without_a_pending_plan_is_acked_and_skipped(
+        self, procurement, entitlement
+    ):
+        assert (
+            self.requested(procurement, state=PENDING_APPROVAL, update_time=LATER)
+            is True
+        )
+
+        procurement.approve_plan_change.assert_not_called()
+
+    def test_request_no_longer_pending_is_not_approved_twice(
+        self, procurement, entitlement
+    ):
+        self.requested(
+            procurement,
+            state=ACTIVE,
+            newPendingPlan="scale-P1Y",
+            update_time=LATER,
+        )
+
+        procurement.approve_plan_change.assert_not_called()
+
+    def test_changed_plan_takes_effect_only_when_google_says_so(
+        self, procurement, entitlement, subscription
+    ):
+        put_on_marketplace(subscription)
+        procurement.get_entitlement.return_value = remote_entitlement(
+            state=ACTIVE, plan="scale-P1Y", update_time=LATER
+        )
+
+        process_event(event("ENTITLEMENT_PLAN_CHANGED", entitlement_id=ENTITLEMENT_ID))
+
+        assert plan_of(entitlement.organization) == (
+            PlanChoices.SCALE,
+            BillingIntervalChoices.ANNUAL,
+            BillingMethodChoices.GCP_MARKETPLACE,
+        )
+        assert row().plan_id == "scale-P1Y"
+
+
+class TestCancellation:
+    def test_pending_cancellation_only_syncs(
+        self, procurement, entitlement, subscription
+    ):
+        put_on_marketplace(subscription)
+        procurement.get_entitlement.return_value = remote_entitlement(
+            state=PENDING_CANCELLATION, update_time=LATER
+        )
+
+        process_event(
+            event("ENTITLEMENT_PENDING_CANCELLATION", entitlement_id=ENTITLEMENT_ID)
+        )
+
+        assert row().status == PENDING_CANCELLATION
+        assert plan_of(entitlement.organization) == PAYG_ON_MARKETPLACE
+
+    def test_cancelled_downgrades_first_and_reports_the_tail_after_commit(
+        self, procurement, entitlement, subscription, django_capture_on_commit_callbacks
+    ):
+        put_on_marketplace(subscription)
+        procurement.get_entitlement.return_value = remote_entitlement(
+            state=CANCELLED, update_time=LATER
+        )
+
+        with (
+            patch("accounts.gcp_marketplace_usage.report_final_window") as final,
+            django_capture_on_commit_callbacks(execute=True),
+        ):
+            process_event(event("ENTITLEMENT_CANCELLED", entitlement_id=ENTITLEMENT_ID))
+
+        assert row().status == CANCELLED
+        assert row().google_update_time == google_time(LATER)
+        assert plan_of(entitlement.organization) == FREE_ON_CARD
+        final.assert_called_once()
+        assert final.call_args.args[0].entitlement_id == ENTITLEMENT_ID
+
+    def test_a_failed_tail_report_does_not_undo_the_downgrade(
+        self, procurement, entitlement, subscription, django_capture_on_commit_callbacks
+    ):
+        put_on_marketplace(subscription)
+        procurement.get_entitlement.return_value = remote_entitlement(
+            state=CANCELLED, update_time=LATER
+        )
+
+        with (
+            patch(
+                "accounts.gcp_marketplace_usage.report_final_window",
+                side_effect=RuntimeError("service control down"),
+            ),
+            django_capture_on_commit_callbacks(execute=True),
+        ):
+            process_event(event("ENTITLEMENT_CANCELLED", entitlement_id=ENTITLEMENT_ID))
+
+        assert plan_of(entitlement.organization) == FREE_ON_CARD
+
+
+class TestEntitlementDeleted:
+    @staticmethod
+    def delete(procurement):
+        return process_event(
+            event("ENTITLEMENT_DELETED", entitlement_id=ENTITLEMENT_ID)
+        )
+
+    def test_marketplace_billed_organization_is_left_alone(
+        self, procurement, entitlement, subscription
+    ):
+        put_on_marketplace(subscription)
+        procurement.get_entitlement.return_value = remote_entitlement(
+            state=CANCELLED, update_time=LATER
+        )
+
+        assert self.delete(procurement) is True
+        assert plan_of(entitlement.organization) == PAYG_ON_MARKETPLACE
+
+    def test_abandoned_organization_is_reported_not_deleted(
+        self, procurement, entitlement, subscription
+    ):
+        procurement.get_entitlement.return_value = remote_entitlement(
+            state=CANCELLED, update_time=LATER
+        )
+
+        assert self.delete(procurement) is True
+        assert OrganizationSubscription.objects.filter(
+            organization=entitlement.organization
+        ).exists()
+
+    def test_entitlement_already_purged_on_google_uses_the_local_row(
+        self, procurement, entitlement, subscription
+    ):
+        procurement.get_entitlement.side_effect = http_error(404)
+
+        assert self.delete(procurement) is True
+        assert row().status == ACTIVE
+
+    def test_other_procurement_errors_propagate(self, procurement, entitlement):
+        procurement.get_entitlement.side_effect = http_error(500)
+
+        with pytest.raises(HttpError):
+            self.delete(procurement)
+
+
+class TestAccountEvents:
+    def test_account_active_refreshes_state_from_google(self, procurement, gcp_account):
+        gcp_account.state = GCPMarketplaceAccountState.ACTIVATION_REQUESTED
+        gcp_account.save(update_fields=["state"])
+        procurement.get_account.return_value = remote_account(state="ACCOUNT_ACTIVE")
+
+        process_event(event("ACCOUNT_ACTIVE", account_id=ACCOUNT_ID))
+
+        gcp_account.refresh_from_db()
+        assert gcp_account.state == GCPMarketplaceAccountState.ACTIVE
+        assert gcp_account.raw_payload["state"] == "ACCOUNT_ACTIVE"
+
+    def test_account_deleted_unlinks_and_hands_billing_back(
+        self, procurement, gcp_account, subscription
+    ):
+        put_on_marketplace(subscription)
+        organization = gcp_account.organization
+
+        process_event(event("ACCOUNT_DELETED", account_id=ACCOUNT_ID))
+
+        gcp_account.refresh_from_db()
+        assert gcp_account.organization is None
+        assert plan_of(organization) == FREE_ON_CARD
+
+    def test_account_deleted_for_an_unknown_account_is_acked(self, procurement):
+        assert process_event(event("ACCOUNT_DELETED", account_id=ACCOUNT_ID)) is True
+
+
+class TestReconcilePlans:
+    def test_repairs_plan_drift(self, procurement, entitlement, subscription):
+        counts = reconcile_entitlement_plans()
+
+        assert counts["checked"] == 1
+        assert counts["repaired"] == 1
+        assert plan_of(entitlement.organization) == PAYG_ON_MARKETPLACE
+
+    def test_leaves_a_matching_plan_alone(self, procurement, entitlement, subscription):
+        put_on_marketplace(subscription)
+
+        counts = reconcile_entitlement_plans()
+
+        assert counts["repaired"] == 0
+        procurement.get_entitlement.assert_not_called()
+
+    def test_recovers_a_missing_usage_reporting_id(
+        self, procurement, entitlement, subscription
+    ):
+        entitlement.usage_reporting_id = ""
+        entitlement.save(update_fields=["usage_reporting_id"])
+        procurement.get_entitlement.return_value = remote_entitlement(state=ACTIVE)
+
+        counts = reconcile_entitlement_plans()
+
+        assert counts["consumer_id_recovered"] == 1
+        assert row().usage_reporting_id == USAGE_REPORTING_ID
+
+    def test_counts_an_id_google_still_has_not_supplied(
+        self, procurement, entitlement, subscription
+    ):
+        entitlement.usage_reporting_id = ""
+        entitlement.save(update_fields=["usage_reporting_id"])
+        procurement.get_entitlement.return_value = remote_entitlement(
+            state=ACTIVE, usage_reporting_id=""
+        )
+
+        counts = reconcile_entitlement_plans()
+
+        assert counts["consumer_id_missing"] == 1
+
+    def test_does_not_reapply_a_plan_the_refetch_shows_leaving_service(
+        self, procurement, entitlement, subscription
+    ):
+        entitlement.usage_reporting_id = ""
+        entitlement.save(update_fields=["usage_reporting_id"])
+        procurement.get_entitlement.return_value = remote_entitlement(
+            state=CANCELLED, update_time=LATER
+        )
+
+        counts = reconcile_entitlement_plans()
+
+        assert counts["repaired"] == 0
+        assert plan_of(entitlement.organization) == FREE_ON_CARD
+
+    def test_counts_unmapped_plans(self, procurement, entitlement, subscription):
+        entitlement.plan_id = "legacy-gold"
+        entitlement.save(update_fields=["plan_id"])
+
+        counts = reconcile_entitlement_plans()
+
+        assert counts["unmapped"] == 1
+        assert plan_of(entitlement.organization) == FREE_ON_CARD
+
+    def test_ignores_rows_out_of_service(self, procurement, entitlement, subscription):
+        entitlement.status = CANCELLED
+        entitlement.save(update_fields=["status"])
+
+        counts = reconcile_entitlement_plans()
+
+        assert counts["checked"] == 0

--- a/futureagi/accounts/tests/gcp_marketplace/test_procurement.py
+++ b/futureagi/accounts/tests/gcp_marketplace/test_procurement.py
@@ -1,0 +1,196 @@
+"""Procurement API client: resource names, request bodies, plan resolution.
+
+No Google calls. The discovery client is replaced with a mock so the exact
+request each method builds can be asserted.
+"""
+
+from unittest.mock import MagicMock, PropertyMock, patch
+
+import pytest
+from django.test import override_settings
+
+from accounts.services.gcp_procurement import (
+    SIGNUP_APPROVAL,
+    GCPProcurementService,
+    base_plan_id,
+    metric_id_for,
+    resolve_plan,
+)
+
+pytestmark = [pytest.mark.unit]
+
+PROVIDER = "futureagiprimary"
+
+
+@pytest.fixture
+def service():
+    return GCPProcurementService(provider_id=PROVIDER)
+
+
+@pytest.fixture
+def client(service):
+    """The discovery client, with reads and writes returning canned dicts."""
+    fake = MagicMock()
+    with (
+        patch.object(
+            GCPProcurementService,
+            "client",
+            new_callable=PropertyMock,
+            return_value=fake,
+        ),
+        patch.object(
+            service, "_read", side_effect=lambda request: {"request": request}
+        ),
+        patch.object(
+            service, "_write", side_effect=lambda request: {"request": request}
+        ),
+    ):
+        yield fake
+
+
+def entitlements(client):
+    return client.providers.return_value.entitlements.return_value
+
+
+def accounts(client):
+    return client.providers.return_value.accounts.return_value
+
+
+class TestResourceNames:
+    @pytest.mark.parametrize(
+        "value, expected",
+        [
+            (f"providers/{PROVIDER}/accounts/E-1234", "E-1234"),
+            (f"providers/{PROVIDER}/entitlements/abc", "abc"),
+            ("bare-id", "bare-id"),
+            ("", ""),
+            (None, ""),
+        ],
+    )
+    def test_bare_id_takes_the_last_segment(self, value, expected):
+        assert GCPProcurementService.bare_id(value) == expected
+
+    def test_names_are_built_from_the_provider(self, service):
+        assert service.account_name("E-1") == f"providers/{PROVIDER}/accounts/E-1"
+        assert service.entitlement_name("x") == f"providers/{PROVIDER}/entitlements/x"
+
+
+class TestPendingApproval:
+    def test_pending_signup_approval(self):
+        account = {"approvals": [{"name": SIGNUP_APPROVAL, "state": "PENDING"}]}
+        assert GCPProcurementService.pending_approval(account) is True
+
+    def test_granted_signup_approval(self):
+        account = {"approvals": [{"name": SIGNUP_APPROVAL, "state": "APPROVED"}]}
+        assert GCPProcurementService.pending_approval(account) is False
+
+    def test_no_approvals_means_nothing_to_grant(self):
+        assert GCPProcurementService.pending_approval({}) is False
+
+
+class TestRequests:
+    def test_account_approval_names_the_signup_approval(self, service, client):
+        service.approve_account("E-1")
+
+        accounts(client).approve.assert_called_once_with(
+            name=f"providers/{PROVIDER}/accounts/E-1",
+            body={"approvalName": SIGNUP_APPROVAL},
+        )
+
+    def test_entitlement_approval_sends_an_empty_body_by_default(self, service, client):
+        service.approve_entitlement("new")
+
+        entitlements(client).approve.assert_called_once_with(
+            name=f"providers/{PROVIDER}/entitlements/new", body={}
+        )
+
+    def test_migrated_entitlement_is_sent_as_a_resource_name(self, service, client):
+        service.approve_entitlement("new", migrated_from_entitlement_id="old")
+
+        entitlements(client).approve.assert_called_once_with(
+            name=f"providers/{PROVIDER}/entitlements/new",
+            body={"entitlementMigrated": f"providers/{PROVIDER}/entitlements/old"},
+        )
+
+    def test_plan_change_approval_names_the_pending_plan(self, service, client):
+        service.approve_plan_change("e-1", "scale-P1Y")
+
+        entitlements(client).approvePlanChange.assert_called_once_with(
+            name=f"providers/{PROVIDER}/entitlements/e-1",
+            body={"pendingPlanName": "scale-P1Y"},
+        )
+
+    def test_rejection_carries_the_reason(self, service, client):
+        service.reject_entitlement("e-1", "duplicate")
+
+        entitlements(client).reject.assert_called_once_with(
+            name=f"providers/{PROVIDER}/entitlements/e-1", body={"reason": "duplicate"}
+        )
+
+    def test_listing_filters_by_the_bare_account_id(self, service, client):
+        service.list_entitlements(account_id="E-1")
+
+        entitlements(client).list.assert_called_once_with(
+            parent=f"providers/{PROVIDER}", pageToken=None, filter="account=E-1"
+        )
+
+    def test_listing_without_an_account_has_no_filter(self, service, client):
+        service.list_entitlements()
+
+        entitlements(client).list.assert_called_once_with(
+            parent=f"providers/{PROVIDER}", pageToken=None
+        )
+
+    def test_iteration_follows_pagination(self, service):
+        pages = [
+            {"entitlements": [{"name": "a"}, {"name": "b"}], "nextPageToken": "p2"},
+            {"entitlements": [{"name": "c"}]},
+        ]
+        with patch.object(service, "list_entitlements", side_effect=pages) as listing:
+            names = [e["name"] for e in service.iter_entitlements(account_id="E-1")]
+
+        assert names == ["a", "b", "c"]
+        assert [call.kwargs["page_token"] for call in listing.call_args_list] == [
+            None,
+            "p2",
+        ]
+
+
+class TestPlanResolution:
+    @pytest.mark.parametrize(
+        "plan_id, expected",
+        [
+            ("payg", ("payg", "monthly")),
+            ("scale", ("scale", "monthly")),
+            ("scale-P1Y", ("scale", "annual")),
+            ("enterprise-P1Y", ("enterprise", "annual")),
+        ],
+    )
+    def test_portal_plans_map_to_internal_plan_and_interval(self, plan_id, expected):
+        assert resolve_plan(plan_id) == expected
+
+    @pytest.mark.parametrize("plan_id", ["enterprise", "legacy-gold", "", None])
+    def test_unmapped_plan_raises_rather_than_defaulting(self, plan_id):
+        with pytest.raises(ValueError, match="Unmapped"):
+            resolve_plan(plan_id)
+
+    def test_annual_variants_share_the_base_plan_metrics(self):
+        assert base_plan_id("scale-P1Y") == "scale"
+        assert base_plan_id("payg") == "payg"
+        assert metric_id_for("scale-P1Y", "storage") == metric_id_for(
+            "scale", "storage"
+        )
+
+    def test_metric_ids_are_per_plan(self):
+        assert metric_id_for("payg", "ai_credits") == "payg_credits"
+        assert metric_id_for("payg", "gateway_requests") == "gateway_request"
+        assert metric_id_for("scale", "gateway_requests") == "scale_gateway_request"
+
+    def test_unknown_plan_or_dimension_is_not_billed(self):
+        assert metric_id_for("legacy-gold", "ai_credits") is None
+        assert metric_id_for("payg", "seats") is None
+
+    @override_settings(GCP_MARKETPLACE_METRIC_MAP={"payg": {"ai_credits": "credits"}})
+    def test_dimension_left_out_of_the_map_is_skipped(self):
+        assert metric_id_for("payg", "ai_credits") == "credits"
+        assert metric_id_for("payg", "storage") is None

--- a/futureagi/accounts/tests/gcp_marketplace/test_signup.py
+++ b/futureagi/accounts/tests/gcp_marketplace/test_signup.py
@@ -1,0 +1,437 @@
+"""Sign-up: from the Producer Portal redirect to an approved entitlement.
+
+Covers the token landing, the form and OAuth entry points that converge on
+process_signup, the approval retry, and the two HTTP views.
+"""
+
+from unittest.mock import patch
+
+import pytest
+
+from accounts.gcp_marketplace_utils import (
+    approve_pending_entitlements,
+    encode_oauth_state,
+    onboard_account,
+    process_signup,
+    read_oauth_state,
+    read_onboarding_token,
+    reconcile_unapproved_accounts,
+)
+from accounts.models.gcp_marketplace import (
+    GCPMarketplaceAccount,
+    GCPMarketplaceAccountState,
+    GCPMarketplaceEntitlement,
+    GCPMarketplaceEntitlementState,
+)
+from accounts.models.organization import Organization
+from accounts.models.organization_membership import OrganizationMembership
+from accounts.models.user import User
+from accounts.tests.gcp_marketplace.support import (
+    ACCOUNT_ID,
+    ENTITLEMENT_ID,
+    PROVIDER_ID,
+    remote_entitlement,
+)
+from ee.usage.models.usage import (
+    BillingMethodChoices,
+    OrganizationSubscription,
+    PlanChoices,
+)
+from tfc.constants.roles import OrganizationRoles
+
+pytestmark = [pytest.mark.integration, pytest.mark.requires_ee, pytest.mark.django_db]
+
+REQUESTED = GCPMarketplaceEntitlementState.ACTIVATION_REQUESTED
+EMAIL = "owner@acme-corp.com"
+FULL_NAME = "Cherukuru Dileep Kumar"
+SECOND_ID = "6450d107-8413-478d-be1b-142c5df5eb31"
+
+
+@pytest.fixture(autouse=True)
+def post_registration():
+    with patch("accounts.gcp_marketplace_utils.process_post_registration") as mocked:
+        yield mocked
+
+
+@pytest.fixture
+def onboarded(procurement, free_tier):
+    """The state after Google's redirect: account and org exist, no user yet."""
+    token, has_user = onboard_account(ACCOUNT_ID, "google-user-1")
+    assert has_user is False
+    return token, GCPMarketplaceAccount.objects.get(procurement_account_id=ACCOUNT_ID)
+
+
+def pending_row(gcp_account, entitlement_id=ENTITLEMENT_ID):
+    return GCPMarketplaceEntitlement.objects.create(
+        entitlement_id=entitlement_id,
+        account=gcp_account,
+        organization=gcp_account.organization,
+        plan_id="payg",
+        status=REQUESTED,
+        raw_payload=remote_entitlement(entitlement_id),
+    )
+
+
+def make_user(organization, email=EMAIL):
+    return User.objects.create_user(
+        email=email,
+        password="testpassword123",
+        name="Existing",
+        organization=organization,
+        organization_role=OrganizationRoles.OWNER,
+    )
+
+
+class TestOnboardAccount:
+    def test_creates_the_account_its_organization_and_marketplace_billing(
+        self, onboarded
+    ):
+        token, account = onboarded
+
+        assert account.organization is not None
+        assert account.organization.name == f"GCP Marketplace {ACCOUNT_ID[:8]}"
+        assert account.google_user_identity == "google-user-1"
+        assert account.approved_at is None
+
+        subscription = OrganizationSubscription.objects.get(
+            organization=account.organization
+        )
+        assert subscription.plan == PlanChoices.FREE
+        assert subscription.billing_method == BillingMethodChoices.GCP_MARKETPLACE
+
+        assert read_onboarding_token(token) == {
+            "procurement_account_id": ACCOUNT_ID,
+            "organization_id": str(account.organization.id),
+        }
+
+    def test_returning_customer_reuses_the_organization(self, onboarded):
+        _, account = onboarded
+        make_user(account.organization)
+
+        token, has_user = onboard_account(ACCOUNT_ID)
+
+        assert has_user is True
+        assert GCPMarketplaceAccount.objects.count() == 1
+        assert (
+            Organization.objects.filter(name__startswith="GCP Marketplace").count() == 1
+        )
+        assert read_onboarding_token(token)["organization_id"] == str(
+            account.organization.id
+        )
+
+
+class TestProcessSignup:
+    def test_creates_the_owner_and_finishes_the_google_side(
+        self, onboarded, procurement, post_registration
+    ):
+        token, account = onboarded
+        pending_row(account)
+
+        user = process_signup(token, "Owner@Acme-Corp.com", FULL_NAME)
+
+        assert user.email == EMAIL
+        assert user.organization == account.organization
+        assert user.organization_role == OrganizationRoles.OWNER
+        membership = OrganizationMembership.objects.get(
+            user=user, organization=account.organization
+        )
+        assert membership.role == OrganizationRoles.OWNER
+
+        account.organization.refresh_from_db()
+        assert account.organization.name == FULL_NAME
+        assert account.organization.display_name == FULL_NAME
+
+        procurement.approve_account.assert_called_once_with(ACCOUNT_ID)
+        account.refresh_from_db()
+        assert account.approved_at is not None
+        assert account.state == GCPMarketplaceAccountState.ACTIVE
+
+        procurement.approve_entitlement.assert_called_once_with(ENTITLEMENT_ID)
+        post_registration.assert_called_once()
+        assert post_registration.call_args.args[0] == user.id
+
+        with pytest.raises(ValueError, match="onboarding token"):
+            read_onboarding_token(token)
+
+    def test_retry_with_the_same_email_resumes_at_approval(
+        self, onboarded, procurement
+    ):
+        token, account = onboarded
+        first = process_signup(token, EMAIL, FULL_NAME)
+        token, _ = onboard_account(ACCOUNT_ID)
+        procurement.approve_account.reset_mock()
+
+        again = process_signup(token, EMAIL.upper(), "Someone Else")
+
+        assert again == first
+        assert User.objects.filter(organization=account.organization).count() == 1
+        procurement.approve_account.assert_called_once_with(ACCOUNT_ID)
+
+    def test_disposable_email_is_refused(self, onboarded):
+        token, _ = onboarded
+
+        with (
+            patch(
+                "accounts.gcp_marketplace_utils.is_disposable_email_domain",
+                return_value=True,
+            ),
+            pytest.raises(ValueError, match="Disposable"),
+        ):
+            process_signup(token, "x@mailinator.com", FULL_NAME)
+
+    def test_second_person_cannot_claim_a_taken_subscription(self, onboarded):
+        token, _ = onboarded
+        process_signup(token, EMAIL, FULL_NAME)
+        token, _ = onboard_account(ACCOUNT_ID)
+
+        with pytest.raises(ValueError, match="already has an account"):
+            process_signup(token, "other@acme-corp.com", "Other Person")
+
+    def test_email_registered_elsewhere_is_refused(self, onboarded):
+        token, _ = onboarded
+        make_user(Organization.objects.create(name="Elsewhere"))
+
+        with pytest.raises(ValueError, match="already exists"):
+            process_signup(token, EMAIL, FULL_NAME)
+
+    def test_unknown_token_is_refused(self, procurement, free_tier):
+        with pytest.raises(ValueError, match="onboarding token"):
+            process_signup("not-a-token", EMAIL, FULL_NAME)
+
+
+class TestApprovePendingEntitlements:
+    def test_links_orphans_and_approves_them(self, procurement, gcp_account):
+        orphan = GCPMarketplaceEntitlement.objects.create(
+            entitlement_id=ENTITLEMENT_ID,
+            plan_id="payg",
+            status=REQUESTED,
+            raw_payload={"account": f"providers/{PROVIDER_ID}/accounts/{ACCOUNT_ID}"},
+        )
+
+        assert approve_pending_entitlements(gcp_account) == 1
+
+        orphan.refresh_from_db()
+        assert orphan.account == gcp_account
+        assert orphan.organization == gcp_account.organization
+        procurement.approve_entitlement.assert_called_once_with(ENTITLEMENT_ID)
+
+    def test_ignores_orphans_of_other_accounts(self, procurement, gcp_account):
+        orphan = GCPMarketplaceEntitlement.objects.create(
+            entitlement_id=ENTITLEMENT_ID,
+            plan_id="payg",
+            status=REQUESTED,
+            raw_payload={"account": f"providers/{PROVIDER_ID}/accounts/someone-else"},
+        )
+
+        assert approve_pending_entitlements(gcp_account) == 0
+
+        orphan.refresh_from_db()
+        assert orphan.account is None
+        procurement.approve_entitlement.assert_not_called()
+
+    def test_one_failed_approval_does_not_stop_the_rest(self, procurement, gcp_account):
+        pending_row(gcp_account)
+        pending_row(gcp_account, SECOND_ID)
+        procurement.approve_entitlement.side_effect = [RuntimeError("timeout"), {}]
+
+        assert approve_pending_entitlements(gcp_account) == 1
+        assert procurement.approve_entitlement.call_count == 2
+
+    @pytest.mark.xfail(
+        strict=True,
+        reason=(
+            "Approval only sees rows the consumer wrote, so a lost or delayed "
+            "creation event strands the purchase. Fixed on "
+            "fix/th-7731-marketplace-event-dedupe."
+        ),
+    )
+    def test_approves_a_pending_entitlement_google_holds_but_we_never_recorded(
+        self, procurement, gcp_account
+    ):
+        procurement.iter_entitlements.side_effect = lambda **kwargs: iter(
+            [remote_entitlement(state=REQUESTED)]
+        )
+
+        assert approve_pending_entitlements(gcp_account) == 1
+        procurement.approve_entitlement.assert_called_once_with(ENTITLEMENT_ID)
+
+
+class TestReconcileUnapprovedAccounts:
+    def test_finishes_a_sign_up_whose_approval_call_failed(
+        self, procurement, gcp_account
+    ):
+        gcp_account.approved_at = None
+        gcp_account.save(update_fields=["approved_at"])
+        make_user(gcp_account.organization)
+        pending_row(gcp_account)
+
+        counts = reconcile_unapproved_accounts()
+
+        assert counts == {"checked": 1, "approved": 1, "failed": 0}
+        procurement.approve_account.assert_called_once_with(ACCOUNT_ID)
+        procurement.approve_entitlement.assert_called_once_with(ENTITLEMENT_ID)
+        gcp_account.refresh_from_db()
+        assert gcp_account.approved_at is not None
+
+    def test_skips_organizations_nobody_signed_up_for(self, procurement, gcp_account):
+        gcp_account.approved_at = None
+        gcp_account.save(update_fields=["approved_at"])
+
+        counts = reconcile_unapproved_accounts()
+
+        assert counts == {"checked": 0, "approved": 0, "failed": 0}
+        procurement.approve_account.assert_not_called()
+
+    def test_a_google_failure_is_counted_and_retried_next_hour(
+        self, procurement, gcp_account
+    ):
+        gcp_account.approved_at = None
+        gcp_account.save(update_fields=["approved_at"])
+        make_user(gcp_account.organization)
+        procurement.approve_account.side_effect = RuntimeError("timeout")
+
+        counts = reconcile_unapproved_accounts()
+
+        assert counts == {"checked": 1, "approved": 0, "failed": 1}
+        gcp_account.refresh_from_db()
+        assert gcp_account.approved_at is None
+
+
+class TestVerifyTokenView:
+    URL = "/accounts/gcp-marketplace/verify-token/"
+
+    def post(self, api_client, token="signed-jwt"):
+        return api_client.post(
+            self.URL,
+            data=f"x-gcp-marketplace-token={token}" if token else "",
+            content_type="application/x-www-form-urlencoded",
+        )
+
+    def test_new_customer_is_sent_to_register_with_a_token(
+        self, api_client, procurement, free_tier
+    ):
+        with patch(
+            "accounts.views.gcp_marketplace.verify_marketplace_token",
+            return_value=(ACCOUNT_ID, "google-user-1", "api.futureagi.com"),
+        ):
+            response = self.post(api_client)
+
+        assert response.status_code == 302
+        location = response["Location"]
+        assert "/auth/jwt/register?onboarding_gcp_token=" in location
+        token = location.rsplit("=", 1)[1]
+        assert read_onboarding_token(token)["procurement_account_id"] == ACCOUNT_ID
+
+    def test_returning_customer_is_sent_to_login(self, api_client, onboarded):
+        _, account = onboarded
+        make_user(account.organization)
+
+        with patch(
+            "accounts.views.gcp_marketplace.verify_marketplace_token",
+            return_value=(ACCOUNT_ID, "", "api.futureagi.com"),
+        ):
+            response = self.post(api_client)
+
+        assert response.status_code == 302
+        assert "/auth/jwt/login" in response["Location"]
+
+    def test_invalid_token_is_rejected(self, api_client, procurement):
+        with patch(
+            "accounts.views.gcp_marketplace.verify_marketplace_token",
+            side_effect=ValueError("bad signature"),
+        ):
+            response = self.post(api_client)
+
+        assert response.status_code == 400
+        assert GCPMarketplaceAccount.objects.count() == 0
+
+    def test_missing_token_is_rejected(self, api_client, procurement):
+        assert self.post(api_client, token="").status_code == 400
+
+
+class TestSignupView:
+    URL = "/accounts/gcp-marketplace/signup/"
+
+    def test_completes_sign_up(self, api_client, onboarded, procurement):
+        token, account = onboarded
+
+        response = api_client.post(
+            self.URL,
+            {"onboarding_token": token, "email": EMAIL, "full_name": FULL_NAME},
+            format="json",
+        )
+
+        assert response.status_code == 200
+        assert response.json()["result"]["user_email"] == EMAIL
+        assert User.objects.filter(
+            email=EMAIL, organization=account.organization
+        ).exists()
+        procurement.approve_account.assert_called_once_with(ACCOUNT_ID)
+
+    def test_unknown_fields_are_rejected(self, api_client, onboarded):
+        token, _ = onboarded
+
+        response = api_client.post(
+            self.URL,
+            {
+                "onboarding_token": token,
+                "email": EMAIL,
+                "full_name": FULL_NAME,
+                "password": "chosen-by-the-customer",
+            },
+            format="json",
+        )
+
+        assert response.status_code == 400
+        assert not User.objects.filter(email=EMAIL).exists()
+
+    def test_expired_token_returns_the_reason(self, api_client, procurement, free_tier):
+        response = api_client.post(
+            self.URL,
+            {"onboarding_token": "expired", "email": EMAIL, "full_name": FULL_NAME},
+            format="json",
+        )
+
+        assert response.status_code == 400
+        assert "onboarding token" in response.content.decode()
+
+
+class TestOAuthState:
+    def test_round_trips_the_onboarding_token(self):
+        assert read_oauth_state(encode_oauth_state("abc123")) == "abc123"
+
+    @pytest.mark.parametrize("state", [None, "", "gcp_onboarding:", "csrf-token-only"])
+    def test_anything_else_is_not_a_marketplace_sign_up(self, state):
+        assert read_oauth_state(state) is None
+
+
+class TestResolveSsoUser:
+    @pytest.fixture(autouse=True)
+    def quiet_analytics(self):
+        with (
+            patch("saml2_auth.views.track_mixpanel_event"),
+            patch("saml2_auth.views.get_mixpanel_properties", return_value={}),
+        ):
+            yield
+
+    def test_new_identity_with_a_token_goes_through_marketplace_sign_up(
+        self, onboarded, procurement
+    ):
+        from saml2_auth.views import get_started_url, resolve_sso_user
+
+        token, account = onboarded
+
+        user, next_url, new_org = resolve_sso_user(EMAIL, FULL_NAME, token, "login")
+
+        assert user.organization == account.organization
+        assert (next_url, new_org) == (get_started_url, "true")
+        procurement.approve_account.assert_called_once_with(ACCOUNT_ID)
+
+    def test_existing_user_cannot_absorb_a_subscription(self, onboarded):
+        from saml2_auth.views import resolve_sso_user
+
+        token, _ = onboarded
+        make_user(Organization.objects.create(name="Elsewhere"))
+
+        with pytest.raises(Exception, match="already exists"):
+            resolve_sso_user(EMAIL, FULL_NAME, token, "login")

--- a/futureagi/accounts/tests/gcp_marketplace/test_usage.py
+++ b/futureagi/accounts/tests/gcp_marketplace/test_usage.py
@@ -1,0 +1,420 @@
+"""Usage reporting to Service Control and the daily reconcile.
+
+Windows are pinned with `_window_end` so every test is independent of the
+clock. Quantities come from UsageSummary rows written directly.
+"""
+
+from datetime import UTC, datetime, timedelta
+from decimal import Decimal
+from unittest.mock import patch
+
+import pytest
+from django.conf import settings
+from django.utils import timezone
+
+from accounts.gcp_marketplace_usage import (
+    _reconcile_entitlement,
+    billable_entitlements,
+    report_all_usage,
+    report_entitlement_usage,
+    report_final_window,
+)
+from accounts.models.gcp_marketplace import (
+    GCPMarketplaceEntitlement,
+    GCPMarketplaceEntitlementState,
+    GCPMarketplaceUsageCheckpoint,
+    GCPUsageReportStatus,
+)
+from accounts.services.gcp_service_control import ReportOutcome
+from accounts.tests.gcp_marketplace.support import (
+    ENTITLEMENT_ID,
+    USAGE_REPORTING_ID,
+    FakeServiceControl,
+)
+from ee.usage.models.usage import UsageSummary
+
+pytestmark = [pytest.mark.integration, pytest.mark.requires_ee, pytest.mark.django_db]
+
+REPORTED = GCPUsageReportStatus.REPORTED
+PENDING = GCPUsageReportStatus.PENDING
+FAILED = GCPUsageReportStatus.FAILED
+
+T0 = datetime(2026, 9, 9, 18, 0, tzinfo=UTC)
+T1 = T0 + timedelta(hours=1)
+PERIOD = "2026-09"
+PERIOD_START = datetime(2026, 9, 1, tzinfo=UTC)
+ALLOWANCE = {"ai_credits": Decimal("100")}
+CONTAINER_LABEL = "cloudmarketplace.googleapis.com/container_name"
+
+
+@pytest.fixture
+def service_control():
+    fake = FakeServiceControl()
+    with patch("accounts.gcp_marketplace_usage.gcp_service_control", fake):
+        yield fake
+
+
+@pytest.fixture
+def alerts():
+    with patch("accounts.gcp_marketplace_usage.capture_message") as mocked:
+        yield mocked
+
+
+@pytest.fixture(autouse=True)
+def allowance():
+    with patch(
+        "accounts.gcp_marketplace_usage._free_allowance",
+        side_effect=lambda dimension, plan: ALLOWANCE.get(dimension, Decimal(0)),
+    ):
+        yield
+
+
+def usage(organization, **totals):
+    for dimension, total in totals.items():
+        UsageSummary.objects.update_or_create(
+            organization=organization,
+            dimension=dimension,
+            period=PERIOD,
+            defaults={
+                "total_usage": Decimal(str(total)),
+                "last_flushed_at": timezone.now(),
+            },
+        )
+
+
+def checkpoints(entitlement) -> dict[str, GCPMarketplaceUsageCheckpoint]:
+    return {
+        c.metric: c
+        for c in GCPMarketplaceUsageCheckpoint.objects.filter(entitlement=entitlement)
+    }
+
+
+def checkpoint(entitlement, metric, status, quantity="0", window_start=PERIOD_START):
+    return GCPMarketplaceUsageCheckpoint.objects.create(
+        organization=entitlement.organization,
+        entitlement=entitlement,
+        metric=metric,
+        window_start=window_start,
+        window_end=T0,
+        quantity_reported=Decimal(quantity),
+        operation_id=f"op-{metric}-{status}",
+        report_status=status,
+        error_detail="",
+    )
+
+
+def metric_of(operation) -> str:
+    return operation["metricValueSets"][0]["metricName"].rsplit("/", 1)[-1]
+
+
+def values_of(operation) -> list:
+    return operation["metricValueSets"][0]["metricValues"]
+
+
+class TestReportEntitlementUsage:
+    def test_reports_every_metric_above_its_allowance(
+        self, entitlement, service_control, alerts
+    ):
+        usage(
+            entitlement.organization,
+            ai_credits=150,
+            storage="1.5",
+            text_sim_tokens="10.7",
+        )
+
+        assert report_entitlement_usage(entitlement, _window_end=T0) == 6
+
+        rows = checkpoints(entitlement)
+        assert set(rows) == set(settings.GCP_MARKETPLACE_DIMENSIONS)
+        assert rows["ai_credits"].quantity_reported == Decimal("50")
+        assert rows["storage"].quantity_reported == Decimal("1.5")
+        assert rows["text_sim_tokens"].quantity_reported == Decimal("10")
+        assert rows["gateway_requests"].quantity_reported == Decimal("0")
+        assert all(
+            row.report_status == REPORTED
+            and row.window_start == PERIOD_START
+            and row.window_end == T0
+            and row.reported_at is not None
+            for row in rows.values()
+        )
+
+        service_control.check.assert_called_once()
+        (operations,), kwargs = service_control.report.call_args
+        by_metric = {metric_of(op): op for op in operations}
+        assert set(by_metric) == set(
+            settings.GCP_MARKETPLACE_METRIC_MAP["payg"].values()
+        )
+        assert {op["consumerId"] for op in operations} == {USAGE_REPORTING_ID}
+        assert values_of(by_metric["payg_credits"]) == [{"int64Value": "50"}]
+        assert values_of(by_metric["payg_storage"]) == [{"doubleValue": 1.5}]
+        assert kwargs["user_labels"] == {CONTAINER_LABEL: "test-organization"}
+        alerts.assert_not_called()
+
+    def test_the_same_window_is_never_sent_twice(self, entitlement, service_control):
+        usage(entitlement.organization, ai_credits=150)
+
+        assert report_entitlement_usage(entitlement, _window_end=T0) == 6
+        assert report_entitlement_usage(entitlement, _window_end=T0) == 0
+
+        assert GCPMarketplaceUsageCheckpoint.objects.count() == 6
+        assert service_control.report.call_count == 1
+
+    def test_the_next_window_reports_only_the_increase(
+        self, entitlement, service_control
+    ):
+        usage(entitlement.organization, ai_credits=150)
+        report_entitlement_usage(entitlement, _window_end=T0)
+        usage(entitlement.organization, ai_credits=175)
+
+        assert report_entitlement_usage(entitlement, _window_end=T1) == 6
+
+        second = GCPMarketplaceUsageCheckpoint.objects.get(
+            entitlement=entitlement, metric="ai_credits", window_start=T0
+        )
+        assert second.quantity_reported == Decimal("25")
+        assert second.window_end == T1
+
+    def test_usage_inside_the_allowance_reports_zero(
+        self, entitlement, service_control
+    ):
+        usage(entitlement.organization, ai_credits=80)
+
+        report_entitlement_usage(entitlement, _window_end=T0)
+
+        assert checkpoints(entitlement)["ai_credits"].quantity_reported == Decimal("0")
+
+    def test_check_failure_marks_every_window_failed_and_sends_nothing(
+        self, entitlement, service_control
+    ):
+        usage(entitlement.organization, ai_credits=150)
+        service_control.check.return_value = [{"code": "CONSUMER_INVALID"}]
+
+        assert report_entitlement_usage(entitlement, _window_end=T0) == 0
+
+        rows = checkpoints(entitlement)
+        assert {row.report_status for row in rows.values()} == {FAILED}
+        assert all("CONSUMER_INVALID" in row.error_detail for row in rows.values())
+        service_control.report.assert_not_called()
+
+    def test_a_rejected_operation_fails_only_its_own_metric(
+        self, entitlement, service_control
+    ):
+        usage(entitlement.organization, ai_credits=150)
+        service_control.report.side_effect = lambda operations, user_labels=None: (
+            ReportOutcome(
+                rejected={
+                    op["operationId"]
+                    for op in operations
+                    if metric_of(op) == "payg_credits"
+                }
+            )
+        )
+
+        assert report_entitlement_usage(entitlement, _window_end=T0) == 5
+
+        rows = checkpoints(entitlement)
+        assert rows["ai_credits"].report_status == FAILED
+        assert rows["ai_credits"].error_detail == "rejected by Service Control"
+        assert {
+            row.report_status for metric, row in rows.items() if metric != "ai_credits"
+        } == {REPORTED}
+
+    def test_an_error_naming_no_operation_leaves_windows_unresolved_and_pages(
+        self, entitlement, service_control, alerts
+    ):
+        usage(entitlement.organization, ai_credits=150)
+        service_control.report.return_value = ReportOutcome(
+            unattributed=[{"description": "quota exceeded"}]
+        )
+
+        assert report_entitlement_usage(entitlement, _window_end=T0) == 0
+
+        rows = checkpoints(entitlement)
+        assert {row.report_status for row in rows.values()} == {PENDING}
+        alerts.assert_called_once()
+        assert (
+            alerts.call_args.kwargs["tags"]["alarm"]
+            == "gcp_marketplace_usage_unresolved"
+        )
+
+    def test_transport_failure_with_unknown_outcome_stays_pending(
+        self, entitlement, service_control, alerts
+    ):
+        usage(entitlement.organization, ai_credits=150)
+        service_control.report.side_effect = ConnectionError("connection reset")
+
+        with pytest.raises(ConnectionError):
+            report_entitlement_usage(entitlement, _window_end=T0)
+
+        assert {row.report_status for row in checkpoints(entitlement).values()} == {
+            PENDING
+        }
+        alerts.assert_called_once()
+
+    def test_definitive_failure_is_marked_failed(
+        self, entitlement, service_control, alerts
+    ):
+        usage(entitlement.organization, ai_credits=150)
+        service_control.report.side_effect = RuntimeError("400 invalid metric")
+        service_control.is_definitive_failure.return_value = True
+
+        with pytest.raises(RuntimeError):
+            report_entitlement_usage(entitlement, _window_end=T0)
+
+        assert {row.report_status for row in checkpoints(entitlement).values()} == {
+            FAILED
+        }
+        alerts.assert_not_called()
+
+    def test_an_unresolved_window_is_never_resent(self, entitlement, service_control):
+        stuck = checkpoint(entitlement, "ai_credits", PENDING, quantity="9")
+        usage(entitlement.organization, ai_credits=150)
+
+        assert report_entitlement_usage(entitlement, _window_end=T0) == 5
+
+        stuck.refresh_from_db()
+        assert stuck.report_status == PENDING
+        assert stuck.operation_id == f"op-ai_credits-{PENDING}"
+
+    def test_without_a_consumer_id_nothing_is_reported(
+        self, entitlement, service_control
+    ):
+        entitlement.usage_reporting_id = ""
+        entitlement.save(update_fields=["usage_reporting_id"])
+
+        assert report_entitlement_usage(entitlement, _window_end=T0) == 0
+
+        assert not GCPMarketplaceUsageCheckpoint.objects.exists()
+        service_control.check.assert_not_called()
+
+    def test_unmapped_plan_reports_nothing(self, entitlement, service_control):
+        entitlement.plan_id = "legacy-gold"
+        entitlement.save(update_fields=["plan_id"])
+
+        assert report_entitlement_usage(entitlement, _window_end=T0) == 0
+        assert not GCPMarketplaceUsageCheckpoint.objects.exists()
+
+
+class TestFinalWindow:
+    def test_ends_a_second_before_the_cancellation_and_skips_check(
+        self, entitlement, service_control
+    ):
+        cancelled_at = datetime(2026, 9, 9, 18, 15, 6, tzinfo=UTC)
+        entitlement.status = GCPMarketplaceEntitlementState.CANCELLED
+        entitlement.google_update_time = cancelled_at
+        entitlement.save(update_fields=["status", "google_update_time"])
+        usage(entitlement.organization, ai_credits=150)
+
+        assert report_final_window(entitlement) == 6
+
+        service_control.check.assert_not_called()
+        rows = checkpoints(entitlement)
+        assert {row.window_end for row in rows.values()} == {
+            cancelled_at - timedelta(seconds=1)
+        }
+        assert rows["ai_credits"].quantity_reported == Decimal("50")
+
+
+class TestBillableEntitlements:
+    def test_one_entitlement_per_organization_oldest_first(self, entitlement):
+        GCPMarketplaceEntitlement.objects.create(
+            entitlement_id="second-purchase",
+            account=entitlement.account,
+            organization=entitlement.organization,
+            plan_id="scale",
+            status=GCPMarketplaceEntitlementState.ACTIVE,
+            usage_reporting_id="project_number:2",
+            effective_at=entitlement.effective_at + timedelta(hours=1),
+        )
+
+        assert [e.entitlement_id for e in billable_entitlements()] == [ENTITLEMENT_ID]
+
+    def test_requires_a_consumer_id_unless_told_otherwise(self, entitlement):
+        entitlement.usage_reporting_id = ""
+        entitlement.save(update_fields=["usage_reporting_id"])
+
+        assert billable_entitlements() == []
+        assert billable_entitlements(require_consumer_id=False) == [entitlement]
+
+    def test_ignores_rows_out_of_service(self, entitlement):
+        entitlement.status = GCPMarketplaceEntitlementState.CANCELLED
+        entitlement.save(update_fields=["status"])
+
+        assert billable_entitlements() == []
+
+
+class TestReportAllUsage:
+    def test_reports_each_billable_entitlement_and_resends_failed_tails(
+        self, entitlement, service_control, alerts
+    ):
+        cancelled = GCPMarketplaceEntitlement.objects.create(
+            entitlement_id="cancelled-1",
+            account=entitlement.account,
+            organization=entitlement.organization,
+            plan_id="payg",
+            status=GCPMarketplaceEntitlementState.CANCELLED,
+            usage_reporting_id="project_number:3",
+            effective_at=entitlement.effective_at,
+            google_update_time=entitlement.google_update_time,
+        )
+        tail = checkpoint(cancelled, "ai_credits", FAILED, quantity="7")
+
+        result = report_all_usage()
+
+        assert result == {
+            "entitlements": 1,
+            "metrics": 6,
+            "failures": 0,
+            "final_windows_resent": 1,
+            "final_window_failures": 0,
+        }
+        tail.refresh_from_db()
+        assert tail.report_status == REPORTED
+        assert tail.operation_id != f"op-ai_credits-{FAILED}"
+        assert tail.quantity_reported == Decimal("7")
+
+    def test_one_failing_entitlement_does_not_stop_the_sweep(
+        self, entitlement, service_control, alerts
+    ):
+        service_control.report.side_effect = RuntimeError("boom")
+        service_control.is_definitive_failure.return_value = True
+
+        result = report_all_usage()
+
+        assert result["failures"] == 1
+        assert result["entitlements"] == 0
+
+
+class TestReconcile:
+    def test_fractional_float_usage_reported_exactly_is_not_a_discrepancy(
+        self, entitlement
+    ):
+        usage(entitlement.organization, storage="1.5")
+        checkpoint(entitlement, "storage", REPORTED, quantity="1.5")
+
+        assert _reconcile_entitlement(entitlement, PERIOD) == []
+
+    def test_integer_usage_is_compared_after_allowance_and_floor(self, entitlement):
+        usage(entitlement.organization, ai_credits="150.9")
+        checkpoint(entitlement, "ai_credits", REPORTED, quantity="40")
+
+        (discrepancy,) = _reconcile_entitlement(entitlement, PERIOD)
+
+        assert discrepancy["metric"] == "ai_credits"
+        assert Decimal(discrepancy["ledger"]) == 50
+        assert Decimal(discrepancy["reported"]) == 40
+        assert Decimal(discrepancy["difference"]) == 10
+
+    def test_only_reported_windows_count_as_reported(self, entitlement):
+        usage(entitlement.organization, ai_credits=150)
+        checkpoint(entitlement, "ai_credits", PENDING, quantity="50")
+
+        (discrepancy,) = _reconcile_entitlement(entitlement, PERIOD)
+
+        assert Decimal(discrepancy["reported"]) == 0
+
+    def test_unmapped_plan_is_skipped(self, entitlement):
+        entitlement.plan_id = "legacy-gold"
+        entitlement.save(update_fields=["plan_id"])
+
+        assert _reconcile_entitlement(entitlement, PERIOD) == []


### PR DESCRIPTION
## Summary

Adds a test suite for the GCP Marketplace integration, which shipped with no tests. It covers the Pub/Sub lifecycle handlers, the sign-up and approval flow, usage reporting to Service Control and the daily reconcile, the Procurement client, and the Temporal consumer activity. 133 tests pass. Four more are strict xfails that pin defects still open on dev, so they fail the build the moment the fix lands and the markers are forgotten.

## Why the changes are done — what is the problem

### Reproduce on dev / main today (before this PR)

1. Run `pytest accounts/tests -k marketplace`. Nothing is collected.
2. Every Marketplace regression found this week on production was a runtime-only error a test would have caught: a `save(update_fields=["updated_at"])` on a model without that column, a property called as a method, a wrong type in a Procurement request body.

### Where it breaks — BE

No coverage. Static review missed all four because they only surface when the code path runs against real models.

## What changed

### accounts/tests/gcp_marketplace/support.py

Payload builders shaped like what the production subscription actually delivered: a Procurement `get` response, an `accounts.get` response, and Pub/Sub bodies where the events of one purchase share an eventId. `FakeProcurement` keeps the real resource-name helpers and records every write. `FakeServiceControl` mirrors `build_operation` so tests can read metric names and values off what `report` received.

### accounts/tests/gcp_marketplace/conftest.py

`procurement` patches the singleton everywhere the handlers reach it. `gcp_account` and `entitlement` give an approved account with a live payg entitlement. `subscription` and `free_tier` build the org's subscription the way `test_stripe_webhook.py` does.

### accounts/tests/gcp_marketplace/test_events.py

Process-once ledger, sync with the staleness guard, and every handler: creation requested (approve, hold, skip, reject duplicate), active (plan and interval per portal plan, unmapped plan, missing consumer id), offer accepted, plan change two-phase, pending cancellation and cancelled (downgrade before the tail report, on commit), deleted (marketplace-billed org left alone, 404 fallback, other errors propagate), account events, and the hourly plan reconcile.

### accounts/tests/gcp_marketplace/test_signup.py

`onboard_account`, `process_signup` including the org rename that crashed production, the same-email retry, the four refusals, orphan linking, the unapproved-account reconcile, both HTTP views, OAuth state, and `resolve_sso_user`.

### accounts/tests/gcp_marketplace/test_usage.py

Windows pinned with `_window_end`. Allowance subtraction, integer floor versus float dimensions, no double send, delta on the next window, check failure, per-operation rejection, unattributed errors paging and staying pending, transport failure versus definitive failure, unresolved windows never resent, the final window ending a second before cancellation, one billable entitlement per org, the hourly sweep resending failed tails, and the reconcile including the float-dimension regression.

### accounts/tests/gcp_marketplace/test_procurement.py

Pure unit: resource names, approval detection, and the exact request body each method builds, including the migrated-entitlement resource name and the bare-id list filter fixed in #2674. Plan and metric resolution.

### accounts/tests/gcp_marketplace/test_activities.py

Configuration gate, poison guard with the 24-hour window, the drain loop's ack decisions per message against a faked subscriber, and the four schedule definitions.

## Tests included — what each scenario covers

| # | Test class | Setup | Action | What it pins |
|---|---|---|---|---|
| 1 | TestProcessEvent | account row | same event twice | handled once, ledger row, rollback on failure |
| 2 | TestSyncEntitlement | account row | sync | account and org linked, older state ignored |
| 3 | TestCreationRequested | approved or pending account | creation event | approve, hold, no double approve, duplicate rejected |
| 4 | TestEntitlementActive | subscription on free | active event | plan, interval, billing method per portal plan |
| 5 | TestOfferAccepted | live entitlement | offer accepted | private offer applies plan |
| 6 | TestPlanChange | live entitlement | requested, changed | approve with pending plan, apply only on changed |
| 7 | TestCancellation | org on payg | pending, cancelled | sync only, then downgrade and tail report after commit |
| 8 | TestEntitlementDeleted | org on payg or free | deleted | left alone, 404 fallback, errors propagate |
| 9 | TestAccountEvents | account row | active, deleted | state refresh, unlink and downgrade |
| 10 | TestReconcilePlans | drifted subscription | hourly reconcile | repair, consumer id recovery, unmapped, out of service |
| 11 | TestOnboardAccount | procurement fake | verify-token flow | org, marketplace billing, token, returning customer |
| 12 | TestProcessSignup | onboarded account | sign-up | owner, membership, org rename, approvals, refusals |
| 13 | TestApprovePendingEntitlements | orphan rows | approve | linking, isolation of one failure |
| 14 | TestReconcileUnapprovedAccounts | unapproved account | hourly reconcile | approval retry, skip without members |
| 15 | TestVerifyTokenView, TestSignupView | api client | POST | redirects, 400s, unknown fields rejected |
| 16 | TestResolveSsoUser | onboarded account | OAuth callback | marketplace sign-up, existing user refused |
| 17 | TestReportEntitlementUsage | usage rows | report | quantities, statuses, Service Control outcomes |
| 18 | TestFinalWindow, TestBillableEntitlements, TestReportAllUsage, TestReconcile | entitlements | sweep, reconcile | tail window, one per org, resend, discrepancies |
| 19 | TestRequests, TestPlanResolution | mocked client | each method | exact request bodies, plan map |
| 20 | TestPoisonGuard, TestDrain, TestSchedules | faked subscriber | drain | ack decisions, 24h drop, schedule ids |

### Strict xfails, to be removed with the fix that lands them

- `test_events_of_one_purchase_share_an_event_id_and_are_all_handled`
- `test_standard_offer_before_activation_does_not_apply_the_plan`
- `test_approves_a_pending_entitlement_google_holds_but_we_never_recorded`
- `test_failure_key_tells_event_types_apart`

## Commands to run tests

```sh
# cwd: futureagi
bin/test accounts/tests/gcp_marketplace/
```

### Local verification results

`bin/test`'s migrate step was refused by the mutation-free startup guard in my checkout, so I ran pytest directly with the same environment the script exports:

```
133 passed, 4 xfailed in 82.98s
```

Ruff check and format pass on the package.

## Backwards compatibility

Test-only. No production code changes.

## Manual verification (UI)

None.

## Type of change

- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📖 Documentation
- [ ] 🧹 Chore / refactor
- [ ] 🚀 Performance
- [x] 🧪 Test-only

## Checklist

- [x] Follows the style guide, lint passes
- [x] Tests added
- [x] No secrets, URLs or PII

## Backout / rollback

Revert the commit. Nothing else depends on it.

## Linear

Part of TH-7731
