### PR TITLE
fix: bound sampled eval task selection scans

### DIFF
--- a/futureagi/tracer/selectors/eval_tasks/row_resolver.py
+++ b/futureagi/tracer/selectors/eval_tasks/row_resolver.py
@@ -1248,6 +1248,7 @@ def _resolve_bounded_historical_span_ids(
             read_settings=bounded_read_settings,
             classify_read_settings=bounded_classify_read_settings,
             workflow_exact=workflow_exact,
+            exact_population_time_discovery=row_type == RowType.SPANS,
             query_timeout_ms=_EVAL_TASK_FILTER_CLASSIFY_QUERY_TIMEOUT_MS,
         )
     except (TypeError, ValueError):

--- a/futureagi/tracer/selectors/trace_filter_reads.py
+++ b/futureagi/tracer/selectors/trace_filter_reads.py
@@ -340,6 +340,7 @@ def read_bounded_filter_page(
     continuation_before_start_time: datetime | None = None,
     continuation_before_id: Any = None,
     bounded_continuation: bool = False,
+    exact_population_time_discovery: bool = False,
     carry_continuation_slice_width: bool = False,
     root_time_discovery: bool = False,
     read_settings: dict[str, Any] | None = None,
@@ -389,6 +390,8 @@ def read_bounded_filter_page(
     empty seed. This reads only project/time columns, retains all versions and
     tombstones, and does not depend on per-statement time/scan abort caps. It
     shares the same conservative interval/checkpoint validation below.
+    ``exact_population_time_discovery`` enables the same proof for a fully
+    buffered page-zero caller that rejects incomplete results.
     """
 
     if page_number < 0 or page_size <= 0 or deadline_ms <= 0:
@@ -457,6 +460,15 @@ def read_bounded_filter_page(
     if bounded_continuation and (not include_incomplete_rows or page_number != 0):
         raise ValueError(
             "bounded continuation requires page-zero classified partial rows"
+        )
+    if exact_population_time_discovery and (
+        page_number != 0
+        or cursor_start_time is not None
+        or continuation_slice_end is not None
+        or include_incomplete_rows
+    ):
+        raise ValueError(
+            "exact population discovery requires a fully buffered page-zero read"
         )
     if carry_continuation_slice_width and not bounded_continuation:
         raise ValueError("continuation slice width carry requires bounded continuation")
@@ -1416,7 +1428,7 @@ def read_bounded_filter_page(
         builder, "build_filter_population_time_discovery_query", None
     )
     population_discovery = bool(
-        bounded_continuation
+        (bounded_continuation or exact_population_time_discovery)
         and key_field == "id"
         and not anchor_probe_only
         and not defer_classification
@@ -2173,7 +2185,10 @@ def read_bounded_filter_page(
         a 10k+1 rejection sentinel.
         """
 
-        nonlocal initial_identity_flush_pending, adaptive_identity_start, empty_prefix_seed
+        nonlocal \
+            initial_identity_flush_pending, \
+            adaptive_identity_start, \
+            empty_prefix_seed
 
         if (
             not identity_only_classification

--- a/futureagi/tracer/services/clickhouse/v2/query_builders/span_list.py
+++ b/futureagi/tracer/services/clickhouse/v2/query_builders/span_list.py
@@ -91,7 +91,6 @@ class SpanListQueryBuilderV2(V2RewriteMixin, SpanListQueryBuilder):
         return bool(
             end - start > timedelta(hours=1)
             and not self._bounded_anchor_probe
-            and self._bounded_sampling_rate is None
             and not self.sort_params
             and not self.supports_filter_candidate_seed_page()
         )
@@ -146,7 +145,8 @@ class SpanListQueryBuilderV2(V2RewriteMixin, SpanListQueryBuilder):
                     value_types := cfg.get(
                         "attribute_value_types", cfg.get("attributeValueTypes")
                     )
-                ) is None
+                )
+                is None
                 or (
                     isinstance(
                         values := cfg.get("filter_value", cfg.get("filterValue")), list
@@ -163,6 +163,13 @@ class SpanListQueryBuilderV2(V2RewriteMixin, SpanListQueryBuilder):
         # Thin text/time probes stay daily; other equality/IN witnesses reuse
         # compiler-proven raw values and other supported leaves keep presence.
         start, end = self._bounded_request_window
+        if (
+            self._bounded_sampling_rate is not None
+            and not self._filter_population_plans()
+        ):
+            # The hourly raw population is a complete superset of the sampled
+            # task population without loading rows through FINAL.
+            return end - start
         return (
             end - start
             if self._filter_population_plans()
@@ -190,14 +197,20 @@ class SpanListQueryBuilderV2(V2RewriteMixin, SpanListQueryBuilder):
         # Keep every cheap necessary conjunct: using just one common value
         # repeatedly visits hours with no joint match when results are sparse.
         # Compile together so each predicate retains distinct parameter names.
-        plans, _ = partition_span_filter_plans([
-            item for item, cfg in raw_leaves
-            if (cfg.get("filter_type") or cfg.get("filterType")) in {"number", "boolean"}
-            # Never extract one branch from a picker OR across physical Maps.
-            and cfg.get("attribute_value_types", cfg.get("attributeValueTypes")) is None
-        ])
+        plans, _ = partition_span_filter_plans(
+            [
+                item
+                for item, cfg in raw_leaves
+                if (cfg.get("filter_type") or cfg.get("filterType"))
+                in {"number", "boolean"}
+                # Never extract one branch from a picker OR across physical Maps.
+                and cfg.get("attribute_value_types", cfg.get("attributeValueTypes"))
+                is None
+            ]
+        )
         return [
-            plan for plan in plans
+            plan
+            for plan in plans
             if not plan.exclude_group_matches
             and self._filter_population_plan_predicate(plan, ordinary_seed=True)
         ]
@@ -209,9 +222,12 @@ class SpanListQueryBuilderV2(V2RewriteMixin, SpanListQueryBuilder):
         probes retain daily widths; witness-filtered probes eventually widen
         to the remaining request. Neither policy truncates older history.
         """
-        if not self._filter_population_plans():
-            return None
+        plans = self._filter_population_plans()
         start, end = self._bounded_request_window
+        if self._bounded_sampling_rate is not None and not plans:
+            return (end - start,)
+        if not plans:
+            return None
         width = end - start
         if self._uses_thin_text_population_discovery():
             return (min(width, timedelta(days=1)),)
@@ -235,19 +251,81 @@ class SpanListQueryBuilderV2(V2RewriteMixin, SpanListQueryBuilder):
         if not self.supports_filter_population_time_discovery():
             raise ValueError("span population discovery is unavailable")
         population_plans = self._filter_population_plans()
+        if self._bounded_sampling_rate == 0:
+            return (
+                "SELECT CAST(NULL AS Nullable(Int64)) AS newest_raw_time_us",
+                dict(self.params),
+            )
+        if self._bounded_sampling_rate is not None and not population_plans:
+            # Sampling needs trace/span IDs, which turns a year-scale max-time
+            # aggregate into a wide raw scan on dense projects. An unsampled
+            # populated hour is a conservative superset: the unchanged seed
+            # applies the exact hash and latest-state classifier before use.
+            # Grouping in the deployed hourly projection shape keeps this
+            # timestamp-only proof cheap without permitting a false absence.
+            population_hour_start = slice_start.replace(
+                minute=0, second=0, microsecond=0
+            )
+            population_hour_end = slice_end.replace(minute=0, second=0, microsecond=0)
+            if population_hour_end < slice_end:
+                population_hour_end += timedelta(hours=1)
+            params = {
+                **self.params,
+                "population_start_us": _unix_microseconds(slice_start),
+                "population_hour_start_us": _unix_microseconds(population_hour_start),
+                "population_hour_end_us": _unix_microseconds(population_hour_end),
+            }
+            return (
+                f"""
+                SELECT if(
+                    newest_hour_us IS NULL,
+                    CAST(NULL AS Nullable(Int64)),
+                    greatest(newest_hour_us, %(population_start_us)s)
+                ) AS newest_raw_time_us
+                FROM (
+                    SELECT maxOrNull(
+                        toUnixTimestamp64Micro(
+                            toDateTime64(population_hour, 6, 'UTC')
+                        )
+                    ) AS newest_hour_us
+                    FROM (
+                        SELECT
+                            project_id,
+                            toStartOfHour(start_time) AS population_hour,
+                            count() AS population_count
+                        FROM {self.TABLE}
+                        PREWHERE {self.project_filter_sql()}
+                        WHERE toStartOfHour(start_time) >=
+                            fromUnixTimestamp64Micro(%(population_hour_start_us)s)
+                          AND toStartOfHour(start_time) <
+                            fromUnixTimestamp64Micro(%(population_hour_end_us)s)
+                        GROUP BY project_id, population_hour
+                    )
+                )
+                """,
+                params,
+            )
         if self._uses_thin_text_population_discovery():
             # NULL proves only this adjacent day. Every raw hit replays its
             # complete physical hour; stale/missing values only add work.
             population_plans = []
         elif witnesses := self._mixed_population_plans():
             population_plans = witnesses
-        key_scope = (
-            "WHERE "
-            + " AND ".join(
-                f"({self._filter_population_plan_predicate(plan, ordinary_seed=True)})"
-                for plan in population_plans
+        population_predicates = [
+            f"({self._filter_population_plan_predicate(plan, ordinary_seed=True)})"
+            for plan in population_plans
+        ]
+        if self._bounded_sampling_rate is not None:
+            # Sampling is stable across physical versions, so stale versions
+            # can only add conservative timestamp witnesses.
+            population_predicates.append(
+                "modulo(cityHash64(%(bounded_sampling_salt)s, "
+                "toString(project_id), toString(trace_id), toString(id)), 100) "
+                "< %(bounded_sampling_rate)s"
             )
-            if population_plans
+        key_scope = (
+            "WHERE " + " AND ".join(population_predicates)
+            if population_predicates
             else ""
         )
         params = {
@@ -255,6 +333,11 @@ class SpanListQueryBuilderV2(V2RewriteMixin, SpanListQueryBuilder):
             "population_start_us": _unix_microseconds(slice_start),
             "population_end_us": _unix_microseconds(slice_end),
         }
+        if self._bounded_sampling_rate is not None:
+            params.update(
+                bounded_sampling_salt=str(self._bounded_sampling_salt),
+                bounded_sampling_rate=float(self._bounded_sampling_rate),
+            )
         for plan in population_plans:
             params.update(
                 {

--- a/futureagi/tracer/tests/test_eval_task_bounded_selector.py
+++ b/futureagi/tracer/tests/test_eval_task_bounded_selector.py
@@ -2399,6 +2399,8 @@ def test_time_only_limit_transition_preserves_newest_first_prefix(
     assert first == second[: len(first)]
     assert calls[0]["workflow_exact"] is False
     assert calls[1]["workflow_exact"] is True
+    assert calls[0]["exact_population_time_discovery"] is True
+    assert calls[1]["exact_population_time_discovery"] is True
 
 
 @pytest.mark.parametrize(

--- a/futureagi/tracer/tests/test_span_population_time_discovery.py
+++ b/futureagi/tracer/tests/test_span_population_time_discovery.py
@@ -365,6 +365,86 @@ def test_engine_selector_preserves_latest_typed_membership(
     assert any(a.kind == "population_time_discovery" for a in payload.attempts)
 
 
+@pytest.mark.integration
+def test_exact_sampled_sparse_selection_preserves_latest_membership(request):
+    from tracer.selectors.trace_filter_reads import read_bounded_filter_page
+
+    execute, insert = request.getfixturevalue("engine")
+    sampled_ids = execute(
+        """SELECT concat('sample-', toString(number)) AS id
+           FROM numbers(100)
+           WHERE modulo(
+               cityHash64(
+                   'task-id', %(project)s, 'trace',
+                   concat('sample-', toString(number))
+               ), 100
+           ) < 50
+           LIMIT 2""",
+        {"project": PROJECT},
+    )
+    excluded_id = execute(
+        """SELECT concat('excluded-', toString(number)) AS id
+           FROM numbers(100)
+           WHERE modulo(
+               cityHash64(
+                   'task-id', %(project)s, 'trace',
+                   concat('excluded-', toString(number))
+               ), 100
+           ) >= 50
+           LIMIT 1""",
+        {"project": PROJECT},
+    )[0]["id"]
+    good_id, deleted_id = [row["id"] for row in sampled_ids]
+    stamp = START + timedelta(minutes=20)
+    insert(id=good_id, start_time=stamp)
+    insert(id=excluded_id, start_time=stamp + timedelta(minutes=1))
+    insert(id=deleted_id, start_time=stamp + timedelta(minutes=2))
+    insert(
+        id=deleted_id,
+        start_time=stamp + timedelta(minutes=2),
+        _version=2,
+        is_deleted=1,
+    )
+
+    filters = [time_filter(START - timedelta(days=365), START + timedelta(days=1))]
+    subject = SpanListQueryBuilderV2(
+        project_id=PROJECT,
+        filters=filters,
+        bounded_internal_scan=True,
+        bounded_identity_only=True,
+        bounded_sampling_salt="task-id",
+        bounded_sampling_rate=50,
+    )
+
+    class Executor:
+        supports_bounded_speculative_reads = False
+
+        def execute_ch_query(self, sql, params, **_kwargs):
+            rows = execute(sql, params)
+            return QueryResult(rows, len(rows), "clickhouse", 0)
+
+    payload = read_bounded_filter_page(
+        builder=subject,
+        analytics=Executor(),
+        filters=filters,
+        key_field="id",
+        page_number=0,
+        page_size=25,
+        deadline_ms=30_000,
+        max_seed_attempts=64,
+        max_query_count=128,
+        exact_population_time_discovery=True,
+        query_timeout_ms=3_000,
+    )
+
+    assert payload.complete and payload.error_code is None
+    assert [row["id"] for row in payload.rows] == [good_id]
+    assert payload.query_count < 10
+    assert any(
+        attempt.kind == "population_time_discovery" for attempt in payload.attempts
+    )
+
+
 @pytest.fixture
 def population_clock(monkeypatch):
     import tracer.selectors.trace_filter_reads as selector
@@ -706,20 +786,13 @@ def test_population_multi_project_scope_preserves_colliding_physical_ids(
 
 
 @pytest.mark.unit
-@pytest.mark.parametrize(
-    "mode", ["anchor", "sample_zero", "sample_half", "sort", "score_seed", "one_hour"]
-)
+@pytest.mark.parametrize("mode", ["anchor", "sort", "score_seed", "one_hour"])
 def test_population_builder_rejects_unqualified_modes(mode):
     kwargs = {"bounded_internal_scan": True}
     start, end = WINDOW_START, END
     additional_filters = []
     if mode == "anchor":
         kwargs["bounded_anchor_probe"] = True
-    elif mode.startswith("sample"):
-        kwargs.update(
-            bounded_sampling_salt="population-mode-test",
-            bounded_sampling_rate=0 if mode == "sample_zero" else 50,
-        )
     elif mode == "sort":
         kwargs["sort_params"] = [{"column_id": "cost", "direction": "asc"}]
     elif mode == "score_seed":
@@ -750,6 +823,107 @@ def test_population_builder_rejects_unqualified_modes(mode):
         subject.build_filter_population_time_discovery_query(
             slice_start=end - timedelta(hours=1), slice_end=end
         )
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("rate", [50.0, 100.0])
+def test_sampled_time_only_discovery_uses_hourly_population_superset(rate):
+    subject = SpanListQueryBuilderV2(
+        project_id=PROJECT,
+        filters=[time_filter(WINDOW_START, END)],
+        bounded_internal_scan=True,
+        bounded_sampling_salt="task-id",
+        bounded_sampling_rate=rate,
+    )
+
+    assert subject.supports_filter_population_time_discovery()
+    width = END - WINDOW_START
+    assert subject.recommended_filter_population_time_discovery_window() == width
+    assert subject.recommended_filter_population_time_discovery_windows() == (width,)
+
+    sql, params = subject.build_filter_population_time_discovery_query(
+        slice_start=WINDOW_START, slice_end=END
+    )
+    normalized_sql = " ".join(sql.split())
+    assert "FROM spans PREWHERE" in normalized_sql
+    assert "FINAL" not in normalized_sql
+    assert "cityHash64" not in normalized_sql
+    assert "toStartOfHour(start_time) AS population_hour" in normalized_sql
+    assert "count() AS population_count" in normalized_sql
+    assert "GROUP BY project_id, population_hour" in normalized_sql
+    assert "greatest(newest_hour_us, %(population_start_us)s)" in normalized_sql
+    assert params["population_start_us"] == _us(WINDOW_START)
+    assert params["population_hour_start_us"] <= params["population_start_us"]
+    assert params["population_hour_end_us"] >= _us(END)
+
+
+@pytest.mark.unit
+def test_zero_sample_population_discovery_is_constant_empty():
+    subject = SpanListQueryBuilderV2(
+        project_id=PROJECT,
+        filters=[time_filter(WINDOW_START, END)],
+        bounded_internal_scan=True,
+        bounded_sampling_salt="task-id",
+        bounded_sampling_rate=0,
+    )
+
+    sql, params = subject.build_filter_population_time_discovery_query(
+        slice_start=WINDOW_START, slice_end=END
+    )
+
+    assert "FROM spans" not in sql
+    assert "CAST(NULL AS Nullable(Int64)) AS newest_raw_time_us" in sql
+    assert params["project_id"] == PROJECT
+
+
+@pytest.mark.unit
+def test_sampled_witness_discovery_retains_exact_hash():
+    subject = SpanListQueryBuilderV2(
+        project_id=PROJECT,
+        filters=[
+            time_filter(WINDOW_START, END),
+            {
+                "column_id": "latency_s",
+                "filter_config": {
+                    "col_type": "SPAN_ATTRIBUTE",
+                    "filter_type": "number",
+                    "filter_op": "greater_than",
+                    "filter_value": 1,
+                },
+            },
+        ],
+        bounded_internal_scan=True,
+        bounded_sampling_salt="task-id",
+        bounded_sampling_rate=50,
+    )
+
+    sql, params = subject.build_filter_population_time_discovery_query(
+        slice_start=WINDOW_START, slice_end=END
+    )
+    normalized_sql = " ".join(sql.split())
+    assert "cityHash64" in normalized_sql
+    assert "toString(project_id)" in normalized_sql
+    assert "toString(trace_id)" in normalized_sql
+    assert "toString(id)" in normalized_sql
+    assert params["bounded_sampling_salt"] == "task-id"
+    assert params["bounded_sampling_rate"] == 50
+
+
+@pytest.mark.unit
+def test_exact_population_discovery_does_not_require_cursor_mode(population_clock):
+    subject = fake()
+    executor = PopulationExecutor(subject)
+
+    page = run(
+        subject,
+        executor,
+        bounded_continuation=False,
+        include_incomplete_rows=False,
+        exact_population_time_discovery=True,
+    )
+
+    assert page.complete
+    assert any(query == "population_probe" for query, _ in executor.calls)
 
 
 @pytest.mark.unit


### PR DESCRIPTION
## Summary

Prevents exact historical span evaluation tasks from repeatedly walking empty time slices when sampled rows are sparse. Sampled time-only discovery uses the hourly project population as a conservative bound while the existing seed and latest-state classifier retain exact sampling, replacement, and tombstone semantics.

Linear: [TH-7936](https://linear.app/future-agi/issue/TH-7936/bound-sampled-evaluation-task-selection-reads)

## Type of change

- [x] Bug fix
- [x] Performance improvement

## E2E coverage

E2E: exempt (backend-internal)

## Changes

- Enable exact population discovery only for fully buffered page-zero span evaluation reads.
- Use hourly project population discovery for sampled time-only selection.
- Preserve exact hash sampling in seed/classification and filtered witness paths.
- Add selector, sampling, boundary, replacement, and tombstone regression coverage.

## Validation

- `569 passed, 10 skipped` for the focused selector/query-builder suite.
- Ruff lint and format checks pass for all five changed files.
- `git diff --check` passes.
- Read-only production query validation reduced the one-year discovery query to approximately 4.8 MB and 0.6-0.8 seconds on the tested dense project.

## Known limitations

- Very low sampling rates can still require repeated discovery across occupied hours.
- Sparse filtered tasks can still use raw witness discovery over long ranges.
- Projection selection currently depends on ClickHouse optimizer routing.

This is opened as a draft while those worst-case scalability paths are reviewed.

## How to test

```bash
cd futureagi
uv run pytest tracer/tests/test_span_population_time_discovery.py tracer/tests/test_eval_task_bounded_selector.py tracer/tests/test_bounded_trace_filter_reads.py -q
```

No API contract, migration, or frontend files changed.
