### PR TITLE
fix(contracts): regenerate swagger for the admin invoice preview docstring [TH-7898]

### DIFF
--- a/api_contracts/openapi/swagger.json
+++ b/api_contracts/openapi/swagger.json
@@ -67936,7 +67936,8 @@
         "/usage/admin/invoice/preview/": {
             "post": {
                 "operationId": "usage_admin_invoice_preview_create",
-                "description": "Preview invoice for an org+period (no side effects).",
+                "summary": "Preview invoice for an org+period.",
+                "description": "Creates no invoice and deducts no credits, but does backfill missing\n``UsageSummary`` rows for the usage period. Open to staff so the admin's\nread-only Generate Invoice page can show what would be billed.",
                 "parameters": [
                     {
                         "name": "data",


### PR DESCRIPTION
AI use: Claude Code diagnosed the drift and regenerated the schema under my direction
E2E: exempt (generated contract only)
Linear: TH-7898

## Summary

`api-contracts / backend-contracts` fails on `dev` for a reason unrelated to whatever PR happens to trigger it. The committed `api_contracts/openapi/swagger.json` no longer matches what the generator produces, so the job's `git diff --exit-code` exits 1. This regenerates the file. One hunk, two lines.

## Why the changes are done - what is the problem

### Reproduce on dev today (before this PR)

1. Open any PR into `dev` that touches a path in the `api-contracts.yml` filter, for example anything under `futureagi/tracer/views/**`.
2. `backend-contracts` runs `./scripts/generate-openapi-schema.sh` then `git diff --exit-code api_contracts/openapi/swagger.json`.
3. It fails with a diff at `/usage/admin/invoice/preview/`, in code the PR never touched.

Seen on #2718 ([run 34575290776](https://github.com/future-agi/future-agi/actions/runs/34575290776/job/103186258373)), which only changes Observe frontend files plus [futureagi/tracer/views/shared_link.py](futureagi/tracer/views/shared_link.py).

### Where it breaks - BE

The source is the private EE repo, not this one. EE commit `45a4fcb` (`feat(admin): let staff read custom-plan and preview invoices [TH-7898]`, 2026-09-08) reworded the `AdminInvoicePreviewView` docstring in `admin/admin_invoice.py` from a single line into a summary plus a longer description.

drf-yasg reads that docstring, so the generated schema changed:

```
-  "description": "Preview invoice for an org+period (no side effects)."
+  "summary": "Preview invoice for an org+period.",
+  "description": "Creates no invoice and deducts no credits, but does backfill missing\n``UsageSummary`` rows for the usage period. ..."
```

The monorepo counterpart, #2625 (`feat(admin): show Custom Tools to staff as read-only [TH-7898]`, merged to `dev` 2026-09-10), touched no files under `api_contracts/`, so the committed schema was never refreshed.

`main` is unaffected. EE `main` still carries the old docstring and this repo's `main` still carries the old text, so those two agree. This is a `dev`-only break.

## What changed

### api_contracts/openapi/swagger.json
Regenerated. The only difference is the `summary` and `description` on `usage_admin_invoice_preview_create`. No path, operation, parameter or definition was added, removed or retyped.

## Tests included - what each scenario covers

None. The change is a generated artifact; `backend-contracts` is itself the test.

## Commands to run tests

From the repo root, with the EE repo checked out at `futureagi/ee/cloud` on its `dev` branch:

```
./scripts/generate-openapi-schema.sh
git diff --exit-code api_contracts/openapi/swagger.json
```

### Local verification results

- [x] Ran the generator locally against EE `dev`. Output blob `dfc6b4e` matches the blob CI computed in the failing run, byte for byte.
- [x] Post-regeneration `git diff --exit-code` is clean, which is exactly the assertion the job makes.
- [x] Generator exits 0, so the surface-shrink guard in the script found no removed paths or definitions.
- [x] Confirmed the frontend contract is unaffected: [openapi-contract.generated.js](frontend/src/api/contracts/openapi-contract.generated.js#L38722) records `operationId`, validation flags, `requestBody` and `queryParameters` for this operation and carries no `description`, so `frontend-contracts` needs no regeneration. That job already passed on #2718.

## Video

n/a, generated file.

## Screenshot of test suit run

n/a, see CI.

## Backwards compatibility

No behaviour change of any kind. Documentation strings in a generated schema. No schema shape change, no API surface change, no caller impact.

## Manual verification

- [ ] `backend-contracts` passes on this PR.
- [ ] Rebase #2718 on `dev` after this merges and confirm its `backend-contracts` goes green.

## Type of change

- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking
- [ ] 📖 Docs
- [x] 🧹 Chore/refactor
- [ ] 🚀 Perf
- [ ] 🧪 Test-only

## Checklist

- [x] Follows the repo style guide
- [x] No hand edits; the file is generator output
- [x] No secrets, URLs or PII added
- [x] No new lint errors

## Backout / rollback

`git revert` this commit. `dev` returns to a stale schema and `backend-contracts` fails again as it does today.

## Linear

Closes TH-7898

🤖 Generated with [Claude Code](https://claude.com/claude-code)
