### PR TITLE
fix: simulate rejects Twilio call data even though Twilio is a supported provider

### DIFF
--- a/futureagi/simulate/semantics.py
+++ b/futureagi/simulate/semantics.py
@@ -30,6 +30,7 @@ SupportedProviders = {
     ProviderChoices.LIVEKIT.value,
     ProviderChoices.BLAND.value,
     ProviderChoices.OTHERS.value,
+    ProviderChoices.TWILIO.value,  # ADDED — fixes #2662
 }
 
 RecordingTypes = {"stereo", "assistant", "customer", "combined"}

--- a/futureagi/simulate/tests/test_semantics_provider_validation.py
+++ b/futureagi/simulate/tests/test_semantics_provider_validation.py
@@ -1,0 +1,18 @@
+import pytest
+from django.core.exceptions import ValidationError
+
+from simulate.semantics import validate_provider_sent_objects
+
+
+class TestValidateProviderSentObjects:
+    def test_twilio_key_is_accepted(self):
+        # should not raise
+        validate_provider_sent_objects({"twilio": {"call_sid": "CA123"}})
+
+    def test_vapi_key_is_accepted(self):
+        # confirms payload shape itself was never the issue (#2662 repro step)
+        validate_provider_sent_objects({"vapi": {"id": "abc"}})
+
+    def test_unknown_key_is_rejected(self):
+        with pytest.raises(ValidationError):
+            validate_provider_sent_objects({"not_a_real_provider": {}})

--- a/futureagi/simulate/tests/test_speaker_role_resolver.py
+++ b/futureagi/simulate/tests/test_speaker_role_resolver.py
@@ -20,6 +20,10 @@ class TestDetectProvider:
         data = {"vapi": {"id": "abc"}}
         assert SpeakerRoleResolver.detect_provider(data) == ProviderChoices.VAPI
 
+    def test_detects_twilio(self):
+        data = {"twilio": {"call_sid": "CA123"}}
+        assert SpeakerRoleResolver.detect_provider(data) == ProviderChoices.TWILIO
+
     def test_none_falls_back_to_vapi(self):
         assert SpeakerRoleResolver.detect_provider(None) == ProviderChoices.VAPI
 
@@ -103,6 +107,41 @@ class TestIsTestedAgent:
         assert (
             SpeakerRoleResolver.is_tested_agent(
                 "user", provider=ProviderChoices.LIVEKIT, is_outbound=is_outbound
+            )
+            is False
+        )
+
+    # Twilio: mirrors Bland's shape until Twilio transcripts are produced.
+    # Inbound: bot/assistant/agent = simulator, user/customer = tested_agent
+    # Outbound: bot/assistant/agent = tested_agent, user/customer = simulator
+    def test_twilio_inbound_user_is_tested_agent(self):
+        assert (
+            SpeakerRoleResolver.is_tested_agent(
+                "user", provider=ProviderChoices.TWILIO, is_outbound=False
+            )
+            is True
+        )
+
+    def test_twilio_inbound_assistant_is_not_tested_agent(self):
+        assert (
+            SpeakerRoleResolver.is_tested_agent(
+                "assistant", provider=ProviderChoices.TWILIO, is_outbound=False
+            )
+            is False
+        )
+
+    def test_twilio_outbound_assistant_is_tested_agent(self):
+        assert (
+            SpeakerRoleResolver.is_tested_agent(
+                "assistant", provider=ProviderChoices.TWILIO, is_outbound=True
+            )
+            is True
+        )
+
+    def test_twilio_outbound_user_is_not_tested_agent(self):
+        assert (
+            SpeakerRoleResolver.is_tested_agent(
+                "user", provider=ProviderChoices.TWILIO, is_outbound=True
             )
             is False
         )
@@ -202,6 +241,22 @@ class TestIsSimulator:
             is False
         )
 
+    def test_twilio_inbound_assistant_is_simulator(self):
+        assert (
+            SpeakerRoleResolver.is_simulator(
+                "assistant", provider=ProviderChoices.TWILIO, is_outbound=False
+            )
+            is True
+        )
+
+    def test_twilio_outbound_user_is_simulator(self):
+        assert (
+            SpeakerRoleResolver.is_simulator(
+                "user", provider=ProviderChoices.TWILIO, is_outbound=True
+            )
+            is True
+        )
+
 
 class TestGetEvalRoleLabel:
 
@@ -274,6 +329,23 @@ class TestGetEvalRoleLabel:
             == "customer"
         )
 
+    # Twilio inbound: assistant -> customer, user -> agent (mirrors VAPI)
+    def test_twilio_inbound_assistant_becomes_customer(self):
+        assert (
+            SpeakerRoleResolver.get_eval_role_label(
+                "assistant", provider=ProviderChoices.TWILIO, is_outbound=False
+            )
+            == "customer"
+        )
+
+    def test_twilio_outbound_assistant_becomes_agent(self):
+        assert (
+            SpeakerRoleResolver.get_eval_role_label(
+                "assistant", provider=ProviderChoices.TWILIO, is_outbound=True
+            )
+            == "agent"
+        )
+
     def test_system_returned_as_is(self):
         assert (
             SpeakerRoleResolver.get_eval_role_label(
@@ -323,6 +395,24 @@ class TestGetTranscriptRoleSets:
         assert "user" in sim
         assert "customer" in sim
 
+    def test_twilio_inbound(self):
+        ta, sim = SpeakerRoleResolver.get_transcript_role_sets(
+            provider=ProviderChoices.TWILIO, is_outbound=False
+        )
+        assert "user" in ta
+        assert "customer" in ta
+        assert "assistant" in sim
+        assert "bot" in sim
+
+    def test_twilio_outbound(self):
+        ta, sim = SpeakerRoleResolver.get_transcript_role_sets(
+            provider=ProviderChoices.TWILIO, is_outbound=True
+        )
+        assert "assistant" in ta
+        assert "bot" in ta
+        assert "user" in sim
+        assert "customer" in sim
+
     def test_sets_are_disjoint(self):
         ta, sim = SpeakerRoleResolver.get_transcript_role_sets(
             provider=ProviderChoices.VAPI, is_outbound=False
@@ -333,7 +423,11 @@ class TestGetTranscriptRoleSets:
 class TestGetSkipDecisionRoleSets:
 
     def test_returns_same_as_transcript_role_sets(self):
-        for provider in [ProviderChoices.VAPI, ProviderChoices.LIVEKIT]:
+        for provider in [
+            ProviderChoices.VAPI,
+            ProviderChoices.LIVEKIT,
+            ProviderChoices.TWILIO,
+        ]:
             for is_outbound in [True, False]:
                 skip = SpeakerRoleResolver.get_skip_decision_role_sets(
                     provider=provider, is_outbound=is_outbound
@@ -449,12 +543,29 @@ class TestRegressionContracts:
             provider=ProviderChoices.LIVEKIT, is_outbound=True
         )
 
+    def test_twilio_inbound_and_outbound_are_mirror_images(self):
+        """Twilio follows the VAPI-style convention (mirrors Bland), not
+        the LiveKit direction-agnostic one. If they ever collapse to the
+        same map, the map has regressed."""
+        ta_in, sim_in = SpeakerRoleResolver.get_transcript_role_sets(
+            provider=ProviderChoices.TWILIO, is_outbound=False
+        )
+        ta_out, sim_out = SpeakerRoleResolver.get_transcript_role_sets(
+            provider=ProviderChoices.TWILIO, is_outbound=True
+        )
+        assert ta_in == sim_out
+        assert sim_in == ta_out
+
     def test_eval_labels_are_stable_across_providers_and_directions(self):
         """Eval templates read `agent` and `customer` regardless of
         provider. If a fifth label ever leaks through, the LLM prompt
         contract has drifted."""
         seen = set()
-        for provider in [ProviderChoices.VAPI, ProviderChoices.LIVEKIT]:
+        for provider in [
+            ProviderChoices.VAPI,
+            ProviderChoices.LIVEKIT,
+            ProviderChoices.TWILIO,
+        ]:
             for is_outbound in [False, True]:
                 for raw in ["assistant", "user", "bot", "customer", "agent"]:
                     label = SpeakerRoleResolver.get_eval_role_label(

--- a/futureagi/simulate/utils/speaker_roles.py
+++ b/futureagi/simulate/utils/speaker_roles.py
@@ -83,6 +83,26 @@ class SpeakerRoleResolver:
         "customer": "simulator",
     }
 
+    # ADDED — Twilio call-log ingestion carries no per-turn transcript
+    # (see tracer/utils/twilio_calls.py), so this map exists for
+    # consistency with the resolver's contract rather than active use.
+    # Mirrors Bland's telephony-provider shape until Twilio transcripts
+    # are actually produced by the platform.
+    _TWILIO_INBOUND: dict[str, str] = {
+        "bot": "simulator",
+        "assistant": "simulator",
+        "agent": "simulator",
+        "user": "tested_agent",
+        "customer": "tested_agent",
+    }
+    _TWILIO_OUTBOUND: dict[str, str] = {
+        "bot": "tested_agent",
+        "assistant": "tested_agent",
+        "agent": "tested_agent",
+        "user": "simulator",
+        "customer": "simulator",
+    }
+
     @staticmethod
     def detect_provider(
         provider_call_data: dict[str, Any] | None,
@@ -101,6 +121,8 @@ class SpeakerRoleResolver:
             return ProviderChoices.VAPI
         if provider_call_data.get(ProviderChoices.BLAND.value):
             return ProviderChoices.BLAND
+        if provider_call_data.get(ProviderChoices.TWILIO.value):  # ADDED
+            return ProviderChoices.TWILIO
         logger.error(
             "speaker_role_resolver_unknown_provider",
             provider_call_data_keys=list(provider_call_data.keys()),
@@ -145,6 +167,8 @@ class SpeakerRoleResolver:
             return cls._LIVEKIT_OUTBOUND if is_outbound else cls._LIVEKIT_INBOUND
         if provider == ProviderChoices.BLAND:
             return cls._BLAND_OUTBOUND if is_outbound else cls._BLAND_INBOUND
+        if provider == ProviderChoices.TWILIO:  # ADDED
+            return cls._TWILIO_OUTBOUND if is_outbound else cls._TWILIO_INBOUND
         logger.error(
             "speaker_role_resolver_unsupported_provider",
             provider=str(provider),


### PR DESCRIPTION
Summary

Twilio is already a first-class provider on the platform — it's one of the values the provider field accepts (alongside Vapi, Retell, LiveKit, Bland, Eleven Labs and Others) and can be set as a project's observability provider. But simulate keeps its own separate, narrower provider set, and Twilio was the one value missing from it. That set backs a validator on the field storing raw provider call data, so any payload keyed by twilio was rejected with a forbidden-keys error before it ever reached storage. This PR adds Twilio to that set and wires up its speaker-role mapping, so a Twilio call execution is accepted, stored, and its transcript/status surface in simulate the same way an existing provider's does.

Linked issues

Closes #2662
Linear:

AI use

AI use: Claude Sonnet 5 helped locate the two consumers of the provider set (the semantics.py validator and the speaker_roles.py resolver) and drafted the Twilio role-map and test structure; I reviewed, adjusted, and verified the changes.

Type of change
 - [x] 🐛 Bug fix (non-breaking change which fixes an issue)

E2E coverage

E2E: exempt (backend-internal)

1) What changes were done

A. futureagi/simulate/semantics.py

Added ProviderChoices.TWILIO.value to SupportedProviders. This is the set that backs validate_provider_sent_objects, the validator that raises the forbidden-keys error. A twilio-keyed provider payload is no longer rejected here.
This same set is also what the ingestion serializer and ingestion service check payload keys against, so adding Twilio here is what actually unblocks a Twilio call execution from being ingested end-to-end, not just from passing one isolated check.

B. futureagi/simulate/utils/speaker_roles.py

Added _TWILIO_INBOUND and _TWILIO_OUTBOUND maps to SpeakerRoleResolver, following the same shape as existing providers: bot/assistant/agent → simulator, user/customer → tested_agent (and reversed for outbound) — the same convention used for Bland.
Added a TWILIO branch in detect_provider() so a payload keyed by twilio is correctly identified as coming from Twilio rather than falling through to the "unknown provider" error path.
Added a TWILIO branch in _get_map() so inbound/outbound role resolution picks the correct map once Twilio is detected.
Left a comment noting Twilio call-log ingestion currently carries no per-turn transcript (see tracer/utils/twilio_calls.py), so this map exists now for contract consistency with the resolver rather than being actively exercised yet — the same position Bland was in before its transcripts existed.

C. Tests

-simulate/tests/test_speaker_role_resolver.py: extended the existing per-provider test classes (TestDetectProvider, TestIsTestedAgent, TestIsSimulator, TestGetEvalRoleLabel, TestGetTranscriptRoleSets, TestGetSkipDecisionRoleSets, TestRegressionContracts) with Twilio cases, following the VAPI-style direction-flip pattern rather than LiveKit's direction-agnostic one.

-simulate/tests/test_semantics_provider_validation.py (new): covers validate_provider_sent_objects directly.

2) Why the changes were done

->Product/UX: A team running their agent on Twilio could configure it as their observability provider — that part already worked — but couldn't get a single call into simulate, because every ingestion attempt failed validation on the provider key alone. This closed off simulate entirely for Twilio users even though Twilio is fully supported everywhere else in the platform.

->Technical: The issue's own investigation pointed at two separate consumers of the provider set: the validator/migration path in semantics.py, and the ingestion serializer/service that independently check against it. Fixing only one would have left the other still rejecting Twilio, so both needed the same change. The speaker-role resolver is a separate contract entirely — it doesn't read SupportedProviders, it has its own per-provider role maps — so it needed its own explicit Twilio entries rather than inheriting anything from the semantics.py change.

->Architecture: Followed the existing per-provider pattern already used for Bland and LiveKit instead of adding a generic/fallback provider path, so Twilio's behavior is explicit, discoverable, and consistent with how the rest of the resolver is structured.

3) Tests written + scenarios each covers

simulate/tests/test_speaker_role_resolver.py — extends the existing provider test suite with Twilio coverage

-test_detects_twilio — a payload keyed by twilio is identified as ProviderChoices.TWILIO
-test_twilio_inbound_user_is_tested_agent / test_twilio_inbound_assistant_is_not_tested_agent — inbound role classification
-test_twilio_outbound_assistant_is_tested_agent / test_twilio_outbound_user_is_not_tested_agent — outbound role classification (confirms the direction flip, matching VAPI/Bland, not LiveKit)
-test_twilio_inbound_assistant_is_simulator / test_twilio_outbound_user_is_simulator — simulator-side classification
-test_twilio_inbound_assistant_becomes_customer / test_twilio_outbound_assistant_becomes_agent — eval role labels resolve correctly by direction
-test_twilio_inbound / test_twilio_outbound (in TestGetTranscriptRoleSets) — transcript role sets split correctly by direction
-test_twilio_inbound_and_outbound_are_mirror_images (in TestRegressionContracts) — locks in that Twilio's inbound/outbound maps are mirror images of each other, the same invariant already enforced for VAPI
->Extended:
                    TestGetSkipDecisionRoleSets.test_returns_same_as_transcript_role_sets and TestRegressionContracts.test_eval_labels_are_stable_across_providers_and_directions to iterate over ProviderChoices.TWILIO alongside VAPI and LiveKit

simulate/tests/test_semantics_provider_validation.py — new file, tests validate_provider_sent_objects directly

-test_twilio_key_is_accepted — a twilio-keyed payload no longer raises ValidationError
-test_vapi_key_is_accepted — confirms the payload shape was never the problem, matching the issue's own repro steps (repeating the request with vapi instead of twilio was already accepted)
-test_unknown_key_is_rejected — a key outside the provider enum still raises ValidationError, confirming validation wasn't loosened beyond Twilio
     
(CI will run the full suite on push; local run was blocked by Windows-incompatible
dependencies in requirements-test.txt — see note in section 7)

4) How to run / test:
Backend tests:
In terminal
-cd futureagi
-uv venv --python 3.11
-source .venv/bin/activate
-uv pip install -r requirements-test.txt
-bin/test app simulate

UI steps (manual):

1-Configure Twilio as the observability provider on a project.
2-Ingest a simulate call execution with a provider payload keyed by twilio.
3-Verify the record is accepted and stored, not rejected with a forbidden-keys error.
4-Verify the call surfaces in simulate with role mapping applied, the same way an existing provider's call does.

6) Edge cases & considerations:

-Twilio has no per-turn transcript yet: _TWILIO_INBOUND/_TWILIO_OUTBOUND are wired up now for contract consistency, but until Twilio call-log ingestion actually produces per-turn transcripts (currently only call-level data via tracer/utils/twilio_calls.py), the map isn't exercised by real traffic — matches how Bland was handled before its transcripts existed.

-Validation stays strict: only twilio was added to the allowed set; a key outside the provider enum is still rejected with the same forbidden-keys error, covered directly by test_unknown_key_is_rejected.

-No effect on other providers: this only adds a new value to a set and new branches gated on TWILIO — existing call executions and rows written before this change are unaffected and still validate.

-Tool-calling provider list untouched: the issue explicitly called this out as a separate, narrower list that should not be widened, and it wasn't touched.

-Out of scope, as stated in the issue: outbound call placement through Twilio. This change is only about ingesting and viewing calls that already happened.

7) Pre-existing issues (NOT introduced by this PR):

requirements-test.txt includes uvloop, which does not support Windows and fails to build in a local Windows dev environment, so the full local bin/test suite (which also requires Docker for Postgres/Redis/ClickHouse/MinIO) could not be run end-to-end on this machine. The two new test files were reviewed carefully against the existing test patterns in the same files and are expected to pass in CI, which runs on Linux.

8) Architectural / important decisions:

-Added Twilio to SupportedProviders rather than relaxing the validator generically: keeps rejection of truly unsupported provider keys intact, which the issue calls out as a required outcome.

-Followed the Bland precedent for speaker-role maps: wired up the map now even though per-turn transcripts aren't produced yet, rather than deferring, so the resolver doesn't need a second follow-up change once Twilio transcripts land.

-Twilio follows VAPI's direction-flip convention, not LiveKit's direction-agnostic one: LiveKit's agent worker normalizes roles at write time, so its map is the same both directions; Twilio (like Bland and VAPI) has no such normalization, so inbound and outbound needed separate, mirrored maps.