### PR TITLE
fix(prompt-workbench): keep image/audio metadata on save (TH-7926)

### DIFF
--- a/frontend/src/components/PromptCards/common.js
+++ b/frontend/src/components/PromptCards/common.js
@@ -599,8 +599,6 @@ export const getBlocks = (quill) => {
         type: "image_url",
         image_url: {
           ...imageObject,
-          img_name: imageObject.imgName,
-          img_size: imageObject.imgSize,
         },
       });
       imageObject = null;
@@ -610,9 +608,6 @@ export const getBlocks = (quill) => {
         type: "audio_url",
         audio_url: {
           ...audioObject,
-          audio_name: audioObject.audioName,
-          audio_size: audioObject.audioSize,
-          audio_type: audioObject.audioType,
         },
       });
       audioObject = null;

--- a/frontend/src/components/PromptCards/common.test.js
+++ b/frontend/src/components/PromptCards/common.test.js
@@ -68,58 +68,63 @@ describe("getBlocks", () => {
     expect(getBlocks(quill)).toEqual([{ type: "text", text: "Hello world" }]);
   });
 
-  it("returns image block with snake_case inner keys", () => {
+  it("keeps the image blot's snake_case metadata on save", () => {
+    // ImageBlot.value() stores { url, img_name, img_size } in data-image-data,
+    // so imageData carries snake_case keys — there is no imgName/imgSize.
     const quill = mockQuill([
       {
         insert: {
           ImageBlot: {
-            imageData: { url: "https://img.com", imgName: "x", imgSize: 100 },
+            imageData: { url: "https://img.com", img_name: "x", img_size: 100 },
           },
         },
       },
     ]);
-    expect(getBlocks(quill)).toEqual([
-      {
-        type: "image_url",
-        image_url: {
-          url: "https://img.com",
-          imgName: "x",
-          imgSize: 100,
-          img_name: "x",
-          img_size: 100,
-        },
-      },
+    const [block] = getBlocks(quill);
+    expect(block).toEqual({
+      type: "image_url",
+      image_url: { url: "https://img.com", img_name: "x", img_size: 100 },
+    });
+    // After JSON serialization (what the save path sends) the block must still
+    // carry exactly the keys PromptEditor rebuilds the card from on reload.
+    expect(Object.keys(JSON.parse(JSON.stringify(block.image_url)))).toEqual([
+      "url",
+      "img_name",
+      "img_size",
     ]);
   });
 
-  it("returns audio block with snake_case inner keys", () => {
+  it("keeps the audio blot's snake_case metadata on save", () => {
+    // AudioBlot.value() stores snake_case keys in data-audio-data.
     const quill = mockQuill([
       {
         insert: {
           AudioBlot: {
             audioData: {
               url: "https://aud.io",
-              audioName: "a",
-              audioSize: 200,
-              audioType: "mp3",
+              audio_name: "a",
+              audio_size: 200,
+              audio_type: "mp3",
             },
           },
         },
       },
     ]);
-    expect(getBlocks(quill)).toEqual([
-      {
-        type: "audio_url",
-        audio_url: {
-          url: "https://aud.io",
-          audioName: "a",
-          audioSize: 200,
-          audioType: "mp3",
-          audio_name: "a",
-          audio_size: 200,
-          audio_type: "mp3",
-        },
+    const [block] = getBlocks(quill);
+    expect(block).toEqual({
+      type: "audio_url",
+      audio_url: {
+        url: "https://aud.io",
+        audio_name: "a",
+        audio_size: 200,
+        audio_type: "mp3",
       },
+    });
+    expect(Object.keys(JSON.parse(JSON.stringify(block.audio_url)))).toEqual([
+      "url",
+      "audio_name",
+      "audio_size",
+      "audio_type",
     ]);
   });
 
@@ -152,7 +157,7 @@ describe("getBlocks", () => {
       {
         insert: {
           ImageBlot: {
-            imageData: { url: "https://img.com", imgName: "x", imgSize: 100 },
+            imageData: { url: "https://img.com", img_name: "x", img_size: 100 },
           },
         },
       },
@@ -162,13 +167,7 @@ describe("getBlocks", () => {
       { type: "text", text: "before" },
       {
         type: "image_url",
-        image_url: {
-          url: "https://img.com",
-          imgName: "x",
-          imgSize: 100,
-          img_name: "x",
-          img_size: 100,
-        },
+        image_url: { url: "https://img.com", img_name: "x", img_size: 100 },
       },
       { type: "text", text: "after" },
     ]);


### PR DESCRIPTION
## TH-7926

Prompt workbench editor dropped an attached image's `img_name`/`img_size` on save → the image card rendered as a generic/broken "Image" card after reload.

### Root cause
`getBlocks` (`frontend/src/components/PromptCards/common.js`) spread the blot object (already `{ url, img_name, img_size }` snake_case) and then re-overwrote `img_name`/`img_size` with `imageObject.imgName`/`imgSize` — **camelCase keys that don't exist** on the object. They resolved to `undefined` and `JSON.stringify` dropped them, so the persisted block kept only `url`. Audio had the identical latent bug (`audio_name`/`audio_size`/`audio_type`). PDF was already correct.

### Fix
Delete the dead camelCase overwrites for image and audio; the spread already carries the correct snake_case values.

### The misleading test (PR headline)
The existing `getBlocks` unit tests fed the blots a **camelCase shape the blots never produce**, so the buggy overwrites "worked" and the tests passed against broken production code. Rewritten to the real snake_case shape the blots emit, with a `JSON.stringify` round-trip assertion (the keys `PromptEditor` reads back on reload).

### Verification
- Unit: red-first showed `img_name: undefined` (the exact defect), green after the fix. Full `PromptCards` suite 16/16. Prettier + eslint clean.
- Backend (code trace): every run funnels media blocks through `handle_media()` which **rebuilds each block reading only `url`** (image → base64 `image_url`, audio → `input_audio`), so the restored metadata keys never reach any `litellm.completion`/provider call. No inbound strict schema rejects them. **The fix cannot cause a provider-side rejection on run.**
- Live: run against a vision model reached the provider and failed only on an expired provider key (`Incorrect API key` / `invalid x-api-key`) — i.e. the backend accepted the metadata-laden payload and forwarded it; the failure is unrelated to this change.

### Follow-up (separate, on the e2e branch)
Extend `e2e/flows/prompts/attach-media-draft.spec.ts` (PROMPT-E2E-017) to assert `img_name`/`img_size` persist — it currently asserts only `url` because this bug blocked it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

![th7926-fix-editor](https://github.com/user-attachments/assets/2c01f523-6e21-4adf-8b58-2f2d6817ff14)
