### PR TITLE
fix(simulate): accept Twilio call data in Simulate

### DIFF
--- a/futureagi/simulate/semantics.py
+++ b/futureagi/simulate/semantics.py
@@ -29,6 +29,7 @@ SupportedProviders = {
     ProviderChoices.ELEVEN_LABS.value,
     ProviderChoices.LIVEKIT.value,
     ProviderChoices.BLAND.value,
+    ProviderChoices.TWILIO.value,
     ProviderChoices.OTHERS.value,
 }
 

--- a/futureagi/simulate/tests/test_alk_simulate_ingestion.py
+++ b/futureagi/simulate/tests/test_alk_simulate_ingestion.py
@@ -636,6 +636,47 @@ class TestResultIngest:
         ).get_recordings(call)
         assert recordings["stereo"] == stereo_url
 
+    @pytest.mark.parametrize("direction", ["inbound", "outbound"])
+    def test_ingest_twilio_result_keeps_provider_and_surfaces_call(
+        self, auth_client, run_test, direction
+    ):
+        """A Twilio result PATCH is stored under its own provider key and reads
+        back with its transcript roles and recording in either direction."""
+        from simulate.serializers.test_execution import (
+            CallExecutionDetailSerializer,
+        )
+
+        _, call_ids = _start_and_batch(auth_client, run_test)
+        call_id = call_ids[0]
+        provider_data = {"twilio": {"sid": "CA" + "0" * 32, "status": "completed"}}
+        recording_url = "https://cdn.example.com/twilio-call.wav"
+        transcript = _transcript_payload()
+
+        resp = auth_client.patch(
+            f"{ALK_BASE}/call-executions/{call_id}/result/",
+            {
+                "status": "completed",
+                "transcript": transcript,
+                "recording_url": recording_url,
+                "provider_call_data": provider_data,
+                "call_metadata": {"call_direction": direction},
+            },
+            format="json",
+        )
+        assert resp.status_code == 200, resp.content
+
+        call = CallExecution.objects.get(id=call_id)
+        assert call.status == CallExecution.CallStatus.COMPLETED
+        assert call.provider_call_data == provider_data
+
+        serializer = CallExecutionDetailSerializer(context={"detail_mode": True})
+        assert serializer.get_provider(call) == "twilio"
+        assert serializer.get_recordings(call) == {"combined": recording_url}
+        assert [
+            (row["speaker_role"], row["content"])
+            for row in serializer.get_transcript(call)
+        ] == [(seg["speaker_role"], seg["content"]) for seg in transcript]
+
     def test_voice_ingest_emits_voice_call_billing_once(self, auth_client, run_test):
         """A completed voice call charges once through TestExecutor._deduct_call_cost
         (the same path native voice uses to emit the VOICE_CALL usage event); a

--- a/futureagi/simulate/tests/test_provider_payload.py
+++ b/futureagi/simulate/tests/test_provider_payload.py
@@ -1,0 +1,32 @@
+"""Provider payload validation shared by Simulate calls and snapshots."""
+
+import pytest
+from django.core.exceptions import ValidationError
+from pydantic import TypeAdapter
+from pydantic import ValidationError as PydanticValidationError
+
+from simulate.models.test_execution import CallExecution, CallExecutionSnapshot
+from simulate.semantics import ProviderPayload
+from tracer.models.observability_provider import ProviderChoices
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("provider", ProviderChoices.values)
+def test_provider_payload_accepts_shared_providers(provider):
+    payload = {provider: {"id": "existing-call"}}
+    assert TypeAdapter(ProviderPayload).validate_python(payload) == payload
+    for model in (CallExecution, CallExecutionSnapshot):
+        assert (
+            model._meta.get_field("provider_call_data").clean(payload, model())
+            == payload
+        )
+
+
+@pytest.mark.unit
+def test_provider_payload_rejects_unknown_key():
+    payload = {"twilio": {}, "unknown_provider": {}}
+    with pytest.raises(PydanticValidationError, match="Contains forbidden keys"):
+        TypeAdapter(ProviderPayload).validate_python(payload)
+    for model in (CallExecution, CallExecutionSnapshot):
+        with pytest.raises(ValidationError, match="Invalid provider keys"):
+            model._meta.get_field("provider_call_data").clean(payload, model())

--- a/futureagi/simulate/utils/speaker_roles.py
+++ b/futureagi/simulate/utils/speaker_roles.py
@@ -7,6 +7,7 @@ Provider raw shape:
   VAPI     | inbound   | simulator       | tested agent
   VAPI     | outbound  | tested agent    | simulator
   LiveKit  | both      | tested agent    | simulator
+  Twilio   | both      | tested agent    | simulator
 
 Direction is tested-agent-perspective: inbound = tested agent receives, outbound
 = tested agent dials out. LiveKit rows are pre-normalised at the agent worker.
@@ -101,6 +102,8 @@ class SpeakerRoleResolver:
             return ProviderChoices.VAPI
         if provider_call_data.get(ProviderChoices.BLAND.value):
             return ProviderChoices.BLAND
+        if provider_call_data.get(ProviderChoices.TWILIO.value):
+            return ProviderChoices.TWILIO
         logger.error(
             "speaker_role_resolver_unknown_provider",
             provider_call_data_keys=list(provider_call_data.keys()),
@@ -141,7 +144,7 @@ class SpeakerRoleResolver:
     ) -> dict[str, str]:
         if provider == ProviderChoices.VAPI:
             return cls._VAPI_OUTBOUND if is_outbound else cls._VAPI_INBOUND
-        if provider == ProviderChoices.LIVEKIT:
+        if provider in (ProviderChoices.LIVEKIT, ProviderChoices.TWILIO):
             return cls._LIVEKIT_OUTBOUND if is_outbound else cls._LIVEKIT_INBOUND
         if provider == ProviderChoices.BLAND:
             return cls._BLAND_OUTBOUND if is_outbound else cls._BLAND_INBOUND


### PR DESCRIPTION
## Summary
- Simulate rejected any call whose provider data was keyed `twilio` with `Contains forbidden keys: {'twilio'}`, even though Twilio is a valid provider everywhere else in the platform. Simulate keeps its own allowlist, `SupportedProviders`, and Twilio was the one value missing from it. Through the ALK ingestion API the call was not rejected, but it was stored under the wrong key: `{"livekit": {"twilio": {...}}}`.
- Fixing the allowlist exposed a second bug on read. `SpeakerRoleResolver.detect_provider` had no Twilio case and fell back to Vapi, and Vapi swaps speakers on inbound calls. An inbound Twilio call showed the agent's lines as the customer's, and the other way round.
- Fixed by adding Twilio to the allowlist and reading it like LiveKit (ALK results already arrive with `assistant` = tested agent). Unknown provider keys are still rejected, other providers are unchanged, and the tool-calling provider list stays Vapi-only.

Closes #2662

E2E: exempt (backend-internal)

## Changes by file
- `futureagi/simulate/semantics.py`: add `ProviderChoices.TWILIO.value` to `SupportedProviders`. This one set backs `ProviderPayload`, the `provider_call_data` model validator and the provider-key check in `_apply_payload`.
- `futureagi/simulate/utils/speaker_roles.py`: `detect_provider` returns `TWILIO` for a `twilio` payload, and `_get_map` gives Twilio the LiveKit role maps, with no swap in either direction. The docstring table gets a Twilio row.
- `futureagi/simulate/tests/test_provider_payload.py` (new): the allowlist accepts every `ProviderChoices` value and still rejects unknown keys.
- `futureagi/simulate/tests/test_alk_simulate_ingestion.py`: a Twilio result goes through the real ingestion endpoint and is read back through `CallExecutionDetailSerializer`.

## Flows touched
- **ALK result ingestion with `twilio` provider data:** it was stored under `livekit`; it is now stored under `twilio`.
- **Call detail, transcript view and eval transcript labels for Twilio calls:** they were read as Vapi, so inbound speakers and recording channels came out swapped. They are now read like LiveKit, with no swap.
- **Unknown provider keys:** still rejected by `ProviderPayload` and the model validator, with the existing errors.
- **Provider data with no provider key:** the ingestion API still stores it under `livekit`, the existing SDK behaviour from `b2c635857`. Left unchanged on purpose.
- **Other providers (Vapi, Retell, LiveKit, Bland, Eleven Labs, Others):** unchanged. So is `ToolCallingSupportedProviders`.
- **Migrations and frontend:** no migration is needed, because `0063` references the validator function, not the set. No frontend change.

## Test coverage
- `test_provider_payload_accepts_shared_providers`, with one case per `ProviderChoices` value: every provider validates through `ProviderPayload` and both model validators, so the allowlist can't drift from the shared enum again.
- `test_provider_payload_rejects_unknown_key`: a payload with an unknown key next to `twilio` is still rejected.
- `test_ingest_twilio_result_keeps_provider_and_surfaces_call`, inbound and outbound: the call is stored under `twilio` as completed. The serializer returns provider `twilio`, the recording, and the transcript roles and content as sent.
- Both new ingestion cases failed on the old code. They got `{'livekit': ...}` instead of `{'twilio': ...}`. With only the allowlist fixed, the inbound case got swapped recording channels (`assistant: None, customer: None`).
- Gap: an inbound Twilio call with a **stereo** recording. `hooks/use-stereo-channels.js` flips stereo lanes on inbound calls for every provider except LiveKit, so the player will flip Twilio lanes too. That is right if the file is Twilio's own dual-channel recording, and wrong if the ALK runner wrote it. I could not verify which without a real recording. Transcripts and single-track recordings are not affected.
- Gap: not run against a live Twilio account. The rejection happened in validation, before anything reached Twilio. Fetching Twilio's own recording and transcription resources needs account credentials and is out of scope.

## How tested
- The new tests against the code before the fix fail, as described above.
- The 18 test files that touch provider detection or provider data (simulate, tracer read paths, model_hub annotation render, ee voice Bland/LiveKit/Vapi): `534 passed, 1 deselected`, run twice. The deselected test is excluded by the `pytest.ini` marker filter.
- The new tests on the committed branch head: 10 passed.
- `node e2e/scripts/e2e-coverage.mjs --base 6e27ad659 --head HEAD` gives `pass — exempt (backend-internal)`.
- black 25.11.0 and isort 7.0.0, the pre-commit versions: clean.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature with breaking side effects)
- [ ] This change requires a documentation update

## Test logs
<details>
<summary>Test run output</summary>

```
# Before the fix (allowlist and resolver both unfixed)
FAILED simulate/tests/test_provider_payload.py::test_provider_payload_accepts_shared_providers[twilio]
E   pydantic_core._pydantic_core.ValidationError: 1 validation error for function-after[functools.partial(<function validate_allowed_keys ...>, allowed_keys={'bland', 'others', 'retell', 'vapi', 'livekit', 'eleven_labs'})(), dict[str,any]]
FAILED simulate/tests/test_alk_simulate_ingestion.py::TestResultIngest::test_ingest_twilio_result_keeps_provider_and_surfaces_call[inbound]
FAILED simulate/tests/test_alk_simulate_ingestion.py::TestResultIngest::test_ingest_twilio_result_keeps_provider_and_surfaces_call[outbound]
E   AssertionError: assert {'livekit': {...'completed'}}} == {'twilio': {'... 'completed'}}
========================= 3 failed, 7 passed in 9.82s ==========================

# Allowlist fixed, resolver unfixed
FAILED simulate/tests/test_alk_simulate_ingestion.py::TestResultIngest::test_ingest_twilio_result_keeps_provider_and_surfaces_call[inbound]
E   AssertionError: assert {'combined': ...stomer': None} == {'combined': ...lio-call.wav'}
========================= 1 failed, 9 passed in 13.17s =========================

# Provider-related suites (18 files), run 1 and run 2
================ 534 passed, 1 deselected in 162.52s (0:02:42) =================
================ 534 passed, 1 deselected in 164.55s (0:02:44) =================

# Committed HEAD 10eb14200
simulate/tests/test_alk_simulate_ingestion.py::TestResultIngest::test_ingest_twilio_result_keeps_provider_and_surfaces_call[inbound] PASSED
simulate/tests/test_alk_simulate_ingestion.py::TestResultIngest::test_ingest_twilio_result_keeps_provider_and_surfaces_call[outbound] PASSED
simulate/tests/test_provider_payload.py::test_provider_payload_accepts_shared_providers[vapi] PASSED
simulate/tests/test_provider_payload.py::test_provider_payload_accepts_shared_providers[eleven_labs] PASSED
simulate/tests/test_provider_payload.py::test_provider_payload_accepts_shared_providers[retell] PASSED
simulate/tests/test_provider_payload.py::test_provider_payload_accepts_shared_providers[livekit] PASSED
simulate/tests/test_provider_payload.py::test_provider_payload_accepts_shared_providers[others] PASSED
simulate/tests/test_provider_payload.py::test_provider_payload_accepts_shared_providers[bland] PASSED
simulate/tests/test_provider_payload.py::test_provider_payload_accepts_shared_providers[twilio] PASSED
simulate/tests/test_provider_payload.py::test_provider_payload_rejects_unknown_key PASSED
============================= 10 passed in 13.19s ==============================
```

</details>

AI use: Made with Codex (code, tests); reviewed manually