### PR TITLE
feat(voice): add tested audio metrics extractor

### DIFF
--- a/futureagi/ee/voice/services/audio_metrics.py
+++ b/futureagi/ee/voice/services/audio_metrics.py
@@ -1,0 +1,156 @@
+from __future__ import annotations
+
+import io
+from dataclasses import dataclass
+
+import librosa
+import numpy as np
+
+
+@dataclass(frozen=True)
+class AudioMetrics:
+    average_pitch_hz: float | None
+    estimated_snr_db: float | None
+
+
+def analyze_audio(audio_bytes: bytes) -> AudioMetrics:
+    """Analyze a single-speaker audio track for pitch and estimated SNR.
+
+    Average pitch is the arithmetic mean of finite fundamental-frequency
+    estimates returned by ``librosa.pyin`` for voiced frames only.
+
+    Estimated SNR is a deterministic frame-energy estimate. RMS energy is
+    calculated over fixed-size frames, the lowest-energy frames are used as a
+    background-noise estimate, and the highest-energy frames are used as a
+    signal estimate. The ratio of the two mean powers is returned in decibels.
+
+    This is only an estimate: without a separate clean reference recording,
+    the returned value is not a ground-truth signal-to-noise ratio.
+
+    Args:
+        audio_bytes: Encoded audio bytes supported by librosa.
+
+    Returns:
+        AudioMetrics containing average pitch and estimated SNR. Either value
+        may be None when the audio does not contain enough information for a
+        meaningful measurement.
+
+    Raises:
+        ValueError: If the supplied bytes cannot be decoded as audio.
+    """
+    try:
+        y, sr = librosa.load(
+            io.BytesIO(audio_bytes),
+            sr=None,
+            mono=True,
+        )
+    except Exception as exc:
+        raise ValueError("Could not decode audio bytes") from exc
+
+    y = np.asarray(y, dtype=float)
+
+    if y.size == 0 or not np.any(np.isfinite(y)):
+        return AudioMetrics(
+            average_pitch_hz=None,
+            estimated_snr_db=None,
+        )
+
+    finite_samples = y[np.isfinite(y)]
+    if finite_samples.size == 0 or np.allclose(finite_samples, 0.0):
+        return AudioMetrics(
+            average_pitch_hz=None,
+            estimated_snr_db=None,
+        )
+
+    average_pitch_hz = _average_pitch_hz(y, sr)
+    estimated_snr_db = _estimate_snr_db(y, sr)
+
+    return AudioMetrics(
+        average_pitch_hz=average_pitch_hz,
+        estimated_snr_db=estimated_snr_db,
+    )
+
+
+def _average_pitch_hz(
+    y: np.ndarray,
+    sr: int,
+) -> float | None:
+    """Return the mean fundamental frequency across finite voiced frames."""
+    try:
+        f0, voiced_flag, _ = librosa.pyin(
+            y,
+            fmin=librosa.note_to_hz("C2"),
+            fmax=librosa.note_to_hz("C7"),
+            sr=sr,
+        )
+    except Exception:
+        return None
+
+    if f0 is None or voiced_flag is None:
+        return None
+
+    voiced_frequencies = f0[np.asarray(voiced_flag, dtype=bool) & np.isfinite(f0)]
+
+    if voiced_frequencies.size == 0:
+        return None
+
+    average = float(np.mean(voiced_frequencies))
+
+    return average if np.isfinite(average) else None
+
+
+def _estimate_snr_db(
+    y: np.ndarray,
+    sr: int,
+) -> float | None:
+    """Estimate SNR from deterministic frame RMS variation.
+
+    The waveform is split into fixed overlapping frames and RMS energy is
+    calculated for each frame. The median RMS is used as a robust estimate of
+    the typical signal-plus-noise level. The median absolute deviation of RMS
+    values estimates background-noise variation.
+
+    Signal power is estimated as the squared median RMS. Noise power is
+    estimated as the squared RMS median absolute deviation. The returned value
+    is ``10 * log10(signal_power / noise_power)``.
+
+    This is an energy-based estimate rather than a ground-truth SNR because no
+    separate clean reference recording is available.
+    """
+    frame_length = max(1, min(len(y), int(0.05 * sr)))
+    hop_length = max(1, frame_length // 2)
+
+    rms = librosa.feature.rms(
+        y=y,
+        frame_length=frame_length,
+        hop_length=hop_length,
+    )[0]
+
+    rms = rms[np.isfinite(rms)]
+
+    if rms.size < 4:
+        return None
+
+    median_rms = float(np.median(rms))
+
+    if not np.isfinite(median_rms) or median_rms <= 0.0:
+        return None
+
+    median_absolute_deviation = float(np.median(np.abs(rms - median_rms)))
+
+    if not np.isfinite(median_absolute_deviation) or median_absolute_deviation <= 0.0:
+        return None
+
+    signal_power = median_rms**2
+    noise_power = median_absolute_deviation**2
+
+    if (
+        not np.isfinite(signal_power)
+        or not np.isfinite(noise_power)
+        or noise_power <= 0.0
+    ):
+        return None
+
+    estimated_snr_db = float(10.0 * np.log10(signal_power / noise_power))
+
+    return estimated_snr_db if np.isfinite(estimated_snr_db) else None

--- a/futureagi/ee/voice/tests/test_audio_metrics.py
+++ b/futureagi/ee/voice/tests/test_audio_metrics.py
@@ -1,0 +1,160 @@
+from __future__ import annotations
+
+import io
+import math
+
+import numpy as np
+import pytest
+import soundfile as sf
+
+from ee.voice.services.audio_metrics import analyze_audio
+
+
+def _synth_wav_bytes(
+    *,
+    frequency_hz: float = 220.0,
+    duration_sec: float = 2.0,
+    sample_rate: int = 22050,
+    noise_amplitude: float = 0.0,
+    stereo: bool = False,
+) -> bytes:
+    n_samples = int(duration_sec * sample_rate)
+
+    t = np.linspace(
+        0,
+        duration_sec,
+        n_samples,
+        endpoint=False,
+    )
+
+    signal = 0.5 * np.sin(2 * math.pi * frequency_hz * t)
+
+    rng = np.random.default_rng(12345)
+
+    if noise_amplitude > 0:
+        signal = signal + (noise_amplitude * rng.normal(size=n_samples))
+
+    signal = signal.astype(np.float32)
+
+    if stereo:
+        signal = np.column_stack(
+            (
+                signal,
+                signal,
+            )
+        )
+
+    buffer = io.BytesIO()
+
+    sf.write(
+        buffer,
+        signal,
+        sample_rate,
+        format="WAV",
+    )
+
+    return buffer.getvalue()
+
+
+def test_220_hz_sine_wave_reports_expected_pitch():
+    audio_bytes = _synth_wav_bytes(
+        frequency_hz=220.0,
+        noise_amplitude=0.01,
+    )
+
+    metrics = analyze_audio(audio_bytes)
+
+    assert metrics.average_pitch_hz is not None
+    assert metrics.average_pitch_hz == pytest.approx(
+        220.0,
+        rel=0.05,
+    )
+
+
+def test_stronger_noise_produces_lower_estimated_snr():
+    low_noise_audio = _synth_wav_bytes(
+        noise_amplitude=0.01,
+    )
+
+    high_noise_audio = _synth_wav_bytes(
+        noise_amplitude=0.20,
+    )
+
+    low_noise_metrics = analyze_audio(low_noise_audio)
+    high_noise_metrics = analyze_audio(high_noise_audio)
+
+    assert low_noise_metrics.estimated_snr_db is not None
+    assert high_noise_metrics.estimated_snr_db is not None
+
+    assert high_noise_metrics.estimated_snr_db < low_noise_metrics.estimated_snr_db
+
+
+def test_silence_returns_none_for_all_metrics():
+    sample_rate = 22050
+    silence = np.zeros(
+        sample_rate,
+        dtype=np.float32,
+    )
+
+    buffer = io.BytesIO()
+
+    sf.write(
+        buffer,
+        silence,
+        sample_rate,
+        format="WAV",
+    )
+
+    metrics = analyze_audio(buffer.getvalue())
+
+    assert metrics.average_pitch_hz is None
+    assert metrics.estimated_snr_db is None
+
+
+def test_malformed_audio_raises_value_error():
+    with pytest.raises(
+        ValueError,
+        match="Could not decode audio bytes",
+    ):
+        analyze_audio(b"this is not valid audio data")
+
+
+def test_numeric_results_are_always_finite():
+    audio_bytes = _synth_wav_bytes(
+        frequency_hz=220.0,
+        noise_amplitude=0.05,
+    )
+
+    metrics = analyze_audio(audio_bytes)
+
+    for value in (
+        metrics.average_pitch_hz,
+        metrics.estimated_snr_db,
+    ):
+        if value is not None:
+            assert math.isfinite(value)
+
+
+def test_stereo_audio_is_safely_downmixed():
+    audio_bytes = _synth_wav_bytes(
+        frequency_hz=220.0,
+        noise_amplitude=0.01,
+        stereo=True,
+    )
+
+    metrics = analyze_audio(audio_bytes)
+
+    assert metrics.average_pitch_hz is not None
+    assert math.isfinite(metrics.average_pitch_hz)
+
+
+def test_analysis_is_deterministic():
+    audio_bytes = _synth_wav_bytes(
+        frequency_hz=220.0,
+        noise_amplitude=0.05,
+    )
+
+    first = analyze_audio(audio_bytes)
+    second = analyze_audio(audio_bytes)
+
+    assert first == second


### PR DESCRIPTION
## Description

Adds a provider-independent audio metrics extractor for single-speaker audio tracks.

### What changed

- Added `AudioMetrics` with:
  - `average_pitch_hz`
  - `estimated_snr_db`
- Added `analyze_audio(audio_bytes)` for decoding and analyzing audio bytes.
- Uses `librosa.load(..., sr=None, mono=True)` for consistent decoding and safe stereo downmixing.
- Calculates average pitch from finite voiced frames using `librosa.pyin`.
- Adds a deterministic energy-based estimated SNR calculation.
- Returns `None` for silence or when there is insufficient signal/noise information for a meaningful estimate.
- Raises `ValueError` for malformed or undecodable audio.
- Ensures numeric results are always finite.

### Tests

Added tests covering:

- 220 Hz sine-wave pitch accuracy
- Lower estimated SNR with stronger noise
- Silence handling
- Malformed audio input
- Finite numeric results
- Stereo downmixing
- Deterministic results

AI use: ChatGPT assisted with implementation and test development. I reviewed, edited, understood, and ran the code and verification locally.

E2E: EXEMPT (backend-internal)

## Validation

```text
uvx ruff check ee/voice/services/audio_metrics.py ee/voice/tests/test_audio_metrics.py

All checks passed!
uv run pytest ee/voice/tests/test_audio_metrics.py -v

collected 7 items

ee/voice/tests/test_audio_metrics.py::test_220_hz_sine_wave_reports_expected_pitch PASSED
ee/voice/tests/test_audio_metrics.py::test_stronger_noise_produces_lower_estimated_snr PASSED
ee/voice/tests/test_audio_metrics.py::test_silence_returns_none_for_all_metrics PASSED
ee/voice/tests/test_audio_metrics.py::test_malformed_audio_raises_value_error PASSED
ee/voice/tests/test_audio_metrics.py::test_numeric_results_are_always_finite PASSED
ee/voice/tests/test_audio_metrics.py::test_stereo_audio_is_safely_downmixed PASSED
ee/voice/tests/test_audio_metrics.py::test_analysis_is_deterministic PASSED

7 passed in 3.42s
yarn coverage

E2E coverage: EXEMPT (backend-internal) — areas: none — flows hit: none
Marker: missing
Verdict: pass — exempt (backend-internal); no declaration needed