### PR TITLE
fix(agent-playground): show errors with partial output

### DIFF
--- a/frontend/src/sections/agent-playground/AgentBuilder/RunAgentPanel/NodeOutputDetail.jsx
+++ b/frontend/src/sections/agent-playground/AgentBuilder/RunAgentPanel/NodeOutputDetail.jsx
@@ -226,6 +226,7 @@ export default function NodeOutputDetail({ executionId, nodeExecutionId }) {
 
   const nodeStatus = nodeDetail?.status?.toLowerCase();
   const isNodeRunning = nodeStatus === "running" || nodeStatus === "pending";
+  const isNodeFailed = nodeStatus === "failed" || nodeStatus === "error";
   const nodeExecutionIdentifier =
     nodeDetail?.nodeExecutionId ||
     nodeDetail?.node_execution_id ||
@@ -237,7 +238,9 @@ export default function NodeOutputDetail({ executionId, nodeExecutionId }) {
     () => nodeDetail?.outputs || [],
     [nodeDetail?.outputs],
   );
-  const hasErrorMessage = !!errorMessage && outputs.length === 0;
+  const hasErrorMessage =
+    isNodeFailed && !!errorMessage && outputs.length === 0;
+  const hasPartialError = isNodeFailed && !!errorMessage && outputs.length > 0;
   const isPairedMode = inputs.length > 0 && inputs.length === outputs.length;
 
   // Map API response to AG Grid row data
@@ -536,6 +539,17 @@ export default function NodeOutputDetail({ executionId, nodeExecutionId }) {
           }
         />
       </Box>
+
+      {hasPartialError && (
+        <Typography
+          role="alert"
+          typography="s2"
+          color="error.main"
+          sx={{ mb: 2, whiteSpace: "pre-wrap", wordBreak: "break-word" }}
+        >
+          {errorMessage}
+        </Typography>
+      )}
 
       {/* AG Grid Table */}
       <Box sx={{ flex: 1, minHeight: 0, overflow: "auto" }}>

--- a/frontend/src/sections/agent-playground/AgentBuilder/RunAgentPanel/__tests__/NodeOutputDetail.test.jsx
+++ b/frontend/src/sections/agent-playground/AgentBuilder/RunAgentPanel/__tests__/NodeOutputDetail.test.jsx
@@ -1,0 +1,91 @@
+/* eslint-disable react/prop-types */
+import React from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import NodeOutputDetail from "../NodeOutputDetail";
+
+let mockNodeDetail;
+
+vi.mock("src/api/agent-playground/agent-playground", () => ({
+  useGetNodeExecutionDetail: () => ({
+    data: mockNodeDetail,
+    isLoading: false,
+    isError: false,
+  }),
+}));
+
+vi.mock("src/hooks/use-ag-theme", () => ({
+  useAgThemeWith: () => ({}),
+}));
+
+vi.mock("ag-grid-react", async () => {
+  const ReactModule = await import("react");
+  return {
+    AgGridReact: ReactModule.forwardRef(function MockAgGridReact(
+      { rowData },
+      _ref,
+    ) {
+      return (
+        <pre data-testid="node-output-grid">{JSON.stringify(rowData)}</pre>
+      );
+    }),
+  };
+});
+
+describe("NodeOutputDetail", () => {
+  beforeEach(() => {
+    mockNodeDetail = {
+      status: "failed",
+      node_execution_id: "node-execution-1",
+      inputs: [],
+      outputs: [],
+      error_message: "Node failed before producing output",
+    };
+  });
+
+  const renderNodeOutputDetail = () =>
+    render(
+      <NodeOutputDetail
+        executionId="execution-1"
+        nodeExecutionId="node-execution-1"
+      />,
+    );
+
+  it("shows the failure alongside partial node output", () => {
+    mockNodeDetail.outputs = [{ payload: "partial result" }];
+    mockNodeDetail.error_message = "Provider connection failed";
+
+    renderNodeOutputDetail();
+
+    expect(screen.getByRole("alert")).toHaveTextContent(
+      "Provider connection failed",
+    );
+    expect(screen.getByTestId("node-output-grid")).toHaveTextContent(
+      "partial result",
+    );
+  });
+
+  it("shows the failure when the node has no output", () => {
+    renderNodeOutputDetail();
+
+    expect(screen.getByTestId("node-output-grid")).toHaveTextContent(
+      "Node failed before producing output",
+    );
+  });
+
+  it("keeps successful node output unchanged without showing an error", () => {
+    mockNodeDetail.status = "success";
+    mockNodeDetail.outputs = [{ payload: "complete result" }];
+    mockNodeDetail.error_message = "Stale failure from an earlier attempt";
+
+    renderNodeOutputDetail();
+
+    expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+    expect(screen.getByTestId("node-output-grid")).toHaveTextContent(
+      "complete result",
+    );
+    expect(screen.getByTestId("node-output-grid")).not.toHaveTextContent(
+      "Stale failure from an earlier attempt",
+    );
+  });
+});


### PR DESCRIPTION
Show the failure reason for Agent Playground nodes that produced partial output before failing.

- Detect failed/error node status independently of output count
- Display the failure reason alongside partial output
- Preserve empty-output error presentation and successful-node behavior
- Add focused tests

Closes #2503.