### PR TITLE
feat: add voice audio metrics [agent]

### DIFF
--- a/futureagi/ee/voice/services/audio_metrics.py
+++ b/futureagi/ee/voice/services/audio_metrics.py
@@ -1,0 +1,108 @@
+"""Provider-independent acoustic measurements for a single voice track."""
+
+from __future__ import annotations
+
+import io
+import math
+from dataclasses import dataclass
+
+import librosa
+import numpy as np
+
+_FRAME_LENGTH = 2048
+_HOP_LENGTH = 512
+_ENERGY_QUANTILE = 0.2
+
+
+@dataclass(frozen=True)
+class AudioMetrics:
+    """Acoustic measurements derived from one decoded audio track."""
+
+    average_pitch_hz: float | None
+    estimated_snr_db: float | None
+
+
+def analyze_audio(audio_bytes: bytes) -> AudioMetrics:
+    """Analyze a single-speaker track without external services or state.
+
+    Pitch is the arithmetic mean of finite fundamental-frequency values from
+    voiced ``librosa.pyin`` frames.  ``estimated_snr_db`` is a deterministic
+    frame-energy estimate: it treats the mean power of the lowest 20 percent
+    of 2048-sample, 512-hop frames as background-noise power and the mean
+    power of the highest 20 percent as speech-plus-noise power.  The estimate
+    is ``10 * log10((high_power - noise_power) / noise_power)``.  It assumes
+    the quietest frames are noise-dominated and the loudest are
+    speech-dominated; without a clean reference it is not ground-truth SNR.
+
+    ``None`` is returned for a measurement when the waveform is silent or
+    does not provide enough finite frame-energy contrast to estimate it.
+    Malformed or undecodable input raises ``ValueError``.
+    """
+    if not isinstance(audio_bytes, bytes):
+        raise ValueError("audio_bytes must be decodable audio bytes")
+
+    try:
+        waveform, sample_rate = librosa.load(
+            io.BytesIO(audio_bytes), sr=None, mono=True
+        )
+    except Exception as exc:
+        raise ValueError("Could not decode audio bytes") from exc
+
+    waveform = np.asarray(waveform)
+    if waveform.size == 0 or not np.any(np.isfinite(waveform)):
+        return AudioMetrics(None, None)
+
+    waveform = waveform[np.isfinite(waveform)]
+    if waveform.size == 0 or np.max(np.abs(waveform)) <= np.finfo(float).eps:
+        return AudioMetrics(None, None)
+
+    average_pitch_hz = _average_pitch_hz(waveform, sample_rate)
+    estimated_snr_db = _estimated_snr_db(waveform)
+    return AudioMetrics(average_pitch_hz, estimated_snr_db)
+
+
+def _average_pitch_hz(waveform: np.ndarray, sample_rate: int) -> float | None:
+    if waveform.size < _FRAME_LENGTH:
+        return None
+
+    pitches, voiced, _ = librosa.pyin(
+        waveform,
+        fmin=librosa.note_to_hz("C2"),
+        fmax=librosa.note_to_hz("C7"),
+        sr=sample_rate,
+        frame_length=_FRAME_LENGTH,
+        hop_length=_HOP_LENGTH,
+    )
+    voiced_pitches = pitches[np.asarray(voiced, dtype=bool) & np.isfinite(pitches)]
+    if voiced_pitches.size == 0:
+        return None
+
+    average = float(np.mean(voiced_pitches))
+    return average if math.isfinite(average) else None
+
+
+def _estimated_snr_db(waveform: np.ndarray) -> float | None:
+    if waveform.size < _FRAME_LENGTH:
+        return None
+
+    rms = librosa.feature.rms(
+        y=waveform,
+        frame_length=_FRAME_LENGTH,
+        hop_length=_HOP_LENGTH,
+        center=False,
+    )[0]
+    powers = np.square(rms[np.isfinite(rms)])
+    frame_count = powers.size
+    quantile_count = max(1, math.ceil(frame_count * _ENERGY_QUANTILE))
+    if frame_count < 5 or quantile_count == frame_count:
+        return None
+
+    ordered_powers = np.sort(powers)
+    noise_power = float(np.mean(ordered_powers[:quantile_count]))
+    speech_plus_noise_power = float(np.mean(ordered_powers[-quantile_count:]))
+    signal_power = speech_plus_noise_power - noise_power
+    if noise_power <= np.finfo(float).eps or signal_power <= 0:
+        return None
+
+    estimated_snr_db = 10.0 * math.log10(signal_power / noise_power)
+    return estimated_snr_db if math.isfinite(estimated_snr_db) else None

--- a/futureagi/ee/voice/tests/test_audio_metrics.py
+++ b/futureagi/ee/voice/tests/test_audio_metrics.py
@@ -1,0 +1,89 @@
+from __future__ import annotations
+
+import io
+import math
+
+import numpy as np
+import pytest
+import soundfile as sf
+
+from ee.voice.services.audio_metrics import analyze_audio
+
+
+def _synth_wav_bytes(
+    *,
+    noise_amplitude: float = 0.0,
+    include_noise_only_prefix: bool = False,
+    stereo: bool = False,
+) -> bytes:
+    sample_rate = 16_000
+    duration_seconds = 2.0
+    sample_count = int(sample_rate * duration_seconds)
+    times = np.arange(sample_count) / sample_rate
+    signal = 0.5 * np.sin(2 * math.pi * 220 * times)
+    noise = noise_amplitude * np.random.default_rng(42).standard_normal(sample_count)
+    waveform = signal + noise
+    if include_noise_only_prefix:
+        waveform[: sample_rate // 2] = noise[: sample_rate // 2]
+    if stereo:
+        waveform = np.column_stack((waveform, waveform))
+
+    buffer = io.BytesIO()
+    sf.write(buffer, waveform.astype("float32"), sample_rate, format="WAV")
+    return buffer.getvalue()
+
+
+def _assert_finite_metrics(metrics) -> None:
+    for value in (metrics.average_pitch_hz, metrics.estimated_snr_db):
+        if value is not None:
+            assert math.isfinite(value)
+
+
+def test_reports_pitch_for_a_220_hz_sine_wave():
+    metrics = analyze_audio(_synth_wav_bytes(noise_amplitude=0.005))
+
+    assert metrics.average_pitch_hz == pytest.approx(220, rel=0.05)
+    _assert_finite_metrics(metrics)
+
+
+def test_stronger_noise_lowers_estimated_snr():
+    low_noise = analyze_audio(
+        _synth_wav_bytes(noise_amplitude=0.005, include_noise_only_prefix=True)
+    )
+    high_noise = analyze_audio(
+        _synth_wav_bytes(noise_amplitude=0.15, include_noise_only_prefix=True)
+    )
+
+    assert low_noise.estimated_snr_db is not None
+    assert high_noise.estimated_snr_db is not None
+    assert high_noise.estimated_snr_db < low_noise.estimated_snr_db
+    _assert_finite_metrics(low_noise)
+    _assert_finite_metrics(high_noise)
+
+
+def test_silence_has_no_measurements():
+    sample_rate = 16_000
+    buffer = io.BytesIO()
+    sf.write(buffer, np.zeros(sample_rate, dtype="float32"), sample_rate, format="WAV")
+    metrics = analyze_audio(buffer.getvalue())
+
+    assert metrics.average_pitch_hz is None
+    assert metrics.estimated_snr_db is None
+
+
+def test_malformed_audio_raises_value_error():
+    with pytest.raises(ValueError, match="Could not decode audio bytes"):
+        analyze_audio(b"not audio")
+
+
+def test_stereo_audio_is_downmixed_safely():
+    metrics = analyze_audio(_synth_wav_bytes(noise_amplitude=0.005, stereo=True))
+
+    assert metrics.average_pitch_hz == pytest.approx(220, rel=0.05)
+    _assert_finite_metrics(metrics)
+
+
+def test_analysis_is_deterministic_for_the_same_input():
+    audio = _synth_wav_bytes(noise_amplitude=0.005, include_noise_only_prefix=True)
+
+    assert analyze_audio(audio) == analyze_audio(audio)


### PR DESCRIPTION
## Summary

Adds a provider-independent, pure audio analysis helper for single-speaker tracks. It reports average voiced-frame pitch and a documented energy-based estimated SNR without adding dependencies or wiring the metric into ingestion.

Closes #2696

## AI use

AI use: Codex implemented the helper and tests; the change was reviewed and verified locally.

## Type of change

- [x] ✨ New feature (non-breaking change)

## E2E coverage

E2E: exempt (backend-internal)

## Tests

`futureagi/ee/voice/tests/test_audio_metrics.py` covers pitch accuracy, SNR ordering, silence, malformed input, finite values, stereo downmixing, and determinism.

```text
uv run --no-sync pytest -c NUL --confcutdir=ee/voice ee/voice/tests/test_audio_metrics.py -v
======================== 6 passed, 1 warning in 5.57s ========================

uv run --no-sync ruff check ee/voice/services/audio_metrics.py ee/voice/tests/test_audio_metrics.py
All checks passed!

uv run --no-sync ruff format --check ee/voice/services/audio_metrics.py ee/voice/tests/test_audio_metrics.py
2 files already formatted
```

The pytest warning is from using Windows' `NUL` as the isolated test configuration path; it does not affect test results.

## Considerations

- `estimated_snr_db` is explicitly an estimate, not reference-based ground-truth SNR.
- Silent, empty, and insufficient-information audio returns `None` instead of NaN or infinity.
- No API, schema, provider, or frontend changes are included.
