### PR TITLE
fix(agent-playground): display node execution duration (#2509)

### DIFF
--- a/frontend/src/sections/agent-playground/AgentBuilder/RunAgentPanel/NodeOutputDetail.jsx
+++ b/frontend/src/sections/agent-playground/AgentBuilder/RunAgentPanel/NodeOutputDetail.jsx
@@ -13,6 +13,8 @@ import { AgGridReact } from "ag-grid-react";
 import { useAgThemeWith } from "src/hooks/use-ag-theme";
 import { useGetNodeExecutionDetail } from "src/api/agent-playground/agent-playground";
 import CustomJsonViewer from "src/components/custom-json-viewer/CustomJsonViewer";
+import { formatDuration } from "src/utils/format-time";
+import SvgColor from "src/components/svg-color";
 
 const tryParseJson = (str) => {
   if (typeof str !== "string") return null;
@@ -226,6 +228,17 @@ export default function NodeOutputDetail({ executionId, nodeExecutionId }) {
 
   const nodeStatus = nodeDetail?.status?.toLowerCase();
   const isNodeRunning = nodeStatus === "running" || nodeStatus === "pending";
+  const durationSeconds = Number(nodeDetail?.duration_seconds);
+  const shouldShowDuration =
+    !isNodeRunning &&
+    nodeStatus !== "idle" &&
+    nodeStatus !== "skipped" &&
+    nodeDetail?.duration_seconds != null &&
+    Number.isFinite(durationSeconds) &&
+    durationSeconds >= 0;
+  const formattedDuration = shouldShowDuration
+    ? formatDuration(durationSeconds)
+    : null;
   const nodeExecutionIdentifier =
     nodeDetail?.nodeExecutionId ||
     nodeDetail?.node_execution_id ||
@@ -511,7 +524,7 @@ export default function NodeOutputDetail({ executionId, nodeExecutionId }) {
           mb: 2,
         }}
       >
-        <Box>
+        <Box sx={{ display: "flex", alignItems: "center", gap: 1 }}>
           <Typography
             typography="m3"
             fontWeight="fontWeightMedium"
@@ -519,6 +532,31 @@ export default function NodeOutputDetail({ executionId, nodeExecutionId }) {
           >
             Agent flow results
           </Typography>
+          {formattedDuration && (
+            <Box
+              component="span"
+              data-testid="node-execution-duration"
+              aria-label={`Duration: ${formattedDuration}`}
+              sx={{
+                display: "inline-flex",
+                alignItems: "center",
+                gap: 0.5,
+              }}
+            >
+              <SvgColor
+                src="/assets/icons/navbar/ic_new_clock.svg"
+                sx={{ width: 14, height: 14, bgcolor: "text.disabled" }}
+              />
+              <Typography
+                component="span"
+                typography="s2"
+                color="text.secondary"
+                fontWeight="fontWeightRegular"
+              >
+                {formattedDuration}
+              </Typography>
+            </Box>
+          )}
         </Box>
 
         <FormControlLabel

--- a/frontend/src/sections/agent-playground/AgentBuilder/RunAgentPanel/__tests__/NodeOutputDetail.test.jsx
+++ b/frontend/src/sections/agent-playground/AgentBuilder/RunAgentPanel/__tests__/NodeOutputDetail.test.jsx
@@ -125,7 +125,9 @@ describe("NodeOutputDetail duration", () => {
       <NodeOutputDetail executionId="execution-1" nodeExecutionId={null} />,
     );
 
-    expect(screen.getByText("Select a node to view details")).toBeInTheDocument();
+    expect(
+      screen.getByText("Select a node to view details"),
+    ).toBeInTheDocument();
     expect(
       screen.queryByTestId("node-execution-duration"),
     ).not.toBeInTheDocument();

--- a/frontend/src/sections/agent-playground/AgentBuilder/RunAgentPanel/__tests__/NodeOutputDetail.test.jsx
+++ b/frontend/src/sections/agent-playground/AgentBuilder/RunAgentPanel/__tests__/NodeOutputDetail.test.jsx
@@ -1,0 +1,133 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import NodeOutputDetail from "../NodeOutputDetail";
+import { useGetNodeExecutionDetail } from "src/api/agent-playground/agent-playground";
+
+vi.mock("src/api/agent-playground/agent-playground", () => ({
+  useGetNodeExecutionDetail: vi.fn(),
+}));
+
+vi.mock("ag-grid-react", async () => {
+  const React = await import("react");
+  const MockAgGrid = React.forwardRef(function MockAgGrid(_props, _ref) {
+    return <div data-testid="ag-grid-mock" />;
+  });
+  return { AgGridReact: MockAgGrid };
+});
+
+vi.mock("src/hooks/use-ag-theme", () => ({
+  useAgThemeWith: () => ({}),
+}));
+
+vi.mock("src/components/custom-json-viewer/CustomJsonViewer", () => ({
+  default: () => null,
+}));
+
+vi.mock("src/components/svg-color", () => ({
+  default: ({ src, ...props }) => (
+    <span data-testid="duration-icon" data-src={src} {...props} />
+  ),
+}));
+
+const renderNodeDetail = (detail) => {
+  useGetNodeExecutionDetail.mockReturnValue({
+    data: detail,
+    isLoading: false,
+    isError: false,
+  });
+
+  return render(
+    <NodeOutputDetail executionId="execution-1" nodeExecutionId="node-1" />,
+  );
+};
+
+describe("NodeOutputDetail duration", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("formats a completed node duration in seconds", () => {
+    renderNodeDetail({
+      status: "success",
+      duration_seconds: 5.2,
+      inputs: [],
+      outputs: [],
+    });
+
+    expect(screen.getByTestId("node-execution-duration")).toHaveAttribute(
+      "aria-label",
+      "Duration: 5.2s",
+    );
+    expect(screen.getByText("5.2s")).toBeInTheDocument();
+  });
+
+  it("formats longer completed node durations as minutes and seconds", () => {
+    renderNodeDetail({
+      status: "success",
+      duration_seconds: 75,
+      inputs: [],
+      outputs: [],
+    });
+
+    expect(screen.getByText("1m 15s")).toBeInTheDocument();
+  });
+
+  it("shows duration for a completed failed node", () => {
+    renderNodeDetail({
+      status: "failed",
+      duration_seconds: 12,
+      error_message: "Process timed out",
+      inputs: [],
+      outputs: [],
+    });
+
+    expect(screen.getByText("12s")).toBeInTheDocument();
+  });
+
+  it.each(["running", "pending", "skipped", "idle"])(
+    "does not show duration for a %s node",
+    (status) => {
+      renderNodeDetail({
+        status,
+        duration_seconds: 10,
+        inputs: [],
+        outputs: [],
+      });
+
+      expect(
+        screen.queryByTestId("node-execution-duration"),
+      ).not.toBeInTheDocument();
+    },
+  );
+
+  it("does not show duration when the API has no elapsed time", () => {
+    renderNodeDetail({
+      status: "success",
+      duration_seconds: null,
+      inputs: [],
+      outputs: [],
+    });
+
+    expect(
+      screen.queryByTestId("node-execution-duration"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("does not show duration for a node that never ran", () => {
+    useGetNodeExecutionDetail.mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      isError: false,
+    });
+
+    render(
+      <NodeOutputDetail executionId="execution-1" nodeExecutionId={null} />,
+    );
+
+    expect(screen.getByText("Select a node to view details")).toBeInTheDocument();
+    expect(
+      screen.queryByTestId("node-execution-duration"),
+    ).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
Closes #2509.

Selecting an executed node in a completed Agent Playground run now shows its elapsed duration beside the existing results heading. Uses the existing duration formatter and the API `duration_seconds` field.