### PR TITLE
fix(agent-playground): mount searchable execution step list (#2508)

### DIFF
--- a/frontend/src/sections/agent-playground/AgentBuilder/RunAgentPanel/CustomTreeNode.jsx
+++ b/frontend/src/sections/agent-playground/AgentBuilder/RunAgentPanel/CustomTreeNode.jsx
@@ -138,51 +138,54 @@ export const CustomTreeNode = ({
                 {formatMs(duration ?? 0)}
               </Typography>
             </Box>
-            {/* Tokens */}
-            <Box
-              component="span"
-              sx={{
-                display: "flex",
-                flexDirection: "row",
-                alignItems: "center",
-                gap: 0.5,
-              }}
-            >
-              <SvgColor
+            {/* Token and cost metadata are rendered only when the API records them. */}
+            {tokens != null && (
+              <Box
+                component="span"
                 sx={{
-                  height: 12,
-                  width: 12,
-                  bgcolor: "text.disabled",
+                  display: "flex",
+                  flexDirection: "row",
+                  alignItems: "center",
+                  gap: 0.5,
                 }}
-                src="/assets/icons/ic_tokens.svg"
-              />
-              <Typography color="text.disabled" typography={"s3"}>
-                {(tokens ?? 0).toLocaleString()}
-              </Typography>
-            </Box>
+              >
+                <SvgColor
+                  sx={{
+                    height: 12,
+                    width: 12,
+                    bgcolor: "text.disabled",
+                  }}
+                  src="/assets/icons/ic_tokens.svg"
+                />
+                <Typography color="text.disabled" typography={"s3"}>
+                  {tokens.toLocaleString()}
+                </Typography>
+              </Box>
+            )}
 
-            {/* Cost */}
-            <Box
-              component="span"
-              sx={{
-                display: "flex",
-                flexDirection: "row",
-                alignItems: "center",
-                gap: 0.5,
-              }}
-            >
-              <SvgColor
+            {cost != null && (
+              <Box
+                component="span"
                 sx={{
-                  height: 12,
-                  width: 12,
-                  bgcolor: "text.disabled",
+                  display: "flex",
+                  flexDirection: "row",
+                  alignItems: "center",
+                  gap: 0.5,
                 }}
-                src="/assets/icons/components/ic_cost.svg"
-              />
-              <Typography color="text.disabled" typography={"s3"}>
-                {(cost ?? 0).toFixed(4)}
-              </Typography>
-            </Box>
+              >
+                <SvgColor
+                  sx={{
+                    height: 12,
+                    width: 12,
+                    bgcolor: "text.disabled",
+                  }}
+                  src="/assets/icons/components/ic_cost.svg"
+                />
+                <Typography color="text.disabled" typography={"s3"}>
+                  {cost.toFixed(4)}
+                </Typography>
+              </Box>
+            )}
           </Box>
         </Box>
       </Stack>

--- a/frontend/src/sections/agent-playground/AgentBuilder/RunAgentPanel/NodeOutputListView.jsx
+++ b/frontend/src/sections/agent-playground/AgentBuilder/RunAgentPanel/NodeOutputListView.jsx
@@ -8,6 +8,24 @@ import { useState, useMemo } from "react";
 import { TreeView } from "../../../../TreeView";
 import { CustomTreeNode } from "./CustomTreeNode";
 
+const filterNodes = (nodes, searchQuery) => {
+  if (!searchQuery) return nodes;
+
+  const query = searchQuery.toLowerCase();
+  return nodes.reduce((matches, node) => {
+    const nameMatches = (node?.name ?? "").toLowerCase().includes(query);
+    const matchingChildren = filterNodes(node.children || [], searchQuery);
+
+    if (nameMatches) {
+      matches.push(node);
+    } else if (matchingChildren.length > 0) {
+      matches.push({ ...node, children: matchingChildren });
+    }
+
+    return matches;
+  }, []);
+};
+
 export default function NodeOutputListView({
   showTitle = true,
   showSearch = true,
@@ -19,9 +37,7 @@ export default function NodeOutputListView({
   const [searchQuery, setSearchQuery] = useState("");
   const filteredNodes = useMemo(() => {
     if (!nodes?.length) return [];
-    return nodes.filter((node) =>
-      (node?.name ?? "").toLowerCase().includes(searchQuery.toLowerCase()),
-    );
+    return filterNodes(nodes, searchQuery);
   }, [nodes, searchQuery]);
   return (
     <Box

--- a/frontend/src/sections/agent-playground/AgentBuilder/RunAgentPanel/RunAgentPanel.jsx
+++ b/frontend/src/sections/agent-playground/AgentBuilder/RunAgentPanel/RunAgentPanel.jsx
@@ -1,11 +1,22 @@
 import { Box } from "@mui/material";
-import React, { useCallback, useRef, useState, useEffect } from "react";
+import React, {
+  useCallback,
+  useRef,
+  useState,
+  useEffect,
+  useMemo,
+} from "react";
 import PropTypes from "prop-types";
 import { AgentGraph } from "src/components/AgentGraph";
 import { START_ID, END_ID } from "src/components/AgentGraph/layoutUtils";
 import useResolvedExecution from "../../hooks/useResolvedExecution";
-import { useWorkflowRunStoreShallow } from "../../store";
+import {
+  useAgentPlaygroundStoreShallow,
+  useWorkflowRunStoreShallow,
+} from "../../store";
 import NodeOutputDetail from "./NodeOutputDetail";
+import NodeOutputListView from "./NodeOutputListView";
+import { mapExecutionNodesToTree } from "./common";
 import ResizablePanels from "src/components/resizablePanels/ResizablePanels";
 import PanelErrorBoundary from "../../components/PanelErrorBoundary";
 
@@ -21,7 +32,12 @@ export default function RunAgentPanel({
   const resizeRef = useRef(null);
   const [isResizing, setIsResizing] = useState(false);
   const isRunning = useWorkflowRunStoreShallow((s) => s.isRunning);
+  const currentAgent = useAgentPlaygroundStoreShallow((s) => s.currentAgent);
   const [selectedNodeId, setSelectedNodeId] = useState(null);
+  const stepNodes = useMemo(
+    () => mapExecutionNodesToTree(executionData?.nodes),
+    [executionData?.nodes],
+  );
 
   // Reset selected node when a new execution starts
   useEffect(() => {
@@ -148,14 +164,29 @@ export default function RunAgentPanel({
         }}
       />
       <ResizablePanels
-        initialLeftWidth={50}
+        initialLeftWidth={60}
         minLeftWidth={15}
         maxLeftWidth={80}
         leftPanel={
-          <AgentGraph
-            executionData={executionData}
-            onNodeClick={handleGraphNodeClick}
-            selectedNodeId={selectedNodeId}
+          <ResizablePanels
+            initialLeftWidth={38}
+            minLeftWidth={25}
+            maxLeftWidth={55}
+            leftPanel={
+              <NodeOutputListView
+                currentAgent={currentAgent}
+                nodes={stepNodes}
+                selectedNodeId={selectedNodeId}
+                onNodeSelect={setSelectedNodeId}
+              />
+            }
+            rightPanel={
+              <AgentGraph
+                executionData={executionData}
+                onNodeClick={handleGraphNodeClick}
+                selectedNodeId={selectedNodeId}
+              />
+            }
           />
         }
         rightPanel={

--- a/frontend/src/sections/agent-playground/AgentBuilder/RunAgentPanel/__tests__/NodeOutputListView.test.jsx
+++ b/frontend/src/sections/agent-playground/AgentBuilder/RunAgentPanel/__tests__/NodeOutputListView.test.jsx
@@ -55,31 +55,25 @@ describe("NodeOutputListView", () => {
       target: { value: "search" },
     });
 
-    expect(screen.getByRole("button", { name: "Research agent" })).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: "Search the web" })).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Research agent" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Search the web" }),
+    ).toBeInTheDocument();
     expect(
       screen.queryByRole("button", { name: "Summarize results" }),
     ).not.toBeInTheDocument();
   });
 
   it("shows an empty state for an execution without nodes", () => {
-    render(
-      <NodeOutputListView
-        nodes={[]}
-        onNodeSelect={vi.fn()}
-      />,
-    );
+    render(<NodeOutputListView nodes={[]} onNodeSelect={vi.fn()} />);
 
     expect(screen.getByText("No nodes to display")).toBeInTheDocument();
   });
 
   it("shows a distinct empty state when search has no matches", () => {
-    render(
-      <NodeOutputListView
-        nodes={nodes}
-        onNodeSelect={vi.fn()}
-      />,
-    );
+    render(<NodeOutputListView nodes={nodes} onNodeSelect={vi.fn()} />);
 
     fireEvent.change(screen.getByPlaceholderText("Search"), {
       target: { value: "missing" },

--- a/frontend/src/sections/agent-playground/AgentBuilder/RunAgentPanel/__tests__/NodeOutputListView.test.jsx
+++ b/frontend/src/sections/agent-playground/AgentBuilder/RunAgentPanel/__tests__/NodeOutputListView.test.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import { describe, expect, it, vi } from "vitest";
 import { fireEvent, render, screen } from "@testing-library/react";
 import NodeOutputListView from "../NodeOutputListView";

--- a/frontend/src/sections/agent-playground/AgentBuilder/RunAgentPanel/__tests__/NodeOutputListView.test.jsx
+++ b/frontend/src/sections/agent-playground/AgentBuilder/RunAgentPanel/__tests__/NodeOutputListView.test.jsx
@@ -1,0 +1,90 @@
+import { describe, expect, it, vi } from "vitest";
+import { fireEvent, render, screen } from "@testing-library/react";
+import NodeOutputListView from "../NodeOutputListView";
+
+vi.mock("src/components/svg-color", () => ({
+  default: () => <span aria-hidden="true" />,
+}));
+
+vi.mock("../CustomTreeNode", () => ({
+  CustomTreeNode: ({ node, onSelect }) => (
+    <button type="button" onClick={onSelect}>
+      {node.name}
+    </button>
+  ),
+}));
+
+const nodes = [
+  {
+    id: "agent",
+    type: "agent",
+    name: "Research agent",
+    duration: 100,
+    children: [
+      {
+        id: "agent__search",
+        type: "llm_prompt",
+        name: "Search the web",
+        duration: 200,
+      },
+    ],
+  },
+  {
+    id: "summarize",
+    type: "llm_prompt",
+    name: "Summarize results",
+    duration: 300,
+  },
+];
+
+describe("NodeOutputListView", () => {
+  it("selects a node and keeps an ancestor when searching for a child", () => {
+    const onNodeSelect = vi.fn();
+    render(
+      <NodeOutputListView
+        nodes={nodes}
+        selectedNodeId="agent__search"
+        onNodeSelect={onNodeSelect}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Search the web" }));
+    expect(onNodeSelect).toHaveBeenCalledWith("agent__search");
+
+    fireEvent.change(screen.getByPlaceholderText("Search"), {
+      target: { value: "search" },
+    });
+
+    expect(screen.getByRole("button", { name: "Research agent" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Search the web" })).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: "Summarize results" }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("shows an empty state for an execution without nodes", () => {
+    render(
+      <NodeOutputListView
+        nodes={[]}
+        onNodeSelect={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText("No nodes to display")).toBeInTheDocument();
+  });
+
+  it("shows a distinct empty state when search has no matches", () => {
+    render(
+      <NodeOutputListView
+        nodes={nodes}
+        onNodeSelect={vi.fn()}
+      />,
+    );
+
+    fireEvent.change(screen.getByPlaceholderText("Search"), {
+      target: { value: "missing" },
+    });
+
+    expect(screen.getByText("No matching nodes")).toBeInTheDocument();
+  });
+});

--- a/frontend/src/sections/agent-playground/AgentBuilder/RunAgentPanel/__tests__/common.test.js
+++ b/frontend/src/sections/agent-playground/AgentBuilder/RunAgentPanel/__tests__/common.test.js
@@ -1,5 +1,9 @@
 import { describe, it, expect } from "vitest";
-import { getNodeConfig } from "../common";
+import {
+  getNodeConfig,
+  getNodeDurationMs,
+  mapExecutionNodesToTree,
+} from "../common";
 
 describe("getNodeConfig", () => {
   it("returns prompt config for 'llm_prompt' type", () => {
@@ -28,5 +32,70 @@ describe("getNodeConfig", () => {
   it("returns default config for undefined type", () => {
     const config = getNodeConfig(undefined);
     expect(config.color).toBe("text.secondary");
+  });
+
+  it("maps executed nodes into the tree shape with nested ids", () => {
+    const nodes = mapExecutionNodesToTree([
+      {
+        id: "parent",
+        name: "Parent",
+        type: "subgraph",
+        node_execution: { id: "parent-exec", duration_seconds: 1.5 },
+        sub_graph: {
+          nodes: [
+            {
+              id: "child",
+              name: "Child",
+              type: "atomic",
+              node_execution: { id: "child-exec" },
+            },
+            { id: "pending-child", name: "Pending child" },
+          ],
+        },
+      },
+      { id: "pending", name: "Pending" },
+    ]);
+
+    expect(nodes).toEqual([
+      {
+        id: "parent",
+        type: "agent",
+        name: "Parent",
+        duration: 1500,
+        children: [
+          {
+            id: "parent__child",
+            type: "llm_prompt",
+            name: "Child",
+            duration: null,
+          },
+        ],
+      },
+    ]);
+  });
+
+  it("derives duration from timestamps when seconds are unavailable", () => {
+    expect(
+      getNodeDurationMs({
+        node_execution: {
+          started_at: "2026-09-11T00:00:00.000Z",
+          completed_at: "2026-09-11T00:00:01.250Z",
+        },
+      }),
+    ).toBe(1250);
+  });
+
+  it("does not create token or cost values when they are absent", () => {
+    const [node] = mapExecutionNodesToTree([
+      {
+        id: "node-1",
+        name: "Node 1",
+        type: "atomic",
+        nodeExecution: { id: "exec-1" },
+      },
+    ]);
+
+    expect(node).not.toHaveProperty("tokens");
+    expect(node).not.toHaveProperty("cost");
   });
 });

--- a/frontend/src/sections/agent-playground/AgentBuilder/RunAgentPanel/common.js
+++ b/frontend/src/sections/agent-playground/AgentBuilder/RunAgentPanel/common.js
@@ -23,8 +23,7 @@ export const getNodeConfig = (type) => {
   return NODE_TYPE_CONFIG[type] || NODE_TYPE_CONFIG.default;
 };
 
-const getNodeExecution = (node) =>
-  node?.nodeExecution || node?.node_execution;
+const getNodeExecution = (node) => node?.nodeExecution || node?.node_execution;
 
 const getSubGraph = (node) => node?.subGraph || node?.sub_graph;
 

--- a/frontend/src/sections/agent-playground/AgentBuilder/RunAgentPanel/common.js
+++ b/frontend/src/sections/agent-playground/AgentBuilder/RunAgentPanel/common.js
@@ -22,3 +22,68 @@ const NODE_TYPE_CONFIG = {
 export const getNodeConfig = (type) => {
   return NODE_TYPE_CONFIG[type] || NODE_TYPE_CONFIG.default;
 };
+
+const getNodeExecution = (node) =>
+  node?.nodeExecution || node?.node_execution;
+
+const getSubGraph = (node) => node?.subGraph || node?.sub_graph;
+
+const toFiniteNumber = (value) => {
+  const number = Number(value);
+  return Number.isFinite(number) ? number : null;
+};
+
+export const getNodeDurationMs = (node) => {
+  const execution = getNodeExecution(node);
+  const durationSeconds = toFiniteNumber(execution?.duration_seconds);
+  if (durationSeconds !== null) return durationSeconds * 1000;
+
+  const durationMs = toFiniteNumber(execution?.duration_ms);
+  if (durationMs !== null) return durationMs;
+
+  const startedAt = Date.parse(execution?.started_at);
+  const completedAt = Date.parse(execution?.completed_at);
+  if (Number.isFinite(startedAt) && Number.isFinite(completedAt)) {
+    return Math.max(0, completedAt - startedAt);
+  }
+
+  return null;
+};
+
+const getTreeNodeType = (node) => {
+  if (node?.type === "atomic") return NODE_TYPES.LLM_PROMPT;
+  if (node?.type === "subgraph") return NODE_TYPES.AGENT;
+  return node?.type || NODE_TYPES.LLM_PROMPT;
+};
+
+const mapNodeToTreeNode = (node, parentId = null) => {
+  const id = parentId ? `${parentId}__${node.id}` : node.id;
+  const subGraph = getSubGraph(node);
+  const children = (subGraph?.nodes || [])
+    .filter((child) => getNodeExecution(child))
+    .map((child) => mapNodeToTreeNode(child, id));
+
+  return {
+    id,
+    type: getTreeNodeType(node),
+    name: node?.name || node?.id || "Unnamed node",
+    duration: getNodeDurationMs(node),
+    ...(getNodeExecution(node)?.total_tokens != null && {
+      tokens: getNodeExecution(node).total_tokens,
+    }),
+    ...(getNodeExecution(node)?.cost != null && {
+      cost: toFiniteNumber(getNodeExecution(node).cost),
+    }),
+    ...(children.length > 0 && { children }),
+  };
+};
+
+/**
+ * Adapt graph execution records to the tree data consumed by NodeOutputListView.
+ * Pending graph nodes are intentionally omitted because this is an execution
+ * history, not a second representation of the configured graph.
+ */
+export const mapExecutionNodesToTree = (nodes) =>
+  (nodes || [])
+    .filter((node) => getNodeExecution(node))
+    .map((node) => mapNodeToTreeNode(node));

--- a/frontend/src/sections/agent-playground/Executions/ExecutionDetailView.jsx
+++ b/frontend/src/sections/agent-playground/Executions/ExecutionDetailView.jsx
@@ -1,10 +1,18 @@
-import React, { useCallback, useEffect, useRef, useState } from "react";
+import React, {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 import { Box, CircularProgress, Typography } from "@mui/material";
 import PropTypes from "prop-types";
 import { useQueryClient } from "@tanstack/react-query";
 import { AgentGraph } from "src/components/AgentGraph";
 import { START_ID, END_ID } from "src/components/AgentGraph/layoutUtils";
 import NodeOutputDetail from "../AgentBuilder/RunAgentPanel/NodeOutputDetail";
+import NodeOutputListView from "../AgentBuilder/RunAgentPanel/NodeOutputListView";
+import { mapExecutionNodesToTree } from "../AgentBuilder/RunAgentPanel/common";
 import ResizablePanels from "src/components/resizablePanels/ResizablePanels";
 import { useGetExecutionDetail } from "src/api/agent-playground/agent-playground";
 import useResolvedExecution from "../hooks/useResolvedExecution";
@@ -19,6 +27,10 @@ export default function ExecutionDetailView({ graphId, executionId }) {
   } = useGetExecutionDetail(graphId, executionId);
 
   const [selectedNodeId, setSelectedNodeId] = useState(null);
+  const stepNodes = useMemo(
+    () => mapExecutionNodesToTree(executionData?.nodes),
+    [executionData?.nodes],
+  );
 
   // Invalidate executions list and node details when polling reaches terminal status
   const prevStatusRef = useRef(null);
@@ -171,14 +183,28 @@ export default function ExecutionDetailView({ graphId, executionId }) {
 
   return (
     <ResizablePanels
-      initialLeftWidth={50}
+      initialLeftWidth={60}
       minLeftWidth={15}
       maxLeftWidth={80}
       leftPanel={
-        <AgentGraph
-          executionData={executionData}
-          onNodeClick={handleGraphNodeClick}
-          selectedNodeId={selectedNodeId}
+        <ResizablePanels
+          initialLeftWidth={38}
+          minLeftWidth={25}
+          maxLeftWidth={55}
+          leftPanel={
+            <NodeOutputListView
+              nodes={stepNodes}
+              selectedNodeId={selectedNodeId}
+              onNodeSelect={setSelectedNodeId}
+            />
+          }
+          rightPanel={
+            <AgentGraph
+              executionData={executionData}
+              onNodeClick={handleGraphNodeClick}
+              selectedNodeId={selectedNodeId}
+            />
+          }
         />
       }
       rightPanel={


### PR DESCRIPTION
## Summary
Mounts the existing searchable hierarchical execution step list beside the graph in live and historical run views.

## Changes
- Wire `NodeOutputListView` into `RunAgentPanel` and `ExecutionDetailView`
- Map nested execution IDs consistently with the graph
- Keep ancestor rows during nested search
- Omit token/cost when the API does not record them

Closes #2508

Note: open competing #2525 / related #2673 appear inactive (>24h); happy to close this if maintainers prefer one of those.

## Test plan
- [x] Focused step-list tests (11) + Agent Playground suite (per draft)
- [ ] Manual: run multi-node workflow → step list searchable; select list row ↔ graph sync; historical execution same