### PR TITLE
fix(charts): keep metric chart timestamps on the correct instant [agent]

### DIFF
--- a/frontend/src/sections/projects/ChartsView/ChartsGenerator.jsx
+++ b/frontend/src/sections/projects/ChartsView/ChartsGenerator.jsx
@@ -75,6 +75,11 @@ const ChartsGenerator = ({
     },
     xaxis: {
       type: "datetime",
+      labels: {
+        // Points are epoch milliseconds; render them in the viewer's timezone
+        // so the axis agrees with the tooltip below.
+        datetimeUTC: false,
+      },
       // title: { text: "Time Period" },
     },
     yaxis: {

--- a/frontend/src/sections/projects/ChartsView/ChartsViewProvider/__tests__/common.test.js
+++ b/frontend/src/sections/projects/ChartsView/ChartsViewProvider/__tests__/common.test.js
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+
+import { normalizeTimestamp } from "../common";
+
+describe("normalizeTimestamp", () => {
+  // Epoch milliseconds are timezone-independent, so these expectations hold
+  // whatever timezone the test process runs in.
+  it.each([
+    ["2024-01-01T00:00:00Z", 1704067200000],
+    ["2024-01-01T00:00:00+05:30", 1704047400000],
+    ["2024-01-01T00:00:00-07:00", 1704092400000],
+    ["2024-07-01T12:34:56.789Z", 1719837296789],
+  ])("maps %s to the instant it names", (timestamp, expected) => {
+    expect(normalizeTimestamp(timestamp)).toBe(expected);
+  });
+
+  it("keeps offsets apart instead of collapsing them to the same value", () => {
+    expect(normalizeTimestamp("2024-01-01T00:00:00+05:30")).not.toBe(
+      normalizeTimestamp("2024-01-01T00:00:00Z"),
+    );
+  });
+
+  it("reads an offset-free timestamp as local time", () => {
+    expect(normalizeTimestamp("2024-01-01T00:00:00")).toBe(
+      new Date(2024, 0, 1, 0, 0, 0).getTime(),
+    );
+  });
+
+  it("returns null for missing or unparseable timestamps", () => {
+    expect(normalizeTimestamp(null)).toBeNull();
+    expect(normalizeTimestamp(undefined)).toBeNull();
+    expect(normalizeTimestamp("")).toBeNull();
+    expect(normalizeTimestamp("not-a-date")).toBeNull();
+  });
+});

--- a/frontend/src/sections/projects/ChartsView/ChartsViewProvider/common.js
+++ b/frontend/src/sections/projects/ChartsView/ChartsViewProvider/common.js
@@ -7,8 +7,10 @@ export const convertToISO = (dateArray) => {
 };
 
 export const normalizeTimestamp = (timestamp) => {
-  if (!timestamp) return timestamp;
+  if (timestamp === null || timestamp === undefined || timestamp === "") {
+    return null;
+  }
 
-  // Remove common timezone patterns: +00:00, -05:00, Z, etc.
-  return timestamp.replace(/([+-]\d{2}:\d{2}|Z)$/, "");
+  const epochMs = new Date(timestamp).getTime();
+  return Number.isFinite(epochMs) ? epochMs : null;
 };


### PR DESCRIPTION
## Summary

On any browser not set to UTC, metric chart points were drawn at the wrong time. A point the backend returned as `2024-01-01T00:00:00+05:30` was plotted at 00:00 in the *viewer's* timezone rather than at the instant it names, so the same series moved on screen depending on who was looking at it. The cause is `normalizeTimestamp`, which strips the timezone suffix off the ISO string before the value reaches the chart. This PR converts the timestamp to epoch milliseconds instead, and sets `xaxis.labels.datetimeUTC: false` in `ChartsGenerator` so the axis is labelled in the same timezone as the custom tooltip in that same file already was.

## Linked issues

Closes #2684
Linear: n/a — I have no access to this project's Linear workspace.

Opened as a **draft** on purpose. `.github/workflows/admission.yml` passes the linked-issue check only when the issue already carries `accepted` or `good first issue` (`if (labels.includes('accepted') || labels.includes('good first issue')) anyAccepted = true;`), and it is triggered on `pull_request_target: [opened, edited, synchronize, reopened, ready_for_review]` — labelling the issue later does not re-run it. Opening this ready-for-review before a maintainer has read #2684 would just leave a red `needs-admission` check that the label alone would not clear. The job is skipped on drafts (`if: github.event.pull_request.draft == false`), so this sits as a draft until #2684 is triaged; marking it ready fires `ready_for_review` and the gate runs then.

On the small-fix route in policy rule 1: `.github/workflows/admission.yml` sets `SMALL_FIX_MAX_LINES: "50"` and computes `const smallFix = !isAgent && added <= 50 && nFiles <= 3 && ...`. This PR's title ends in `[agent]`, so `isAgent` is true and `smallFix` is false whatever the size. An issue is linked rather than the exemption argued.

## AI use

AI use: Claude Code (Opus). It produced all of this change — the fix, the test file and this description. Every command quoted below was run again before this was posted, and the diff was read hunk by hunk. The title ends with `[agent]` as CONTRIBUTING.md asks.

## Type of change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📖 Documentation only
- [ ] 🧹 Chore / refactor (no user-visible change)
- [ ] 🚀 Performance improvement
- [ ] 🧪 Test-only change

## E2E coverage

E2E: exempt (harness-gap no flows cover the dashboards area yet)

---

## 1) What changes were done

3 files changed, +45/-3, of which +35/-0 is the new test file (`git diff --numstat 6e27ad65..fix/chart-timestamp-timezone`).

**A. `normalizeTimestamp` returns an instant instead of a rewritten string**

`frontend/src/sections/projects/ChartsView/ChartsViewProvider/common.js`, line 13 on `dev`:

```js
return timestamp.replace(/([+-]\d{2}:\d{2}|Z)$/, "");
```

- For the user: metric chart points now land on the instant the backend reported, whatever timezone the browser is in.
- The function now returns `new Date(timestamp).getTime()`, i.e. epoch milliseconds — a value with no timezone in it at all.
- Missing, `undefined` and empty-string input now return `null` rather than being handed back unchanged, and an unparseable string returns `null` rather than `NaN`. The point object itself is still emitted, as `{ x: null, y: … }` — I did not verify what ApexCharts does with a null-x point, so I am not claiming it is dropped from the series.
- No API, serializer, storage or contract change. `convertToISO` in the same file is untouched.

**B. The axis is told which timezone it is labelling**

`frontend/src/sections/projects/ChartsView/ChartsGenerator.jsx`, the `xaxis` block (line 76 on `dev`):

- ApexCharts 3.49.1 defaults `xaxis.labels.datetimeUTC` to `true` (`node_modules/apexcharts/src/modules/settings/Options.js:1021`), so once the x values are epoch milliseconds the axis would render them in UTC.
- The custom tooltip in the same file already formats with date-fns `format(new Date(xValue), "dd/MM/yyyy, HH:mm:ss")` (line 120 on `dev`), which is local. Without this line the axis and the tooltip disagree by the viewer's offset.
- `datetimeUTC: false` is what every other datetime chart in this repo does — `grep -rn datetimeUTC frontend/src` returns 10 hits on this branch: the new one plus `WidgetChart.jsx:1288`, `WidgetEditorView.jsx:3788`, `PrimaryGraph.jsx:1048`, `GraphSection.jsx:742`, `UsageChart.jsx:80`, `OverviewTab.jsx:170`, `OverviewTab.jsx:372`, `TrendsTab.jsx:80`, `PerformanceGraph.jsx:46`.

**C. Tests**

- New `frontend/src/sections/projects/ChartsView/ChartsViewProvider/__tests__/common.test.js`, importing `normalizeTimestamp` from `../common` — the module the bug lives in, so reverting the fix breaks the tests. Layout matches the sibling `__tests__/` directories under `src/sections/projects`.

---

## 2) Why the changes were done

- **Product/UX:** the chart was answering a different question than the one the user asked. Two people in different timezones looking at the same metric saw the same point in two different places, and neither position was necessarily the one the event happened at.
- **Technical:** removing an offset from an ISO string does not convert it, it discards information. `2024-01-01T00:00:00+05:30` and `2024-01-01T00:00:00Z` both became `2024-01-01T00:00:00`, and whatever built a `Date` from that afterwards re-anchored it to the browser's timezone. Epoch milliseconds carry the instant unambiguously and are a value ApexCharts accepts directly for `type: "datetime"`.
- **Architecture:** the conversion stays in `normalizeTimestamp` rather than moving to a new helper module, so every existing call site is fixed without touching them, and the regression test can point straight at the function that was wrong.

---

## 3) Tests written + scenarios each covers

**`frontend/src/sections/projects/ChartsView/ChartsViewProvider/__tests__/common.test.js`** — what `normalizeTimestamp` returns for offsets, offset-free input, and junk.

- `maps 2024-01-01T00:00:00Z to the instant it names` — expects the hardcoded `1704067200000`.
- `maps 2024-01-01T00:00:00+05:30 to the instant it names` — expects `1704047400000`.
- `maps 2024-01-01T00:00:00-07:00 to the instant it names` — expects `1704092400000`.
- `maps 2024-07-01T12:34:56.789Z to the instant it names` — expects `1719837296789`, covering sub-second precision.
- `keeps offsets apart instead of collapsing them to the same value` — asserts `+05:30` and `Z` do not produce the same result. This is the shape of the old bug stated directly.
- `reads an offset-free timestamp as local time` — compares against `new Date(2024, 0, 1, 0, 0, 0).getTime()`, built component-wise so the expectation is not the implementation restated.
- `returns null for missing or unparseable timestamps` — `null`, `undefined`, `""` and `"not-a-date"`.

The four epoch numbers are hardcoded rather than derived, so a wrong-but-self-consistent implementation cannot satisfy them. They are timezone-independent, so the file passes wherever it is run.

Targeted run, Node v22.22.0:

```
$ cd frontend && ./node_modules/.bin/vitest run src/sections/projects/ChartsView

 RUN  v3.2.3 /…/future-agi/frontend

 ✓ src/sections/projects/ChartsView/ChartsViewProvider/__tests__/common.test.js (7 tests) 2ms

 Test Files  1 passed (1)
      Tests  7 passed (7)
```

Regression proof — the same tests against the unpatched file. `git checkout 6e27ad65 -- frontend/src/sections/projects/ChartsView/ChartsViewProvider/common.js`, tests kept, same command:

```
   × normalizeTimestamp > maps 2024-01-01T00:00:00Z to the instant it names 3ms
     → expected '2024-01-01T00:00:00' to be 1704067200000 // Object.is equality
   × normalizeTimestamp > maps 2024-01-01T00:00:00+05:30 to the instant it names 0ms
     → expected '2024-01-01T00:00:00' to be 1704047400000 // Object.is equality
   × normalizeTimestamp > maps 2024-01-01T00:00:00-07:00 to the instant it names 0ms
     → expected '2024-01-01T00:00:00' to be 1704092400000 // Object.is equality
   × normalizeTimestamp > maps 2024-07-01T12:34:56.789Z to the instant it names 0ms
     → expected '2024-07-01T12:34:56.789' to be 1719837296789 // Object.is equality
   × normalizeTimestamp > keeps offsets apart instead of collapsing them to the same value 0ms
     → expected '2024-01-01T00:00:00' not to be '2024-01-01T00:00:00' // Object.is equality
   × normalizeTimestamp > reads an offset-free timestamp as local time 0ms
     → expected '2024-01-01T00:00:00' to be 1704047400000 // Object.is equality
   × normalizeTimestamp > returns null for missing or unparseable timestamps 0ms
     → expected undefined to be null

 Test Files  1 failed (1)
      Tests  7 failed (7)
```

Restoring the fix returns it to 7 passed (7). The second failure line is the bug in one line: with `dev`'s code, `+05:30` and `Z` really do collapse to the same string.

Surrounding subtree, same Node:

```
$ ./node_modules/.bin/vitest run src/sections/projects

 Test Files  82 passed (82)
      Tests  1134 passed (1134)
   Duration  44.07s
```

Whole frontend suite, same Node:

```
$ ./node_modules/.bin/vitest run

 Test Files  460 passed (460)
      Tests  4950 passed (4950)
   Duration  184.01s
```

Lint and formatting on the three touched files:

```
$ ./node_modules/.bin/eslint src/sections/projects/ChartsView/ChartsGenerator.jsx src/sections/projects/ChartsView/ChartsViewProvider/common.js src/sections/projects/ChartsView/ChartsViewProvider/__tests__/common.test.js
eslint exit=0
$ ./node_modules/.bin/prettier --check <same three files>
Checking formatting...
All matched files use Prettier code style!
prettier exit=0
$ git diff --check 6e27ad65..HEAD
diff --check exit=0
```

E2E coverage classifier, run from `e2e/`. The bare command does not pass, and I would rather paste that than hide it:

```
$ node scripts/e2e-coverage.mjs --base 6e27ad65 --head fix/chart-timestamp-timezone
E2E coverage: UNDETERMINED — areas: dashboards — flows hit: none
Areas with no flows yet: dashboards
Marker: missing
Verdict: needs-marker — behaviour files changed with no recognised signal: declare `E2E: updated|covered-by <ID>` or `E2E: exempt (<reason>)`
exit=1
```

`Marker: missing` because the script reads the marker out of the PR body, which it only has when given `--pr <n>` (once the PR exists) or `--body <file>`. With the body above saved to a file:

```
$ node scripts/e2e-coverage.mjs --base 6e27ad65 --head fix/chart-timestamp-timezone --body <this-body.md>
E2E coverage: UNDETERMINED — areas: dashboards — flows hit: none
Areas with no flows yet: dashboards
Marker: E2E: exempt (harness-gap no flows cover the dashboards area yet)
Verdict: pass — declared E2E: exempt (harness-gap no flows cover the dashboards area yet)
exit=0
```

---

## 4) How to run / test

### Frontend tests

```bash
cd frontend
eval "$(fnm env)" && fnm use 22
yarn install
./node_modules/.bin/vitest run src/sections/projects/ChartsView
./node_modules/.bin/vitest run src/sections/projects
```

To check the regression proof the way the policy describes:

```bash
git checkout 6e27ad65 -- frontend/src/sections/projects/ChartsView/ChartsViewProvider/common.js
cd frontend && ./node_modules/.bin/vitest run src/sections/projects/ChartsView   # 7 failed
git checkout HEAD -- frontend/src/sections/projects/ChartsView/ChartsViewProvider/common.js
```

### Backend tests

Not applicable — no Python file is touched.

### Contract verification

Not applicable — no API surface change.

### UI steps (manual)

I did not run these; they are what I would ask a reviewer with the stack up to do.

1. Set the browser or OS timezone to something with a non-zero offset, e.g. `Asia/Kolkata`.
2. Start the stack and log in at **http://localhost:3031**.
3. Open a project with metric data and go to the charts view.
4. Hover a point: the tooltip time and the x-axis tick beneath it should now name the same time, and both should be the local rendering of the instant the backend returned.

---

## 5) Screenshots / recordings

None. I did not run this in a browser — see "What was not verified" below. The test output above is pasted as text rather than as a screenshot of the same text.

---

## 6) Edge cases & considerations

- **Offset-free timestamps** (`2024-01-01T00:00:00`, no `Z`, no offset): `new Date()` reads these as local time. That is a change from `dev`, where the string was passed through and re-anchored later — the resulting instant is the same, it is just now decided in one place. Pinned by a test.
- **Unparseable or missing input:** returns `null`. The point object is still emitted as `{ x: null, y: … }`; what ApexCharts renders for that is not verified and not claimed.
- **Sub-second precision:** `2024-07-01T12:34:56.789Z` keeps its milliseconds; pinned by a test.
- **The zoom callback** in `ChartsGenerator.jsx` (line 59) formats `xaxis.min`/`xaxis.max` with date-fns and hands the strings to `onZoom`. Those were already local-time strings built from epoch numbers ApexCharts supplies, so this PR does not change that path.
- **Other consumers of `ChartsGenerator`:** the `datetimeUTC` line affects every chart this component renders, not just the two that call `normalizeTimestamp`. Spelled out under "What was not verified" below.

---

## 7) Pre-existing issues (NOT introduced by this PR)

- **Node version matters here.** I ran the same subtree command on this branch under the machine's default Node, v25.2.1, and it reports:

```
 Test Files  2 failed | 80 passed (82)
      Tests  8 failed | 1126 passed (1134)
```

  Every one of the eight is `window.localStorage.clear is not a function`, in `src/sections/projects/LLMTracing/__tests__/` — a subtree this diff does not touch. On the Node 22 that CONTRIBUTING pins, the same command on the same checkout is `82 passed (82)` / `1134 passed (1134)`. Every other number in this PR is from Node v22.22.0. Mentioning it only so a v25 run of yours does not look like something I broke.
- **That v25.2.1 failure count is itself unstable, reported rather than buried.** One v25 run of the same command on the same checkout gave `Test Files 3 failed | 79 passed (82)` / `Tests 9 failed | 1125 passed (1134)` — a third failing file I did not capture the name of. The repeat run is the `2 failed` / `8 failed` output pasted above. I cannot tell you what the third one was. On Node 22 there is no such wobble: I ran `vitest run src/sections/projects` three times on this branch and got `82 passed (82)` / `1134 passed (1134)` every time, plus the whole-suite run above, which includes that subtree. The seven tests added here were also run on their own repeatedly, including against the unpatched file.

---

## 8) Architectural / important decisions

- **Fix `normalizeTimestamp` in place rather than add a helper module.** A new module would have left the buggy function on the call path unless every call site was edited, and would have let the regression test pass while the bug was still shipped. Keeping it here means reverting the fix fails the tests, which is the check this repo's reviewers perform.
- **Ship the `datetimeUTC` line in the same PR.** Converting `x` to epoch milliseconds changes what ApexCharts renders on the axis, because the default is UTC. Splitting the axis line into a separate PR would leave this one correct in the data and wrong on screen for exactly the users it targets, with the axis disagreeing with its own tooltip. I would rather it be reviewed together; if you would prefer it separate, say so and I will split it.
- **`null` rather than `NaN` for bad input.** `NaN` propagates silently into chart internals; `null` is at least a value the calling code can test for.

---

## What was not verified

Stating this plainly rather than leaving it implied.

- **No browser, no running stack.** I did not run `docker compose up` or `yarn dev`, and there are no screenshots. The user-visible claims about the axis and the tooltip are reasoned from the ApexCharts default at `Options.js:1021`, from the date-fns call at `ChartsGenerator.jsx:120`, and from the nine sibling call sites — not from watching a chart.
- **`datetimeUTC: false` has no test.** It is a one-line config change in a component with no test file. Nothing in this PR would fail if it were removed.
- **It changes what more than the metric charts look like.** `grep -rn ChartsGenerator frontend/src` finds five places that render it — four app screens plus one Storybook story. The app screens are `ChartsView.jsx:659` and `ChartsWithFetch.jsx:130` (the two that go through `normalizeTimestamp`), plus `MonitorsView/MonitorGraph.jsx:157` and `UsersView/UserDetails/UserMetricsGraphSection.jsx:102`; the fifth is `ChartsView/ChartsGenerator.stories.jsx:14`, which is not user-facing. The latter two already pass epoch milliseconds of their own (`MonitorGraph.jsx:92`, and `transformGraphDataToChartData` in `UsersView/common.js`), so their axis tick labels move from UTC to local too. I believe that is the right direction — their tooltips were already local and disagreed with their own axes — but it is a user-visible change on two screens this PR is not otherwise about.
- **CI, as opposed to this machine.** The whole frontend suite is green here on Node v22.22.0, but it was run on macOS with a local `node_modules`, not in this repo's CI.
- **Backend and contract checks.** `bin/test` and `yarn contracts:check` were not run. No Python file and no API surface is touched by this diff, so I do not expect them to be affected, but I did not run them.
- **The `--body` form of the e2e classifier** uses a local file, which you cannot re-run verbatim. The reproducible form is `--pr <n>` once this PR exists; the bare run is pasted above with its real failing output.

---

## Checklist

- [x] My code follows the [style guide](../CONTRIBUTING.md#code-style) — ESLint and Prettier run on the touched files, output above.
- [x] I've added tests that prove my fix is effective — and they fail against `6e27ad65`, output above.
- [ ] `bin/test` passes locally (backend) — not run; this diff touches no Python.
- [x] `yarn test:run` passes locally (frontend) — `./node_modules/.bin/vitest run` from `frontend/` on Node v22.22.0: `Test Files 460 passed (460)` / `Tests 4950 passed (4950)`, exit 0.
- [ ] `yarn contracts:check` passes if API surface changed — not run; no API surface change.
- [ ] I've updated the documentation where relevant — no documentation in this repo describes this behaviour, so nothing was updated.
- [x] No hardcoded secrets, URLs, or PII — the diff adds four epoch integers, an ISO string set and one config line.
- [ ] I've signed the [CLA](../CONTRIBUTING.md#contributor-license-agreement-cla) — will sign when the bot prompts on this PR.
- [x] PR title follows Conventional Commits — `fix(charts): …`, with the `[agent]` suffix CONTRIBUTING.md asks for.
- [ ] Linear issue is linked and updated with status — no access to this project's Linear workspace.
