### PR TITLE
fix(dashboards): apply Dataset and Eval Source filters to eval metric charts (TH-7938)

### DIFF
--- a/futureagi/tracer/services/clickhouse/query_builders/dashboard.py
+++ b/futureagi/tracer/services/clickhouse/query_builders/dashboard.py
@@ -164,6 +164,10 @@ SYSTEM_METRICS: dict[str, tuple[str, str]] = {
 # anti-membership over the authoritative eval/annotation stores.
 PRESENCE_SYSTEM_METRIC_FILTERS = frozenset({"has_eval", "has_annotation"})
 
+# Eval-row dimensions answered from ``usage_apicalllog`` itself, not from spans.
+EVAL_SOURCE_DIMENSIONS = frozenset({"source", "eval_source"})
+EVAL_DATASET_DIMENSION = "dataset"
+
 METRIC_UNITS: dict[str, str] = {
     "latency": "ms",
     "error_rate": "%",
@@ -1867,11 +1871,13 @@ class DashboardQueryBuilder:
         # Scope to workspace when available, otherwise org
         if self.workspace_id:
             _scope_filter = "e.workspace_id = toUUID(%(workspace_id)s)"
+            _dataset_scope = "workspace_id = toUUID(%(workspace_id)s)"
             _usage_main_scope = (
                 "usage_main_scan.workspace_id = toUUID(%(workspace_id)s)"
             )
         else:
             _scope_filter = "e.organization_id = toUUID(%(organization_id)s)"
+            _dataset_scope = "organization_id = toUUID(%(organization_id)s)"
             _usage_main_scope = (
                 "usage_main_scan.organization_id = toUUID(%(organization_id)s)"
             )
@@ -1944,10 +1950,10 @@ class DashboardQueryBuilder:
             bd_name = (bd.get("name") or bd.get("id") or "").lower()
             bd_type = bd.get("type", "system_metric")
 
-            if bd_name in ("source", "eval_source"):
+            if bd_name in EVAL_SOURCE_DIMENSIONS:
                 bd_expr = "if(e.source = '', '(not set)', e.source)"
 
-            elif bd_name == "dataset":
+            elif bd_name == EVAL_DATASET_DIMENSION:
                 bd_expr = (
                     "if(e.eval_dataset_id != '', e.eval_dataset_id, "
                     + _eval_source_bucket_expr(exclude="dataset")
@@ -2127,6 +2133,28 @@ class DashboardQueryBuilder:
                     if string_expression is not None
                     else _coerce_filter_value(val, op)
                 )
+
+            elif (
+                f_type == "system_metric"
+                and f_name.lower() in EVAL_SOURCE_DIMENSIONS
+            ):
+                where_parts.append(f"e.source {op_symbol} %({val_key})s")
+                params[val_key] = _coerce_string_filter_value(val, op)
+
+            elif (
+                f_type == "system_metric"
+                and f_name.lower() == EVAL_DATASET_DIMENSION
+            ):
+                positive_op = _NEGATED_TO_POSITIVE_OPERATORS.get(op, op)
+                membership = "IN" if positive_op == op else "NOT IN"
+                # Deleted datasets stay matchable: their eval rows outlive them.
+                where_parts.append(
+                    f"e.eval_dataset_id {membership} ("
+                    "SELECT toString(id) FROM model_hub_dataset FINAL "
+                    f"WHERE {_dataset_scope} "
+                    f"AND name {_get_operator_symbol(positive_op)} %({val_key})s)"
+                )
+                params[val_key] = _coerce_string_filter_value(val, positive_op)
 
             elif f_type == "system_metric":
                 self._reject_unknown_cataloged_system_dimension(
@@ -3696,6 +3724,12 @@ _OPERATOR_SYMBOLS: dict[str, str] = {
     "not_contains": "NOT IN",
     "str_contains": "LIKE",
     "str_not_contains": "NOT LIKE",
+}
+
+_NEGATED_TO_POSITIVE_OPERATORS: dict[str, str] = {
+    "not_equal_to": "equal_to",
+    "not_contains": "contains",
+    "str_not_contains": "str_contains",
 }
 
 

--- a/futureagi/tracer/tests/test_dashboard.py
+++ b/futureagi/tracer/tests/test_dashboard.py
@@ -1325,12 +1325,33 @@ def _get_metrics_with_annotation_labels(auth_client, project_id, label_ids):
     return response
 
 
+def _eval_dimension_filter(column_id, filter_op, filter_value):
+    """A Dataset / Eval Source filter exactly as the widget editor sends it."""
+    return {
+        "column_id": column_id,
+        "property_id": f"system_attribute:all:{column_id}",
+        "display_name": column_id.replace("_", " ").title(),
+        "source": "all",
+        "filter_config": {
+            "filter_type": "text",
+            "filter_op": filter_op,
+            "filter_value": filter_value,
+            "col_type": "SYSTEM_METRIC",
+        },
+    }
+
+
 @pytest.fixture
 def isolated_eval_usage_analytics():
-    """Real CH25 executor with a unique, test-owned eval usage table."""
+    """Real CH25 executor over test-owned eval usage and dataset tables."""
 
     from tracer.services.clickhouse.client import ClickHouseClient
     from tracer.services.clickhouse.query_service import AnalyticsQueryService
+    from tracer.services.clickhouse.schema import (
+        CDC_MODEL_HUB_DATASET,
+        CDC_USAGE_APICALLLOG,
+        _to_single_node_engine,
+    )
     from tracer.services.clickhouse.v2 import get_v2_config
 
     config = get_v2_config()
@@ -1341,35 +1362,24 @@ def isolated_eval_usage_analytics():
         password=config["password"],
         database=config["database"],
     )
-    table = f"_test_dashboard_eval_usage_{uuid.uuid4().hex[:12]}"
+    suffix = uuid.uuid4().hex[:12]
+    table = f"_test_dashboard_eval_usage_{suffix}"
+    dataset_table = f"_test_dashboard_eval_datasets_{suffix}"
     try:
         client.execute(
-            f"""
-            CREATE TABLE {table} (
-                id Int64,
-                organization_id UUID,
-                workspace_id Nullable(UUID),
-                status LowCardinality(String),
-                config String DEFAULT '{{}}',
-                eval_score Float64 MATERIALIZED
-                    JSONExtractFloat(JSONExtractString(config), 'output', 'output'),
-                eval_output_str String MATERIALIZED
-                    JSONExtractString(JSONExtractString(config), 'output', 'output'),
-                eval_trace_id String MATERIALIZED
-                    JSONExtractString(JSONExtractString(config), 'trace_id'),
-                eval_dataset_id String MATERIALIZED
-                    JSONExtractString(JSONExtractString(config), 'dataset_id'),
-                source LowCardinality(String),
-                source_id String,
-                deleted UInt8,
-                created_at DateTime64(6, 'UTC'),
-                _peerdb_is_deleted UInt8,
-                _peerdb_version Int64
-            ) ENGINE = ReplacingMergeTree(_peerdb_version)
-            ORDER BY (organization_id, source_id, created_at, id)
-            """
+            _to_single_node_engine(CDC_USAGE_APICALLLOG).replace(
+                "CREATE TABLE IF NOT EXISTS usage_apicalllog",
+                f"CREATE TABLE {table}",
+            )
+        )
+        client.execute(
+            _to_single_node_engine(CDC_MODEL_HUB_DATASET).replace(
+                "CREATE TABLE IF NOT EXISTS model_hub_dataset",
+                f"CREATE TABLE {dataset_table}",
+            )
         )
     except Exception:
+        client.execute(f"DROP TABLE IF EXISTS {table}")
         client.close()
         raise
 
@@ -1377,10 +1387,17 @@ def isolated_eval_usage_analytics():
     delegate._ch_client = client
 
     class IsolatedEvalUsageAnalytics:
+        def __init__(self):
+            self.ch_client = client
+            self.usage_table = table
+            self.dataset_table = dataset_table
+
         def execute_ch_query(self, query, params=None, timeout_ms=10000, settings=None):
             assert "usage_apicalllog" in query
             return delegate.execute_ch_query(
-                query.replace("usage_apicalllog", table),
+                query.replace("usage_apicalllog", table).replace(
+                    "model_hub_dataset", dataset_table
+                ),
                 params,
                 timeout_ms=timeout_ms,
                 settings=settings,
@@ -1390,6 +1407,7 @@ def isolated_eval_usage_analytics():
         yield IsolatedEvalUsageAnalytics()
     finally:
         client.execute(f"DROP TABLE IF EXISTS {table}")
+        client.execute(f"DROP TABLE IF EXISTS {dataset_table}")
         client.close()
 
 
@@ -7527,6 +7545,132 @@ class TestDashboardQueryExecution:
         assert len(metrics) == 1
         # Query parsed + executed cleanly; no per-widget error attached.
         assert "error" not in metrics[0]
+
+    @pytest.mark.integration
+    @pytest.mark.django_db
+    @pytest.mark.parametrize(
+        ("filters", "expected_pass_rate"),
+        [
+            pytest.param([], 4 / 6, id="no_filter_keeps_every_row"),
+            pytest.param(
+                [_eval_dimension_filter("dataset", "contains", "-prod-")],
+                1.0,
+                id="dataset_contains_matches_only_this_workspaces_datasets",
+            ),
+            pytest.param(
+                [_eval_dimension_filter("dataset", "not_contains", "-prod-")],
+                2 / 4,
+                id="dataset_not_contains_keeps_rows_without_a_dataset",
+            ),
+            pytest.param(
+                [_eval_dimension_filter("eval_source", "in", ["dataset_evaluation"])],
+                3 / 5,
+                id="eval_source_is_excludes_other_sources",
+            ),
+            pytest.param(
+                [
+                    {
+                        "metric_type": "system_metric",
+                        "metric_name": "dataset",
+                        "operator": "str_contains",
+                        "value": "-prod-",
+                    }
+                ],
+                1.0,
+                id="legacy_dataset_filter_without_property_id",
+            ),
+        ],
+    )
+    def test_eval_metric_dataset_and_source_filters_chart_only_matching_rows(
+        self,
+        observe_project,
+        isolated_eval_usage_analytics,
+        filters,
+        expected_pass_rate,
+    ):
+        ch = isolated_eval_usage_analytics
+        workspace = observe_project.workspace
+        template_id = str(uuid.uuid4())
+        prod, sandbox, other_tenant = (str(uuid.uuid4()) for _ in range(3))
+        seeded_at = "now64(6) - toIntervalHour(1)"
+
+        for dataset_id, name, org_id, workspace_id in (
+            (prod, "ci-acc-prod-r1", workspace.organization_id, workspace.id),
+            (sandbox, "ci-acc-sandbox-r1", workspace.organization_id, workspace.id),
+            (other_tenant, "ci-acc-prod-other", uuid.uuid4(), uuid.uuid4()),
+        ):
+            ch.ch_client.execute(
+                f"INSERT INTO {ch.dataset_table} "
+                "(id, name, organization_id, workspace_id, created_at, updated_at, "
+                "_peerdb_synced_at, _peerdb_version) "
+                f"SELECT toUUID('{dataset_id}'), '{name}', toUUID('{org_id}'), "
+                f"toUUID('{workspace_id}'), {seeded_at}, {seeded_at}, {seeded_at}, 1"
+            )
+
+        # The other tenant's "-prod-" dataset is referenced from this workspace,
+        # so only the dataset lookup's tenant scope keeps it out of the match.
+        eval_rows = (
+            ("dataset_evaluation", prod, "Passed"),
+            ("dataset_evaluation", prod, "Passed"),
+            ("dataset_evaluation", sandbox, "Passed"),
+            ("dataset_evaluation", sandbox, "Failed"),
+            ("dataset_evaluation", other_tenant, "Failed"),
+            ("tracer", None, "Passed"),
+        )
+        for row_id, (source, dataset_id, output) in enumerate(eval_rows, start=1):
+            config = {"output": {"output": output}}
+            if dataset_id:
+                config["dataset_id"] = dataset_id
+            ch.ch_client.execute(
+                f"INSERT INTO {ch.usage_table} "
+                "(id, log_id, organization_id, workspace_id, status, config, "
+                "source, source_id, created_at, updated_at, _peerdb_synced_at, "
+                "_peerdb_is_deleted, _peerdb_version) "
+                f"SELECT {row_id}, generateUUIDv4(), "
+                f"toUUID('{workspace.organization_id}'), toUUID('{workspace.id}'), "
+                f"'success', toJSONString('{json.dumps(config)}'), '{source}', "
+                f"'{template_id}', {seeded_at}, {seeded_at}, {seeded_at}, 0, 1"
+            )
+
+        query_config = {
+            "project_ids": [str(observe_project.id)],
+            "granularity": "month",
+            "time_range": {"preset": "6M"},
+            "metrics": [
+                {
+                    "id": template_id,
+                    "name": "task_completion",
+                    "type": "eval_metric",
+                    "source": "all",
+                    "config_id": template_id,
+                    "output_type": "PASS_FAIL",
+                    "aggregation": "pass_rate",
+                }
+            ],
+            "filters": filters,
+        }
+        with patch("tracer.views.dashboard.V2AnalyticsQueryService", return_value=ch):
+            response = DashboardWidgetViewSet()._execute_ch_query_config(
+                query_config,
+                workspace,
+                refresh=True,
+                _exact_worker=True,
+                cache_identity_override={
+                    "workspace_id": str(workspace.id),
+                    "query_config": query_config,
+                },
+            )
+
+        assert response.status_code == 200, response.data
+        [metric] = response.data["result"]["metrics"]
+        assert metric.get("error") is None
+        charted = [
+            point["value"]
+            for series in metric["series"]
+            for point in series["data"]
+            if point["value"] is not None
+        ]
+        assert charted == [pytest.approx(expected_pass_rate, abs=1e-6)]
 
     @pytest.mark.django_db
     @patch("tracer.views.dashboard.AnalyticsQueryService")


### PR DESCRIPTION
## The problem

On a dashboard, a chart of an evaluation offers a Dataset filter and an Eval Source filter.

Picking either one does not filter the chart.

On a chart built today, the chart fails to load and shows "Failed to load chart data".

On an older chart, the filter is quietly ignored, so the line still counts every run of that eval.

So there is no way to chart one group of eval runs on its own, for example only the runs a release pipeline makes against production.

## Why nobody catches it

Both filters are offered in the filter picker, and a chart title can still say it is filtered.

When the filter is ignored, the numbers look plausible, so nothing on screen says the filter did nothing.

No saved eval chart uses a filter yet, so nobody has met the error on an existing dashboard.

---

Eval metric charts drop the `dataset` and `eval_source` filters. The eval-metric filter loop in `_build_eval_metric_query` compiles only span `SYSTEM_METRICS`, `eval_metric` and `custom_attribute` filters, so these two catalogued eval dimensions fall through to `_reject_unknown_cataloged_system_dimension`: a silent no-op for legacy payloads, and `InvalidMetricCombinationError("Unsupported cataloged system filter: dataset")` for the registry-bound payloads the widget editor sends today. The fix compiles both against columns every eval row already carries (`e.source`, `e.eval_dataset_id`), the same columns the breakdown path in that method already uses. Adds 5 test scenarios, run through the production exact-read path against real ClickHouse.

## Why the changes are done: what is the problem

### Reproduce on main today (before this PR)

1. Have eval runs of one eval on two datasets, for example `ci-acc-prod-r1` and `ci-acc-sandbox-r1`.
2. Dashboards → a dashboard → Add Widget → metric: that eval, aggregation Pass Rate.
3. Filter → Dataset → Contains → `-prod-`.
4. The preview returns `Dashboard query could not be completed`; saved, the widget shows `Failed to load chart data`. Backend log: `InvalidMetricCombinationError: Unsupported cataloged system filter: dataset`.
5. Same with Filter → Eval Source → Is → `dataset_evaluation`.
6. A widget saved in the older flattened filter shape (no `property_id`) loads instead, but its line is unfiltered.

### Where it breaks: BE

`futureagi/tracer/services/clickhouse/query_builders/dashboard.py`, `_build_eval_metric_query`:

- The filter loop handles `system_metric` filters only when the name is in `SYSTEM_METRICS` (span columns, joined through `spans`), plus `eval_metric` and `custom_attribute`.
- `dataset` and `eval_source` are catalogued for eval metrics in `tracer/services/dashboard_metrics_catalog.py` ("Eval-specific dimensions", source `all`), so the picker offers them, but they are not span columns and are not in `SYSTEM_METRICS`.
- They fall through to `_reject_unknown_cataloged_system_dimension`, which returns without adding a predicate when the payload has no `property_id` and raises when it has one.
- The breakdown branch of the same method already resolves both (`e.source`, `e.eval_dataset_id`), so the filter and the breakdown disagreed about the same dimension.
- `DashboardQueryBuilderV2` subclasses this builder and inherits the behaviour.

No frontend change is needed: the widget editor already sends the canonical filter (`column_id: "dataset"`, `filter_op: "contains"`), and the Dataset value picker already lists dataset names.

## What changed

### `futureagi/tracer/services/clickhouse/query_builders/dashboard.py`

- Two branches before the unknown-dimension fallthrough:
  - `eval_source` / `source` → `e.source <op> value`.
  - `dataset` → `e.eval_dataset_id IN (SELECT toString(id) FROM model_hub_dataset FINAL WHERE <workspace or org scope> AND name <op> value)`.
- Negated operators (`not_contains`, `str_not_contains`, `not_equal_to`) compile to `NOT IN` over the positive name match via `_NEGATED_TO_POSITIVE_OPERATORS`, so "Dataset does not contain -prod-" keeps runs with no dataset (trace and playground evals) instead of dropping them.
- The dataset lookup takes the same workspace-or-org scope as the eval rows it filters (`_dataset_scope`, set beside `_scope_filter`), so a same-named dataset in another tenant never matches.
- `EVAL_SOURCE_DIMENSIONS` and `EVAL_DATASET_DIMENSION` replace the literals and are now shared by the breakdown and the filter, so the two paths cannot drift apart again.

### `futureagi/tracer/tests/test_dashboard.py`

- One parametrized test in `TestDashboardQueryExecution` with 5 scenarios. It calls `_execute_ch_query_config(..., refresh=True, _exact_worker=True)`, the call the production exact-read worker makes, so it covers the query serializer, `_dashboard_filter_to_internal`, `DashboardQueryBuilderV2` and real test ClickHouse. The preview endpoint only schedules that read in the background and returns a pending placeholder, which is why the test does not go through HTTP.
- The `isolated_eval_usage_analytics` fixture now builds its tables from the canonical DDL in `schema.py` (`CDC_USAGE_APICALLLOG`, `CDC_MODEL_HUB_DATASET`) instead of a hand-written copy of the usage table, so the fixture cannot drift from the real columns. Every existing test that uses the fixture still passes.

## Why these decisions

- **Name lookup in a ClickHouse subquery, not ids resolved in Python.** The builder stays a pure SQL compiler with no ORM read, the lookup costs no extra round trip, and it is the same shape as the filter-value query that already lists dataset names from `model_hub_dataset`.
- **Match on name, not id.** The value picker lists names, and pipelines that create one dataset per run put the environment in the name. Ids change every run, so an id filter would never cover tomorrow's run.
- **`NOT IN` over the positive match, not `name NOT LIKE`.** `NOT LIKE` inside the subquery would silently drop every eval row that has no dataset. A person who excludes one dataset expects to keep everything else.
- **Deleted datasets stay matchable.** Their eval rows stay in the usage log and the unfiltered chart already counts them. Excluding them would let a dataset cleanup rewrite a filtered chart's history.
- **No `_peerdb_is_deleted` token in the subquery.** The v2 rewrite renames that token for spans. Leaving it out keeps the subquery valid under `DashboardQueryBuilderV2`, which the tests exercise.

## Tests included: what each scenario covers

New: 1 parametrized test, 5 scenarios. Existing coverage: the `dataset` tests already in the repo cover the Datasets-source dashboard (`test_dataset_dashboard.py`) and the filter-value picker (`test_dashboard.py`), not an eval metric; no test filtered an eval chart on Dataset or Eval Source before this PR. Changed: the `isolated_eval_usage_analytics` fixture (canonical DDL), no assertion changes.

Seed for every scenario: 3 datasets (`ci-acc-prod-r1`, `ci-acc-sandbox-r1` in the test workspace, `ci-acc-prod-other` in another org), 6 eval rows of one template: prod Passed ×2, sandbox Passed + Failed, a row pointing at the other org's dataset (Failed), and one `tracer` row with no dataset (Passed).

| # | Test | Scenario | Action | What it pins |
|---|---|---|---|---|
| 1 | `[no_filter_keeps_every_row]` | no filter | pass rate over all rows | an unfiltered eval chart is unchanged: 4/6 |
| 2 | `[dataset_contains_matches_only_this_workspaces_datasets]` | Dataset contains `-prod-`, UI payload with `property_id` | pass rate | only this workspace's `-prod-` datasets count: 1.0. The other org's `-prod-` dataset is referenced from this workspace, so a scope leak would give 2/3 |
| 3 | `[dataset_not_contains_keeps_rows_without_a_dataset]` | Dataset does not contain `-prod-` | pass rate | a negative filter keeps sandbox rows and the row with no dataset: 2/4 |
| 4 | `[eval_source_is_excludes_other_sources]` | Eval Source is `dataset_evaluation` | pass rate | the `tracer` row is excluded: 3/5 |
| 5 | `[legacy_dataset_filter_without_property_id]` | flattened legacy filter, no `property_id` | pass rate | the old silent-drop path now filters: 1.0 |

Reverting the fix: scenarios 2 to 4 fail with `InvalidMetricCombinationError: Unsupported cataloged system filter: dataset` / `eval_source`, and scenario 5 fails with `assert [0.666667] == [1.0 ± 1.0e-06]` because the filter is dropped (`4 failed, 1 passed`).

## Commands to run tests

```bash
cd futureagi
bin/test up    # Postgres :15432, Redis :16379, ClickHouse :18123, MinIO :19005
export DJANGO_SETTINGS_MODULE=tfc.settings.test \
  DATABASE_URL=postgres://test_user:test_password@localhost:15432/test_tfc \
  REDIS_URL=redis://localhost:16379/0 \
  CH_HOST=localhost CH_DATABASE=test_tfc CH25_HOST=localhost CH25_HTTP_PORT=18123 CH25_DATABASE=test_tfc \
  TEST_CLICKHOUSE_HOST=localhost TEST_CLICKHOUSE_PORT=18123 \
  MINIO_ENDPOINT=localhost:19005 MINIO_ACCESS_KEY=minioadmin MINIO_SECRET_KEY=minioadmin DEBUG=1 TEST=1

# 1. only the new tests
.venv/bin/pytest -v "tracer/tests/test_dashboard.py::TestDashboardQueryExecution::test_eval_metric_dataset_and_source_filters_chart_only_matching_rows"

# 2. the dashboard module
.venv/bin/pytest -q tracer/tests/test_dashboard.py tracer/tests/test_dashboard_presence_filters.py

# 3. every test file that imports the dashboard query builder (11 files)
.venv/bin/pytest -q tracer/tests/test_ch25_builder_contract.py tracer/tests/test_ch25_dispatch.py \
  tracer/tests/test_clickhouse_integration.py tracer/tests/test_dashboard_attr_rollup_integration.py \
  tracer/tests/test_dashboard_error_boundaries.py tracer/tests/test_dashboard_exact_candidate_optimization.py \
  tracer/tests/test_dashboard_presence_filters.py tracer/tests/test_dashboard.py \
  tracer/tests/test_dataset_dashboard.py tracer/tests/test_exact_aggregation_contract.py \
  tracer/tests/test_simulation_dashboard.py
```

Tests that don't match a filter appear as `deselected`: not broken, just not run.

## Local verification results

```bash
$ pytest -v tracer/tests/test_dashboard.py::TestDashboardQueryExecution::test_eval_metric_dataset_and_source_filters_chart_only_matching_rows
...[no_filter_keeps_every_row] PASSED [ 20%]
...[dataset_contains_matches_only_this_workspaces_datasets] PASSED [ 40%]
...[dataset_not_contains_keeps_rows_without_a_dataset] PASSED [ 60%]
...[eval_source_is_excludes_other_sources] PASSED [ 80%]
...[legacy_dataset_filter_without_property_id] PASSED [100%]
============================== 5 passed in 2.14s ===============================

$ pytest -q  (the 11 files above)
========== 1035 passed, 32 skipped, 1 deselected in 95.00s (0:01:35) ===========

# with the fix reverted, same 5 scenarios
========================= 4 failed, 1 passed in 7.40s ==========================
```

## Before / After: live UI

Same two saved widgets and the same seeded eval runs on a local stack, served by two backends that differ only by this commit: `origin/main` on the left, `origin/main` + this fix on the right. The right-hand widget is Pass Rate filtered to datasets whose name contains `-prod-`.

<img width="100%" alt="Before: the Dataset-filtered eval widget fails to load. After: it draws the prod-only line (0.80 to 1.00) next to the unfiltered line (0.60 to 0.70)." src="https://github.com/user-attachments/assets/c555ed9b-9d58-4c39-873e-fb99d4bd8c35" />

## Video

The same walkthrough twice, first against `origin/main` (red banner), then against `origin/main` + this fix (green banner): the dashboard, then the filtered widget opened in the editor with its Dataset "Contains -prod-" filter.

- Before: the filtered widget shows "Failed to load chart data". In the editor the filter is set, yet the preview still draws the unfiltered line (0.60 to 0.70, average 0.65).
- After: the widget and the editor both draw the prod-only line (0.80 to 1.00, average 0.90).

https://github.com/user-attachments/assets/37b1092d-da74-4a0c-9cf8-f974770b49d0

## Screenshot of test suite run

**Command** - the new tests, then the 11 dashboard-builder test files, from `futureagi/` against the `bin/test` services

<img width="100%" alt="Local run: the 5 new scenarios pass, then 1035 passed, 32 skipped, 1 deselected across the 11 dashboard-builder test files." src="https://github.com/user-attachments/assets/9767c1a0-ea85-41f2-9d14-0066fbce3750" />

## Backwards compatibility

No schema, migration, API shape or frontend change. The only semantic change: an eval-metric widget that carries a Dataset or Eval Source filter now applies it.

| Caller | Pre-PR | Post-PR |
|---|---|---|
| Eval widget with a Dataset / Eval Source filter (current UI, `property_id` set) | 400, "Failed to load chart data" | chart filtered as configured |
| Eval widget with a legacy flattened Dataset / Eval Source filter | loads, filter ignored | chart filtered as configured |
| Eval widget with any other filter, or none | unchanged | unchanged |
| Eval breakdown by Dataset / Eval Source | unchanged | unchanged (same expressions, now via shared constants) |
| Trace (system) and annotation metrics | unchanged | unchanged |

Blast radius checked on production on 11 Sep: 129 live dashboard widgets, 40 of them chart evals, and none of those 40 carries any filter. No saved chart changes its numbers when this ships.

Out of scope, deliberately:

- "Is set" / "Is not set" on an eval chart's system filters are still skipped. Every eval-chart system filter shares that operator gate, not just these two, so it is a separate change.
- Dataset / Eval Source on a trace metric (spans carry no dataset, the filter is logged and skipped) or an annotation metric (it raises a clear "Unsupported annotation dashboard filter" error). Different data sources, unchanged here.

## Manual verification (UI)

1. On a local stack, have eval runs of one eval on two datasets whose names differ by environment (`...-prod-...`, `...-sandbox-...`).
2. Dashboards → a dashboard → Add Widget → metric: that eval, Pass Rate, Day.
3. Filter → Dataset → Contains → `-prod-`. The preview draws the prod-only line.
4. Change it to Does not contain → `-prod-`. The line now includes sandbox and any runs with no dataset.
5. Replace it with Eval Source → Is → `dataset_evaluation`. Trace and playground runs drop out.
6. Remove the filter. The line matches the unfiltered chart.

## Type of change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📖 Documentation only
- [ ] 🧹 Chore / refactor (no user-visible change)
- [ ] 🚀 Performance improvement
- [ ] 🧪 Test-only change

## Checklist

- [x] My code follows the style guide
- [x] I've added tests that prove my fix is effective
- [x] No hardcoded secrets, URLs, or PII

## Backout / rollback

- No migration and no new file: a clean revert of this commit.
- Reverting returns eval charts to ignoring (legacy payload) or failing on (current payload) the Dataset and Eval Source filters. No data is written or lost either way; the chart only reads.
- Hotfix raised against `main`. After merge, back-merge `main` → `dev` so the fix is not lost in the next release cycle.

E2E: none. Backend query-builder change with no UI change; the behavior is pinned by the integration test above against real ClickHouse.

Closes TH-7938
