### PR TITLE
Derive simulator egress from each provider lane's effective value

### DIFF
--- a/futureagi/simulate/services/hosted_harness_gateway.py
+++ b/futureagi/simulate/services/hosted_harness_gateway.py
@@ -36,6 +36,11 @@ from simulate.services.hosted_harness import (
     register_attempt,
     request_cancellation,
 )
+from simulate.services.hosted_runner import (
+    SIMULATOR_DEFAULT_LLM_PROVIDER,
+    SIMULATOR_DEFAULT_STT_PROVIDER,
+    SIMULATOR_DEFAULT_TTS_PROVIDERS,
+)
 from tfc.settings.settings import UPLOAD_BUCKET_NAME
 from tfc.utils.storage_client import ensure_bucket, get_storage_client
 
@@ -948,18 +953,37 @@ def _validate_resolved_egress_domains(domains: Iterable[str]) -> None:
         _validate_egress_host(domain)
 
 
-def _provider_egress_domains(secrets_map: Mapping[str, Any]) -> set[str]:
-    """Return provider hosts implied by credential aliases and provider selectors."""
+def _provider_egress_domains(
+    secrets_map: Mapping[str, Any], *, simulator: bool = False
+) -> set[str]:
+    """Return provider hosts implied by credential aliases and provider selectors.
+
+    ``simulator`` fills each unset selector with the simulated caller's own default. A provider it
+    falls back to still has to be reachable, and the selectors are independent: reading them as one
+    set meant configuring any single lane dropped every other lane's host, which left the caller
+    unable to reach its speech provider and reported only as an infrastructure failure. The target
+    agent gets no defaults, because its runtime chooses providers we cannot see.
+    """
     aliases = {str(name).upper().removeprefix("SIMULATOR_") for name in secrets_map}
     values = {str(name).upper(): value for name, value in secrets_map.items()}
-    selected_audio_providers = {
-        str(values.get(name) or "").strip().lower()
-        for name in ("SIMULATOR_STT_PROVIDER", "SIMULATOR_TTS_PROVIDER")
-        if str(values.get(name) or "").strip()
-    }
-    selected_llm_provider = (
-        str(values.get("SIMULATOR_LLM_PROVIDER") or "").strip().lower()
+
+    def _lane(name: str, defaults: tuple[str, ...]) -> set[str]:
+        chosen = str(values.get(name) or "").strip().lower()
+        if chosen:
+            return {chosen}
+        return set(defaults) if simulator else set()
+
+    # A provider can serve more than one lane, so a host is justified by any lane selecting it.
+    selected_providers = (
+        _lane("SIMULATOR_STT_PROVIDER", (SIMULATOR_DEFAULT_STT_PROVIDER,))
+        | _lane("SIMULATOR_TTS_PROVIDER", SIMULATOR_DEFAULT_TTS_PROVIDERS)
+        | _lane("SIMULATOR_LLM_PROVIDER", (SIMULATOR_DEFAULT_LLM_PROVIDER,))
     )
+
+    def _uses(*names: str) -> bool:
+        """No selector resolved means nothing is excluded, which is the target agent's case."""
+        return not selected_providers or bool(selected_providers.intersection(names))
+
     domains: set[str] = set()
     if aliases & {
         "GOOGLE_APPLICATION_CREDENTIALS_JSON",
@@ -981,9 +1005,8 @@ def _provider_egress_domains(secrets_map: Mapping[str, Any]) -> set[str]:
             region = str(values.get(name) or "").strip().lower()
             if _GOOGLE_REGION.fullmatch(region):
                 domains.add(f"{region}-aiplatform.googleapis.com")
-    if aliases & {"GEMINI_API_KEY", "GOOGLE_API_KEY"} and (
-        not selected_llm_provider
-        or selected_llm_provider in {"gemini", "google", "google-ai"}
+    if aliases & {"GEMINI_API_KEY", "GOOGLE_API_KEY"} and _uses(
+        "gemini", "google", "google-ai"
     ):
         domains.add("generativelanguage.googleapis.com")
     if "VAPI_API_KEY" in aliases:
@@ -1001,21 +1024,17 @@ def _provider_egress_domains(secrets_map: Mapping[str, Any]) -> set[str]:
                 "*.turn.livekit.cloud",
             }
         )
-    if aliases & {"DEEPGRAM_API_KEY"} and (
-        not selected_audio_providers or "deepgram" in selected_audio_providers
-    ):
+    if aliases & {"DEEPGRAM_API_KEY"} and _uses("deepgram"):
         domains.add("api.deepgram.com")
-    if aliases & {"CARTESIA_API_KEY"} and (
-        not selected_audio_providers or "cartesia" in selected_audio_providers
-    ):
+    if aliases & {"CARTESIA_API_KEY"} and _uses("cartesia"):
         domains.add("api.cartesia.ai")
-    if aliases & {"OPENAI_API_KEY"} and (
-        not selected_llm_provider or selected_llm_provider == "openai"
+    if aliases & {"ELEVENLABS_API_KEY", "ELEVEN_API_KEY"} and _uses(
+        "elevenlabs", "eleven_labs"
     ):
+        domains.add("api.elevenlabs.io")
+    if aliases & {"OPENAI_API_KEY"} and _uses("openai"):
         domains.add("api.openai.com")
-    if aliases & {"ANTHROPIC_API_KEY"} and (
-        not selected_llm_provider or selected_llm_provider == "anthropic"
-    ):
+    if aliases & {"ANTHROPIC_API_KEY"} and _uses("anthropic"):
         domains.add("api.anthropic.com")
     return domains
 
@@ -1040,7 +1059,7 @@ def _resolved_egress_domains(
         callback_host = _hostname_from_url(callback_host)
     values: list[str] = [domain for domain in base_domains if isinstance(domain, str)]
     values.extend(_provider_egress_domains(target_secrets))
-    values.extend(_provider_egress_domains(simulator_env))
+    values.extend(_provider_egress_domains(simulator_env, simulator=True))
     # The simulated caller rides the platform LiveKit server whenever the target connector does
     # not supply its own (Vapi/Retell); its signaling and TURN hosts are platform config, never
     # derivable from customer input. LiveKit targets share the customer's server, so skipping

--- a/futureagi/simulate/services/hosted_runner.py
+++ b/futureagi/simulate/services/hosted_runner.py
@@ -36,6 +36,17 @@ from simulate.models import AgentDefinition, CallExecution, Scenarios, TestExecu
 
 logger = structlog.get_logger(__name__)
 
+# The simulated caller's own provider defaults. Egress derivation imports these: a provider the
+# simulator falls back to still has to be reachable from the sandbox.
+SIMULATOR_DEFAULT_LLM_PROVIDER = "openai"
+SIMULATOR_DEFAULT_STT_PROVIDER = "deepgram"
+SIMULATOR_DEFAULT_TTS_PROVIDER_ENGLISH = "deepgram"
+SIMULATOR_DEFAULT_TTS_PROVIDER_OTHER = "gemini"
+SIMULATOR_DEFAULT_TTS_PROVIDERS = (
+    SIMULATOR_DEFAULT_TTS_PROVIDER_ENGLISH,
+    SIMULATOR_DEFAULT_TTS_PROVIDER_OTHER,
+)
+
 _SPEC_SCHEMA_VERSION = "futureagi.simulation-spec.v1"
 _JOB_SCHEMA_VERSION = "futureagi.runner-job.v1"
 
@@ -914,7 +925,8 @@ def _voice_simulator_config(
     dataset: list[dict[str, Any]] | None = None,
 ) -> dict[str, Any]:
     stt = {
-        "provider": _voice_setting("SIMULATOR_STT_PROVIDER") or "deepgram",
+        "provider": _voice_setting("SIMULATOR_STT_PROVIDER")
+        or SIMULATOR_DEFAULT_STT_PROVIDER,
         "model": _voice_setting("SIMULATOR_STT_MODEL") or "nova-3",
     }
     language = _voice_setting("SIMULATOR_STT_LANGUAGE") or _dataset_language(dataset)
@@ -929,10 +941,13 @@ def _voice_simulator_config(
     # otherwise come out as English gibberish. Env overrides
     # (SIMULATOR_TTS_PROVIDER / SIMULATOR_TTS_MODEL) still win per field.
     if _is_english_language(language):
-        default_tts_provider, default_tts_model = "deepgram", "aura-2-andromeda-en"
+        default_tts_provider, default_tts_model = (
+            SIMULATOR_DEFAULT_TTS_PROVIDER_ENGLISH,
+            "aura-2-andromeda-en",
+        )
     else:
         default_tts_provider, default_tts_model = (
-            "gemini",
+            SIMULATOR_DEFAULT_TTS_PROVIDER_OTHER,
             "gemini-3.1-flash-tts-preview",
         )
     tts = {
@@ -946,7 +961,8 @@ def _voice_simulator_config(
             # hosted worker. The previous Google default selected Vertex from
             # a configured-but-unmounted credentials path, so the simulator
             # never spoke and otherwise-connected calls timed out.
-            "provider": _voice_setting("SIMULATOR_LLM_PROVIDER") or "openai",
+            "provider": _voice_setting("SIMULATOR_LLM_PROVIDER")
+            or SIMULATOR_DEFAULT_LLM_PROVIDER,
             "model": _voice_setting("SIMULATOR_LLM_MODEL") or "gpt-4.1",
         },
         "stt": stt,

--- a/futureagi/simulate/tests/test_hosted_harness_gateway.py
+++ b/futureagi/simulate/tests/test_hosted_harness_gateway.py
@@ -260,6 +260,63 @@ def test_provider_egress_uses_selected_simulator_llm_provider():
     assert domains == {"api.openai.com"}
 
 
+def test_simulator_keeps_its_default_stt_host_when_only_tts_is_configured():
+    """Configuring one lane must not drop another lane's default provider host.
+
+    A deployment that set only ``SIMULATOR_TTS_PROVIDER`` lost ``api.deepgram.com``, so the
+    simulated caller could not transcribe the agent and every call failed as infrastructure.
+    """
+    domains = _provider_egress_domains(
+        {
+            "SIMULATOR_DEEPGRAM_API_KEY": "configured",
+            "SIMULATOR_CARTESIA_API_KEY": "configured",
+            "SIMULATOR_TTS_PROVIDER": "cartesia",
+        },
+        simulator=True,
+    )
+
+    assert domains == {"api.deepgram.com", "api.cartesia.ai"}
+
+
+def test_simulator_with_no_selectors_gets_the_hosts_its_defaults_need():
+    domains = _provider_egress_domains(
+        {
+            "SIMULATOR_DEEPGRAM_API_KEY": "configured",
+            "SIMULATOR_GEMINI_API_KEY": "configured",
+            "SIMULATOR_OPENAI_API_KEY": "configured",
+            "SIMULATOR_ANTHROPIC_API_KEY": "configured",
+        },
+        simulator=True,
+    )
+
+    # Deepgram speech, the Gemini voice a non-English persona falls back to, and the OpenAI chat
+    # model. Anthropic is not a simulator default, so its host would only waste a domain slot.
+    assert domains == {
+        "api.deepgram.com",
+        "generativelanguage.googleapis.com",
+        "api.openai.com",
+    }
+
+
+def test_target_agent_credentials_get_no_simulator_defaults():
+    """The target's runtime picks its own providers, so presence of the credential is the signal."""
+    domains = _provider_egress_domains(
+        {"CARTESIA_API_KEY": "configured", "ANTHROPIC_API_KEY": "configured"}
+    )
+
+    assert domains == {"api.cartesia.ai", "api.anthropic.com"}
+
+
+def test_provider_egress_includes_elevenlabs_when_selected():
+    assert _provider_egress_domains(
+        {
+            "SIMULATOR_ELEVENLABS_API_KEY": "configured",
+            "SIMULATOR_TTS_PROVIDER": "elevenlabs",
+        },
+        simulator=True,
+    ) == {"api.elevenlabs.io"}
+
+
 def test_livekit_cloud_connector_egress_is_wildcard_minimized(settings):
     settings.ALK_HOSTED_BASE_EGRESS_DOMAINS = []
     payload = {


### PR DESCRIPTION
## Problem

The simulated caller picks its providers in `hosted_runner._voice_simulator_config`, which falls back
to Deepgram for speech-to-text, Deepgram or Gemini for text-to-speech depending on the persona's
language, and OpenAI for chat. The egress resolver did not know about any of those defaults. It read
`SIMULATOR_STT_PROVIDER` and `SIMULATOR_TTS_PROVIDER` into a single set and treated an empty set as
"no constraint":

```python
selected_audio_providers = {... for name in ("SIMULATOR_STT_PROVIDER", "SIMULATOR_TTS_PROVIDER") if set}
if aliases & {"DEEPGRAM_API_KEY"} and (not selected_audio_providers or "deepgram" in selected_audio_providers):
```

Two independent selectors sharing one set means configuring either lane constrains both. An
environment that set only `SIMULATOR_TTS_PROVIDER=cartesia` produced `{"cartesia"}`, the Deepgram
guard failed, and `api.deepgram.com` was left out of the sandbox allow list. The caller could not
transcribe the agent, so the call produced no turns and surfaced to the user as
`Infrastructure - Call failed` with nothing else to go on. This is reachable from the UI: any run
whose agent does not itself use Deepgram hits it.

Verified inside a running sandbox before the change, with the same egress list submitted both times
and only the environment variable differing:

```
before:  api.deepgram.com http=000 (blocked)   cartesia 200   livekit 200
after:   api.deepgram.com http=404 (reachable) cartesia 200   livekit 200
```

## Fix

Resolve each lane independently and fill an unset one with the simulator's own default, then let any
lane justify a host. The defaults now live as named constants in `hosted_runner` and are imported by
the resolver, so the two cannot drift apart again.

The target agent keeps today's behaviour exactly: it gets no defaults, because its runtime chooses
providers we cannot see, so credential presence remains the only signal there.

Also folded in ElevenLabs, which the resolver had no entry for at all.

## Effect on resolved egress

For a simulator environment with Deepgram, Cartesia, OpenAI and Gemini credentials present:

| configuration | before | after |
|---|---|---|
| `SIMULATOR_TTS_PROVIDER=cartesia`, STT unset, LLM vertex | `api.cartesia.ai` | `api.cartesia.ai`, `api.deepgram.com` |
| nothing configured | cartesia, deepgram, openai, generativelanguage | deepgram, openai, generativelanguage |

The first row is the bug. The second is a small saving under Daytona's 20 domain cap: Cartesia is
only reachable when something actually selects it.

## Tests

Four cases added to `simulate/tests/test_hosted_harness_gateway.py`, covering the exact production
configuration, the fully unconfigured simulator, the target agent keeping credential-presence
derivation, and ElevenLabs.

```
pytest simulate/tests/test_hosted_harness_gateway.py -k "egress or simulator"
24 passed
```

Full-file runs before and after the change give an identical failure set, all of them DB-backed
launch and reconcile tests, none touched by this change. They fail locally only: `pytest.ini` carries
`--reuse-db`, and the reused database holds `diagnostics_error` as NOT NULL while migration 0086
declares it `null=True`. A run with `--create-db` should clear them, and CI builds the schema fresh.

Base merged in rather than rebased, so the branch carries the diagnostics work already on it.

