### PR TITLE
fix(marketplace): make the consumer heartbeat, follow Google's state, and type usage per metric

### DIFF
--- a/futureagi/accounts/gcp_marketplace_events.py
+++ b/futureagi/accounts/gcp_marketplace_events.py
@@ -22,6 +22,7 @@ from accounts.models.gcp_marketplace import (
     GCPMarketplaceEntitlement,
     GCPMarketplaceEntitlementState,
     GCPMarketplaceProcessedEvent,
+    GCPMarketplaceUsageCheckpoint,
 )
 from accounts.services.gcp_procurement import gcp_procurement, resolve_plan
 
@@ -154,11 +155,12 @@ SECOND_ENTITLEMENT_REASON = (
 def other_in_service_entitlement(
     row: GCPMarketplaceEntitlement,
 ) -> GCPMarketplaceEntitlement | None:
-    """Another live entitlement on the same organization, if there is one.
+    """Another live entitlement on the same organization, newest first.
 
     Usage is metered per organization, so a second entitlement cannot be
-    billed separately: whichever plan applied last would win and the other
-    would be paid for and ignored. One subscription per organization.
+    billed separately. One subscription per organization; when there are
+    more, the newest purchase is the one the customer is on (see
+    handle_entitlement_active and billable_entitlements).
     """
     if not row.organization_id:
         return None
@@ -167,7 +169,7 @@ def other_in_service_entitlement(
             organization_id=row.organization_id, status__in=IN_SERVICE_STATES
         )
         .exclude(pk=row.pk)
-        .order_by("effective_at", "created_at")
+        .order_by("-effective_at", "-created_at")
         .first()
     )
 
@@ -307,7 +309,38 @@ def handle_entitlement_active(payload: dict) -> None:
     row = sync_entitlement(_subject_id(payload))
     if row is None:
         return
+    _activate(row)
+
+
+def _activate(row: GCPMarketplaceEntitlement) -> None:
+    """Put the organization on the entitlement's plan. Google's state decides.
+
+    Shared by the ENTITLEMENT_ACTIVE event and the hourly pending pass, which
+    catches an activation whose event never arrived. The plan follows the
+    state just fetched from Google, never the message: a row Google still
+    shows awaiting activation gets nothing, and the pending pass revisits it.
+    """
+    if row.status not in IN_SERVICE_STATES:
+        logger.warning(
+            "gcp_marketplace_activation_not_in_service_at_google",
+            entitlement_id=row.entitlement_id,
+            status=row.status,
+        )
+        return
     _apply_plan(row)
+
+    # Under automatic offer approval nothing rejects a second purchase before
+    # it activates. The customer bought this one, so it wins: the plan above
+    # and billable_entitlements both follow it. The older one keeps costing
+    # the customer at Google until it is cancelled, which needs a human.
+    overlap = other_in_service_entitlement(row)
+    if overlap is not None:
+        logger.error(
+            "gcp_marketplace_multiple_in_service_entitlements",
+            entitlement_id=row.entitlement_id,
+            superseded_entitlement_id=overlap.entitlement_id,
+            organization_id=str(row.organization_id),
+        )
 
     if not row.usage_reporting_id:
         # The plan is applied and the customer is consuming, but nothing can
@@ -377,14 +410,50 @@ def _report_final_window_after_commit(row: GCPMarketplaceEntitlement) -> None:
 
 
 def handle_entitlement_cancelled(payload: dict) -> None:
-    row = sync_entitlement(_subject_id(payload))
+    entitlement_id = _subject_id(payload)
+    # What this row was before Google's cancellation overwrote it. Whether the
+    # tail is billed depends on it, and sync_entitlement discards it.
+    was_live = (
+        GCPMarketplaceEntitlement.objects.filter(
+            entitlement_id=entitlement_id, status__in=IN_SERVICE_STATES
+        ).exists()
+    )
+    row = sync_entitlement(entitlement_id)
     if row is None:
         return
+    _settle_left_service(row, was_live=was_live)
 
+
+def _settle_left_service(row: GCPMarketplaceEntitlement, *, was_live: bool) -> None:
+    """The entitlement is no longer in service: hand access back, bill the tail.
+
+    Shared by the cancellation event and the hourly reconcile, which catches
+    the same transition when the event never arrived (lost past retention or
+    dead-lettered) or when there is no event at all, as with a suspension.
+    """
     # Access first: a billing failure must never leave a cancelled customer on
-    # a paid plan.
-    _downgrade_to_free(row)
-    _report_final_window_after_commit(row)
+    # a paid plan. But the organization may already be on another entitlement:
+    # a customer who cancels one plan and buys another, or the two events
+    # arriving in the wrong order since Pub/Sub does not order them. Dropping
+    # to free then would take away a subscription that is live and paid for.
+    survivor = other_in_service_entitlement(row)
+    if survivor is None:
+        _downgrade_to_free(row)
+    else:
+        _apply_plan(survivor)
+        logger.info(
+            "gcp_marketplace_cancelled_org_stays_on_other_entitlement",
+            entitlement_id=row.entitlement_id,
+            surviving_entitlement_id=survivor.entitlement_id,
+        )
+
+    if was_live or GCPMarketplaceUsageCheckpoint.objects.filter(entitlement=row).exists():
+        _report_final_window_after_commit(row)
+    else:
+        logger.info(
+            "gcp_marketplace_final_usage_skipped_never_live",
+            entitlement_id=row.entitlement_id,
+        )
 
 
 def handle_entitlement_renewed(payload: dict) -> None:
@@ -396,13 +465,36 @@ def handle_entitlement_renewed(payload: dict) -> None:
 
 
 def handle_offer_accepted(payload: dict) -> None:
-    """A private offer, so the entitlement resolves to enterprise.
+    """Every purchase goes through an offer, standard or private.
 
-    Negotiated economics stay on the Marketplace offer. Nothing here reads a
-    discount or a committed amount.
+    For a standard offer this arrives with the creation request, while the
+    entitlement is still awaiting approval, so the plan is applied only once
+    Google reports it active. ENTITLEMENT_ACTIVE covers the usual case; this
+    covers a private offer accepted on an entitlement that is already live.
+    Negotiated economics stay on the Marketplace offer.
     """
     row = sync_entitlement(_subject_id(payload))
     if row is None:
+        return
+    if row.status == GCPMarketplaceEntitlementState.ACTIVATION_REQUESTED:
+        # One subscription per organization. With automatic offer approval
+        # there is no creation request to reject, so this is the only moment
+        # a second purchase is still rejectable: it stays awaiting activation
+        # until the offer's start time, and reject is valid in that state.
+        if reject_duplicate_entitlement(row):
+            return
+    if row.status != GCPMarketplaceEntitlementState.ACTIVE:
+        # With automatic offer approval this is the only message that carries
+        # the offer's start time: Google activates at that moment, not on any
+        # approve call, and the entitlement resource never shows it.
+        offer = payload.get("entitlement") or {}
+        logger.info(
+            "gcp_marketplace_offer_accepted_before_active",
+            entitlement_id=row.entitlement_id,
+            status=row.status,
+            new_offer_start_time=offer.get("newOfferStartTime"),
+            new_offer_end_time=offer.get("newOfferEndTime"),
+        )
         return
     _apply_plan(row)
 
@@ -490,7 +582,7 @@ HANDLERS = {
 
 
 def reconcile_entitlement_plans() -> dict:
-    """Hourly repair for in-service entitlements the events could not finish.
+    """Hourly repair for entitlements the events could not finish.
 
     Two gaps, both terminal events Google never redelivers:
 
@@ -508,16 +600,32 @@ def reconcile_entitlement_plans() -> dict:
         "unmapped": 0,
         "consumer_id_recovered": 0,
         "consumer_id_missing": 0,
+        "pending_checked": 0,
+        "pending_resolved": 0,
+        "pending_approved": 0,
+        "left_service": 0,
+        "paid_without_entitlement": 0,
         "failed": 0,
     }
     if OrganizationSubscription is None:
         return counts
 
-    entitlements = GCPMarketplaceEntitlement.objects.filter(
-        status__in=IN_SERVICE_STATES, organization__isnull=False
-    ).iterator(chunk_size=200)
+    entitlements = (
+        GCPMarketplaceEntitlement.objects.filter(
+            status__in=IN_SERVICE_STATES, organization__isnull=False
+        )
+        .order_by("organization_id", "-effective_at", "-created_at")
+        .iterator(chunk_size=200)
+    )
 
+    # Newest per organization, matching handle_entitlement_active and
+    # billable_entitlements; re-applying every row would let an older
+    # entitlement overwrite the plan the customer actually bought.
+    seen_orgs: set = set()
     for row in entitlements:
+        if row.organization_id in seen_orgs:
+            continue
+        seen_orgs.add(row.organization_id)
         counts["checked"] += 1
         try:
             _reconcile_entitlement_plan(row, counts)
@@ -529,6 +637,8 @@ def reconcile_entitlement_plans() -> dict:
                 organization_id=str(row.organization_id),
             )
 
+    _reconcile_pending_entitlements(counts)
+    _reconcile_paid_orgs_without_entitlement(counts)
     if counts["failed"]:
         logger.error(
             "gcp_marketplace_plan_reconcile_incomplete", failed=counts["failed"]
@@ -536,16 +646,112 @@ def reconcile_entitlement_plans() -> dict:
     return counts
 
 
+def _reconcile_paid_orgs_without_entitlement(counts: dict) -> None:
+    """A Marketplace-billed organization on a paid plan must hold an entitlement.
+
+    Everything above works from entitlement rows. An organization whose rows
+    are all terminal, or which has none (a deleted account, a row removed by
+    hand), is invisible to those passes and would stay paid with nothing
+    behind it. Pending activation is left alone: that is the normal state
+    between purchase and Google's start time, and the plan is still free.
+    """
+    backed = GCPMarketplaceEntitlement.objects.filter(
+        status__in=(
+            *IN_SERVICE_STATES,
+            GCPMarketplaceEntitlementState.ACTIVATION_REQUESTED,
+        ),
+        organization__isnull=False,
+    ).values("organization_id")
+    stranded = (
+        OrganizationSubscription.objects.filter(
+            billing_method=BillingMethodChoices.GCP_MARKETPLACE
+        )
+        .exclude(plan=PlanChoices.FREE)
+        .exclude(organization_id__in=backed)
+    )
+    for subscription in stranded.iterator(chunk_size=200):
+        counts["paid_without_entitlement"] += 1
+        logger.error(
+            "gcp_marketplace_paid_plan_without_entitlement_downgraded",
+            organization_id=str(subscription.organization_id),
+            plan=subscription.plan,
+        )
+        _downgrade_org_to_free(subscription.organization_id)
+
+
+def _reconcile_pending_entitlements(counts: dict) -> None:
+    """Re-fetch rows still awaiting approval and finish what sign-up could not.
+
+    A pending row is not in service, so the plan loop above never revisits it.
+    Two things go wrong without this: Google cancels or rejects the order and
+    the row keeps saying awaiting approval, and an approval that the sign-up
+    and the creation event both missed is never attempted again.
+    """
+    from accounts.gcp_marketplace_utils import approve_pending_entitlements
+
+    pending = GCPMarketplaceEntitlement.objects.filter(
+        status=GCPMarketplaceEntitlementState.ACTIVATION_REQUESTED
+    ).select_related("account")
+    accounts_done: set = set()
+    for row in pending.iterator(chunk_size=200):
+        counts["pending_checked"] += 1
+        try:
+            refreshed = sync_entitlement(row.entitlement_id)
+            if refreshed is None:
+                continue
+            if refreshed.status != GCPMarketplaceEntitlementState.ACTIVATION_REQUESTED:
+                counts["pending_resolved"] += 1
+                if refreshed.status in IN_SERVICE_STATES:
+                    # Google activated it and ENTITLEMENT_ACTIVE never reached
+                    # us. The customer has paid; give them the plan now rather
+                    # than never.
+                    logger.warning(
+                        "gcp_marketplace_activated_without_event",
+                        entitlement_id=refreshed.entitlement_id,
+                    )
+                    _activate(refreshed)
+                continue
+            account = refreshed.account
+            if account is None or not account.approved_at:
+                continue
+            if account.pk in accounts_done:
+                continue
+            accounts_done.add(account.pk)
+            counts["pending_approved"] += approve_pending_entitlements(account)
+        except Exception:
+            counts["failed"] += 1
+            logger.exception(
+                "gcp_marketplace_pending_reconcile_failed",
+                entitlement_id=row.entitlement_id,
+            )
+
+
 def _reconcile_entitlement_plan(row: GCPMarketplaceEntitlement, counts: dict) -> None:
-    if not row.usage_reporting_id:
-        refreshed = sync_entitlement(row.entitlement_id)
-        if refreshed is not None:
-            row = refreshed
-        if row.status not in IN_SERVICE_STATES:
-            # The re-fetch just showed it left service. Re-applying the paid
-            # plan now would undo a cancellation the event handler will, or
-            # already did, process.
-            return
+    had_consumer_id = bool(row.usage_reporting_id)
+    # Always re-fetch. Terminal events are delivered at most once and never
+    # replayed after retention or the dead-letter queue, and a suspension has
+    # no event at all; a row that is in service here and not at Google would
+    # otherwise keep its paid plan, and report usage to a consumer Google has
+    # closed, for ever.
+    refreshed = sync_entitlement(row.entitlement_id)
+    if refreshed is not None:
+        row = refreshed
+    if row.status not in IN_SERVICE_STATES:
+        counts["left_service"] += 1
+        logger.warning(
+            "gcp_marketplace_left_service_without_event",
+            entitlement_id=row.entitlement_id,
+            status=row.status,
+            organization_id=str(row.organization_id),
+        )
+        # A row back at awaiting activation was never live at Google, so
+        # there is no consumer to bill a tail to; anything else was.
+        _settle_left_service(
+            row,
+            was_live=row.status != GCPMarketplaceEntitlementState.ACTIVATION_REQUESTED,
+        )
+        return
+    if not had_consumer_id:
         if row.usage_reporting_id:
             counts["consumer_id_recovered"] += 1
             logger.info(
@@ -591,6 +797,16 @@ def _reconcile_entitlement_plan(row: GCPMarketplaceEntitlement, counts: dict) ->
     _apply_plan(row)
 
 
+def ledger_key(event_type: str, event_id: str) -> str:
+    """Google reuses one eventId across every event of a single operation.
+
+    A purchase publishes ACCOUNT_ACTIVE, ENTITLEMENT_CREATION_REQUESTED and
+    ENTITLEMENT_OFFER_ACCEPTED under the same id, so the id alone would let
+    the first one processed swallow the other two.
+    """
+    return f"{event_type}:{event_id}"
+
+
 def process_event(payload: dict) -> bool:
     """Handle one message exactly once. Returns False if already seen.
 
@@ -618,7 +834,7 @@ def process_event(payload: dict) -> bool:
 
     with transaction.atomic():
         _, created = GCPMarketplaceProcessedEvent.objects.get_or_create(
-            event_id=event_id,
+            event_id=ledger_key(event_type, event_id),
             defaults={
                 "event_type": event_type,
                 "subject_id": _subject_id(payload),

--- a/futureagi/accounts/gcp_marketplace_usage.py
+++ b/futureagi/accounts/gcp_marketplace_usage.py
@@ -405,19 +405,25 @@ def _add_window(
         },
     )
     by_operation[operation_id] = checkpoint
-    operations.append(_operation_for(entitlement, checkpoint, metric_id, is_float))
+    operations.append(_operation_for(entitlement, checkpoint, metric_id))
 
 
-def _operation_for(entitlement, checkpoint, metric_id: str, is_float: bool) -> dict:
-    """The Service Control operation for one checkpoint, exactly as stored."""
+def _operation_for(entitlement, checkpoint, metric_id: str) -> dict:
+    """The Service Control operation for one checkpoint, exactly as stored.
+
+    The wire type follows the metric, not the dimension: the same count is an
+    int64 on scale_gateway_request and a double on payg's gateway_request, and
+    Service Control rejects the operation when the two disagree.
+    """
     start = _rfc3339(checkpoint.window_start)
     end = _rfc3339(checkpoint.window_end)
+    as_double = metric_id in settings.GCP_MARKETPLACE_DOUBLE_METRICS
     return gcp_service_control.build_operation(
         consumer_id=entitlement.usage_reporting_id,
         operation_id=checkpoint.operation_id,
         start_time=start,
         end_time=end,
-        metric_values={metric_id: (float(checkpoint.quantity_reported), is_float)},
+        metric_values={metric_id: (float(checkpoint.quantity_reported), as_double)},
         operation_name=(
             f"usage_report_{_org_label(entitlement)}_{checkpoint.metric}_{start}_{end}"
         ),
@@ -549,13 +555,15 @@ def _mark(checkpoints, status, error_detail) -> None:
 
 
 def billable_entitlements(require_consumer_id: bool = True):
-    """One in-service entitlement per organization, oldest first.
+    """One in-service entitlement per organization: the newest.
 
     Usage is metered per organization, so two entitlements on one
     organization would each report the whole delta and Google would bill it
-    twice. Google can send several ENTITLEMENT_ACTIVE events for one account
-    when the listing allows multiple orders. Only the first purchase bills;
-    the rest are logged as an error every run until someone resolves them.
+    twice. With automatic offer approval a second purchase activates without
+    the provider ever getting to reject it, and ENTITLEMENT_ACTIVE puts the
+    organization on that newer plan. Billing follows the plan the customer is
+    on, so the newest purchase bills; older ones are logged as an error every
+    run until someone resolves them.
     """
     active = GCPMarketplaceEntitlement.objects.filter(
         status__in=IN_SERVICE_STATES, organization__isnull=False
@@ -564,15 +572,15 @@ def billable_entitlements(require_consumer_id: bool = True):
         active = active.exclude(usage_reporting_id="")
 
     chosen: dict = {}
-    for entitlement in active.order_by("effective_at", "created_at"):
-        first = chosen.get(entitlement.organization_id)
-        if first is None:
+    for entitlement in active.order_by("-effective_at", "-created_at"):
+        newest = chosen.get(entitlement.organization_id)
+        if newest is None:
             chosen[entitlement.organization_id] = entitlement
             continue
         logger.error(
             "gcp_marketplace_multiple_entitlements_for_org",
             organization_id=str(entitlement.organization_id),
-            billing_entitlement_id=first.entitlement_id,
+            billing_entitlement_id=newest.entitlement_id,
             ignored_entitlement_id=entitlement.entitlement_id,
         )
     return list(chosen.values())
@@ -686,14 +694,7 @@ def _resend_checkpoints(entitlement, checkpoints) -> int:
             ]
         )
         by_operation[checkpoint.operation_id] = checkpoint
-        operations.append(
-            _operation_for(
-                entitlement,
-                checkpoint,
-                metric_id,
-                checkpoint.metric in settings.GCP_MARKETPLACE_FLOAT_DIMENSIONS,
-            )
-        )
+        operations.append(_operation_for(entitlement, checkpoint, metric_id))
 
     if not operations:
         return 0

--- a/futureagi/accounts/gcp_marketplace_utils.py
+++ b/futureagi/accounts/gcp_marketplace_utils.py
@@ -381,6 +381,7 @@ def _link_orphan_entitlements(gcp_account: GCPMarketplaceAccount) -> int:
     entitlement is waiting, and no approval path can see it.
     """
     linked = 0
+    linked_rows: list[GCPMarketplaceEntitlement] = []
     orphans = GCPMarketplaceEntitlement.objects.filter(account__isnull=True)
     for entitlement in orphans:
         account_ref = (entitlement.raw_payload or {}).get("account", "")
@@ -389,7 +390,21 @@ def _link_orphan_entitlements(gcp_account: GCPMarketplaceAccount) -> int:
         entitlement.account = gcp_account
         entitlement.organization = gcp_account.organization
         entitlement.save(update_fields=["account", "organization", "updated_at"])
+        linked_rows.append(entitlement)
         linked += 1
+
+    # With automatic offer approval Google can activate before sign-up ends,
+    # and ENTITLEMENT_ACTIVE on an orphan row had no organization to put on
+    # the plan. Now it does: apply it here, or the customer who just paid
+    # sits on free until the hourly reconcile. Newest wins, as everywhere.
+    from accounts.models.gcp_marketplace import IN_SERVICE_STATES
+
+    live = [row for row in linked_rows if row.status in IN_SERVICE_STATES]
+    if live and gcp_account.organization_id:
+        from accounts.gcp_marketplace_events import _apply_plan
+
+        newest = max(live, key=lambda row: (row.effective_at or row.created_at, row.created_at))
+        _apply_plan(newest)
 
     if linked:
         logger.info(
@@ -400,6 +415,44 @@ def _link_orphan_entitlements(gcp_account: GCPMarketplaceAccount) -> int:
     return linked
 
 
+def _sync_pending_entitlements_from_google(gcp_account: GCPMarketplaceAccount) -> int:
+    """Mirror the account's unapproved entitlements straight from Google.
+
+    Approval must not depend on ENTITLEMENT_CREATION_REQUESTED having been
+    consumed: Pub/Sub is unordered and the events of one purchase share an
+    eventId, so the message can be delayed or lost. The Procurement API is the
+    source of truth; a failed listing falls back to whatever is held locally.
+    """
+    from accounts.gcp_marketplace_events import sync_entitlement
+
+    synced = 0
+    try:
+        for remote in gcp_procurement.iter_entitlements(
+            account_id=gcp_account.procurement_account_id
+        ):
+            if (
+                remote.get("state")
+                != GCPMarketplaceEntitlementState.ACTIVATION_REQUESTED
+            ):
+                continue
+            if sync_entitlement(gcp_procurement.bare_id(remote.get("name", ""))):
+                synced += 1
+    except Exception:
+        logger.exception(
+            "gcp_marketplace_entitlement_listing_failed",
+            account_id=gcp_account.procurement_account_id,
+        )
+        return synced
+
+    if synced:
+        logger.info(
+            "gcp_marketplace_pending_entitlements_synced",
+            account_id=gcp_account.procurement_account_id,
+            count=synced,
+        )
+    return synced
+
+
 def approve_pending_entitlements(gcp_account: GCPMarketplaceAccount) -> int:
     """Approve entitlements that arrived before sign-up completed.
 
@@ -408,6 +461,7 @@ def approve_pending_entitlements(gcp_account: GCPMarketplaceAccount) -> int:
     account is approved, anything waiting is approved here.
     """
     _link_orphan_entitlements(gcp_account)
+    _sync_pending_entitlements_from_google(gcp_account)
 
     from accounts.gcp_marketplace_events import reject_duplicate_entitlement
 

--- a/futureagi/accounts/tests/test_gcp_marketplace_cancel_and_wire_types.py
+++ b/futureagi/accounts/tests/test_gcp_marketplace_cancel_and_wire_types.py
@@ -1,0 +1,574 @@
+"""Cancel-then-resubscribe keeps the surviving plan; usage wire types follow the metric.
+
+Two production incidents behind these:
+
+- A cancellation for an old entitlement dropped the organization to free even
+  though a newer entitlement was live (Pub/Sub delivers out of order, and a
+  customer who cancels one plan and buys another sees exactly this).
+- Service Control rejected every payg report with "Inconsistent metric value
+  type for metric name '.../gateway_request'. Expecting double, got int64":
+  the service config types that one metric DOUBLE while scale's and
+  enterprise's gateway metrics are INT64, so a per-dimension rule can never
+  match all three plans.
+"""
+
+from datetime import timedelta
+from decimal import Decimal
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+from django.utils import timezone
+
+from accounts import gcp_marketplace_events as events
+from accounts import gcp_marketplace_usage as usage
+from accounts.models import Organization
+from accounts.models.gcp_marketplace import (
+    GCPMarketplaceEntitlement,
+    GCPMarketplaceEntitlementState,
+    GCPMarketplaceUsageCheckpoint,
+)
+
+
+def _entitlement(org, entitlement_id, status, plan_id="payg"):
+    return GCPMarketplaceEntitlement.objects.create(
+        entitlement_id=entitlement_id,
+        organization=org,
+        status=status,
+        plan_id=plan_id,
+        usage_reporting_id="project_number:1",
+        google_update_time=timezone.now(),
+    )
+
+
+def _cancel_payload(entitlement_id):
+    return {
+        "eventId": f"CANCEL_ENTITLEMENT-{entitlement_id}",
+        "eventType": "ENTITLEMENT_CANCELLED",
+        "entitlement": {"id": entitlement_id},
+    }
+
+
+def _sync_to_cancelled(entitlement_id):
+    """Stand in for sync_entitlement: Google now says CANCELLED."""
+    row = GCPMarketplaceEntitlement.objects.get(entitlement_id=entitlement_id)
+    row.status = GCPMarketplaceEntitlementState.CANCELLED
+    row.google_update_time = timezone.now()
+    row.save(update_fields=["status", "google_update_time", "updated_at"])
+    return row
+
+
+@pytest.mark.django_db
+class TestCancelKeepsSurvivingEntitlement:
+    def test_downgrades_when_nothing_else_is_live(self):
+        org = Organization.objects.create(name="solo")
+        _entitlement(org, "old", GCPMarketplaceEntitlementState.ACTIVE)
+
+        with (
+            patch.object(events, "sync_entitlement", side_effect=_sync_to_cancelled),
+            patch.object(events, "_downgrade_to_free") as downgrade,
+            patch.object(events, "_apply_plan") as apply_plan,
+            patch.object(events, "_report_final_window_after_commit") as report,
+        ):
+            events.handle_entitlement_cancelled(_cancel_payload("old"))
+
+        downgrade.assert_called_once()
+        apply_plan.assert_not_called()
+        report.assert_called_once()  # it was live, so its tail is billed
+
+    def test_keeps_org_on_the_newer_live_entitlement(self):
+        org = Organization.objects.create(name="resubscribed")
+        _entitlement(org, "old", GCPMarketplaceEntitlementState.ACTIVE, plan_id="payg")
+        newer = _entitlement(
+            org, "new", GCPMarketplaceEntitlementState.ACTIVE, plan_id="scale"
+        )
+
+        with (
+            patch.object(events, "sync_entitlement", side_effect=_sync_to_cancelled),
+            patch.object(events, "_downgrade_to_free") as downgrade,
+            patch.object(events, "_apply_plan") as apply_plan,
+            patch.object(events, "_report_final_window_after_commit"),
+        ):
+            events.handle_entitlement_cancelled(_cancel_payload("old"))
+
+        downgrade.assert_not_called()
+        apply_plan.assert_called_once()
+        assert apply_plan.call_args.args[0].pk == newer.pk
+
+    def test_pending_new_entitlement_does_not_block_downgrade(self):
+        # ACTIVATION_REQUESTED is not in service: the plan is applied when it
+        # goes ACTIVE, by that handler. Cancelling the old one drops to free.
+        org = Organization.objects.create(name="pending-new")
+        _entitlement(org, "old", GCPMarketplaceEntitlementState.ACTIVE)
+        _entitlement(org, "new", GCPMarketplaceEntitlementState.ACTIVATION_REQUESTED)
+
+        with (
+            patch.object(events, "sync_entitlement", side_effect=_sync_to_cancelled),
+            patch.object(events, "_downgrade_to_free") as downgrade,
+            patch.object(events, "_apply_plan") as apply_plan,
+            patch.object(events, "_report_final_window_after_commit"),
+        ):
+            events.handle_entitlement_cancelled(_cancel_payload("old"))
+
+        downgrade.assert_called_once()
+        apply_plan.assert_not_called()
+
+
+@pytest.mark.django_db
+class TestFinalWindowOnlyForLiveEntitlements:
+    def test_never_live_entitlement_is_not_reported(self):
+        # Cancelled straight from ACTIVATION_REQUESTED: no usage, and the
+        # consumer project never had the service enabled (SERVICE_DISABLED).
+        org = Organization.objects.create(name="never-live")
+        _entitlement(org, "abandoned", GCPMarketplaceEntitlementState.ACTIVATION_REQUESTED)
+
+        with (
+            patch.object(events, "sync_entitlement", side_effect=_sync_to_cancelled),
+            patch.object(events, "_downgrade_to_free"),
+            patch.object(events, "_report_final_window_after_commit") as report,
+        ):
+            events.handle_entitlement_cancelled(_cancel_payload("abandoned"))
+
+        report.assert_not_called()
+
+    def test_recorded_window_is_still_reported_even_if_status_was_stale(self):
+        # Local status never caught up to ACTIVE, but a window was recorded
+        # against it: that usage is real and must be billed.
+        org = Organization.objects.create(name="stale-status")
+        row = _entitlement(
+            org, "stale", GCPMarketplaceEntitlementState.ACTIVATION_REQUESTED
+        )
+        now = timezone.now()
+        GCPMarketplaceUsageCheckpoint.objects.create(
+            entitlement=row,
+            organization=org,
+            metric="gateway_requests",
+            window_start=now - timedelta(hours=1),
+            window_end=now,
+            quantity_reported=Decimal("3"),
+            operation_id="op-1",
+        )
+
+        with (
+            patch.object(events, "sync_entitlement", side_effect=_sync_to_cancelled),
+            patch.object(events, "_downgrade_to_free"),
+            patch.object(events, "_report_final_window_after_commit") as report,
+        ):
+            events.handle_entitlement_cancelled(_cancel_payload("stale"))
+
+        report.assert_called_once()
+
+
+@pytest.mark.django_db
+class TestNewestEntitlementWins:
+    """A second purchase activates under automatic approval; it is the one the customer is on."""
+
+    @staticmethod
+    def _dated(row, days_ago):
+        row.effective_at = timezone.now() - timedelta(days=days_ago)
+        row.save(update_fields=["effective_at"])
+        return row
+
+    def test_active_applies_newest_and_flags_the_overlap(self):
+        org = Organization.objects.create(name="overlap")
+        self._dated(_entitlement(org, "older", GCPMarketplaceEntitlementState.ACTIVE, plan_id="payg"), 1)
+        newer = self._dated(_entitlement(org, "newer", GCPMarketplaceEntitlementState.ACTIVE, plan_id="scale"), 0)
+
+        with (
+            patch.object(events, "sync_entitlement", return_value=newer),
+            patch.object(events, "_apply_plan") as apply_plan,
+            patch.object(events.logger, "error") as log_error,
+        ):
+            events.handle_entitlement_active({"entitlement": {"id": "newer"}})
+
+        assert apply_plan.call_args.args[0].pk == newer.pk
+        assert log_error.call_args.args[0] == "gcp_marketplace_multiple_in_service_entitlements"
+        assert log_error.call_args.kwargs["superseded_entitlement_id"] == "older"
+
+    def test_billing_follows_the_newest_entitlement(self):
+        org = Organization.objects.create(name="billing-newest")
+        self._dated(_entitlement(org, "older", GCPMarketplaceEntitlementState.ACTIVE), 1)
+        newer = self._dated(_entitlement(org, "newer", GCPMarketplaceEntitlementState.ACTIVE), 0)
+
+        assert [e.pk for e in usage.billable_entitlements()] == [newer.pk]
+
+    def test_cancel_survivor_is_the_newest(self):
+        org = Organization.objects.create(name="survivor-newest")
+        _entitlement(org, "old", GCPMarketplaceEntitlementState.ACTIVE)
+        self._dated(_entitlement(org, "a", GCPMarketplaceEntitlementState.ACTIVE), 1)
+        b = self._dated(_entitlement(org, "b", GCPMarketplaceEntitlementState.ACTIVE), 0)
+
+        with (
+            patch.object(events, "sync_entitlement", side_effect=_sync_to_cancelled),
+            patch.object(events, "_downgrade_to_free") as downgrade,
+            patch.object(events, "_apply_plan") as apply_plan,
+            patch.object(events, "_report_final_window_after_commit"),
+        ):
+            events.handle_entitlement_cancelled(_cancel_payload("old"))
+
+        downgrade.assert_not_called()
+        assert apply_plan.call_args.args[0].pk == b.pk
+
+
+@pytest.mark.django_db
+class TestSignupAppliesPlanOfOrphanEntitlement:
+    """Google activated before sign-up finished; linking the row must apply its plan."""
+
+    def test_linked_active_orphan_gets_its_plan_applied(self):
+        from accounts import gcp_marketplace_utils as utils
+        from accounts.models.gcp_marketplace import GCPMarketplaceAccount
+
+        org = Organization.objects.create(name="late-signup")
+        account = GCPMarketplaceAccount.objects.create(
+            procurement_account_id="acct-1", organization=org
+        )
+        orphan = GCPMarketplaceEntitlement.objects.create(
+            entitlement_id="paid-before-signup",
+            status=GCPMarketplaceEntitlementState.ACTIVE,
+            plan_id="payg",
+            usage_reporting_id="project_number:1",
+            raw_payload={"account": "providers/p/accounts/acct-1"},
+        )
+        GCPMarketplaceEntitlement.objects.create(
+            entitlement_id="someone-elses",
+            status=GCPMarketplaceEntitlementState.ACTIVE,
+            plan_id="payg",
+            raw_payload={"account": "providers/p/accounts/acct-2"},
+        )
+
+        with patch.object(events, "_apply_plan") as apply_plan:
+            linked = utils._link_orphan_entitlements(account)
+
+        orphan.refresh_from_db()
+        assert linked == 1
+        assert orphan.organization_id == org.id and orphan.account_id == account.id
+        apply_plan.assert_called_once()
+        assert apply_plan.call_args.args[0].pk == orphan.pk
+
+    def test_pending_orphan_is_linked_but_not_applied(self):
+        from accounts import gcp_marketplace_utils as utils
+        from accounts.models.gcp_marketplace import GCPMarketplaceAccount
+
+        org = Organization.objects.create(name="pending-signup")
+        account = GCPMarketplaceAccount.objects.create(
+            procurement_account_id="acct-3", organization=org
+        )
+        GCPMarketplaceEntitlement.objects.create(
+            entitlement_id="still-pending",
+            status=GCPMarketplaceEntitlementState.ACTIVATION_REQUESTED,
+            plan_id="payg",
+            raw_payload={"account": "providers/p/accounts/acct-3"},
+        )
+
+        with patch.object(events, "_apply_plan") as apply_plan:
+            assert utils._link_orphan_entitlements(account) == 1
+
+        apply_plan.assert_not_called()  # ENTITLEMENT_ACTIVE will do it
+
+
+@pytest.mark.django_db
+class TestSecondPurchaseRejectedAtOfferAccepted:
+    """Automatic approval sends no creation request; OFFER_ACCEPTED is where a duplicate is still rejectable."""
+
+    @staticmethod
+    def _offer_accepted(entitlement_id):
+        return {
+            "eventId": f"CREATE_ENTITLEMENT-{entitlement_id}",
+            "eventType": "ENTITLEMENT_OFFER_ACCEPTED",
+            "entitlement": {"id": entitlement_id, "newOfferStartTime": "2026-09-11T07:00:00Z"},
+        }
+
+    def test_second_purchase_while_one_is_live_is_rejected(self):
+        org = Organization.objects.create(name="already-subscribed")
+        _entitlement(org, "live", GCPMarketplaceEntitlementState.ACTIVE)
+        second = _entitlement(org, "second", GCPMarketplaceEntitlementState.ACTIVATION_REQUESTED)
+
+        with (
+            patch.object(events, "sync_entitlement", return_value=second),
+            patch.object(events.gcp_procurement, "reject_entitlement") as reject,
+            patch.object(events, "_apply_plan") as apply_plan,
+        ):
+            events.handle_offer_accepted(self._offer_accepted("second"))
+
+        reject.assert_called_once()
+        assert reject.call_args.args[0] == "second"
+        apply_plan.assert_not_called()
+
+    def test_first_purchase_is_left_to_activate(self):
+        org = Organization.objects.create(name="first-purchase")
+        first = _entitlement(org, "first", GCPMarketplaceEntitlementState.ACTIVATION_REQUESTED)
+
+        with (
+            patch.object(events, "sync_entitlement", return_value=first),
+            patch.object(events.gcp_procurement, "reject_entitlement") as reject,
+            patch.object(events, "_apply_plan") as apply_plan,
+        ):
+            events.handle_offer_accepted(self._offer_accepted("first"))
+
+        reject.assert_not_called()
+        apply_plan.assert_not_called()  # ENTITLEMENT_ACTIVE applies it
+
+    def test_repurchase_after_cancel_is_not_a_duplicate(self):
+        org = Organization.objects.create(name="resubscribe")
+        _entitlement(org, "old", GCPMarketplaceEntitlementState.CANCELLED)
+        new = _entitlement(org, "new", GCPMarketplaceEntitlementState.ACTIVATION_REQUESTED)
+
+        with (
+            patch.object(events, "sync_entitlement", return_value=new),
+            patch.object(events.gcp_procurement, "reject_entitlement") as reject,
+        ):
+            events.handle_offer_accepted(self._offer_accepted("new"))
+
+        reject.assert_not_called()
+
+
+@pytest.mark.django_db
+class TestReconcileCatchesWhatEventsMissed:
+    """A lost CANCELLED, or a suspension (no event), must not leave an org paid for ever."""
+
+    def test_row_that_left_service_at_google_is_settled(self):
+        org = Organization.objects.create(name="lost-cancel")
+        row = _entitlement(org, "gone", GCPMarketplaceEntitlementState.ACTIVE)
+
+        def google_says_cancelled(entitlement_id):
+            row.status = GCPMarketplaceEntitlementState.CANCELLED
+            row.save(update_fields=["status", "updated_at"])
+            return row
+
+        counts = {"left_service": 0, "consumer_id_recovered": 0, "consumer_id_missing": 0,
+                  "unmapped": 0, "repaired": 0}
+        with (
+            patch.object(events, "sync_entitlement", side_effect=google_says_cancelled),
+            patch.object(events, "_downgrade_to_free") as downgrade,
+            patch.object(events, "_report_final_window_after_commit") as report,
+        ):
+            events._reconcile_entitlement_plan(row, counts)
+
+        assert counts["left_service"] == 1
+        downgrade.assert_called_once()
+        report.assert_called_once()
+
+    def test_locally_forced_active_row_is_downgraded_without_a_tail(self):
+        # Status written by hand while Google still says awaiting activation:
+        # access is handed back, but there is no live consumer to bill.
+        org = Organization.objects.create(name="forced-active")
+        row = _entitlement(org, "forced", GCPMarketplaceEntitlementState.ACTIVE)
+
+        def google_says_pending(entitlement_id):
+            row.status = GCPMarketplaceEntitlementState.ACTIVATION_REQUESTED
+            row.save(update_fields=["status", "updated_at"])
+            return row
+
+        counts = {"left_service": 0, "consumer_id_recovered": 0, "consumer_id_missing": 0,
+                  "unmapped": 0, "repaired": 0}
+        with (
+            patch.object(events, "sync_entitlement", side_effect=google_says_pending),
+            patch.object(events, "_downgrade_to_free") as downgrade,
+            patch.object(events, "_report_final_window_after_commit") as report,
+        ):
+            events._reconcile_entitlement_plan(row, counts)
+
+        downgrade.assert_called_once()
+        report.assert_not_called()
+
+    def test_paid_marketplace_org_with_no_entitlement_is_downgraded(self):
+        from ee.usage.models.usage import BillingMethodChoices, OrganizationSubscription
+
+        org = Organization.objects.create(name="stranded")
+        OrganizationSubscription.objects.create(
+            organization=org, plan="scale", billing_method=BillingMethodChoices.GCP_MARKETPLACE
+        )
+        _entitlement(org, "dead", GCPMarketplaceEntitlementState.CANCELLED)
+        counts = {"paid_without_entitlement": 0}
+
+        with patch.object(events, "_downgrade_org_to_free") as downgrade:
+            events._reconcile_paid_orgs_without_entitlement(counts)
+
+        assert counts["paid_without_entitlement"] == 1
+        downgrade.assert_called_once_with(org.id)
+
+    def test_org_awaiting_activation_is_left_alone(self):
+        from ee.usage.models.usage import BillingMethodChoices, OrganizationSubscription
+
+        org = Organization.objects.create(name="awaiting")
+        OrganizationSubscription.objects.create(
+            organization=org, plan="free", billing_method=BillingMethodChoices.GCP_MARKETPLACE
+        )
+        _entitlement(org, "pending", GCPMarketplaceEntitlementState.ACTIVATION_REQUESTED)
+        counts = {"paid_without_entitlement": 0}
+
+        with patch.object(events, "_downgrade_org_to_free") as downgrade:
+            events._reconcile_paid_orgs_without_entitlement(counts)
+
+        assert counts["paid_without_entitlement"] == 0
+        downgrade.assert_not_called()
+
+
+class TestDrainActivityHeartbeatsFromPullThread:
+    """The pull runs on a worker thread; heartbeat must be delivered on the activity's loop.
+
+    Production failure: RuntimeError("no running event loop") from
+    activity.heartbeat() inside _drain_sync, on the first message of every
+    batch, so nothing was ever processed or acked.
+    """
+
+    @staticmethod
+    def _run(fn, messages=5):
+        import asyncio
+        from temporalio.testing import ActivityEnvironment
+        import tfc.temporal.marketplace.activities as act
+
+        def fake_drain(heartbeat):
+            for _ in range(messages):
+                heartbeat()
+            return {"events_processed": messages, "had_events": True}
+
+        beats = []
+
+        def worker_like_heartbeat(*details):
+            # temporalio's worker schedules a task on the loop; from any other
+            # thread this is the exact error seen in production.
+            asyncio.get_running_loop()
+            beats.append(details)
+
+        async def go():
+            env = ActivityEnvironment()
+            env.on_heartbeat = worker_like_heartbeat
+            with (
+                patch.object(act, "_is_configured", return_value=True),
+                patch.object(act, "_drain_sync", fake_drain),
+            ):
+                return await env.run(fn)
+
+        return asyncio.run(go()), len(beats)
+
+    def test_fixed_activity_heartbeats_once_per_message(self):
+        import tfc.temporal.marketplace.activities as act
+
+        result, beats = self._run(act.drain_gcp_marketplace_events_activity)
+        assert result.events_processed == 5 and result.had_events is True
+        assert beats == 5
+
+    def test_passing_heartbeat_straight_into_the_thread_reproduces_the_outage(self):
+        import asyncio
+        from temporalio import activity
+        import tfc.temporal.marketplace.activities as act
+
+        @activity.defn(name="drain_as_shipped_in_v1_37_1")
+        async def old(input=None):
+            return await asyncio.to_thread(act._drain_sync, activity.heartbeat)
+
+        with pytest.raises(RuntimeError, match="no running event loop"):
+            self._run(old)
+
+
+@pytest.mark.django_db
+class TestPlanFollowsGoogleState:
+    """The plan is applied from Google's state, never from the message alone."""
+
+    def test_active_event_but_google_still_pending_applies_nothing(self):
+        org = Organization.objects.create(name="early-active-event")
+        row = _entitlement(org, "early", GCPMarketplaceEntitlementState.ACTIVATION_REQUESTED)
+
+        with (
+            patch.object(events, "sync_entitlement", return_value=row),
+            patch.object(events, "_apply_plan") as apply_plan,
+        ):
+            events.handle_entitlement_active({"entitlement": {"id": "early"}})
+
+        apply_plan.assert_not_called()
+
+    def test_pending_pass_activates_when_google_did_without_an_event(self):
+        org = Organization.objects.create(name="lost-active-event")
+        row = _entitlement(org, "silent", GCPMarketplaceEntitlementState.ACTIVATION_REQUESTED)
+
+        def google_says_active(entitlement_id):
+            row.status = GCPMarketplaceEntitlementState.ACTIVE
+            row.save(update_fields=["status", "updated_at"])
+            return row
+
+        counts = {"pending_checked": 0, "pending_resolved": 0, "pending_approved": 0, "failed": 0}
+        with (
+            patch.object(events, "sync_entitlement", side_effect=google_says_active),
+            patch.object(events, "_apply_plan") as apply_plan,
+        ):
+            events._reconcile_pending_entitlements(counts)
+
+        assert counts["pending_resolved"] == 1
+        apply_plan.assert_called_once()
+        assert apply_plan.call_args.args[0].pk == row.pk
+
+    def test_pending_pass_does_not_touch_a_cancelled_one(self):
+        org = Organization.objects.create(name="cancelled-before-active")
+        row = _entitlement(org, "dead", GCPMarketplaceEntitlementState.ACTIVATION_REQUESTED)
+
+        def google_says_cancelled(entitlement_id):
+            row.status = GCPMarketplaceEntitlementState.CANCELLED
+            row.save(update_fields=["status", "updated_at"])
+            return row
+
+        counts = {"pending_checked": 0, "pending_resolved": 0, "pending_approved": 0, "failed": 0}
+        with (
+            patch.object(events, "sync_entitlement", side_effect=google_says_cancelled),
+            patch.object(events, "_apply_plan") as apply_plan,
+        ):
+            events._reconcile_pending_entitlements(counts)
+
+        assert counts["pending_resolved"] == 1
+        apply_plan.assert_not_called()
+
+
+class TestWireTypeFollowsMetric:
+    """A count is int64 on scale_gateway_request and double on payg's gateway_request."""
+
+    @pytest.fixture(autouse=True)
+    def _configured_service_control(self):
+        # build_operation qualifies metric ids with the service name. The
+        # module singleton read the (unset) test setting at import time, so
+        # hand the usage module a configured instance instead.
+        from accounts.services.gcp_service_control import GCPServiceControlService
+
+        configured = GCPServiceControlService(
+            service_name="futureagi.endpoints.test.cloud.goog"
+        )
+        with patch.object(usage, "gcp_service_control", configured):
+            yield
+
+    @staticmethod
+    def _operation(metric_id, quantity):
+        now = timezone.now()
+        entitlement = SimpleNamespace(usage_reporting_id="project_number:1")
+        checkpoint = SimpleNamespace(
+            operation_id="op",
+            window_start=now - timedelta(hours=1),
+            window_end=now,
+            quantity_reported=Decimal(quantity),
+            metric="gateway_requests",
+        )
+        with patch.object(usage, "_org_label", return_value="org"):
+            return usage._operation_for(entitlement, checkpoint, metric_id)
+
+    @pytest.mark.parametrize(
+        "metric_id, expected_key",
+        [
+            ("gateway_request", "doubleValue"),  # payg: DOUBLE in the service config
+            ("scale_gateway_request", "int64Value"),
+            ("enterprise_gateway_request", "int64Value"),
+            ("payg_storage", "doubleValue"),
+            ("scale_storage", "doubleValue"),
+            ("payg_cache_hits", "int64Value"),
+            ("scale_credits", "int64Value"),
+        ],
+    )
+    def test_value_type_matches_service_config(self, metric_id, expected_key):
+        op = self._operation(metric_id, "7")
+        (value,) = op["metricValueSets"][0]["metricValues"]
+        assert list(value) == [expected_key]
+
+    def test_double_metric_carries_a_float(self):
+        op = self._operation("gateway_request", "7")
+        assert op["metricValueSets"][0]["metricValues"][0] == {"doubleValue": 7.0}
+
+    def test_int_metric_carries_a_string_int64(self):
+        op = self._operation("scale_gateway_request", "7")
+        assert op["metricValueSets"][0]["metricValues"][0] == {"int64Value": "7"}

--- a/futureagi/tfc/settings/settings.py
+++ b/futureagi/tfc/settings/settings.py
@@ -674,8 +674,25 @@ GCP_MARKETPLACE_DIMENSIONS = [
     "voice_sim_minutes",
 ]
 
-# Google accepts these two as floating point. The other four must be integers.
+# Ledger semantics: these two dimensions are fractional, the other four are
+# whole counts and are floored before they are recorded as reported.
 GCP_MARKETPLACE_FLOAT_DIMENSIONS = {"storage", "voice_sim_minutes"}
+# Wire type is a property of the metric, not the dimension, and Service Control
+# rejects a value whose type differs from the service config ("Inconsistent
+# metric value type ... Expecting double, got int64"). Mirrors the config the
+# service is on -- note payg's gateway_request is DOUBLE while scale's and
+# enterprise's are INT64. Verify against:
+#   gcloud endpoints configs describe <id> \
+#     --service=futureagi.endpoints.futureagiprimary.cloud.goog --format="yaml(metrics)"
+GCP_MARKETPLACE_DOUBLE_METRICS = {
+    "gateway_request",
+    "payg_storage",
+    "payg_voice_simulation",
+    "scale_storage",
+    "scale_voice_simulation",
+    "enterprise_storage",
+    "enterprise_voice_simulation",
+}
 
 # EE license key (self-hosted only, JWT RS256)
 EE_LICENSE_KEY = os.environ.get("EE_LICENSE_KEY", "")

--- a/futureagi/tfc/temporal/marketplace/activities.py
+++ b/futureagi/tfc/temporal/marketplace/activities.py
@@ -8,6 +8,7 @@ out of the batch, so Google redelivers it while the rest of the batch completes.
 """
 
 import asyncio
+import contextvars
 import json
 from datetime import datetime, timedelta
 
@@ -126,8 +127,12 @@ def _drain_sync(heartbeat) -> dict:
 
 
 def _failure_key(payload: dict) -> str | None:
+    from accounts.gcp_marketplace_events import ledger_key
+
     event_id = payload.get("eventId")
-    return f"{POISON_CACHE_PREFIX}:{event_id}" if event_id else None
+    if not event_id:
+        return None
+    return f"{POISON_CACHE_PREFIX}:{ledger_key(payload.get('eventType', ''), event_id)}"
 
 
 def _is_poison(payload: dict) -> bool:
@@ -186,7 +191,17 @@ async def drain_gcp_marketplace_events_activity(input=None) -> DrainResult:
         # Cloud-only. Elsewhere this would fail every five minutes for ever.
         return DrainResult(events_processed=0, had_events=False)
 
-    result = await asyncio.to_thread(_drain_sync, activity.heartbeat)
+    # _drain_sync runs on a worker thread, but activity.heartbeat must run on
+    # the activity's event loop: it schedules a task with asyncio.create_task,
+    # which raises "no running event loop" from any other thread. Hop back to
+    # the loop, carrying the activity context so heartbeat finds its activity.
+    loop = asyncio.get_running_loop()
+    ctx = contextvars.copy_context()
+
+    def heartbeat_from_thread(*details) -> None:
+        loop.call_soon_threadsafe(activity.heartbeat, *details, context=ctx)
+
+    result = await asyncio.to_thread(_drain_sync, heartbeat_from_thread)
     return DrainResult(
         events_processed=result["events_processed"],
         had_events=result["had_events"],


### PR DESCRIPTION
## Summary

Hotfix for the GCP Marketplace integration as observed in US production on 2026-09-09/10. Six files, all under `accounts/` marketplace modules, `tfc/settings`, and the Temporal marketplace activity. Branched from `main`; nothing from `fix/th-7731-marketplace-event-dedupe` rides along.

### Outages fixed

| symptom in prod | cause | fix |
|---|---|---|
| Consumer workflow failed on the first message of every batch: `RuntimeError: no running event loop`; nothing processed or acked; 12-message backlog accruing dead-letter attempts | `_drain_sync` runs on a worker thread and called `activity.heartbeat` there ([activities.py:189](../blob/main/futureagi/tfc/temporal/marketplace/activities.py#L189)) | heartbeat hops back onto the activity loop via `call_soon_threadsafe` with the activity context |
| Every payg usage report 400: `Inconsistent metric value type for 'gateway_request'. Expecting double, got int64` | service config types payg's `gateway_request` DOUBLE while `scale_gateway_request`/`enterprise_gateway_request` are INT64; wire type was chosen per dimension | wire type follows the metric id: `GCP_MARKETPLACE_DOUBLE_METRICS`, mirrored from the live service config (`gcloud endpoints configs describe` in the comment) |
| Cancel of an old entitlement dropped the org to free while a newer one was live | unconditional downgrade in `handle_entitlement_cancelled` | keeps the surviving (newest) entitlement's plan |
| Final-window report for never-activated entitlements: 403 `SERVICE_DISABLED` | reported regardless of whether the entitlement was ever live | reported only when it was live or has checkpoints |

### Automatic offer approval

The product has automatic offer approval on. Google then sends **no** `ENTITLEMENT_CREATION_REQUESTED` / `PLAN_CHANGE_REQUESTED`, `entitlements.approve` is a no-op, and activation happens at the offer start time. Observed: six entitlements, only `OFFER_ACCEPTED` + `CANCELLED` events ever received.

- A second purchase is rejected at `ENTITLEMENT_OFFER_ACCEPTED` — the only state where `reject` is still valid — restoring one-subscription-per-org.
- Newest purchase wins wherever a choice is made: active handler, `billable_entitlements`, plan reconcile, cancel survivor.
- Sign-up after purchase applies the plan of an already-active orphan entitlement it links (`_link_orphan_entitlements`).
- The plan follows Google's fetched state, never the message (`_activate`): nothing is applied while Google still shows `ACTIVATION_REQUESTED`; the hourly pending pass activates when Google did without an event.
- Reconcile re-fetches every in-service row hourly, settles rows that left service without an event (lost `CANCELLED`, suspension — no event type exists) via the same path as the cancel handler (`_settle_left_service`), and downgrades a paid marketplace org holding no live or pending entitlement.

All 15 documented event types remain mapped in `HANDLERS`.

## Testing

`accounts/tests/test_gcp_marketplace_cancel_and_wire_types.py` — 31 tests.

- **Heartbeat**: `ActivityEnvironment` with a worker-faithful heartbeat (`asyncio.get_running_loop()` on the calling thread). The v1.37.1 one-liner reproduces `no running event loop`; the fix delivers one heartbeat per message. Run locally: **pass**.
- **Wire types**: 9 parametrised cases against the service config. Run locally: **pass**.
- Cancel/survivor, newest-wins, sign-up linking, duplicate rejection, both reconcile directions, plan-follows-state: 20 DB-backed tests — **not run locally** (Docker unavailable); run `bin/test accounts/tests/test_gcp_marketplace_cancel_and_wire_types.py` in CI / before merge.

Handlers were also exercised against production today: the manual `_drain_sync` path processed 14 real events (4 `OFFER_ACCEPTED`, 4 `CANCELLED`, 4 duplicates deduped, plus today's order) with the expected `plan_applied` / `downgraded_to_free` outcomes.

## Rollout

After the image is on `temporal-worker-default`:

```
python manage.py register_temporal_schedules --unpause gcp-marketplace-consumer
python manage.py register_temporal_schedules --unpause gcp-marketplace-plan-reconcile
```

(both were paused in US prod on 2026-09-10 to stop the crashing consumer burning dead-letter attempts).

## Still open, not code

Google accepts `entitlements.approve` (HTTP 200 `{}`, `updateTime` advances) but leaves entitlements in `ENTITLEMENT_ACTIVATION_REQUESTED` and the storefront on "Purchase pending provider approval" — reproduced on all six entitlements across payg / scale / scale-P1Y. Needs Producer Portal (Orders page, product version in review) or partner support; independent of this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
