### PR TITLE
fix(agent-playground): show a failed node's error alongside partial output [agent]

### DIFF
--- a/frontend/src/sections/agent-playground/AgentBuilder/RunAgentPanel/NodeOutputDetail.jsx
+++ b/frontend/src/sections/agent-playground/AgentBuilder/RunAgentPanel/NodeOutputDetail.jsx
@@ -195,7 +195,7 @@ const ErrorCellRenderer = ({ data }) => (
       color="error.main"
       sx={{ whiteSpace: "pre-wrap" }}
     >
-      {data.output}
+      {data.error ?? data.output}
     </Typography>
   </Box>
 );
@@ -225,6 +225,7 @@ export default function NodeOutputDetail({ executionId, nodeExecutionId }) {
   }, []);
 
   const nodeStatus = nodeDetail?.status?.toLowerCase();
+  const isNodeError = nodeStatus === "error" || nodeStatus === "failed";
   const isNodeRunning = nodeStatus === "running" || nodeStatus === "pending";
   const nodeExecutionIdentifier =
     nodeDetail?.nodeExecutionId ||
@@ -237,7 +238,8 @@ export default function NodeOutputDetail({ executionId, nodeExecutionId }) {
     () => nodeDetail?.outputs || [],
     [nodeDetail?.outputs],
   );
-  const hasErrorMessage = !!errorMessage && outputs.length === 0;
+  const hasErrorMessage = isNodeError && !!errorMessage;
+  const hasOnlyErrorMessage = hasErrorMessage && outputs.length === 0;
   const isPairedMode = inputs.length > 0 && inputs.length === outputs.length;
 
   // Map API response to AG Grid row data
@@ -255,7 +257,7 @@ export default function NodeOutputDetail({ executionId, nodeExecutionId }) {
       return [{ id: nodeExecutionIdentifier, _running: true }];
     }
 
-    if (hasErrorMessage) {
+    if (hasOnlyErrorMessage) {
       if (inputs.length > 0) {
         // Has inputs but output errored — one row per input
         return inputs.map((inp, i) => ({
@@ -281,6 +283,7 @@ export default function NodeOutputDetail({ executionId, nodeExecutionId }) {
         id: `${nodeExecutionIdentifier}-${i}`,
         input: inp?.payload ?? "",
         output: outputs[i]?.payload ?? "",
+        error: errorMessage,
       }));
     }
 
@@ -290,13 +293,14 @@ export default function NodeOutputDetail({ executionId, nodeExecutionId }) {
         id: nodeExecutionIdentifier,
         inputs,
         outputs,
+        error: errorMessage,
       },
     ];
   }, [
     nodeDetail,
     nodeExecutionIdentifier,
     errorMessage,
-    hasErrorMessage,
+    hasOnlyErrorMessage,
     isPairedMode,
     isNodeRunning,
     inputs,
@@ -330,7 +334,7 @@ export default function NodeOutputDetail({ executionId, nodeExecutionId }) {
     }
 
     const usePairedInput =
-      isPairedMode || (hasErrorMessage && inputs.length > 0);
+      isPairedMode || (hasOnlyErrorMessage && inputs.length > 0);
     const cols = [];
 
     if (showInputs) {
@@ -353,7 +357,7 @@ export default function NodeOutputDetail({ executionId, nodeExecutionId }) {
       );
     }
 
-    if (hasErrorMessage) {
+    if (hasOnlyErrorMessage) {
       cols.push({
         field: "output",
         headerName: "Output",
@@ -379,10 +383,26 @@ export default function NodeOutputDetail({ executionId, nodeExecutionId }) {
               cellRenderer: PortListCellRenderer,
             },
       );
+      if (hasErrorMessage) {
+        cols.push({
+          field: "error",
+          headerName: "Error",
+          minWidth: 300,
+          flex: 1,
+          cellRenderer: ErrorCellRenderer,
+        });
+      }
     }
 
     return cols;
-  }, [showInputs, hasErrorMessage, isPairedMode, isNodeRunning, inputs.length]);
+  }, [
+    showInputs,
+    hasErrorMessage,
+    hasOnlyErrorMessage,
+    isPairedMode,
+    isNodeRunning,
+    inputs.length,
+  ]);
 
   const PORT_ROW_HEIGHT = 120;
 

--- a/frontend/src/sections/agent-playground/AgentBuilder/RunAgentPanel/__tests__/NodeOutputDetail.test.jsx
+++ b/frontend/src/sections/agent-playground/AgentBuilder/RunAgentPanel/__tests__/NodeOutputDetail.test.jsx
@@ -1,0 +1,120 @@
+/* eslint-disable react/prop-types */
+import React from "react";
+import { describe, expect, it, vi } from "vitest";
+import { fireEvent, render, screen } from "src/utils/test-utils";
+import NodeOutputDetail from "../NodeOutputDetail";
+
+let detail;
+
+vi.mock("src/api/agent-playground/agent-playground", () => ({
+  useGetNodeExecutionDetail: () => ({
+    data: detail,
+    isLoading: false,
+    isError: false,
+  }),
+}));
+vi.mock("src/hooks/use-ag-theme", () => ({ useAgThemeWith: () => ({}) }));
+vi.mock("ag-grid-react", () => ({
+  AgGridReact: React.forwardRef(function MockAgGridReact(
+    { columnDefs, rowData },
+    _ref,
+  ) {
+    return (
+      <div>
+        {columnDefs.map((column) => (
+          <span key={column.field}>{column.headerName}</span>
+        ))}
+        {rowData.map((row, rowIndex) =>
+          columnDefs.map((column) => {
+            if (column.cellRenderer) {
+              return React.createElement(column.cellRenderer, {
+                key: `${rowIndex}-${column.field}`,
+                data: row,
+                value: row[column.field],
+              });
+            }
+            const value = row[column.field];
+            const text = Array.isArray(value)
+              ? value.map((item) => item.payload).join(" ")
+              : value;
+            return (
+              <span key={`${rowIndex}-${column.field}`}>
+                {typeof text === "string" ? text : ""}
+              </span>
+            );
+          }),
+        )}
+      </div>
+    );
+  }),
+}));
+
+describe("NodeOutputDetail errors", () => {
+  it("renders partial output and backend error for failed nodes", () => {
+    detail = {
+      status: "failed",
+      outputs: [{ payload: "partial" }],
+      errorMessage: "backend failed",
+    };
+    render(<NodeOutputDetail executionId="e" nodeExecutionId="n" />);
+    expect(screen.getByText("partial")).toBeInTheDocument();
+    expect(screen.getByText("Error")).toBeInTheDocument();
+    expect(screen.getByText("backend failed")).toBeInTheDocument();
+  });
+
+  it("keeps no-output failures in the output error cell", () => {
+    detail = { status: "error", outputs: [], errorMessage: "backend failed" };
+    render(<NodeOutputDetail executionId="e" nodeExecutionId="n" />);
+    expect(screen.getByText("Output")).toBeInTheDocument();
+    expect(screen.getByText("backend failed")).toBeInTheDocument();
+  });
+
+  it("does not render stale errors for successful nodes", () => {
+    detail = {
+      status: "success",
+      outputs: [{ payload: "ok" }],
+      errorMessage: "stale",
+    };
+    render(<NodeOutputDetail executionId="e" nodeExecutionId="n" />);
+    expect(screen.getByText("ok")).toBeInTheDocument();
+    expect(screen.queryByText("Error")).not.toBeInTheDocument();
+    expect(screen.queryByText("stale")).not.toBeInTheDocument();
+  });
+
+  it("does not render a stale error for a successful node with no output", () => {
+    detail = { status: "success", outputs: [], errorMessage: "stale" };
+    render(<NodeOutputDetail executionId="e" nodeExecutionId="n" />);
+    expect(screen.queryByText("Error")).not.toBeInTheDocument();
+    expect(screen.queryByText("stale")).not.toBeInTheDocument();
+  });
+  it("repeats the node-level error on every paired row", () => {
+    detail = {
+      status: "failed",
+      inputs: [{ payload: "in-a" }, { payload: "in-b" }],
+      outputs: [{ payload: "out-a" }, { payload: "out-b" }],
+      errorMessage: "backend failed",
+    };
+    render(<NodeOutputDetail executionId="e" nodeExecutionId="n" />);
+    expect(screen.getByText("out-a")).toBeInTheDocument();
+    expect(screen.getByText("out-b")).toBeInTheDocument();
+    // The error is node-level, not per-port, so the same string appears on
+    // both rows — the same way the no-output error path already fills one
+    // row per input.
+    expect(screen.getAllByText("backend failed")).toHaveLength(2);
+  });
+
+  it("keeps the input port list for a failed node with unequal port counts", () => {
+    detail = {
+      status: "failed",
+      inputs: [{ payload: "in-a" }, { payload: "in-b" }],
+      outputs: [{ payload: "partial" }],
+      errorMessage: "backend failed",
+    };
+    render(<NodeOutputDetail executionId="e" nodeExecutionId="n" />);
+    fireEvent.click(screen.getByRole("checkbox"));
+    expect(screen.getByText("in-a")).toBeInTheDocument();
+    expect(screen.getByText("in-b")).toBeInTheDocument();
+    expect(screen.getByText("partial")).toBeInTheDocument();
+    expect(screen.getByText("backend failed")).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary

When an agent node failed *after* it had already emitted some output, the run panel showed the partial output and no error at all. The user saw a node marked failed, rows of data, and nothing saying what went wrong — the only way to get the backend message was to make the node fail again with no output. `NodeOutputDetail` decided whether to show an error from output emptiness rather than from node status, so any output at all made the failure invisible. This PR splits that one flag into two: whether the node failed, and whether the error is the only thing there is to show.

## Linked issues

Closes #2685
Linear: n/a — I have no access to this project's Linear workspace.

Opened as a **draft** on purpose. `.github/workflows/admission.yml` passes the linked-issue check only when the issue already carries `accepted` or `good first issue` (`if (labels.includes('accepted') || labels.includes('good first issue')) anyAccepted = true;`), and it is triggered on `pull_request_target: [opened, edited, synchronize, reopened, ready_for_review]` — labelling the issue later does not re-run it. Opening this ready-for-review before a maintainer has read #2685 would just leave a red `needs-admission` check that the label alone would not clear. The job is skipped on drafts (`if: github.event.pull_request.draft == false`), so this sits as a draft until #2685 is triaged; marking it ready fires `ready_for_review` and the gate runs then.

On the small-fix route in policy rule 1: `.github/workflows/admission.yml` sets `SMALL_FIX_MAX_LINES: "50"` and computes `const smallFix = !isAgent && added <= 50 && nFiles <= 3 && ...`. It counts total additions, not production-only additions, and this PR's `[agent]` title makes `isAgent` true, which sets `smallFix` false whatever the size. An issue is linked rather than the exemption argued.

## AI use

AI use: Claude Code (Opus). It produced all of this change — the fix, the test file and this description. Every command quoted below was run again before this was posted, and the diff was read hunk by hunk. The title ends with `[agent]` as CONTRIBUTING.md asks.

## Type of change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📖 Documentation only
- [ ] 🧹 Chore / refactor (no user-visible change)
- [ ] 🚀 Performance improvement
- [ ] 🧪 Test-only change

## E2E coverage

E2E: exempt (harness-gap no flows cover the agents area yet)

---

## 1) What changes were done

2 files changed, +147/-7, of which +120/-0 is the new test file (`git diff --numstat 6e27ad65..fix/node-error-with-partial-output`).

**A. One flag became two**

`frontend/src/sections/agent-playground/AgentBuilder/RunAgentPanel/NodeOutputDetail.jsx`, line 240 on `dev`:

```js
const hasErrorMessage = !!errorMessage && outputs.length === 0;
```

That single boolean drove the row data (line 258), the column definitions (line 356) and the input-column layout (line 333). Because it was false whenever there was output, a failed node with partial output could not display its error at all.

- `hasErrorMessage` now means *this node terminated in failure and has a message*: `isNodeError && !!errorMessage`, where `isNodeError` is `status === "error" || status === "failed"`.
- `hasOnlyErrorMessage` is the old condition (`hasErrorMessage && outputs.length === 0`) and keeps the existing no-output presentation, where the message occupies the Output column.
- Each of the old flag's five use sites was remapped to whichever of the two preserves its intent.

**B. What the user sees**

- A failed node that produced partial output keeps its output columns and gains a separate **Error** column alongside them, so both are visible at once.
- A failed node with no output is unchanged: same single Output column carrying the message, same one-row-per-input layout.
- A node whose status is *success* but whose payload still carries an `errorMessage` no longer renders that string. On `dev` it did, whenever the node also had no output.
- `ErrorCellRenderer` reads `data.error` with a fallback to `data.output` (line 198 on `dev`), so the existing no-output rows render exactly as before.

**C. The error is node-level, and repeats**

The backend message belongs to the node, not to a port, so in paired mode (`inputs.length === outputs.length > 0`) the same string appears on every row. That matches what the no-output error path already did — it fills one row per input with the same message — and a blank cell on rows 2..n would read as "this row was fine". A test pins the repetition so it is a decision rather than an accident. If you would rather it appeared once, say so and I will change it.

No API, serializer, storage or contract change. This is presentation logic in the run panel.

---

## 2) Why the changes were done

- **Product/UX:** a failed node that shows data and no reason is worse than one that shows nothing, because it looks like it worked. The information was already in the payload; the panel just refused to render it.
- **Technical:** output emptiness and failure are two different questions and the code was using one variable for both. Splitting them is smaller than special-casing the render, and it makes the intent of each use site explicit.
- **Architecture:** no new component and no change to the grid wiring — the Error column reuses the existing `ErrorCellRenderer`, which is why its `data.error ?? data.output` fallback exists.

---

## 3) Tests written + scenarios each covers

**`frontend/src/sections/agent-playground/AgentBuilder/RunAgentPanel/__tests__/NodeOutputDetail.test.jsx`** — what the run panel renders for a node in each combination of status, output and error message. It renders the real component and the real column definitions; the AgGrid mock invokes each column's actual `cellRenderer`, so the assertions exercise the render path rather than a stand-in.

- `renders partial output and backend error for failed nodes` — status `failed`, one output, an error message: both the output and an `Error` column are present. This is the bug.
- `keeps no-output failures in the output error cell` — status `error`, no output: the message still occupies the `Output` column, i.e. the existing layout is preserved.
- `does not render stale errors for successful nodes` — status `success` with output and a leftover error string: no `Error` column, no message.
- `does not render a stale error for a successful node with no output` — status `success`, no output, leftover error string. This is the case that actually changes behaviour, and it is the one the previous test does not reach.
- `repeats the node-level error on every paired row` — two inputs, two outputs, status `failed`: both outputs render and the message appears exactly twice.
- `keeps the input port list for a failed node with unequal port counts` — two inputs, one output, status `failed`: the Input column still lists both ports. This pins the reason `usePairedInput` takes `hasOnlyErrorMessage` and not the broader flag; pointing it at the broader flag blanks the Input column here, because the single unpaired row exposes `inputs`, not `input`.

Targeted run, Node v22.22.0:

```
$ cd frontend && ./node_modules/.bin/vitest run src/sections/agent-playground/AgentBuilder/RunAgentPanel

 RUN  v3.2.3 /…/future-agi/frontend

 ✓ src/sections/agent-playground/AgentBuilder/RunAgentPanel/__tests__/common.test.js (5 tests) 2ms
 ✓ src/sections/agent-playground/AgentBuilder/RunAgentPanel/__tests__/NodeOutputDetail.test.jsx (6 tests) 100ms

 Test Files  2 passed (2)
      Tests  11 passed (11)
```

Regression proof. `git checkout 6e27ad65 -- frontend/src/sections/agent-playground/AgentBuilder/RunAgentPanel/NodeOutputDetail.jsx`, tests kept, same command:

```
   × NodeOutputDetail errors > renders partial output and backend error for failed nodes 42ms
     → Unable to find an element with the text: Error. …
   ✓ NodeOutputDetail errors > keeps no-output failures in the output error cell 7ms
   ✓ NodeOutputDetail errors > does not render stale errors for successful nodes 7ms
   × NodeOutputDetail errors > does not render a stale error for a successful node with no output 8ms
     → expect(element).not.toBeInTheDocument()
   × NodeOutputDetail errors > repeats the node-level error on every paired row 6ms
     → Unable to find an element with the text: backend failed. …
   × NodeOutputDetail errors > keeps the input port list for a failed node with unequal port counts 39ms
     → Unable to find an element with the text: backend failed. …

 Test Files  1 failed | 1 passed (2)
      Tests  4 failed | 7 passed (11)
```

Restoring the fix returns it to 11 passed (11). Being explicit about the two that pass on the unpatched file: `keeps no-output failures in the output error cell` and `does not render stale errors for successful nodes` assert behaviour this PR deliberately preserves, so they are new coverage of old behaviour rather than proof of the fix. The other four fail without it.

Surrounding subtree, same Node:

```
$ ./node_modules/.bin/vitest run src/sections/agent-playground

 Test Files  44 passed (44)
      Tests  602 passed (602)
   Duration  13.15s
```

Whole frontend suite, same Node:

```
$ ./node_modules/.bin/vitest run

 Test Files  460 passed (460)
      Tests  4949 passed (4949)
   Duration  171.84s
```

Lint and formatting on both touched files:

```
$ ./node_modules/.bin/eslint <NodeOutputDetail.jsx> <NodeOutputDetail.test.jsx>
eslint exit=0
$ ./node_modules/.bin/prettier --check <same two files>
Checking formatting...
All matched files use Prettier code style!
prettier exit=0
$ git diff --check 6e27ad65..HEAD
diff --check exit=0
```

E2E coverage classifier, run from `e2e/`. The bare command does not pass, and I would rather paste that than hide it:

```
$ node scripts/e2e-coverage.mjs --base 6e27ad65 --head fix/node-error-with-partial-output
E2E coverage: UNDETERMINED — areas: agents — flows hit: none
Areas with no flows yet: agents
Marker: missing
Verdict: needs-marker — behaviour files changed with no recognised signal: declare `E2E: updated|covered-by <ID>` or `E2E: exempt (<reason>)`
exit=1
```

`Marker: missing` because the script reads the marker out of the PR body, which it only has when given `--pr <n>` (once the PR exists) or `--body <file>`. With the body above saved to a file:

```
$ node scripts/e2e-coverage.mjs --base 6e27ad65 --head fix/node-error-with-partial-output --body <this-body.md>
E2E coverage: UNDETERMINED — areas: agents — flows hit: none
Areas with no flows yet: agents
Marker: E2E: exempt (harness-gap no flows cover the agents area yet)
Verdict: pass — declared E2E: exempt (harness-gap no flows cover the agents area yet)
exit=0
```

---

## 4) How to run / test

### Frontend tests

```bash
cd frontend
eval "$(fnm env)" && fnm use 22
yarn install
./node_modules/.bin/vitest run src/sections/agent-playground/AgentBuilder/RunAgentPanel
./node_modules/.bin/vitest run src/sections/agent-playground
```

To check the regression proof the way the policy describes:

```bash
git checkout 6e27ad65 -- frontend/src/sections/agent-playground/AgentBuilder/RunAgentPanel/NodeOutputDetail.jsx
cd frontend && ./node_modules/.bin/vitest run src/sections/agent-playground/AgentBuilder/RunAgentPanel   # 4 failed
git checkout HEAD -- frontend/src/sections/agent-playground/AgentBuilder/RunAgentPanel/NodeOutputDetail.jsx
```

### Backend tests

Not applicable — no Python file is touched.

### Contract verification

Not applicable — no API surface change.

### UI steps (manual)

I did not run these; they are what I would ask a reviewer with the stack up to do.

1. Start the stack and log in at **http://localhost:3031**.
2. Build an agent with a node that emits some output and then fails (for example a node whose downstream call errors after the first port has been produced).
3. Run it, open the run panel and select the failed node.
4. Expected: the partial output columns are still there, and an **Error** column next to them carries the backend message.

---

## 5) Screenshots / recordings

None. I did not run this in a browser — see "What was not verified" below. The test output above is pasted as text rather than as a screenshot of the same text.

---

## 6) Edge cases & considerations

- **Failed, no output:** unchanged — one Output column carrying the message, one row per input when inputs exist.
- **Failed, unequal non-zero input/output counts:** the unpaired row shape is used, so the Input column keeps the port list. Pinned by a test, because getting this wrong blanks the Input column.
- **Failed, paired inputs and outputs:** the node-level message repeats on every row. Deliberate, pinned by a test, discussed in section 1C.
- **Success with a stale `errorMessage`:** no longer rendered, with or without output. The no-output half of that is the only behaviour change beyond the bug fix itself, and it now has its own test.
- **Running or pending node:** untouched — the running-row branch returns before either flag is consulted.
- **Missing `status`:** `nodeStatus` is `undefined`, so `isNodeError` is false and no error is shown. On `dev` an error message with no output would have been shown regardless of status. If the backend can report a failure without a status field, this is a behaviour change I have not been able to rule out — I could not find a case in the codebase where it does, but I did not see real payloads.

---

## 7) Pre-existing issues (NOT introduced by this PR)

None observed in the suites run here — `src/sections/agent-playground` and the full frontend suite are both green on this branch and the numbers are pasted above.

One environment note, in case your run disagrees. Under the machine's default Node v25.2.1, eight tests under `src/sections/projects/LLMTracing/__tests__/` fail with `window.localStorage.clear is not a function` — I ran that subtree on this branch and saw `Test Files 2 failed | 79 passed (81)` / `Tests 8 failed | 1119 passed (1127)`. That subtree is nowhere near this diff, and the same command is green on the Node 22 that CONTRIBUTING pins. Everything in this PR was run on Node v22.22.0.

---

## 8) Architectural / important decisions

- **Two booleans rather than a render-time special case.** The alternative was to keep `hasErrorMessage` and branch inside the column builder. Two named flags make each of the five use sites say which question it is asking, which is what made the `usePairedInput` case findable at all.
- **Reuse `ErrorCellRenderer` with a `data.error ?? data.output` fallback** instead of adding a second renderer. It keeps the no-output rows byte-identical in behaviour and avoids two components that style the same thing.
- **Repeat the node-level error on paired rows** rather than showing it once. Consistent with the existing no-output path; an empty cell would read as "this row succeeded". Reversible in one line if a reviewer prefers otherwise.

---

## What was not verified

Stating this plainly rather than leaving it implied.

- **No browser, no running stack.** I did not run `docker compose up` or `yarn dev`, and there are no screenshots. The claims about what the panel looks like come from the component test, which renders the real column definitions through a mocked AgGrid, not from a real grid.
- **AgGrid itself is mocked** in the test. Column widths, flex behaviour and how the real grid lays out an extra column are not exercised.
- **Real backend payloads.** The tests build node-detail objects by hand. I did not observe an actual failed-with-partial-output execution, so I cannot confirm the backend populates `errorMessage` and non-empty `outputs` together in the shape assumed here; the fix follows the shapes the component already handles.
- **CI, as opposed to this machine.** The whole frontend suite is green here on Node v22.22.0, but it was run on macOS with a local `node_modules`, not in this repo's CI.
- **Backend and contract checks.** `bin/test` and `yarn contracts:check` were not run. No Python file and no API surface is touched by this diff, so I do not expect them to be affected, but I did not run them.
- **The `--body` form of the e2e classifier** uses a local file, which you cannot re-run verbatim. The reproducible form is `--pr <n>` once this PR exists; the bare run is pasted above with its real failing output.

---

## Checklist

- [x] My code follows the [style guide](../CONTRIBUTING.md#code-style) — ESLint and Prettier run on the touched files, output above.
- [x] I've added tests that prove my fix is effective — four of the six fail against `6e27ad65`, output above.
- [ ] `bin/test` passes locally (backend) — not run; this diff touches no Python.
- [x] `yarn test:run` passes locally (frontend) — `./node_modules/.bin/vitest run` from `frontend/` on Node v22.22.0: `Test Files 460 passed (460)` / `Tests 4949 passed (4949)`, exit 0.
- [ ] `yarn contracts:check` passes if API surface changed — not run; no API surface change.
- [ ] I've updated the documentation where relevant — no documentation in this repo describes this panel's behaviour, so nothing was updated.
- [x] No hardcoded secrets, URLs, or PII — the diff adds two booleans, a grid column and a test file of hand-built fixtures.
- [ ] I've signed the [CLA](../CONTRIBUTING.md#contributor-license-agreement-cla) — will sign when the bot prompts on this PR.
- [x] PR title follows Conventional Commits — `fix(agent-playground): …`, with the `[agent]` suffix CONTRIBUTING.md asks for.
- [ ] Linear issue is linked and updated with status — no access to this project's Linear workspace.
