### PR TITLE
test: make live ClickHouse suites opt-in (FI_LIVE_CH_TESTS)

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -88,6 +88,8 @@ jobs:
       CH_DATABASE: test_tfc
       PYTHONHASHSEED: "0"
       FI_CH25_SCHEMA_APPLY_STRICT: "1"
+      # Live-ClickHouse suites are opt-in; CI owns the compose sidecar.
+      FI_LIVE_CH_TESTS: "1"
       EE_REPO_BRANCH: ${{ github.head_ref || github.ref_name }}
       EE_BASE_REF: ${{ github.base_ref || 'dev' }}
       IS_INTERNAL_RUN: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork == false }}

--- a/TESTING.md
+++ b/TESTING.md
@@ -54,6 +54,8 @@ make test-shell          # Shell inside the test container
 
 Under the hood, `make test` delegates to `bin/test`, which runs pytest inside an isolated Compose stack (`docker-compose.test.yml`) with its own Postgres, Redis, ClickHouse, and MinIO. See `bin/test --help` for lower-level options.
 
+A handful of suites talk to a real ClickHouse and create, write and drop tables in it. They are opt-in with `FI_LIVE_CH_TESTS=1`, which `bin/test` and CI set for you because they own the disposable ClickHouse they point at; a bare `pytest` skips them, so a stray process listening on the default ClickHouse port never gets written to.
+
 ### End-to-end (browser + full stack, Playwright)
 
 ```bash

--- a/futureagi/bin/test
+++ b/futureagi/bin/test
@@ -41,6 +41,10 @@ export CH_DATABASE="${CH_DATABASE:-test_tfc}"
 export CH25_HOST="${CH25_HOST:-localhost}"
 export CH25_HTTP_PORT="${CH25_HTTP_PORT:-18123}"
 export CH25_DATABASE="${CH25_DATABASE:-test_tfc}"
+# Suites that open a real ClickHouse connection are opt-in (they run DDL/DML
+# against whatever answers on the default port). This runner owns the sidecar
+# it points at, so it opts in; a bare `pytest` does not. Export 0 to skip them.
+export FI_LIVE_CH_TESTS="${FI_LIVE_CH_TESTS:-1}"
 
 export MINIO_ENDPOINT=localhost:19005
 export MINIO_ACCESS_KEY=minioadmin

--- a/futureagi/conftest.py
+++ b/futureagi/conftest.py
@@ -167,6 +167,31 @@ def _strict_ch25_apply() -> bool:
     return _os.getenv("FI_CH25_SCHEMA_APPLY_STRICT", "").lower() in ("1", "true", "yes")
 
 
+LIVE_CH_TESTS_ENV_VAR = "FI_LIVE_CH_TESTS"
+
+_LIVE_CH_SKIP_REASON = "live ClickHouse tests are opt-in: set FI_LIVE_CH_TESTS=1"
+
+
+def require_live_clickhouse() -> None:
+    """Skip the caller unless live ClickHouse suites were opted into.
+
+    The live suites connect to whatever answers on the configured host/port
+    (``CH_PORT`` / ``CH25_NATIVE_PORT`` / ``CH25_TCP_PORT``, all defaulting to
+    the local native port) and then run DDL and DML against it. That is fine
+    when the port belongs to the disposable test stack, and destructive when a
+    developer port-forward happens to be holding the same default port.
+
+    So nothing reaches a live ClickHouse unless it is asked for: call this
+    before the first socket is opened. ``bin/test`` and CI set the variable,
+    because they own the ClickHouse they point at.
+    """
+
+    import pytest
+
+    if os.environ.get(LIVE_CH_TESTS_ENV_VAR) != "1":
+        pytest.skip(_LIVE_CH_SKIP_REASON)
+
+
 class UnsafeClickHouseTestTarget(RuntimeError):
     """Raised before a test helper can mutate an unsafe ClickHouse target."""
 

--- a/futureagi/model_hub/tests/test_bulk_selection_bounded_ch25.py
+++ b/futureagi/model_hub/tests/test_bulk_selection_bounded_ch25.py
@@ -10,6 +10,7 @@ from types import SimpleNamespace
 import pytest
 from clickhouse_driver import Client
 
+from conftest import require_live_clickhouse
 from model_hub.services.bulk_selection import (
     BulkSelectionAmbiguousIdentity,
     _resolve_span_ids_clickhouse,
@@ -32,6 +33,7 @@ CH_PASSWORD = os.environ.get("CH25_PASSWORD", "")
 
 @pytest.fixture(scope="module")
 def ch_client():
+    require_live_clickhouse()
     client = Client(
         host=CH_HOST,
         port=CH_NATIVE_PORT,

--- a/futureagi/model_hub/tests/test_eval_usage_clickhouse_selector.py
+++ b/futureagi/model_hub/tests/test_eval_usage_clickhouse_selector.py
@@ -9,6 +9,7 @@ import pytest
 from clickhouse_driver import Client
 from clickhouse_driver.errors import NetworkError, ServerException
 
+from conftest import require_live_clickhouse
 from model_hub.selectors import eval_usage
 from model_hub.selectors.eval_usage import read_eval_usage
 from tracer.services.clickhouse import trace_project_scope
@@ -765,6 +766,7 @@ def test_eval_usage_empty_project_set_fails_closed_for_trace_rows(monkeypatch):
 
 @pytest.fixture(scope="module")
 def ch_client():
+    require_live_clickhouse()
     host = os.environ.get("CH25_HOST", "127.0.0.1")
     port = int(os.environ.get("CH25_NATIVE_PORT", "19000"))
     client = Client(host=host, port=port, connect_timeout=3)

--- a/futureagi/model_hub/tests/test_ground_truth_ch_isolation.py
+++ b/futureagi/model_hub/tests/test_ground_truth_ch_isolation.py
@@ -24,12 +24,14 @@ from agentic_eval.core.embeddings.embedding_manager import (
     GROUND_TRUTH_TABLE_NAME,
     EmbeddingManager,
 )
+from conftest import require_live_clickhouse
 
 _DIM = 384
 
 
 @pytest.fixture
 def gt_table(monkeypatch):
+    require_live_clickhouse()
     # ``ClickHouseVectorDB`` reads CH connection from raw env vars (not
     # Django settings), so point them at the test compose CH on
     # localhost:19000 before construction.

--- a/futureagi/tracer/tests/integration/conftest.py
+++ b/futureagi/tracer/tests/integration/conftest.py
@@ -10,6 +10,8 @@ import pytest
 from django.conf import settings
 from django.test import override_settings
 
+from conftest import require_live_clickhouse
+
 _CH_TABLES_TO_TRUNCATE = [
     "spans",
     "traces",
@@ -61,6 +63,7 @@ def ch_client():
     The wrapper exposes a ``.command()`` method so the rest of the suite can
     pretend it's talking to the clickhouse_connect HTTP client.
     """
+    require_live_clickhouse()
     try:
         from clickhouse_driver import Client
     except ImportError:

--- a/futureagi/tracer/tests/test_bounded_filter_key_ch25.py
+++ b/futureagi/tracer/tests/test_bounded_filter_key_ch25.py
@@ -12,6 +12,7 @@ from unittest import mock
 import pytest
 from clickhouse_driver import Client
 
+from conftest import require_live_clickhouse
 from tracer.selectors.trace_filter_reads import read_bounded_filter_page
 from tracer.services.clickhouse.attribute_reads import (
     _STRATIFIED_CANDIDATE_SQL,
@@ -58,6 +59,7 @@ def _unix_microseconds(value: datetime) -> int:
 
 @pytest.fixture(scope="module")
 def ch_client():
+    require_live_clickhouse()
     client = Client(
         host=CH_HOST,
         port=CH_NATIVE_PORT,

--- a/futureagi/tracer/tests/test_eval_status_reads_ch25.py
+++ b/futureagi/tracer/tests/test_eval_status_reads_ch25.py
@@ -8,6 +8,7 @@ import pytest
 from clickhouse_driver import Client
 from django.test import override_settings
 
+from conftest import require_live_clickhouse
 from tracer.services.clickhouse import eval_logger_table as eval_logger_table_config
 from tracer.services.clickhouse import query_service as query_service_config
 from tracer.services.clickhouse.client import ClickHouseClient
@@ -18,6 +19,7 @@ pytestmark = pytest.mark.integration
 
 @pytest.fixture(scope="module")
 def ch_client():
+    require_live_clickhouse()
     host = os.environ.get("CH25_HOST", "127.0.0.1")
     port = int(os.environ.get("CH25_NATIVE_PORT", "19000"))
     client = Client(host=host, port=port, connect_timeout=3)

--- a/futureagi/tracer/tests/test_exact_attribute_detail.py
+++ b/futureagi/tracer/tests/test_exact_attribute_detail.py
@@ -10,6 +10,7 @@ import pytest
 from accounts.models.workspace import Workspace
 from model_hub.models.ai_model import AIModel
 
+from conftest import require_live_clickhouse
 from tracer.models.project import Project
 from tracer.serializers.dashboard import DashboardFilterValuesQuerySerializer
 from tracer.serializers.span_attributes import SpanAttributeDetailResponseSerializer
@@ -43,6 +44,7 @@ def isolated_exact_attribute_ch25():
     relying on a textual table-name rewrite.
     """
 
+    require_live_clickhouse()
     host = os.environ.get("CH25_HOST", "127.0.0.1")
     if host not in {"127.0.0.1", "localhost", "::1"}:
         pytest.skip("exact attribute SQL integration proof is local-only")

--- a/futureagi/tracer/tests/test_score_filter_hard_tombstone_ch25.py
+++ b/futureagi/tracer/tests/test_score_filter_hard_tombstone_ch25.py
@@ -9,6 +9,7 @@ from datetime import UTC, datetime, timedelta
 import pytest
 from clickhouse_driver import Client
 
+from conftest import require_live_clickhouse
 from tracer.services.clickhouse.v2.query_builders.filters import rewrite_v1_sql_to_v2
 from tracer.services.clickhouse.v2.query_builders.session_list import (
     SessionListQueryBuilderV2,
@@ -128,6 +129,7 @@ def test_v2_rewrite_preserves_only_proven_score_alias_cdc_columns() -> None:
 
 @pytest.fixture(scope="module")
 def ch_client():
+    require_live_clickhouse()
     client = Client(
         host=CH_HOST,
         port=CH_NATIVE_PORT,

--- a/futureagi/tracer/tests/test_session_user_candidate_reads.py
+++ b/futureagi/tracer/tests/test_session_user_candidate_reads.py
@@ -13,6 +13,7 @@ import pytest
 from django.conf import settings as django_settings
 from django.test import override_settings
 
+from conftest import require_live_clickhouse
 from tracer.selectors.trace_filter_reads import read_bounded_filter_page
 from tracer.services.clickhouse.query_builders.user_list import (
     UnsupportedBoundedUserListQuery,
@@ -1894,6 +1895,7 @@ def test_session_page_enrichments_replay_tombstones_and_resolve_remaps():
 
 
 def _ch25_client():
+    require_live_clickhouse()
     host = os.getenv("CH25_HOST")
     port = int(
         os.getenv("CH25_NATIVE_PORT")

--- a/futureagi/tracer/tests/test_span_attribute_null_target_grain.py
+++ b/futureagi/tracer/tests/test_span_attribute_null_target_grain.py
@@ -4,6 +4,7 @@ from uuid import uuid4
 
 import pytest
 
+from conftest import require_live_clickhouse
 from tracer.services.clickhouse.query_builders.session_list import (
     SessionListQueryBuilder,
 )
@@ -184,6 +185,7 @@ def test_bounded_surfaces_apply_attribute_nullness_at_target_grain(
 
 
 def _local_ch25_client():
+    require_live_clickhouse()
     host = os.environ.get("CH25_HOST", "127.0.0.1")
     if host not in {"127.0.0.1", "localhost", "::1"}:
         pytest.skip("physical-version proof is restricted to local ClickHouse")

--- a/futureagi/tracer/tests/test_trace_classifier_rmt_identity_ch25.py
+++ b/futureagi/tracer/tests/test_trace_classifier_rmt_identity_ch25.py
@@ -6,6 +6,7 @@ from uuid import uuid4
 
 import pytest
 
+from conftest import require_live_clickhouse
 from tracer.services.clickhouse.exact_graph_reads import (
     _session_aggregate_source_sql,
 )
@@ -18,6 +19,7 @@ from tracer.services.clickhouse.v2.query_builders.trace_list import (
 def _local_ch25_client():
     """Return an explicitly local native client or skip the live proof."""
 
+    require_live_clickhouse()
     host = os.environ.get("CH25_HOST", "127.0.0.1")
     if host not in {"127.0.0.1", "localhost", "::1"}:
         pytest.skip("RMT identity proof is restricted to local ClickHouse")

--- a/futureagi/tracer/tests/test_trace_session_ch_query.py
+++ b/futureagi/tracer/tests/test_trace_session_ch_query.py
@@ -27,6 +27,7 @@ import pytest
 
 # Cycle-breaker -- same rationale as test_eval_task_runtime.
 import model_hub.tasks  # noqa: F401, E402
+from conftest import require_live_clickhouse  # noqa: E402
 
 
 _TEST_DATABASE = "test_trace_session_ch_query"
@@ -36,6 +37,7 @@ _TEST_DATABASE = "test_trace_session_ch_query"
 def ch_client():
     """Connect to test ClickHouse via clickhouse-driver (the same client
     the app uses). Skip when unavailable."""
+    require_live_clickhouse()
     try:
         from clickhouse_driver import Client as CHDriver
     except ImportError:

--- a/futureagi/tracer/tests/test_user_graph_latest_state_ch25.py
+++ b/futureagi/tracer/tests/test_user_graph_latest_state_ch25.py
@@ -12,7 +12,7 @@ from time import monotonic, sleep
 import pytest
 from clickhouse_driver import Client
 
-from conftest import _require_safe_ch25_test_target
+from conftest import _require_safe_ch25_test_target, require_live_clickhouse
 from tracer.services.clickhouse.query_builders import TimeSeriesQueryBuilder
 from tracer.services.clickhouse.query_builders.user_list import UserListQueryBuilder
 from tracer.services.clickhouse.v2.query_builders.agent_graph import (
@@ -48,6 +48,7 @@ def _ch_client(*, database: str) -> Client:
 def ch_database():
     """Create one unique test-owned database and remove it after the module."""
 
+    require_live_clickhouse()
     database = f"test_user_graph_{uuid.uuid4().hex}"
     _require_safe_ch25_test_target(host=CH_HOST, database=database)
     admin = _ch_client(database="default")

--- a/futureagi/tracer/tests/test_v2_trace_user_enrichment.py
+++ b/futureagi/tracer/tests/test_v2_trace_user_enrichment.py
@@ -10,6 +10,7 @@ from uuid import UUID, uuid4
 
 import pytest
 
+from conftest import require_live_clickhouse
 from tracer.services.clickhouse.v2.query_builders.trace_list import (
     MAX_USER_PHYSICAL_IDENTITIES_PER_PAGE,
     TraceListQueryBuilderV2,
@@ -298,6 +299,7 @@ def test_content_query_preserves_project_in_public_identity() -> None:
 def _local_ch25_client():
     """Return an explicitly local native client or skip the integration proof."""
 
+    require_live_clickhouse()
     host = os.environ.get("CH25_HOST", "127.0.0.1")
     if host not in {"127.0.0.1", "localhost", "::1"}:
         pytest.skip("V2 trace-user integration proof is restricted to local ClickHouse")

--- a/futureagi/tracer/tests/test_voice_trace_detail_bounded_ch25.py
+++ b/futureagi/tracer/tests/test_voice_trace_detail_bounded_ch25.py
@@ -11,6 +11,7 @@ import pytest
 from clickhouse_driver import Client
 from django.test import override_settings
 
+from conftest import require_live_clickhouse
 from tracer.selectors.trace_filter_reads import read_bounded_filter_page
 from tracer.services.clickhouse import eval_logger_table as eval_logger_table_config
 from tracer.services.clickhouse.query_builders.voice_call_list import VAPI_PHONE_NUMBERS
@@ -34,6 +35,7 @@ CH_NATIVE_PORT = int(os.environ.get("CH25_NATIVE_PORT", "19000"))
 
 @pytest.fixture(scope="module")
 def ch_client():
+    require_live_clickhouse()
     client = Client(host=CH_HOST, port=CH_NATIVE_PORT, connect_timeout=3)
     try:
         client.execute("SELECT 1")


### PR DESCRIPTION
## What

## Linked issues

Related to #2734 — hygiene prerequisite for that lane's suites; this PR ships no product change.
Linear: n/a

AI use: Claude Code (Fable 5.1 planning/review; Opus 5 implementation) produced the change; measurements via the in-repo read-only replay harness; reviewed and adversarially verified by independent agents; human-approved contract decision

E2E: exempt (tests-only)

Test suites that open a real ClickHouse connection now skip unless `FI_LIVE_CH_TESTS=1` is set. `bin/test` and the backend-ci pytest job set it, so nothing about the sanctioned runs changes; a bare `pytest` no longer reaches a live server.

## Why

These suites resolve their target from `CH_HOST`/`CH_PORT`, `CH25_HOST`/`CH25_NATIVE_PORT` or `CH25_TCP_PORT`, and each of those defaults to loopback on a well-known ClickHouse port. Once connected they run `CREATE TABLE` / `INSERT` / `SYSTEM STOP MERGES` / `DROP TABLE`.

That is exactly right when the port belongs to the disposable compose sidecar. It is destructive when a developer port-forward is holding the same default port on the same machine — a plain `pytest tracer/tests/` then issues DDL and DML down that forward. The default should be "connect to nothing", with the runners that own a ClickHouse opting in.

## How

- `futureagi/conftest.py` gains `require_live_clickhouse()`, alongside the existing `_require_safe_ch25_test_target` gate. It skips with `live ClickHouse tests are opt-in: set FI_LIVE_CH_TESTS=1` unless the variable is `1`.
- Each live suite calls it as the first statement of its connection fixture/helper, before a socket is opened. Host/port env names are untouched, and the pure-unit tests that share those files keep running.
- `futureagi/bin/test` exports `FI_LIVE_CH_TESTS="${FI_LIVE_CH_TESTS:-1}"` (export `0` to skip them locally); `.github/workflows/backend-ci.yml` sets `FI_LIVE_CH_TESTS: "1"` on the pytest job, so CI coverage is unchanged.
- One line in `TESTING.md` under the backend section documents the variable.

Gated (16 files): `tracer/tests/integration/conftest.py`, `tracer/tests/test_bounded_filter_key_ch25.py`, `test_eval_status_reads_ch25.py`, `test_exact_attribute_detail.py`, `test_score_filter_hard_tombstone_ch25.py`, `test_session_user_candidate_reads.py`, `test_span_attribute_null_target_grain.py`, `test_trace_classifier_rmt_identity_ch25.py`, `test_trace_session_ch_query.py`, `test_user_graph_latest_state_ch25.py`, `test_v2_trace_user_enrichment.py`, `test_voice_trace_detail_bounded_ch25.py`, `model_hub/tests/test_bulk_selection_bounded_ch25.py`, `test_eval_usage_clickhouse_selector.py`, `test_ground_truth_ch_isolation.py`, plus the helper in the root conftest.

Deliberately out of scope: suites reaching ClickHouse over HTTP via `clickhouse_connect` / `get_reader()` (e.g. `test_span_reader_limit_by_dedup.py`, `test_clickhouse_integration.py`, the `tests/stress/` suite). Those resolve the HTTP port, not the native default, and can follow in a second pass. `test_ch25_trace_detail_v2.py` and `test_property_catalog_dev_rollout.py` look like candidates by grep but only ever build fake clients.

## Test evidence

Run against the touched files with an isolated env (`CH_PORT=1 CH25_NATIVE_PORT=1 CH25_TCP_PORT=1`) and an audit hook that raises on any connect to a real ClickHouse port.

Default (no `FI_LIVE_CH_TESTS`): `113 passed, 69 skipped` — every one of the 69 skips reports `live ClickHouse tests are opt-in: set FI_LIVE_CH_TESTS=1`, and no socket is attempted.

With `FI_LIVE_CH_TESTS=1`: `113 passed, 69 skipped` — the same 69 now report the suites' own pre-existing reachability skips (`CH25 is not reachable on 127.0.0.1:1 (NetworkError('Connection refused'))`, `local ClickHouse is unavailable`, ...), i.e. the connection is attempted and fails on the unused port. Same pass/skip counts either way, so the gate is the only behaviour change.

`tracer/tests/integration/test_seed_smoke.py` skips on the new reason by default too.

`ruff check` on the touched files: 8 findings, all pre-existing on `origin/dev` (baseline 9 — adding the conftest import happens to fix one `I001`). No new findings; `ruff format` reports no diff on the added lines.

Collection is also clean under `--import-mode=importlib` (the mode `bin/test` uses): `1359 tests collected` across `tracer/tests/integration/` and `model_hub/tests/test_bulk_selection_bounded_ch25.py`.

(The 2 `ERROR`s in `test_exact_attribute_detail.py` are environmental — `@pytest.mark.django_db` tests with no Postgres on this host — and sit on lines the diff does not touch.)

**Lane-suite evidence (the mandated isolated run).** Because this PR is what makes a bare `pytest`
safe, here is the same ten-file lane the stacked Observe PRs (#2728-#2732) report, run at this branch
head (`3bf8e84c0`) from the repo root; two absolute local paths appear as placeholders, everything else
is verbatim:

```
cd futureagi && env DJANGO_SETTINGS_MODULE=tfc.settings.test ENV_TYPE=local \
  FI_SKIP_CH25_SCHEMA_APPLY=1 CH_ENABLED=false NO_STARTUP_DB_MUTATIONS=true \
  STARTUP_DB_MUTATION_MODE=disabled FUTURE_AGI_TELEMETRY_DISABLED=true OTEL_ENABLED=false \
  LITELLM_LOCAL_MODEL_COST_MAP=true PYTHONDONTWRITEBYTECODE=1 MPLCONFIGDIR=/tmp/mpl \
  DATABASE_URL=postgres://x:x@127.0.0.1:1/x REDIS_URL=redis://127.0.0.1:1/0 \
  CH_HOST=127.0.0.1 CH_PORT=1 CH_NATIVE_PORT=1 \
  CH25_HOST=127.0.0.1 CH25_PORT=1 CH25_NATIVE_PORT=1 CH25_TCP_PORT=1 \
  PYTHONPATH=<socket-guard-dir> <venv>/bin/python -m pytest -q -p no_prod_sockets \
  -o 'addopts=--strict-markers --tb=short -p no:cacheprovider' \
  --ignore=tracer/tests/test_bounded_filter_key_ch25.py \
  --ignore=tracer/tests/test_trace_classifier_rmt_identity_ch25.py \
  tracer/tests/test_list_cursor.py tracer/tests/test_bounded_trace_filter_reads.py \
  tracer/tests/test_trace_long_text_candidate_seed.py tracer/tests/test_trace_numeric_primary_seed.py \
  tracer/tests/test_trace_boolean_candidate_seed.py tracer/tests/test_trace_scalar_candidate_witness.py \
  tracer/tests/test_query_service_read_policy.py tfc/tests/test_runtime_setting_specs.py \
  tracer/tests/test_ch25_builder_contract.py
```

```
859 passed, 174 skipped in 6.81s
```

(`test_trace_text_candidate_seed.py` is the tenth file of that lane and does not exist on this branch —
it arrives with #2728 — so it is absent from the file list above.)

Traceability: this PR adds **0** `def test_` methods — it gates existing suites, it does not write new
ones. `git diff origin/dev...HEAD | grep -c '^+.*def test_'` -> `0`. The 19 changed files are the 16
gated suites plus `conftest.py`, `bin/test`, the CI workflow and `TESTING.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


