### PR TITLE
perf: omit unused root ID from trace seeds [agent]

### DIFF
--- a/futureagi/tracer/services/clickhouse/query_builders/trace_list.py
+++ b/futureagi/tracer/services/clickhouse/query_builders/trace_list.py
@@ -3626,7 +3626,7 @@ class TraceListQueryBuilder(BaseQueryBuilder):
             """
         query = f"""
         {candidate_cte}
-        SELECT {identity_select}, id AS root_span_id, start_time
+        SELECT {identity_select}, start_time
         FROM {self.TABLE}
         PREWHERE {self.project_filter_sql()}
           AND is_deleted = 0

--- a/futureagi/tracer/tests/test_bounded_filter_key_ch25.py
+++ b/futureagi/tracer/tests/test_bounded_filter_key_ch25.py
@@ -2535,7 +2535,8 @@ def test_trace_pages_keep_older_live_root_when_newer_raw_root_is_tombstoned(
     seed_names = [name for name, _type in seed_schema]
     seed_rows = [dict(zip(seed_names, row, strict=True)) for row in seed_data]
     multi_seed = next(row for row in seed_rows if row["trace_id"] == "trace-multi")
-    assert multi_seed["root_span_id"] == "root-a-tombstoned"
+    assert seed_names == ["trace_id", "start_time"]
+    assert multi_seed["start_time"] == window_end - timedelta(minutes=1)
 
     first = read_bounded_filter_page(
         builder=builder,

--- a/futureagi/tracer/tests/test_bounded_filter_key_ch25.py
+++ b/futureagi/tracer/tests/test_bounded_filter_key_ch25.py
@@ -2536,7 +2536,9 @@ def test_trace_pages_keep_older_live_root_when_newer_raw_root_is_tombstoned(
     seed_rows = [dict(zip(seed_names, row, strict=True)) for row in seed_data]
     multi_seed = next(row for row in seed_rows if row["trace_id"] == "trace-multi")
     assert seed_names == ["trace_id", "start_time"]
-    assert multi_seed["start_time"] == window_end - timedelta(minutes=1)
+    assert _unix_microseconds(multi_seed["start_time"]) == _unix_microseconds(
+        window_end - timedelta(minutes=1)
+    )
 
     first = read_bounded_filter_page(
         builder=builder,

--- a/futureagi/tracer/tests/test_bounded_trace_filter_reads.py
+++ b/futureagi/tracer/tests/test_bounded_trace_filter_reads.py
@@ -935,7 +935,7 @@ def test_structural_end_user_id_candidate_seed_uses_direct_uuid_predicate(
         slice_end=END,
         limit=26,
     )
-    candidate_sql = sql.split("SELECT trace_id, id AS root_span_id", 1)[0]
+    candidate_sql = sql.split("SELECT trace_id, start_time", 1)[0]
 
     assert builder.supports_filter_candidate_seed_page() is True
     assert builder.filter_seed_proves_result_order() is True
@@ -3369,7 +3369,7 @@ def test_org_trace_builder_keeps_project_in_seed_classifier_and_page_keys() -> N
         in normalized_anchor_sql
     )
     assert "LIMIT 1 BY project_id, trace_id" in normalized_anchor_sql
-    assert "SELECT project_id, trace_id, id AS root_span_id" in ordered_sql
+    assert "SELECT project_id, trace_id, start_time" in ordered_sql
     assert (
         "ORDER BY start_time DESC, trace_id DESC, toString(project_id) DESC"
         in ordered_sql

--- a/futureagi/tracer/tests/test_eval_task_bounded_selector.py
+++ b/futureagi/tracer/tests/test_eval_task_bounded_selector.py
@@ -1209,7 +1209,7 @@ def test_ui_default_100k_trace_task_accepts_a_complete_sparse_population(
                 ]
                 return QueryResult(rows, len(rows), "clickhouse", 1.0)
 
-            assert "id AS root_span_id" in query
+            assert "SELECT trace_id, start_time" in query
             assert "parent_span_id IS NULL" in query
             assert "max_rows_to_read" not in settings
             assert settings["max_block_size"] == 8_192
@@ -1217,7 +1217,6 @@ def test_ui_default_100k_trace_task_accepts_a_complete_sparse_population(
             rows = [
                 {
                     "trace_id": row["trace_id"],
-                    "root_span_id": row["root_span_id"],
                     "start_time": row["start_time"],
                 }
                 for row in source_rows.values()

--- a/futureagi/tracer/tests/test_trace_boolean_candidate_seed.py
+++ b/futureagi/tracer/tests/test_trace_boolean_candidate_seed.py
@@ -593,7 +593,7 @@ def test_boolean_plan_preserves_presence_all_history_and_existing_batch_sizes(va
     sql, params = builder.build_filter_candidate_seed_page(
         slice_start=start, slice_end=end, limit=200
     )
-    witness, root = sql.split("SELECT trace_id, id AS root_span_id, start_time", 1)
+    witness, root = sql.split("SELECT trace_id, start_time", 1)
     assert (
         "SELECT DISTINCT trace_id" in witness
         and "matching_scalar_trace_identities" in witness

--- a/futureagi/tracer/tests/test_trace_indexed_coordinate_reads.py
+++ b/futureagi/tracer/tests/test_trace_indexed_coordinate_reads.py
@@ -198,7 +198,7 @@ def test_numeric_seed_limits_root_population_not_child_history(days):
         assert forbidden not in population
     # Time belongs only to the necessary raw-root subquery, not to the
     # all-history numeric witness query wrapped around that subquery.
-    seed, _ = sql.split("SELECT trace_id, id AS root_span_id, start_time", 1)
+    seed, _ = sql.split("SELECT trace_id, start_time", 1)
     assert seed.count("start_time >=") == 1
     assert seed.count("start_time <") == 1
     assert "attrs_number" in seed

--- a/futureagi/tracer/tests/test_trace_long_text_candidate_seed.py
+++ b/futureagi/tracer/tests/test_trace_long_text_candidate_seed.py
@@ -37,7 +37,7 @@ def test_long_text_candidate_is_root_window_scoped_not_child_time_scoped(
     sql, params = subject.build_filter_candidate_seed_page(
         slice_start=END - timedelta(days=365), slice_end=END, limit=50
     )
-    cte = sql.split("SELECT trace_id, id AS root_span_id", 1)[0]
+    cte = sql.split("SELECT trace_id, start_time", 1)[0]
     assert "matching_scalar_trace_identities" in cte
     assert "AND trace_id IN (" in cte
     assert "WHERE parent_span_id IS NULL OR parent_span_id = ''" in cte
@@ -245,7 +245,7 @@ def test_numeric_candidate_priority_and_windowed_fallback_are_unchanged():
     sql, _ = subject.build_filter_candidate_seed_page(
         slice_start=END - timedelta(days=365), slice_end=END, limit=50
     )
-    cte = sql.split("SELECT trace_id, id AS root_span_id", 1)[0]
+    cte = sql.split("SELECT trace_id, start_time", 1)[0]
     assert "attrs_number[" in cte
     assert "parent_span_id" not in cte
 
@@ -274,7 +274,7 @@ def test_page_keyset_does_not_limit_the_necessary_child_witness():
         before_start_time=END - timedelta(days=1),
         before_id="previous",
     )
-    cte, roots = sql.split("SELECT trace_id, id AS root_span_id", 1)
+    cte, roots = sql.split("SELECT trace_id, start_time", 1)
     assert "filter_before" not in cte
     assert "filter_before_start_us" in roots
     assert params["filter_before_id"] == "previous"

--- a/futureagi/tracer/tests/test_trace_numeric_primary_seed.py
+++ b/futureagi/tracer/tests/test_trace_numeric_primary_seed.py
@@ -289,7 +289,7 @@ def test_uncapped_selector_reaches_numeric_seed_without_five_minute_fallback(wid
     assert result.complete and not result.rows and not result.has_more
     assert len(transport.calls) == 1
     query, params, _ = transport.calls[0]
-    child, root = query.split("SELECT trace_id, id AS root_span_id, start_time", 1)
+    child, root = query.split("SELECT trace_id, start_time", 1)
     assert "matching_scalar_trace_identities" in child and "attrs_number" in child
     assert "indexHint(has(mapKeys(" in child
     for forbidden in (
@@ -576,7 +576,7 @@ def test_rmt_numeric_and_uses_one_witness_and_all_latest_leaf_predicates(
     )
     assert len(transport.calls) == 3
     seed_sql, seed_params, _ = transport.calls[0]
-    child = seed_sql.split("SELECT trace_id, id AS root_span_id", 1)[0]
+    child = seed_sql.split("SELECT trace_id, start_time", 1)[0]
     selected = builder._public_scalar_candidate_seed_plan()
     selected_keys = [
         name for name in selected.params if name.startswith("latest_filter_key_")
@@ -807,7 +807,7 @@ def test_rmt_mixed_and_distinct_latest_children_and_root_order(request, width, d
     assert [row["trace_id"] for row in rows] == ["tie-c", "tie-b", "tie-a", "corrected"]
     assert rows[-1]["start_time"] == corrected and rows[-1]["_root_version"] == 2
     seed, params, _ = transport.calls[0]
-    raw = seed.split("SELECT trace_id, id AS root_span_id", 1)[0]
+    raw = seed.split("SELECT trace_id, start_time", 1)[0]
     assert "matching_scalar_trace_identities" in raw
     for forbidden in (
         "start_time",

--- a/futureagi/tracer/tests/test_trace_scalar_candidate_witness.py
+++ b/futureagi/tracer/tests/test_trace_scalar_candidate_witness.py
@@ -170,7 +170,7 @@ def test_scalar_candidate_seed_bounds_roots_to_12m_but_keeps_all_child_history()
         before_start_time=datetime(2026, 8, 1),
         before_id="previous-root",
     )
-    child, root = sql.split("SELECT trace_id, id AS root_span_id, start_time", 1)
+    child, root = sql.split("SELECT trace_id, start_time", 1)
     assert "matching_scalar_trace_identities" in child
     assert "indexHint(has(mapKeys(" in child
     assert "project_id = %(project_id)s" in child
@@ -319,7 +319,7 @@ def test_user_detail_company_seeds_native_user_and_replays_both_filters(
     child = sql.split(
         "SELECT "
         + ("project_id, " if org_scope else "")
-        + "trace_id, id AS root_span_id",
+        + "trace_id, start_time",
         1,
     )[0]
     assert "start_time" not in child

--- a/futureagi/tracer/tests/test_voice_long_text_candidate_seed.py
+++ b/futureagi/tracer/tests/test_voice_long_text_candidate_seed.py
@@ -135,7 +135,7 @@ def test_voice_candidate_keeps_complete_child_history_and_outer_keyset(operation
         before_start_time=end - timedelta(days=1),
         before_id="previous-call",
     )
-    candidates, roots = query.split("SELECT trace_id, id AS root_span_id", 1)
+    candidates, roots = query.split("SELECT trace_id, start_time", 1)
     assert "matching_scalar_trace_identities" in candidates
     assert "indexHint(arrayStringConcat" in candidates
     assert "attrs_string[" in candidates


### PR DESCRIPTION
Ordered trace seeds fetched a raw root ID that their consumers do not use. Remove that column and update the seed-shape tests; latest-state classification still supplies the canonical root identity for hydration.

One paired read-only seed query returned the same 200 ordered trace/time values. Read bytes decreased from 1.875 GB to 1.481 GB; elapsed time was 1.573 s versus 1.245 s. This was a single pair with uncontrolled cache/load, not an API latency measurement.

Offline validation on original head `319ea500e`:

```text
45 named direct compiler/fake cases passed
10 changed Python files parsed
Source unchanged during checks
Native tests executed: 0
git diff --check: passed
```

The focused checks cover trace/voice candidate compilation, tenant identity, complete child-history bounds, keysets, and sparse task selection. The native tombstone test retains its canonical-root and pagination assertions. Full local stack and local E2E suites were not run.

E2E: exempt (backend-internal)
AI use: Codex prepared the one-line query cleanup, focused test updates, and this draft for maintainer review.

CI run `34443991658` on the original head passed nine backend shards, E2E and API contract checks. Shard 4 reported one failure because ClickHouse returned a UTC-aware timestamp while the fixture used a naive UTC datetime. Its summary was `1 failed, 3340 passed, 142 skipped, 31966 deselected, 3 xfailed, 1 xpassed in 494.50s`.

Commit `980bb125a` changes only that assertion to compare both instants using the existing microsecond helper. It preserves microsecond precision and the canonical-root/pagination checks; runtime code is unchanged. On corrected head `980bb125a`, Backend CI run `34445139942` passed all ten shards after one failed-jobs rerun of an unchanged lock-timeout test. The corrected native tombstone/pagination case executed and passed. E2E and both API contract checks also passed. The separate admission gate remains blocked for a missing accepted issue.
