### PR TITLE
fix(gateway): support custom provider API path prefixes (#2628)

### DIFF
--- a/agentcc-gateway/internal/contracts/generated/gateway_admin.go
+++ b/agentcc-gateway/internal/contracts/generated/gateway_admin.go
@@ -6,6 +6,7 @@ type ProviderConfig struct {
 	APIKey             *string  `json:"api_key,omitempty"`
 	BaseURL            *string  `json:"base_url,omitempty"`
 	APIFormat          *string  `json:"api_format,omitempty"`
+	APIPathPrefix      *string  `json:"api_path_prefix,omitempty"`
 	Models             []string `json:"models,omitempty"`
 	Timeout            *int     `json:"timeout,omitempty"`
 	Weight             *float64 `json:"weight,omitempty"`

--- a/agentcc-gateway/internal/contracts/generated/gateway_admin_test.go
+++ b/agentcc-gateway/internal/contracts/generated/gateway_admin_test.go
@@ -38,6 +38,18 @@ func TestOrgConfigContractRoundTripsIntoGatewayTenantConfig(t *testing.T) {
 	if openai.APIKey != "sk-test-openai" {
 		t.Fatalf("provider api key mismatch: %q", openai.APIKey)
 	}
+	emptyPrefix := ""
+	contract.Providers["openai"].APIPathPrefix = &emptyPrefix
+	encoded, err = json.Marshal(contract)
+	if err != nil {
+		t.Fatalf("encode generated contract with path prefix: %v", err)
+	}
+	if err := json.Unmarshal(encoded, &runtime); err != nil {
+		t.Fatalf("decode gateway runtime path prefix: %v", err)
+	}
+	if got := runtime.Providers["openai"].APIPathPrefix; got == nil || *got != "" {
+		t.Fatalf("provider api path prefix mismatch: %#v", got)
+	}
 	if runtime.Routing == nil || runtime.Routing.Strategy != "weighted" {
 		t.Fatalf("routing strategy mismatch: %#v", runtime.Routing)
 	}

--- a/agentcc-gateway/internal/providers/openai/openai_test.go
+++ b/agentcc-gateway/internal/providers/openai/openai_test.go
@@ -28,6 +28,34 @@ func newTestProvider(t *testing.T, serverURL string) *Provider {
 	return p
 }
 
+func TestChatCompletion_UsesCustomAPIPathPrefix(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/chat/completions" {
+			t.Errorf("path = %s, want /chat/completions", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(models.ChatCompletionResponse{ID: "custom-prefix"})
+	}))
+	defer ts.Close()
+
+	emptyPrefix := ""
+	p, err := New("test-openai", config.ProviderConfig{
+		BaseURL:       ts.URL,
+		APIKey:        "test-key",
+		APIPathPrefix: &emptyPrefix,
+	})
+	if err != nil {
+		t.Fatalf("New() error: %v", err)
+	}
+
+	_, err = p.ChatCompletion(context.Background(), &models.ChatCompletionRequest{
+		Model: "sonar",
+	})
+	if err != nil {
+		t.Fatalf("ChatCompletion() error: %v", err)
+	}
+}
+
 // ─────────────────────────────────────────────────────────────
 // CreateImage tests
 // ─────────────────────────────────────────────────────────────

--- a/agentcc-gateway/internal/providers/override.go
+++ b/agentcc-gateway/internal/providers/override.go
@@ -19,7 +19,7 @@ import (
 // Thread-safe: protects the cache with a RWMutex.
 type OrgProviderCache struct {
 	mu        sync.RWMutex
-	providers map[string]Provider // key: "orgID:providerID"
+	providers map[string]Provider              // key: "orgID:providerID"
 	baseCfgs  map[string]config.ProviderConfig // providerID → base config
 }
 
@@ -95,6 +95,7 @@ func (c *OrgProviderCache) GetOrCreateWithTenantConfig(orgID, providerID, apiKey
 			BaseURL:            tenantCfg.BaseURL,
 			APIKey:             apiKey,
 			APIFormat:          apiFormat,
+			APIPathPrefix:      tenantCfg.APIPathPrefix,
 			DefaultTimeout:     timeout,
 			MaxConcurrent:      maxConc,
 			ConnPoolSize:       poolSize,

--- a/agentcc-gateway/internal/tenant/config.go
+++ b/agentcc-gateway/internal/tenant/config.go
@@ -7,35 +7,36 @@ package tenant
 
 // OrgConfig holds the merged configuration for a single organization.
 type OrgConfig struct {
-	Providers    map[string]*ProviderConfig `json:"providers,omitempty"`
-	Guardrails   *GuardrailConfig           `json:"guardrails,omitempty"`
-	Routing      *RoutingConfig             `json:"routing,omitempty"`
-	Cache        *CacheConfig               `json:"cache,omitempty"`
-	RateLimiting *RateLimitConfig           `json:"rate_limiting,omitempty"`
-	Budgets      *BudgetsConfig             `json:"budgets,omitempty"`
-	CostTracking *CostTrackingConfig        `json:"cost_tracking,omitempty"`
-	IPACL        *IPACLConfig               `json:"ip_acl,omitempty"`
-	Alerting     *AlertingConfig            `json:"alerting,omitempty"`
-	Privacy      *PrivacyConfig             `json:"privacy,omitempty"`
-	ToolPolicy   *ToolPolicyConfig          `json:"tool_policy,omitempty"`
+	Providers     map[string]*ProviderConfig `json:"providers,omitempty"`
+	Guardrails    *GuardrailConfig           `json:"guardrails,omitempty"`
+	Routing       *RoutingConfig             `json:"routing,omitempty"`
+	Cache         *CacheConfig               `json:"cache,omitempty"`
+	RateLimiting  *RateLimitConfig           `json:"rate_limiting,omitempty"`
+	Budgets       *BudgetsConfig             `json:"budgets,omitempty"`
+	CostTracking  *CostTrackingConfig        `json:"cost_tracking,omitempty"`
+	IPACL         *IPACLConfig               `json:"ip_acl,omitempty"`
+	Alerting      *AlertingConfig            `json:"alerting,omitempty"`
+	Privacy       *PrivacyConfig             `json:"privacy,omitempty"`
+	ToolPolicy    *ToolPolicyConfig          `json:"tool_policy,omitempty"`
 	MCP           *MCPOrgConfig              `json:"mcp,omitempty"`
 	Audit         *AuditOrgConfig            `json:"audit,omitempty"`
 	A2A           *A2AOrgConfig              `json:"a2a,omitempty"`
 	ModelDatabase *ModelDatabaseOrgConfig    `json:"model_database,omitempty"`
-	ModelMap       map[string]string          `json:"model_map,omitempty"`
+	ModelMap      map[string]string          `json:"model_map,omitempty"`
 }
 
 // ProviderConfig holds per-org provider settings.
 type ProviderConfig struct {
-	APIKey         string   `json:"api_key"`
-	BaseURL        string   `json:"base_url,omitempty"`
-	APIFormat      string   `json:"api_format,omitempty"`
-	Models         []string `json:"models,omitempty"`
-	Timeout        int      `json:"timeout,omitempty"` // seconds
-	Weight         float64  `json:"weight,omitempty"`
-	Enabled        bool     `json:"enabled"`
-	MaxConcurrent  int      `json:"max_concurrent,omitempty"`
-	ConnPoolSize   int      `json:"conn_pool_size,omitempty"`
+	APIKey        string   `json:"api_key"`
+	BaseURL       string   `json:"base_url,omitempty"`
+	APIFormat     string   `json:"api_format,omitempty"`
+	APIPathPrefix *string  `json:"api_path_prefix,omitempty"`
+	Models        []string `json:"models,omitempty"`
+	Timeout       int      `json:"timeout,omitempty"` // seconds
+	Weight        float64  `json:"weight,omitempty"`
+	Enabled       bool     `json:"enabled"`
+	MaxConcurrent int      `json:"max_concurrent,omitempty"`
+	ConnPoolSize  int      `json:"conn_pool_size,omitempty"`
 
 	// AWS Bedrock credentials (per-org, pushed from Django).
 	AWSAccessKeyID     string `json:"aws_access_key_id,omitempty"`
@@ -70,8 +71,8 @@ type RoutingConfig struct {
 	Strategy            string              `json:"strategy,omitempty"` // "round_robin", "weighted", "least_latency", "cost_optimized", "fastest"
 	FallbackEnabled     bool                `json:"fallback_enabled,omitempty"`
 	FallbackStatusCodes []int               `json:"fallback_on_status_codes,omitempty"`
-	ModelFallbacks      map[string][]string  `json:"model_fallbacks,omitempty"`
-	ConditionalRoutes   []ConditionalRoute   `json:"conditional_routes,omitempty"`
+	ModelFallbacks      map[string][]string `json:"model_fallbacks,omitempty"`
+	ConditionalRoutes   []ConditionalRoute  `json:"conditional_routes,omitempty"`
 	DefaultModel        string              `json:"default_model,omitempty"`
 
 	// Advanced routing features (Phase 12A)
@@ -83,11 +84,11 @@ type RoutingConfig struct {
 	AccessGroups map[string]*AccessGroup  `json:"access_groups,omitempty"`
 
 	// Reliability features
-	Failover       *FailoverConfig          `json:"failover,omitempty"`
-	CircuitBreaker *CircuitBreakerConfig    `json:"circuit_breaker,omitempty"`
-	Retry          *RetryConfig             `json:"retry,omitempty"`
-	Mirror         *MirrorConfig            `json:"mirror,omitempty"`
-	ModelTimeouts  map[string]string        `json:"model_timeouts,omitempty"` // model -> duration string e.g. "30s"
+	Failover       *FailoverConfig       `json:"failover,omitempty"`
+	CircuitBreaker *CircuitBreakerConfig `json:"circuit_breaker,omitempty"`
+	Retry          *RetryConfig          `json:"retry,omitempty"`
+	Mirror         *MirrorConfig         `json:"mirror,omitempty"`
+	ModelTimeouts  map[string]string     `json:"model_timeouts,omitempty"` // model -> duration string e.g. "30s"
 }
 
 // ConditionalRoute defines a metadata-based routing rule.
@@ -100,10 +101,10 @@ type ConditionalRoute struct {
 
 // ComplexityRoutingConfig routes requests to different models based on prompt complexity.
 type ComplexityRoutingConfig struct {
-	Enabled     bool                           `json:"enabled"`
-	DefaultTier string                         `json:"default_tier,omitempty"`
-	Tiers       map[string]*ComplexityTier     `json:"tiers,omitempty"`
-	Weights     map[string]float64             `json:"weights,omitempty"` // signal weights for scoring
+	Enabled     bool                       `json:"enabled"`
+	DefaultTier string                     `json:"default_tier,omitempty"`
+	Tiers       map[string]*ComplexityTier `json:"tiers,omitempty"`
+	Weights     map[string]float64         `json:"weights,omitempty"` // signal weights for scoring
 }
 
 // ComplexityTier maps a complexity tier to a model/provider.
@@ -133,12 +134,12 @@ type ScheduledConfig struct {
 
 // AdaptiveRoutingConfig dynamically adjusts provider weights based on real-time performance.
 type AdaptiveRoutingConfig struct {
-	Enabled          bool                `json:"enabled"`
-	LearningRequests int                 `json:"learning_requests,omitempty"`
-	UpdateInterval   string              `json:"update_interval,omitempty"` // duration string
-	SmoothingFactor  float64             `json:"smoothing_factor,omitempty"`
-	MinWeight        float64             `json:"min_weight,omitempty"`
-	SignalWeights    *SignalWeights      `json:"signal_weights,omitempty"`
+	Enabled          bool           `json:"enabled"`
+	LearningRequests int            `json:"learning_requests,omitempty"`
+	UpdateInterval   string         `json:"update_interval,omitempty"` // duration string
+	SmoothingFactor  float64        `json:"smoothing_factor,omitempty"`
+	MinWeight        float64        `json:"min_weight,omitempty"`
+	SignalWeights    *SignalWeights `json:"signal_weights,omitempty"`
 }
 
 // SignalWeights configures how different performance signals affect adaptive routing weights.
@@ -193,8 +194,8 @@ type RetryConfig struct {
 
 // MirrorConfig controls traffic mirroring per org.
 type MirrorConfig struct {
-	Enabled bool          `json:"enabled"`
-	Rules   []MirrorRule  `json:"rules,omitempty"`
+	Enabled bool         `json:"enabled"`
+	Rules   []MirrorRule `json:"rules,omitempty"`
 }
 
 // MirrorRule defines a single traffic mirroring rule.
@@ -207,10 +208,10 @@ type MirrorRule struct {
 
 // CacheConfig holds per-org cache settings.
 type CacheConfig struct {
-	Enabled    bool              `json:"enabled"`
-	Backend    string            `json:"backend,omitempty"`    // "memory", "disk", "redis", "s3", "azure-blob", "gcs"
-	DefaultTTL int               `json:"default_ttl,omitempty"` // seconds
-	MaxEntries int               `json:"max_entries,omitempty"`
+	Enabled    bool   `json:"enabled"`
+	Backend    string `json:"backend,omitempty"`     // "memory", "disk", "redis", "s3", "azure-blob", "gcs"
+	DefaultTTL int    `json:"default_ttl,omitempty"` // seconds
+	MaxEntries int    `json:"max_entries,omitempty"`
 
 	// L1 backend-specific configs
 	Disk      *DiskCacheConfig      `json:"disk,omitempty"`
@@ -249,12 +250,12 @@ type RedisCacheConfig struct {
 
 // S3CacheConfig holds S3 cache settings.
 type S3CacheConfig struct {
-	Bucket         string `json:"bucket,omitempty"`
-	Prefix         string `json:"prefix,omitempty"`
-	Region         string `json:"region,omitempty"`
-	AccessKeyID    string `json:"access_key_id,omitempty"`
+	Bucket          string `json:"bucket,omitempty"`
+	Prefix          string `json:"prefix,omitempty"`
+	Region          string `json:"region,omitempty"`
+	AccessKeyID     string `json:"access_key_id,omitempty"`
 	SecretAccessKey string `json:"secret_access_key,omitempty"`
-	Compress       bool   `json:"compress,omitempty"`
+	Compress        bool   `json:"compress,omitempty"`
 }
 
 // AzureBlobCacheConfig holds Azure Blob Storage cache settings.
@@ -277,14 +278,14 @@ type GCSCacheConfig struct {
 
 // SemanticCacheConfig holds L2 semantic/vector cache settings.
 type SemanticCacheConfig struct {
-	Enabled    bool              `json:"enabled"`
-	Backend    string            `json:"backend,omitempty"` // "qdrant", "weaviate", "pinecone"
-	Threshold  float64           `json:"threshold,omitempty"`
-	Dimensions int               `json:"dimensions,omitempty"`
-	MaxEntries int               `json:"max_entries,omitempty"`
-	Qdrant     *QdrantConfig     `json:"qdrant,omitempty"`
-	Weaviate   *WeaviateConfig   `json:"weaviate,omitempty"`
-	Pinecone   *PineconeConfig   `json:"pinecone,omitempty"`
+	Enabled    bool            `json:"enabled"`
+	Backend    string          `json:"backend,omitempty"` // "qdrant", "weaviate", "pinecone"
+	Threshold  float64         `json:"threshold,omitempty"`
+	Dimensions int             `json:"dimensions,omitempty"`
+	MaxEntries int             `json:"max_entries,omitempty"`
+	Qdrant     *QdrantConfig   `json:"qdrant,omitempty"`
+	Weaviate   *WeaviateConfig `json:"weaviate,omitempty"`
+	Pinecone   *PineconeConfig `json:"pinecone,omitempty"`
 }
 
 // QdrantConfig holds Qdrant vector DB settings.
@@ -346,8 +347,8 @@ type BudgetsConfig struct {
 // BudgetLevelConfig defines a spend budget at any hierarchy level.
 type BudgetLevelConfig struct {
 	Limit    float64            `json:"limit"`
-	Period   string             `json:"period,omitempty"`     // overrides default_period
-	Hard     *bool              `json:"hard,omitempty"`       // nil = default true
+	Period   string             `json:"period,omitempty"` // overrides default_period
+	Hard     *bool              `json:"hard,omitempty"`   // nil = default true
 	PerModel map[string]float64 `json:"per_model,omitempty"`
 }
 
@@ -372,35 +373,35 @@ type IPACLConfig struct {
 
 // AlertingConfig holds per-org alerting settings.
 type AlertingConfig struct {
-	Enabled  bool                `json:"enabled"`
-	Rules    []*AlertRuleConfig  `json:"rules,omitempty"`
+	Enabled  bool                  `json:"enabled"`
+	Rules    []*AlertRuleConfig    `json:"rules,omitempty"`
 	Channels []*AlertChannelConfig `json:"channels,omitempty"`
 }
 
 // AlertRuleConfig configures a single alert rule for an org.
 type AlertRuleConfig struct {
-	Name      string  `json:"name"`
-	Metric    string  `json:"metric"`              // error_count, request_count, cost_total, latency_avg, tokens_total
-	Condition string  `json:"condition"`            // ">=", ">", "<=", "<", "=="
-	Threshold float64 `json:"threshold"`
-	Window    string  `json:"window,omitempty"`     // duration string e.g. "5m"
-	Cooldown  string  `json:"cooldown,omitempty"`   // duration string e.g. "15m"
-	Channels  []string `json:"channels,omitempty"`  // channel names to notify
+	Name      string   `json:"name"`
+	Metric    string   `json:"metric"`    // error_count, request_count, cost_total, latency_avg, tokens_total
+	Condition string   `json:"condition"` // ">=", ">", "<=", "<", "=="
+	Threshold float64  `json:"threshold"`
+	Window    string   `json:"window,omitempty"`   // duration string e.g. "5m"
+	Cooldown  string   `json:"cooldown,omitempty"` // duration string e.g. "15m"
+	Channels  []string `json:"channels,omitempty"` // channel names to notify
 }
 
 // AlertChannelConfig configures an alert notification channel.
 type AlertChannelConfig struct {
 	Name    string            `json:"name"`
-	Type    string            `json:"type"`              // "webhook", "slack", "log"
+	Type    string            `json:"type"` // "webhook", "slack", "log"
 	URL     string            `json:"url,omitempty"`
 	Headers map[string]string `json:"headers,omitempty"`
 }
 
 // PrivacyConfig holds per-org PII redaction settings.
 type PrivacyConfig struct {
-	Enabled  bool                    `json:"enabled"`
-	Mode     string                  `json:"mode,omitempty"` // "full", "patterns", "none"
-	Patterns []*RedactPatternConfig  `json:"redact_patterns,omitempty"`
+	Enabled  bool                   `json:"enabled"`
+	Mode     string                 `json:"mode,omitempty"` // "full", "patterns", "none"
+	Patterns []*RedactPatternConfig `json:"redact_patterns,omitempty"`
 }
 
 // RedactPatternConfig defines a named regex pattern for PII redaction.
@@ -420,9 +421,9 @@ type ToolPolicyConfig struct {
 
 // MCPOrgConfig holds per-org MCP (Model Context Protocol) settings.
 type MCPOrgConfig struct {
-	Enabled    bool                          `json:"enabled"`
+	Enabled    bool                           `json:"enabled"`
 	Servers    map[string]*MCPServerOrgConfig `json:"servers,omitempty"`
-	Guardrails *MCPGuardrailOrgConfig        `json:"guardrails,omitempty"`
+	Guardrails *MCPGuardrailOrgConfig         `json:"guardrails,omitempty"`
 }
 
 // MCPServerOrgConfig configures a single upstream MCP server for an org.
@@ -469,9 +470,9 @@ type AuditSinkConfig struct {
 
 // A2AOrgConfig holds per-org A2A (Agent-to-Agent) protocol settings.
 type A2AOrgConfig struct {
-	Enabled bool                        `json:"enabled"`
-	Card    *A2ACardConfig              `json:"card,omitempty"`
-	Agents  map[string]*A2AAgentConfig  `json:"agents,omitempty"`
+	Enabled bool                       `json:"enabled"`
+	Card    *A2ACardConfig             `json:"card,omitempty"`
+	Agents  map[string]*A2AAgentConfig `json:"agents,omitempty"`
 }
 
 // A2ACardConfig holds per-org agent card customization.
@@ -491,7 +492,7 @@ type A2AAgentConfig struct {
 
 // A2AAuthConfig holds auth settings for an external A2A agent.
 type A2AAuthConfig struct {
-	Type   string `json:"type,omitempty"`   // "bearer", "api_key", "none"
+	Type   string `json:"type,omitempty"` // "bearer", "api_key", "none"
 	Token  string `json:"token,omitempty"`
 	Header string `json:"header,omitempty"`
 }

--- a/agentcc-gateway/internal/tenant/sync_test.go
+++ b/agentcc-gateway/internal/tenant/sync_test.go
@@ -27,6 +27,7 @@ func TestSyncFromControlPlane_Success(t *testing.T) {
 						"openai": map[string]interface{}{
 							"api_key": "sk-org1",
 							"enabled": true,
+						"api_path_prefix": "",
 						},
 					},
 				},
@@ -62,6 +63,9 @@ func TestSyncFromControlPlane_Success(t *testing.T) {
 	}
 	if cfg1.Providers["openai"].APIKey != "sk-org1" {
 		t.Errorf("org-1 openai key = %q, want sk-org1", cfg1.Providers["openai"].APIKey)
+	}
+	if prefix := cfg1.Providers["openai"].APIPathPrefix; prefix == nil || *prefix != "" {
+		t.Errorf("org-1 openai api path prefix = %#v, want explicit empty string", prefix)
 	}
 
 	cfg2 := store.Get("org-2")

--- a/api_contracts/gateway/agentcc-admin.schema.json
+++ b/api_contracts/gateway/agentcc-admin.schema.json
@@ -12,6 +12,7 @@
         "api_key": { "type": "string" },
         "base_url": { "type": "string" },
         "api_format": { "type": "string" },
+        "api_path_prefix": { "type": "string" },
         "models": { "type": "array", "items": { "type": "string" } },
         "timeout": { "type": "integer" },
         "weight": { "type": "number" },

--- a/api_contracts/openapi/swagger.json
+++ b/api_contracts/openapi/swagger.json
@@ -82994,6 +82994,11 @@
                     "type": "string",
                     "x-nullable": true
                 },
+                "api_path_prefix": {
+                    "title": "Api path prefix",
+                    "type": "string",
+                    "x-nullable": true
+                },
                 "models": {
                     "type": "array",
                     "items": {

--- a/frontend/src/api/contracts/openapi-contract.generated.js
+++ b/frontend/src/api/contracts/openapi-contract.generated.js
@@ -98190,6 +98190,11 @@ export const OPENAPI_CONTRACT = Object.freeze({
           type: "string",
           "x-nullable": true,
         },
+        api_path_prefix: {
+          title: "Api path prefix",
+          type: "string",
+          "x-nullable": true,
+        },
         models: {
           type: "array",
           items: {

--- a/frontend/src/generated/api-contracts/api.schemas.ts
+++ b/frontend/src/generated/api-contracts/api.schemas.ts
@@ -2620,6 +2620,7 @@ export interface GatewayConfigProviderApi {
   base_url: string;
   /** Gateway protocol adapter name. This intentionally remains a string because self-hosted/custom providers may register adapters outside the built-in openai/anthropic/gemini/google set. */
   api_format: string;
+  api_path_prefix?: string;
   models: GatewayConfigProviderApiModelsItem[];
   is_active: boolean;
   default_timeout: number;

--- a/frontend/src/generated/api-contracts/api.zod.ts
+++ b/frontend/src/generated/api-contracts/api.zod.ts
@@ -5236,6 +5236,7 @@ export const AgentccGatewaysConfigResponse = zod.object({
           .describe(
             "Gateway protocol adapter name. This intentionally remains a string because self-hosted/custom providers may register adapters outside the built-in openai/anthropic/gemini/google set.",
           ),
+        api_path_prefix: zod.string().optional(),
         models: zod.array(zod.object({}).passthrough()),
         is_active: zod.boolean(),
         default_timeout: zod.number(),

--- a/frontend/src/sections/gateway/providers/AddProviderDialog.jsx
+++ b/frontend/src/sections/gateway/providers/AddProviderDialog.jsx
@@ -23,7 +23,12 @@ import {
   useUpdateProvider,
   useFetchProviderModels,
 } from "./hooks/useGatewayConfig";
-import { parseTimeoutSeconds } from "./utils";
+import {
+  DEFAULT_API_PATH_PREFIX,
+  getApiPathPrefix,
+  parseTimeoutSeconds,
+  withApiPathPrefix,
+} from "./utils";
 
 const PROVIDER_PRESETS = {
   openai: {
@@ -171,6 +176,7 @@ const AddProviderDialog = ({ open, onClose, gatewayId, provider }) => {
   const [baseUrl, setBaseUrl] = useState(PROVIDER_PRESETS.openai.baseUrl);
   const [apiKey, setApiKey] = useState("");
   const [apiFormat, setApiFormat] = useState("openai");
+  const [apiPathPrefix, setApiPathPrefix] = useState(DEFAULT_API_PATH_PREFIX);
   const [models, setModels] = useState([]);
   const [timeoutVal, setTimeoutVal] = useState("");
   const [maxConcurrent, setMaxConcurrent] = useState("");
@@ -273,6 +279,7 @@ const AddProviderDialog = ({ open, onClose, gatewayId, provider }) => {
       setBaseUrl(c.base_url ?? c.baseUrl ?? "");
       setApiKey("");
       setApiFormat(c.api_format ?? c.apiFormat ?? "openai");
+      setApiPathPrefix(getApiPathPrefix(c));
       setModels(normalizeModels(c.models));
       const timeoutRaw = c.default_timeout ?? c.defaultTimeout;
       setTimeoutVal(timeoutRaw != null ? String(timeoutRaw) : "");
@@ -357,6 +364,7 @@ const AddProviderDialog = ({ open, onClose, gatewayId, provider }) => {
     setBaseUrl(defaultPreset.baseUrl);
     setApiKey("");
     setApiFormat(defaultPreset.apiFormat);
+    setApiPathPrefix(DEFAULT_API_PATH_PREFIX);
     setModels([]);
     setModelOptions([]);
     setFetchError("");
@@ -396,6 +404,7 @@ const AddProviderDialog = ({ open, onClose, gatewayId, provider }) => {
           : prev,
       );
     }
+    setApiPathPrefix(DEFAULT_API_PATH_PREFIX);
     // Clear models since provider changed
     setModels([]);
     setModelOptions([]);
@@ -489,7 +498,11 @@ const AddProviderDialog = ({ open, onClose, gatewayId, provider }) => {
       return;
     }
 
-    const config = { base_url: baseUrl, api_format: apiFormat };
+    const config = withApiPathPrefix(
+      { base_url: baseUrl, api_format: apiFormat },
+      apiFormat,
+      apiPathPrefix,
+    );
     if (isAwsAuth) {
       if (awsAccessKeyId) config.aws_access_key_id = awsAccessKeyId;
       if (awsSecretAccessKey) config.aws_secret_access_key = awsSecretAccessKey;
@@ -758,6 +771,17 @@ const AddProviderDialog = ({ open, onClose, gatewayId, provider }) => {
               </TextField>
             );
           })()}
+
+          {apiFormat === "openai" && (
+            <TextField
+              label="API Path Prefix"
+              fullWidth
+              value={apiPathPrefix}
+              onChange={(e) => setApiPathPrefix(e.target.value)}
+              placeholder="/v1"
+              helperText="Leave blank when the provider endpoint is not versioned, such as Perplexity Sonar."
+            />
+          )}
 
           <Box>
             <Stack

--- a/frontend/src/sections/gateway/providers/AddProviderDialog.test.jsx
+++ b/frontend/src/sections/gateway/providers/AddProviderDialog.test.jsx
@@ -1,7 +1,12 @@
 import React from "react";
 import { describe, expect, it, vi, beforeEach } from "vitest";
 import { render, screen, userEvent, waitFor } from "src/utils/test-utils";
-import { parseTimeoutSeconds } from "./utils";
+import {
+  DEFAULT_API_PATH_PREFIX,
+  getApiPathPrefix,
+  parseTimeoutSeconds,
+  withApiPathPrefix,
+} from "./utils";
 import AddProviderDialog from "./AddProviderDialog";
 
 const { updateMutate, fetchMutate, fetchState } = vi.hoisted(() => ({
@@ -486,5 +491,28 @@ describe("AddProviderDialog validation", () => {
 
     const save = await screen.findByRole("button", { name: "Save Changes" });
     expect(save.disabled).toBe(false);
+  });
+});
+
+describe("API path prefix", () => {
+  it("preserves an explicitly empty prefix", () => {
+    expect(getApiPathPrefix({ api_path_prefix: "" })).toBe("");
+  });
+
+  it("defaults providers saved before the field existed to /v1", () => {
+    expect(getApiPathPrefix({})).toBe(DEFAULT_API_PATH_PREFIX);
+  });
+
+  it("includes an explicit empty prefix in the OpenAI config", () => {
+    expect(
+      withApiPathPrefix(
+        { base_url: "https://api.perplexity.ai" },
+        "openai",
+        "",
+      ),
+    ).toEqual({
+      base_url: "https://api.perplexity.ai",
+      api_path_prefix: "",
+    });
   });
 });

--- a/frontend/src/sections/gateway/providers/utils.js
+++ b/frontend/src/sections/gateway/providers/utils.js
@@ -1,3 +1,17 @@
+export const DEFAULT_API_PATH_PREFIX = "/v1";
+
+export function getApiPathPrefix(config) {
+  return (
+    config?.api_path_prefix ?? config?.apiPathPrefix ?? DEFAULT_API_PATH_PREFIX
+  );
+}
+
+export function withApiPathPrefix(config, apiFormat, apiPathPrefix) {
+  return apiFormat === "openai"
+    ? { ...config, api_path_prefix: apiPathPrefix }
+    : config;
+}
+
 export function parseTimeoutSeconds(value) {
   const text = String(value ?? "")
     .trim()

--- a/futureagi/agentcc/contracts/gateway_admin.py
+++ b/futureagi/agentcc/contracts/gateway_admin.py
@@ -37,6 +37,7 @@ class ProviderConfig(GatewayAdminContractModel):
     api_key: str | None = Field(None, validation_alias=AliasChoices('api_key', 'apiKey'))
     base_url: str | None = Field(None, validation_alias=AliasChoices('base_url', 'baseUrl', 'baseURL'))
     api_format: str | None = Field(None, validation_alias=AliasChoices('api_format', 'apiFormat'))
+    api_path_prefix: str | None = Field(None, validation_alias=AliasChoices('api_path_prefix', 'apiPathPrefix'))
     models: list[str] | None = None
     timeout: int | None = None
     weight: float | None = None

--- a/futureagi/agentcc/serializers/contracts.py
+++ b/futureagi/agentcc/serializers/contracts.py
@@ -90,6 +90,11 @@ class GatewayConfigProviderSerializer(serializers.Serializer):
         allow_null=True,
         help_text=API_FORMAT_HELP_TEXT,
     )
+    api_path_prefix = serializers.CharField(
+        required=False,
+        allow_blank=True,
+        allow_null=True,
+    )
     models = serializers.ListField(child=serializers.JSONField())
     is_active = serializers.BooleanField()
     default_timeout = serializers.IntegerField(allow_null=True)

--- a/futureagi/agentcc/tests/test_api.py
+++ b/futureagi/agentcc/tests/test_api.py
@@ -197,6 +197,7 @@ class TestAgentccGatewayAPI:
                     "max_concurrent": 3,
                     "conn_pool_size": 5,
                     "base_url": "https://api.example.com/v1",
+                    "api_path_prefix": "",
                 },
             },
             format="json",
@@ -216,6 +217,7 @@ class TestAgentccGatewayAPI:
         assert credential.display_name == "Gateway Action Provider"
         assert credential.models_list == ["gpt-4o-mini"]
         assert credential.default_timeout_seconds == 17
+        assert credential.extra_config == {"api_path_prefix": ""}
         assert CredentialManager.decrypt(credential.encrypted_credentials) == {
             "api_key": "sk-gateway-action-secret"
         }

--- a/futureagi/agentcc/tests/test_gateway_admin_contracts.py
+++ b/futureagi/agentcc/tests/test_gateway_admin_contracts.py
@@ -69,6 +69,16 @@ def test_gateway_org_config_accepts_camel_case_input_and_dumps_snake_case():
     assert dumped["cache"]["max_entries"] == 25
 
 
+def test_gateway_provider_contract_preserves_empty_api_path_prefix():
+    contract = GatewayOrgConfig.model_validate(
+        {"providers": {"perplexity": {"api_path_prefix": ""}}}
+    )
+
+    assert contract.model_dump(by_alias=True, exclude_none=True)["providers"][
+        "perplexity"
+    ]["api_path_prefix"] == ""
+
+
 def test_gateway_org_config_accepts_duplicate_saved_aliases():
     contract = GatewayOrgConfig.model_validate(
         {
@@ -171,7 +181,11 @@ def test_assemble_providers_maps_legacy_aws_credentials_to_gateway_contract(
         SimpleNamespace(
             provider_name="bedrock",
             encrypted_credentials=b"encrypted",
-            extra_config={"weight": 2, "ignored": "not-supported"},
+            extra_config={
+                "weight": 2,
+                "api_path_prefix": "",
+                "ignored": "not-supported",
+            },
             base_url="https://bedrock-runtime.us-east-1.amazonaws.com",
             api_format="bedrock",
             models_list=["anthropic.claude-3-5-sonnet-20241022-v2:0"],
@@ -188,6 +202,7 @@ def test_assemble_providers_maps_legacy_aws_credentials_to_gateway_contract(
     assert providers["bedrock"]["aws_secret_access_key"] == "sk"
     assert providers["bedrock"]["aws_region"] == "us-east-1"
     assert providers["bedrock"]["weight"] == 2
+    assert providers["bedrock"]["api_path_prefix"] == ""
     assert "access_key" not in providers["bedrock"]
     assert "ignored" not in providers["bedrock"]
 

--- a/futureagi/agentcc/tests/test_gateway_provider_org_isolation.py
+++ b/futureagi/agentcc/tests/test_gateway_provider_org_isolation.py
@@ -74,6 +74,7 @@ class TestGatewayProvidersOrgIsolation:
             encrypted_credentials=CredentialManager.encrypt({"api_key": "sk-org-b"}),
             api_format="anthropic",
             models_list=["claude-3-5-sonnet"],
+            extra_config={"api_path_prefix": ""},
         )
 
         mock_client = MagicMock()
@@ -124,6 +125,7 @@ class TestGatewayProvidersOrgIsolation:
         assert response.status_code == 200, response.json()
         providers = response.json()["result"]["providers"]
         assert set(providers.keys()) == {"anthropic"}
+        assert providers["anthropic"]["api_path_prefix"] == ""
 
     @patch("agentcc.views.gateway.get_gateway_client")
     def test_gateway_health_check_uses_active_request_organization(

--- a/futureagi/agentcc/views/gateway.py
+++ b/futureagi/agentcc/views/gateway.py
@@ -337,6 +337,7 @@ class AgentccGatewayViewSet(ViewSet):
                     "base_url",
                     "api_format",
                     "models_list",
+                    "extra_config",
                     "is_active",
                     "default_timeout_seconds",
                     "max_concurrent",
@@ -346,12 +347,14 @@ class AgentccGatewayViewSet(ViewSet):
             )
             providers_map = {}
             for p in providers:
+                extra_config = p.get("extra_config") or {}
                 providers_map[p["provider_name"]] = {
                     "id": str(p["id"]),
                     "name": p["provider_name"],
                     "display_name": p["display_name"] or p["provider_name"],
                     "base_url": p["base_url"],
                     "api_format": p["api_format"],
+                    "api_path_prefix": extra_config.get("api_path_prefix", "/v1"),
                     "models": p["models_list"] or [],
                     "is_active": p["is_active"],
                     "default_timeout": p["default_timeout_seconds"],


### PR DESCRIPTION
Closes #2628.

- Add an API path prefix field to the UI-managed OpenAI-compatible provider dialog
- Preserve an explicitly empty prefix through Django, contracts, and tenant runtime
- Apply the tenant prefix when constructing upstream provider URLs