### PR TITLE
Persist polled Daytona diagnostics before cleanup

### DIFF
--- a/api_contracts/openapi/swagger.json
+++ b/api_contracts/openapi/swagger.json
@@ -689,7 +689,7 @@
             "get": {
                 "operationId": "accounts_accept-invitation_read",
                 "summary": "Accept an invitation link.",
-                "description": "GET  \u2014 validate the token without consuming it. Returns org info so the\n       frontend can render a \"Set Password\" page.\nPOST \u2014 set the user's password, activate the account, accept the invite,\n       and return JWT tokens for auto-login.",
+                "description": "GET  — validate the token without consuming it. Returns org info so the\n       frontend can render a \"Set Password\" page.\nPOST — set the user's password, activate the account, accept the invite,\n       and return JWT tokens for auto-login.",
                 "parameters": [],
                 "responses": {
                     "200": {
@@ -742,7 +742,7 @@
             "post": {
                 "operationId": "accounts_accept-invitation_create",
                 "summary": "Accept an invitation link.",
-                "description": "GET  \u2014 validate the token without consuming it. Returns org info so the\n       frontend can render a \"Set Password\" page.\nPOST \u2014 set the user's password, activate the account, accept the invite,\n       and return JWT tokens for auto-login.",
+                "description": "GET  — validate the token without consuming it. Returns org info so the\n       frontend can render a \"Set Password\" page.\nPOST — set the user's password, activate the account, accept the invite,\n       and return JWT tokens for auto-login.",
                 "parameters": [
                     {
                         "name": "data",
@@ -7636,7 +7636,7 @@
             "get": {
                 "operationId": "agent-playground_graphs_read",
                 "summary": "Get graph detail with the active version expanded (or latest draft if no active).",
-                "description": "Returns full nested structure: nodes\u2192ports, edges.",
+                "description": "Returns full nested structure: nodes→ports, edges.",
                 "parameters": [],
                 "responses": {
                     "200": {
@@ -8011,7 +8011,7 @@
         "/agent-playground/graphs/{id}/versions/{version_id}/": {
             "get": {
                 "operationId": "agent-playground_graphs_versions_read",
-                "description": "Get a specific version with full nested structure (nodes\u2192ports, edges).",
+                "description": "Get a specific version with full nested structure (nodes→ports, edges).",
                 "parameters": [
                     {
                         "name": "page",
@@ -8092,7 +8092,7 @@
             "put": {
                 "operationId": "agent-playground_graphs_versions_update",
                 "summary": "Metadata-only update endpoint (PUT/PATCH).",
-                "description": "Updates commit_message and/or promotes draft \u2192 active.\nContent changes (nodes, ports, edges) are done via granular CRUD or create_version.",
+                "description": "Updates commit_message and/or promotes draft → active.\nContent changes (nodes, ports, edges) are done via granular CRUD or create_version.",
                 "parameters": [
                     {
                         "name": "data",
@@ -8142,7 +8142,7 @@
             "patch": {
                 "operationId": "agent-playground_graphs_versions_partial_update",
                 "summary": "Metadata-only update endpoint (PUT/PATCH).",
-                "description": "Updates commit_message and/or promotes draft \u2192 active.\nContent changes (nodes, ports, edges) are done via granular CRUD or create_version.",
+                "description": "Updates commit_message and/or promotes draft → active.\nContent changes (nodes, ports, edges) are done via granular CRUD or create_version.",
                 "parameters": [
                     {
                         "name": "data",
@@ -10657,7 +10657,7 @@
         "/agentcc/gateways/": {
             "get": {
                 "operationId": "agentcc_gateways_list",
-                "description": "Stateless proxy to the Go gateway (configured via env vars).\nNo DB model \u2014 returns a virtual singleton gateway with live health.",
+                "description": "Stateless proxy to the Go gateway (configured via env vars).\nNo DB model — returns a virtual singleton gateway with live health.",
                 "parameters": [],
                 "responses": {
                     "200": {
@@ -10719,7 +10719,7 @@
         "/agentcc/gateways/{id}/": {
             "get": {
                 "operationId": "agentcc_gateways_read",
-                "description": "Accept any pk and ignore it \u2014 there is only one gateway.",
+                "description": "Accept any pk and ignore it — there is only one gateway.",
                 "parameters": [],
                 "responses": {
                     "200": {
@@ -10757,7 +10757,7 @@
         "/agentcc/gateways/{id}/cancel-batch/": {
             "post": {
                 "operationId": "agentcc_gateways_cancel_batch",
-                "description": "Stateless proxy to the Go gateway (configured via env vars).\nNo DB model \u2014 returns a virtual singleton gateway with live health.",
+                "description": "Stateless proxy to the Go gateway (configured via env vars).\nNo DB model — returns a virtual singleton gateway with live health.",
                 "parameters": [
                     {
                         "name": "data",
@@ -10812,7 +10812,7 @@
         "/agentcc/gateways/{id}/config/": {
             "get": {
                 "operationId": "agentcc_gateways_config",
-                "description": "Stateless proxy to the Go gateway (configured via env vars).\nNo DB model \u2014 returns a virtual singleton gateway with live health.",
+                "description": "Stateless proxy to the Go gateway (configured via env vars).\nNo DB model — returns a virtual singleton gateway with live health.",
                 "parameters": [],
                 "responses": {
                     "200": {
@@ -10850,7 +10850,7 @@
         "/agentcc/gateways/{id}/get-batch/": {
             "get": {
                 "operationId": "agentcc_gateways_get_batch",
-                "description": "Stateless proxy to the Go gateway (configured via env vars).\nNo DB model \u2014 returns a virtual singleton gateway with live health.",
+                "description": "Stateless proxy to the Go gateway (configured via env vars).\nNo DB model — returns a virtual singleton gateway with live health.",
                 "parameters": [],
                 "responses": {
                     "200": {
@@ -10894,7 +10894,7 @@
         "/agentcc/gateways/{id}/health_check/": {
             "post": {
                 "operationId": "agentcc_gateways_health_check",
-                "description": "Stateless proxy to the Go gateway (configured via env vars).\nNo DB model \u2014 returns a virtual singleton gateway with live health.",
+                "description": "Stateless proxy to the Go gateway (configured via env vars).\nNo DB model — returns a virtual singleton gateway with live health.",
                 "parameters": [
                     {
                         "name": "data",
@@ -10943,7 +10943,7 @@
         "/agentcc/gateways/{id}/mcp-prompts/": {
             "get": {
                 "operationId": "agentcc_gateways_mcp_prompts",
-                "description": "Stateless proxy to the Go gateway (configured via env vars).\nNo DB model \u2014 returns a virtual singleton gateway with live health.",
+                "description": "Stateless proxy to the Go gateway (configured via env vars).\nNo DB model — returns a virtual singleton gateway with live health.",
                 "parameters": [],
                 "responses": {
                     "200": {
@@ -10975,7 +10975,7 @@
         "/agentcc/gateways/{id}/mcp-resources/": {
             "get": {
                 "operationId": "agentcc_gateways_mcp_resources",
-                "description": "Stateless proxy to the Go gateway (configured via env vars).\nNo DB model \u2014 returns a virtual singleton gateway with live health.",
+                "description": "Stateless proxy to the Go gateway (configured via env vars).\nNo DB model — returns a virtual singleton gateway with live health.",
                 "parameters": [],
                 "responses": {
                     "200": {
@@ -11007,7 +11007,7 @@
         "/agentcc/gateways/{id}/mcp-status/": {
             "get": {
                 "operationId": "agentcc_gateways_mcp_status",
-                "description": "Stateless proxy to the Go gateway (configured via env vars).\nNo DB model \u2014 returns a virtual singleton gateway with live health.",
+                "description": "Stateless proxy to the Go gateway (configured via env vars).\nNo DB model — returns a virtual singleton gateway with live health.",
                 "parameters": [],
                 "responses": {
                     "200": {
@@ -11045,7 +11045,7 @@
         "/agentcc/gateways/{id}/mcp-tools/": {
             "get": {
                 "operationId": "agentcc_gateways_mcp_tools",
-                "description": "Stateless proxy to the Go gateway (configured via env vars).\nNo DB model \u2014 returns a virtual singleton gateway with live health.",
+                "description": "Stateless proxy to the Go gateway (configured via env vars).\nNo DB model — returns a virtual singleton gateway with live health.",
                 "parameters": [],
                 "responses": {
                     "200": {
@@ -11077,7 +11077,7 @@
         "/agentcc/gateways/{id}/providers/": {
             "get": {
                 "operationId": "agentcc_gateways_providers",
-                "description": "Stateless proxy to the Go gateway (configured via env vars).\nNo DB model \u2014 returns a virtual singleton gateway with live health.",
+                "description": "Stateless proxy to the Go gateway (configured via env vars).\nNo DB model — returns a virtual singleton gateway with live health.",
                 "parameters": [],
                 "responses": {
                     "200": {
@@ -11164,7 +11164,7 @@
         "/agentcc/gateways/{id}/remove-budget/": {
             "post": {
                 "operationId": "agentcc_gateways_remove_budget",
-                "description": "Stateless proxy to the Go gateway (configured via env vars).\nNo DB model \u2014 returns a virtual singleton gateway with live health.",
+                "description": "Stateless proxy to the Go gateway (configured via env vars).\nNo DB model — returns a virtual singleton gateway with live health.",
                 "parameters": [
                     {
                         "name": "data",
@@ -11213,7 +11213,7 @@
         "/agentcc/gateways/{id}/remove-mcp-server/": {
             "post": {
                 "operationId": "agentcc_gateways_remove_mcp_server",
-                "description": "Stateless proxy to the Go gateway (configured via env vars).\nNo DB model \u2014 returns a virtual singleton gateway with live health.",
+                "description": "Stateless proxy to the Go gateway (configured via env vars).\nNo DB model — returns a virtual singleton gateway with live health.",
                 "parameters": [
                     {
                         "name": "data",
@@ -11323,7 +11323,7 @@
         "/agentcc/gateways/{id}/set-budget/": {
             "post": {
                 "operationId": "agentcc_gateways_set_budget",
-                "description": "Stateless proxy to the Go gateway (configured via env vars).\nNo DB model \u2014 returns a virtual singleton gateway with live health.",
+                "description": "Stateless proxy to the Go gateway (configured via env vars).\nNo DB model — returns a virtual singleton gateway with live health.",
                 "parameters": [
                     {
                         "name": "data",
@@ -11372,7 +11372,7 @@
         "/agentcc/gateways/{id}/submit-batch/": {
             "post": {
                 "operationId": "agentcc_gateways_submit_batch",
-                "description": "Stateless proxy to the Go gateway (configured via env vars).\nNo DB model \u2014 returns a virtual singleton gateway with live health.",
+                "description": "Stateless proxy to the Go gateway (configured via env vars).\nNo DB model — returns a virtual singleton gateway with live health.",
                 "parameters": [
                     {
                         "name": "data",
@@ -11421,7 +11421,7 @@
         "/agentcc/gateways/{id}/test-mcp-tool/": {
             "post": {
                 "operationId": "agentcc_gateways_test_mcp_tool",
-                "description": "Stateless proxy to the Go gateway (configured via env vars).\nNo DB model \u2014 returns a virtual singleton gateway with live health.",
+                "description": "Stateless proxy to the Go gateway (configured via env vars).\nNo DB model — returns a virtual singleton gateway with live health.",
                 "parameters": [
                     {
                         "name": "data",
@@ -11519,7 +11519,7 @@
         "/agentcc/gateways/{id}/toggle-guardrail/": {
             "post": {
                 "operationId": "agentcc_gateways_toggle_guardrail",
-                "description": "Stateless proxy to the Go gateway (configured via env vars).\nNo DB model \u2014 returns a virtual singleton gateway with live health.",
+                "description": "Stateless proxy to the Go gateway (configured via env vars).\nNo DB model — returns a virtual singleton gateway with live health.",
                 "parameters": [
                     {
                         "name": "data",
@@ -11617,7 +11617,7 @@
         "/agentcc/gateways/{id}/update-guardrail/": {
             "post": {
                 "operationId": "agentcc_gateways_update_guardrail",
-                "description": "Stateless proxy to the Go gateway (configured via env vars).\nNo DB model \u2014 returns a virtual singleton gateway with live health.",
+                "description": "Stateless proxy to the Go gateway (configured via env vars).\nNo DB model — returns a virtual singleton gateway with live health.",
                 "parameters": [
                     {
                         "name": "data",
@@ -11666,7 +11666,7 @@
         "/agentcc/gateways/{id}/update-mcp-guardrails/": {
             "post": {
                 "operationId": "agentcc_gateways_update_mcp_guardrails",
-                "description": "Stateless proxy to the Go gateway (configured via env vars).\nNo DB model \u2014 returns a virtual singleton gateway with live health.",
+                "description": "Stateless proxy to the Go gateway (configured via env vars).\nNo DB model — returns a virtual singleton gateway with live health.",
                 "parameters": [
                     {
                         "name": "data",
@@ -11715,7 +11715,7 @@
         "/agentcc/gateways/{id}/update-mcp-server/": {
             "post": {
                 "operationId": "agentcc_gateways_update_mcp_server",
-                "description": "Stateless proxy to the Go gateway (configured via env vars).\nNo DB model \u2014 returns a virtual singleton gateway with live health.",
+                "description": "Stateless proxy to the Go gateway (configured via env vars).\nNo DB model — returns a virtual singleton gateway with live health.",
                 "parameters": [
                     {
                         "name": "data",
@@ -12713,7 +12713,7 @@
             },
             "put": {
                 "operationId": "agentcc_org-configs_update",
-                "description": "Disabled \u2014 configs are immutable versions. Create a new one instead.",
+                "description": "Disabled — configs are immutable versions. Create a new one instead.",
                 "parameters": [
                     {
                         "name": "data",
@@ -13129,7 +13129,7 @@
         "/agentcc/provider-credentials/{id}/rotate/": {
             "post": {
                 "operationId": "agentcc_provider-credentials_rotate",
-                "description": "Rotate credentials \u2014 accepts new credentials, encrypts, and updates.",
+                "description": "Rotate credentials — accepts new credentials, encrypts, and updates.",
                 "parameters": [
                     {
                         "name": "data",
@@ -13690,7 +13690,7 @@
             },
             "put": {
                 "operationId": "agentcc_routing-policies_update",
-                "description": "Updates are disabled \u2014 create a new version instead.",
+                "description": "Updates are disabled — create a new version instead.",
                 "parameters": [
                     {
                         "name": "data",
@@ -13826,7 +13826,7 @@
         "/agentcc/sessions/": {
             "get": {
                 "operationId": "agentcc_sessions_list",
-                "description": "Session management \u2014 create, list, retrieve sessions with stats.",
+                "description": "Session management — create, list, retrieve sessions with stats.",
                 "parameters": [
                     {
                         "name": "page",
@@ -13888,7 +13888,7 @@
             },
             "post": {
                 "operationId": "agentcc_sessions_create",
-                "description": "Session management \u2014 create, list, retrieve sessions with stats.",
+                "description": "Session management — create, list, retrieve sessions with stats.",
                 "parameters": [
                     {
                         "name": "data",
@@ -13922,7 +13922,7 @@
         "/agentcc/sessions/{id}/": {
             "get": {
                 "operationId": "agentcc_sessions_read",
-                "description": "Session management \u2014 create, list, retrieve sessions with stats.",
+                "description": "Session management — create, list, retrieve sessions with stats.",
                 "parameters": [],
                 "responses": {
                     "200": {
@@ -13944,7 +13944,7 @@
             },
             "put": {
                 "operationId": "agentcc_sessions_update",
-                "description": "Session management \u2014 create, list, retrieve sessions with stats.",
+                "description": "Session management — create, list, retrieve sessions with stats.",
                 "parameters": [
                     {
                         "name": "data",
@@ -13975,7 +13975,7 @@
             },
             "patch": {
                 "operationId": "agentcc_sessions_partial_update",
-                "description": "Session management \u2014 create, list, retrieve sessions with stats.",
+                "description": "Session management — create, list, retrieve sessions with stats.",
                 "parameters": [
                     {
                         "name": "data",
@@ -14006,7 +14006,7 @@
             },
             "delete": {
                 "operationId": "agentcc_sessions_delete",
-                "description": "Session management \u2014 create, list, retrieve sessions with stats.",
+                "description": "Session management — create, list, retrieve sessions with stats.",
                 "parameters": [],
                 "responses": {
                     "204": {
@@ -15176,7 +15176,7 @@
             "get": {
                 "operationId": "api_deployment-info_list",
                 "summary": "Public deployment-mode probe used by the frontend to gate UI.",
-                "description": "Returns ``{\"mode\": \"oss\"|\"ee\"|\"cloud\"}``. No auth \u2014 public config.",
+                "description": "Returns ``{\"mode\": \"oss\"|\"ee\"|\"cloud\"}``. No auth — public config.",
                 "parameters": [],
                 "responses": {
                     "200": {
@@ -15374,7 +15374,7 @@
             "get": {
                 "operationId": "api_setup-checks_list",
                 "summary": "Public infrastructure probe for the OSS first-run setup screen.",
-                "description": "Returns ``{\"status\": \"ok\"|\"issues\", \"mode\": ..., \"checks\": [...]}``. No auth \u2014\nit runs before any account exists. Self-hosted only: on cloud and EE the\nroute answers 404, so neither the internal service topology nor the outbound\nprobes it triggers are reachable by an anonymous caller.",
+                "description": "Returns ``{\"status\": \"ok\"|\"issues\", \"mode\": ..., \"checks\": [...]}``. No auth —\nit runs before any account exists. Self-hosted only: on cloud and EE the\nroute answers 404, so neither the internal service topology nor the outbound\nprobes it triggers are reachable by an anonymous caller.",
                 "parameters": [],
                 "responses": {
                     "200": {
@@ -18107,7 +18107,7 @@
         "/mcp/oauth/authorize/": {
             "get": {
                 "operationId": "mcp_oauth_authorize_list",
-                "description": "GET /mcp/oauth/authorize/ \u2014 Return consent screen data.",
+                "description": "GET /mcp/oauth/authorize/ — Return consent screen data.",
                 "parameters": [],
                 "responses": {
                     "200": {
@@ -18138,7 +18138,7 @@
         "/mcp/oauth/consent/": {
             "post": {
                 "operationId": "mcp_oauth_consent_create",
-                "description": "POST /mcp/oauth/consent/ \u2014 Process user consent decision.",
+                "description": "POST /mcp/oauth/consent/ — Process user consent decision.",
                 "parameters": [
                     {
                         "name": "data",
@@ -18186,7 +18186,7 @@
         "/mcp/oauth/token/": {
             "post": {
                 "operationId": "mcp_oauth_token_create",
-                "description": "POST /mcp/oauth/token/ \u2014 Exchange code or refresh token for access token.",
+                "description": "POST /mcp/oauth/token/ — Exchange code or refresh token for access token.",
                 "parameters": [
                     {
                         "name": "data",
@@ -19283,7 +19283,7 @@
             "post": {
                 "operationId": "model-hub_annotation-queues_hard_delete",
                 "summary": "Permanently remove a queue + everything attached.",
-                "description": "Hard delete cascades through the FK graph (rules, items,\nassignments, scores) via ``on_delete=CASCADE``. There is no\nrecovery \u2014 callers must pass ``force=true`` AND the queue's\nexact name as ``confirm_name`` so the action can't fire from\na typo'd request.",
+                "description": "Hard delete cascades through the FK graph (rules, items,\nassignments, scores) via ``on_delete=CASCADE``. There is no\nrecovery — callers must pass ``force=true`` AND the queue's\nexact name as ``confirm_name`` so the action can't fire from\na typo'd request.",
                 "parameters": [
                     {
                         "name": "data",
@@ -19872,7 +19872,7 @@
             "post": {
                 "operationId": "model-hub_annotation-queues_automation-rules_evaluate",
                 "summary": "Trigger a manual rule run with a sync-or-async branch.",
-                "description": "Small runs (filter resolves to \u2264 ``RULE_RUN_SYNC_THRESHOLD``) finish\nin the HTTP request and return 200 with the result \u2014 fast feedback\nfor the common case. Large runs (mostly first-ever runs on backlogs\nor rules with wide filters) hand the work to a Temporal activity and\nreturn 202 immediately. The activity emails creator + queue managers\non completion.\n\nThe peek is a cheap dry-run (``[:cap+1]`` LIMIT, no COUNT(*)) \u2014 sub-\n100ms even on 10M+ row trace tables \u2014 so this branch costs little\neven when it ends up taking the sync path.",
+                "description": "Small runs (filter resolves to ≤ ``RULE_RUN_SYNC_THRESHOLD``) finish\nin the HTTP request and return 200 with the result — fast feedback\nfor the common case. Large runs (mostly first-ever runs on backlogs\nor rules with wide filters) hand the work to a Temporal activity and\nreturn 202 immediately. The activity emails creator + queue managers\non completion.\n\nThe peek is a cheap dry-run (``[:cap+1]`` LIMIT, no COUNT(*)) — sub-\n100ms even on 10M+ row trace tables — so this branch costs little\neven when it ends up taking the sync path.",
                 "parameters": [
                     {
                         "name": "data",
@@ -20468,7 +20468,7 @@
             "get": {
                 "operationId": "model-hub_annotation-queues_items_next_item",
                 "summary": "Get the next or previous item in the queue.",
-                "description": "Query params:\n  exclude: comma-separated item IDs to skip\n  before:  item ID \u2014 returns the item immediately before this one in order\n  review_status: optional review status filter (for reviewer queues)\n  exclude_review_status: optional review status to omit (for annotator queues)\n  include_completed: when true, navigation can visit completed items too",
+                "description": "Query params:\n  exclude: comma-separated item IDs to skip\n  before:  item ID — returns the item immediately before this one in order\n  review_status: optional review status filter (for reviewer queues)\n  exclude_review_status: optional review status to omit (for annotator queues)\n  include_completed: when true, navigation can visit completed items too",
                 "parameters": [
                     {
                         "name": "page",
@@ -23311,7 +23311,7 @@
         "/model-hub/cells/{cell_id}/run-error-localizer/": {
             "get": {
                 "operationId": "model-hub_cells_run-error-localizer_list",
-                "description": "Poll endpoint \u2014 returns the current state of the localizer task\nfor a given cell, including the analysis once completed.",
+                "description": "Poll endpoint — returns the current state of the localizer task\nfor a given cell, including the analysis once completed.",
                 "parameters": [],
                 "responses": {
                     "200": {
@@ -23364,7 +23364,7 @@
             "post": {
                 "operationId": "model-hub_cells_run-error-localizer_create",
                 "summary": "On-demand error localization for a single dataset cell.",
-                "description": "Use case: in the dataset detail drawer, the user opens an eval cell\nthat doesn't have an `error_analysis` block (because the eval was\nrun before error_localization was enabled, or the user wants a\nfresh run). They click \"Run error localization\" and we:\n\n  1. Look up the cell + its UserEvalMetric (column.source_id) +\n     the EvalTemplate.\n  2. Resolve the metric's `mapping` (template_var \u2192 column UUID)\n     against the row's other cells to build `input_data`.\n  3. Pull the eval verdict + reason from `cell.value` /\n     `cell.value_infos`.\n  4. Upsert an `ErrorLocalizerTask(source=DATASET, source_id=cell.id,\n     status=PENDING)` so the existing 30s Temporal schedule picks it\n     up and processes it via `process_single_error_localization`.\n\nReturns the task id + status. The frontend then polls the cell\ndetail / task status endpoint until `error_analysis` lands in\n`cell.value_infos`.\n\nPOST /model-hub/cells/{cell_id}/run-error-localizer/",
+                "description": "Use case: in the dataset detail drawer, the user opens an eval cell\nthat doesn't have an `error_analysis` block (because the eval was\nrun before error_localization was enabled, or the user wants a\nfresh run). They click \"Run error localization\" and we:\n\n  1. Look up the cell + its UserEvalMetric (column.source_id) +\n     the EvalTemplate.\n  2. Resolve the metric's `mapping` (template_var → column UUID)\n     against the row's other cells to build `input_data`.\n  3. Pull the eval verdict + reason from `cell.value` /\n     `cell.value_infos`.\n  4. Upsert an `ErrorLocalizerTask(source=DATASET, source_id=cell.id,\n     status=PENDING)` so the existing 30s Temporal schedule picks it\n     up and processes it via `process_single_error_localization`.\n\nReturns the task id + status. The frontend then polls the cell\ndetail / task status endpoint until `error_analysis` lands in\n`cell.value_infos`.\n\nPOST /model-hub/cells/{cell_id}/run-error-localizer/",
                 "parameters": [
                     {
                         "name": "data",
@@ -32549,7 +32549,7 @@
             },
             "patch": {
                 "operationId": "model-hub_eval-templates_composite_partial_update",
-                "summary": "PATCH \u2014 partial update of a composite eval.",
+                "summary": "PATCH — partial update of a composite eval.",
                 "description": "Supported fields (all optional):\n  name, description, tags,\n  aggregation_enabled, aggregation_function,\n  child_template_ids (replaces the child list),\n  child_weights (map of child_id -> weight).",
                 "parameters": [
                     {
@@ -32624,7 +32624,7 @@
             "post": {
                 "operationId": "model-hub_eval-templates_composite_execute_create",
                 "summary": "POST /model-hub/eval-templates/<template_id>/composite/execute/",
-                "description": "Execute all child evals in a composite and optionally aggregate results.\nThin wrapper around `execute_composite_children_sync` \u2014 the same helper\nthe dataset/experiment `CompositeEvaluationRunner` uses, so aggregation\nsemantics stay consistent across surfaces.",
+                "description": "Execute all child evals in a composite and optionally aggregate results.\nThin wrapper around `execute_composite_children_sync` — the same helper\nthe dataset/experiment `CompositeEvaluationRunner` uses, so aggregation\nsemantics stay consistent across surfaces.",
                 "parameters": [
                     {
                         "name": "data",
@@ -33034,7 +33034,7 @@
             "get": {
                 "operationId": "model-hub_eval-templates_usage_list",
                 "summary": "GET /model-hub/eval-templates/<id>/usage/",
-                "description": "Returns usage stats, chart data, and the paginated usage table.\nQuery params: page (0-based), page_size, period\n(30m|6h|1d|7d|30d|90d|180d|365d), optional start_date/end_date pair\n(overrides period \u2014 sent by the FE for Today / Yesterday / Custom).\n\nThe response is rendered through\n``EvalUsageStatsResponseResultSerializer(instance=...).data`` at the\nboundary so shape drift surfaces here instead of shipping silently.",
+                "description": "Returns usage stats, chart data, and the paginated usage table.\nQuery params: page (0-based), page_size, period\n(30m|6h|1d|7d|30d|90d|180d|365d), optional start_date/end_date pair\n(overrides period — sent by the FE for Today / Yesterday / Custom).\n\nThe response is rendered through\n``EvalUsageStatsResponseResultSerializer(instance=...).data`` at the\nboundary so shape drift surfaces here instead of shipping silently.",
                 "parameters": [
                     {
                         "name": "page",
@@ -33295,7 +33295,7 @@
             "post": {
                 "operationId": "model-hub_eval-templates_versions_restore_create",
                 "summary": "POST /model-hub/eval-templates/<id>/versions/<version_id>/restore/",
-                "description": "Restore a version by creating a new version with the old version's config.\nDoes NOT modify the old version \u2014 creates a new one on top.",
+                "description": "Restore a version by creating a new version with the old version's config.\nDoes NOT modify the old version — creates a new one on top.",
                 "parameters": [
                     {
                         "name": "data",
@@ -34174,7 +34174,7 @@
             "post": {
                 "operationId": "model-hub_experiments_v2_re-run_create",
                 "summary": "V2 re-run: org-scoped, uses V2 Temporal workflow.",
-                "description": "No manual workflow cancel needed \u2014 Temporal's TERMINATE_IF_RUNNING ID\nreuse policy automatically cancels any running workflow with the same ID.\nCell reset is handled by the workflow itself (cleanup + setup activities).",
+                "description": "No manual workflow cancel needed — Temporal's TERMINATE_IF_RUNNING ID\nreuse policy automatically cancels any running workflow with the same ID.\nCell reset is handled by the workflow itself (cleanup + setup activities).",
                 "parameters": [
                     {
                         "name": "data",
@@ -34476,7 +34476,7 @@
             "put": {
                 "operationId": "model-hub_experiments_v2_update",
                 "summary": "Update a V2 experiment with diff-based selective re-run.",
-                "description": "Editable fields: column_id, prompt_config, user_eval_metrics.\nRe-run triggers (determined by fingerprint diffs, not field presence):\n- prompt_config has new/modified entries \u2192 re-run those configs + ALL dependent evals\n- user_eval_metrics has new/modified entries \u2192 re-run only those evals\n- column_id changed \u2192 delete old base eval columns, re-run base evals\n- If FE sends unchanged data, diffs return empty \u2192 no re-run",
+                "description": "Editable fields: column_id, prompt_config, user_eval_metrics.\nRe-run triggers (determined by fingerprint diffs, not field presence):\n- prompt_config has new/modified entries → re-run those configs + ALL dependent evals\n- user_eval_metrics has new/modified entries → re-run only those evals\n- column_id changed → delete old base eval columns, re-run base evals\n- If FE sends unchanged data, diffs return empty → no re-run",
                 "parameters": [
                     {
                         "name": "data",
@@ -35074,7 +35074,7 @@
         "/model-hub/experiments/v2/{experiment_id}/feedback/submit-feedback/": {
             "post": {
                 "operationId": "model-hub_experiments_v2_feedback_submit-feedback_create",
-                "description": "Submit feedback action \u2014 triggers temporal eval rerun for experiments.",
+                "description": "Submit feedback action — triggers temporal eval rerun for experiments.",
                 "parameters": [
                     {
                         "name": "data",
@@ -37625,7 +37625,7 @@
         "/model-hub/ground-truth/{ground_truth_id}/embed/": {
             "post": {
                 "operationId": "model-hub_ground-truth_embed_create",
-                "description": "POST /model-hub/ground-truth/<id>/embed/ \u2014 trigger embedding generation.",
+                "description": "POST /model-hub/ground-truth/<id>/embed/ — trigger embedding generation.",
                 "parameters": [
                     {
                         "name": "data",
@@ -49618,7 +49618,7 @@
         "/simulate/api/alk-simulate/call-executions/{call_execution_id}/status/": {
             "patch": {
                 "operationId": "simulate_api_alk-simulate_call-executions_status",
-                "description": "Non-terminal per-call status ping (currently only ``ongoing``): the\nSDK marks a pre-created PENDING row ONGOING the moment its call starts,\nso the UI shows progress instead of PENDING \u2192 terminal. PENDING-gated in\nthe service, so a late ping never clobbers a result that already landed.",
+                "description": "Non-terminal per-call status ping (currently only ``ongoing``): the\nSDK marks a pre-created PENDING row ONGOING the moment its call starts,\nso the UI shows progress instead of PENDING → terminal. PENDING-gated in\nthe service, so a late ping never clobbers a result that already landed.",
                 "parameters": [
                     {
                         "name": "data",
@@ -49679,7 +49679,7 @@
         "/simulate/api/alk-simulate/run-tests/provision/": {
             "post": {
                 "operationId": "simulate_api_alk-simulate_run-tests_provision_run_test",
-                "description": "Stand up a chat RunTest + scenario-of-record from SDK personas so an\nSDK-first run has somewhere to post \u2014 without the native UI's async\nscenario generation. See ``provision_alk_sim_run_test``.",
+                "description": "Stand up a chat RunTest + scenario-of-record from SDK personas so an\nSDK-first run has somewhere to post — without the native UI's async\nscenario generation. See ``provision_alk_sim_run_test``.",
                 "parameters": [
                     {
                         "name": "data",
@@ -50952,7 +50952,7 @@
             "post": {
                 "operationId": "simulate_api_livekit_webhook_create",
                 "summary": "Receive and process LiveKit server webhooks.",
-                "description": "Handles lifecycle events (room start/finish, participant join/leave,\negress completion). This is the **reliable** path for updating call\nlifecycle and signaling Temporal \u2014 it fires even if the agent worker\ncrashes mid-call.",
+                "description": "Handles lifecycle events (room start/finish, participant join/leave,\negress completion). This is the **reliable** path for updating call\nlifecycle and signaling Temporal — it fires even if the agent worker\ncrashes mid-call.",
                 "parameters": [
                     {
                         "name": "data",
@@ -58828,7 +58828,7 @@
         "/tracer/feed/issues/": {
             "get": {
                 "operationId": "tracer_feed_issues_list",
-                "description": "GET /tracer/feed/issues/ \u2014 paginated cluster list with filters/sort.",
+                "description": "GET /tracer/feed/issues/ — paginated cluster list with filters/sort.",
                 "parameters": [
                     {
                         "name": "project_id",
@@ -58988,7 +58988,7 @@
         "/tracer/feed/issues/stats/": {
             "get": {
                 "operationId": "tracer_feed_issues_stats_list",
-                "description": "GET /tracer/feed/issues/stats/ \u2014 top stats bar totals.",
+                "description": "GET /tracer/feed/issues/stats/ — top stats bar totals.",
                 "parameters": [
                     {
                         "name": "project_id",
@@ -64496,7 +64496,7 @@
             "post": {
                 "operationId": "tracer_trace-session_get_session_graph_data",
                 "summary": "Fetch time-series session metrics for the observe graph.",
-                "description": "Supports the same metric types as the trace graph endpoint:\n- SYSTEM_METRIC: latency, tokens, cost, error_rate, session_count,\n  avg_duration, avg_traces_per_session \u2014 all aggregated at session level\n- EVAL: eval scores averaged across sessions\n- ANNOTATION: annotation scores averaged across sessions\n\nResponse shape matches trace graph: {metric_name, data: [{timestamp, value, primary_traffic}]}",
+                "description": "Supports the same metric types as the trace graph endpoint:\n- SYSTEM_METRIC: latency, tokens, cost, error_rate, session_count,\n  avg_duration, avg_traces_per_session — all aggregated at session level\n- EVAL: eval scores averaged across sessions\n- ANNOTATION: annotation scores averaged across sessions\n\nResponse shape matches trace graph: {metric_name, data: [{timestamp, value, primary_traffic}]}",
                 "parameters": [
                     {
                         "name": "data",
@@ -65030,7 +65030,7 @@
             "get": {
                 "operationId": "tracer_trace-session_eval_logs",
                 "summary": "Session-scoped eval log feed for TracesDrawer's \"Evals\" tab.",
-                "description": "Session-level eval results are walled off from span/trace surfaces\nby ``target_type='session'`` \u2014 this endpoint is the only place\nthey appear.\n\nQuery params:\n    page (int, 0-indexed, default 0)\n    page_size (int, default 25, max 100)",
+                "description": "Session-level eval results are walled off from span/trace surfaces\nby ``target_type='session'`` — this endpoint is the only place\nthey appear.\n\nQuery params:\n    page (int, 0-indexed, default 0)\n    page_size (int, default 25, max 100)",
                 "parameters": [],
                 "responses": {
                     "200": {
@@ -66526,7 +66526,7 @@
             "get": {
                 "operationId": "tracer_trace_voice_call_detail",
                 "summary": "Return the heavy / detail-only fields for a single voice call.",
-                "description": "Query params:\n- trace_id or legacy traceId (required) \u2014 UUID of the voice call trace.",
+                "description": "Query params:\n- trace_id or legacy traceId (required) — UUID of the voice call trace.",
                 "parameters": [
                     {
                         "name": "trace_id",
@@ -75329,7 +75329,7 @@
             "post": {
                 "operationId": "usage_v2_stripe-webhook_create",
                 "summary": "Handle Stripe webhook events.",
-                "description": "No auth \u2014 Stripe authenticates via signature header.\nAPIView.as_view() auto-applies csrf_exempt.",
+                "description": "No auth — Stripe authenticates via signature header.\nAPIView.as_view() auto-applies csrf_exempt.",
                 "parameters": [
                     {
                         "name": "data",
@@ -75801,7 +75801,7 @@
             "post": {
                 "operationId": "usage_webhook_create",
                 "summary": "Handle Stripe webhook events.",
-                "description": "No auth \u2014 Stripe authenticates via signature header.\nAPIView.as_view() auto-applies csrf_exempt.",
+                "description": "No auth — Stripe authenticates via signature header.\nAPIView.as_view() auto-applies csrf_exempt.",
                 "parameters": [
                     {
                         "name": "data",
@@ -85620,7 +85620,7 @@
                 },
                 "sample_rate": {
                     "title": "Sample rate",
-                    "description": "Fraction of traffic to mirror (0.0\u20131.0)",
+                    "description": "Fraction of traffic to mirror (0.0–1.0)",
                     "type": "number"
                 },
                 "status": {
@@ -129373,7 +129373,7 @@
                                 "12m",
                                 "custom"
                             ],
-                            "description": "Which time-window preset the user chose. The frontend resolves it to date_range at save time; this records the intent so a relative window can be re-anchored on the next save. Never read when building a query \u2014 date_range remains authoritative. Absent on tasks predating this field. The enum documents the accepted values; it is not enforced."
+                            "description": "Which time-window preset the user chose. The frontend resolves it to date_range at save time; this records the intent so a relative window can be re-anchored on the next save. Never read when building a query — date_range remains authoritative. Absent on tasks predating this field. The enum documents the accepted values; it is not enforced."
                         },
                         "created_at": {
                             "type": "string",
@@ -130448,7 +130448,7 @@
                                 "12m",
                                 "custom"
                             ],
-                            "description": "Which time-window preset the user chose. The frontend resolves it to date_range at save time; this records the intent so a relative window can be re-anchored on the next save. Never read when building a query \u2014 date_range remains authoritative. Absent on tasks predating this field. The enum documents the accepted values; it is not enforced."
+                            "description": "Which time-window preset the user chose. The frontend resolves it to date_range at save time; this records the intent so a relative window can be re-anchored on the next save. Never read when building a query — date_range remains authoritative. Absent on tasks predating this field. The enum documents the accepted values; it is not enforced."
                         },
                         "created_at": {
                             "type": "string",
@@ -144688,11 +144688,6 @@
             "properties": {
                 "sandbox_id": {
                     "title": "Sandbox id",
-                    "type": "string",
-                    "minLength": 1
-                },
-                "snapshot_name": {
-                    "title": "Snapshot name",
                     "type": "string",
                     "minLength": 1
                 },

--- a/api_contracts/openapi/swagger.json
+++ b/api_contracts/openapi/swagger.json
@@ -689,7 +689,7 @@
             "get": {
                 "operationId": "accounts_accept-invitation_read",
                 "summary": "Accept an invitation link.",
-                "description": "GET  — validate the token without consuming it. Returns org info so the\n       frontend can render a \"Set Password\" page.\nPOST — set the user's password, activate the account, accept the invite,\n       and return JWT tokens for auto-login.",
+                "description": "GET  \u2014 validate the token without consuming it. Returns org info so the\n       frontend can render a \"Set Password\" page.\nPOST \u2014 set the user's password, activate the account, accept the invite,\n       and return JWT tokens for auto-login.",
                 "parameters": [],
                 "responses": {
                     "200": {
@@ -742,7 +742,7 @@
             "post": {
                 "operationId": "accounts_accept-invitation_create",
                 "summary": "Accept an invitation link.",
-                "description": "GET  — validate the token without consuming it. Returns org info so the\n       frontend can render a \"Set Password\" page.\nPOST — set the user's password, activate the account, accept the invite,\n       and return JWT tokens for auto-login.",
+                "description": "GET  \u2014 validate the token without consuming it. Returns org info so the\n       frontend can render a \"Set Password\" page.\nPOST \u2014 set the user's password, activate the account, accept the invite,\n       and return JWT tokens for auto-login.",
                 "parameters": [
                     {
                         "name": "data",
@@ -7636,7 +7636,7 @@
             "get": {
                 "operationId": "agent-playground_graphs_read",
                 "summary": "Get graph detail with the active version expanded (or latest draft if no active).",
-                "description": "Returns full nested structure: nodes→ports, edges.",
+                "description": "Returns full nested structure: nodes\u2192ports, edges.",
                 "parameters": [],
                 "responses": {
                     "200": {
@@ -8011,7 +8011,7 @@
         "/agent-playground/graphs/{id}/versions/{version_id}/": {
             "get": {
                 "operationId": "agent-playground_graphs_versions_read",
-                "description": "Get a specific version with full nested structure (nodes→ports, edges).",
+                "description": "Get a specific version with full nested structure (nodes\u2192ports, edges).",
                 "parameters": [
                     {
                         "name": "page",
@@ -8092,7 +8092,7 @@
             "put": {
                 "operationId": "agent-playground_graphs_versions_update",
                 "summary": "Metadata-only update endpoint (PUT/PATCH).",
-                "description": "Updates commit_message and/or promotes draft → active.\nContent changes (nodes, ports, edges) are done via granular CRUD or create_version.",
+                "description": "Updates commit_message and/or promotes draft \u2192 active.\nContent changes (nodes, ports, edges) are done via granular CRUD or create_version.",
                 "parameters": [
                     {
                         "name": "data",
@@ -8142,7 +8142,7 @@
             "patch": {
                 "operationId": "agent-playground_graphs_versions_partial_update",
                 "summary": "Metadata-only update endpoint (PUT/PATCH).",
-                "description": "Updates commit_message and/or promotes draft → active.\nContent changes (nodes, ports, edges) are done via granular CRUD or create_version.",
+                "description": "Updates commit_message and/or promotes draft \u2192 active.\nContent changes (nodes, ports, edges) are done via granular CRUD or create_version.",
                 "parameters": [
                     {
                         "name": "data",
@@ -10657,7 +10657,7 @@
         "/agentcc/gateways/": {
             "get": {
                 "operationId": "agentcc_gateways_list",
-                "description": "Stateless proxy to the Go gateway (configured via env vars).\nNo DB model — returns a virtual singleton gateway with live health.",
+                "description": "Stateless proxy to the Go gateway (configured via env vars).\nNo DB model \u2014 returns a virtual singleton gateway with live health.",
                 "parameters": [],
                 "responses": {
                     "200": {
@@ -10719,7 +10719,7 @@
         "/agentcc/gateways/{id}/": {
             "get": {
                 "operationId": "agentcc_gateways_read",
-                "description": "Accept any pk and ignore it — there is only one gateway.",
+                "description": "Accept any pk and ignore it \u2014 there is only one gateway.",
                 "parameters": [],
                 "responses": {
                     "200": {
@@ -10757,7 +10757,7 @@
         "/agentcc/gateways/{id}/cancel-batch/": {
             "post": {
                 "operationId": "agentcc_gateways_cancel_batch",
-                "description": "Stateless proxy to the Go gateway (configured via env vars).\nNo DB model — returns a virtual singleton gateway with live health.",
+                "description": "Stateless proxy to the Go gateway (configured via env vars).\nNo DB model \u2014 returns a virtual singleton gateway with live health.",
                 "parameters": [
                     {
                         "name": "data",
@@ -10812,7 +10812,7 @@
         "/agentcc/gateways/{id}/config/": {
             "get": {
                 "operationId": "agentcc_gateways_config",
-                "description": "Stateless proxy to the Go gateway (configured via env vars).\nNo DB model — returns a virtual singleton gateway with live health.",
+                "description": "Stateless proxy to the Go gateway (configured via env vars).\nNo DB model \u2014 returns a virtual singleton gateway with live health.",
                 "parameters": [],
                 "responses": {
                     "200": {
@@ -10850,7 +10850,7 @@
         "/agentcc/gateways/{id}/get-batch/": {
             "get": {
                 "operationId": "agentcc_gateways_get_batch",
-                "description": "Stateless proxy to the Go gateway (configured via env vars).\nNo DB model — returns a virtual singleton gateway with live health.",
+                "description": "Stateless proxy to the Go gateway (configured via env vars).\nNo DB model \u2014 returns a virtual singleton gateway with live health.",
                 "parameters": [],
                 "responses": {
                     "200": {
@@ -10894,7 +10894,7 @@
         "/agentcc/gateways/{id}/health_check/": {
             "post": {
                 "operationId": "agentcc_gateways_health_check",
-                "description": "Stateless proxy to the Go gateway (configured via env vars).\nNo DB model — returns a virtual singleton gateway with live health.",
+                "description": "Stateless proxy to the Go gateway (configured via env vars).\nNo DB model \u2014 returns a virtual singleton gateway with live health.",
                 "parameters": [
                     {
                         "name": "data",
@@ -10943,7 +10943,7 @@
         "/agentcc/gateways/{id}/mcp-prompts/": {
             "get": {
                 "operationId": "agentcc_gateways_mcp_prompts",
-                "description": "Stateless proxy to the Go gateway (configured via env vars).\nNo DB model — returns a virtual singleton gateway with live health.",
+                "description": "Stateless proxy to the Go gateway (configured via env vars).\nNo DB model \u2014 returns a virtual singleton gateway with live health.",
                 "parameters": [],
                 "responses": {
                     "200": {
@@ -10975,7 +10975,7 @@
         "/agentcc/gateways/{id}/mcp-resources/": {
             "get": {
                 "operationId": "agentcc_gateways_mcp_resources",
-                "description": "Stateless proxy to the Go gateway (configured via env vars).\nNo DB model — returns a virtual singleton gateway with live health.",
+                "description": "Stateless proxy to the Go gateway (configured via env vars).\nNo DB model \u2014 returns a virtual singleton gateway with live health.",
                 "parameters": [],
                 "responses": {
                     "200": {
@@ -11007,7 +11007,7 @@
         "/agentcc/gateways/{id}/mcp-status/": {
             "get": {
                 "operationId": "agentcc_gateways_mcp_status",
-                "description": "Stateless proxy to the Go gateway (configured via env vars).\nNo DB model — returns a virtual singleton gateway with live health.",
+                "description": "Stateless proxy to the Go gateway (configured via env vars).\nNo DB model \u2014 returns a virtual singleton gateway with live health.",
                 "parameters": [],
                 "responses": {
                     "200": {
@@ -11045,7 +11045,7 @@
         "/agentcc/gateways/{id}/mcp-tools/": {
             "get": {
                 "operationId": "agentcc_gateways_mcp_tools",
-                "description": "Stateless proxy to the Go gateway (configured via env vars).\nNo DB model — returns a virtual singleton gateway with live health.",
+                "description": "Stateless proxy to the Go gateway (configured via env vars).\nNo DB model \u2014 returns a virtual singleton gateway with live health.",
                 "parameters": [],
                 "responses": {
                     "200": {
@@ -11077,7 +11077,7 @@
         "/agentcc/gateways/{id}/providers/": {
             "get": {
                 "operationId": "agentcc_gateways_providers",
-                "description": "Stateless proxy to the Go gateway (configured via env vars).\nNo DB model — returns a virtual singleton gateway with live health.",
+                "description": "Stateless proxy to the Go gateway (configured via env vars).\nNo DB model \u2014 returns a virtual singleton gateway with live health.",
                 "parameters": [],
                 "responses": {
                     "200": {
@@ -11164,7 +11164,7 @@
         "/agentcc/gateways/{id}/remove-budget/": {
             "post": {
                 "operationId": "agentcc_gateways_remove_budget",
-                "description": "Stateless proxy to the Go gateway (configured via env vars).\nNo DB model — returns a virtual singleton gateway with live health.",
+                "description": "Stateless proxy to the Go gateway (configured via env vars).\nNo DB model \u2014 returns a virtual singleton gateway with live health.",
                 "parameters": [
                     {
                         "name": "data",
@@ -11213,7 +11213,7 @@
         "/agentcc/gateways/{id}/remove-mcp-server/": {
             "post": {
                 "operationId": "agentcc_gateways_remove_mcp_server",
-                "description": "Stateless proxy to the Go gateway (configured via env vars).\nNo DB model — returns a virtual singleton gateway with live health.",
+                "description": "Stateless proxy to the Go gateway (configured via env vars).\nNo DB model \u2014 returns a virtual singleton gateway with live health.",
                 "parameters": [
                     {
                         "name": "data",
@@ -11323,7 +11323,7 @@
         "/agentcc/gateways/{id}/set-budget/": {
             "post": {
                 "operationId": "agentcc_gateways_set_budget",
-                "description": "Stateless proxy to the Go gateway (configured via env vars).\nNo DB model — returns a virtual singleton gateway with live health.",
+                "description": "Stateless proxy to the Go gateway (configured via env vars).\nNo DB model \u2014 returns a virtual singleton gateway with live health.",
                 "parameters": [
                     {
                         "name": "data",
@@ -11372,7 +11372,7 @@
         "/agentcc/gateways/{id}/submit-batch/": {
             "post": {
                 "operationId": "agentcc_gateways_submit_batch",
-                "description": "Stateless proxy to the Go gateway (configured via env vars).\nNo DB model — returns a virtual singleton gateway with live health.",
+                "description": "Stateless proxy to the Go gateway (configured via env vars).\nNo DB model \u2014 returns a virtual singleton gateway with live health.",
                 "parameters": [
                     {
                         "name": "data",
@@ -11421,7 +11421,7 @@
         "/agentcc/gateways/{id}/test-mcp-tool/": {
             "post": {
                 "operationId": "agentcc_gateways_test_mcp_tool",
-                "description": "Stateless proxy to the Go gateway (configured via env vars).\nNo DB model — returns a virtual singleton gateway with live health.",
+                "description": "Stateless proxy to the Go gateway (configured via env vars).\nNo DB model \u2014 returns a virtual singleton gateway with live health.",
                 "parameters": [
                     {
                         "name": "data",
@@ -11519,7 +11519,7 @@
         "/agentcc/gateways/{id}/toggle-guardrail/": {
             "post": {
                 "operationId": "agentcc_gateways_toggle_guardrail",
-                "description": "Stateless proxy to the Go gateway (configured via env vars).\nNo DB model — returns a virtual singleton gateway with live health.",
+                "description": "Stateless proxy to the Go gateway (configured via env vars).\nNo DB model \u2014 returns a virtual singleton gateway with live health.",
                 "parameters": [
                     {
                         "name": "data",
@@ -11617,7 +11617,7 @@
         "/agentcc/gateways/{id}/update-guardrail/": {
             "post": {
                 "operationId": "agentcc_gateways_update_guardrail",
-                "description": "Stateless proxy to the Go gateway (configured via env vars).\nNo DB model — returns a virtual singleton gateway with live health.",
+                "description": "Stateless proxy to the Go gateway (configured via env vars).\nNo DB model \u2014 returns a virtual singleton gateway with live health.",
                 "parameters": [
                     {
                         "name": "data",
@@ -11666,7 +11666,7 @@
         "/agentcc/gateways/{id}/update-mcp-guardrails/": {
             "post": {
                 "operationId": "agentcc_gateways_update_mcp_guardrails",
-                "description": "Stateless proxy to the Go gateway (configured via env vars).\nNo DB model — returns a virtual singleton gateway with live health.",
+                "description": "Stateless proxy to the Go gateway (configured via env vars).\nNo DB model \u2014 returns a virtual singleton gateway with live health.",
                 "parameters": [
                     {
                         "name": "data",
@@ -11715,7 +11715,7 @@
         "/agentcc/gateways/{id}/update-mcp-server/": {
             "post": {
                 "operationId": "agentcc_gateways_update_mcp_server",
-                "description": "Stateless proxy to the Go gateway (configured via env vars).\nNo DB model — returns a virtual singleton gateway with live health.",
+                "description": "Stateless proxy to the Go gateway (configured via env vars).\nNo DB model \u2014 returns a virtual singleton gateway with live health.",
                 "parameters": [
                     {
                         "name": "data",
@@ -12713,7 +12713,7 @@
             },
             "put": {
                 "operationId": "agentcc_org-configs_update",
-                "description": "Disabled — configs are immutable versions. Create a new one instead.",
+                "description": "Disabled \u2014 configs are immutable versions. Create a new one instead.",
                 "parameters": [
                     {
                         "name": "data",
@@ -13129,7 +13129,7 @@
         "/agentcc/provider-credentials/{id}/rotate/": {
             "post": {
                 "operationId": "agentcc_provider-credentials_rotate",
-                "description": "Rotate credentials — accepts new credentials, encrypts, and updates.",
+                "description": "Rotate credentials \u2014 accepts new credentials, encrypts, and updates.",
                 "parameters": [
                     {
                         "name": "data",
@@ -13690,7 +13690,7 @@
             },
             "put": {
                 "operationId": "agentcc_routing-policies_update",
-                "description": "Updates are disabled — create a new version instead.",
+                "description": "Updates are disabled \u2014 create a new version instead.",
                 "parameters": [
                     {
                         "name": "data",
@@ -13826,7 +13826,7 @@
         "/agentcc/sessions/": {
             "get": {
                 "operationId": "agentcc_sessions_list",
-                "description": "Session management — create, list, retrieve sessions with stats.",
+                "description": "Session management \u2014 create, list, retrieve sessions with stats.",
                 "parameters": [
                     {
                         "name": "page",
@@ -13888,7 +13888,7 @@
             },
             "post": {
                 "operationId": "agentcc_sessions_create",
-                "description": "Session management — create, list, retrieve sessions with stats.",
+                "description": "Session management \u2014 create, list, retrieve sessions with stats.",
                 "parameters": [
                     {
                         "name": "data",
@@ -13922,7 +13922,7 @@
         "/agentcc/sessions/{id}/": {
             "get": {
                 "operationId": "agentcc_sessions_read",
-                "description": "Session management — create, list, retrieve sessions with stats.",
+                "description": "Session management \u2014 create, list, retrieve sessions with stats.",
                 "parameters": [],
                 "responses": {
                     "200": {
@@ -13944,7 +13944,7 @@
             },
             "put": {
                 "operationId": "agentcc_sessions_update",
-                "description": "Session management — create, list, retrieve sessions with stats.",
+                "description": "Session management \u2014 create, list, retrieve sessions with stats.",
                 "parameters": [
                     {
                         "name": "data",
@@ -13975,7 +13975,7 @@
             },
             "patch": {
                 "operationId": "agentcc_sessions_partial_update",
-                "description": "Session management — create, list, retrieve sessions with stats.",
+                "description": "Session management \u2014 create, list, retrieve sessions with stats.",
                 "parameters": [
                     {
                         "name": "data",
@@ -14006,7 +14006,7 @@
             },
             "delete": {
                 "operationId": "agentcc_sessions_delete",
-                "description": "Session management — create, list, retrieve sessions with stats.",
+                "description": "Session management \u2014 create, list, retrieve sessions with stats.",
                 "parameters": [],
                 "responses": {
                     "204": {
@@ -15176,7 +15176,7 @@
             "get": {
                 "operationId": "api_deployment-info_list",
                 "summary": "Public deployment-mode probe used by the frontend to gate UI.",
-                "description": "Returns ``{\"mode\": \"oss\"|\"ee\"|\"cloud\"}``. No auth — public config.",
+                "description": "Returns ``{\"mode\": \"oss\"|\"ee\"|\"cloud\"}``. No auth \u2014 public config.",
                 "parameters": [],
                 "responses": {
                     "200": {
@@ -15374,7 +15374,7 @@
             "get": {
                 "operationId": "api_setup-checks_list",
                 "summary": "Public infrastructure probe for the OSS first-run setup screen.",
-                "description": "Returns ``{\"status\": \"ok\"|\"issues\", \"mode\": ..., \"checks\": [...]}``. No auth —\nit runs before any account exists. Self-hosted only: on cloud and EE the\nroute answers 404, so neither the internal service topology nor the outbound\nprobes it triggers are reachable by an anonymous caller.",
+                "description": "Returns ``{\"status\": \"ok\"|\"issues\", \"mode\": ..., \"checks\": [...]}``. No auth \u2014\nit runs before any account exists. Self-hosted only: on cloud and EE the\nroute answers 404, so neither the internal service topology nor the outbound\nprobes it triggers are reachable by an anonymous caller.",
                 "parameters": [],
                 "responses": {
                     "200": {
@@ -18107,7 +18107,7 @@
         "/mcp/oauth/authorize/": {
             "get": {
                 "operationId": "mcp_oauth_authorize_list",
-                "description": "GET /mcp/oauth/authorize/ — Return consent screen data.",
+                "description": "GET /mcp/oauth/authorize/ \u2014 Return consent screen data.",
                 "parameters": [],
                 "responses": {
                     "200": {
@@ -18138,7 +18138,7 @@
         "/mcp/oauth/consent/": {
             "post": {
                 "operationId": "mcp_oauth_consent_create",
-                "description": "POST /mcp/oauth/consent/ — Process user consent decision.",
+                "description": "POST /mcp/oauth/consent/ \u2014 Process user consent decision.",
                 "parameters": [
                     {
                         "name": "data",
@@ -18186,7 +18186,7 @@
         "/mcp/oauth/token/": {
             "post": {
                 "operationId": "mcp_oauth_token_create",
-                "description": "POST /mcp/oauth/token/ — Exchange code or refresh token for access token.",
+                "description": "POST /mcp/oauth/token/ \u2014 Exchange code or refresh token for access token.",
                 "parameters": [
                     {
                         "name": "data",
@@ -19283,7 +19283,7 @@
             "post": {
                 "operationId": "model-hub_annotation-queues_hard_delete",
                 "summary": "Permanently remove a queue + everything attached.",
-                "description": "Hard delete cascades through the FK graph (rules, items,\nassignments, scores) via ``on_delete=CASCADE``. There is no\nrecovery — callers must pass ``force=true`` AND the queue's\nexact name as ``confirm_name`` so the action can't fire from\na typo'd request.",
+                "description": "Hard delete cascades through the FK graph (rules, items,\nassignments, scores) via ``on_delete=CASCADE``. There is no\nrecovery \u2014 callers must pass ``force=true`` AND the queue's\nexact name as ``confirm_name`` so the action can't fire from\na typo'd request.",
                 "parameters": [
                     {
                         "name": "data",
@@ -19872,7 +19872,7 @@
             "post": {
                 "operationId": "model-hub_annotation-queues_automation-rules_evaluate",
                 "summary": "Trigger a manual rule run with a sync-or-async branch.",
-                "description": "Small runs (filter resolves to ≤ ``RULE_RUN_SYNC_THRESHOLD``) finish\nin the HTTP request and return 200 with the result — fast feedback\nfor the common case. Large runs (mostly first-ever runs on backlogs\nor rules with wide filters) hand the work to a Temporal activity and\nreturn 202 immediately. The activity emails creator + queue managers\non completion.\n\nThe peek is a cheap dry-run (``[:cap+1]`` LIMIT, no COUNT(*)) — sub-\n100ms even on 10M+ row trace tables — so this branch costs little\neven when it ends up taking the sync path.",
+                "description": "Small runs (filter resolves to \u2264 ``RULE_RUN_SYNC_THRESHOLD``) finish\nin the HTTP request and return 200 with the result \u2014 fast feedback\nfor the common case. Large runs (mostly first-ever runs on backlogs\nor rules with wide filters) hand the work to a Temporal activity and\nreturn 202 immediately. The activity emails creator + queue managers\non completion.\n\nThe peek is a cheap dry-run (``[:cap+1]`` LIMIT, no COUNT(*)) \u2014 sub-\n100ms even on 10M+ row trace tables \u2014 so this branch costs little\neven when it ends up taking the sync path.",
                 "parameters": [
                     {
                         "name": "data",
@@ -20468,7 +20468,7 @@
             "get": {
                 "operationId": "model-hub_annotation-queues_items_next_item",
                 "summary": "Get the next or previous item in the queue.",
-                "description": "Query params:\n  exclude: comma-separated item IDs to skip\n  before:  item ID — returns the item immediately before this one in order\n  review_status: optional review status filter (for reviewer queues)\n  exclude_review_status: optional review status to omit (for annotator queues)\n  include_completed: when true, navigation can visit completed items too",
+                "description": "Query params:\n  exclude: comma-separated item IDs to skip\n  before:  item ID \u2014 returns the item immediately before this one in order\n  review_status: optional review status filter (for reviewer queues)\n  exclude_review_status: optional review status to omit (for annotator queues)\n  include_completed: when true, navigation can visit completed items too",
                 "parameters": [
                     {
                         "name": "page",
@@ -23311,7 +23311,7 @@
         "/model-hub/cells/{cell_id}/run-error-localizer/": {
             "get": {
                 "operationId": "model-hub_cells_run-error-localizer_list",
-                "description": "Poll endpoint — returns the current state of the localizer task\nfor a given cell, including the analysis once completed.",
+                "description": "Poll endpoint \u2014 returns the current state of the localizer task\nfor a given cell, including the analysis once completed.",
                 "parameters": [],
                 "responses": {
                     "200": {
@@ -23364,7 +23364,7 @@
             "post": {
                 "operationId": "model-hub_cells_run-error-localizer_create",
                 "summary": "On-demand error localization for a single dataset cell.",
-                "description": "Use case: in the dataset detail drawer, the user opens an eval cell\nthat doesn't have an `error_analysis` block (because the eval was\nrun before error_localization was enabled, or the user wants a\nfresh run). They click \"Run error localization\" and we:\n\n  1. Look up the cell + its UserEvalMetric (column.source_id) +\n     the EvalTemplate.\n  2. Resolve the metric's `mapping` (template_var → column UUID)\n     against the row's other cells to build `input_data`.\n  3. Pull the eval verdict + reason from `cell.value` /\n     `cell.value_infos`.\n  4. Upsert an `ErrorLocalizerTask(source=DATASET, source_id=cell.id,\n     status=PENDING)` so the existing 30s Temporal schedule picks it\n     up and processes it via `process_single_error_localization`.\n\nReturns the task id + status. The frontend then polls the cell\ndetail / task status endpoint until `error_analysis` lands in\n`cell.value_infos`.\n\nPOST /model-hub/cells/{cell_id}/run-error-localizer/",
+                "description": "Use case: in the dataset detail drawer, the user opens an eval cell\nthat doesn't have an `error_analysis` block (because the eval was\nrun before error_localization was enabled, or the user wants a\nfresh run). They click \"Run error localization\" and we:\n\n  1. Look up the cell + its UserEvalMetric (column.source_id) +\n     the EvalTemplate.\n  2. Resolve the metric's `mapping` (template_var \u2192 column UUID)\n     against the row's other cells to build `input_data`.\n  3. Pull the eval verdict + reason from `cell.value` /\n     `cell.value_infos`.\n  4. Upsert an `ErrorLocalizerTask(source=DATASET, source_id=cell.id,\n     status=PENDING)` so the existing 30s Temporal schedule picks it\n     up and processes it via `process_single_error_localization`.\n\nReturns the task id + status. The frontend then polls the cell\ndetail / task status endpoint until `error_analysis` lands in\n`cell.value_infos`.\n\nPOST /model-hub/cells/{cell_id}/run-error-localizer/",
                 "parameters": [
                     {
                         "name": "data",
@@ -32549,7 +32549,7 @@
             },
             "patch": {
                 "operationId": "model-hub_eval-templates_composite_partial_update",
-                "summary": "PATCH — partial update of a composite eval.",
+                "summary": "PATCH \u2014 partial update of a composite eval.",
                 "description": "Supported fields (all optional):\n  name, description, tags,\n  aggregation_enabled, aggregation_function,\n  child_template_ids (replaces the child list),\n  child_weights (map of child_id -> weight).",
                 "parameters": [
                     {
@@ -32624,7 +32624,7 @@
             "post": {
                 "operationId": "model-hub_eval-templates_composite_execute_create",
                 "summary": "POST /model-hub/eval-templates/<template_id>/composite/execute/",
-                "description": "Execute all child evals in a composite and optionally aggregate results.\nThin wrapper around `execute_composite_children_sync` — the same helper\nthe dataset/experiment `CompositeEvaluationRunner` uses, so aggregation\nsemantics stay consistent across surfaces.",
+                "description": "Execute all child evals in a composite and optionally aggregate results.\nThin wrapper around `execute_composite_children_sync` \u2014 the same helper\nthe dataset/experiment `CompositeEvaluationRunner` uses, so aggregation\nsemantics stay consistent across surfaces.",
                 "parameters": [
                     {
                         "name": "data",
@@ -33034,7 +33034,7 @@
             "get": {
                 "operationId": "model-hub_eval-templates_usage_list",
                 "summary": "GET /model-hub/eval-templates/<id>/usage/",
-                "description": "Returns usage stats, chart data, and the paginated usage table.\nQuery params: page (0-based), page_size, period\n(30m|6h|1d|7d|30d|90d|180d|365d), optional start_date/end_date pair\n(overrides period — sent by the FE for Today / Yesterday / Custom).\n\nThe response is rendered through\n``EvalUsageStatsResponseResultSerializer(instance=...).data`` at the\nboundary so shape drift surfaces here instead of shipping silently.",
+                "description": "Returns usage stats, chart data, and the paginated usage table.\nQuery params: page (0-based), page_size, period\n(30m|6h|1d|7d|30d|90d|180d|365d), optional start_date/end_date pair\n(overrides period \u2014 sent by the FE for Today / Yesterday / Custom).\n\nThe response is rendered through\n``EvalUsageStatsResponseResultSerializer(instance=...).data`` at the\nboundary so shape drift surfaces here instead of shipping silently.",
                 "parameters": [
                     {
                         "name": "page",
@@ -33295,7 +33295,7 @@
             "post": {
                 "operationId": "model-hub_eval-templates_versions_restore_create",
                 "summary": "POST /model-hub/eval-templates/<id>/versions/<version_id>/restore/",
-                "description": "Restore a version by creating a new version with the old version's config.\nDoes NOT modify the old version — creates a new one on top.",
+                "description": "Restore a version by creating a new version with the old version's config.\nDoes NOT modify the old version \u2014 creates a new one on top.",
                 "parameters": [
                     {
                         "name": "data",
@@ -34174,7 +34174,7 @@
             "post": {
                 "operationId": "model-hub_experiments_v2_re-run_create",
                 "summary": "V2 re-run: org-scoped, uses V2 Temporal workflow.",
-                "description": "No manual workflow cancel needed — Temporal's TERMINATE_IF_RUNNING ID\nreuse policy automatically cancels any running workflow with the same ID.\nCell reset is handled by the workflow itself (cleanup + setup activities).",
+                "description": "No manual workflow cancel needed \u2014 Temporal's TERMINATE_IF_RUNNING ID\nreuse policy automatically cancels any running workflow with the same ID.\nCell reset is handled by the workflow itself (cleanup + setup activities).",
                 "parameters": [
                     {
                         "name": "data",
@@ -34476,7 +34476,7 @@
             "put": {
                 "operationId": "model-hub_experiments_v2_update",
                 "summary": "Update a V2 experiment with diff-based selective re-run.",
-                "description": "Editable fields: column_id, prompt_config, user_eval_metrics.\nRe-run triggers (determined by fingerprint diffs, not field presence):\n- prompt_config has new/modified entries → re-run those configs + ALL dependent evals\n- user_eval_metrics has new/modified entries → re-run only those evals\n- column_id changed → delete old base eval columns, re-run base evals\n- If FE sends unchanged data, diffs return empty → no re-run",
+                "description": "Editable fields: column_id, prompt_config, user_eval_metrics.\nRe-run triggers (determined by fingerprint diffs, not field presence):\n- prompt_config has new/modified entries \u2192 re-run those configs + ALL dependent evals\n- user_eval_metrics has new/modified entries \u2192 re-run only those evals\n- column_id changed \u2192 delete old base eval columns, re-run base evals\n- If FE sends unchanged data, diffs return empty \u2192 no re-run",
                 "parameters": [
                     {
                         "name": "data",
@@ -35074,7 +35074,7 @@
         "/model-hub/experiments/v2/{experiment_id}/feedback/submit-feedback/": {
             "post": {
                 "operationId": "model-hub_experiments_v2_feedback_submit-feedback_create",
-                "description": "Submit feedback action — triggers temporal eval rerun for experiments.",
+                "description": "Submit feedback action \u2014 triggers temporal eval rerun for experiments.",
                 "parameters": [
                     {
                         "name": "data",
@@ -37625,7 +37625,7 @@
         "/model-hub/ground-truth/{ground_truth_id}/embed/": {
             "post": {
                 "operationId": "model-hub_ground-truth_embed_create",
-                "description": "POST /model-hub/ground-truth/<id>/embed/ — trigger embedding generation.",
+                "description": "POST /model-hub/ground-truth/<id>/embed/ \u2014 trigger embedding generation.",
                 "parameters": [
                     {
                         "name": "data",
@@ -49618,7 +49618,7 @@
         "/simulate/api/alk-simulate/call-executions/{call_execution_id}/status/": {
             "patch": {
                 "operationId": "simulate_api_alk-simulate_call-executions_status",
-                "description": "Non-terminal per-call status ping (currently only ``ongoing``): the\nSDK marks a pre-created PENDING row ONGOING the moment its call starts,\nso the UI shows progress instead of PENDING → terminal. PENDING-gated in\nthe service, so a late ping never clobbers a result that already landed.",
+                "description": "Non-terminal per-call status ping (currently only ``ongoing``): the\nSDK marks a pre-created PENDING row ONGOING the moment its call starts,\nso the UI shows progress instead of PENDING \u2192 terminal. PENDING-gated in\nthe service, so a late ping never clobbers a result that already landed.",
                 "parameters": [
                     {
                         "name": "data",
@@ -49679,7 +49679,7 @@
         "/simulate/api/alk-simulate/run-tests/provision/": {
             "post": {
                 "operationId": "simulate_api_alk-simulate_run-tests_provision_run_test",
-                "description": "Stand up a chat RunTest + scenario-of-record from SDK personas so an\nSDK-first run has somewhere to post — without the native UI's async\nscenario generation. See ``provision_alk_sim_run_test``.",
+                "description": "Stand up a chat RunTest + scenario-of-record from SDK personas so an\nSDK-first run has somewhere to post \u2014 without the native UI's async\nscenario generation. See ``provision_alk_sim_run_test``.",
                 "parameters": [
                     {
                         "name": "data",
@@ -50952,7 +50952,7 @@
             "post": {
                 "operationId": "simulate_api_livekit_webhook_create",
                 "summary": "Receive and process LiveKit server webhooks.",
-                "description": "Handles lifecycle events (room start/finish, participant join/leave,\negress completion). This is the **reliable** path for updating call\nlifecycle and signaling Temporal — it fires even if the agent worker\ncrashes mid-call.",
+                "description": "Handles lifecycle events (room start/finish, participant join/leave,\negress completion). This is the **reliable** path for updating call\nlifecycle and signaling Temporal \u2014 it fires even if the agent worker\ncrashes mid-call.",
                 "parameters": [
                     {
                         "name": "data",
@@ -58828,7 +58828,7 @@
         "/tracer/feed/issues/": {
             "get": {
                 "operationId": "tracer_feed_issues_list",
-                "description": "GET /tracer/feed/issues/ — paginated cluster list with filters/sort.",
+                "description": "GET /tracer/feed/issues/ \u2014 paginated cluster list with filters/sort.",
                 "parameters": [
                     {
                         "name": "project_id",
@@ -58988,7 +58988,7 @@
         "/tracer/feed/issues/stats/": {
             "get": {
                 "operationId": "tracer_feed_issues_stats_list",
-                "description": "GET /tracer/feed/issues/stats/ — top stats bar totals.",
+                "description": "GET /tracer/feed/issues/stats/ \u2014 top stats bar totals.",
                 "parameters": [
                     {
                         "name": "project_id",
@@ -64496,7 +64496,7 @@
             "post": {
                 "operationId": "tracer_trace-session_get_session_graph_data",
                 "summary": "Fetch time-series session metrics for the observe graph.",
-                "description": "Supports the same metric types as the trace graph endpoint:\n- SYSTEM_METRIC: latency, tokens, cost, error_rate, session_count,\n  avg_duration, avg_traces_per_session — all aggregated at session level\n- EVAL: eval scores averaged across sessions\n- ANNOTATION: annotation scores averaged across sessions\n\nResponse shape matches trace graph: {metric_name, data: [{timestamp, value, primary_traffic}]}",
+                "description": "Supports the same metric types as the trace graph endpoint:\n- SYSTEM_METRIC: latency, tokens, cost, error_rate, session_count,\n  avg_duration, avg_traces_per_session \u2014 all aggregated at session level\n- EVAL: eval scores averaged across sessions\n- ANNOTATION: annotation scores averaged across sessions\n\nResponse shape matches trace graph: {metric_name, data: [{timestamp, value, primary_traffic}]}",
                 "parameters": [
                     {
                         "name": "data",
@@ -65030,7 +65030,7 @@
             "get": {
                 "operationId": "tracer_trace-session_eval_logs",
                 "summary": "Session-scoped eval log feed for TracesDrawer's \"Evals\" tab.",
-                "description": "Session-level eval results are walled off from span/trace surfaces\nby ``target_type='session'`` — this endpoint is the only place\nthey appear.\n\nQuery params:\n    page (int, 0-indexed, default 0)\n    page_size (int, default 25, max 100)",
+                "description": "Session-level eval results are walled off from span/trace surfaces\nby ``target_type='session'`` \u2014 this endpoint is the only place\nthey appear.\n\nQuery params:\n    page (int, 0-indexed, default 0)\n    page_size (int, default 25, max 100)",
                 "parameters": [],
                 "responses": {
                     "200": {
@@ -66526,7 +66526,7 @@
             "get": {
                 "operationId": "tracer_trace_voice_call_detail",
                 "summary": "Return the heavy / detail-only fields for a single voice call.",
-                "description": "Query params:\n- trace_id or legacy traceId (required) — UUID of the voice call trace.",
+                "description": "Query params:\n- trace_id or legacy traceId (required) \u2014 UUID of the voice call trace.",
                 "parameters": [
                     {
                         "name": "trace_id",
@@ -75329,7 +75329,7 @@
             "post": {
                 "operationId": "usage_v2_stripe-webhook_create",
                 "summary": "Handle Stripe webhook events.",
-                "description": "No auth — Stripe authenticates via signature header.\nAPIView.as_view() auto-applies csrf_exempt.",
+                "description": "No auth \u2014 Stripe authenticates via signature header.\nAPIView.as_view() auto-applies csrf_exempt.",
                 "parameters": [
                     {
                         "name": "data",
@@ -75801,7 +75801,7 @@
             "post": {
                 "operationId": "usage_webhook_create",
                 "summary": "Handle Stripe webhook events.",
-                "description": "No auth — Stripe authenticates via signature header.\nAPIView.as_view() auto-applies csrf_exempt.",
+                "description": "No auth \u2014 Stripe authenticates via signature header.\nAPIView.as_view() auto-applies csrf_exempt.",
                 "parameters": [
                     {
                         "name": "data",
@@ -85620,7 +85620,7 @@
                 },
                 "sample_rate": {
                     "title": "Sample rate",
-                    "description": "Fraction of traffic to mirror (0.0–1.0)",
+                    "description": "Fraction of traffic to mirror (0.0\u20131.0)",
                     "type": "number"
                 },
                 "status": {
@@ -118531,6 +118531,9 @@
                 },
                 "platform": {
                     "$ref": "#/definitions/HarnessPlatform"
+                },
+                "runtime": {
+                    "$ref": "#/definitions/HarnessRuntimeRead"
                 }
             }
         },
@@ -129370,7 +129373,7 @@
                                 "12m",
                                 "custom"
                             ],
-                            "description": "Which time-window preset the user chose. The frontend resolves it to date_range at save time; this records the intent so a relative window can be re-anchored on the next save. Never read when building a query — date_range remains authoritative. Absent on tasks predating this field. The enum documents the accepted values; it is not enforced."
+                            "description": "Which time-window preset the user chose. The frontend resolves it to date_range at save time; this records the intent so a relative window can be re-anchored on the next save. Never read when building a query \u2014 date_range remains authoritative. Absent on tasks predating this field. The enum documents the accepted values; it is not enforced."
                         },
                         "created_at": {
                             "type": "string",
@@ -130445,7 +130448,7 @@
                                 "12m",
                                 "custom"
                             ],
-                            "description": "Which time-window preset the user chose. The frontend resolves it to date_range at save time; this records the intent so a relative window can be re-anchored on the next save. Never read when building a query — date_range remains authoritative. Absent on tasks predating this field. The enum documents the accepted values; it is not enforced."
+                            "description": "Which time-window preset the user chose. The frontend resolves it to date_range at save time; this records the intent so a relative window can be re-anchored on the next save. Never read when building a query \u2014 date_range remains authoritative. Absent on tasks predating this field. The enum documents the accepted values; it is not enforced."
                         },
                         "created_at": {
                             "type": "string",
@@ -144640,6 +144643,61 @@
                         "oss",
                         "enterprise"
                     ]
+                }
+            }
+        },
+        "HarnessDiagnostics": {
+            "required": [
+                "size",
+                "final",
+                "error"
+            ],
+            "type": "object",
+            "properties": {
+                "object_key": {
+                    "title": "Object key",
+                    "type": "string",
+                    "minLength": 1
+                },
+                "sha256": {
+                    "title": "Sha256",
+                    "type": "string",
+                    "minLength": 1
+                },
+                "size": {
+                    "title": "Size",
+                    "type": "integer"
+                },
+                "captured_at": {
+                    "title": "Captured at",
+                    "type": "string",
+                    "minLength": 1
+                },
+                "final": {
+                    "title": "Final",
+                    "type": "boolean"
+                },
+                "error": {
+                    "title": "Error",
+                    "type": "string"
+                }
+            }
+        },
+        "HarnessRuntimeRead": {
+            "type": "object",
+            "properties": {
+                "sandbox_id": {
+                    "title": "Sandbox id",
+                    "type": "string",
+                    "minLength": 1
+                },
+                "snapshot_name": {
+                    "title": "Snapshot name",
+                    "type": "string",
+                    "minLength": 1
+                },
+                "diagnostics": {
+                    "$ref": "#/definitions/HarnessDiagnostics"
                 }
             }
         }

--- a/frontend/src/api/contracts/openapi-contract.generated.js
+++ b/frontend/src/api/contracts/openapi-contract.generated.js
@@ -86295,11 +86295,6 @@ export const OPENAPI_CONTRACT = Object.freeze({
           type: "string",
           minLength: 1,
         },
-        snapshot_name: {
-          title: "Snapshot name",
-          type: "string",
-          minLength: 1,
-        },
         diagnostics: {
           $ref: "#/definitions/HarnessDiagnostics",
         },

--- a/frontend/src/api/contracts/openapi-contract.generated.js
+++ b/frontend/src/api/contracts/openapi-contract.generated.js
@@ -59275,6 +59275,9 @@ export const OPENAPI_CONTRACT = Object.freeze({
         platform: {
           $ref: "#/definitions/HarnessPlatform",
         },
+        runtime: {
+          $ref: "#/definitions/HarnessRuntimeRead",
+        },
       },
     },
     HarnessManifest: {
@@ -86284,6 +86287,24 @@ export const OPENAPI_CONTRACT = Object.freeze({
         },
       },
     },
+    HarnessRuntimeRead: {
+      type: "object",
+      properties: {
+        sandbox_id: {
+          title: "Sandbox id",
+          type: "string",
+          minLength: 1,
+        },
+        snapshot_name: {
+          title: "Snapshot name",
+          type: "string",
+          minLength: 1,
+        },
+        diagnostics: {
+          $ref: "#/definitions/HarnessDiagnostics",
+        },
+      },
+    },
     HarnessScenario: {
       required: ["scenario_key", "scenario_id", "name"],
       type: "object",
@@ -100314,6 +100335,39 @@ export const OPENAPI_CONTRACT = Object.freeze({
           type: "number",
           maximum: 1,
           minimum: 0,
+        },
+      },
+    },
+    HarnessDiagnostics: {
+      required: ["size", "final", "error"],
+      type: "object",
+      properties: {
+        object_key: {
+          title: "Object key",
+          type: "string",
+          minLength: 1,
+        },
+        sha256: {
+          title: "Sha256",
+          type: "string",
+          minLength: 1,
+        },
+        size: {
+          title: "Size",
+          type: "integer",
+        },
+        captured_at: {
+          title: "Captured at",
+          type: "string",
+          minLength: 1,
+        },
+        final: {
+          title: "Final",
+          type: "boolean",
+        },
+        error: {
+          title: "Error",
+          type: "string",
         },
       },
     },

--- a/frontend/src/generated/api-contracts/api.schemas.ts
+++ b/frontend/src/generated/api-contracts/api.schemas.ts
@@ -16939,8 +16939,6 @@ export interface HarnessDiagnosticsApi {
 export interface HarnessRuntimeReadApi {
   /** @minLength 1 */
   sandbox_id?: string;
-  /** @minLength 1 */
-  snapshot_name?: string;
   diagnostics?: HarnessDiagnosticsApi;
 }
 

--- a/frontend/src/generated/api-contracts/api.schemas.ts
+++ b/frontend/src/generated/api-contracts/api.schemas.ts
@@ -16924,6 +16924,26 @@ export interface HarnessPlatformApi {
   url: string;
 }
 
+export interface HarnessDiagnosticsApi {
+  /** @minLength 1 */
+  object_key?: string;
+  /** @minLength 1 */
+  sha256?: string;
+  size: number;
+  /** @minLength 1 */
+  captured_at?: string;
+  final: boolean;
+  error: string;
+}
+
+export interface HarnessRuntimeReadApi {
+  /** @minLength 1 */
+  sandbox_id?: string;
+  /** @minLength 1 */
+  snapshot_name?: string;
+  diagnostics?: HarnessDiagnosticsApi;
+}
+
 export interface HarnessJobReadApi {
   job: HarnessJobInfoApi;
   status: HarnessJobStatusApi;
@@ -16932,6 +16952,7 @@ export interface HarnessJobReadApi {
   scenarios: HarnessScenarioApi[];
   receipts: HarnessJobReadApiReceiptsItem[];
   platform: HarnessPlatformApi;
+  runtime?: HarnessRuntimeReadApi;
 }
 
 export type HarnessJobCreateApiSchemaVersion =

--- a/frontend/src/generated/api-contracts/api.zod.ts
+++ b/frontend/src/generated/api-contracts/api.zod.ts
@@ -34962,7 +34962,6 @@ export const SimulateApiHarnessJobsListResponseItem = zod.object({
   runtime: zod
     .object({
       sandbox_id: zod.string().min(1).optional(),
-      snapshot_name: zod.string().min(1).optional(),
       diagnostics: zod
         .object({
           object_key: zod.string().min(1).optional(),
@@ -35730,7 +35729,6 @@ export const SimulateApiHarnessJobsReadResponse = zod.object({
   runtime: zod
     .object({
       sandbox_id: zod.string().min(1).optional(),
-      snapshot_name: zod.string().min(1).optional(),
       diagnostics: zod
         .object({
           object_key: zod.string().min(1).optional(),
@@ -35851,7 +35849,6 @@ export const SimulateApiHarnessJobsCancelResponse = zod.object({
   runtime: zod
     .object({
       sandbox_id: zod.string().min(1).optional(),
-      snapshot_name: zod.string().min(1).optional(),
       diagnostics: zod
         .object({
           object_key: zod.string().min(1).optional(),

--- a/frontend/src/generated/api-contracts/api.zod.ts
+++ b/frontend/src/generated/api-contracts/api.zod.ts
@@ -34959,6 +34959,22 @@ export const SimulateApiHarnessJobsListResponseItem = zod.object({
     test_execution_id: zod.string().uuid(),
     url: zod.string().min(1),
   }),
+  runtime: zod
+    .object({
+      sandbox_id: zod.string().min(1).optional(),
+      snapshot_name: zod.string().min(1).optional(),
+      diagnostics: zod
+        .object({
+          object_key: zod.string().min(1).optional(),
+          sha256: zod.string().min(1).optional(),
+          size: zod.number(),
+          captured_at: zod.string().min(1).optional(),
+          final: zod.boolean(),
+          error: zod.string(),
+        })
+        .optional(),
+    })
+    .optional(),
 });
 export const SimulateApiHarnessJobsListResponse = zod.array(
   SimulateApiHarnessJobsListResponseItem,
@@ -35711,6 +35727,22 @@ export const SimulateApiHarnessJobsReadResponse = zod.object({
     test_execution_id: zod.string().uuid(),
     url: zod.string().min(1),
   }),
+  runtime: zod
+    .object({
+      sandbox_id: zod.string().min(1).optional(),
+      snapshot_name: zod.string().min(1).optional(),
+      diagnostics: zod
+        .object({
+          object_key: zod.string().min(1).optional(),
+          sha256: zod.string().min(1).optional(),
+          size: zod.number(),
+          captured_at: zod.string().min(1).optional(),
+          final: zod.boolean(),
+          error: zod.string(),
+        })
+        .optional(),
+    })
+    .optional(),
 });
 
 /**
@@ -35816,6 +35848,22 @@ export const SimulateApiHarnessJobsCancelResponse = zod.object({
     test_execution_id: zod.string().uuid(),
     url: zod.string().min(1),
   }),
+  runtime: zod
+    .object({
+      sandbox_id: zod.string().min(1).optional(),
+      snapshot_name: zod.string().min(1).optional(),
+      diagnostics: zod
+        .object({
+          object_key: zod.string().min(1).optional(),
+          sha256: zod.string().min(1).optional(),
+          size: zod.number(),
+          captured_at: zod.string().min(1).optional(),
+          final: zod.boolean(),
+          error: zod.string(),
+        })
+        .optional(),
+    })
+    .optional(),
 });
 
 /**

--- a/futureagi/simulate/migrations/0086_hostedharnessattempt_diagnostics.py
+++ b/futureagi/simulate/migrations/0086_hostedharnessattempt_diagnostics.py
@@ -1,0 +1,40 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("simulate", "0085_hostedharnessscenario_dataset_row"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="hostedharnessattempt",
+            name="diagnostics_captured_at",
+            field=models.DateTimeField(blank=True, null=True),
+        ),
+        migrations.AddField(
+            model_name="hostedharnessattempt",
+            name="diagnostics_error",
+            field=models.CharField(blank=True, default="", max_length=500),
+        ),
+        migrations.AddField(
+            model_name="hostedharnessattempt",
+            name="diagnostics_final",
+            field=models.BooleanField(default=False),
+        ),
+        migrations.AddField(
+            model_name="hostedharnessattempt",
+            name="diagnostics_object_key",
+            field=models.CharField(blank=True, max_length=1024, null=True),
+        ),
+        migrations.AddField(
+            model_name="hostedharnessattempt",
+            name="diagnostics_sha256",
+            field=models.CharField(blank=True, max_length=64, null=True),
+        ),
+        migrations.AddField(
+            model_name="hostedharnessattempt",
+            name="diagnostics_size",
+            field=models.BigIntegerField(default=0),
+        ),
+    ]

--- a/futureagi/simulate/migrations/0086_hostedharnessattempt_diagnostics.py
+++ b/futureagi/simulate/migrations/0086_hostedharnessattempt_diagnostics.py
@@ -15,12 +15,12 @@ class Migration(migrations.Migration):
         migrations.AddField(
             model_name="hostedharnessattempt",
             name="diagnostics_error",
-            field=models.CharField(blank=True, default="", max_length=500),
+            field=models.CharField(blank=True, max_length=500, null=True),
         ),
         migrations.AddField(
             model_name="hostedharnessattempt",
             name="diagnostics_final",
-            field=models.BooleanField(default=False),
+            field=models.BooleanField(blank=True, null=True),
         ),
         migrations.AddField(
             model_name="hostedharnessattempt",
@@ -35,6 +35,6 @@ class Migration(migrations.Migration):
         migrations.AddField(
             model_name="hostedharnessattempt",
             name="diagnostics_size",
-            field=models.BigIntegerField(default=0),
+            field=models.BigIntegerField(blank=True, null=True),
         ),
     ]

--- a/futureagi/simulate/models/hosted_harness.py
+++ b/futureagi/simulate/models/hosted_harness.py
@@ -139,10 +139,10 @@ class HostedHarnessAttempt(BaseModel):
     heartbeat_at = models.DateTimeField(null=True, blank=True)
     diagnostics_object_key = models.CharField(max_length=1024, null=True, blank=True)
     diagnostics_sha256 = models.CharField(max_length=64, null=True, blank=True)
-    diagnostics_size = models.BigIntegerField(default=0)
+    diagnostics_size = models.BigIntegerField(null=True, blank=True)
     diagnostics_captured_at = models.DateTimeField(null=True, blank=True)
-    diagnostics_final = models.BooleanField(default=False)
-    diagnostics_error = models.CharField(max_length=500, default="", blank=True)
+    diagnostics_final = models.BooleanField(null=True, blank=True)
+    diagnostics_error = models.CharField(max_length=500, null=True, blank=True)
     cleanup_verified_at = models.DateTimeField(null=True, blank=True)
 
     class Meta:

--- a/futureagi/simulate/models/hosted_harness.py
+++ b/futureagi/simulate/models/hosted_harness.py
@@ -137,6 +137,12 @@ class HostedHarnessAttempt(BaseModel):
     source_digest = models.CharField(max_length=71, null=True, blank=True)
     bundle_digest = models.CharField(max_length=71, null=True, blank=True)
     heartbeat_at = models.DateTimeField(null=True, blank=True)
+    diagnostics_object_key = models.CharField(max_length=1024, null=True, blank=True)
+    diagnostics_sha256 = models.CharField(max_length=64, null=True, blank=True)
+    diagnostics_size = models.BigIntegerField(default=0)
+    diagnostics_captured_at = models.DateTimeField(null=True, blank=True)
+    diagnostics_final = models.BooleanField(default=False)
+    diagnostics_error = models.CharField(max_length=500, default="", blank=True)
     cleanup_verified_at = models.DateTimeField(null=True, blank=True)
 
     class Meta:

--- a/futureagi/simulate/serializers/harness_job.py
+++ b/futureagi/simulate/serializers/harness_job.py
@@ -562,7 +562,6 @@ class HarnessDiagnosticsSerializer(serializers.Serializer):
 
 class HarnessRuntimeReadSerializer(serializers.Serializer):
     sandbox_id = serializers.CharField(required=False)
-    snapshot_name = serializers.CharField(required=False)
     diagnostics = HarnessDiagnosticsSerializer(required=False)
 
 

--- a/futureagi/simulate/serializers/harness_job.py
+++ b/futureagi/simulate/serializers/harness_job.py
@@ -551,6 +551,21 @@ class HarnessPlatformSerializer(serializers.Serializer):
     url = serializers.CharField(allow_null=True)
 
 
+class HarnessDiagnosticsSerializer(serializers.Serializer):
+    object_key = serializers.CharField(required=False)
+    sha256 = serializers.CharField(required=False)
+    size = serializers.IntegerField()
+    captured_at = serializers.CharField(required=False)
+    final = serializers.BooleanField()
+    error = serializers.CharField(allow_blank=True)
+
+
+class HarnessRuntimeReadSerializer(serializers.Serializer):
+    sandbox_id = serializers.CharField(required=False)
+    snapshot_name = serializers.CharField(required=False)
+    diagnostics = HarnessDiagnosticsSerializer(required=False)
+
+
 class HarnessJobReadSerializer(serializers.Serializer):
     """Consolidated public read DTO for list/create/retrieve/cancel/poll."""
 
@@ -561,3 +576,4 @@ class HarnessJobReadSerializer(serializers.Serializer):
     scenarios = HarnessScenarioSerializer(many=True)
     receipts = serializers.ListField(child=serializers.JSONField())
     platform = HarnessPlatformSerializer()
+    runtime = HarnessRuntimeReadSerializer(required=False)

--- a/futureagi/simulate/services/harness_provider.py
+++ b/futureagi/simulate/services/harness_provider.py
@@ -208,6 +208,25 @@ def serialize_job(job: HostedHarnessJob) -> dict[str, Any]:
             else None
         ),
     }
+    runtime = {}
+    if attempt:
+        if attempt.provider_ref:
+            runtime["sandbox_id"] = attempt.provider_ref
+        if attempt.snapshot_name:
+            runtime["snapshot_name"] = attempt.snapshot_name
+        if attempt.diagnostics_object_key or attempt.diagnostics_error:
+            diagnostics = {
+                "size": attempt.diagnostics_size,
+                "final": attempt.diagnostics_final,
+                "error": attempt.diagnostics_error,
+            }
+            if attempt.diagnostics_object_key:
+                diagnostics["object_key"] = attempt.diagnostics_object_key
+            if attempt.diagnostics_sha256:
+                diagnostics["sha256"] = attempt.diagnostics_sha256
+            if attempt.diagnostics_captured_at:
+                diagnostics["captured_at"] = attempt.diagnostics_captured_at.isoformat()
+            runtime["diagnostics"] = diagnostics
     # Surface the resolved transport connector so the environments list can show
     # the agent Type (voice/chat). ``resolve_authored_connector`` pins a concrete
     # connector (e.g. "livekit") on the payload during authoring; before that it
@@ -244,6 +263,7 @@ def serialize_job(job: HostedHarnessJob) -> dict[str, Any]:
         "stage_outputs": stage_outputs,
         "scenarios": scenarios,
         "receipts": receipts,
+        "runtime": runtime,
         "adjustments": list(
             (job.payload.get("metadata") or {}).get("adjustments") or []
         ),

--- a/futureagi/simulate/services/harness_provider.py
+++ b/futureagi/simulate/services/harness_provider.py
@@ -212,13 +212,11 @@ def serialize_job(job: HostedHarnessJob) -> dict[str, Any]:
     if attempt:
         if attempt.provider_ref:
             runtime["sandbox_id"] = attempt.provider_ref
-        if attempt.snapshot_name:
-            runtime["snapshot_name"] = attempt.snapshot_name
         if attempt.diagnostics_object_key or attempt.diagnostics_error:
             diagnostics = {
-                "size": attempt.diagnostics_size,
-                "final": attempt.diagnostics_final,
-                "error": attempt.diagnostics_error,
+                "size": attempt.diagnostics_size or 0,
+                "final": bool(attempt.diagnostics_final),
+                "error": attempt.diagnostics_error or "",
             }
             if attempt.diagnostics_object_key:
                 diagnostics["object_key"] = attempt.diagnostics_object_key

--- a/futureagi/simulate/services/hosted_harness_diagnostics.py
+++ b/futureagi/simulate/services/hosted_harness_diagnostics.py
@@ -32,6 +32,12 @@ _PROCESS_LOG_COMMAND = (
 )
 _BEARER_TOKEN = re.compile(r"(?i)(bearer\s+)[A-Za-z0-9._~+/=-]+")
 _QUERY_TOKEN = re.compile(r"(?i)([?&](?:access_)?token=)[^&\s]+")
+_ANSI_ESCAPE = re.compile(r"\x1B(?:[@-Z\\-_]|\[[0-?]*[ -/]*[@-~])")
+_CONTROL_CHARACTER_TRANSLATION = {
+    code: None
+    for code in range(128)
+    if (code < 32 and code not in {9, 10, 13}) or code == 127
+}
 _SENSITIVE_ASSIGNMENT = re.compile(
     r"""(?ix)
     (
@@ -118,8 +124,13 @@ def _secret_fragments(values: Iterable[str]) -> list[str]:
     return sorted(fragments, key=len, reverse=True)
 
 
+def _normalize_log_text(text: str) -> str:
+    without_ansi = _ANSI_ESCAPE.sub("", str(text or ""))
+    return without_ansi.translate(_CONTROL_CHARACTER_TRANSLATION)
+
+
 def _redact(text: str, secret_fragments: Iterable[str]) -> str:
-    redacted = str(text or "")
+    redacted = _normalize_log_text(text)
     for secret in secret_fragments:
         redacted = redacted.replace(secret, "[REDACTED]")
     redacted = _PRIVATE_KEY.sub("[REDACTED PRIVATE KEY]", redacted)

--- a/futureagi/simulate/services/hosted_harness_diagnostics.py
+++ b/futureagi/simulate/services/hosted_harness_diagnostics.py
@@ -1,0 +1,243 @@
+from __future__ import annotations
+
+import gzip
+import hashlib
+import io
+import json
+import logging
+import re
+from collections.abc import Iterable
+from dataclasses import dataclass
+from typing import Any
+
+from django.utils import timezone
+
+from simulate.models import HostedHarnessAttempt
+from tfc.settings.settings import UPLOAD_BUCKET_NAME
+from tfc.utils.storage_client import get_storage_client
+
+logger = logging.getLogger("simulate.hosted_harness_diagnostics")
+
+_ENTRYPOINT_LOG_LIMIT_BYTES = 2 * 1024 * 1024
+_PROCESS_LOG_LIMIT_BYTES = 4 * 1024 * 1024
+_PROCESS_LOG_COMMAND = (
+    "for f in $(find /work/authoring /work/build /work/worlds "
+    "-type f -name '*.log' 2>/dev/null | sort); do "
+    'echo "===== $f ====="; tail -400 "$f"; done'
+)
+_BEARER_TOKEN = re.compile(r"(?i)(bearer\s+)[A-Za-z0-9._~+/=-]+")
+_QUERY_TOKEN = re.compile(r"(?i)([?&](?:access_)?token=)[^&\s]+")
+_SENSITIVE_ASSIGNMENT = re.compile(
+    r"""(?ix)
+    (
+        ["']?
+        (?:authorization|api[_-]?key|secret|token|password)
+        ["']?
+        \s*[:=]\s*
+        ["']?
+    )
+    [^"',}\s]+
+    """
+)
+_PRIVATE_KEY = re.compile(
+    r"-----BEGIN [^-\n]*PRIVATE KEY-----.*?-----END [^-\n]*PRIVATE KEY-----",
+    re.DOTALL,
+)
+
+
+@dataclass(frozen=True)
+class DaytonaDiagnostics:
+    entrypoint_log: str
+    process_logs: str
+    command_status: str | None
+    exit_code: int | None
+
+
+def _json_string_values(value: Any) -> Iterable[str]:
+    if isinstance(value, str):
+        yield value
+    elif isinstance(value, dict):
+        for item in value.values():
+            yield from _json_string_values(item)
+    elif isinstance(value, list):
+        for item in value:
+            yield from _json_string_values(item)
+
+
+def _secret_fragments(values: Iterable[str]) -> list[str]:
+    fragments: set[str] = set()
+    for value in values:
+        text = str(value or "")
+        if len(text) >= 4:
+            fragments.add(text)
+        try:
+            document = json.loads(text)
+        except (TypeError, ValueError):
+            continue
+        fragments.update(
+            item for item in _json_string_values(document) if len(item) >= 4
+        )
+    return sorted(fragments, key=len, reverse=True)
+
+
+def _redact(text: str, secret_fragments: Iterable[str]) -> str:
+    redacted = str(text or "")
+    for secret in secret_fragments:
+        redacted = redacted.replace(secret, "[REDACTED]")
+    redacted = _PRIVATE_KEY.sub("[REDACTED PRIVATE KEY]", redacted)
+    redacted = _BEARER_TOKEN.sub(r"\1[REDACTED]", redacted)
+    redacted = _QUERY_TOKEN.sub(r"\1[REDACTED]", redacted)
+    return _SENSITIVE_ASSIGNMENT.sub(r"\1[REDACTED]", redacted)
+
+
+def _tail_utf8(text: str, limit: int) -> str:
+    encoded = text.encode("utf-8", errors="replace")
+    if len(encoded) <= limit:
+        return encoded.decode("utf-8")
+    return "[earlier output truncated]\n" + encoded[-limit:].decode(
+        "utf-8", errors="replace"
+    )
+
+
+def _command_logs(sandbox: Any, session_id: str, command_id: str) -> str:
+    logs = sandbox.process.get_session_command_logs(
+        session_id,
+        command_id,
+        request_timeout=30,
+    )
+    return getattr(logs, "output", None) or "\n".join(
+        part
+        for part in (
+            getattr(logs, "stdout", ""),
+            getattr(logs, "stderr", ""),
+        )
+        if part
+    )
+
+
+def poll_daytona_diagnostics(
+    attempt: HostedHarnessAttempt,
+    sandbox: Any,
+    *,
+    session_id: str,
+    command_id: str | None = None,
+    command: Any | None = None,
+    final: bool = False,
+    secret_values: Iterable[str] = (),
+) -> DaytonaDiagnostics:
+    """Poll one sandbox and persist its latest secret-safe diagnostics snapshot.
+
+    Collection and storage are deliberately best-effort: diagnostics must never change the
+    harness verdict or prevent cleanup. A stable object key is overwritten on every poll, so one
+    long run cannot create an unbounded number of S3 objects.
+    """
+
+    errors: list[str] = []
+    if command_id is None:
+        try:
+            command_id = (
+                sandbox.fs.download_file("/run/futureagi/entrypoint-command-id", 30)
+                .decode()
+                .strip()
+            )
+        except Exception as exc:  # noqa: BLE001 - external diagnostics are fail-open
+            errors.append(f"command_id:{type(exc).__name__}")
+
+    if command is None and command_id:
+        try:
+            command = sandbox.process.get_session_command(
+                session_id,
+                command_id,
+                request_timeout=30,
+            )
+        except Exception as exc:  # noqa: BLE001 - external diagnostics are fail-open
+            errors.append(f"command_status:{type(exc).__name__}")
+
+    command_status = getattr(command, "status", None)
+    exit_code = getattr(command, "exit_code", None)
+    entrypoint_log = ""
+    if command_id:
+        try:
+            entrypoint_log = _command_logs(sandbox, session_id, command_id)
+        except Exception as exc:  # noqa: BLE001 - a child log can still be captured
+            errors.append(f"entrypoint:{type(exc).__name__}")
+
+    process_logs = ""
+    try:
+        result = sandbox.process.exec(_PROCESS_LOG_COMMAND, timeout=30)
+        process_logs = getattr(result, "result", "") or ""
+    except Exception as exc:  # noqa: BLE001 - entrypoint output can still be captured
+        errors.append(f"processes:{type(exc).__name__}")
+
+    fragments = _secret_fragments(secret_values)
+    entrypoint_log = _tail_utf8(
+        _redact(entrypoint_log, fragments), _ENTRYPOINT_LOG_LIMIT_BYTES
+    )
+    process_logs = _tail_utf8(
+        _redact(process_logs, fragments), _PROCESS_LOG_LIMIT_BYTES
+    )
+    capture = DaytonaDiagnostics(
+        entrypoint_log=entrypoint_log,
+        process_logs=process_logs,
+        command_status=str(command_status) if command_status is not None else None,
+        exit_code=exit_code,
+    )
+    captured_at = timezone.now()
+    document = {
+        "schema_version": "futureagi.harness-diagnostics.v1",
+        "job_id": str(attempt.job_id),
+        "attempt_id": str(attempt.id),
+        "attempt_number": attempt.attempt_number,
+        "sandbox_id": str(attempt.provider_ref or ""),
+        "snapshot_name": str(attempt.snapshot_name or ""),
+        "captured_at": captured_at.isoformat(),
+        "final": final,
+        "command_status": capture.command_status,
+        "exit_code": capture.exit_code,
+        "collection_errors": errors,
+        "entrypoint_log": capture.entrypoint_log,
+        "process_logs": capture.process_logs,
+    }
+    body = gzip.compress(
+        json.dumps(document, sort_keys=True, separators=(",", ":")).encode("utf-8"),
+        compresslevel=6,
+        mtime=0,
+    )
+    digest = hashlib.sha256(body).hexdigest()
+    object_key = (
+        f"harness-diagnostics/{attempt.job.organization_id}/{attempt.job_id}/"
+        f"{attempt.id}.json.gz"
+    )
+
+    try:
+        get_storage_client().put_object(
+            bucket_name=UPLOAD_BUCKET_NAME,
+            object_name=object_key,
+            data=io.BytesIO(body),
+            length=len(body),
+            content_type="application/gzip",
+        )
+    except Exception as exc:  # noqa: BLE001 - diagnostics cannot block the harness lifecycle
+        attempt.diagnostics_error = f"storage:{type(exc).__name__}"
+        attempt.save(update_fields=["diagnostics_error", "updated_at"])
+        logger.exception("could not persist Daytona diagnostics attempt=%s", attempt.id)
+        return capture
+
+    attempt.diagnostics_object_key = object_key
+    attempt.diagnostics_sha256 = digest
+    attempt.diagnostics_size = len(body)
+    attempt.diagnostics_captured_at = captured_at
+    attempt.diagnostics_final = final
+    attempt.diagnostics_error = ",".join(errors)[:500]
+    attempt.save(
+        update_fields=[
+            "diagnostics_object_key",
+            "diagnostics_sha256",
+            "diagnostics_size",
+            "diagnostics_captured_at",
+            "diagnostics_final",
+            "diagnostics_error",
+            "updated_at",
+        ]
+    )
+    return capture

--- a/futureagi/simulate/services/hosted_harness_diagnostics.py
+++ b/futureagi/simulate/services/hosted_harness_diagnostics.py
@@ -23,17 +23,6 @@ _ENTRYPOINT_LOG_LIMIT_BYTES = 2 * 1024 * 1024
 _PROCESS_LOG_LIMIT_BYTES = 4 * 1024 * 1024
 _MIN_SECRET_FRAGMENT_LENGTH = 8
 _REDACTION_CACHE_LIMIT = 128
-_CREDENTIAL_NAME_MARKERS = (
-    "AUTH",
-    "CREDENTIAL",
-    "KEY",
-    "PASSWORD",
-    "PRIVATE",
-    "SECRET",
-    "TOKEN",
-    "ANI",
-    "DSN",
-)
 _redaction_cache: dict[str, tuple[str, ...]] = {}
 _redaction_cache_lock = Lock()
 _PROCESS_LOG_COMMAND = (
@@ -69,15 +58,10 @@ class DaytonaDiagnostics:
     exit_code: int | None
 
 
-def credential_redaction_values(
+def redaction_values(
     values: Mapping[str, Any], *, extra: Iterable[str] = ()
 ) -> tuple[str, ...]:
-    selected = [
-        str(value)
-        for name, value in values.items()
-        if value
-        and any(marker in str(name).upper() for marker in _CREDENTIAL_NAME_MARKERS)
-    ]
+    selected = [str(value) for value in values.values() if value]
     selected.extend(str(value) for value in extra if value)
     return tuple(selected)
 

--- a/futureagi/simulate/services/hosted_harness_diagnostics.py
+++ b/futureagi/simulate/services/hosted_harness_diagnostics.py
@@ -6,8 +6,9 @@ import io
 import json
 import logging
 import re
-from collections.abc import Iterable
+from collections.abc import Iterable, Mapping
 from dataclasses import dataclass
+from threading import Lock
 from typing import Any
 
 from django.utils import timezone
@@ -20,6 +21,21 @@ logger = logging.getLogger("simulate.hosted_harness_diagnostics")
 
 _ENTRYPOINT_LOG_LIMIT_BYTES = 2 * 1024 * 1024
 _PROCESS_LOG_LIMIT_BYTES = 4 * 1024 * 1024
+_MIN_SECRET_FRAGMENT_LENGTH = 8
+_REDACTION_CACHE_LIMIT = 128
+_CREDENTIAL_NAME_MARKERS = (
+    "AUTH",
+    "CREDENTIAL",
+    "KEY",
+    "PASSWORD",
+    "PRIVATE",
+    "SECRET",
+    "TOKEN",
+    "ANI",
+    "DSN",
+)
+_redaction_cache: dict[str, tuple[str, ...]] = {}
+_redaction_cache_lock = Lock()
 _PROCESS_LOG_COMMAND = (
     "for f in $(find /work/authoring /work/build /work/worlds "
     "-type f -name '*.log' 2>/dev/null | sort); do "
@@ -53,6 +69,42 @@ class DaytonaDiagnostics:
     exit_code: int | None
 
 
+def credential_redaction_values(
+    values: Mapping[str, Any], *, extra: Iterable[str] = ()
+) -> tuple[str, ...]:
+    selected = [
+        str(value)
+        for name, value in values.items()
+        if value
+        and any(marker in str(name).upper() for marker in _CREDENTIAL_NAME_MARKERS)
+    ]
+    selected.extend(str(value) for value in extra if value)
+    return tuple(selected)
+
+
+def cache_attempt_redaction_values(
+    attempt_id: Any, values: Iterable[str]
+) -> tuple[str, ...]:
+    key = str(attempt_id)
+    cached = tuple(values)
+    with _redaction_cache_lock:
+        _redaction_cache.pop(key, None)
+        if len(_redaction_cache) >= _REDACTION_CACHE_LIMIT:
+            _redaction_cache.pop(next(iter(_redaction_cache)))
+        _redaction_cache[key] = cached
+    return cached
+
+
+def cached_attempt_redaction_values(attempt_id: Any) -> tuple[str, ...] | None:
+    with _redaction_cache_lock:
+        return _redaction_cache.get(str(attempt_id))
+
+
+def forget_attempt_redaction_values(attempt_id: Any) -> None:
+    with _redaction_cache_lock:
+        _redaction_cache.pop(str(attempt_id), None)
+
+
 def _json_string_values(value: Any) -> Iterable[str]:
     if isinstance(value, str):
         yield value
@@ -68,14 +120,16 @@ def _secret_fragments(values: Iterable[str]) -> list[str]:
     fragments: set[str] = set()
     for value in values:
         text = str(value or "")
-        if len(text) >= 4:
+        if len(text) >= _MIN_SECRET_FRAGMENT_LENGTH:
             fragments.add(text)
         try:
             document = json.loads(text)
         except (TypeError, ValueError):
             continue
         fragments.update(
-            item for item in _json_string_values(document) if len(item) >= 4
+            item
+            for item in _json_string_values(document)
+            if len(item) >= _MIN_SECRET_FRAGMENT_LENGTH
         )
     return sorted(fragments, key=len, reverse=True)
 

--- a/futureagi/simulate/services/hosted_harness_gateway.py
+++ b/futureagi/simulate/services/hosted_harness_gateway.py
@@ -40,9 +40,9 @@ from simulate.services.hosted_harness_diagnostics import (
     DaytonaDiagnostics,
     cache_attempt_redaction_values,
     cached_attempt_redaction_values,
-    credential_redaction_values,
     forget_attempt_redaction_values,
     poll_daytona_diagnostics,
+    redaction_values,
 )
 from tfc.settings.settings import UPLOAD_BUCKET_NAME
 from tfc.utils.storage_client import ensure_bucket, get_storage_client
@@ -1637,7 +1637,7 @@ class DaytonaHostedGateway:
         attempt = capability.attempt
         cache_attempt_redaction_values(
             attempt.id,
-            credential_redaction_values(
+            redaction_values(
                 {**secrets_map, **simulator_env},
                 extra=(simulator_vertex_credentials.decode("utf-8", errors="replace"),)
                 if simulator_vertex_credentials
@@ -1964,9 +1964,7 @@ class DaytonaHostedGateway:
                 simulator_secrets = resolve_platform_simulator_secrets()
                 secret_values = cache_attempt_redaction_values(
                     attempt.id,
-                    credential_redaction_values(
-                        {**target_secrets, **simulator_secrets}
-                    ),
+                    redaction_values({**target_secrets, **simulator_secrets}),
                 )
             except Exception as exc:  # noqa: BLE001 - unsafe logs must not be persisted
                 attempt.diagnostics_error = f"redaction:{type(exc).__name__}"

--- a/futureagi/simulate/services/hosted_harness_gateway.py
+++ b/futureagi/simulate/services/hosted_harness_gateway.py
@@ -36,6 +36,10 @@ from simulate.services.hosted_harness import (
     register_attempt,
     request_cancellation,
 )
+from simulate.services.hosted_harness_diagnostics import (
+    DaytonaDiagnostics,
+    poll_daytona_diagnostics,
+)
 from tfc.settings.settings import UPLOAD_BUCKET_NAME
 from tfc.utils.storage_client import ensure_bucket, get_storage_client
 
@@ -77,6 +81,7 @@ _DIRECT_IMAGE_WITH_ADJUSTMENTS = "direct-image-adjustments-v1"
 _SIMULATOR_SECRETS_PATH = "/run/futureagi/simulator-secrets.json"
 _SIMULATOR_VERTEX_CREDENTIALS_PATH = "/run/futureagi/simulator-vertex-sa.json"
 _PROVIDER_POLL_TIMEOUT_SECONDS = 15
+_DIAGNOSTICS_POLL_INTERVAL_SECONDS = 15
 _PROGRESS_FILE_TIMEOUT_SECONDS = 5
 _PROVIDER_UNREACHABLE_GRACE_SECONDS = 180
 
@@ -1922,6 +1927,42 @@ class DaytonaHostedGateway:
             attempt.job = job
             return attempt
 
+    @staticmethod
+    def _capture_diagnostics(
+        attempt: HostedHarnessAttempt,
+        sandbox,
+        *,
+        command_id: str | None = None,
+        command: Any | None = None,
+        final: bool = False,
+    ) -> DaytonaDiagnostics | None:
+        if (
+            not final
+            and attempt.diagnostics_captured_at
+            and (timezone.now() - attempt.diagnostics_captured_at).total_seconds()
+            < _DIAGNOSTICS_POLL_INTERVAL_SECONDS
+        ):
+            return None
+        try:
+            target_secrets = PlatformSecretResolver().resolve(attempt.job)
+            simulator_secrets = resolve_platform_simulator_secrets()
+        except Exception as exc:  # noqa: BLE001 - unsafe logs must not be persisted
+            attempt.diagnostics_error = f"redaction:{type(exc).__name__}"
+            attempt.save(update_fields=["diagnostics_error", "updated_at"])
+            logger.exception(
+                "could not resolve diagnostics redaction inputs attempt=%s", attempt.id
+            )
+            return None
+        return poll_daytona_diagnostics(
+            attempt,
+            sandbox,
+            session_id=_ENTRYPOINT_SESSION,
+            command_id=command_id,
+            command=command,
+            final=final,
+            secret_values=[*target_secrets.values(), *simulator_secrets.values()],
+        )
+
     def inspect(self, attempt: HostedHarnessAttempt) -> dict[str, Any]:
         sandbox = self.client.get(
             str(attempt.provider_ref),
@@ -1948,43 +1989,21 @@ class DaytonaHostedGateway:
             "exit_code": command.exit_code,
             "status": getattr(command, "status", None),
             "logs": "",
+            "process_logs": "",
         }
+        capture = self._capture_diagnostics(
+            attempt,
+            sandbox,
+            command_id=command_id,
+            command=command,
+            final=command.exit_code is not None,
+        )
+        if capture is not None:
+            observation["logs"] = capture.entrypoint_log[-8000:]
+            observation["process_logs"] = capture.process_logs[-16000:]
         if command.exit_code is not None:
-            # Capture the guest's combined stdout/stderr before the sandbox is
-            # torn down, so crashes are diagnosable without keeping sandboxes.
-            try:
-                logs = sandbox.process.get_session_command_logs(
-                    _ENTRYPOINT_SESSION,
-                    command_id,
-                    request_timeout=_PROVIDER_POLL_TIMEOUT_SECONDS,
-                )
-                text = getattr(logs, "output", None) or "\n".join(
-                    part
-                    for part in (
-                        getattr(logs, "stdout", ""),
-                        getattr(logs, "stderr", ""),
-                    )
-                    if part
-                )
-                observation["logs"] = (text or "")[-8000:]
-            except Exception:  # noqa: BLE001
-                observation["logs"] = ""
-            # The agent/tools-api/postgres run as CHILD processes; their stdout/stderr goes to
-            # per-world/build process.log files, never the entrypoint's own stream. Collect their
-            # tails too -- an "agent did not become ready" failure is only diagnosable from the
-            # agent's own log (STT/LLM/TTS init), which the entrypoint stream never sees.
-            try:
-                child = sandbox.process.exec(
-                    "for f in $(find /work/worlds /work/build -name '*.log' 2>/dev/null | sort); do "
-                    'echo "===== $f ====="; tail -120 "$f"; done',
-                    timeout=60,
-                )
-                child_logs = getattr(child, "result", "") or ""
-            except Exception:  # noqa: BLE001
-                child_logs = ""
-            observation["process_logs"] = child_logs[-16000:]
-            # Surface everything to the simulation-runner worker log so failures are visible via
-            # `docker logs temporal-worker-simulation-runner`, not only the truncated receipt tail.
+            # Keep the bounded failure tails in the worker log as well as the durable S3
+            # snapshot so an operator can diagnose a run from either surface.
             logger.info(
                 "hosted guest attempt=%s exit_code=%s\n--- entrypoint ---\n%s\n--- processes ---\n%s",
                 attempt.id,
@@ -2606,6 +2625,11 @@ class DaytonaHostedGateway:
         except DaytonaNotFoundError:
             absent = True
         else:
+            # A terminal poll normally finalized diagnostics already. Launch failures and
+            # forced cancellations can reach cleanup first, so make one last bounded attempt
+            # while the sandbox is still available.
+            if not attempt.diagnostics_final:
+                self._capture_diagnostics(attempt, sandbox, final=True)
             # The last moment the ledger exists: after the delete there is nothing to ask.
             _read_harness_spend(attempt, sandbox)
             self.client.delete(sandbox, timeout=120, wait=True)
@@ -3067,7 +3091,11 @@ def _record_harness_spend(
     payload = dict(job.payload or {})
     metadata = dict(payload.get("metadata") or {})
     recorded = metadata.get("harness_spend")
-    attempts = dict((recorded or {}).get("attempts") or {}) if isinstance(recorded, dict) else {}
+    attempts = (
+        dict((recorded or {}).get("attempts") or {})
+        if isinstance(recorded, dict)
+        else {}
+    )
     key = str(int(attempt_number or 1))
     mine = attempts.get(key)
     if isinstance(mine, dict):
@@ -3082,8 +3110,12 @@ def _record_harness_spend(
         "stages": spend.get("stages") or [],
     }
     metadata["harness_spend"] = {
-        "total_usd": round(sum(float(one.get("total_usd") or 0.0) for one in attempts.values()), 6),
-        "unpriced_turns": sum(int(one.get("unpriced_turns") or 0) for one in attempts.values()),
+        "total_usd": round(
+            sum(float(one.get("total_usd") or 0.0) for one in attempts.values()), 6
+        ),
+        "unpriced_turns": sum(
+            int(one.get("unpriced_turns") or 0) for one in attempts.values()
+        ),
         "attempts": attempts,
     }
     payload["metadata"] = metadata

--- a/futureagi/simulate/services/hosted_harness_gateway.py
+++ b/futureagi/simulate/services/hosted_harness_gateway.py
@@ -38,6 +38,10 @@ from simulate.services.hosted_harness import (
 )
 from simulate.services.hosted_harness_diagnostics import (
     DaytonaDiagnostics,
+    cache_attempt_redaction_values,
+    cached_attempt_redaction_values,
+    credential_redaction_values,
+    forget_attempt_redaction_values,
     poll_daytona_diagnostics,
 )
 from tfc.settings.settings import UPLOAD_BUCKET_NAME
@@ -1631,6 +1635,15 @@ class DaytonaHostedGateway:
             snapshot_digest=(self.snapshot_digest or None) if self.snapshot else None,
         )
         attempt = capability.attempt
+        cache_attempt_redaction_values(
+            attempt.id,
+            credential_redaction_values(
+                {**secrets_map, **simulator_env},
+                extra=(simulator_vertex_credentials.decode("utf-8", errors="replace"),)
+                if simulator_vertex_credentials
+                else (),
+            ),
+        )
         # Record provenance digests on the attempt.
         if commit_sha:
             attempt.source_digest = (
@@ -1919,6 +1932,7 @@ class DaytonaHostedGateway:
                 )
             else:
                 job = self._delete_and_record(attempt, retry_pending=retry_pending)
+            forget_attempt_redaction_values(attempt.id)
             # Launch failures are part of the same durable retry protocol as guest crashes.
             # Returning the recorded attempt lets the workflow observe RETRY_WAIT and create a
             # genuinely fresh attempt after its configured backoff.  Raising here delegates to
@@ -1943,25 +1957,38 @@ class DaytonaHostedGateway:
             < _DIAGNOSTICS_POLL_INTERVAL_SECONDS
         ):
             return None
+        secret_values = cached_attempt_redaction_values(attempt.id)
+        if secret_values is None:
+            try:
+                target_secrets = PlatformSecretResolver().resolve(attempt.job)
+                simulator_secrets = resolve_platform_simulator_secrets()
+                secret_values = cache_attempt_redaction_values(
+                    attempt.id,
+                    credential_redaction_values(
+                        {**target_secrets, **simulator_secrets}
+                    ),
+                )
+            except Exception as exc:  # noqa: BLE001 - unsafe logs must not be persisted
+                attempt.diagnostics_error = f"redaction:{type(exc).__name__}"
+                attempt.save(update_fields=["diagnostics_error", "updated_at"])
+                logger.exception(
+                    "could not resolve diagnostics redaction inputs attempt=%s",
+                    attempt.id,
+                )
+                return None
         try:
-            target_secrets = PlatformSecretResolver().resolve(attempt.job)
-            simulator_secrets = resolve_platform_simulator_secrets()
-        except Exception as exc:  # noqa: BLE001 - unsafe logs must not be persisted
-            attempt.diagnostics_error = f"redaction:{type(exc).__name__}"
-            attempt.save(update_fields=["diagnostics_error", "updated_at"])
-            logger.exception(
-                "could not resolve diagnostics redaction inputs attempt=%s", attempt.id
+            return poll_daytona_diagnostics(
+                attempt,
+                sandbox,
+                session_id=_ENTRYPOINT_SESSION,
+                command_id=command_id,
+                command=command,
+                final=final,
+                secret_values=secret_values,
             )
-            return None
-        return poll_daytona_diagnostics(
-            attempt,
-            sandbox,
-            session_id=_ENTRYPOINT_SESSION,
-            command_id=command_id,
-            command=command,
-            final=final,
-            secret_values=[*target_secrets.values(), *simulator_secrets.values()],
-        )
+        finally:
+            if final:
+                forget_attempt_redaction_values(attempt.id)
 
     def inspect(self, attempt: HostedHarnessAttempt) -> dict[str, Any]:
         sandbox = self.client.get(
@@ -2308,6 +2335,7 @@ class DaytonaHostedGateway:
             attempt.save(
                 update_fields=["terminal_stage", "terminal_reason", "updated_at"]
             )
+            forget_attempt_redaction_values(attempt.id)
             return record_cleanup(
                 attempt.id,
                 provider_ref=str(attempt.provider_ref),
@@ -2406,6 +2434,7 @@ class DaytonaHostedGateway:
                     ]
                 )
                 retry_pending = self._should_retry(attempt, "infrastructure")
+            forget_attempt_redaction_values(attempt.id)
             return record_cleanup(
                 attempt.id,
                 provider_ref=str(attempt.provider_ref),

--- a/futureagi/simulate/tests/test_harness_read_dto.py
+++ b/futureagi/simulate/tests/test_harness_read_dto.py
@@ -47,11 +47,25 @@ from simulate.services.hosted_harness_gateway import (
     authoring_stage_outputs_from_archive,
 )
 
-
 _LIVEKIT_REFS = {
-    "LIVEKIT_URL": {"key": "harness-livekit_url", "manager": "platform-vault", "purpose": "target_provider", "version": "1"},
-    "LIVEKIT_API_KEY": {"key": "harness-livekit_api_key", "manager": "platform-vault", "purpose": "target_provider", "version": "1"},
-    "LIVEKIT_API_SECRET": {"key": "harness-livekit_api_secret", "manager": "platform-vault", "purpose": "target_provider", "version": "1"},
+    "LIVEKIT_URL": {
+        "key": "harness-livekit_url",
+        "manager": "platform-vault",
+        "purpose": "target_provider",
+        "version": "1",
+    },
+    "LIVEKIT_API_KEY": {
+        "key": "harness-livekit_api_key",
+        "manager": "platform-vault",
+        "purpose": "target_provider",
+        "version": "1",
+    },
+    "LIVEKIT_API_SECRET": {
+        "key": "harness-livekit_api_secret",
+        "manager": "platform-vault",
+        "purpose": "target_provider",
+        "version": "1",
+    },
 }
 
 
@@ -113,8 +127,8 @@ def _v1_payload(**overrides):
 def test_serialize_job_returns_full_dto_shape(organization):
     job, _ = create_hosted_job(organization, _v1_payload(), idempotency_key="dto-shape")
     result = serialize_job(job)
-    # Top-level keys
-    assert set(result.keys()) == {
+    # Required top-level keys; additive response fields remain backward compatible.
+    assert {
         "job",
         "status",
         "events",
@@ -122,7 +136,8 @@ def test_serialize_job_returns_full_dto_shape(organization):
         "scenarios",
         "receipts",
         "platform",
-    }
+        "runtime",
+    } <= set(result)
     # Job sub-keys
     assert "job_id" in result["job"]
     assert "run_id" in result["job"]
@@ -145,6 +160,7 @@ def test_serialize_job_returns_full_dto_shape(organization):
         "test_execution_id": None,
         "url": None,
     }
+    assert result["runtime"] == {}
 
 
 @pytest.mark.django_db

--- a/futureagi/simulate/tests/test_hosted_harness_gateway.py
+++ b/futureagi/simulate/tests/test_hosted_harness_gateway.py
@@ -1239,7 +1239,9 @@ def test_gateway_polls_diagnostics_to_s3_and_finalizes_before_cleanup(
     ).attempt
     client = _Daytona()
     process = client.sandbox.process
-    process.entrypoint_output = "production prod true 13 target-secret\nwaiting"
+    process.entrypoint_output = (
+        "production prod true 13 target-secret custom-secret-value\nwaiting"
+    )
     process.process_output = "worker simulator-secret\nready"
     uploaded = []
 
@@ -1260,6 +1262,7 @@ def test_gateway_polls_diagnostics_to_s3_and_finalizes_before_cleanup(
             "TARGET_API_KEY": "target-secret",
             "SHORT_API_KEY": "prod",
             "FEATURE_FLAG": "true",
+            "STRIPE_SK": "custom-secret-value",
         }
 
     monkeypatch.setattr(
@@ -1277,7 +1280,9 @@ def test_gateway_polls_diagnostics_to_s3_and_finalizes_before_cleanup(
     attempt.refresh_from_db()
     running = json.loads(gzip.decompress(uploaded[-1]))
     assert running["final"] is False
-    assert running["entrypoint_log"] == "production prod true 13 [REDACTED]\nwaiting"
+    assert running["entrypoint_log"] == (
+        "production prod true 13 [REDACTED] [REDACTED]\nwaiting"
+    )
     assert running["process_logs"] == "worker [REDACTED]\nready"
     assert attempt.diagnostics_final is False
     assert attempt.diagnostics_object_key.endswith(f"/{attempt.id}.json.gz")

--- a/futureagi/simulate/tests/test_hosted_harness_gateway.py
+++ b/futureagi/simulate/tests/test_hosted_harness_gateway.py
@@ -1239,7 +1239,7 @@ def test_gateway_polls_diagnostics_to_s3_and_finalizes_before_cleanup(
     ).attempt
     client = _Daytona()
     process = client.sandbox.process
-    process.entrypoint_output = "boot target-secret\nwaiting"
+    process.entrypoint_output = "production prod true 13 target-secret\nwaiting"
     process.process_output = "worker simulator-secret\nready"
     uploaded = []
 
@@ -1252,9 +1252,19 @@ def test_gateway_polls_diagnostics_to_s3_and_finalizes_before_cleanup(
         "simulate.services.hosted_harness_diagnostics.get_storage_client",
         lambda: _Storage(),
     )
+    resolver_calls = []
+
+    def _resolve_target_secrets(_resolver, _job):
+        resolver_calls.append(_job.id)
+        return {
+            "TARGET_API_KEY": "target-secret",
+            "SHORT_API_KEY": "prod",
+            "FEATURE_FLAG": "true",
+        }
+
     monkeypatch.setattr(
         "simulate.services.hosted_harness_gateway.PlatformSecretResolver.resolve",
-        lambda _resolver, _job: {"TARGET_API_KEY": "target-secret"},
+        _resolve_target_secrets,
     )
     monkeypatch.setattr(
         "simulate.services.hosted_harness_gateway.resolve_platform_simulator_secrets",
@@ -1267,7 +1277,7 @@ def test_gateway_polls_diagnostics_to_s3_and_finalizes_before_cleanup(
     attempt.refresh_from_db()
     running = json.loads(gzip.decompress(uploaded[-1]))
     assert running["final"] is False
-    assert running["entrypoint_log"] == "boot [REDACTED]\nwaiting"
+    assert running["entrypoint_log"] == "production prod true 13 [REDACTED]\nwaiting"
     assert running["process_logs"] == "worker [REDACTED]\nready"
     assert attempt.diagnostics_final is False
     assert attempt.diagnostics_object_key.endswith(f"/{attempt.id}.json.gz")
@@ -1286,9 +1296,9 @@ def test_gateway_polls_diagnostics_to_s3_and_finalizes_before_cleanup(
     assert attempt.diagnostics_final is True
     assert attempt.diagnostics_size == len(uploaded[-1])
     assert client.lifecycle[-2:] == ["upload", "delete"]
+    assert resolver_calls == [job.id]
     assert serialize_job(job)["runtime"] == {
         "sandbox_id": "sandbox-1",
-        "snapshot_name": "alk-hosted-v1",
         "diagnostics": {
             "object_key": attempt.diagnostics_object_key,
             "sha256": attempt.diagnostics_sha256,

--- a/futureagi/simulate/tests/test_hosted_harness_gateway.py
+++ b/futureagi/simulate/tests/test_hosted_harness_gateway.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import gzip
 import io
 import json
 import tarfile
@@ -12,6 +13,7 @@ import pytest
 from django.utils import timezone
 
 from simulate.models import HostedHarnessAttempt, HostedHarnessJob
+from simulate.services.harness_provider import serialize_job
 from simulate.services.hosted_harness import (
     HostedHarnessError,
     create_hosted_job,
@@ -754,10 +756,15 @@ class _Process:
     def __init__(self):
         self.exec_calls = []
         self.sessions = []
+        self.command_exit_code = None
+        self.command_status = "running"
+        self.entrypoint_output = ""
+        self.process_output = ""
 
     def exec(self, command, **kwargs):
         self.exec_calls.append(command)
-        return SimpleNamespace(exit_code=0, result="")
+        result = self.process_output if "find /work/authoring" in command else ""
+        return SimpleNamespace(exit_code=0, result=result)
 
     def create_session(self, session_id):
         self.sessions.append(session_id)
@@ -767,7 +774,13 @@ class _Process:
         return SimpleNamespace(cmd_id="command-1")
 
     def get_session_command(self, session_id, command_id, request_timeout=None):
-        return SimpleNamespace(exit_code=None, status="running")
+        return SimpleNamespace(
+            exit_code=self.command_exit_code,
+            status=self.command_status,
+        )
+
+    def get_session_command_logs(self, session_id, command_id, request_timeout=None):
+        return SimpleNamespace(output=self.entrypoint_output)
 
 
 class _Sandbox:
@@ -782,15 +795,21 @@ class _Daytona:
         self.sandbox = _Sandbox()
         self.params = None
         self.deleted = False
+        self.lifecycle = []
 
     def create(self, params, **kwargs):
         self.params = params
         return self.sandbox
 
     def get(self, sandbox_id, request_timeout=None):
+        if self.deleted:
+            from daytona import DaytonaNotFoundError
+
+            raise DaytonaNotFoundError("sandbox not found", 404)
         return self.sandbox
 
     def delete(self, sandbox, **kwargs):
+        self.lifecycle.append("delete")
         self.deleted = True
 
 
@@ -1202,6 +1221,82 @@ def test_daytona_livekit_launch_uses_coturn_domain_allowlist(
         "coturn.turn-eu.futureagi.com",
         "ingest.example.com",
         "platform.example.com",
+    }
+
+
+@pytest.mark.django_db
+def test_gateway_polls_diagnostics_to_s3_and_finalizes_before_cleanup(
+    organization, monkeypatch
+):
+    job, _ = create_hosted_job(
+        organization, _payload(), idempotency_key="polled-diagnostics"
+    )
+    attempt = register_attempt(
+        job.id,
+        endpoint_base_url="https://platform.example.com",
+        provider_ref="sandbox-1",
+        snapshot_name="alk-hosted-v1",
+    ).attempt
+    client = _Daytona()
+    process = client.sandbox.process
+    process.entrypoint_output = "boot target-secret\nwaiting"
+    process.process_output = "worker simulator-secret\nready"
+    uploaded = []
+
+    class _Storage:
+        def put_object(self, **kwargs):
+            client.lifecycle.append("upload")
+            uploaded.append(kwargs["data"].read())
+
+    monkeypatch.setattr(
+        "simulate.services.hosted_harness_diagnostics.get_storage_client",
+        lambda: _Storage(),
+    )
+    monkeypatch.setattr(
+        "simulate.services.hosted_harness_gateway.PlatformSecretResolver.resolve",
+        lambda _resolver, _job: {"TARGET_API_KEY": "target-secret"},
+    )
+    monkeypatch.setattr(
+        "simulate.services.hosted_harness_gateway.resolve_platform_simulator_secrets",
+        lambda: {"SIMULATOR_API_KEY": "simulator-secret"},
+    )
+    gateway = object.__new__(DaytonaHostedGateway)
+    gateway.client = client
+
+    assert gateway.reconcile_completed(attempt) is None
+    attempt.refresh_from_db()
+    running = json.loads(gzip.decompress(uploaded[-1]))
+    assert running["final"] is False
+    assert running["entrypoint_log"] == "boot [REDACTED]\nwaiting"
+    assert running["process_logs"] == "worker [REDACTED]\nready"
+    assert attempt.diagnostics_final is False
+    assert attempt.diagnostics_object_key.endswith(f"/{attempt.id}.json.gz")
+    assert client.deleted is False
+
+    process.command_exit_code = 2
+    process.command_status = "finished"
+    process.entrypoint_output += "\nfatal"
+    gateway.reconcile_completed(attempt)
+
+    attempt.refresh_from_db()
+    final = json.loads(gzip.decompress(uploaded[-1]))
+    assert final["final"] is True
+    assert final["exit_code"] == 2
+    assert final["entrypoint_log"].endswith("fatal")
+    assert attempt.diagnostics_final is True
+    assert attempt.diagnostics_size == len(uploaded[-1])
+    assert client.lifecycle[-2:] == ["upload", "delete"]
+    assert serialize_job(job)["runtime"] == {
+        "sandbox_id": "sandbox-1",
+        "snapshot_name": "alk-hosted-v1",
+        "diagnostics": {
+            "object_key": attempt.diagnostics_object_key,
+            "sha256": attempt.diagnostics_sha256,
+            "size": attempt.diagnostics_size,
+            "captured_at": attempt.diagnostics_captured_at.isoformat(),
+            "final": True,
+            "error": "",
+        },
     }
 
 

--- a/futureagi/simulate/tests/test_hosted_harness_gateway.py
+++ b/futureagi/simulate/tests/test_hosted_harness_gateway.py
@@ -1240,7 +1240,8 @@ def test_gateway_polls_diagnostics_to_s3_and_finalizes_before_cleanup(
     client = _Daytona()
     process = client.sandbox.process
     process.entrypoint_output = (
-        "production prod true 13 target-secret custom-secret-value\nwaiting"
+        "\x01\x02\x1b[31mproduction prod true 13 target-secret "
+        "custom-secret-value\x1b[0m\nwaiting"
     )
     process.process_output = "worker simulator-secret\nready"
     uploaded = []


### PR DESCRIPTION
## Summary
- poll the active Daytona command and child-process logs from the existing Temporal gateway loop
- redact target and simulator secrets, bound the captured output, gzip it, and overwrite one AWS S3 object per attempt
- finalize diagnostics before platform-managed sandbox deletion, including cancellation and launch-failure cleanup paths
- expose additive sandbox and diagnostics metadata through the existing harness job response; no new router
- keep retries isolated by attempt ID and keep diagnostics failures fail-open so they never change the harness verdict or block cleanup
- keep diagnostics columns nullable for old-code/new-schema rolling deploy compatibility
- cache credential-only redaction inputs per attempt and preserve ordinary configuration values in logs

## Scope
Platform polling only. This does not add an ALK-side log publisher, watchdog, direct sandbox-to-S3 credentials, or sandbox self-delete handling.

## Verification
- `99 passed in 94.00s` across `test_hosted_harness_gateway.py`, `test_harness_provider.py`, and the affected read-DTO integration cases
- focused lifecycle integration proves running capture, immediate terminal finalization inside the polling interval, secret redaction, per-attempt redaction-input caching, persisted attempt metadata, existing-response exposure, and S3 upload before Daytona deletion
- real test-MinIO smoke wrote the diagnostics object through the production storage client, read/decompressed it, verified that credentials were redacted while `prod`, `true`, and `13` remained intact, then removed it
- all six diagnostics columns verified nullable with no database defaults after migration
- Ruff format/check passes on every changed Python file
- frontend contract generation/check passes: 1004 paths, 1363 operations, 792/792 endpoint registry coverage
- diagnostics migration applied cleanly in the disposable test graph; `makemigrations --check` only reports two unrelated pre-existing `HarnessCredential*` Meta-option changes from the base branch