### PR TITLE
Pass Observe configuration to the harness guest and allow its collector

### DIFF
--- a/futureagi/simulate/services/hosted_harness_gateway.py
+++ b/futureagi/simulate/services/hosted_harness_gateway.py
@@ -1068,9 +1068,10 @@ def _resolved_egress_domains(
         and simulator_values.get("FI_API_KEY")
         and simulator_values.get("FI_SECRET_KEY")
     ):
-        collector = _hostname_from_url(
-            str(simulator_values.get("FI_BASE_URL") or "https://api.futureagi.com")
-        )
+        # No default: the collector is reached on its own port and the host differs per
+        # environment, so an unset FI_BASE_URL means the guest has nowhere to report and there is
+        # nothing to allow. Guessing one would open a domain that never receives a span.
+        collector = _hostname_from_url(simulator_values.get("FI_BASE_URL"))
         if collector:
             values.append(collector)
     # The simulated caller rides the platform LiveKit server whenever the target connector does

--- a/futureagi/simulate/services/hosted_harness_gateway.py
+++ b/futureagi/simulate/services/hosted_harness_gateway.py
@@ -160,7 +160,6 @@ def _platform_simulator_material() -> tuple[dict[str, str], bytes | None]:
         "HARNESS_OBSERVABILITY",
         "FI_API_KEY",
         "FI_SECRET_KEY",
-        "FI_BASE_URL",
         "FI_HARNESS_PROJECT",
         # The caller's surroundings. Without these a hosted call is always heard in the clear,
         # whatever the scenario asked for, because the simulator reads them from its environment.
@@ -173,6 +172,15 @@ def _platform_simulator_material() -> tuple[dict[str, str], bytes | None]:
         value = str(os.environ.get(name) or "").strip()
         if value:
             values[name] = value
+    # The sandbox resolves nothing on our network, so the guest's collector is configured
+    # separately and only falls back to ours when they are the same host.
+    collector = str(
+        os.environ.get("ALK_HOSTED_FI_BASE_URL")
+        or os.environ.get("FI_BASE_URL")
+        or ""
+    ).strip()
+    if collector:
+        values["FI_BASE_URL"] = collector
     if project:
         values["GOOGLE_CLOUD_PROJECT"] = project
     if credential_bytes is not None:

--- a/futureagi/simulate/services/hosted_harness_gateway.py
+++ b/futureagi/simulate/services/hosted_harness_gateway.py
@@ -155,6 +155,13 @@ def _platform_simulator_material() -> tuple[dict[str, str], bytes | None]:
         "SIMULATOR_STT_PROVIDER",
         "SIMULATOR_TTS_MODEL",
         "SIMULATOR_TTS_PROVIDER",
+        # Observe credentials for the guest. The harness's model calls happen inside the sandbox,
+        # so without these a run is only readable as log text in the diagnostics archive.
+        "HARNESS_OBSERVABILITY",
+        "FI_API_KEY",
+        "FI_SECRET_KEY",
+        "FI_BASE_URL",
+        "FI_HARNESS_PROJECT",
         # The caller's surroundings. Without these a hosted call is always heard in the clear,
         # whatever the scenario asked for, because the simulator reads them from its environment.
         "ALK_BACKGROUND_NOISE",
@@ -1050,6 +1057,22 @@ def _resolved_egress_domains(
     values: list[str] = [domain for domain in base_domains if isinstance(domain, str)]
     values.extend(_provider_egress_domains(target_secrets))
     values.extend(_provider_egress_domains(simulator_env))
+    # Observe, when the guest is given credentials for it. Derived rather than requested, because a
+    # customer cannot be expected to know the collector is a dependency of their own run.
+    simulator_values = {str(k).upper(): v for k, v in simulator_env.items()}
+    observability_off = str(
+        simulator_values.get("HARNESS_OBSERVABILITY") or ""
+    ).strip().lower() in {"0", "off", "false", "no"}
+    if (
+        not observability_off
+        and simulator_values.get("FI_API_KEY")
+        and simulator_values.get("FI_SECRET_KEY")
+    ):
+        collector = _hostname_from_url(
+            str(simulator_values.get("FI_BASE_URL") or "https://api.futureagi.com")
+        )
+        if collector:
+            values.append(collector)
     # The simulated caller rides the platform LiveKit server whenever the target connector does
     # not supply its own (Vapi/Retell); its signaling and TURN hosts are platform config, never
     # derivable from customer input. LiveKit targets share the customer's server, so skipping

--- a/futureagi/simulate/services/hosted_harness_gateway.py
+++ b/futureagi/simulate/services/hosted_harness_gateway.py
@@ -3028,13 +3028,38 @@ def prepare_dispatch_payload(
         agent["config"] = config
         dispatched["agent"] = agent
     if job is not None:
+        metadata = dict(dispatched.get("metadata") or {})
         offered = _offered_eval_catalogue(job)
         if offered:
             # Offered, not required: a guest that ignores it selects nothing.
-            metadata = dict(dispatched.get("metadata") or {})
             metadata["available_evals"] = offered
-            dispatched["metadata"] = metadata
+        metadata["telemetry"] = _telemetry_context(job, dispatched)
+        dispatched["metadata"] = metadata
     return dispatched
+
+
+def _telemetry_context(job: Any, dispatched: dict[str, Any]) -> dict[str, Any]:
+    """Identifiers the guest attaches to its traces.
+
+    Every harness job reports into one platform-owned Observe account rather than the customer's,
+    so tenancy has to travel as attributes or a run cannot be told apart from the thousands of
+    others in the same project. These are identifiers only: no names, addresses, emails, prompts or
+    credentials, so the trace stays debuggable without carrying anyone's data into it.
+    """
+    agent = dispatched.get("agent") or {}
+    security = dispatched.get("security") or {}
+    context = {
+        "organization_id": str(getattr(job, "organization_id", "") or ""),
+        "workspace_id": str(getattr(job, "workspace_id", "") or ""),
+        "job_id": str(getattr(job, "id", "") or ""),
+        "run_id": str(getattr(job, "run_id", "") or ""),
+        "connector": str(agent.get("connector") or ""),
+        "scenario_count": dispatched.get("scenario_count"),
+        "read_only_source": bool(security.get("read_only_source", True)),
+        "snapshot": str(os.environ.get("ALK_DAYTONA_SNAPSHOT") or ""),
+        "deployment": str(os.environ.get("CLOUD_DEPLOYMENT") or "self-hosted"),
+    }
+    return {name: value for name, value in context.items() if value not in ("", None)}
 
 
 def _offered_eval_catalogue(job: Any) -> list[dict[str, Any]]:


### PR DESCRIPTION
Supplies the harness guest with its Observe configuration and the one egress host it needs. Pairs
with agent-learning-kit PR 89, which does the tracing. Neither half does anything alone.

## What changes

`HARNESS_OBSERVABILITY`, `FI_API_KEY`, `FI_SECRET_KEY` and `FI_HARNESS_PROJECT` join the values
uploaded to the guest on the platform's own channel. Like the simulator settings already there, they
never enter `secrets.json` and so can never reach the agent under test.

The guest's collector is configured separately, as `ALK_HOSTED_FI_BASE_URL`, falling back to ours.
A sandbox resolves nothing on our network, so an internal platform URL would reach nothing from
inside it and the export would fail silently.

The collector host is derived from that value and allowed, but only when both credentials are
present and observability is not switched off, so an unconfigured run spends none of Daytona's
twenty domain slots.

`prepare_dispatch_payload` adds a `telemetry` block to the job document: organization, workspace,
job, run, connector, scenario count and deployment. Every harness job reports into one
platform-owned account, so tenancy has to travel as attributes or a run cannot be told apart from
the thousands beside it. Identifiers only.

## Turning it off, and pointing it elsewhere

`HARNESS_OBSERVABILITY=off` disables both halves. Account and instance are `FI_API_KEY` /
`FI_SECRET_KEY` and `ALK_HOSTED_FI_BASE_URL`; the derived egress host follows the latter, so
redirecting an environment needs no matching allow-list change.

A customer cannot redirect harness telemetry by supplying their own keys in the environments field:
those carry the `target_provider` purpose and reach only the agent subprocess, never the control
process that registers the tracer.

## Testing

`simulate/tests/test_hosted_harness_gateway.py -k "egress or simulator"`: 24 passed.

Egress resolution checked in four states: no credentials, both, a redirected base url, and one
credential only. Only the middle two add a host.

Verified against the running backend that the guest receives all the expected values and that the
collector host is present in the resolved egress for a real job.

## Not covered

Platform-side stages before the guest starts, such as provisioning and source acquisition, are not
emitted. They run in a different process that would need its own registration.
