### PR TITLE
feat(observe): carry witness slack in the trace list cursor

### DIFF
--- a/futureagi/tfc/settings/runtime_setting_specs.py
+++ b/futureagi/tfc/settings/runtime_setting_specs.py
@@ -384,6 +384,47 @@ INTERACTIVE_READ_SETTING_SPECS = {
                 100_000,
                 50_000_000,
             ),
+            # Hours of slack the same seed's child-witness scan is allowed
+            # around the roots one statement can publish. ZERO - the default -
+            # is the shipped contract, under which that scan carries no time
+            # bound at all: a trace is a candidate when ANY raw span of it
+            # carries the value, whenever that span started. At zero the
+            # generated SQL and its parameters are byte-identical to what
+            # shipped, so this setting is inert until an operator raises it.
+            #
+            # Above zero the seed statement additionally requires a witness to
+            # start inside the envelope
+            #     [hour_floor(slice_start) - slack, hour_ceil(slice_end) + slack)
+            # where the roots that statement can publish are the ones inside
+            # the slice, tightened on a keyset continuation to the cursor's own
+            # position - so the envelope is the tightest one that still carries
+            # every publishable root's own witness. Every published row is
+            # still an exact any-span match: the latest-state classifier
+            # (``build_filter_match_query``) stays UNBOUNDED, so the switch can
+            # only OMIT a trace whose sole witness lies outside the envelope
+            # and can never admit one the unbounded contract would reject.
+            #
+            # Why it is a switch and not a tuning knob: the unbounded witness
+            # was measured (read-only, against production) to cost a flat
+            # ~4-5 GB bloom false-positive scan per seed statement whatever the
+            # slice's width, with no measured path to a page under five
+            # seconds; the bounded shape's cost is instead LINEAR in envelope
+            # hours (~0.46-0.49 GB per hour - a dense four-hour slice reads
+            # 3.66M rows / 4.47 GB in 3.8 s at ``max_threads`` 1 and 1.76 s at
+            # 2, sparse hours 30-116 MB / 0.4 s), and at one hour of slack it
+            # reproduced the unbounded results exactly on the measured cohort
+            # (3 of 3 page digests, 150 of 150 classifier rows). What one hour
+            # rests on there: the root itself carried the value in 165 of 165
+            # matching traces, the largest child-witness lag was 468 s, and 0
+            # of 1,000 sampled traces held a span more than two days from their
+            # root. That is one project over one burst - bounds, not
+            # guarantees - which is why narrowing the contract stays an owner
+            # decision and the default is off. The 168 h ceiling is one week;
+            # beyond that the envelope stops bounding this lane's own windows.
+            # See ``filter_seed_width_policy`` for the width schedule each mode
+            # uses, which differs because only the bounded shape's cost tracks
+            # the slice.
+            ("FILTER_SELECTOR_TEXT_SEED_WITNESS_SLACK_HOURS", 0, 0, 168),
             # Broad key-only span population proofs read thin raw columns;
             # their CPU budget is separate from the normal seed/classifier.
             ("FILTER_SELECTOR_POPULATION_MAX_THREADS", 2, 1, 4),

--- a/futureagi/tfc/settings/runtime_setting_specs.py
+++ b/futureagi/tfc/settings/runtime_setting_specs.py
@@ -360,6 +360,30 @@ INTERACTIVE_READ_SETTING_SPECS = {
             ("FILTER_SELECTOR_MAX_OPT_IN_QUERY_TIMEOUT_MS", 3_000, 25, 30_000),
             ("FILTER_SELECTOR_MAX_BUILDER_QUERY_TIMEOUT_MS", 30_000, 25, 120_000),
             ("FILTER_SELECTOR_MAX_THREADS", 1, 1, 8),
+            # Rows one short exact-string seed statement should read. That
+            # seed's cost tracks the rows inside its slice, not the slice's
+            # width, and its child witness is time-unbounded, so read rows
+            # chiefly measure the ROOTS inside the slice through a trace-id
+            # bloom false-positive scan (~1 - 0.999 ** roots of a ~107M-row
+            # history; 52.4M rows / 4.29 GB measured once, over a dense
+            # fifteen-minute window at k=676 roots - a single point, not a
+            # measured saturation curve). The selector doubles a slice that
+            # reads under a quarter of this budget and halves one that
+            # overruns it, but never below the lane's own floor, which is the
+            # four-hour fixed ceiling this budget replaced. So in practice the
+            # knob decides how far the seed may WIDEN across near-empty
+            # history (four hours of sparse history cost 110-220 ms at any
+            # width); anywhere results actually live it holds at four hours,
+            # i.e. at least what the fixed ceiling gave. That floor is
+            # provisional, and bounding the dense statement itself is the
+            # pending owner decision on the child-witness contract, not this
+            # setting.
+            (
+                "FILTER_SELECTOR_TEXT_SEED_TARGET_READ_ROWS",
+                2_000_000,
+                100_000,
+                50_000_000,
+            ),
             # Broad key-only span population proofs read thin raw columns;
             # their CPU budget is separate from the normal seed/classifier.
             ("FILTER_SELECTOR_POPULATION_MAX_THREADS", 2, 1, 4),

--- a/futureagi/tfc/tests/test_runtime_setting_specs.py
+++ b/futureagi/tfc/tests/test_runtime_setting_specs.py
@@ -80,6 +80,34 @@ def test_text_seed_row_budget_rejects_values_outside_the_measured_range(value):
         )
 
 
+def test_the_text_seed_witness_slack_is_off_by_default_and_opt_in():
+    """Narrowing the seed's witness contract is a decision, not a default.
+
+    Zero means the shipped contract - no time bound on the witness scan at all
+    - so an operator who never touches this setting keeps byte-identical SQL.
+    """
+
+    defaults = load_numeric_settings(INTERACTIVE_READ_SETTING_SPECS, source={})
+    assert defaults["FILTER_SELECTOR_TEXT_SEED_WITNESS_SLACK_HOURS"] == 0
+
+    for raw, expected in (("1", 1), (24, 24), ("168", 168)):
+        enabled = load_numeric_settings(
+            INTERACTIVE_READ_SETTING_SPECS,
+            source={"FILTER_SELECTOR_TEXT_SEED_WITNESS_SLACK_HOURS": raw},
+        )
+        validate_interactive_read_settings(enabled)
+        assert enabled["FILTER_SELECTOR_TEXT_SEED_WITNESS_SLACK_HOURS"] == expected
+
+
+@pytest.mark.parametrize("value", [-1, 169, 1.5, True, "off"])
+def test_the_text_seed_witness_slack_rejects_values_outside_one_week(value):
+    with pytest.raises(ValueError):
+        load_numeric_settings(
+            INTERACTIVE_READ_SETTING_SPECS,
+            source={"FILTER_SELECTOR_TEXT_SEED_WITNESS_SLACK_HOURS": value},
+        )
+
+
 @pytest.mark.parametrize("value", [0, -1, 5, True, "unlimited"])
 def test_population_worker_budget_rejects_unbounded_or_invalid_values(value):
     with pytest.raises(ValueError):

--- a/futureagi/tfc/tests/test_runtime_setting_specs.py
+++ b/futureagi/tfc/tests/test_runtime_setting_specs.py
@@ -57,6 +57,29 @@ def test_population_worker_budget_is_separate_and_can_be_lowered():
     assert reduced["FILTER_SELECTOR_POPULATION_MAX_THREADS"] == 1
 
 
+def test_text_seed_row_budget_is_operator_tunable_within_a_measured_range():
+    """The short exact-string seed is sized by rows read, not by slice hours."""
+
+    defaults = load_numeric_settings(INTERACTIVE_READ_SETTING_SPECS, source={})
+    assert defaults["FILTER_SELECTOR_TEXT_SEED_TARGET_READ_ROWS"] == 2_000_000
+
+    lowered = load_numeric_settings(
+        INTERACTIVE_READ_SETTING_SPECS,
+        source={"FILTER_SELECTOR_TEXT_SEED_TARGET_READ_ROWS": "100000"},
+    )
+    validate_interactive_read_settings(lowered)
+    assert lowered["FILTER_SELECTOR_TEXT_SEED_TARGET_READ_ROWS"] == 100_000
+
+
+@pytest.mark.parametrize("value", [0, -1, 99_999, 50_000_001, True, "unlimited"])
+def test_text_seed_row_budget_rejects_values_outside_the_measured_range(value):
+    with pytest.raises(ValueError):
+        load_numeric_settings(
+            INTERACTIVE_READ_SETTING_SPECS,
+            source={"FILTER_SELECTOR_TEXT_SEED_TARGET_READ_ROWS": value},
+        )
+
+
 @pytest.mark.parametrize("value", [0, -1, 5, True, "unlimited"])
 def test_population_worker_budget_rejects_unbounded_or_invalid_values(value):
     with pytest.raises(ValueError):

--- a/futureagi/tracer/selectors/filter_seed_width.py
+++ b/futureagi/tracer/selectors/filter_seed_width.py
@@ -47,9 +47,28 @@ class FilterSeedWidthPolicy:
 
     ``target_read_rows`` is the rows a single seed statement should read.
     ``initial_width`` is the width of the first statement of a read, before any
-    measurement exists. ``unsignalled_cap`` is the only ceiling that applies
-    while no statement of this read has reported read rows — a transport
-    without native progress, or the first slice of a read.
+    measurement exists. ``unsignalled_cap`` is the ceiling that applies to any
+    width this read cannot justify from a measurement: a transport without
+    native progress, the first slice of a read, and — the reason it is also
+    called the *unprobed* cap — any widening past it that no density probe has
+    approved.
+
+    THE WIDENING CONTRACT. Doubling is reactive: it fires on the rows the
+    PREVIOUS slice read, and knows nothing about the population of the NEXT
+    one. Across a sparse tail that is exactly right, and it is how a lane
+    reaches old data in log(n) statements instead of n. But a tail that ends at
+    a dense region ends the doubling on a slice whose measured predecessor was
+    empty and whose own contents are not: eight doublings across a 166 h sparse
+    tail land a 128 h slice on dense history, and that one statement read over
+    12 GiB in production measurement. So a width ABOVE ``unsignalled_cap`` is
+    not a width this policy may issue on the strength of the previous slice
+    alone. The selector must first prove the candidate slice's row population
+    with a cheap density probe and pass the count to ``probed_width``; a probe
+    that fails, or a transport with no probe at all, gets the cap.
+
+    The resulting contract is the one worth stating plainly: *a seed statement
+    never reads more than ~``target_read_rows`` knowingly, and a sparse tail is
+    crossed at probe cost (~1-2 MB and ~70 ms each), not at slice cost.*
 
     ``min_width`` is the width this lane refuses to narrow below. It is a
     declaration, not a derived quantity: a seed whose child witness is
@@ -123,6 +142,54 @@ class FilterSeedWidthPolicy:
                 self.min_width,
             )
         return width
+
+    @property
+    def unprobed_cap(self) -> timedelta:
+        """The widest slice this lane may issue without a density proof.
+
+        The same width as ``unsignalled_cap`` and deliberately not a second
+        knob: both answer one question — how wide may a statement be when this
+        read has measured nothing about what is inside it? An unsignalled
+        transport has measured nothing because it cannot report; an unprobed
+        widening has measured only the slice next door.
+        """
+
+        return self.unsignalled_cap
+
+    def requires_density_probe(self, width: timedelta) -> bool:
+        """Whether issuing ``width`` needs a density proof first."""
+
+        return width > self.unprobed_cap
+
+    def probed_width(self, width: timedelta, slice_rows: int) -> timedelta:
+        """Fit a probed candidate slice to the row budget.
+
+        ``slice_rows`` is the probe's count of live rows inside the candidate
+        slice ``[end - width, end)``. A count within budget issues the slice
+        unchanged — this is the sparse-tail case, and it is why the tail is
+        still crossed by doubling rather than one floor-width slice at a time.
+        A count over budget shrinks the slice proportionally: rows are assumed
+        uniform across the candidate, so the largest width whose share of the
+        count fits is ``width * target / slice_rows``, snapped DOWN onto the
+        lane's whole-hour power-of-two lattice and never below the floor.
+
+        The proportional estimate is an estimate. It is wrong in both
+        directions on a slice whose density is not uniform, which is precisely
+        the shape that produced the defect — but it is wrong by the ratio of
+        the densest part to the mean, not by the two orders of magnitude that
+        separate a sparse week from a dense hour, and the next statement's own
+        read rows correct it through the ordinary halving rule.
+        """
+
+        if slice_rows < 0:
+            raise ValueError("a density probe cannot count negative rows")
+        if slice_rows <= self.target_read_rows:
+            return width
+        fitted = width * (self.target_read_rows / slice_rows)
+        return max(
+            min(_snap_whole_hour_power_of_two(fitted, round_up=False), width),
+            self.min_width,
+        )
 
     def unsignalled_width(self, width: timedelta) -> timedelta:
         """Clamp a width proposed before any statement reported its read rows.

--- a/futureagi/tracer/selectors/filter_seed_width.py
+++ b/futureagi/tracer/selectors/filter_seed_width.py
@@ -1,0 +1,149 @@
+"""Row-budgeted adaptive slice widths for bounded candidate-seed acquisition.
+
+A seed whose statement cost tracks the *rows* its slice contains cannot be
+bounded by a fixed wall-clock ceiling: a dense hour and a sparse week differ by
+two orders of magnitude in read rows, so any single hour count is either a
+useless cap on the dense end or a scan that never reaches data on the sparse
+end. Such a builder declares a policy instead, and the bounded filter selector
+resizes each following slice from the rows the previous seed statement actually
+read.
+
+This moves only the acquisition boundary. Predicates, ordering, the exact
+latest-state classifier, publication and the signed cursor payload are
+untouched; slices stay contiguous and half-open, so a narrower slice defers
+older history to the next adjacent slice rather than skipping it.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import timedelta
+
+_HOUR = timedelta(hours=1)
+
+
+def _snap_whole_hour_power_of_two(width: timedelta, *, round_up: bool) -> timedelta:
+    """Snap a width of an hour or more onto the whole-hour power-of-two lattice.
+
+    Widths below an hour are returned unchanged: the sub-hour lattice is the
+    halving sequence (30m, 15m) and has no whole-hour representation. Callers
+    round up only a width that is already a lower bound, and down only a width
+    that is already an upper bound, so neither direction loses its guarantee.
+    """
+
+    if width <= _HOUR:
+        return width
+    hours = 1
+    while (hours * 2) * _HOUR <= width:
+        hours *= 2
+    if round_up and hours * _HOUR < width:
+        hours *= 2
+    return hours * _HOUR
+
+
+@dataclass(frozen=True)
+class FilterSeedWidthPolicy:
+    """The row budget one seed lane admits per statement, and its width lattice.
+
+    ``target_read_rows`` is the rows a single seed statement should read.
+    ``initial_width`` is the width of the first statement of a read, before any
+    measurement exists. ``unsignalled_cap`` is the only ceiling that applies
+    while no statement of this read has reported read rows — a transport
+    without native progress, or the first slice of a read.
+
+    ``min_width`` is the width this lane refuses to narrow below. It is a
+    declaration, not a derived quantity: a seed whose child witness is
+    time-unbounded pays a flat per-statement term that does not shrink with
+    the slice, so below some width a statement pays the same cost for a
+    fraction of the coverage, and only the declaring lane knows where that is.
+    Each lane must therefore state its own floor. Halving applies to every
+    width above the floor — a slice that grew on sparse history and then ran
+    into dense data walks back down to it — and a width already *below* the
+    floor is left alone rather than lifted to it, because a sub-floor width is
+    always something another mechanism proved necessary (a keyset resume, a
+    read-budget retry, a root-time-discovery hour).
+
+    Widths at or above an hour are whole-hour powers of two (1h, 2h, 4h, ...),
+    which is the granularity the ``toStartOfHour`` primary-key prefix can prune
+    on; the request-width clamp is deliberately exempt, because the oldest
+    slice is truncated at the request start in any case.
+    """
+
+    initial_width: timedelta
+    target_read_rows: int
+    min_width: timedelta
+    unsignalled_cap: timedelta = timedelta(hours=4)
+
+    def __post_init__(self) -> None:
+        if self.target_read_rows <= 0:
+            raise ValueError("seed width policy requires a positive row target")
+        if not (
+            timedelta(0) < self.min_width <= self.initial_width <= self.unsignalled_cap
+        ):
+            raise ValueError("seed width policy widths must be positive and ordered")
+
+    def next_width(
+        self,
+        width: timedelta,
+        read_rows: int | None,
+        *,
+        request_width: timedelta,
+    ) -> timedelta:
+        """Return the next slice width from the last seed statement's read rows.
+
+        A statement that read less than a quarter of the budget doubles, one
+        that overran the budget halves, and anything between leaves the width
+        alone so a correctly sized scan does not oscillate. A statement that
+        reported no progress cannot justify more than the unsignalled cap.
+
+        The halving branch only ever narrows. A width at or below the floor is
+        returned as it stands (clamped to the request), never lifted to the
+        floor: widths below the floor are reached by mechanisms that proved
+        that exact interval necessary — a cursor keyset resuming at a
+        microsecond boundary, the read-budget retry's five-minute reset, the
+        single hour a root-time-discovery hit pins — and widening one of those
+        because its statement was expensive would be the wrong direction.
+        """
+
+        if read_rows is None:
+            return min(
+                _snap_whole_hour_power_of_two(width * 2, round_up=True),
+                self.unsignalled_cap,
+            )
+        if read_rows < self.target_read_rows // 4:
+            return min(
+                _snap_whole_hour_power_of_two(width * 2, round_up=True),
+                request_width,
+            )
+        if read_rows > self.target_read_rows:
+            if width <= self.min_width:
+                return min(width, request_width)
+            return max(
+                _snap_whole_hour_power_of_two(width / 2, round_up=False),
+                self.min_width,
+            )
+        return width
+
+    def unsignalled_width(self, width: timedelta) -> timedelta:
+        """Clamp a width proposed before any statement reported its read rows.
+
+        The selector's non-cursor lane inflates the first slice so the whole
+        request window is scheduled inside one request's attempt count. That
+        inflation is a lower bound and may land off the lattice, so it rounds
+        up before the cap applies.
+        """
+
+        return min(
+            _snap_whole_hour_power_of_two(width, round_up=True),
+            self.unsignalled_cap,
+        )
+
+    def carried_width(self, width: timedelta) -> timedelta:
+        """Clamp a slice width carried in from a previous HTTP hop.
+
+        A carried width is a hint from a read that has measured nothing in this
+        request, so it may shrink but never widen: a cursor signed before this
+        policy shipped can carry a slice many times the unsignalled cap.
+        """
+
+        return min(width, self.unsignalled_cap)

--- a/futureagi/tracer/selectors/trace_filter_reads.py
+++ b/futureagi/tracer/selectors/trace_filter_reads.py
@@ -12,6 +12,7 @@ from typing import Any, Protocol
 
 from django.conf import settings
 
+from tracer.selectors.filter_seed_width import FilterSeedWidthPolicy
 from tracer.services.clickhouse.query_builders.base import BaseQueryBuilder
 from tracer.services.clickhouse.query_service import QueryResult
 from tracer.services.clickhouse.read_budget import is_read_budget_error
@@ -163,6 +164,9 @@ class FilterReadAttempt:
     result_payload_bytes: int
     query_count: int = 1
     error_code: str | None = None
+    # Server-side work, not result size, and ``None`` whenever the transport
+    # reports no native progress. Slice widths are the only thing sized from it.
+    read_rows: int | None = None
 
 
 @dataclass(frozen=True)
@@ -1327,6 +1331,19 @@ def read_bounded_filter_page(
     # cursors did not carry it, so resume from the frozen window start: slower,
     # but exact and gap-free.
     active_slice_start: datetime | None
+    # A carried slice that still owns an in-slice keyset is honoured verbatim:
+    # its lower boundary is the exact interval the keyset was proven inside, so
+    # narrowing it would strand the rows between the new and old boundaries. A
+    # carried slice without a keyset only *proposes* a width and may be shrunk.
+    #
+    # A cursor signed before a row budget shipped can therefore still carry one
+    # keyset-bearing slice far wider than that budget would schedule. This is
+    # accepted as a transient bounded by the signed cursor's own maximum age
+    # (TRACER_LIST_CURSOR_MAX_AGE_SECONDS), not repaired by CURSOR_VERSION:
+    # rejecting those cursors turns every open page into a 400, and the grid
+    # answers a 400 by falling back to the numbered lane, whose reads are
+    # strictly worse than one wide slice.
+    carried_slice_width_is_hint = False
     if (
         continuation_slice_end is not None
         and continuation_before_start_time is not None
@@ -1341,6 +1358,7 @@ def read_bounded_filter_page(
         # successful 1h -> 2h -> 4h widening schedule survives the HTTP round
         # trip. Older cursors omit it and retain the conservative initial width.
         active_slice_start = continuation_slice_start
+        carried_slice_width_is_hint = active_slice_start is not None
     else:
         active_slice_start = None
     # Five minutes remains the conservative default for every selector.  A
@@ -1363,6 +1381,43 @@ def read_bounded_filter_page(
             ):
                 raise ValueError("recommended max slice width exceeds bounded contract")
             max_slice_width = max(max_slice_width, raw_max_slice_width)
+    # A wall-clock ceiling is the wrong bound for a seed whose statement cost
+    # tracks the rows inside its slice rather than the slice's width. Such a
+    # builder declares a row budget and every following slice is sized from the
+    # rows the previous seed statement actually read. Only the acquisition
+    # boundary moves: slices stay contiguous, and predicates, ordering, the
+    # exact classifier and the signed cursor payload are unchanged.
+    seed_width_policy_builder = getattr(builder, "filter_seed_width_policy", None)
+    seed_width_policy: FilterSeedWidthPolicy | None = (
+        seed_width_policy_builder() if callable(seed_width_policy_builder) else None
+    )
+    if seed_width_policy is not None and not isinstance(
+        seed_width_policy, FilterSeedWidthPolicy
+    ):
+        raise ValueError("filter seed width policy must be a FilterSeedWidthPolicy")
+    # The window an empty-seed root-time discovery narrows to. One hour is the
+    # wall-clock lane's smallest useful slice; a row-budgeted lane cannot use a
+    # window below the floor it declared, and would be pinned there, because
+    # its own rule leaves a sub-floor width alone instead of widening it.
+    discovery_reset_width = (
+        timedelta(hours=1)
+        if seed_width_policy is None
+        else max(timedelta(hours=1), seed_width_policy.min_width)
+    )
+    if (
+        seed_width_policy is not None
+        and carried_slice_width_is_hint
+        and active_slice_start is not None
+    ):
+        # A carried slice is a width this request has not measured, and cursors
+        # signed before this policy shipped can carry many times the cap. Shrink
+        # it to what an unmeasured statement may read; the uncovered older part
+        # of the carried slice is the next contiguous slice's work, so the scan
+        # stays exact.
+        active_slice_start = max(
+            active_slice_start,
+            slice_end - seed_width_policy.carried_width(slice_end - active_slice_start),
+        )
 
     slice_width = _INITIAL_SLICE
     initial_slice_width_builder = getattr(
@@ -1402,6 +1457,10 @@ def read_bounded_filter_page(
     # slice.  Keep the failed-width ceiling for later widening, but make the
     # immediate recovery attempt use the normal five-minute slice.
     retry_slice_width: timedelta | None = None
+    # The row budget's only inputs. Until one seed statement reports progress,
+    # the unsignalled cap is the sole ceiling the budget can justify.
+    last_seed_read_rows: int | None = None
+    seed_read_rows_signalled = False
     page_complete = False
     degraded_error_code: str | None = None
     safe_slice_end = slice_end
@@ -1733,6 +1792,7 @@ def read_bounded_filter_page(
                 elapsed_ms=(monotonic() - attempt_started) * 1000,
                 rows_returned=len(rows),
                 result_payload_bytes=_result_payload_bytes(rows),
+                read_rows=getattr(result, "read_rows", None),
             )
         )
         return result
@@ -2871,12 +2931,30 @@ def read_bounded_filter_page(
                             discovery_ready = False
                         next_end = min(slice_end, hour_start + timedelta(hours=1))
                         next_start = max(request_start, hour_start)
+                        if discovery_reset_width > timedelta(hours=1):
+                            # A row-budgeted lane's reset window is its floor,
+                            # so extend the replayed hour DOWNWARDS to it. The
+                            # hit hour is still replayed whole and the extra
+                            # coverage is the next contiguous slice's work
+                            # brought forward, so the scan stays exact; without
+                            # it the lane would re-enter the budget holding a
+                            # one-hour slice it can never widen again.
+                            next_start = max(
+                                request_start,
+                                min(next_start, next_end - discovery_reset_width),
+                            )
                     advanced = next_end < slice_end
                     slice_end = next_end
                     active_slice_start = next_start
-                    # Discovery may widen coverage, never the ordered seed's
-                    # working set. Keep a known failed-width ceiling too.
-                    slice_width = min(slice_width, timedelta(hours=1))
+                    # Discovery narrows the next slice so a hit lands in a small
+                    # window: proving where the newest row is only pays if the
+                    # slice that follows is cheap. A wall-clock lane's smallest
+                    # useful window is an hour, the granularity its primary-key
+                    # prefix prunes on; a row-budgeted lane's is the floor it
+                    # declared, below which a statement pays the same flat cost
+                    # for a fraction of the coverage. Narrow to that, never past
+                    # it, and never widen a slice discovery did not widen.
+                    slice_width = min(slice_width, discovery_reset_width)
                     if forced_width_cap is not None and next_start is not None:
                         active_slice_start = max(
                             next_start, slice_end - forced_width_cap
@@ -2906,8 +2984,19 @@ def read_bounded_filter_page(
             # entire request window inside this request's attempt count; that
             # turns a configured one-hour root seed into a multi-day read on
             # year-scale projects and can fail before emitting a checkpoint.
-            if not bounded_continuation and scheduled_coverage < remaining_window:
+            if (
+                not bounded_continuation
+                and scheduled_coverage < remaining_window
+                and not (seed_width_policy is not None and seed_read_rows_signalled)
+            ):
+                # Numbered pages have no cursor to resume from, so they still
+                # schedule the whole remaining window inside this request's
+                # attempt count. Once a statement has reported its read rows the
+                # row budget is the better estimator and supersedes it; the
+                # budget's own doubling reaches a sparse month in ten slices.
                 active_width = max(active_width, remaining_window / remaining_attempts)
+            if seed_width_policy is not None and not seed_read_rows_signalled:
+                active_width = seed_width_policy.unsignalled_width(active_width)
             if forced_width_cap is not None:
                 active_width = min(active_width, forced_width_cap)
             scheduled_slice_start = max(request_start, slice_end - active_width)
@@ -3056,6 +3145,10 @@ def read_bounded_filter_page(
                     continue
                 else:
                     raise
+            last_seed_read_rows = getattr(seed_result, "read_rows", None)
+            seed_read_rows_signalled = (
+                seed_read_rows_signalled or last_seed_read_rows is not None
+            )
             seed_rows = sorted(seed_result.data, key=seed_row_key, reverse=True)
             if (
                 population_discovery
@@ -3227,7 +3320,18 @@ def read_bounded_filter_page(
                     force=True,
                 )
             slice_end = slice_start
-            slice_width = min(active_width * 2, max_slice_width)
+            if seed_width_policy is not None:
+                # The budget replaces the doubling rule, not the contract the
+                # builder declared around it: a lane that both declares a
+                # policy and recommends a maximum slice keeps that maximum.
+                slice_width = min(
+                    seed_width_policy.next_width(
+                        active_width, last_seed_read_rows, request_width=request_width
+                    ),
+                    max_slice_width,
+                )
+            else:
+                slice_width = min(active_width * 2, max_slice_width)
             active_slice_start = (
                 max(request_start, slice_end - slice_width)
                 if carry_continuation_slice_width and slice_end > request_start

--- a/futureagi/tracer/selectors/trace_filter_reads.py
+++ b/futureagi/tracer/selectors/trace_filter_reads.py
@@ -69,6 +69,12 @@ _ROOT_TIME_DISCOVERY_MAX_WINDOW = timedelta(hours=24)
 _ROOT_TIME_DISCOVERY_TIMEOUT_MS = 1_000
 _ROOT_TIME_DISCOVERY_MAX_BYTES = 1024 * 1024 * 1024
 _ROOT_TIME_DISCOVERY_MAX_ATTEMPTS = 3
+# The density probe a row-budgeted seed must pass before it may widen past its
+# unprobed cap. It is the same shape of cheap metadata read as root-time
+# discovery - a PK-range count with no attribute predicate - so it carries the
+# same caps: one second, one gibibyte, one worker, and never a partial result.
+_SEED_DENSITY_PROBE_TIMEOUT_MS = 1_000
+_SEED_DENSITY_PROBE_MAX_BYTES = 1024 * 1024 * 1024
 _POPULATION_TIME_DISCOVERY_MAX_THREADS = settings.FILTER_SELECTOR_POPULATION_MAX_THREADS
 # Trace/span list queries fetch one additional page-sized de-duplication
 # margin; 5,000 is also the existing server-side result ceiling used by those
@@ -1395,6 +1401,27 @@ def read_bounded_filter_page(
         seed_width_policy, FilterSeedWidthPolicy
     ):
         raise ValueError("filter seed width policy must be a FilterSeedWidthPolicy")
+    # A width above the policy's unprobed cap is a width no measurement in this
+    # read justifies: reactive doubling sizes the next slice from the PREVIOUS
+    # one's rows and is blind to what the next slice contains. A lane that
+    # offers a density probe may buy that knowledge for ~1-2 MB; one that does
+    # not keeps the cap, which is the behaviour the row budget replaced.
+    seed_density_probe_builder = getattr(
+        builder, "build_filter_seed_density_probe_query", None
+    )
+    seed_density_probe_support = getattr(
+        builder, "supports_filter_seed_density_probe", None
+    )
+    seed_density_probe_enabled = bool(
+        seed_width_policy is not None
+        and callable(seed_density_probe_builder)
+        and callable(seed_density_probe_support)
+        and seed_density_probe_support() is True
+    )
+    # One probe per distinct candidate slice per request. The schedule only
+    # ever proposes a given boundary/width pair once, so this is a guard
+    # against a retry paying twice, not an optimization of the common path.
+    seed_density_counts: dict[tuple[datetime, datetime], int | None] = {}
     # The window an empty-seed root-time discovery narrows to. One hour is the
     # wall-clock lane's smallest useful slice; a row-budgeted lane cannot use a
     # window below the floor it declared, and would be pinned there, because
@@ -1711,6 +1738,21 @@ def read_bounded_filter_page(
                     int(settings["max_bytes_to_read"]),
                     max_bytes_to_read_cap,
                 )
+            if kind == "seed_density_probe":
+                # A cost question, never a membership one: one worker, a
+                # gibibyte, and never a partial count (a truncated count would
+                # under-report density and approve the very slice this probe
+                # exists to refuse).
+                settings["max_threads"] = min(int(settings["max_threads"]), 1)
+                settings["max_memory_usage"] = min(
+                    int(settings["max_memory_usage"]),
+                    _SEED_DENSITY_PROBE_MAX_BYTES,
+                )
+                settings.update(
+                    read_overflow_mode="throw",
+                    result_overflow_mode="throw",
+                    timeout_overflow_mode="throw",
+                )
             if kind in {"root_time_discovery", "population_time_discovery"}:
                 if (
                     kind == "population_time_discovery"
@@ -1750,7 +1792,7 @@ def read_bounded_filter_page(
             if is_read_budget_error(exc):
                 error_code = "read_budget_exceeded"
             elif (
-                kind in {"prefilter", "micro_seed", "zero_probe"}
+                kind in {"prefilter", "micro_seed", "zero_probe", "seed_density_probe"}
                 and isinstance(exc, (RuntimeError, TimeoutError))
             ) or (
                 kind
@@ -1796,6 +1838,93 @@ def read_bounded_filter_page(
             )
         )
         return result
+
+    def probe_guarded_width(width: timedelta, boundary: datetime) -> timedelta:
+        """Refuse to issue a slice wider than the cap without a density proof.
+
+        ``width`` is what the row budget proposes for the slice ending at
+        ``boundary``; the return value is what this read is allowed to issue.
+
+        Below the unprobed cap nothing happens - the ordinary 1 h -> 2 h -> 4 h
+        schedule is untouched and costs no extra statement. Above it, the
+        candidate slice is counted first:
+
+        * count within the row budget -> issue the proposed width. This is the
+          sparse tail, and it is why the tail is still crossed logarithmically
+          (8 h, 16 h, 32 h, 64 h ... each approved by its own ~1-2 MB probe)
+          rather than one cap-width slice at a time, which is the regression a
+          bare absolute cap would reintroduce: a 166 h tail at 4 h a slice is
+          42 statements and needs several HTTP continuations before the first
+          row reaches the user;
+        * count over budget -> shrink proportionally, never below the floor.
+          This is the sparse-tail-meets-dense-region case the guard exists for:
+          the 128 h slice whose probe reports tens of millions of rows becomes
+          a few hours, and the first dense seed reads ~1-2M rows instead of
+          over 12 GiB;
+        * probe unavailable, failed or timed out -> the unprobed cap. A lane
+          with no probe hook, and a transport that cannot answer one, get the
+          fixed ceiling the row budget replaced, which is never worse than the
+          behaviour before the budget shipped.
+
+        Shrinking is always safe. Slices are contiguous and half-open, so a
+        narrower slice defers its older part to the next adjacent slice rather
+        than skipping it; predicates, ordering, the exact latest-state
+        classifier and the signed cursor payload are untouched. A failed probe
+        is recorded in ``optional_failed_attempts`` for the same reason the
+        other speculative reads are: it supplies acceleration only, and must
+        not turn an otherwise exact page into a degraded one.
+        """
+
+        if seed_width_policy is None or not seed_width_policy.requires_density_probe(
+            width
+        ):
+            return width
+        if not seed_density_probe_enabled:
+            return min(width, seed_width_policy.unprobed_cap)
+        probe_start = max(request_start, boundary - width)
+        if probe_start >= boundary:
+            return min(width, seed_width_policy.unprobed_cap)
+        probe_key = (probe_start, boundary)
+        if probe_key in seed_density_counts:
+            counted = seed_density_counts[probe_key]
+        else:
+            counted = None
+            try:
+                probe_query, probe_params = seed_density_probe_builder(
+                    slice_start=probe_start, slice_end=boundary
+                )
+                probe_result = execute(
+                    kind="seed_density_probe",
+                    query=probe_query,
+                    params=probe_params,
+                    active_start=probe_start,
+                    active_end=boundary,
+                    result_limit=1,
+                    timeout_cap_ms=_SEED_DENSITY_PROBE_TIMEOUT_MS,
+                    max_bytes_to_read_cap=_SEED_DENSITY_PROBE_MAX_BYTES,
+                )
+            except _BudgetExceeded as exc:
+                if exc.error_code in {"read_budget_exceeded", "prefilter_unavailable"}:
+                    optional_failed_attempts.add(len(attempts) - 1)
+            except (TypeError, ValueError):
+                # A builder that cannot shape this probe for this slice is a
+                # lane without a probe, not a failed read.
+                pass
+            else:
+                probe_rows = list(probe_result.data or [])
+                raw_count = (
+                    probe_rows[0].get("seed_density_rows") if probe_rows else None
+                )
+                if isinstance(raw_count, bool) or not isinstance(
+                    raw_count, (int, float)
+                ):
+                    counted = None
+                else:
+                    counted = max(0, int(raw_count))
+            seed_density_counts[probe_key] = counted
+        if counted is None:
+            return min(width, seed_width_policy.unprobed_cap)
+        return seed_width_policy.probed_width(width, counted)
 
     def row_identity(row: dict[str, Any]) -> Hashable:
         identity_builder = getattr(builder, "bounded_filter_row_identity", None)
@@ -3324,11 +3453,16 @@ def read_bounded_filter_page(
                 # The budget replaces the doubling rule, not the contract the
                 # builder declared around it: a lane that both declares a
                 # policy and recommends a maximum slice keeps that maximum.
-                slice_width = min(
-                    seed_width_policy.next_width(
-                        active_width, last_seed_read_rows, request_width=request_width
+                slice_width = probe_guarded_width(
+                    min(
+                        seed_width_policy.next_width(
+                            active_width,
+                            last_seed_read_rows,
+                            request_width=request_width,
+                        ),
+                        max_slice_width,
                     ),
-                    max_slice_width,
+                    slice_end,
                 )
             else:
                 slice_width = min(active_width * 2, max_slice_width)

--- a/futureagi/tracer/services/clickhouse/list_cursor.py
+++ b/futureagi/tracer/services/clickhouse/list_cursor.py
@@ -28,6 +28,11 @@ CURSOR_VERSION = 4
 CURSOR_SALT = "tracer.clickhouse-list-cursor.v4"
 DEFAULT_CURSOR_MAX_AGE_SECONDS = 24 * 60 * 60
 
+# Hours of witness slack a running pagination may carry. The ceiling matches
+# FILTER_SELECTOR_TEXT_SEED_WITNESS_SLACK_HOURS's own range; a token outside it
+# was not minted by this codec.
+MAX_CURSOR_WITNESS_SLACK_HOURS = 168
+
 
 class ListCursorError(ValueError):
     """A sanitized cursor validation error safe to expose at the API edge."""
@@ -48,6 +53,14 @@ class ListCursor:
     scan_slice_end: datetime | None = None
     scan_before_start_time: datetime | None = None
     scan_before_id: Any = None
+    # The witness slack the pagination STARTED with, when the read that minted
+    # this token had one. ``None`` is the legacy shape - a token minted before
+    # this field, or by a lane that has no witness envelope - and resolves to
+    # the current runtime setting, which is exactly what those tokens got
+    # before. Deliberately NOT a CURSOR_VERSION bump: rejecting live tokens
+    # would 400 the grid down to the numbered lane for a field whose absence
+    # is already well defined.
+    witness_slack_hours: int | None = None
 
 
 def _utc_datetime(value: datetime, field_name: str) -> datetime:
@@ -308,6 +321,7 @@ def encode_list_cursor(
     scan_slice_end: datetime | None = None,
     scan_before_start_time: datetime | None = None,
     scan_before_id: Any = None,
+    witness_slack_hours: int | None = None,
 ) -> str:
     window_start = _utc_datetime(window_start, "window_start")
     window_end = _utc_datetime(window_end, "window_end")
@@ -339,6 +353,12 @@ def encode_list_cursor(
         < (scan_slice_end or window_end)
     ):
         raise ValueError("invalid list scan checkpoint")
+    if witness_slack_hours is not None and (
+        not isinstance(witness_slack_hours, int)
+        or isinstance(witness_slack_hours, bool)
+        or not 0 <= witness_slack_hours <= MAX_CURSOR_WITNESS_SLACK_HOURS
+    ):
+        raise ValueError("invalid list cursor witness slack")
     payload = {
         "v": CURSOR_VERSION,
         "resource": resource,
@@ -355,6 +375,11 @@ def encode_list_cursor(
         "scan_before_start_time": _json_value(scan_before_start_time),
         "scan_before_id": _json_value(scan_before_id),
     }
+    if witness_slack_hours is not None:
+        # Absent, not null: a caller with no slack to carry must mint the same
+        # payload - and therefore the same boundary fingerprint - as before
+        # this field existed.
+        payload["witness_slack_hours"] = int(witness_slack_hours)
     return signing.dumps(
         payload, key=settings.SECRET_KEY, salt=CURSOR_SALT, compress=True
     )
@@ -458,6 +483,13 @@ def decode_list_cursor(
         raise ListCursorError("invalid_cursor", "The continuation cursor is invalid.")
     if (scan_before_start_time is None) != (scan_before_id is None):
         raise ListCursorError("invalid_cursor", "The continuation cursor is invalid.")
+    witness_slack_hours = payload.get("witness_slack_hours")
+    if witness_slack_hours is not None and (
+        not isinstance(witness_slack_hours, int)
+        or isinstance(witness_slack_hours, bool)
+        or not 0 <= witness_slack_hours <= MAX_CURSOR_WITNESS_SLACK_HOURS
+    ):
+        raise ListCursorError("invalid_cursor", "The continuation cursor is invalid.")
     if scan_before_start_time is not None and (
         not isinstance(scan_before_start_time, datetime)
         or not (scan_slice_start or window_start)
@@ -479,6 +511,7 @@ def decode_list_cursor(
         scan_slice_end=scan_slice_end,
         scan_before_start_time=scan_before_start_time,
         scan_before_id=scan_before_id,
+        witness_slack_hours=witness_slack_hours,
     )
 
 

--- a/futureagi/tracer/services/clickhouse/query_builders/trace_list.py
+++ b/futureagi/tracer/services/clickhouse/query_builders/trace_list.py
@@ -3589,6 +3589,28 @@ class TraceListQueryBuilder(BaseQueryBuilder):
                 if _restrict_scalar_root_population
                 else ""
             )
+            # The roots THIS statement can publish are the ones inside the
+            # slice, tightened to the cursor on a keyset continuation: an
+            # older-direction resume can never publish a root above the
+            # cursor, a newer-direction one never below it. A lane that
+            # declares a witness envelope derives it from those bounds, so its
+            # envelope is the tightest one that still carries every
+            # publishable root's own witness.
+            witness_envelope_fragment, witness_envelope_params = (
+                self._scalar_candidate_witness_envelope(
+                    root_start=(
+                        before_start_time
+                        if before_start_time is not None and direction == "newer"
+                        else slice_start
+                    ),
+                    root_end=(
+                        before_start_time
+                        if before_start_time is not None and direction == "older"
+                        else slice_end
+                    ),
+                )
+            )
+            params.update(witness_envelope_params)
             # All child timestamps and physical versions must participate.
             # No inner LIMIT: truncating raw witnesses could hide an older
             # matching root. Statement limits throw instead of proving absence.
@@ -3597,7 +3619,7 @@ class TraceListQueryBuilder(BaseQueryBuilder):
             SELECT DISTINCT trace_id
             FROM {self.TABLE}
             PREWHERE {self.project_filter_sql()}
-              {project_version_fragment}
+              {project_version_fragment}{witness_envelope_fragment}
               {root_population}
             WHERE {raw_witness}
         )
@@ -3650,6 +3672,24 @@ class TraceListQueryBuilder(BaseQueryBuilder):
         """Storage-specific necessary trace population; never leaf semantics."""
 
         return ""
+
+    def _scalar_candidate_witness_envelope(
+        self, *, root_start: datetime, root_end: datetime
+    ) -> tuple[str, dict[str, Any]]:
+        """Optional time bound on the candidate witness scan; none by default.
+
+        The shipped contract lets any raw span of a candidate trace carry the
+        value whatever its own start time, so this emits nothing and the
+        witness CTE stays time-unbounded. A lane may declare an envelope
+        around ``[root_start, root_end]`` - the roots the calling statement can
+        publish - which narrows *candidacy*, never membership: the exact
+        latest-state classifier is a separate statement and is unaffected.
+
+        An empty fragment must leave the statement byte-identical, so the
+        fragment carries its own leading newline and indentation.
+        """
+
+        return "", {}
 
     def build_filter_candidate_seed_page(
         self,

--- a/futureagi/tracer/services/clickhouse/query_service.py
+++ b/futureagi/tracer/services/clickhouse/query_service.py
@@ -100,13 +100,21 @@ class QueryType(StrEnum):
 
 @dataclass
 class QueryResult:
-    """Container for query results with metadata."""
+    """Container for query results with metadata.
+
+    ``read_rows`` is the server's own native rows-read counter for the
+    statement, or ``None`` when the transport cannot report it. It describes
+    the work the statement did, never its result: a caller sizing its next read
+    by it must treat ``None`` as "unmeasured", not as zero. Bytes read are
+    logged but not carried here, because nothing decides on them.
+    """
 
     data: Any  # Can be list, dict, or any serializable structure
     row_count: int
     backend_used: str  # "clickhouse" or "postgres"
     query_time_ms: float
     columns: list[str] | None = None
+    read_rows: int | None = None
 
     @classmethod
     def from_clickhouse_rows(cls, rows, columns, query_time_ms):
@@ -217,13 +225,24 @@ class AnalyticsQueryService:
         ``timeout_ms`` is retained for legacy selector compatibility; it is no
         longer a statement deadline. Request/continuation admission and transport
         failure detection are separate from server query execution limits.
+
+        The result carries the statement's own native rows-read progress, which
+        a caller may use to size its next read; the transport leaves it
+        unmeasured when the server reported none. Bytes read reach the log line
+        only - no caller decides on them.
         """
         if self.supports_per_query_read_settings:
             settings = application_read_settings(settings)
         start = time.monotonic()
         try:
             with application_read_context():
-                rows, columns, qt = self.ch_client.execute_read(
+                (
+                    rows,
+                    columns,
+                    _,
+                    read_rows,
+                    read_bytes,
+                ) = self.ch_client.execute_read_with_progress(
                     query, params or {}, timeout_ms=None, settings=settings
                 )
         except TimeoutError as exc:
@@ -243,6 +262,8 @@ class AnalyticsQueryService:
             "ch_query_executed",
             query_time_ms=round(elapsed, 2),
             rows=len(rows),
+            read_rows=read_rows,
+            read_bytes=read_bytes,
             backend="clickhouse",
         )
 
@@ -252,6 +273,7 @@ class AnalyticsQueryService:
             backend_used="clickhouse",
             query_time_ms=round(elapsed, 2),
             columns=col_names,
+            read_rows=read_rows,
         )
 
     def get_span_attribute_keys_ch_for_projects(

--- a/futureagi/tracer/services/clickhouse/v2/query_builders/trace_list.py
+++ b/futureagi/tracer/services/clickhouse/v2/query_builders/trace_list.py
@@ -55,6 +55,10 @@ MAX_USER_PHYSICAL_IDENTITIES_PER_PAGE = 4_096
 # locates an optimum below it.
 _SHORT_TEXT_SEED_PROVISIONAL_FLOOR = timedelta(hours=4)
 
+# One week, the same ceiling ``FILTER_SELECTOR_TEXT_SEED_WITNESS_SLACK_HOURS``
+# declares: beyond it the envelope stops bounding this lane's own windows.
+_MAX_WITNESS_SLACK_HOURS = 168
+
 # The same two widths once ``FILTER_SELECTOR_TEXT_SEED_WITNESS_SLACK_HOURS``
 # bounds the witness. There the statement's cost is linear in the envelope's
 # hours, so a narrower slice really is a cheaper statement and the row budget
@@ -706,22 +710,64 @@ class _TraceListQueryBuilderV2Core(_TraceRootReplayV2, TraceListQueryBuilder):
             target_read_rows=settings.FILTER_SELECTOR_TEXT_SEED_TARGET_READ_ROWS,
         )
 
+    def pin_filter_seed_witness_slack_hours(self, hours: int | None) -> None:
+        """Finish a pagination with the witness slack it STARTED with.
+
+        The slack decides which traces are candidates at all, so changing it
+        between two hops of one cursor moves the boundary underneath a
+        half-published page: rows already returned can become non-candidates
+        (the user sees a duplicate when the next hop re-seeds) and rows already
+        skipped can become candidates (the user never sees them). An operator
+        turning the knob mid-request is a real event, not a hypothetical - the
+        setting is deliberately runtime-tunable.
+
+        So a continuation carries the slack it was minted with and pins it
+        here. ``None`` clears the pin and returns the builder to the runtime
+        setting, which is both the legacy behaviour and what a cursor minted
+        before this field carried resolves to.
+        """
+
+        if hours is None:
+            self._pinned_witness_slack_hours = None
+            return
+        if isinstance(hours, bool) or not isinstance(hours, int):
+            raise ValueError("pinned witness slack must be whole hours")
+        if not 0 <= hours <= _MAX_WITNESS_SLACK_HOURS:
+            raise ValueError("pinned witness slack is outside the supported range")
+        self._pinned_witness_slack_hours = hours
+
+    def filter_seed_witness_slack_hours(self) -> int | None:
+        """The slack this read will use, for the cursor to carry forward.
+
+        ``None`` means this request has no witness envelope to preserve - the
+        lane is not active - and a cursor minted from it carries no slack, so
+        it stays byte-identical to one minted before the field existed.
+        """
+
+        if not self._uses_short_text_candidate_seed():
+            return None
+        return int(self._short_text_seed_witness_slack().total_seconds() // 3600)
+
     def _short_text_seed_witness_slack(self) -> timedelta:
         """Hours of lag this lane's witness envelope allows; zero means none.
 
-        Zero is the shipped contract and the default: no envelope is emitted
-        at all and the witness CTE stays time-unbounded. The setting is read
-        per statement rather than cached, so an operator change takes effect
-        on the next read; a change made mid-pagination shifts candidacy
-        between hops of one cursor, because the slack is not carried in the
-        signed cursor payload.
+        Zero is the legacy contract and remains the escape hatch: no envelope
+        is emitted at all and the witness CTE stays time-unbounded. The setting
+        is read per statement rather than cached, so an operator change takes
+        effect on the next read - EXCEPT inside a running pagination, where
+        ``pin_filter_seed_witness_slack_hours`` holds the value the cursor was
+        minted with so a mid-flight change cannot skip or duplicate rows.
         """
 
         if not self._uses_short_text_candidate_seed():
             return timedelta(0)
-        return timedelta(
-            hours=max(int(settings.FILTER_SELECTOR_TEXT_SEED_WITNESS_SLACK_HOURS), 0)
+        pinned = getattr(self, "_pinned_witness_slack_hours", None)
+        hours = (
+            pinned
+            if pinned is not None
+            else int(settings.FILTER_SELECTOR_TEXT_SEED_WITNESS_SLACK_HOURS)
         )
+        return timedelta(hours=min(max(hours, 0), _MAX_WITNESS_SLACK_HOURS))
 
     def _scalar_candidate_witness_envelope(
         self, *, root_start: datetime, root_end: datetime

--- a/futureagi/tracer/services/clickhouse/v2/query_builders/trace_list.py
+++ b/futureagi/tracer/services/clickhouse/v2/query_builders/trace_list.py
@@ -13,7 +13,6 @@ table on the CH25 connection; annotations retain their own source boundary.
 
 from __future__ import annotations
 
-import functools
 import re
 from collections.abc import Callable, Iterable, Iterator, Mapping
 from dataclasses import dataclass, replace
@@ -850,8 +849,15 @@ class _TraceListQueryBuilderV2Core(_TraceRootReplayV2, TraceListQueryBuilder):
             if values and all(isinstance(value, str) for value in values):
                 yield plan, witness, values
 
-    @functools.cached_property
+    @property
     def _long_text_candidate_seed_plan(self):
+        """Memoize the long-text plan against the inputs that decided it."""
+
+        return self._seed_plan_cached(
+            "long_text", self._compute_long_text_candidate_seed_plan
+        )
+
+    def _compute_long_text_candidate_seed_plan(self):
         """Find a selective, compiler-proven necessary typed-string witness.
 
         Long positive text filters otherwise classify hundreds of unrelated
@@ -889,8 +895,15 @@ class _TraceListQueryBuilderV2Core(_TraceRootReplayV2, TraceListQueryBuilder):
             )
         return None
 
-    @functools.cached_property
+    @property
     def _short_text_candidate_seed_plan(self):
+        """Memoize the short-text plan against the inputs that decided it."""
+
+        return self._seed_plan_cached(
+            "short_text", self._compute_short_text_candidate_seed_plan
+        )
+
+    def _compute_short_text_candidate_seed_plan(self):
         """Seed short exact strings from the compiler's own typed value bloom.
 
         Selectivity policy for positive typed-string acquisition. A seed is
@@ -970,36 +983,86 @@ class _TraceListQueryBuilderV2Core(_TraceRootReplayV2, TraceListQueryBuilder):
             or self._public_short_text_candidate_seed_plan()
         )
 
-    @functools.cached_property
+    @property
     def _short_text_candidate_seed_lane(self) -> bool:
-        """Compile the three seed plans once per builder, not per hook call.
+        """Compile the three seed plans once per input shape, not per hook call.
 
         Deciding this recompiles ``_partition_trace_filter_plans`` several
         times over, and the bounded-witness hooks
         (``_scalar_candidate_witness_envelope`` ->
         ``_short_text_seed_witness_slack`` -> here) ask for it on every
-        statement and twice inside ``filter_seed_width_policy``. The answer
-        cannot change over a builder's life: every attribute it reads -
-        ``filters``, ``search``, ``sort_params``, ``project_version_id``,
-        ``project_id``/``project_ids`` and the ``_bounded_*`` flags - is
-        assigned in ``__init__`` and never rebound afterwards by this class.
+        statement and twice inside ``filter_seed_width_policy``.
 
-        The one post-construction ``builder.filters`` rebind in the tree
-        (``tracer/selectors/eval_tasks/row_resolver.py``, which pins a
-        resolved ``created_at`` window) is on a builder constructed with
-        ``bounded_identity_only=True``; that makes
-        ``_uses_attribute_coordinate_replay`` - and so
-        ``_uses_scalar_coordinate_replay`` and every text seed plan below it -
-        False whatever the filters say, so the cached answer is invariant
-        there. Only the *lane* is cached: the slack setting and the width
-        policy are still read per statement, so an operator change still takes
-        effect on the next read.
+        The cache is keyed on the inputs that decide the answer, NOT held for
+        the life of the builder. An earlier revision of this memo asserted that
+        ``filters`` is assigned in ``__init__`` and never rebound; that premise
+        is false. ``tracer/selectors/eval_tasks/row_resolver.py`` rebinds
+        ``builder.filters`` after construction on a production path, and at
+        least five test modules do the same. That rebind is harmless today only
+        because its builder carries ``bounded_identity_only=True``, which forces
+        every text seed plan below ``_uses_scalar_coordinate_replay`` to None
+        whatever the filters say - a coincidence of the current call sites, not
+        an invariant. A lane-changing rebind against a life-of-builder cache
+        would serve a stale plan, and a stale plan here means a seed statement
+        restricted by a predicate the caller has removed: an under-inclusive
+        page that silently drops rows.
+
+        So ``_seed_plan_cache_key`` freezes every input the three plans read -
+        filters, search, sort params, project scope, project version and the
+        ``_bounded_*`` flags - and any change to them recomputes. Only the
+        plans are cached: the slack setting and the width policy are still read
+        per statement, so an operator change still takes effect on the next
+        read.
         """
+        return self._seed_plan_cached("lane", self._compute_short_text_seed_lane)
+
+    def _compute_short_text_seed_lane(self) -> bool:
         return (
             super()._public_scalar_candidate_seed_plan() is None
             and self._public_long_text_candidate_seed_plan() is None
             and self._public_short_text_candidate_seed_plan() is not None
         )
+
+    def _seed_plan_cache_key(self) -> tuple[str, ...]:
+        """Freeze every input the three text seed plans read.
+
+        ``repr`` rather than a hash: the filter leaves carry datetimes, UUIDs
+        and nested dicts, and an equal-valued rebind whose dicts were built in
+        a different insertion order only costs a recompute, never a wrong
+        answer. Anything that is not read here must not be able to change the
+        plans.
+        """
+
+        return (
+            repr(self.filters),
+            repr(self.search),
+            repr(self.sort_params),
+            repr(getattr(self, "project_id", None)),
+            repr(getattr(self, "project_ids", None)),
+            repr(self.project_version_id),
+            repr(
+                (
+                    self._bounded_identity_only,
+                    self._bounded_internal_scan,
+                    self._bounded_bulk_scan,
+                    self._bounded_population_proof,
+                    self._bounded_sampling_rate,
+                )
+            ),
+        )
+
+    def _seed_plan_cached(self, name: str, compute: Callable[[], Any]) -> Any:
+        """Return ``compute()`` memoized for as long as the inputs hold still."""
+
+        key = self._seed_plan_cache_key()
+        cached = getattr(self, "_seed_plan_memo", None)
+        if cached is None or cached[0] != key:
+            cached = (key, {})
+            self._seed_plan_memo = cached
+        values = cached[1]
+        if name not in values:
+            values[name] = compute()
+        return values[name]
 
     def _uses_short_text_candidate_seed(self) -> bool:
         """True when the short exact-string lane is the active seed plan."""

--- a/futureagi/tracer/services/clickhouse/v2/query_builders/trace_list.py
+++ b/futureagi/tracer/services/clickhouse/v2/query_builders/trace_list.py
@@ -1179,6 +1179,71 @@ class _TraceListQueryBuilderV2Core(_TraceRootReplayV2, TraceListQueryBuilder):
             )
         return super().build_filter_candidate_seed_page(**kwargs)
 
+    def supports_filter_seed_density_probe(self) -> bool:
+        """Only the row-budgeted short exact-string lane probes for density."""
+
+        return self._uses_short_text_candidate_seed()
+
+    def build_filter_seed_density_probe_query(
+        self, *, slice_start: datetime, slice_end: datetime
+    ) -> tuple[str, dict[str, Any]]:
+        """Count the live rows a candidate seed slice would put under the seed.
+
+        This is the density proof ``FilterSeedWidthPolicy`` requires before the
+        row budget may issue a slice wider than its unprobed cap. The reactive
+        doubling rule sizes the next slice from the PREVIOUS one's read rows,
+        so it crosses a sparse tail cheaply and then drops its accumulated
+        width onto whatever comes next; measured in production, eight doublings
+        over a 166 h sparse tail issued a 128 h slice that read over 12 GiB in
+        one statement. This probe is what makes that impossible: the widened
+        slice is costed before it is issued, and shrunk to fit the budget.
+
+        Deliberately the cheapest statement that answers the question:
+
+        * a PK-range count over ``[hour_floor(start), hour_ceil(end))`` clamped
+          to the request window, which is exactly the ``toStartOfHour`` primary
+          key prefix - so the server prunes to granule boundaries and reads
+          marks, not rows. Rounding OUT rather than in keeps the count an upper
+          bound on the slice it is approving, so the estimate can only make the
+          issued slice narrower, never wider;
+        * no attribute predicate, no typed-Map access, no child witness, no
+          ``FINAL``, no ordering, no per-trace sets. Attribute selectivity is
+          irrelevant to the question asked: the seed's cost tracks the rows the
+          bounded witness envelope must scan, not the rows that match;
+        * every row, roots and children alike, and ``is_deleted = 0`` for the
+          live population the seed itself reads.
+
+        It answers a COST question only. It never decides membership, never
+        prunes candidates and never reaches the published page: shrinking a
+        slice defers its older part to the next contiguous slice, so the scan
+        stays exact whatever the probe says, and a probe that fails or times
+        out simply pins the width at the unprobed cap.
+        """
+
+        request_start, request_end = self.parse_time_range(self.filters)
+        if not request_start <= slice_start < slice_end <= request_end:
+            raise ValueError("seed density probe must stay inside the request window")
+        if not self.supports_filter_seed_density_probe():
+            raise ValueError("seed density probe is unavailable")
+        probe_start = max(request_start, _floor_hour(slice_start))
+        probe_end = min(request_end, _ceil_hour(slice_end))
+        params = {
+            **self.params,
+            "seed_density_start_us": _unix_microseconds(probe_start),
+            "seed_density_end_us": _unix_microseconds(probe_end),
+        }
+        return (
+            f"""
+            SELECT count() AS seed_density_rows
+            FROM {self.TABLE}
+            PREWHERE {self.project_filter_sql()}
+              AND start_time >= fromUnixTimestamp64Micro(%(seed_density_start_us)s)
+              AND start_time < fromUnixTimestamp64Micro(%(seed_density_end_us)s)
+            WHERE is_deleted = 0
+            """,
+            params,
+        )
+
     def supports_filter_windowed_candidate_seed_page(self) -> bool:
         return bool(
             self._uses_scalar_coordinate_replay()

--- a/futureagi/tracer/services/clickhouse/v2/query_builders/trace_list.py
+++ b/futureagi/tracer/services/clickhouse/v2/query_builders/trace_list.py
@@ -13,6 +13,7 @@ table on the CH25 connection; annotations retain their own source boundary.
 
 from __future__ import annotations
 
+import functools
 import re
 from collections.abc import Callable, Iterable, Iterator, Mapping
 from dataclasses import dataclass, replace
@@ -849,7 +850,8 @@ class _TraceListQueryBuilderV2Core(_TraceRootReplayV2, TraceListQueryBuilder):
             if values and all(isinstance(value, str) for value in values):
                 yield plan, witness, values
 
-    def _public_long_text_candidate_seed_plan(self):
+    @functools.cached_property
+    def _long_text_candidate_seed_plan(self):
         """Find a selective, compiler-proven necessary typed-string witness.
 
         Long positive text filters otherwise classify hundreds of unrelated
@@ -887,7 +889,8 @@ class _TraceListQueryBuilderV2Core(_TraceRootReplayV2, TraceListQueryBuilder):
             )
         return None
 
-    def _public_short_text_candidate_seed_plan(self):
+    @functools.cached_property
+    def _short_text_candidate_seed_plan(self):
         """Seed short exact strings from the compiler's own typed value bloom.
 
         Selectivity policy for positive typed-string acquisition. A seed is
@@ -952,6 +955,14 @@ class _TraceListQueryBuilderV2Core(_TraceRootReplayV2, TraceListQueryBuilder):
                 return plan
         return None
 
+    def _public_long_text_candidate_seed_plan(self):
+        """Stable seam over the once-compiled long-text plan."""
+        return self._long_text_candidate_seed_plan
+
+    def _public_short_text_candidate_seed_plan(self):
+        """Stable seam over the once-compiled short-text plan."""
+        return self._short_text_candidate_seed_plan
+
     def _public_text_candidate_seed_plan(self):
         """Either typed-string regime, whichever value index is available."""
         return (
@@ -959,13 +970,40 @@ class _TraceListQueryBuilderV2Core(_TraceRootReplayV2, TraceListQueryBuilder):
             or self._public_short_text_candidate_seed_plan()
         )
 
-    def _uses_short_text_candidate_seed(self) -> bool:
-        """True when the short exact-string lane is the active seed plan."""
+    @functools.cached_property
+    def _short_text_candidate_seed_lane(self) -> bool:
+        """Compile the three seed plans once per builder, not per hook call.
+
+        Deciding this recompiles ``_partition_trace_filter_plans`` several
+        times over, and the bounded-witness hooks
+        (``_scalar_candidate_witness_envelope`` ->
+        ``_short_text_seed_witness_slack`` -> here) ask for it on every
+        statement and twice inside ``filter_seed_width_policy``. The answer
+        cannot change over a builder's life: every attribute it reads -
+        ``filters``, ``search``, ``sort_params``, ``project_version_id``,
+        ``project_id``/``project_ids`` and the ``_bounded_*`` flags - is
+        assigned in ``__init__`` and never rebound afterwards by this class.
+
+        The one post-construction ``builder.filters`` rebind in the tree
+        (``tracer/selectors/eval_tasks/row_resolver.py``, which pins a
+        resolved ``created_at`` window) is on a builder constructed with
+        ``bounded_identity_only=True``; that makes
+        ``_uses_attribute_coordinate_replay`` - and so
+        ``_uses_scalar_coordinate_replay`` and every text seed plan below it -
+        False whatever the filters say, so the cached answer is invariant
+        there. Only the *lane* is cached: the slack setting and the width
+        policy are still read per statement, so an operator change still takes
+        effect on the next read.
+        """
         return (
             super()._public_scalar_candidate_seed_plan() is None
             and self._public_long_text_candidate_seed_plan() is None
             and self._public_short_text_candidate_seed_plan() is not None
         )
+
+    def _uses_short_text_candidate_seed(self) -> bool:
+        """True when the short exact-string lane is the active seed plan."""
+        return self._short_text_candidate_seed_lane
 
     def _public_boolean_candidate_seed_plan(self):
         leaves = self._active_non_time_filters()

--- a/futureagi/tracer/services/clickhouse/v2/query_builders/trace_list.py
+++ b/futureagi/tracer/services/clickhouse/v2/query_builders/trace_list.py
@@ -14,14 +14,18 @@ table on the CH25 connection; annotations retain their own source boundary.
 from __future__ import annotations
 
 import re
-from collections.abc import Callable, Iterable, Mapping
+from collections.abc import Callable, Iterable, Iterator, Mapping
 from dataclasses import dataclass, replace
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 from typing import Any
 
+from django.conf import settings
+
+from tracer.selectors.filter_seed_width import FilterSeedWidthPolicy
 from tracer.services.clickhouse.query_builders.trace_list import (
     _LONG_WINDOW_ORDERED_ROOT_INITIAL_SLICE,
     _SELECTIVE_EXACT_TEXT_MIN_LENGTH,
+    LatestFilterPredicate,
     TraceListQueryBuilder,
     _unix_microseconds,
 )
@@ -41,6 +45,14 @@ class BoundedUserResolution:
 
 
 MAX_USER_PHYSICAL_IDENTITIES_PER_PAGE = 4_096
+
+# The width the short exact-string seed opens at and refuses to narrow below.
+# It is the fixed ceiling this lane's row budget replaced, kept as the floor so
+# the budget can only ever buy MORE coverage per statement than the ceiling did
+# - see ``filter_seed_width_policy``. Provisional: the dense per-statement cost
+# belongs to the pending owner decision on bounding this seed's child witness,
+# and no measurement here locates an optimum.
+_SHORT_TEXT_SEED_PROVISIONAL_FLOOR = timedelta(hours=4)
 
 
 def _caseless_ascii_ngram_anchor(value: str) -> str | None:
@@ -561,10 +573,87 @@ class _TraceListQueryBuilderV2Core(_TraceRootReplayV2, TraceListQueryBuilder):
         return self._public_boolean_candidate_seed_plan() is not None
 
     def recommended_filter_initial_slice_width(self):
+        # A row-budgeted lane opens at its policy's own initial width, clamped
+        # to the request: the shared candidate-witness contract declines any
+        # window of an hour or less, but a two-hour window still reaches this
+        # lane and is narrower than the floor the policy declares.
+        policy = self.filter_seed_width_policy()
+        if policy is not None:
+            start, end = self._bounded_request_window
+            return min(end - start, policy.initial_width)
         if self.filter_candidate_seed_requires_empty_prefix():
             start, end = self._bounded_request_window
             return min(end - start, _LONG_WINDOW_ORDERED_ROOT_INITIAL_SLICE)
         return super().recommended_filter_initial_slice_width()
+
+    def filter_seed_width_policy(self) -> FilterSeedWidthPolicy | None:
+        """Budget the short exact-string seed by rows read, not by hours.
+
+        The long-text and numeric lanes prune raw granules by value, so the
+        base builder lets them widen to the whole request window. A short exact
+        literal only prunes by key/value bloom, and this seed's cost has two
+        terms, neither of which a wall-clock ceiling tracks:
+
+        * A flat term, which dominates: the child witness in this CTE is
+          deliberately time-unbounded (any live span of a candidate trace may
+          carry the value), so every statement scans the trace-id bloom's
+          false positives across retained history. A measured unbounded child
+          lookup over a fifteen-minute dense root window read 52.4M rows /
+          4.29 GB after the trace-id, key and value blooms had each roughly
+          halved the granule count (55,689 -> 27,219 -> 14,528 -> 9,069 ->
+          7,902). Modelling the bloom pass rate as ``1 - 0.999 ** roots`` over
+          a ~107M-row history fits that funnel, so read rows here chiefly
+          measure the *roots inside the slice*. Extrapolating that one point
+          (k = 676 roots in fifteen minutes of the densest tenant) the term
+          would pass 90% of its ceiling within about an hour of the same
+          traffic, after which it is paid per statement whatever the width.
+          That is an extrapolation from a single measurement, not a measured
+          saturation curve: nothing has been read at two widths of the same
+          data.
+        * A linear term: the ``attrs_string`` materialized for the traces whose
+          raw roots fall inside the slice, ~0.48 GB per slice-hour on a dense
+          project. It grows with the slice's *row* population, not its width,
+          and a project's density varies by two orders of magnitude across its
+          own retention: four hours of the same project's sparse history cost
+          110-220 ms server-side whatever the width.
+
+        What the budget can and cannot do therefore follows from the flat
+        term. Doubling fires only below a quarter of the target, which at the
+        default is roughly four or five roots in the slice, so the budget
+        *widens across near-empty history* - the regime a fixed four-hour
+        ceiling walked one slice at a time down a 166 h sparse tail. Anywhere
+        the user's own results live, every width is over budget instead, and
+        there the budget must not be allowed to buy less coverage than the
+        fixed ceiling it replaces. Hence the floor, and the initial width, are
+        both the four hours that ceiling was: this lane only ever *widens* on
+        sparse history and otherwise holds at four hours, which is at least
+        the previous behaviour in both regimes. Halving therefore applies only
+        to a width that first grew above four hours and then ran into data.
+
+        The four-hour floor is provisional. It is a deliberately conservative
+        choice pending the owner decision on bounding this seed's child
+        witness, which is what actually owns the dense per-statement cost; it
+        is not a measured optimum, and no measurement here says where
+        narrowing stops paying. (The 3.66M rows / 4.47 GB / 3.8 s at
+        ``max_threads`` 1, 1.76 s at 2 sometimes quoted for a dense four-hour
+        slice belongs to that *bounded*-witness design experiment, whose child
+        lookup is confined to the window plus an hour of slack. It is not a
+        measurement of the seed this builder emits.)
+
+        Slices at or above an hour are whole-hour multiples of the immutable
+        ``toStartOfHour`` primary-key prefix; their boundaries snap onto an hour
+        only after an empty-seed root-time discovery hit. This changes only
+        physical chunking; predicates, order, pagination and the exact
+        latest-state classifier are untouched, and the cursor resumes the
+        remaining window on the next request.
+        """
+        if not self._uses_short_text_candidate_seed():
+            return None
+        return FilterSeedWidthPolicy(
+            initial_width=_SHORT_TEXT_SEED_PROVISIONAL_FLOOR,
+            min_width=_SHORT_TEXT_SEED_PROVISIONAL_FLOOR,
+            target_read_rows=settings.FILTER_SELECTOR_TEXT_SEED_TARGET_READ_ROWS,
+        )
 
     def recommended_filter_classify_batch_size(self) -> int | None:
         if self._uses_attribute_coordinate_replay():
@@ -608,16 +697,20 @@ class _TraceListQueryBuilderV2Core(_TraceRootReplayV2, TraceListQueryBuilder):
               )
         """
 
-    def _public_long_text_candidate_seed_plan(self):
-        """Find a selective, compiler-proven necessary typed-string witness.
+    def _positive_text_candidate_witnesses(
+        self,
+    ) -> Iterator[tuple[LatestFilterPredicate, str, list[str]]]:
+        """Yield compiler-proven positive string-only witnesses and their values.
 
-        Long positive text filters otherwise classify hundreds of unrelated
-        roots per read. Length selects an execution plan only, never semantics.
-        Missing-key defaults, negation, JSON and mixed-type witnesses must still
-        satisfy the existing compiler's exhaustive raw-witness contract.
+        Shared acquisition shape for both typed-string regimes below. It proves
+        only that a positive ``span_attr_str`` value witness exists and extracts
+        the bound literals it compares; no length, operation or index policy is
+        applied here. Numeric/Boolean branches, JSON, negation, missing-key
+        defaults and residual filters are rejected by the existing compiler and
+        ``_uses_scalar_coordinate_replay`` contract, not by this helper.
         """
         if not self._uses_scalar_coordinate_replay():
-            return None
+            return
         for plan in self._candidate_witness_plans():
             witness = self._public_scalar_candidate_witness_predicate(plan)
             if (
@@ -631,38 +724,130 @@ class _TraceListQueryBuilderV2Core(_TraceRootReplayV2, TraceListQueryBuilder):
                 re.findall(r"%\((\w+)\)s", plan.raw_key_witness_predicate or "")
             )
             value_params = set(re.findall(r"%\((\w+)\)s", witness)) - key_params
-            values = []
+            values: list[str] = []
             for name in sorted(value_params):
                 value = plan.params.get(name)
                 values.extend(value if isinstance(value, (list, tuple)) else [value])
-            if values and all(
-                isinstance(value, str)
-                and len(value.strip()) >= _SELECTIVE_EXACT_TEXT_MIN_LENGTH
+            if values and all(isinstance(value, str) for value in values):
+                yield plan, witness, values
+
+    def _public_long_text_candidate_seed_plan(self):
+        """Find a selective, compiler-proven necessary typed-string witness.
+
+        Long positive text filters otherwise classify hundreds of unrelated
+        roots per read. Length selects an execution plan only, never semantics.
+        Missing-key defaults, negation, JSON and mixed-type witnesses must still
+        satisfy the existing compiler's exhaustive raw-witness contract.
+        """
+        for plan, witness, values in self._positive_text_candidate_witnesses():
+            if not all(
+                len(value.strip()) >= _SELECTIVE_EXACT_TEXT_MIN_LENGTH
                 for value in values
             ):
-                anchors = [_caseless_ascii_ngram_anchor(value) for value in values]
-                if any(anchor is None for anchor in anchors):
-                    continue
-                params = dict(plan.params)
-                hints = []
-                for index, anchor in enumerate(anchors):
-                    name = f"long_text_ngram_{index}"
-                    params[name] = anchor
-                    # Match schema 023's index expression exactly. indexHint
-                    # only prunes impossible granules; it is never a value
-                    # predicate or a substitute for latest-state replay.
-                    hints.append(
-                        "arrayStringConcat(arrayMap(x -> lower(x), "
-                        f"mapValues(span_attr_str))) LIKE %({name})s"
-                    )
-                return replace(
-                    plan,
-                    params=params,
-                    raw_graph_value_witness_predicate=(
-                        "indexHint(" + " OR ".join(hints) + ") AND (" + witness + ")"
-                    ),
+                continue
+            anchors = [_caseless_ascii_ngram_anchor(value) for value in values]
+            if any(anchor is None for anchor in anchors):
+                continue
+            params = dict(plan.params)
+            hints = []
+            for index, anchor in enumerate(anchors):
+                name = f"long_text_ngram_{index}"
+                params[name] = anchor
+                # Match schema 023's index expression exactly. indexHint
+                # only prunes impossible granules; it is never a value
+                # predicate or a substitute for latest-state replay.
+                hints.append(
+                    "arrayStringConcat(arrayMap(x -> lower(x), "
+                    f"mapValues(span_attr_str))) LIKE %({name})s"
                 )
+            return replace(
+                plan,
+                params=params,
+                raw_graph_value_witness_predicate=(
+                    "indexHint(" + " OR ".join(hints) + ") AND (" + witness + ")"
+                ),
+            )
         return None
+
+    def _public_short_text_candidate_seed_plan(self):
+        """Seed short exact strings from the compiler's own typed value bloom.
+
+        Selectivity policy for positive typed-string acquisition. A seed is
+        worth running only when one usable value index already exists, and
+        which index that is depends on value length and operation alone:
+
+        * long values (and only they) can anchor schema 023's concatenated
+          lowercase LIKE index, so substring operations stay on the long
+          regime above;
+        * a short literal has no usable LIKE anchor, but exact membership does
+          carry the compiler's value companion over ``mapValues(span_attr_str)``
+          (``has``/``hasAny`` plus its ASCII legacy variant), emitted for
+          ``equals``/``in`` only. That companion is a necessary condition, so
+          it may prune raw granules; exact Unicode comparison and the complete
+          six-key latest-state classifier still decide membership.
+
+        Everything else — mixed value lengths, substring/negative operations,
+        JSON, structured overflow, versioned requests, relational or end-user
+        seeds — keeps the existing acquisition path unchanged. This is the same
+        flat scalar typed-map AND envelope the numeric lane requires: at most
+        ten leaves, each its own typed Map plan, and no residual filter.
+        """
+        leaves = self._active_non_time_filters()
+        if (
+            self.project_version_id is not None
+            or not 1 <= len(leaves) <= 10
+            or not self._uses_scalar_coordinate_replay()
+            or self._positive_exact_end_user_seed_filter() is not None
+            or self._positive_relational_seed_filter() is not None
+        ):
+            return None
+        plans, residual = self._partition_trace_filter_plans(self._bounded_filters())
+        if (
+            residual
+            or len(plans) != len(leaves)
+            or not all(
+                plan.scope == "any"
+                and plan.aggregates
+                and all(
+                    any(
+                        column in sql
+                        for column in (
+                            "span_attr_num",
+                            "span_attr_str",
+                            "span_attr_bool",
+                        )
+                    )
+                    for sql in plan.aggregates
+                )
+                for plan in plans
+            )
+        ):
+            return None
+        for plan, witness, values in self._positive_text_candidate_witnesses():
+            if (
+                all(
+                    0 < len(value.strip()) < _SELECTIVE_EXACT_TEXT_MIN_LENGTH
+                    for value in values
+                )
+                and "mapValues(span_attr_str)" in witness
+            ):
+                return plan
+        return None
+
+    def _public_text_candidate_seed_plan(self):
+        """Either typed-string regime, whichever value index is available."""
+        return (
+            self._public_long_text_candidate_seed_plan()
+            or self._public_short_text_candidate_seed_plan()
+        )
+
+    def _uses_short_text_candidate_seed(self) -> bool:
+        """True when the short exact-string lane is the active seed plan."""
+        return (
+            super()._public_scalar_candidate_seed_plan() is None
+            and self._public_long_text_candidate_seed_plan() is None
+            and self._public_short_text_candidate_seed_plan() is not None
+        )
 
     def _public_boolean_candidate_seed_plan(self):
         leaves = self._active_non_time_filters()
@@ -693,7 +878,7 @@ class _TraceListQueryBuilderV2Core(_TraceRootReplayV2, TraceListQueryBuilder):
     def _public_scalar_candidate_seed_plan(self):
         return (
             super()._public_scalar_candidate_seed_plan()
-            or self._public_long_text_candidate_seed_plan()
+            or self._public_text_candidate_seed_plan()
             or self._public_boolean_candidate_seed_plan()
         )
 
@@ -710,7 +895,7 @@ class _TraceListQueryBuilderV2Core(_TraceRootReplayV2, TraceListQueryBuilder):
         # policy. Memory safety, exact ordering and pagination are unchanged.
         if (
             super()._public_scalar_candidate_seed_plan() is None
-            and self._public_long_text_candidate_seed_plan() is not None
+            and self._public_text_candidate_seed_plan() is not None
         ):
             return False
         # One compiler-proven positive numeric value witness can seed up to ten
@@ -763,7 +948,7 @@ class _TraceListQueryBuilderV2Core(_TraceRootReplayV2, TraceListQueryBuilder):
         # witness. Stale values remain candidates for exact latest-state replay.
         if (
             super()._public_scalar_candidate_seed_plan() is None
-            and self._public_long_text_candidate_seed_plan() is not None
+            and self._public_text_candidate_seed_plan() is not None
             and self._positive_exact_end_user_seed_filter() is None
             and self._positive_relational_seed_filter() is None
         ):
@@ -780,6 +965,12 @@ class _TraceListQueryBuilderV2Core(_TraceRootReplayV2, TraceListQueryBuilder):
             self._uses_scalar_coordinate_replay()
             # Text already starts with this population. Do not repeat the same
             # failed query before falling back to the exact ordered-root walk.
+            # The selector also offers this fallback only for an *optional*
+            # candidate seed, and both text regimes are required, so the gate
+            # is unreachable for them by construction. Application reads
+            # deliberately strip statement time/scan caps, so there is no
+            # in-statement recovery to fall back to either: the short lane's
+            # declared row budget is what bounds a text seed's working set.
             and super()._public_scalar_candidate_seed_plan() is not None
         )
 

--- a/futureagi/tracer/services/clickhouse/v2/query_builders/trace_list.py
+++ b/futureagi/tracer/services/clickhouse/v2/query_builders/trace_list.py
@@ -46,13 +46,31 @@ class BoundedUserResolution:
 
 MAX_USER_PHYSICAL_IDENTITIES_PER_PAGE = 4_096
 
-# The width the short exact-string seed opens at and refuses to narrow below.
-# It is the fixed ceiling this lane's row budget replaced, kept as the floor so
-# the budget can only ever buy MORE coverage per statement than the ceiling did
-# - see ``filter_seed_width_policy``. Provisional: the dense per-statement cost
-# belongs to the pending owner decision on bounding this seed's child witness,
-# and no measurement here locates an optimum.
+# The width the short exact-string seed opens at and refuses to narrow below
+# while its child witness stays time-unbounded. It is the fixed ceiling this
+# lane's row budget replaced, kept as the floor so the budget can only ever buy
+# MORE coverage per statement than the ceiling did - see
+# ``filter_seed_width_policy``. Provisional: with an unbounded witness the
+# dense per-statement cost does not shrink with the slice, so no measurement
+# locates an optimum below it.
 _SHORT_TEXT_SEED_PROVISIONAL_FLOOR = timedelta(hours=4)
+
+# The same two widths once ``FILTER_SELECTOR_TEXT_SEED_WITNESS_SLACK_HOURS``
+# bounds the witness. There the statement's cost is linear in the envelope's
+# hours, so a narrower slice really is a cheaper statement and the row budget
+# is a signal rather than a constant; one hour is the measured schedule's
+# opening width and the granularity the ``toStartOfHour`` primary-key prefix
+# prunes on.
+_SHORT_TEXT_SEED_BOUNDED_WITNESS_FLOOR = timedelta(hours=1)
+
+
+def _floor_hour(moment: datetime) -> datetime:
+    return moment.replace(minute=0, second=0, microsecond=0)
+
+
+def _ceil_hour(moment: datetime) -> datetime:
+    floored = _floor_hour(moment)
+    return floored if floored == moment else floored + timedelta(hours=1)
 
 
 def _caseless_ascii_ngram_anchor(value: str) -> str | None:
@@ -589,15 +607,41 @@ class _TraceListQueryBuilderV2Core(_TraceRootReplayV2, TraceListQueryBuilder):
     def filter_seed_width_policy(self) -> FilterSeedWidthPolicy | None:
         """Budget the short exact-string seed by rows read, not by hours.
 
-        The long-text and numeric lanes prune raw granules by value, so the
-        base builder lets them widen to the whole request window. A short exact
-        literal only prunes by key/value bloom, and this seed's cost has two
+        The lane has two width schedules because it has two cost shapes, and
+        ``FILTER_SELECTOR_TEXT_SEED_WITNESS_SLACK_HOURS`` selects between them:
+
+        * slack zero (the default, and the shipped contract): the witness is
+          time-unbounded, its flat term dominates, and the floor and initial
+          width are both the four hours of the fixed ceiling this budget
+          replaced - ``_SHORT_TEXT_SEED_PROVISIONAL_FLOOR``. Narrowing below
+          that would pay the same flat cost for a fraction of the coverage,
+          which is why the row budget can only widen this mode.
+        * slack above zero: the witness scan is confined to the roots'
+          own hours plus the slack, so the statement's cost is linear in the
+          envelope's hours (~0.46-0.49 GB per hour measured) and a narrower
+          slice really is a cheaper statement. Floor and initial width both
+          drop to ``_SHORT_TEXT_SEED_BOUNDED_WITNESS_FLOOR``, one hour, which
+          is the opening width of the measured 1 h -> 2 h -> 4 h schedule; the
+          row budget then does real work in both directions, halving a dense
+          slice back down toward that hour.
+
+        Both modes keep the same ``target_read_rows`` and the same four-hour
+        ``unsignalled_cap``: a transport that reports no progress justifies no
+        more than the ceiling this lane started from, whichever mode is on.
+        The post-discovery reset follows the floor by construction - it is
+        ``max(1 h, policy.min_width)`` - so it is one hour in the bounded mode
+        and four in the unbounded one, with no second constant to keep in step.
+
+        Why the unbounded mode's floor is what it is. The long-text and
+        numeric lanes prune raw granules by value, so the base builder lets
+        them widen to the whole request window. A short exact literal only prunes by
+        key/value bloom, and with an unbounded witness this seed's cost has two
         terms, neither of which a wall-clock ceiling tracks:
 
         * A flat term, which dominates: the child witness in this CTE is
-          deliberately time-unbounded (any live span of a candidate trace may
-          carry the value), so every statement scans the trace-id bloom's
-          false positives across retained history. A measured unbounded child
+          time-unbounded in that mode (any raw span of a candidate trace may
+          carry the value, whenever it started), so every statement scans the
+          trace-id bloom's false positives across retained history. A measured unbounded child
           lookup over a fifteen-minute dense root window read 52.4M rows /
           4.29 GB after the trace-id, key and value blooms had each roughly
           halved the granule count (55,689 -> 27,219 -> 14,528 -> 9,069 ->
@@ -624,21 +668,23 @@ class _TraceListQueryBuilderV2Core(_TraceRootReplayV2, TraceListQueryBuilder):
         ceiling walked one slice at a time down a 166 h sparse tail. Anywhere
         the user's own results live, every width is over budget instead, and
         there the budget must not be allowed to buy less coverage than the
-        fixed ceiling it replaces. Hence the floor, and the initial width, are
-        both the four hours that ceiling was: this lane only ever *widens* on
-        sparse history and otherwise holds at four hours, which is at least
-        the previous behaviour in both regimes. Halving therefore applies only
-        to a width that first grew above four hours and then ran into data.
+        fixed ceiling it replaces. Hence the unbounded mode's floor, and its
+        initial width, are both the four hours that ceiling was: there this
+        lane only ever *widens* on sparse history and otherwise holds at four
+        hours, which is at least the previous behaviour in both regimes.
+        Halving therefore applies only to a width that first grew above four
+        hours and then ran into data.
 
-        The four-hour floor is provisional. It is a deliberately conservative
-        choice pending the owner decision on bounding this seed's child
-        witness, which is what actually owns the dense per-statement cost; it
-        is not a measured optimum, and no measurement here says where
-        narrowing stops paying. (The 3.66M rows / 4.47 GB / 3.8 s at
-        ``max_threads`` 1, 1.76 s at 2 sometimes quoted for a dense four-hour
-        slice belongs to that *bounded*-witness design experiment, whose child
-        lookup is confined to the window plus an hour of slack. It is not a
-        measurement of the seed this builder emits.)
+        The four-hour floor is provisional, and it is provisional precisely
+        because the flat term above is what a narrower slice cannot buy back.
+        It is not a measured optimum, and no measurement says where narrowing
+        an unbounded-witness statement stops paying. Bounding the witness is
+        the other half of that question, and it is what the slack switch
+        settles: the 3.66M rows / 4.47 GB / 3.8 s at ``max_threads`` 1 and
+        1.76 s at 2 measured for a dense four-hour slice is a measurement of
+        the *bounded* statement, confined to the window plus an hour of slack -
+        which this builder emits only when the switch is on, and never at the
+        default.
 
         Slices at or above an hour are whole-hour multiples of the immutable
         ``toStartOfHour`` primary-key prefix; their boundaries snap onto an hour
@@ -649,11 +695,83 @@ class _TraceListQueryBuilderV2Core(_TraceRootReplayV2, TraceListQueryBuilder):
         """
         if not self._uses_short_text_candidate_seed():
             return None
+        floor = (
+            _SHORT_TEXT_SEED_BOUNDED_WITNESS_FLOOR
+            if self._short_text_seed_witness_slack()
+            else _SHORT_TEXT_SEED_PROVISIONAL_FLOOR
+        )
         return FilterSeedWidthPolicy(
-            initial_width=_SHORT_TEXT_SEED_PROVISIONAL_FLOOR,
-            min_width=_SHORT_TEXT_SEED_PROVISIONAL_FLOOR,
+            initial_width=floor,
+            min_width=floor,
             target_read_rows=settings.FILTER_SELECTOR_TEXT_SEED_TARGET_READ_ROWS,
         )
+
+    def _short_text_seed_witness_slack(self) -> timedelta:
+        """Hours of lag this lane's witness envelope allows; zero means none.
+
+        Zero is the shipped contract and the default: no envelope is emitted
+        at all and the witness CTE stays time-unbounded. The setting is read
+        per statement rather than cached, so an operator change takes effect
+        on the next read; a change made mid-pagination shifts candidacy
+        between hops of one cursor, because the slack is not carried in the
+        signed cursor payload.
+        """
+
+        if not self._uses_short_text_candidate_seed():
+            return timedelta(0)
+        return timedelta(
+            hours=max(int(settings.FILTER_SELECTOR_TEXT_SEED_WITNESS_SLACK_HOURS), 0)
+        )
+
+    def _scalar_candidate_witness_envelope(
+        self, *, root_start: datetime, root_end: datetime
+    ) -> tuple[str, dict[str, Any]]:
+        """Bound the short exact-string seed's witness scan, when switched on.
+
+        Off (slack zero, the default) this emits nothing and the statement is
+        byte-identical to the unbounded contract. On, the witness must start
+        inside ``[hour_floor(root_start) - slack, hour_ceil(root_end) + slack)``
+        where ``[root_start, root_end]`` is the interval of roots the calling
+        statement can publish. Every root it publishes therefore keeps any
+        witness within ``slack`` of itself, and the hour alignment matches the
+        immutable ``toStartOfHour`` primary-key prefix the bound prunes on.
+
+        The bound is spelled exactly like the sibling root-population subquery
+        in the same CTE - epoch microseconds through
+        ``fromUnixTimestamp64Micro`` - rather than as a datetime literal, so
+        neither bound depends on how the driver or the server resolves a
+        timezone. Because both ends are whole hours this is identical in
+        meaning to the measured shape, which additionally spelled the
+        hour-aligned prefix out.
+
+        This narrows candidacy only. The exact latest-state classifier is a
+        separate statement and stays unbounded, so a published row is still an
+        exact any-span match; the envelope can only omit a trace whose sole
+        witness lies outside it. Physical versions and tombstones still
+        participate - the CTE deliberately carries no ``is_deleted`` filter -
+        so this bounds *when* a witness row starts, never which versions count.
+        """
+
+        slack = self._short_text_seed_witness_slack()
+        if not slack:
+            return "", {}
+        witness_start = _floor_hour(root_start) - slack
+        witness_end = _ceil_hour(root_end) + slack
+        fragment = (
+            "\n              AND start_time >= "
+            "fromUnixTimestamp64Micro(%(filter_witness_start_us)s)"
+            "\n              AND start_time < "
+            "fromUnixTimestamp64Micro(%(filter_witness_end_us)s)"
+        )
+        return fragment, {
+            # The datetime pair is bound for the orchestration contract only,
+            # exactly as ``filter_slice_start``/``_end`` are; SQL reads the
+            # microsecond pair so a boundary microsecond cannot be rounded off.
+            "filter_witness_start": witness_start,
+            "filter_witness_end": witness_end,
+            "filter_witness_start_us": _unix_microseconds(witness_start),
+            "filter_witness_end_us": _unix_microseconds(witness_end),
+        }
 
     def recommended_filter_classify_batch_size(self) -> int | None:
         if self._uses_attribute_coordinate_replay():

--- a/futureagi/tracer/tests/test_bounded_trace_filter_reads.py
+++ b/futureagi/tracer/tests/test_bounded_trace_filter_reads.py
@@ -1144,7 +1144,7 @@ def test_raw_annotator_span_attribute_never_uses_score_candidate_seed() -> None:
 
 
 @pytest.mark.parametrize("column_id", ["end_user_id", "user", "user_id"])
-def test_raw_user_named_span_attribute_does_not_use_candidate_seed(
+def test_raw_user_named_span_attribute_never_uses_the_end_user_candidate_seed(
     column_id: str,
 ) -> None:
     builder = TraceListQueryBuilderV2(
@@ -1163,7 +1163,6 @@ def test_raw_user_named_span_attribute_does_not_use_candidate_seed(
         ],
     )
 
-    assert builder.supports_filter_candidate_seed_page() is False
     raw_sql, _ = builder.build_filter_seed_page(
         slice_start=END - timedelta(days=30),
         slice_end=END,
@@ -1173,12 +1172,26 @@ def test_raw_user_named_span_attribute_does_not_use_candidate_seed(
     assert "attrs_string[" in raw_sql
     assert "end_users" not in raw_sql
     assert "end_user_id_remap" not in raw_sql
-    with pytest.raises(ValueError, match="trace user candidate seed is unavailable"):
-        builder.build_filter_candidate_seed_page(
+    # A user-named raw attribute is an ordinary typed string leaf: it may seed
+    # through the exact-string candidate lane, but never through the end-user
+    # relation.
+    assert builder._positive_exact_end_user_seed_filter() is None
+    with pytest.raises(ValueError, match="trace user candidate predicate"):
+        builder.build_filter_ordered_seed_page(
             slice_start=END - timedelta(days=30),
             slice_end=END,
             limit=26,
+            _positive_user_candidate_first=True,
         )
+    candidate_sql, _ = builder.build_filter_candidate_seed_page(
+        slice_start=END - timedelta(days=30),
+        slice_end=END,
+        limit=26,
+    )
+    assert "matching_scalar_trace_identities" in candidate_sql
+    assert "attrs_string[" in candidate_sql
+    assert "end_users" not in candidate_sql
+    assert "end_user_id_remap" not in candidate_sql
 
 
 @override_settings(CH25_EVAL_LOGGER_TABLE="tracer_eval_logger_v2")

--- a/futureagi/tracer/tests/test_ch25_builder_contract.py
+++ b/futureagi/tracer/tests/test_ch25_builder_contract.py
@@ -255,6 +255,37 @@ class TestListBuilderOutputContract:
                     )
                 finally:
                     builder._bounded_internal_scan = original_internal
+            elif name == "build_filter_seed_density_probe_query":
+                # The density probe is offered only by the short exact-string
+                # row-budgeted lane, so exercise it with the smallest filter
+                # that turns that lane on.
+                original_filters = builder.filters
+                original_internal = builder._bounded_internal_scan
+                builder.filters = [
+                    *original_filters,
+                    {
+                        "column_id": "contract.density",
+                        "filter_config": {
+                            "col_type": "SPAN_ATTRIBUTE",
+                            "filter_type": "text",
+                            "filter_op": "in",
+                            "filter_value": ["v1"],
+                            "attribute_value_types": ["string"],
+                        },
+                    },
+                ]
+                builder._bounded_internal_scan = False
+                try:
+                    start, end = builder.parse_time_range(builder.filters)
+                    if not builder.supports_filter_seed_density_probe():
+                        continue
+                    result = method(
+                        slice_start=max(start, end - timedelta(days=1)),
+                        slice_end=end,
+                    )
+                finally:
+                    builder.filters = original_filters
+                    builder._bounded_internal_scan = original_internal
             elif name in {
                 "build_filter_anchor_probe",
                 "build_filter_graph_key_witness_probe",

--- a/futureagi/tracer/tests/test_clickhouse.py
+++ b/futureagi/tracer/tests/test_clickhouse.py
@@ -4584,7 +4584,9 @@ class TestAnalyticsQueryService:
         from tracer.services.clickhouse.read_budget import ReadDeadlineExceeded
 
         class TimeoutClient:
-            def execute_read(self, query, params, *, timeout_ms, settings):
+            def execute_read_with_progress(
+                self, query, params, *, timeout_ms, settings
+            ):
                 raise TimeoutError("private ClickHouse driver timeout detail")
 
         service = AnalyticsQueryService()

--- a/futureagi/tracer/tests/test_dashboard_error_boundaries.py
+++ b/futureagi/tracer/tests/test_dashboard_error_boundaries.py
@@ -604,10 +604,16 @@ def test_widget_trace_queries_use_direct_write_backend_independent_of_routing(
     dashboard_widget.save(update_fields=["query_config"])
 
     v2_client = MagicMock()
-    v2_client.execute_read.return_value = (
+    # ``execute_ch_query`` reads through the progress-reporting transport so
+    # the result can carry the server's rows-read counter; the fake answers
+    # with that transport's five-tuple (rows, columns, elapsed, rows read,
+    # bytes read) and the legacy ``execute_read`` must stay untouched.
+    v2_client.execute_read_with_progress.return_value = (
         [(datetime(2026, 8, 1, tzinfo=UTC), 123.0)],
         [("time_bucket", "DateTime('UTC')"), ("metric_0", "Float64")],
         1.0,
+        1,
+        64,
     )
     v2_client.server_enforced_readonly = False
     v2_client.server_profile_locked = False
@@ -653,7 +659,8 @@ def test_widget_trace_queries_use_direct_write_backend_independent_of_routing(
     assert response.status_code == 200
     assert response.json()["result"]["query_status"] == "complete"
     assert response.json()["result"]["query_provenance"] == "exact_snapshot"
-    assert v2_client.execute_read.call_count == 1
+    assert v2_client.execute_read_with_progress.call_count == 1
+    v2_client.execute_read.assert_not_called()
     # Cache planning and execution build separate configs; only execution reads CH.
     assert v2_builder.call_count == 2
     assert v2_builder.call_args_list[0].args[0]["require_versioned_snapshot"] is True

--- a/futureagi/tracer/tests/test_exact_aggregation_background_timeout.py
+++ b/futureagi/tracer/tests/test_exact_aggregation_background_timeout.py
@@ -15,9 +15,9 @@ class _DedicatedClient:
         self.server_profile_locked = False
         self.instances.append(self)
 
-    def execute_read(self, query, params, *, timeout_ms, settings):
+    def execute_read_with_progress(self, query, params, *, timeout_ms, settings):
         self.calls.append((query, params, timeout_ms, settings))
-        return [(1,)], [("value", "UInt8")], 1.0
+        return [(1,)], [("value", "UInt8")], 1.0, 1, 8
 
     def close(self):
         self.closed = True

--- a/futureagi/tracer/tests/test_list_cursor.py
+++ b/futureagi/tracer/tests/test_list_cursor.py
@@ -4,6 +4,8 @@ from types import SimpleNamespace
 from unittest.mock import patch
 
 import pytest
+from django.conf import settings
+from django.core import signing
 from django.test import override_settings
 
 from tracer.serializers.observation_span import SpanObserveListQuerySerializer
@@ -12,6 +14,7 @@ from tracer.serializers.trace import (
     TraceVoiceCallListQuerySerializer,
 )
 from tracer.services.clickhouse.list_cursor import (
+    CURSOR_SALT,
     ListCursorError,
     cursor_page_metadata,
     cursor_scope_for_request,
@@ -666,3 +669,161 @@ def test_cursor_datetime_precision_matches_canonical_ch25_schema():
     # Python datetime preserves six fractional digits, so the signed cursor's
     # ordering timestamp is lossless for the canonical direct-write schema.
     assert "start_time          DateTime64(6, 'UTC')" in schema
+
+
+def test_a_cursor_carries_the_witness_slack_its_pagination_started_with():
+    """Candidacy must not move between two hops of one cursor.
+
+    The witness slack decides which traces are candidates at all, and it is a
+    runtime setting an operator may turn at any moment. A change between hops
+    would move that boundary under a half-published page: rows already returned
+    stop being candidates (the user sees a duplicate when the next hop
+    re-seeds) and rows already skipped start being them (the user never sees
+    them). So the first hop mints the slack it used and every later hop honours
+    it.
+    """
+
+    token, values = _token(witness_slack_hours=1)
+
+    cursor = decode_list_cursor(
+        token,
+        resource=values["resource"],
+        scope=values["scope"],
+        query=values["query"],
+        page_size=values["page_size"],
+    )
+
+    assert cursor.witness_slack_hours == 1
+
+
+def test_zero_witness_slack_survives_the_round_trip_as_zero_not_absence():
+    """Zero is the legacy escape hatch and a real, carryable choice."""
+
+    token, values = _token(witness_slack_hours=0)
+    cursor = decode_list_cursor(
+        token,
+        resource=values["resource"],
+        scope=values["scope"],
+        query=values["query"],
+        page_size=values["page_size"],
+    )
+
+    assert cursor.witness_slack_hours == 0
+    assert cursor.witness_slack_hours is not None
+
+
+def test_a_legacy_cursor_without_slack_decodes_and_keeps_the_current_setting():
+    """Absence is well defined, so this field is NOT a CURSOR_VERSION bump.
+
+    Rejecting live tokens would 400 the grid down to the numbered lane for a
+    field whose absence already means 'use the runtime setting' - which is
+    precisely what those tokens got before it existed.
+    """
+
+    token, values = _token()
+
+    cursor = decode_list_cursor(
+        token,
+        resource=values["resource"],
+        scope=values["scope"],
+        query=values["query"],
+        page_size=values["page_size"],
+    )
+
+    assert cursor.witness_slack_hours is None
+
+
+def test_a_cursor_with_no_slack_is_byte_identical_to_a_pre_field_cursor():
+    """No slack to carry means no payload change, so no fingerprint change."""
+
+    with patch("django.core.signing.time.time", return_value=1_700_000_000):
+        without, _ = _token()
+        explicit_none, _ = _token(witness_slack_hours=None)
+        with_slack, _ = _token(witness_slack_hours=2)
+
+    assert without == explicit_none
+    assert list_cursor_boundary_fingerprint(without) == (
+        list_cursor_boundary_fingerprint(explicit_none)
+    )
+    assert with_slack != without
+    assert list_cursor_boundary_fingerprint(with_slack) != (
+        list_cursor_boundary_fingerprint(without)
+    )
+
+
+@pytest.mark.parametrize("slack", [-1, 169, 1.5, True, "1"])
+def test_a_cursor_cannot_be_minted_with_an_unsupported_slack(slack):
+    with pytest.raises(ValueError, match="witness slack"):
+        _token(witness_slack_hours=slack)
+
+
+@pytest.mark.parametrize("slack", [-1, 169, "1", 1.5])
+def test_a_tampered_slack_is_rejected_as_an_invalid_cursor(slack):
+    """A payload outside the codec's own range was not minted by the codec."""
+
+    token, values = _token(witness_slack_hours=1)
+    payload = signing.loads(token, key=settings.SECRET_KEY, salt=CURSOR_SALT)
+    payload["witness_slack_hours"] = slack
+    forged = signing.dumps(
+        payload, key=settings.SECRET_KEY, salt=CURSOR_SALT, compress=True
+    )
+
+    with pytest.raises(ListCursorError) as excinfo:
+        decode_list_cursor(
+            forged,
+            resource=values["resource"],
+            scope=values["scope"],
+            query=values["query"],
+            page_size=values["page_size"],
+        )
+    assert excinfo.value.code == "invalid_cursor"
+
+
+def test_the_view_helpers_read_and_pin_the_witness_slack_they_are_given():
+    """The two seams the list views use, on builders that do and do not care.
+
+    ``getattr``-based on purpose: every list resource shares this cursor codec,
+    and only the lanes with a witness envelope answer. A builder that does not
+    publishes no slack, so its cursors stay byte-identical, and pinning one is
+    a no-op rather than an error.
+    """
+
+    from tracer.views.trace import (
+        _pin_cursor_filter_seed_witness_slack,
+        _read_filter_seed_witness_slack,
+    )
+
+    class _WithEnvelope:
+        def __init__(self):
+            self.pinned = "unset"
+
+        def filter_seed_witness_slack_hours(self):
+            return 2
+
+        def pin_filter_seed_witness_slack_hours(self, hours):
+            self.pinned = hours
+
+    builder = _WithEnvelope()
+    assert _read_filter_seed_witness_slack(builder) == 2
+
+    # No cursor: a first hop must not pin anything.
+    _pin_cursor_filter_seed_witness_slack(builder, None)
+    assert builder.pinned == "unset"
+
+    _pin_cursor_filter_seed_witness_slack(
+        builder, SimpleNamespace(witness_slack_hours=1)
+    )
+    assert builder.pinned == 1
+
+    # A legacy token clears the pin back to the runtime setting.
+    _pin_cursor_filter_seed_witness_slack(
+        builder, SimpleNamespace(witness_slack_hours=None)
+    )
+    assert builder.pinned is None
+
+    # A builder with no envelope answers nothing and is never pinned.
+    indifferent = SimpleNamespace()
+    assert _read_filter_seed_witness_slack(indifferent) is None
+    _pin_cursor_filter_seed_witness_slack(
+        indifferent, SimpleNamespace(witness_slack_hours=1)
+    )

--- a/futureagi/tracer/tests/test_query_service_read_policy.py
+++ b/futureagi/tracer/tests/test_query_service_read_policy.py
@@ -4,7 +4,10 @@ from django.test import override_settings
 
 from tracer.services.clickhouse import query_service as query_service_module
 from tracer.services.clickhouse.application_read_policy import application_read_settings
-from tracer.services.clickhouse.query_service import AnalyticsQueryService
+from tracer.services.clickhouse.query_service import (
+    AnalyticsQueryService,
+    QueryResult,
+)
 from tracer.services.clickhouse.v2.query_settings import (
     ch_query_settings,
     current_settings,
@@ -12,13 +15,15 @@ from tracer.services.clickhouse.v2.query_settings import (
 
 
 class _Client:
-    def __init__(self):
+    def __init__(self, *, read_rows=None, read_bytes=None):
         self.calls = []
         self.server_enforced_readonly = False
+        self.read_rows = read_rows
+        self.read_bytes = read_bytes
 
-    def execute_read(self, query, params, *, timeout_ms, settings):
+    def execute_read_with_progress(self, query, params, *, timeout_ms, settings):
         self.calls.append((query, params, timeout_ms, settings))
-        return [(1,)], [("value", "UInt8")], 1.0
+        return [(1,)], [("value", "UInt8")], 1.0, self.read_rows, self.read_bytes
 
 
 def test_application_query_service_normalizes_every_read_policy():
@@ -44,6 +49,34 @@ def test_application_query_service_normalizes_every_read_policy():
     assert query_settings["max_memory_usage"] == 2 * 1024 * 1024 * 1024
     assert query_settings["max_bytes_to_read"] == 0
     assert query_settings["max_threads"] == 2
+
+
+@pytest.mark.parametrize(
+    "read_rows,read_bytes",
+    [(3_664_921, 4_798_123_456), (None, None), (0, 0)],
+)
+def test_application_query_service_reports_native_read_progress(read_rows, read_bytes):
+    """A caller sizing its next read needs the work this statement actually did.
+
+    The transport reports rows and bytes together; only rows are carried on the
+    result, because only rows size anything. Bytes reach the log line and stop
+    there, so no caller can grow a dependency on a counter nothing decides on.
+    """
+
+    client = _Client(read_rows=read_rows, read_bytes=read_bytes)
+
+    result = AnalyticsQueryService(ch_client=client).execute_ch_query("SELECT 1", {})
+
+    assert result.read_rows == read_rows
+    assert not hasattr(result, "read_bytes")
+    # Progress is the statement's server-side work, never its result size.
+    assert result.row_count == 1
+
+
+def test_query_result_without_a_measured_transport_stays_unmeasured():
+    result = QueryResult.from_clickhouse_rows([(1,)], ["value"], query_time_ms=42.0)
+
+    assert result.read_rows is None
 
 
 def test_application_query_service_supplies_memory_policy_when_omitted():

--- a/futureagi/tracer/tests/test_span_population_time_discovery.py
+++ b/futureagi/tracer/tests/test_span_population_time_discovery.py
@@ -974,7 +974,7 @@ def test_population_real_application_wrapper_clears_caps_and_restores_context(
         server_enforced_readonly = False
         server_profile_locked = False
 
-        def execute_read(self, query, params, *, timeout_ms, settings):
+        def execute_read_with_progress(self, query, params, *, timeout_ms, settings):
             assert is_application_read()
             assert timeout_ms is None
             assert all(settings[key] == 0 for key in UNLIMITED_STATEMENT_SETTINGS)
@@ -996,6 +996,8 @@ def test_population_real_application_wrapper_clears_caps_and_restores_context(
                 [tuple(row[key] for key in columns) for row in result.data],
                 [(key, "String") for key in columns],
                 0.0,
+                len(result.data),
+                0,
             )
 
     monkeypatch.setattr(query_service, "get_v2_query_client", lambda: LocalClient())

--- a/futureagi/tracer/tests/test_trace_long_text_candidate_seed.py
+++ b/futureagi/tracer/tests/test_trace_long_text_candidate_seed.py
@@ -202,7 +202,6 @@ def test_long_text_primary_seed_runs_without_speculative_caps_and_replays_exactl
 @pytest.mark.parametrize(
     "operation,value",
     [
-        ("equals", "short"),
         ("contains", "short"),
         ("in", [LONG_TEXT, "short"]),
         ("not_equals", LONG_TEXT),

--- a/futureagi/tracer/tests/test_trace_numeric_primary_seed.py
+++ b/futureagi/tracer/tests/test_trace_numeric_primary_seed.py
@@ -916,8 +916,17 @@ def test_mixed_scalar_siblings_cannot_create_numeric_anchor(anchor):
     builder = subject(
         leaves=[mixed_leaf_cases()[0][0], mixed_leaf_cases()[1][0], anchor]
     )
-    assert builder._public_scalar_candidate_seed_plan() is None
-    assert not builder.supports_filter_candidate_seed_page()
+    # A zero-default or negative numeric sibling still cannot become the
+    # numeric anchor. The short exact-string leaf in this mix does carry the
+    # compiler's typed value companion, so it — and only it — seeds the page;
+    # every sibling leaf remains the classifier's exact responsibility.
+    assert TraceListQueryBuilder._public_scalar_candidate_seed_plan(builder) is None
+    plan = builder._public_scalar_candidate_seed_plan()
+    assert plan == builder._public_short_text_candidate_seed_plan()
+    assert "span_attr_str[" in plan.raw_graph_value_witness_predicate
+    assert "span_attr_num" not in plan.raw_graph_value_witness_predicate
+    assert builder.supports_filter_candidate_seed_page()
+    assert not builder.filter_candidate_seed_is_optional()
 
 
 @pytest.mark.parametrize("width", [2, 5, 10])

--- a/futureagi/tracer/tests/test_trace_text_candidate_seed.py
+++ b/futureagi/tracer/tests/test_trace_text_candidate_seed.py
@@ -2412,3 +2412,84 @@ def test_only_the_row_budgeted_lane_offers_a_density_probe():
         subject(1, kind="number", value=5).build_filter_seed_density_probe_query(
             slice_start=END - timedelta(hours=2), slice_end=END
         )
+
+
+# ---------------------------------------------------------------------------
+# The witness slack a pagination starts with must survive its HTTP hops.
+# ---------------------------------------------------------------------------
+
+
+@override_settings(FILTER_SELECTOR_TEXT_SEED_WITNESS_SLACK_HOURS=1)
+def test_the_lane_publishes_the_slack_a_cursor_must_carry():
+    builder = picker_leaves(2)
+    assert builder.filter_seed_witness_slack_hours() == 1
+    assert builder._short_text_seed_witness_slack() == timedelta(hours=1)
+
+
+@override_settings(FILTER_SELECTOR_TEXT_SEED_WITNESS_SLACK_HOURS=1)
+def test_a_request_with_no_envelope_publishes_no_slack_to_carry():
+    """A lane that emits no envelope must not make its cursors differ."""
+
+    assert subject(1, kind="number", value=5).filter_seed_witness_slack_hours() is None
+
+
+@override_settings(FILTER_SELECTOR_TEXT_SEED_WITNESS_SLACK_HOURS=4)
+@pytest.mark.parametrize("pinned", [0, 1, 3])
+def test_a_pinned_slack_outranks_a_mid_pagination_setting_change(pinned):
+    """The operator's new value is for the NEXT read, not this pagination."""
+
+    builder = picker_leaves(2)
+    assert builder.filter_seed_witness_slack_hours() == 4
+
+    builder.pin_filter_seed_witness_slack_hours(pinned)
+
+    assert builder.filter_seed_witness_slack_hours() == pinned
+    assert builder._short_text_seed_witness_slack() == timedelta(hours=pinned)
+    fragment, params = builder._scalar_candidate_witness_envelope(
+        root_start=END - timedelta(hours=2), root_end=END
+    )
+    if pinned:
+        assert params["filter_witness_end"] == END + timedelta(hours=pinned)
+        assert params["filter_witness_start"] == END - timedelta(hours=2 + pinned)
+    else:
+        # Zero is the legacy escape hatch: no envelope at all.
+        assert (fragment, params) == ("", {})
+
+
+@override_settings(FILTER_SELECTOR_TEXT_SEED_WITNESS_SLACK_HOURS=4)
+def test_a_legacy_cursor_carrying_no_slack_clears_the_pin():
+    """Absent means 'use the setting', which is what that token got before."""
+
+    builder = picker_leaves(2)
+    builder.pin_filter_seed_witness_slack_hours(1)
+    assert builder.filter_seed_witness_slack_hours() == 1
+
+    builder.pin_filter_seed_witness_slack_hours(None)
+
+    assert builder.filter_seed_witness_slack_hours() == 4
+
+
+@pytest.mark.parametrize("pinned", [-1, 169, 1.5, True, "1"])
+def test_an_unsupported_pinned_slack_is_refused(pinned):
+    with pytest.raises(ValueError, match="witness slack"):
+        picker_leaves(2).pin_filter_seed_witness_slack_hours(pinned)
+
+
+@override_settings(FILTER_SELECTOR_TEXT_SEED_WITNESS_SLACK_HOURS=0)
+def test_a_pinned_slack_changes_the_seed_sql_the_next_hop_emits():
+    """The pin has to reach the statement, not just the accessor."""
+
+    builder = picker_leaves(2)
+    unbounded, unbounded_params = builder.build_filter_candidate_seed_page(
+        slice_start=END - timedelta(hours=1), slice_end=END, limit=200
+    )
+    assert "filter_witness_start_us" not in unbounded_params
+
+    builder.pin_filter_seed_witness_slack_hours(1)
+    bounded, bounded_params = builder.build_filter_candidate_seed_page(
+        slice_start=END - timedelta(hours=1), slice_end=END, limit=200
+    )
+
+    assert "filter_witness_start_us" in bounded_params
+    assert bounded != unbounded
+    _render_driver_sql(bounded, bounded_params)

--- a/futureagi/tracer/tests/test_trace_text_candidate_seed.py
+++ b/futureagi/tracer/tests/test_trace_text_candidate_seed.py
@@ -17,7 +17,10 @@ from django.test import override_settings
 
 from tracer.selectors.filter_seed_width import FilterSeedWidthPolicy
 from tracer.selectors.trace_filter_reads import read_bounded_filter_page
-from tracer.services.clickhouse.query_builders.trace_list import TraceListQueryBuilder
+from tracer.services.clickhouse.query_builders.trace_list import (
+    TraceListQueryBuilder,
+    _unix_microseconds,
+)
 from tracer.services.clickhouse.query_service import QueryResult
 from tracer.services.clickhouse.v2.query_builders.trace_list import (
     TraceListQueryBuilderV2,
@@ -1071,6 +1074,7 @@ def _picker_lane_read(
     page_size: int = 500,
     max_seed_attempts: int = 24,
     continuation: dict[str, Any] | None = None,
+    transport_factory: Callable[[], _PopulationLaneTransport] | None = None,
 ):
     """The grid's own call: one attribute leaf, cursor lane, discovery enabled.
 
@@ -1084,7 +1088,11 @@ def _picker_lane_read(
 
     builder = picker_leaves(1, window=window)
     assert builder.supports_filter_empty_seed_root_time_discovery() is True
-    transport = _PopulationLaneTransport(population)
+    transport = (
+        _PopulationLaneTransport(population)
+        if transport_factory is None
+        else transport_factory()
+    )
     page = read_bounded_filter_page(
         builder=builder,
         analytics=transport,
@@ -1203,8 +1211,13 @@ def _picker_lane_hop_chain(
     page_size: int,
     max_seed_attempts: int,
     max_hops: int = 40,
+    transport_factory: Callable[[], _PopulationLaneTransport] | None = None,
 ) -> list[str]:
-    """Walk the cursor exactly as ``views/trace.py`` re-signs and resumes it."""
+    """Walk the cursor exactly as ``views/trace.py`` re-signs and resumes it.
+
+    A fresh transport per hop, because every hop is its own HTTP request;
+    ``transport_factory`` lets a variant transport answer the same chain.
+    """
 
     cursor: dict[str, Any] | None = None
     published: list[str] = []
@@ -1213,6 +1226,7 @@ def _picker_lane_hop_chain(
             population,
             page_size=page_size,
             max_seed_attempts=max_seed_attempts,
+            transport_factory=transport_factory,
             continuation={
                 "cursor_start_time": cursor["order"][0] if cursor else None,
                 "cursor_order_token": cursor["order"][1] if cursor else None,
@@ -1329,3 +1343,451 @@ def test_a_discovery_widened_slice_still_publishes_every_root_exactly_once(clust
 
     assert published == ground_truth
     assert len(published) == len(set(published)) == len(population)
+
+
+# ---------------------------------------------------------------------------
+# The bounded-witness switch: FILTER_SELECTOR_TEXT_SEED_WITNESS_SLACK_HOURS
+#
+# Off (zero, the default) the seed statement is the shipped one, byte for byte.
+# On, the witness scan is confined to the hours the statement's own roots can
+# occupy plus the slack, which narrows CANDIDACY only: the exact latest-state
+# classifier stays unbounded, so a published row is still an exact any-span
+# match and the switch can only omit a trace whose sole witness lies outside
+# the envelope. That omission is the contract change, and it is pinned below.
+# ---------------------------------------------------------------------------
+
+# The seed CTE's PREWHERE exactly as HEAD emitted it before the switch existed,
+# for ``picker_leaves(1)`` over one four-hour slice with no keyset. ``~`` marks
+# the end of a line that is blank apart from the template's own indentation, so
+# neither an editor nor a linter trimming trailing whitespace can weaken the
+# pin without the marker going missing.
+_HEAD_SEED_CTE_PREWHERE = """
+        ~
+        WITH matching_scalar_trace_identities AS (
+            SELECT DISTINCT trace_id
+            FROM spans
+            PREWHERE project_id = %(project_id)s
+              ~
+              ~
+              AND trace_id IN (
+                  SELECT trace_id FROM spans
+                  PREWHERE project_id = %(project_id)s
+                      AND start_time >= fromUnixTimestamp64Micro(%(filter_slice_start_us)s)
+                      AND start_time < fromUnixTimestamp64Micro(%(filter_slice_end_us)s)
+                  WHERE parent_span_id IS NULL OR parent_span_id = ''
+              )
+        ~
+            """
+
+# The whole of the difference the switch may make to the statement.
+_ENVELOPE_SQL = (
+    "\n              AND start_time >= "
+    "fromUnixTimestamp64Micro(%(filter_witness_start_us)s)"
+    "\n              AND start_time < "
+    "fromUnixTimestamp64Micro(%(filter_witness_end_us)s)"
+)
+
+SLICE = (END - timedelta(hours=4), END)
+
+
+def _head_seed_cte_prewhere() -> str:
+    return _HEAD_SEED_CTE_PREWHERE.replace("~", "")
+
+
+def _seed(builder=None, *, slack: int | None = None, **kwargs):
+    """One seed statement, optionally with the switch on."""
+
+    call = dict(slice_start=SLICE[0], slice_end=SLICE[1], limit=200, **kwargs)
+    if slack is None:
+        return (builder or picker_leaves(1)).build_filter_candidate_seed_page(**call)
+    with override_settings(FILTER_SELECTOR_TEXT_SEED_WITNESS_SLACK_HOURS=slack):
+        return (builder or picker_leaves(1)).build_filter_candidate_seed_page(**call)
+
+
+def test_the_seed_statement_is_byte_identical_while_the_switch_is_off():
+    """Off is not "a narrower envelope of zero hours"; it is no envelope at all.
+
+    Pinned twice over: against the literal statement HEAD emitted before the
+    switch existed, and against the switched-on statement, whose only
+    difference may be the two-line envelope and its own parameters.
+    """
+
+    assert settings.FILTER_SELECTOR_TEXT_SEED_WITNESS_SLACK_HOURS == 0
+    sql, params = _seed()
+
+    assert sql.startswith(_head_seed_cte_prewhere())
+    assert _ENVELOPE_SQL not in sql
+    assert [name for name in params if name.startswith("filter_witness")] == []
+
+    bounded_sql, bounded_params = _seed(slack=1)
+    assert bounded_sql.replace(_ENVELOPE_SQL, "") == sql
+    assert {
+        name: value
+        for name, value in bounded_params.items()
+        if not name.startswith("filter_witness")
+    } == params
+
+
+@pytest.mark.parametrize(
+    "offset,expected_start",
+    [
+        (timedelta(0), END - timedelta(hours=5)),
+        # A slice that does not start on the hour floors before the slack is
+        # applied, so the bound always lands on the pruning granularity.
+        (timedelta(minutes=17), END - timedelta(hours=6)),
+    ],
+    ids=["hour_aligned_slice", "ragged_slice"],
+)
+def test_the_switch_bounds_the_witness_scan_on_hour_aligned_parameters(
+    offset, expected_start
+):
+    slice_start, slice_end = SLICE[0] - offset, SLICE[1]
+    with override_settings(FILTER_SELECTOR_TEXT_SEED_WITNESS_SLACK_HOURS=1):
+        sql, params = picker_leaves(1).build_filter_candidate_seed_page(
+            slice_start=slice_start, slice_end=slice_end, limit=200
+        )
+    cte, roots = sql.split("SELECT trace_id, id AS root_span_id", 1)
+
+    # The bound belongs to the witness scan, not to the root population.
+    assert _ENVELOPE_SQL in cte
+    assert _ENVELOPE_SQL not in roots
+    assert params["filter_witness_start"] == expected_start
+    assert params["filter_witness_end"] == slice_end + timedelta(hours=1)
+    for name in ("filter_witness_start", "filter_witness_end"):
+        moment = params[name]
+        assert (moment.minute, moment.second, moment.microsecond) == (0, 0, 0)
+        # SQL reads microseconds; the datetimes are the orchestration contract.
+        assert params[f"{name}_us"] == _unix_microseconds(moment)
+    assert f"%({name}_us)s" not in roots
+
+    # Everything else about the CTE is exactly what it was: the root-population
+    # subquery on the slice, the membership join, no tombstone or page keyset.
+    assert "AND trace_id IN (\n                  SELECT trace_id FROM spans" in cte
+    assert (
+        "AND start_time >= fromUnixTimestamp64Micro(%(filter_slice_start_us)s)" in cte
+    )
+    assert "WHERE parent_span_id IS NULL OR parent_span_id = ''" in cte
+    assert "AND trace_id IN (" in roots
+    assert "SELECT trace_id FROM matching_scalar_trace_identities" in roots
+    assert "is_deleted" not in cte
+    assert "LIMIT" not in cte
+    assert "filter_before" not in cte
+
+
+def test_a_keyset_continuation_tightens_the_envelope_to_the_cursor_hour():
+    """No root above the cursor can be published, so none may widen the scan.
+
+    The continuation resumes strictly below its keyset, so the newest root the
+    statement can publish is the cursor's own position rather than the slice's
+    end - and the envelope that has to carry its witness shrinks with it.
+    """
+
+    cursor = END - timedelta(hours=1, minutes=17)
+    sql, params = _seed(slack=1, before_start_time=cursor, before_id="tr-mid")
+    page_one_params = _seed(slack=1)[1]
+
+    assert params["filter_witness_end"] == END
+    assert params["filter_witness_end"] < page_one_params["filter_witness_end"]
+    # The lower bound is the slice's, which the cursor does not move.
+    assert params["filter_witness_start"] == page_one_params["filter_witness_start"]
+    # The keyset itself stays where it was: outside the witness scan.
+    cte, roots = sql.split("SELECT trace_id, id AS root_span_id", 1)
+    assert "filter_before_start_us" in roots
+    assert "filter_before" not in cte
+
+
+def test_org_scope_never_reaches_this_lane_and_keeps_its_composite_keyset():
+    """Org reads are outside the lane by construction, so outside the switch.
+
+    ``_uses_attribute_coordinate_replay`` requires a single project, so an
+    org-scoped read has no scalar candidate seed to bound at all. Its ordered
+    seed - composite ``(trace_id, project_id)`` keyset and all - must therefore
+    come out identical in both modes.
+    """
+
+    project_b = "00000000-0000-4000-8000-000000000002"
+    leaf = _attribute_filter(ACCOUNT_KEY, ACCOUNT_VALUES, operation="in")
+    leaf["filter_config"]["attribute_value_types"] = ["string"] * len(ACCOUNT_VALUES)
+    builder = TraceListQueryBuilderV2(
+        project_ids=[str(PROJECT), project_b],
+        filters=[_time_filter(END - timedelta(days=7), END), leaf],
+        page_size=25,
+    )
+    assert not builder._uses_short_text_candidate_seed()
+    assert builder.filter_seed_width_policy() is None
+
+    statements = []
+    for slack in (0, 1):
+        with override_settings(FILTER_SELECTOR_TEXT_SEED_WITNESS_SLACK_HOURS=slack):
+            statements.append(
+                builder.build_filter_ordered_seed_page(
+                    slice_start=SLICE[0],
+                    slice_end=SLICE[1],
+                    limit=200,
+                    before_start_time=END - timedelta(hours=1),
+                    before_id=("tr-mid", str(PROJECT)),
+                )
+            )
+
+    assert statements[0] == statements[1]
+    sql, params = statements[0]
+    assert "toString(project_id) < %(filter_before_project_id)s" in sql
+    assert "matching_scalar_trace_identities" not in sql
+    assert _ENVELOPE_SQL not in sql
+    assert [name for name in params if name.startswith("filter_witness")] == []
+
+
+@pytest.mark.parametrize(
+    "make",
+    [
+        lambda: subject(
+            extra_leaves=[
+                _attribute_filter(
+                    "duration_s", 0.01, filter_type="number", operation="greater_than"
+                )
+            ]
+        ),
+        lambda: subject(1, kind="boolean", value=True),
+        lambda: subject(value=LONG_TEXT),
+    ],
+    ids=["numeric", "boolean", "long_text"],
+)
+def test_the_other_seed_lanes_are_untouched_by_the_switch(make):
+    """The switch is the short exact-string lane's alone.
+
+    The numeric and long-text lanes prune raw granules by value and the boolean
+    lane is a different plan entirely; none of them pays the trace-id bloom
+    scan this envelope exists to bound, so none of them may change.
+    """
+
+    unbounded_sql, unbounded_params = _seed(make())
+    bounded_sql, bounded_params = _seed(make(), slack=1)
+
+    assert bounded_sql == unbounded_sql
+    assert bounded_params == unbounded_params
+    assert _ENVELOPE_SQL not in bounded_sql
+    assert [name for name in bounded_params if name.startswith("filter_witness")] == []
+    with override_settings(FILTER_SELECTOR_TEXT_SEED_WITNESS_SLACK_HOURS=24):
+        assert make().filter_seed_width_policy() is None
+
+
+@pytest.mark.parametrize(
+    "slack,floor",
+    [
+        (0, timedelta(hours=4)),
+        (1, timedelta(hours=1)),
+        (24, timedelta(hours=1)),
+        (168, timedelta(hours=1)),
+    ],
+)
+def test_the_width_floor_follows_the_witness_contract(slack, floor):
+    """Two cost shapes, two schedules, one setting choosing between them.
+
+    Unbounded, the flat bloom term does not shrink with the slice, so narrowing
+    below the four hours of the ceiling this budget replaced would buy less
+    coverage for the same statement. Bounded, cost is linear in the envelope's
+    hours, so the row budget becomes a real signal and the lane opens at - and
+    floors on - the measured schedule's one hour. The unsignalled cap is the
+    same four hours in both: a transport that reports nothing justifies no more
+    than what already shipped.
+    """
+
+    with override_settings(FILTER_SELECTOR_TEXT_SEED_WITNESS_SLACK_HOURS=slack):
+        builder = picker_leaves(2)
+        policy = builder.filter_seed_width_policy()
+
+        assert policy.initial_width == policy.min_width == floor
+        assert policy.unsignalled_cap == timedelta(hours=4)
+        assert (
+            policy.target_read_rows
+            == settings.FILTER_SELECTOR_TEXT_SEED_TARGET_READ_ROWS
+        )
+        assert builder.recommended_filter_initial_slice_width() == floor
+        # The post-discovery reset is single-sourced from the same floor.
+        assert max(timedelta(hours=1), policy.min_width) == floor
+        # A dense statement walks back down to the floor, never below it.
+        assert policy.next_width(
+            timedelta(hours=4),
+            policy.target_read_rows + 1,
+            request_width=timedelta(days=7),
+        ) == (timedelta(hours=2) if slack else timedelta(hours=4))
+
+
+@pytest.mark.parametrize(
+    "candidate_ids", [["tr-1"], ["tr-1", "tr-2", "tr-3"]], ids=["one", "many"]
+)
+def test_the_exact_classifier_is_identical_in_both_modes(candidate_ids):
+    """The oracle never moves; only what reaches it does.
+
+    This is what keeps the switch one-sided: because the classifier is still
+    unbounded, every row the bounded mode publishes is an exact any-span match
+    on the shipped contract. The switch can only subtract candidates.
+    """
+
+    unbounded = picker_leaves(1).build_filter_match_query(candidate_ids)
+    with override_settings(FILTER_SELECTOR_TEXT_SEED_WITNESS_SLACK_HOURS=1):
+        bounded = picker_leaves(1).build_filter_match_query(candidate_ids)
+
+    assert bounded == unbounded
+    assert "filter_witness" not in bounded[0]
+    assert [name for name in bounded[1] if name.startswith("filter_witness")] == []
+    assert_coherent_classifier(bounded[0])
+
+
+@pytest.mark.parametrize(
+    "slack,floor",
+    [(0, timedelta(hours=4)), (1, timedelta(hours=1))],
+    ids=["unbounded", "bounded"],
+)
+def test_a_dense_read_holds_at_whichever_floor_its_mode_declares(slack, floor):
+    """The schedule change, on the builder and kwargs the view actually sends.
+
+    Every statement here overruns the row budget, so the read sits on its floor
+    throughout - which is the whole point of having two: with an unbounded
+    witness four hours is the cheapest useful statement, and with a bounded one
+    the same budget can afford to stop at an hour. Coverage per statement falls
+    accordingly, and the cursor checkpoint follows it, so nothing is skipped.
+    """
+
+    with override_settings(FILTER_SELECTOR_TEXT_SEED_WITNESS_SLACK_HOURS=slack):
+        transport, page = _lane_read(
+            window=timedelta(days=7),
+            read_rows=52_000_000,
+            cursor=True,
+            max_seed_attempts=6,
+        )
+
+    assert transport.seed_widths == [floor] * 6
+    assert _is_contiguous(transport.seed_intervals)
+    assert page.complete is False
+    assert page.continuation_slice_end == transport.seed_intervals[-1][0]
+    assert page.continuation_slice_end == END - 6 * floor
+
+
+class _WitnessLaneTransport(_PopulationLaneTransport):
+    """A population whose value may be carried by a span other than the root.
+
+    ``witness_at`` maps a trace id to the start time of the only span of that
+    trace carrying the filter value; a trace absent from the map is witnessed
+    by its own root, which is the shape both modes must agree on. The seed
+    branch applies the envelope exactly as the CTE does - a trace is a
+    candidate only when its witness starts inside ``[start, end)`` - and only
+    when the statement carries one, so the unbounded mode filters nothing.
+    Classification and hydration keep seeing the whole population, because the
+    classifier this lane publishes through is unbounded in both modes.
+    """
+
+    def __init__(self, population, witness_at=None):
+        super().__init__(population)
+        self.witness_at = dict(witness_at or {})
+        self.envelopes: list[tuple[datetime, datetime]] = []
+
+    def execute_ch_query(self, query, params, *, timeout_ms, settings):
+        witness_start = params.get("filter_witness_start")
+        if (
+            witness_start is None
+            or "matching_scalar_trace_identities" not in query
+            or "filter_seed_limit" not in params
+        ):
+            return super().execute_ch_query(
+                query, params, timeout_ms=timeout_ms, settings=settings
+            )
+        witness_end = params["filter_witness_end"]
+        self.envelopes.append((witness_start, witness_end))
+        whole_population = self.population
+        self.population = [
+            row
+            for row in whole_population
+            if witness_start
+            <= self.witness_at.get(row["trace_id"], row["start_time"])
+            < witness_end
+        ]
+        try:
+            return super().execute_ch_query(
+                query, params, timeout_ms=timeout_ms, settings=settings
+            )
+        finally:
+            self.population = whole_population
+
+
+def _witness_hop_chain(population, witness_at=None, *, slack, page_size=25):
+    """The full cursor chain under one mode, plus every envelope it emitted."""
+
+    transports: list[_WitnessLaneTransport] = []
+
+    def factory() -> _WitnessLaneTransport:
+        transports.append(_WitnessLaneTransport(population, witness_at))
+        return transports[-1]
+
+    with override_settings(FILTER_SELECTOR_TEXT_SEED_WITNESS_SLACK_HOURS=slack):
+        published = _picker_lane_hop_chain(
+            population,
+            page_size=page_size,
+            max_seed_attempts=24,
+            transport_factory=factory,
+        )
+    return published, [window for one in transports for window in one.envelopes]
+
+
+def _newest_first(population) -> list[str]:
+    return [
+        row["trace_id"]
+        for row in sorted(
+            population,
+            key=lambda row: (row["start_time"], row["trace_id"]),
+            reverse=True,
+        )
+    ]
+
+
+@pytest.mark.parametrize("slack", [0, 1])
+def test_both_modes_are_exact_when_every_witness_is_its_own_root(slack):
+    """Where the modes agree they must agree completely, not approximately.
+
+    A root carries the value itself in the overwhelming majority of measured
+    traces, and on that population the envelope excludes nothing - so the
+    bounded mode has to publish the identical set, in the identical order, once
+    each, even though it walks a different width schedule to get there.
+    """
+
+    population = _root_population(_SPARSE_TAIL + _DENSE_REGION)
+
+    published, envelopes = _witness_hop_chain(population, slack=slack)
+
+    assert published == _newest_first(population)
+    assert len(published) == len(set(published)) == len(population)
+    assert bool(envelopes) is bool(slack)
+    # Every envelope is whole hours and contains the slack on both sides.
+    assert all(
+        (start.minute, start.second, start.microsecond) == (0, 0, 0)
+        and (end.minute, end.second, end.microsecond) == (0, 0, 0)
+        and end - start >= timedelta(hours=2)
+        for start, end in envelopes
+    )
+
+
+def test_only_the_bounded_mode_omits_a_witness_outside_its_envelope():
+    """THE contract change, pinned as an omission and nothing else.
+
+    One trace's only span carrying the value starts three days after the whole
+    request window, so it lies outside every envelope any slice of this read
+    can produce. Today's contract publishes that trace; the bounded mode does
+    not, and that single row is the entire difference - everything else about
+    both pages, including order and exactness, is unchanged.
+    """
+
+    population = _root_population([(5, 3), (11, 3)])
+    stranded = population[0]["trace_id"]
+    witness_at = {stranded: END + timedelta(days=3)}
+
+    unbounded, _ = _witness_hop_chain(population, witness_at, slack=0)
+    bounded, envelopes = _witness_hop_chain(population, witness_at, slack=1)
+
+    assert unbounded == _newest_first(population)
+    assert bounded == [trace for trace in unbounded if trace != stranded]
+    assert set(unbounded) - set(bounded) == {stranded}
+    assert len(bounded) == len(set(bounded)) == len(population) - 1
+    # Not an accident of an empty read: the envelopes really were emitted, and
+    # the stranded witness really does sit outside all of them.
+    assert envelopes
+    assert all(end <= END + timedelta(hours=1) for _start, end in envelopes)

--- a/futureagi/tracer/tests/test_trace_text_candidate_seed.py
+++ b/futureagi/tracer/tests/test_trace_text_candidate_seed.py
@@ -488,6 +488,44 @@ def test_an_over_budget_slice_below_the_floor_is_never_widened_to_it(
     assert BUDGET.next_width(width, 52_000_000, request_width=request_width) == expected
 
 
+def test_the_unprobed_cap_is_the_unsignalled_cap_under_another_name():
+    """One question, one number: what may a statement be worth unmeasured?"""
+
+    assert BUDGET.unprobed_cap == BUDGET.unsignalled_cap
+    assert BUDGET.requires_density_probe(BUDGET.unprobed_cap) is False
+    assert BUDGET.requires_density_probe(BUDGET.unprobed_cap + timedelta(hours=1))
+
+
+@pytest.mark.parametrize(
+    "width,slice_rows,expected",
+    [
+        # Within budget: the proposal stands. This is the sparse tail, and it
+        # is why the tail is still crossed logarithmically.
+        (timedelta(hours=8), 0, timedelta(hours=8)),
+        (timedelta(hours=64), 1_999_999, timedelta(hours=64)),
+        (timedelta(hours=64), 2_000_000, timedelta(hours=64)),
+        # Over budget: shrink proportionally, snapped DOWN onto the lattice.
+        # 128 h holding 50M rows fits 5.12 h of budget -> 4 h on the lattice.
+        (timedelta(hours=128), 50_000_000, timedelta(hours=4)),
+        # 128 h holding 76.8M (the 600k rows/h end of the measured dense band)
+        # fits 3.33 h -> 2 h.
+        (timedelta(hours=128), 76_800_000, timedelta(hours=2)),
+        # A slice so dense that even one hour is over budget stops at the
+        # floor; narrowing past it buys nothing this lane can spend.
+        (timedelta(hours=128), 10_000_000_000, BUDGET.min_width),
+        # The fit can never widen a proposal.
+        (timedelta(hours=8), 1, timedelta(hours=8)),
+    ],
+)
+def test_a_probed_slice_is_fitted_to_the_row_budget(width, slice_rows, expected):
+    assert BUDGET.probed_width(width, slice_rows) == expected
+
+
+def test_a_density_probe_may_not_report_a_negative_count():
+    with pytest.raises(ValueError, match="negative rows"):
+        BUDGET.probed_width(timedelta(hours=8), -1)
+
+
 def test_an_unmeasured_statement_may_widen_only_to_the_unsignalled_cap():
     assert _walk(None, statements=5) == [
         timedelta(hours=hours) for hours in (1, 2, 4, 4, 4)
@@ -561,17 +599,58 @@ class _RowBudgetFakeBuilder(_FakeBuilder):
     def filter_seed_width_policy() -> FilterSeedWidthPolicy:
         return BUDGET
 
+    @staticmethod
+    def supports_filter_seed_density_probe() -> bool:
+        return True
+
+    @staticmethod
+    def build_filter_seed_density_probe_query(*, slice_start, slice_end):
+        return "density", {"slice_start": slice_start, "slice_end": slice_end}
+
+
+@dataclass
+class _UnprobedRowBudgetFakeBuilder(_RowBudgetFakeBuilder):
+    """A row-budgeted lane that cannot cost a slice before issuing it."""
+
+    @staticmethod
+    def supports_filter_seed_density_probe() -> bool:
+        return False
+
 
 class _RowBudgetFakeExecutor(_FakeExecutor):
     """Report one statement's native read rows the way the transport does."""
 
-    def __init__(self, builder, *, seed_read_rows: Callable[[int], int | None] | int):
+    def __init__(
+        self,
+        builder,
+        *,
+        seed_read_rows: Callable[[int], int | None] | int,
+        density_rows: Callable[[datetime, datetime], int] | int = 0,
+        density_fails: bool = False,
+    ):
         super().__init__(builder)
         self._seed_read_rows = seed_read_rows
+        self._density_rows = density_rows
+        self._density_fails = density_fails
         self.seed_intervals: list[tuple[datetime, datetime]] = []
         self.seed_keysets: list[datetime | None] = []
+        self.density_intervals: list[tuple[datetime, datetime]] = []
 
     def execute_ch_query(self, query, params, *, timeout_ms, settings):
+        if query == "density":
+            self.density_intervals.append((params["slice_start"], params["slice_end"]))
+            if self._density_fails:
+                raise RuntimeError("density probe unavailable")
+            rows = self._density_rows
+            if callable(rows):
+                rows = rows(params["slice_start"], params["slice_end"])
+            return QueryResult(
+                data=[{"seed_density_rows": rows}],
+                row_count=1,
+                backend_used="clickhouse",
+                query_time_ms=1.0,
+                read_rows=1_000,
+            )
         result = super().execute_ch_query(
             query, params, timeout_ms=timeout_ms, settings=settings
         )
@@ -602,9 +681,22 @@ def _read(executor, builder, *, window=timedelta(days=7), **kwargs):
     )
 
 
-def _budget_read(*, window, seed_read_rows, **kwargs):
-    builder = _RowBudgetFakeBuilder([], start=END - window, end=END)
-    executor = _RowBudgetFakeExecutor(builder, seed_read_rows=seed_read_rows)
+def _budget_read(
+    *,
+    window,
+    seed_read_rows,
+    density_rows=0,
+    density_fails=False,
+    builder_cls=_RowBudgetFakeBuilder,
+    **kwargs,
+):
+    builder = builder_cls([], start=END - window, end=END)
+    executor = _RowBudgetFakeExecutor(
+        builder,
+        seed_read_rows=seed_read_rows,
+        density_rows=density_rows,
+        density_fails=density_fails,
+    )
     page = _read(executor, builder, window=window, **kwargs)
     return executor, page
 
@@ -790,6 +882,137 @@ def test_a_declared_maximum_slice_still_binds_a_row_budgeted_lane():
     assert _is_contiguous(executor.seed_intervals)
 
 
+def test_a_widening_past_the_cap_is_probed_before_it_is_issued():
+    """The guard's whole shape, on the fake lane, in one schedule.
+
+    Read rows stay far under a quarter of the budget, so the policy proposes a
+    doubling every time. Below the cap nothing is probed - the statement is
+    issued on the strength of the previous one, exactly as before. Every width
+    ABOVE the cap is costed first, and the probe interval is always the
+    candidate slice itself.
+    """
+
+    executor, page = _budget_read(
+        window=timedelta(days=30), seed_read_rows=5_000, density_rows=0
+    )
+
+    assert page.complete is True
+    # 1 h, 2 h and 4 h are at or below the cap and cost no probe. Everything
+    # above it is probed; this fake builder recommends no maximum slice, so
+    # the shared two-day ceiling is what finally stops the doubling.
+    assert executor.seed_widths[:7] == [
+        timedelta(hours=1),
+        timedelta(hours=2),
+        timedelta(hours=4),
+        timedelta(hours=8),
+        timedelta(hours=16),
+        timedelta(hours=32),
+        timedelta(days=2),
+    ]
+    assert [end - start for start, end in executor.density_intervals][:4] == [
+        timedelta(hours=8),
+        timedelta(hours=16),
+        timedelta(hours=32),
+        timedelta(days=2),
+    ]
+    # Every probe covers exactly the slice it approved, and every slice wider
+    # than the cap was approved by one.
+    approved = {
+        (start, end)
+        for start, end in executor.seed_intervals
+        if end - start > timedelta(hours=4)
+    }
+    assert approved == set(executor.density_intervals)
+    assert _is_contiguous(executor.seed_intervals)
+
+
+def test_an_over_budget_probe_shrinks_the_slice_it_was_asked_about():
+    """A tail that ends in dense history never issues the accumulated width."""
+
+    dense_from = END - timedelta(hours=16)
+
+    def density(slice_start, slice_end):
+        overlap = min(slice_end, dense_from) - slice_start
+        hours = max(0.0, overlap.total_seconds() / 3600.0)
+        return int(hours * 500_000)
+
+    executor, _ = _budget_read(
+        window=timedelta(days=30), seed_read_rows=5_000, density_rows=density
+    )
+
+    # 1 h, 2 h, 4 h below the cap; the 8 h proposal is the first probed one,
+    # and nothing older than 16 h back is inside it yet, so it is issued.
+    assert executor.seed_widths[:4] == [
+        timedelta(hours=1),
+        timedelta(hours=2),
+        timedelta(hours=4),
+        timedelta(hours=8),
+    ]
+    assert executor.density_intervals[0] == (
+        END - timedelta(hours=15),
+        END - timedelta(hours=7),
+    )
+    # The 16 h proposal ending 15 h back reaches into dense history and is
+    # refused at its full width: 16 h holding 8M rows fits 4 h of a 2M budget.
+    refused = executor.density_intervals[1]
+    assert refused == (END - timedelta(hours=31), END - timedelta(hours=15))
+    assert executor.seed_widths[4] == timedelta(hours=4)
+    assert max(executor.seed_widths) == timedelta(hours=8)
+
+
+def test_a_failed_density_probe_pins_the_width_at_the_unprobed_cap():
+    """A probe is an accelerator: it may fail, and only cost coverage."""
+
+    executor, page = _budget_read(
+        window=timedelta(days=7), seed_read_rows=5_000, density_fails=True
+    )
+
+    assert executor.density_intervals, "the guard must still have asked"
+    assert max(executor.seed_widths) == timedelta(hours=4)
+    # A speculative failure must not degrade an otherwise exact page.
+    probe_attempts = [
+        attempt for attempt in page.attempts if attempt.kind == "seed_density_probe"
+    ]
+    assert probe_attempts
+    assert all(
+        attempt.error_code == "prefilter_unavailable" for attempt in probe_attempts
+    )
+    assert page.error_code != "prefilter_unavailable"
+
+
+def test_a_lane_that_cannot_probe_keeps_the_unprobed_cap():
+    """No hook, no proof, no widening: the ceiling the row budget replaced."""
+
+    executor, _ = _budget_read(
+        window=timedelta(days=7),
+        seed_read_rows=5_000,
+        builder_cls=_UnprobedRowBudgetFakeBuilder,
+    )
+
+    assert executor.density_intervals == []
+    assert max(executor.seed_widths) == timedelta(hours=4)
+
+
+def test_a_density_probe_spends_the_request_query_budget():
+    """Probes are statements. They must be counted, or they are free lunch."""
+
+    executor, page = _budget_read(
+        window=timedelta(days=30),
+        seed_read_rows=5_000,
+        density_rows=0,
+        max_query_count=8,
+    )
+
+    probes = [
+        attempt for attempt in page.attempts if attempt.kind == "seed_density_probe"
+    ]
+    assert probes
+    assert len(probes) == len(executor.density_intervals)
+    assert len(page.attempts) <= 8
+    assert page.complete is False
+    assert page.error_code == "query_budget_exceeded"
+
+
 def test_a_lane_without_a_declared_budget_keeps_its_doubling_schedule():
     builder = _FakeBuilder([], start=END - timedelta(days=7), end=END)
     executor = _RowBudgetFakeExecutor(builder, seed_read_rows=3_600_000)
@@ -823,12 +1046,31 @@ class _LaneTransport:
 
     supports_bounded_speculative_reads = False
 
-    def __init__(self, read_rows: int | None):
+    def __init__(self, read_rows: int | None, density_rows: Any = 0):
         self._read_rows = read_rows
+        self._density_rows = density_rows
         self.seed_intervals: list[tuple[datetime, datetime]] = []
+        self.density_intervals: list[tuple[datetime, datetime]] = []
         self.other_statements = 0
 
+    def _density_result(self, params) -> QueryResult:
+        start = _EPOCH + timedelta(microseconds=params["seed_density_start_us"])
+        end = _EPOCH + timedelta(microseconds=params["seed_density_end_us"])
+        self.density_intervals.append((start, end))
+        rows = self._density_rows
+        if callable(rows):
+            rows = rows(start, end)
+        return QueryResult(
+            data=[{"seed_density_rows": rows}],
+            row_count=1,
+            backend_used="clickhouse",
+            query_time_ms=1.0,
+            read_rows=2_000,
+        )
+
     def execute_ch_query(self, query, params, *, timeout_ms, settings):
+        if "seed_density_rows" in query:
+            return self._density_result(params)
         if (
             "matching_scalar_trace_identities" in query
             and "filter_seed_limit" in params
@@ -1039,12 +1281,48 @@ class _PopulationLaneTransport(_LaneTransport):
     the widen-then-halve walk this lane exists for.
     """
 
-    def __init__(self, population: list[dict[str, Any]]):
+    def __init__(
+        self,
+        population: list[dict[str, Any]],
+        *,
+        rows_per_root: int = 1,
+        density_profile: Callable[[datetime, datetime], int] | None = None,
+    ):
         super().__init__(read_rows=None)
         self.population = population
+        # A density probe counts live rows, MATCHING OR NOT. The population
+        # above holds only the roots this filter matches, so a shape whose
+        # sparse tail is sparse in matching roots but dense in traffic needs
+        # its own row profile; without one the count is the population itself.
+        self._density_profile = density_profile
+        # A density probe counts EVERY live row in the slice, roots and
+        # children alike, which is what makes it a cost proof rather than a
+        # membership one. The synthetic population stores roots only, so one
+        # knob turns each root into the trace it stands for.
+        self._rows_per_root = rows_per_root
         self.probes: list[tuple[datetime, datetime, bool]] = []
 
+    def _density_result(self, params) -> QueryResult:
+        start = _EPOCH + timedelta(microseconds=params["seed_density_start_us"])
+        end = _EPOCH + timedelta(microseconds=params["seed_density_end_us"])
+        self.density_intervals.append((start, end))
+        counted = (
+            self._density_profile(start, end)
+            if self._density_profile is not None
+            else sum(1 for row in self.population if start <= row["start_time"] < end)
+            * self._rows_per_root
+        )
+        return QueryResult(
+            data=[{"seed_density_rows": counted}],
+            row_count=1,
+            backend_used="clickhouse",
+            query_time_ms=1.0,
+            read_rows=2_000,
+        )
+
     def execute_ch_query(self, query, params, *, timeout_ms, settings):
+        if "seed_density_rows" in query:
+            return self._density_result(params)
         if (
             "matching_scalar_trace_identities" in query
             and "filter_seed_limit" in params
@@ -1924,3 +2202,213 @@ def test_only_the_bounded_mode_omits_a_witness_outside_its_envelope():
     # the stranded witness really does sit outside all of them.
     assert envelopes
     assert all(end <= END + timedelta(hours=1) for _start, end in envelopes)
+
+
+# ---------------------------------------------------------------------------
+# The shape the guard exists for: a window END far from the newest matching
+# root. This is what the 12M and 30D presets select on a tenant whose traffic
+# stopped days ago, and it is the shape that made one seed statement read over
+# 12 GiB in production measurement.
+# ---------------------------------------------------------------------------
+
+# Measured: ~166 h of tail between the frozen window END and the newest
+# matching root, then a dense region running at 400-600k rows/h.
+_FROZEN_END_TAIL_HOURS = 166
+_DENSE_ROWS_PER_HOUR = 500_000
+
+
+def _frozen_end_density(slice_start: datetime, slice_end: datetime) -> int:
+    """Live rows in a slice: nothing in the tail, then the dense band."""
+
+    dense_from = END - timedelta(hours=_FROZEN_END_TAIL_HOURS)
+    overlap = min(slice_end, dense_from) - slice_start
+    return int(max(0.0, overlap.total_seconds() / 3600.0) * _DENSE_ROWS_PER_HOUR)
+
+
+_FROZEN_END_POPULATION = _root_population(
+    [
+        (hours, 20)
+        for hours in range(_FROZEN_END_TAIL_HOURS, _FROZEN_END_TAIL_HOURS + 40, 2)
+    ]
+)
+
+
+def _frozen_end_read(**kwargs):
+    return _picker_lane_read(
+        _FROZEN_END_POPULATION,
+        window=timedelta(days=365),
+        page_size=50,
+        transport_factory=lambda: _PopulationLaneTransport(
+            _FROZEN_END_POPULATION, density_profile=_frozen_end_density
+        ),
+        **kwargs,
+    )
+
+
+@override_settings(FILTER_SELECTOR_TEXT_SEED_WITNESS_SLACK_HOURS=1)
+def test_a_frozen_window_end_never_drops_a_widened_slice_onto_dense_history():
+    """THE defect, pinned as a schedule.
+
+    Without the guard this population reproduces the measured failure exactly:
+    the reactive doubling crosses the sparse tail in eight cheap seeds and then
+    proposes a 128 h slice whose far end sits in the dense band. That one
+    statement read over 12 GiB. With the guard, every proposal above the
+    four-hour unprobed cap is costed first, so the only slices that reach the
+    dense band are ones a probe has fitted to the row budget.
+
+    What the schedule below shows, in order: the opening 1 h; the root-time
+    discovery jump that skips ~72 h of proven-empty tail; the 1 h -> 32 h
+    doubling across what remains, each width above 4 h approved by its own
+    ~1-2 MB probe; the 64 h proposal REFUSED (its probe reaches 34 h into the
+    dense band) and fitted down to 4 h; the walk repeating twice more as the
+    doubling re-approaches the boundary; and the first genuinely dense seed
+    reading ~2.1M rows - the row budget, not twelve gibibytes.
+
+    Nineteen cheap statements replace one catastrophic one. The statement count
+    is higher than a uniform-density estimate predicts because the proportional
+    fit assumes the candidate slice's rows are spread evenly and they are not:
+    the fitted width lands back in the empty part of the tail and has to widen
+    again. Every one of those statements is a probe or an empty seed.
+    """
+
+    transport, page = _frozen_end_read()
+
+    assert page.complete is True
+    assert page.error_code is None
+    assert len(page.rows) == 50
+    assert transport.seed_widths == [
+        timedelta(hours=1),  # opening width
+        timedelta(hours=1),  # after the root-time discovery jump
+        timedelta(hours=2),
+        timedelta(hours=4),
+        timedelta(hours=8),  # first probed width
+        timedelta(hours=16),
+        timedelta(hours=32),
+        timedelta(hours=4),  # the 64 h proposal, fitted to the budget
+        timedelta(hours=8),
+        timedelta(hours=16),
+        timedelta(hours=4),  # the 32 h proposal, fitted again
+        timedelta(hours=2),  # halved by the first dense statement's read rows
+    ]
+    # Seven probes, one per proposal above the cap, and never more than one per
+    # seed statement.
+    assert [end - start for start, end in transport.density_intervals] == [
+        timedelta(hours=8),
+        timedelta(hours=16),
+        timedelta(hours=32),
+        timedelta(hours=64),
+        timedelta(hours=8),
+        timedelta(hours=16),
+        timedelta(hours=32),
+    ]
+    assert len(transport.density_intervals) <= len(transport.seed_intervals)
+    probe_attempts = [
+        attempt for attempt in page.attempts if attempt.kind == "seed_density_probe"
+    ]
+    assert len(probe_attempts) == 7
+    assert all(attempt.error_code is None for attempt in probe_attempts)
+    # No slice above the cap was issued without its own approving probe, and
+    # the refused 64 h slice was never issued at any width above four hours.
+    approved = set(transport.density_intervals)
+    assert all(
+        (start, end) in approved
+        for start, end in transport.seed_intervals
+        if end - start > timedelta(hours=4)
+    )
+    assert max(transport.seed_widths) == timedelta(hours=32)
+    # Slices walk strictly older and never overlap. They are NOT contiguous
+    # here, and must not be: the root-time discovery probe proved the newest
+    # ~72 h carry no physical root at all and the scan jumped that interval
+    # rather than seeding it hour by hour.
+    assert all(
+        older_end <= newer_start
+        for (newer_start, _), (_, older_end) in zip(
+            transport.seed_intervals, transport.seed_intervals[1:], strict=False
+        )
+    )
+    # Exactness is untouched: the newest fifty matching roots, newest first.
+    assert [row["trace_id"] for row in page.rows] == _newest_first(
+        _FROZEN_END_POPULATION
+    )[:50]
+
+
+@override_settings(FILTER_SELECTOR_TEXT_SEED_WITNESS_SLACK_HOURS=1)
+def test_a_data_anchored_window_is_unchanged_because_it_never_passes_the_cap():
+    """The guard must cost nothing where the defect cannot occur.
+
+    A window anchored on the data - the measured 7 d shape that already runs in
+    2.3-3.8 s - finds matching roots in its first slices, so the row budget
+    holds or halves and never proposes a width above the cap. Zero probes means
+    zero added statements and, because the guard is the identity below the cap,
+    a schedule identical to the one without it.
+    """
+
+    population = _root_population([(hours, 20) for hours in range(1, 169, 2)])
+    transport, page = _picker_lane_read(
+        population,
+        window=timedelta(days=7),
+        page_size=50,
+        transport_factory=lambda: _PopulationLaneTransport(population),
+    )
+
+    assert page.complete is True
+    assert transport.density_intervals == []
+    assert not [
+        attempt for attempt in page.attempts if attempt.kind == "seed_density_probe"
+    ]
+    # Dense from the first statement: the budget holds at the floor and the
+    # proposal never approaches the cap, let alone passes it.
+    assert set(transport.seed_widths) == {timedelta(hours=1), timedelta(hours=2)}
+    assert max(transport.seed_widths) <= timedelta(hours=4)
+    assert [row["trace_id"] for row in page.rows] == _newest_first(population)[:50]
+
+
+def test_the_density_probe_asks_the_cheapest_question_that_answers_the_cost():
+    """The probe's SQL contract: a PK-range count and nothing else."""
+
+    builder = picker_leaves(2)
+    assert builder.supports_filter_seed_density_probe() is True
+
+    sql, params = builder.build_filter_seed_density_probe_query(
+        slice_start=END - timedelta(hours=64, minutes=20),
+        slice_end=END - timedelta(hours=7, minutes=40),
+    )
+
+    assert "count()" in sql
+    assert "AS seed_density_rows" in sql
+    assert "PREWHERE" in sql
+    assert "is_deleted = 0" in sql
+    # A cost question, not a membership one: no attribute predicate, no child
+    # witness, no root restriction, no ordering, no FINAL, no keyset.
+    assert "attrs_string" not in sql
+    assert "parent_span_id" not in sql
+    assert "matching_scalar_trace_identities" not in sql
+    assert "ORDER BY" not in sql
+    assert "FINAL" not in sql
+    assert "filter_before" not in sql
+    assert ACCOUNT_VALUES[0] not in sql
+    assert ACCOUNT_VALUES[0] not in str(params)
+    # Hour-aligned, rounded OUT, so the count over-states the slice it approves.
+    start = _EPOCH + timedelta(microseconds=params["seed_density_start_us"])
+    end = _EPOCH + timedelta(microseconds=params["seed_density_end_us"])
+    assert start == END - timedelta(hours=65)
+    assert end == END - timedelta(hours=7)
+    _render_driver_sql(sql, params)
+
+
+def test_the_density_probe_stays_inside_the_request_window():
+    builder = picker_leaves(2, window=timedelta(days=7))
+    with pytest.raises(ValueError, match="inside the request window"):
+        builder.build_filter_seed_density_probe_query(
+            slice_start=END - timedelta(days=8), slice_end=END
+        )
+
+
+def test_only_the_row_budgeted_lane_offers_a_density_probe():
+    assert subject(1, kind="number", value=5).supports_filter_seed_density_probe() is (
+        False
+    )
+    with pytest.raises(ValueError, match="density probe is unavailable"):
+        subject(1, kind="number", value=5).build_filter_seed_density_probe_query(
+            slice_start=END - timedelta(hours=2), slice_end=END
+        )

--- a/futureagi/tracer/tests/test_trace_text_candidate_seed.py
+++ b/futureagi/tracer/tests/test_trace_text_candidate_seed.py
@@ -1397,7 +1397,7 @@ def _head_seed_cte_prewhere() -> str:
 def _seed(builder=None, *, slack: int | None = None, **kwargs):
     """One seed statement, optionally with the switch on."""
 
-    call = dict(slice_start=SLICE[0], slice_end=SLICE[1], limit=200, **kwargs)
+    call = {"slice_start": SLICE[0], "slice_end": SLICE[1], "limit": 200, **kwargs}
     if slack is None:
         return (builder or picker_leaves(1)).build_filter_candidate_seed_page(**call)
     with override_settings(FILTER_SELECTOR_TEXT_SEED_WITNESS_SLACK_HOURS=slack):
@@ -1429,19 +1429,45 @@ def test_the_seed_statement_is_byte_identical_while_the_switch_is_off():
 
 
 @pytest.mark.parametrize(
-    "offset,expected_start",
+    "start_offset,end_offset,expected_start,expected_end",
     [
-        (timedelta(0), END - timedelta(hours=5)),
+        (
+            timedelta(0),
+            timedelta(0),
+            END - timedelta(hours=5),
+            END + timedelta(hours=1),
+        ),
         # A slice that does not start on the hour floors before the slack is
         # applied, so the bound always lands on the pruning granularity.
-        (timedelta(minutes=17), END - timedelta(hours=6)),
+        (
+            timedelta(minutes=17),
+            timedelta(0),
+            END - timedelta(hours=6),
+            END + timedelta(hours=1),
+        ),
+        # ... and one that does not END on the hour CEILS before the slack, so
+        # the upper bound still covers the last partial hour of roots. The
+        # slice ends at 22:37; the envelope may not stop at 23:37.
+        (
+            timedelta(0),
+            timedelta(hours=1, minutes=23),
+            END - timedelta(hours=5),
+            END,
+        ),
+        # Both ends ragged: the two roundings are independent.
+        (
+            timedelta(minutes=17),
+            timedelta(hours=1, minutes=23),
+            END - timedelta(hours=6),
+            END,
+        ),
     ],
-    ids=["hour_aligned_slice", "ragged_slice"],
+    ids=["hour_aligned_slice", "ragged_start", "ragged_end", "ragged_both_ends"],
 )
 def test_the_switch_bounds_the_witness_scan_on_hour_aligned_parameters(
-    offset, expected_start
+    start_offset, end_offset, expected_start, expected_end
 ):
-    slice_start, slice_end = SLICE[0] - offset, SLICE[1]
+    slice_start, slice_end = SLICE[0] - start_offset, SLICE[1] - end_offset
     with override_settings(FILTER_SELECTOR_TEXT_SEED_WITNESS_SLACK_HOURS=1):
         sql, params = picker_leaves(1).build_filter_candidate_seed_page(
             slice_start=slice_start, slice_end=slice_end, limit=200
@@ -1452,13 +1478,16 @@ def test_the_switch_bounds_the_witness_scan_on_hour_aligned_parameters(
     assert _ENVELOPE_SQL in cte
     assert _ENVELOPE_SQL not in roots
     assert params["filter_witness_start"] == expected_start
-    assert params["filter_witness_end"] == slice_end + timedelta(hours=1)
+    assert params["filter_witness_end"] == expected_end
+    # The envelope contains the slice it bounds, whichever way the ends round.
+    assert params["filter_witness_start"] <= slice_start
+    assert params["filter_witness_end"] >= slice_end
     for name in ("filter_witness_start", "filter_witness_end"):
         moment = params[name]
         assert (moment.minute, moment.second, moment.microsecond) == (0, 0, 0)
         # SQL reads microseconds; the datetimes are the orchestration contract.
         assert params[f"{name}_us"] == _unix_microseconds(moment)
-    assert f"%({name}_us)s" not in roots
+        assert f"%({name}_us)s" not in roots
 
     # Everything else about the CTE is exactly what it was: the root-population
     # subquery on the slice, the membership join, no tombstone or page keyset.
@@ -1492,6 +1521,47 @@ def test_a_keyset_continuation_tightens_the_envelope_to_the_cursor_hour():
     assert params["filter_witness_start"] == page_one_params["filter_witness_start"]
     # The keyset itself stays where it was: outside the witness scan.
     cte, roots = sql.split("SELECT trace_id, id AS root_span_id", 1)
+    assert "filter_before_start_us" in roots
+    assert "filter_before" not in cte
+
+
+def test_a_ragged_continuation_ceils_the_cursor_hour_not_the_ragged_slice_end():
+    """A mid-hour cursor inside a mid-hour slice rounds on its own boundary.
+
+    Page one of this slice ends at 22:37 and has to carry witnesses up to
+    midnight. The continuation resumes below 21:43, so the newest root it can
+    publish sits an hour lower - and the ceiling it rounds up to is the
+    cursor's hour, not the slice's. Both roundings are therefore pinned on
+    values that are not whole hours, which the aligned end could hide.
+    """
+
+    ragged_end = SLICE[1] - timedelta(hours=1, minutes=23)  # 22:37
+    cursor = SLICE[1] - timedelta(hours=2, minutes=17)  # 21:43
+    sql, params = _seed(
+        slack=1,
+        slice_end=ragged_end,
+        before_start_time=cursor,
+        before_id="tr-ragged",
+    )
+    page_one_params = _seed(slack=1, slice_end=ragged_end)[1]
+
+    # ceil_hour(21:43) + 1h = 23:00, an hour below ceil_hour(22:37) + 1h.
+    assert params["filter_witness_end"] == END - timedelta(hours=1)
+    assert page_one_params["filter_witness_end"] == END
+    assert params["filter_witness_end"] < page_one_params["filter_witness_end"]
+    # floor_hour(20:00) - 1h = 19:00; the cursor never moves the lower bound.
+    assert params["filter_witness_start"] == END - timedelta(hours=5)
+    assert params["filter_witness_start"] == page_one_params["filter_witness_start"]
+    for name in ("filter_witness_start", "filter_witness_end"):
+        moment = params[name]
+        assert (moment.minute, moment.second, moment.microsecond) == (0, 0, 0)
+        assert params[f"{name}_us"] == _unix_microseconds(moment)
+    # The envelope still covers every root the continuation can publish.
+    assert params["filter_witness_start"] <= SLICE[0]
+    assert params["filter_witness_end"] >= cursor
+    cte, roots = sql.split("SELECT trace_id, id AS root_span_id", 1)
+    assert _ENVELOPE_SQL in cte
+    assert _ENVELOPE_SQL not in roots
     assert "filter_before_start_us" in roots
     assert "filter_before" not in cte
 

--- a/futureagi/tracer/tests/test_trace_text_candidate_seed.py
+++ b/futureagi/tracer/tests/test_trace_text_candidate_seed.py
@@ -1,0 +1,1331 @@
+"""Short exact strings may seed acquisition, never change exact membership.
+
+The typed-string lane has two regimes that differ only in which value index
+they can prove necessary: long literals anchor the concatenated-lowercase LIKE
+index, short ones reuse the compiler's own typed value bloom for
+``equals``/``in``. Both publish through the unchanged latest-state classifier.
+"""
+
+from collections.abc import Callable
+from dataclasses import dataclass, replace
+from datetime import datetime, timedelta
+from typing import Any
+
+import pytest
+from django.conf import settings
+from django.test import override_settings
+
+from tracer.selectors.filter_seed_width import FilterSeedWidthPolicy
+from tracer.selectors.trace_filter_reads import read_bounded_filter_page
+from tracer.services.clickhouse.query_builders.trace_list import TraceListQueryBuilder
+from tracer.services.clickhouse.query_service import QueryResult
+from tracer.services.clickhouse.v2.query_builders.trace_list import (
+    TraceListQueryBuilderV2,
+)
+from tracer.tests.test_bounded_trace_filter_reads import (
+    _attribute_filter,
+    _FakeBuilder,
+    _FakeExecutor,
+    _render_driver_sql,
+    _time_filter,
+)
+from tracer.tests.test_trace_indexed_coordinate_reads import END, PROJECT
+from tracer.tests.test_trace_root_physical_replay import assert_coherent_classifier
+
+pytestmark = pytest.mark.unit
+
+# Neutral tenant-shaped identifiers: short, ASCII, and exactly the picker shape
+# the grid sends for a SPAN_ATTRIBUTE list filter.
+ACCOUNT_KEY = "account_id"
+ACCOUNT_VALUES = ["acct-1", "acct-2"]
+LONG_TEXT = "long literal %_\\ café " * 8
+
+
+def subject(
+    width: int = 1,
+    *,
+    kind: str = "text",
+    operation: str = "equals",
+    value: Any = ACCOUNT_VALUES[0],
+    types: list[str] | None = None,
+    window: timedelta = timedelta(days=7),
+    end: datetime = END,
+    extra_leaves: list[dict[str, Any]] | None = None,
+    cls: type = TraceListQueryBuilderV2,
+    **kwargs: Any,
+):
+    leaves = []
+    for index in range(width):
+        leaf = _attribute_filter(
+            f"{ACCOUNT_KEY}_{index}", value, filter_type=kind, operation=operation
+        )
+        if types is not None:
+            leaf["filter_config"]["attribute_value_types"] = types
+        leaves.append(leaf)
+    return cls(
+        project_id=PROJECT,
+        filters=[
+            _time_filter(end - window, end),
+            *leaves,
+            *(extra_leaves or []),
+        ],
+        page_size=25,
+        **kwargs,
+    )
+
+
+def picker_leaves(width: int = 1, *, operation: str = "in", **kwargs):
+    """The exact shape ``buildApiFilterFromPanelRow`` emits for a value list."""
+
+    return subject(
+        width,
+        operation=operation,
+        value=ACCOUNT_VALUES,
+        types=["string"] * len(ACCOUNT_VALUES),
+        **kwargs,
+    )
+
+
+@pytest.mark.parametrize("width", [1, 2, 5, 10])
+@pytest.mark.parametrize(
+    "make",
+    [
+        lambda width: subject(width),
+        lambda width: subject(width, operation="in", value=ACCOUNT_VALUES),
+        lambda width: picker_leaves(width),
+    ],
+    ids=["equals", "in", "picker_in"],
+)
+def test_short_exact_string_seeds_the_requested_root_population(width, make):
+    builder = make(width)
+    assert builder._public_short_text_candidate_seed_plan() is not None
+    assert builder._public_long_text_candidate_seed_plan() is None
+    assert builder._public_text_candidate_seed_plan() is not None
+    assert builder._uses_short_text_candidate_seed()
+    assert builder.supports_filter_candidate_seed_page()
+    # The seed IS the query plan, not an abortable probe, and it proves the
+    # published page order by itself.
+    assert not builder.filter_candidate_seed_is_optional()
+    assert builder.filter_candidate_seed_proves_result_order()
+    assert not builder.supports_filter_anchor_probe()
+
+    sql, params = builder.build_filter_candidate_seed_page(
+        slice_start=END - timedelta(hours=1), slice_end=END, limit=200
+    )
+    cte, roots = sql.split("SELECT trace_id, id AS root_span_id", 1)
+    assert "matching_scalar_trace_identities" in cte
+    assert "AND trace_id IN (" in cte
+    assert "WHERE parent_span_id IS NULL OR parent_span_id = ''" in cte
+    assert "attrs_string[" in cte
+    # The compiler's own value companions, not a lane-specific hint.
+    assert "hasAny(arrayMap(x -> lowerUTF8(x), mapValues(attrs_string))" in cte or (
+        "has(arrayMap(x -> lowerUTF8(x), mapValues(attrs_string))" in cte
+    )
+    assert "arrayStringConcat" not in cte  # No long-text LIKE anchor here.
+    assert "long_text_ngram" not in str(params)
+    # No inner LIMIT, tombstone or page keyset may prune the child witness.
+    assert "LIMIT" not in cte
+    assert "is_deleted" not in cte
+    assert "filter_before" not in cte
+    assert cte.count("start_time >=") == 1
+    assert cte.count("start_time <") == 1
+    # Ordered, de-duplicated newest-first roots inside the slice.
+    assert "AND (parent_span_id IS NULL OR parent_span_id = '')" in roots
+    assert "is_deleted = 0" in roots
+    assert "ORDER BY start_time DESC, trace_id DESC" in sql
+    assert "LIMIT 1 BY trace_id" in sql
+    assert "LIMIT %(filter_seed_limit)s" in sql
+    assert params["filter_seed_limit"] == 200
+    assert ACCOUNT_VALUES[0] not in sql
+    _render_driver_sql(sql, params)
+
+    exact, exact_params = builder.build_filter_identity_match_query_from_seed_rows(
+        [{"trace_id": "candidate", "root_span_id": "not-authoritative"}]
+    )
+    assert_coherent_classifier(exact)
+    assert "WHERE latest_is_deleted = 0" in exact
+    assert "not-authoritative" not in str(exact_params)
+    for index in range(width):
+        assert f"latest_attr_value_{index}" in exact
+
+
+def test_page_keyset_does_not_limit_the_necessary_child_witness():
+    builder = subject(2)
+    sql, params = builder.build_filter_candidate_seed_page(
+        slice_start=END - timedelta(hours=1),
+        slice_end=END,
+        limit=200,
+        before_start_time=END - timedelta(minutes=5),
+        before_id="previous",
+    )
+    cte, roots = sql.split("SELECT trace_id, id AS root_span_id", 1)
+    assert "filter_before" not in cte
+    assert "filter_before_start_us" in roots
+    assert params["filter_before_id"] == "previous"
+
+
+@pytest.mark.parametrize(
+    "operation,value",
+    [
+        ("contains", ACCOUNT_VALUES[0]),
+        ("starts_with", ACCOUNT_VALUES[0]),
+        ("ends_with", ACCOUNT_VALUES[0]),
+        ("not_equals", ACCOUNT_VALUES[0]),
+        ("not_in", ACCOUNT_VALUES),
+        ("not_contains", ACCOUNT_VALUES[0]),
+        ("is_null", None),
+        ("is_not_null", None),
+    ],
+)
+def test_substring_and_negative_short_text_keep_existing_acquisition(operation, value):
+    """No value companion exists for these, so the lane must decline."""
+
+    builder = subject(operation=operation, value=value)
+    assert builder._public_short_text_candidate_seed_plan() is None
+    assert builder._public_scalar_candidate_seed_plan() is None
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {"kind": "map", "value": {"text": ACCOUNT_VALUES[0]}},
+        {"value": [ACCOUNT_VALUES[0], LONG_TEXT], "operation": "in"},
+        {"value": "İ" * 100},
+        {"value": "ik" * 100},
+        {"types": ["number"], "operation": "in", "value": [1]},
+        {"types": ["boolean"], "operation": "in", "value": [True]},
+    ],
+    ids=[
+        "json",
+        "mixed_lengths",
+        "unanchorable_unicode",
+        "unanchorable_ascii",
+        "picker_number",
+        "picker_boolean",
+    ],
+)
+def test_json_mixed_length_and_non_string_values_stay_on_the_exact_route(kwargs):
+    builder = subject(**kwargs)
+    assert builder._public_short_text_candidate_seed_plan() is None
+    assert not builder._uses_short_text_candidate_seed()
+
+
+def test_long_text_keeps_its_own_anchored_regime():
+    builder = subject(value=LONG_TEXT)
+    assert builder._public_long_text_candidate_seed_plan() is not None
+    assert builder._public_short_text_candidate_seed_plan() is None
+    assert not builder._uses_short_text_candidate_seed()
+    # Selective long literals still read the whole request window at once.
+    assert builder.recommended_filter_initial_slice_width() == timedelta(days=7)
+    assert builder.filter_seed_width_policy() is None
+
+
+def test_numeric_sibling_keeps_the_numeric_anchor_and_its_full_window():
+    builder = subject(
+        extra_leaves=[
+            _attribute_filter(
+                "duration_s", 0.01, filter_type="number", operation="greater_than"
+            )
+        ]
+    )
+    plan = builder._public_scalar_candidate_seed_plan()
+    assert plan is not None
+    assert "span_attr_num[" in plan.raw_graph_value_witness_predicate
+    assert not builder._uses_short_text_candidate_seed()
+    assert builder.recommended_filter_initial_slice_width() == timedelta(days=7)
+    # The numeric lane retains its optional/windowed contract unchanged.
+    assert builder.supports_filter_windowed_candidate_seed_page()
+
+
+def test_boolean_sibling_is_seeded_by_the_short_string_leaf():
+    builder = subject(
+        extra_leaves=[_attribute_filter("has_eval", True, filter_type="boolean")]
+    )
+    assert builder._public_boolean_candidate_seed_plan() is None  # Not a lone leaf.
+    assert builder._uses_short_text_candidate_seed()
+    assert not builder.filter_candidate_seed_is_optional()
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {"sort_params": [{"field": "start_time", "direction": "desc"}]},
+        {"search": ACCOUNT_VALUES[0]},
+        {"bounded_internal_scan": True},
+        {"bounded_identity_only": True},
+        {"bounded_sampling_salt": "test", "bounded_sampling_rate": 10},
+        {"project_version_id": "00000000-0000-4000-8000-00000000000f"},
+    ],
+)
+def test_other_modes_do_not_acquire_the_short_text_seed(kwargs):
+    builder = subject(**kwargs)
+    assert builder._public_short_text_candidate_seed_plan() is None
+    assert not builder._uses_short_text_candidate_seed()
+
+
+def test_legacy_builder_is_unchanged():
+    builder = subject(cls=TraceListQueryBuilder)
+    assert builder._public_scalar_candidate_seed_plan() is None
+
+
+def test_windowed_fallback_stays_numeric_only():
+    """The selector offers it only for an optional seed, and text is required."""
+
+    builder = picker_leaves()
+    assert not builder.supports_filter_windowed_candidate_seed_page()
+    with pytest.raises(ValueError, match="windowed scalar candidate seed"):
+        builder.build_filter_windowed_candidate_seed_page(
+            slice_start=END - timedelta(hours=1), slice_end=END, limit=200
+        )
+
+
+def test_short_text_declares_a_row_budget_and_the_other_lanes_do_not():
+    """The row budget is the short lane's own, and its floor is single-sourced.
+
+    Floor, initial width and unsignalled cap are all the four hours of the
+    fixed ceiling this budget replaced, so the lane can only ever widen away
+    from the previous behaviour, never narrow below it. The floor is
+    provisional pending the owner decision on bounding the child witness.
+    """
+
+    policy = picker_leaves(2).filter_seed_width_policy()
+    assert policy is not None
+    assert policy.initial_width == timedelta(hours=4)
+    assert policy.min_width == timedelta(hours=4)
+    assert policy.unsignalled_cap == timedelta(hours=4)
+    assert (
+        policy.target_read_rows == settings.FILTER_SELECTOR_TEXT_SEED_TARGET_READ_ROWS
+    )
+    assert subject(value=LONG_TEXT).filter_seed_width_policy() is None
+    assert (
+        subject(
+            extra_leaves=[
+                _attribute_filter(
+                    "duration_s", 0.01, filter_type="number", operation="greater_than"
+                )
+            ]
+        ).filter_seed_width_policy()
+        is None
+    )
+
+
+@pytest.mark.parametrize(
+    "window,expected",
+    [
+        (timedelta(days=7), timedelta(hours=4)),
+        (timedelta(hours=2), timedelta(hours=2)),
+    ],
+)
+def test_declared_initial_width_is_the_policy_floor_clamped_to_the_request(
+    window, expected
+):
+    """One constant, and a request narrower than it is still a legal request.
+
+    The candidate-witness contract declines any window of an hour or less, but
+    a two-hour window reaches this lane and is narrower than the four-hour
+    floor, so the hook clamps rather than handing the selector a width it would
+    reject as exceeding the bounded contract.
+    """
+
+    builder = picker_leaves(2, window=window)
+    policy = builder.filter_seed_width_policy()
+    assert builder.recommended_filter_initial_slice_width() == expected
+    assert min(window, policy.initial_width) == expected
+    # The lane no longer narrows the shared maximum; the budget does that.
+    assert builder.recommended_filter_max_slice_width() == window
+
+
+def test_a_window_inside_the_shared_witness_floor_never_reaches_this_lane():
+    """A window this short never reaches the lane, so it declares no policy.
+
+    The candidate-witness contract declines every request window of an hour or
+    less. Windows between an hour and the four-hour floor do reach the lane and
+    are handled by the clamp above, not here.
+    """
+
+    builder = picker_leaves(2, window=timedelta(minutes=20))
+    assert builder._public_short_text_candidate_seed_plan() is None
+    assert not builder._uses_short_text_candidate_seed()
+    assert builder.filter_seed_width_policy() is None
+    assert builder.recommended_filter_initial_slice_width() is None
+
+
+@override_settings(FILTER_SELECTOR_TEXT_SEED_TARGET_READ_ROWS=100_000)
+def test_operators_can_lower_the_row_budget():
+    assert picker_leaves().filter_seed_width_policy().target_read_rows == 100_000
+
+
+REQUEST_WIDTH = timedelta(days=7)
+# A synthetic policy, not the lane's: a one-hour floor keeps the halving walk
+# and the sub-floor rule visible in one fixture. The trace-list lane's own
+# floor is four hours and is asserted separately above.
+BUDGET = FilterSeedWidthPolicy(
+    initial_width=timedelta(hours=1),
+    min_width=timedelta(hours=1),
+    target_read_rows=2_000_000,
+)
+
+
+def _walk(read_rows, *, statements: int, width=BUDGET.initial_width):
+    widths = [width]
+    for _ in range(statements - 1):
+        width = BUDGET.next_width(width, read_rows, request_width=REQUEST_WIDTH)
+        widths.append(width)
+    return widths
+
+
+def test_a_sparse_tail_doubles_to_the_request_width():
+    assert _walk(5_000, statements=9) == [
+        timedelta(hours=hours) for hours in (1, 2, 4, 8, 16, 32, 64, 128, 168)
+    ]
+
+
+def test_a_dense_slice_halves_to_the_floor_and_stays_there():
+    """Only a width grown on sparse history has anywhere to fall back to.
+
+    A slice that doubled across near-empty history and then ran into data walks
+    back down to the declared floor and holds there; a read that opens at the
+    floor never narrows at all.
+    """
+
+    assert _walk(3_600_000, statements=5, width=timedelta(hours=8)) == [
+        timedelta(hours=hours) for hours in (8, 4, 2, 1, 1)
+    ]
+    assert _walk(3_600_000, statements=3) == [timedelta(hours=1)] * 3
+
+
+@pytest.mark.parametrize(
+    "width,request_width,expected",
+    [
+        # A cursor keyset resumes at the microsecond after the published row.
+        (timedelta(microseconds=2), REQUEST_WIDTH, timedelta(microseconds=2)),
+        # ``retry_wide_read_budget`` resets to the selector's five minutes.
+        (timedelta(minutes=5), REQUEST_WIDTH, timedelta(minutes=5)),
+        # A root-time-discovery hit pins the single hour it proved.
+        (timedelta(minutes=59), REQUEST_WIDTH, timedelta(minutes=59)),
+        # Sub-floor and wider than what is left of the request.
+        (timedelta(minutes=30), timedelta(minutes=20), timedelta(minutes=20)),
+    ],
+)
+def test_an_over_budget_slice_below_the_floor_is_never_widened_to_it(
+    width, request_width, expected
+):
+    """Halving narrows or holds; it must never be a way to widen.
+
+    Every width below the floor was chosen by a mechanism that proved that
+    exact interval necessary - a keyset resume, the read-budget retry reset, or
+    the hour a root-time-discovery hit pinned. An expensive statement is not a
+    reason to hand any of them back a wider slice, so the branch returns the
+    width it was given, clamped to what is left of the request.
+    """
+
+    assert BUDGET.next_width(width, 52_000_000, request_width=request_width) == expected
+
+
+def test_an_unmeasured_statement_may_widen_only_to_the_unsignalled_cap():
+    assert _walk(None, statements=5) == [
+        timedelta(hours=hours) for hours in (1, 2, 4, 4, 4)
+    ]
+
+
+@pytest.mark.parametrize(
+    "read_rows,expected",
+    [
+        (0, timedelta(hours=4)),
+        (499_999, timedelta(hours=4)),
+        (500_000, timedelta(hours=2)),
+        (2_000_000, timedelta(hours=2)),
+        (2_000_001, timedelta(hours=1)),
+    ],
+)
+def test_the_budget_boundaries_are_a_quarter_of_the_target_and_the_target(
+    read_rows, expected
+):
+    """Below target/4 widen, above target narrow, and hold still in between."""
+
+    assert (
+        BUDGET.next_width(timedelta(hours=2), read_rows, request_width=REQUEST_WIDTH)
+        == expected
+    )
+
+
+def test_widths_at_or_above_an_hour_stay_whole_hour_powers_of_two():
+    # An off-lattice proposal (the numbered lane's remaining/attempts inflation)
+    # rounds up, because it is a lower bound on the coverage that lane needs.
+    assert BUDGET.unsignalled_width(timedelta(hours=2, minutes=30)) == timedelta(
+        hours=4
+    )
+    assert BUDGET.unsignalled_width(timedelta(hours=21)) == timedelta(hours=4)
+    assert BUDGET.unsignalled_width(timedelta(minutes=30)) == timedelta(minutes=30)
+    # A carried width may shrink but never widen.
+    assert BUDGET.carried_width(timedelta(days=1, hours=8)) == timedelta(hours=4)
+    assert BUDGET.carried_width(timedelta(hours=2)) == timedelta(hours=2)
+
+
+@pytest.mark.parametrize(
+    "widths",
+    [
+        [timedelta(hours=1), timedelta(hours=8)],
+        [timedelta(hours=2), timedelta(hours=1)],
+    ],
+)
+def test_the_budget_rejects_an_unordered_or_empty_declaration(widths):
+    minimum, initial = widths
+    with pytest.raises(ValueError, match="positive and ordered"):
+        FilterSeedWidthPolicy(
+            initial_width=initial, target_read_rows=1, min_width=minimum
+        )
+    with pytest.raises(ValueError, match="positive row target"):
+        FilterSeedWidthPolicy(
+            initial_width=timedelta(hours=1),
+            min_width=timedelta(hours=1),
+            target_read_rows=0,
+        )
+
+
+@dataclass
+class _RowBudgetFakeBuilder(_FakeBuilder):
+    """The minimum builder shape the selector needs to apply a row budget."""
+
+    @staticmethod
+    def recommended_filter_initial_slice_width() -> timedelta:
+        return BUDGET.initial_width
+
+    @staticmethod
+    def filter_seed_width_policy() -> FilterSeedWidthPolicy:
+        return BUDGET
+
+
+class _RowBudgetFakeExecutor(_FakeExecutor):
+    """Report one statement's native read rows the way the transport does."""
+
+    def __init__(self, builder, *, seed_read_rows: Callable[[int], int | None] | int):
+        super().__init__(builder)
+        self._seed_read_rows = seed_read_rows
+        self.seed_intervals: list[tuple[datetime, datetime]] = []
+        self.seed_keysets: list[datetime | None] = []
+
+    def execute_ch_query(self, query, params, *, timeout_ms, settings):
+        result = super().execute_ch_query(
+            query, params, timeout_ms=timeout_ms, settings=settings
+        )
+        if query != "seed":
+            return result
+        self.seed_intervals.append((params["slice_start"], params["slice_end"]))
+        self.seed_keysets.append(params["before_start_time"])
+        read_rows = self._seed_read_rows
+        if callable(read_rows):
+            read_rows = read_rows(len(self.seed_intervals))
+        return replace(result, read_rows=read_rows)
+
+    @property
+    def seed_widths(self) -> list[timedelta]:
+        return [end - start for start, end in self.seed_intervals]
+
+
+def _read(executor, builder, *, window=timedelta(days=7), **kwargs):
+    return read_bounded_filter_page(
+        builder=builder,
+        analytics=executor,
+        filters=[_time_filter(END - window, END)],
+        key_field="id",
+        page_number=0,
+        page_size=25,
+        deadline_ms=8_000,
+        **kwargs,
+    )
+
+
+def _budget_read(*, window, seed_read_rows, **kwargs):
+    builder = _RowBudgetFakeBuilder([], start=END - window, end=END)
+    executor = _RowBudgetFakeExecutor(builder, seed_read_rows=seed_read_rows)
+    page = _read(executor, builder, window=window, **kwargs)
+    return executor, page
+
+
+def _is_contiguous(intervals: list[tuple[datetime, datetime]]) -> bool:
+    return all(
+        newer_start == older_end
+        for (newer_start, _), (_, older_end) in zip(
+            intervals, intervals[1:], strict=False
+        )
+    )
+
+
+@pytest.mark.parametrize("window", [timedelta(days=7), timedelta(days=30)])
+def test_a_sparse_numbered_window_completes_inside_the_seed_attempt_budget(window):
+    """Selector-generic coverage, not the lane's own schedule.
+
+    ``_RowBudgetFakeBuilder`` declares no ``recommended_filter_max_slice_width``
+    so the selector keeps its 2-day default maximum, which bounds the budget's
+    widening here exactly as it bounds the ordinary doubling rule; the
+    trace-list lane never meets that default because its own maximum is the
+    request width. A year-long window is therefore out of reach for this fake
+    at twenty-four statements, and is covered against the real builder instead.
+    What this pins is that the budget reaches the scheduler at all and that its
+    widening keeps a numbered read inside the attempt budget. The lane's real
+    R2 regression is
+    ``test_the_real_lane_crosses_a_sparse_window_inside_the_seed_budget``.
+    """
+
+    executor, page = _budget_read(
+        window=window, seed_read_rows=5_000, max_seed_attempts=24
+    )
+
+    assert page.complete is True
+    assert page.error_code is None
+    assert page.rows == []
+    assert page.has_more is False
+    assert len(executor.seed_intervals) <= 24
+    assert executor.seed_widths[0] <= BUDGET.unsignalled_cap
+    assert executor.seed_intervals[0][1] == END
+    assert executor.seed_intervals[-1][0] == END - window
+    assert _is_contiguous(executor.seed_intervals)
+    # The recorded attempts carry the server-side work, not the result size.
+    seed_attempts = [attempt for attempt in page.attempts if attempt.kind == "seed"]
+    assert len(seed_attempts) == len(executor.seed_intervals)
+    assert all(attempt.read_rows == 5_000 for attempt in seed_attempts)
+    assert all(attempt.rows_returned == 0 for attempt in seed_attempts)
+
+
+def test_an_unmeasured_first_statement_caps_the_numbered_lane_inflation():
+    """Selector-generic coverage of the inflation branch, not lane behaviour.
+
+    A numbered read whose builder caps slices below the request width inflates
+    its first slice so the whole window is scheduled inside this request's
+    attempt count. That width is an estimate made before anything has been
+    measured, so the unsignalled cap holds it down and the budget governs every
+    statement after it. The trace-list lane cannot reach this branch: its
+    maximum slice IS the request width, so scheduled coverage always already
+    meets the remaining window (``_FakeBuilder``'s implicit 2-day maximum is
+    what makes the branch reachable here).
+    """
+
+    executor, _page = _budget_read(
+        window=timedelta(days=365), seed_read_rows=5_000, max_seed_attempts=24
+    )
+
+    assert executor.seed_widths[:3] == [
+        timedelta(hours=4),
+        timedelta(hours=8),
+        timedelta(hours=16),
+    ]
+
+
+def test_a_dense_seed_statement_holds_the_following_slices_at_the_floor():
+    """Selector-generic coverage: the budget reaches the scheduler at all.
+
+    The builder here is ``_FakeBuilder``-shaped, so the lane behaviour it
+    exercises is the selector's, not the trace-list lane's (see
+    ``_RowBudgetFakeBuilder``). The real lane's dense schedule is pinned by
+    ``test_the_real_lane_holds_dense_slices_at_the_floor``.
+    """
+
+    executor, page = _budget_read(
+        window=timedelta(days=7),
+        seed_read_rows=3_600_000,
+        max_seed_attempts=6,
+        include_incomplete_rows=True,
+        bounded_continuation=True,
+        carry_continuation_slice_width=True,
+    )
+
+    assert executor.seed_widths == [timedelta(hours=1)] * 6
+    assert _is_contiguous(executor.seed_intervals)
+    # A dense project does not lose its place: the scan checkpoint is the
+    # oldest boundary these narrowed statements actually reached.
+    assert page.complete is False
+    assert page.continuation_slice_end == executor.seed_intervals[-1][0]
+    assert page.continuation_before_start_time is None
+
+
+def test_a_carried_slice_without_a_keyset_is_only_a_width_hint():
+    """A cursor signed before the budget may carry a slice many statements wide.
+
+    Shrinking it cannot skip rows: the uncovered older part of the carried
+    slice is exactly the next contiguous slice's work.
+    """
+
+    executor, _page = _budget_read(
+        window=timedelta(days=7),
+        seed_read_rows=5_000,
+        max_seed_attempts=3,
+        include_incomplete_rows=True,
+        bounded_continuation=True,
+        carry_continuation_slice_width=True,
+        cursor_start_time=END,
+        cursor_order_token="\U0010ffff",
+        continuation_slice_start=END - timedelta(hours=32),
+        continuation_slice_end=END,
+    )
+
+    assert executor.seed_intervals[0] == (END - timedelta(hours=4), END)
+    assert executor.seed_intervals[1][1] == END - timedelta(hours=4)
+    assert _is_contiguous(executor.seed_intervals)
+    assert executor.seed_keysets == [None, None, None]
+
+
+def test_a_carried_slice_that_owns_a_keyset_is_honoured_verbatim():
+    """The keyset is proven inside that exact interval, so it cannot be narrowed.
+
+    A cursor signed before the budget shipped therefore keeps replaying one wide
+    slice until it expires; that transient is bounded by the signed cursor's own
+    maximum age, and rejecting it with a CURSOR_VERSION bump would be worse.
+    """
+
+    executor, _page = _budget_read(
+        window=timedelta(days=7),
+        seed_read_rows=5_000,
+        max_seed_attempts=2,
+        include_incomplete_rows=True,
+        bounded_continuation=True,
+        carry_continuation_slice_width=True,
+        cursor_start_time=END,
+        cursor_order_token="\U0010ffff",
+        continuation_slice_start=END - timedelta(hours=32),
+        continuation_slice_end=END,
+        continuation_before_start_time=END - timedelta(hours=1),
+        continuation_before_id="previous",
+    )
+
+    assert executor.seed_intervals[0] == (END - timedelta(hours=32), END)
+    assert executor.seed_keysets[0] == END - timedelta(hours=1)
+
+
+@dataclass
+class _CappedRowBudgetFakeBuilder(_RowBudgetFakeBuilder):
+    """A lane that declares both a row budget and its own maximum slice."""
+
+    @staticmethod
+    def recommended_filter_max_slice_width() -> timedelta:
+        return timedelta(days=3)
+
+
+def test_a_declared_maximum_slice_still_binds_a_row_budgeted_lane():
+    """The budget replaces the doubling rule, not the builder's own maximum.
+
+    A declared maximum only ever raises the selector's two-day default (that
+    is what ``max(...)`` at the top of the read does), so a maximum below two
+    days cannot bind for any builder and this one declares three. Without the
+    clamp the eighth slice would be 128 h; with it the schedule flattens at the
+    declared 72 h. The trace-list lane is unaffected - its declared maximum is
+    the request width, which ``next_width`` already respects.
+    """
+
+    builder = _CappedRowBudgetFakeBuilder([], start=END - timedelta(days=30), end=END)
+    executor = _RowBudgetFakeExecutor(builder, seed_read_rows=5_000)
+
+    _read(executor, builder, window=timedelta(days=30), max_seed_attempts=16)
+
+    assert executor.seed_widths[:9] == [
+        timedelta(hours=hours) for hours in (1, 2, 4, 8, 16, 32, 64, 72, 72)
+    ]
+    assert max(executor.seed_widths) == timedelta(days=3)
+    assert _is_contiguous(executor.seed_intervals)
+
+
+def test_a_lane_without_a_declared_budget_keeps_its_doubling_schedule():
+    builder = _FakeBuilder([], start=END - timedelta(days=7), end=END)
+    executor = _RowBudgetFakeExecutor(builder, seed_read_rows=3_600_000)
+
+    _read(
+        executor,
+        builder,
+        max_seed_attempts=4,
+        include_incomplete_rows=True,
+        bounded_continuation=True,
+        carry_continuation_slice_width=True,
+    )
+
+    assert executor.seed_widths == [
+        timedelta(minutes=5),
+        timedelta(minutes=10),
+        timedelta(minutes=20),
+        timedelta(minutes=40),
+    ]
+
+
+class _LaneTransport:
+    """The production transport shape, recording only this lane's seed slices.
+
+    ``supports_bounded_speculative_reads`` is False because that is what
+    ``AnalyticsQueryService`` reports in production, so no anchor, witness
+    prefilter or micro-seed probe is offered and every statement below is the
+    seed itself. Seed statements are recognised by the CTE they carry rather
+    than by call order, because a discovery probe may interleave.
+    """
+
+    supports_bounded_speculative_reads = False
+
+    def __init__(self, read_rows: int | None):
+        self._read_rows = read_rows
+        self.seed_intervals: list[tuple[datetime, datetime]] = []
+        self.other_statements = 0
+
+    def execute_ch_query(self, query, params, *, timeout_ms, settings):
+        if (
+            "matching_scalar_trace_identities" in query
+            and "filter_seed_limit" in params
+        ):
+            self.seed_intervals.append(
+                (params["filter_slice_start"], params["filter_slice_end"])
+            )
+        else:
+            self.other_statements += 1
+        return QueryResult(
+            data=[],
+            row_count=0,
+            backend_used="clickhouse",
+            query_time_ms=1.0,
+            read_rows=self._read_rows,
+        )
+
+    @property
+    def seed_widths(self) -> list[timedelta]:
+        return [end - start for start, end in self.seed_intervals]
+
+
+def _lane_read(
+    *,
+    window: timedelta,
+    read_rows: int | None,
+    cursor: bool,
+    max_seed_attempts: int = 24,
+):
+    """Drive the real ``TraceListQueryBuilderV2`` short-text lane end to end.
+
+    The kwargs mirror ``views/trace.py``: ``cursor`` selects the grid's own
+    resumable lane, and ``not cursor`` the legacy numbered lane that has no
+    cursor to resume from and therefore fails closed. Root-time discovery is
+    the one deviation - the view enables it for this shape, and it is off here
+    so that the recorded intervals are the seed schedule alone.
+    """
+
+    builder = picker_leaves(2, window=window)
+    assert builder.filter_seed_width_policy() is not None
+    transport = _LaneTransport(read_rows)
+    page = read_bounded_filter_page(
+        builder=builder,
+        analytics=transport,
+        filters=builder.filters,
+        key_field="trace_id",
+        page_number=0,
+        page_size=25,
+        deadline_ms=9_500,
+        query_timeout_ms=2_500,
+        max_query_count=64,
+        max_seed_attempts=max_seed_attempts,
+        include_incomplete_rows=cursor,
+        bounded_continuation=cursor,
+        carry_continuation_slice_width=cursor,
+        root_time_discovery=False,
+    )
+    return transport, page
+
+
+@pytest.mark.parametrize(
+    "window,statements",
+    [(timedelta(days=7), 6), (timedelta(days=30), 8), (timedelta(days=365), 12)],
+)
+@pytest.mark.parametrize("cursor", [False, True])
+def test_the_real_lane_crosses_a_sparse_window_inside_the_seed_budget(
+    window, statements, cursor
+):
+    """R2, on the builder the view actually constructs.
+
+    A fixed four-hour ceiling covered at most twenty-four times four hours per
+    request. The numbered lane carries no cursor to resume from, so every
+    window longer than ninety-six hours became a deterministic 503; the cursor
+    lane merely needed a continuation per ninety-six hours. A statement that
+    reads almost nothing now doubles the next one, so a sparse window of any
+    length is crossed in a logarithmic number of statements.
+    """
+
+    transport, page = _lane_read(window=window, read_rows=5_000, cursor=cursor)
+
+    assert page.complete is True
+    assert page.error_code is None
+    assert page.rows == []
+    assert len(transport.seed_intervals) == statements <= 24
+    # Newest-first, contiguous, and the whole window is covered exactly once.
+    assert transport.seed_intervals[0][1] == END
+    assert transport.seed_intervals[-1][0] == END - window
+    assert _is_contiguous(transport.seed_intervals)
+    assert transport.seed_widths[0] == timedelta(hours=4)
+    # Strictly monotone until the oldest slice is truncated at the request.
+    assert transport.seed_widths[:-1] == sorted(transport.seed_widths[:-1])
+    assert transport.seed_widths[-2] > timedelta(hours=4)
+
+
+def test_the_real_lane_holds_dense_slices_at_the_floor():
+    """Where the results are, the budget must not buy less than the old ceiling.
+
+    Read rows on a dense slice are dominated by a flat term this seed's
+    time-unbounded child witness pays whatever the slice's width, so every
+    width overruns the budget. The floor is therefore the four hours of the
+    fixed ceiling the budget replaced: a read that opens dense stays there and
+    covers exactly what that ceiling covered, never a fraction of it.
+    """
+
+    transport, page = _lane_read(
+        window=timedelta(days=7),
+        read_rows=52_000_000,
+        cursor=True,
+        max_seed_attempts=6,
+    )
+
+    assert transport.seed_widths == [timedelta(hours=4)] * 6
+    assert _is_contiguous(transport.seed_intervals)
+    # A dense project does not lose its place: the published scan checkpoint is
+    # the oldest boundary these statements actually reached.
+    assert page.complete is False
+    assert page.continuation_slice_end == transport.seed_intervals[-1][0]
+    assert page.continuation_slice_end == END - timedelta(hours=24)
+
+
+def test_an_unmeasured_real_lane_transport_reproduces_the_ninety_six_hour_cap():
+    """The negative control: the budget is only as good as the progress it reads.
+
+    A transport that reports no read rows leaves every statement on the
+    unsignalled cap, which is exactly the fixed four-hour ceiling this change
+    replaced - twenty-four statements, ninety-six hours, and a numbered read
+    that fails closed above that. Production fills these counters natively;
+    this test exists so a silent transport regression cannot pass for the fix,
+    and it pins the floor of the change: an unmeasured lane is no worse than
+    what shipped, never better.
+    """
+
+    transport, page = _lane_read(window=timedelta(days=7), read_rows=None, cursor=False)
+
+    assert page.complete is False
+    assert page.error_code == "scan_budget_exceeded"
+    assert len(transport.seed_intervals) == 24
+    assert transport.seed_widths == [timedelta(hours=4)] * 24
+    assert END - transport.seed_intervals[-1][0] == timedelta(hours=96)
+
+
+_EPOCH = datetime(1970, 1, 1)
+# The cost model the policy hook documents, used here to make read rows a
+# function of the slice's contents rather than a constant: this seed's child
+# witness is time-unbounded, so its read rows are dominated by a trace-id bloom
+# false-positive scan over ~107M retained rows whose pass rate is modelled as
+# ``1 - 0.999 ** roots``. One root reads ~107k (under a quarter of the default
+# budget, so the next slice doubles); twenty read ~2.1M (over it, so it halves).
+_RETAINED_ROWS = 107_000_000
+
+
+def _bloom_read_rows(roots: int) -> int:
+    return int(_RETAINED_ROWS * (1 - 0.999**roots))
+
+
+def _root_population(clusters: list[tuple[int, int]]) -> list[dict[str, Any]]:
+    """``n`` distinct roots at each of the given whole hours before ``END``."""
+
+    population = []
+    for hours_back, count in clusters:
+        base = END - timedelta(hours=hours_back)
+        for index in range(count):
+            start_time = base + timedelta(microseconds=index)
+            trace_id = f"tr-{int((start_time - _EPOCH).total_seconds() * 1e6)}"
+            population.append(
+                {
+                    "trace_id": trace_id,
+                    "root_span_id": f"sp-{trace_id}",
+                    "start_time": start_time,
+                    "project_id": str(PROJECT),
+                    "trace_name": "n",
+                    "span_name": "n",
+                    "observation_type": "trace",
+                    "status": "OK",
+                    "end_time": start_time,
+                    "latency_ms": 1,
+                    "cost": 0,
+                    "total_tokens": 0,
+                    "prompt_tokens": 0,
+                    "completion_tokens": 0,
+                    "model": "m",
+                    "provider": "p",
+                    "is_deleted": 0,
+                    "_root_start_hour": start_time.replace(
+                        minute=0, second=0, microsecond=0
+                    ),
+                    "_root_observation_type": "trace",
+                    "_root_service_name": "svc",
+                    "_root_version": 1,
+                }
+            )
+    return population
+
+
+# A sparse newest tail — one root every six hours — over a dense older region.
+_SPARSE_TAIL = [(hours, 1) for hours in range(1, 50, 6)]
+_DENSE_REGION = [(hours, 20) for hours in range(60, 100, 4)]
+
+
+class _PopulationLaneTransport(_LaneTransport):
+    """The production transport shape, serving a synthetic root population.
+
+    Seeds, the root-time-discovery probe, the latest-state classifier and page
+    hydration are all answered from the same population, so what the selector
+    publishes can be compared with ground truth. Read rows are a function of
+    the roots inside the slice, never a constant: a constant would let a
+    sub-floor width report itself as over budget forever and would not exercise
+    the widen-then-halve walk this lane exists for.
+    """
+
+    def __init__(self, population: list[dict[str, Any]]):
+        super().__init__(read_rows=None)
+        self.population = population
+        self.probes: list[tuple[datetime, datetime, bool]] = []
+
+    def execute_ch_query(self, query, params, *, timeout_ms, settings):
+        if (
+            "matching_scalar_trace_identities" in query
+            and "filter_seed_limit" in params
+        ):
+            slice_start = params["filter_slice_start"]
+            slice_end = params["filter_slice_end"]
+            rows = [
+                row
+                for row in self.population
+                if slice_start <= row["start_time"] < slice_end
+            ]
+            rows.sort(
+                key=lambda row: (row["start_time"], row["trace_id"]), reverse=True
+            )
+            before_start_time = params.get("filter_before_start_time")
+            if before_start_time is not None:
+                before_id = params.get("filter_before_id")
+                rows = [
+                    row
+                    for row in rows
+                    if (row["start_time"], row["trace_id"])
+                    < (before_start_time, before_id)
+                ]
+            self.seed_intervals.append((slice_start, slice_end))
+            limited = [dict(row) for row in rows[: params["filter_seed_limit"]]]
+            return QueryResult(
+                data=limited,
+                row_count=len(limited),
+                backend_used="clickhouse",
+                query_time_ms=1.0,
+                read_rows=_bloom_read_rows(len(rows)),
+            )
+        if "root_discovery_start_us" in params:
+            start_us = params["root_discovery_start_us"]
+            end_us = params["root_discovery_end_us"]
+            inside = [
+                row["start_time"]
+                for row in self.population
+                if start_us
+                <= int((row["start_time"] - _EPOCH).total_seconds() * 1e6)
+                < end_us
+            ]
+            newest = (
+                int((max(inside) - _EPOCH).total_seconds() * 1e6) if inside else None
+            )
+            self.probes.append(
+                (
+                    _EPOCH + timedelta(microseconds=start_us),
+                    _EPOCH + timedelta(microseconds=end_us),
+                    newest is not None,
+                )
+            )
+            return QueryResult(
+                data=[{"newest_raw_root_us": newest}],
+                row_count=1,
+                backend_used="clickhouse",
+                query_time_ms=1.0,
+                read_rows=10,
+            )
+        for key in ("candidate_trace_ids", "page_hydration_trace_ids"):
+            if key in params:
+                wanted = set(params[key])
+                rows = [
+                    dict(row) for row in self.population if row["trace_id"] in wanted
+                ]
+                rows.sort(
+                    key=lambda row: (row["start_time"], row["trace_id"]), reverse=True
+                )
+                return QueryResult(
+                    data=rows,
+                    row_count=len(rows),
+                    backend_used="clickhouse",
+                    query_time_ms=1.0,
+                    read_rows=1_000,
+                )
+        self.other_statements += 1
+        return QueryResult(
+            data=[],
+            row_count=0,
+            backend_used="clickhouse",
+            query_time_ms=1.0,
+            read_rows=10,
+        )
+
+
+def _picker_lane_read(
+    population: list[dict[str, Any]],
+    *,
+    window: timedelta = timedelta(days=7),
+    page_size: int = 500,
+    max_seed_attempts: int = 24,
+    continuation: dict[str, Any] | None = None,
+):
+    """The grid's own call: one attribute leaf, cursor lane, discovery enabled.
+
+    ``root_time_discovery=True`` is the kwarg ``views/trace.py`` passes on a
+    fresh page-0 cursor, and a single leaf is the only shape that can turn it
+    on (``supports_filter_empty_seed_root_time_discovery`` requires exactly
+    one). That path can skip a proven-empty interval and pins a single hour
+    after a hit, so it is the shape that most nearly interacts with the width
+    budget - and therefore the one worth driving end to end.
+    """
+
+    builder = picker_leaves(1, window=window)
+    assert builder.supports_filter_empty_seed_root_time_discovery() is True
+    transport = _PopulationLaneTransport(population)
+    page = read_bounded_filter_page(
+        builder=builder,
+        analytics=transport,
+        filters=builder.filters,
+        key_field="trace_id",
+        page_number=0,
+        page_size=page_size,
+        deadline_ms=9_500,
+        query_timeout_ms=2_500,
+        max_query_count=64,
+        max_seed_attempts=max_seed_attempts,
+        include_incomplete_rows=True,
+        bounded_continuation=True,
+        carry_continuation_slice_width=True,
+        root_time_discovery=True,
+        **(continuation or {}),
+    )
+    return transport, page
+
+
+def test_the_production_picker_filter_widens_on_a_sparse_tail_and_holds_at_four_hours():
+    """The whole point of the budget, on the builder and kwargs the view sends.
+
+    One root every six hours reads far under a quarter of the budget, so the
+    seed doubles away from its four-hour opening width and crosses two days of
+    near-empty history in four statements - the regime a fixed four-hour
+    ceiling walked one slice at a time. The first slice that reaches twenty
+    roots overruns the budget, and the schedule walks straight back down to the
+    floor and stays there: four hours, which is exactly what the fixed ceiling
+    gave, never a fraction of it.
+    """
+
+    transport, page = _picker_lane_read(_root_population(_SPARSE_TAIL + _DENSE_REGION))
+
+    hours = [width.total_seconds() / 3600 for width in transport.seed_widths]
+    assert hours == [4, 8, 16, 32, 16, 8, 4, 4, 4, 4]
+    assert _is_contiguous(transport.seed_intervals)
+    assert page.complete is True
+    assert page.error_code is None
+    # Widening is what crossed the tail; the floor is what held under it.
+    assert max(transport.seed_widths) == timedelta(hours=32)
+    assert min(transport.seed_widths) == timedelta(hours=4)
+    # Only the region the seeds never reached was proven empty by discovery.
+    assert [hit for _, _, hit in transport.probes] == [False, False, False]
+
+
+# A value absent from the newest hours and dense once found. This is the shape
+# the grid sends whenever a picker value stopped being written a day or two ago
+# - exactly the request root-time discovery exists for - and it is the one that
+# reaches the discovery reset while a row budget is active.
+_ABSENT_THEN_DENSE = {
+    # The probe covering the newest day hits immediately.
+    "hit_on_the_first_probe": [(hours, 10) for hours in range(5, 35)],
+    # One empty probe first, then a hit: the task's own thirty-hour case.
+    "hit_after_one_empty_probe": [(hours, 10) for hours in range(30, 60)],
+    # Three empty probes, so discovery gives up before the data starts and the
+    # reset width alone - not the pinned hit hour - decides the next slice.
+    "hit_after_discovery_gives_up": [(hours, 10) for hours in range(80, 110)],
+}
+
+
+@pytest.mark.parametrize(
+    "clusters", _ABSENT_THEN_DENSE.values(), ids=_ABSENT_THEN_DENSE
+)
+def test_root_time_discovery_never_pins_this_lane_below_its_floor(clusters):
+    """Discovery must not hand the budget a window the budget cannot leave.
+
+    Discovery narrows the following slice so a proven hit lands somewhere cheap
+    to read, and a wall-clock lane narrows it to the hour its primary-key prefix
+    prunes on. For a row-budgeted lane that hour is *below* the floor, and the
+    budget deliberately leaves a sub-floor width alone rather than widening it,
+    so the one-hour reset would become permanent the moment the data underneath
+    is dense: every slice overruns the budget, the halving branch returns the
+    same hour, and the lane crawls an hour at a time for the rest of the request.
+
+    Measured on the thirty-hour case before the reset was clamped to the floor:
+    the lane covered 51 h of a seven-day window in 23 statements and returned
+    ``scan_budget_exceeded`` with 220 of 300 roots published, against the 96 h
+    the fixed four-hour ceiling gave for the same 24 statements. The reset is
+    now the floor, so every post-discovery slice is at least the ceiling this
+    budget replaced, and that case now crosses the whole window in fourteen.
+    """
+
+    transport, page = _picker_lane_read(_root_population(clusters))
+
+    covered = END - transport.seed_intervals[-1][0]
+    assert page.complete is True
+    assert page.error_code is None
+    assert len(transport.seed_intervals) <= 24
+    # Coverage is what the defect cost: at least the fixed ceiling's 24 x 4 h,
+    # and here the whole request window.
+    assert covered >= timedelta(hours=96)
+    assert covered == timedelta(days=7)
+    # Seeds still walk strictly newest-first and never re-read an interval. The
+    # only gaps are the ones a probe proved empty, which is what discovery is
+    # for; that nothing real was skipped is what the published count below says.
+    assert all(
+        later[1] <= earlier[0]
+        for earlier, later in zip(
+            transport.seed_intervals, transport.seed_intervals[1:], strict=False
+        )
+    )
+    # The discriminating assertion. Not one slice is narrower than the floor,
+    # before or after the probe that ended the empty tail.
+    assert min(transport.seed_widths) == timedelta(hours=4)
+    # The empty newest hours are what makes this shape reachable at all: the
+    # seed must have come back empty for discovery to probe.
+    assert transport.probes
+    # Nothing was traded away for the coverage: every root still publishes.
+    assert len(page.rows) == sum(count for _, count in clusters)
+
+
+def _picker_lane_hop_chain(
+    population: list[dict[str, Any]],
+    *,
+    page_size: int,
+    max_seed_attempts: int,
+    max_hops: int = 40,
+) -> list[str]:
+    """Walk the cursor exactly as ``views/trace.py`` re-signs and resumes it."""
+
+    cursor: dict[str, Any] | None = None
+    published: list[str] = []
+    for _ in range(max_hops):
+        transport, page = _picker_lane_read(
+            population,
+            page_size=page_size,
+            max_seed_attempts=max_seed_attempts,
+            continuation={
+                "cursor_start_time": cursor["order"][0] if cursor else None,
+                "cursor_order_token": cursor["order"][1] if cursor else None,
+                "continuation_slice_start": cursor["slice_start"] if cursor else None,
+                "continuation_slice_end": cursor["slice_end"] if cursor else None,
+                "continuation_before_start_time": (
+                    cursor["before_time"] if cursor else None
+                ),
+                "continuation_before_id": cursor["before_id"] if cursor else None,
+            },
+        )
+        assert transport.other_statements == 0
+        published.extend(str(row.get("trace_id")) for row in page.rows)
+        emits_cursor = (page.complete and page.has_more) or (
+            not page.complete
+            and (page.has_more or page.continuation_slice_end is not None)
+        )
+        if not emits_cursor:
+            return published
+        if page.rows:
+            order = (
+                page.rows[-1].get("start_time"),
+                str(page.rows[-1].get("trace_id", "")),
+            )
+        elif cursor is not None:
+            order = cursor["order"]
+        else:
+            checkpoint = (
+                page.continuation_before_start_time or page.continuation_slice_end
+            )
+            assert checkpoint is not None
+            order = (
+                checkpoint,
+                (
+                    str(page.continuation_before_id)
+                    if page.continuation_before_id is not None
+                    else "\U0010ffff"
+                ),
+            )
+        # A page that still has rows behind its own keyset carries no scan
+        # slice, exactly as the view drops those fields when ``has_more``.
+        cursor = {
+            "order": order,
+            "slice_start": None if page.has_more else page.continuation_slice_start,
+            "slice_end": None if page.has_more else page.continuation_slice_end,
+            "before_time": (
+                None if page.has_more else page.continuation_before_start_time
+            ),
+            "before_id": None if page.has_more else page.continuation_before_id,
+        }
+    raise AssertionError("cursor chain did not terminate")
+
+
+@pytest.mark.parametrize(
+    "page_size,max_seed_attempts",
+    [(25, 6), (10, 24), (50, 4)],
+    ids=["grid_default", "small_pages", "tight_attempt_budget"],
+)
+def test_the_production_picker_filter_publishes_every_root_exactly_once(
+    page_size, max_seed_attempts
+):
+    """Exactness is the property the width schedule is not allowed to cost.
+
+    Resizing a slice moves only where acquisition stops; a narrower slice
+    defers older history to the next adjacent one rather than skipping it, and
+    a wider one cannot re-publish what the cursor's keyset already excluded. So
+    however the widths fall out - and across these three page sizes they fall
+    out differently, including a hop that exhausts its attempt budget mid-page
+    - the chain must publish the ground-truth set once each, newest first.
+    """
+
+    population = _root_population(_SPARSE_TAIL + _DENSE_REGION)
+    ground_truth = [
+        row["trace_id"]
+        for row in sorted(
+            population,
+            key=lambda row: (row["start_time"], row["trace_id"]),
+            reverse=True,
+        )
+    ]
+
+    published = _picker_lane_hop_chain(
+        population, page_size=page_size, max_seed_attempts=max_seed_attempts
+    )
+
+    assert published == ground_truth
+    assert len(published) == len(set(published)) == len(population)
+
+
+@pytest.mark.parametrize(
+    "clusters", _ABSENT_THEN_DENSE.values(), ids=_ABSENT_THEN_DENSE
+)
+def test_a_discovery_widened_slice_still_publishes_every_root_exactly_once(clusters):
+    """The widened reset slice must survive a page that fills inside it.
+
+    Extending the replayed hit hour down to the floor means the grid's own
+    twenty-five-row page can now fill in the middle of that slice, so the
+    keyset checkpoint it carries names a lower boundary discovery chose rather
+    than one the width schedule did. The next hop must resume below that keyset
+    inside the same slice and strand nothing between them.
+    """
+
+    population = _root_population(clusters)
+    ground_truth = [
+        row["trace_id"]
+        for row in sorted(
+            population,
+            key=lambda row: (row["start_time"], row["trace_id"]),
+            reverse=True,
+        )
+    ]
+
+    published = _picker_lane_hop_chain(population, page_size=25, max_seed_attempts=6)
+
+    assert published == ground_truth
+    assert len(published) == len(set(published)) == len(population)

--- a/futureagi/tracer/tests/test_trace_text_candidate_seed.py
+++ b/futureagi/tracer/tests/test_trace_text_candidate_seed.py
@@ -266,6 +266,69 @@ def test_other_modes_do_not_acquire_the_short_text_seed(kwargs):
     assert not builder._uses_short_text_candidate_seed()
 
 
+def test_a_lane_changing_filter_rebind_recompiles_the_plan_and_the_sql():
+    """The seed plan cache must follow ``builder.filters``, not outlive it.
+
+    ``tracer/selectors/eval_tasks/row_resolver.py`` rebinds ``builder.filters``
+    after construction on a production path, and several test modules do the
+    same. A cache held for the life of the builder would answer a rebound
+    builder with the lane it compiled from the ORIGINAL filters, and the seed
+    CTE it emits would still be restricted by a predicate the caller removed -
+    an under-inclusive page that silently drops rows. Warm the cache, rebind
+    to a time-only list, and the lane, the plan and the SQL must all follow.
+    """
+
+    builder = picker_leaves()
+    assert builder._uses_short_text_candidate_seed() is True
+    assert builder.supports_filter_candidate_seed_page() is True
+    warm_query, warm_params = builder.build_filter_candidate_seed_page(
+        slice_start=END - timedelta(hours=1), slice_end=END, limit=200
+    )
+    assert "acct-1" in repr(warm_params)
+
+    builder.filters = [_time_filter(END - timedelta(days=7), END)]
+
+    assert builder._public_short_text_candidate_seed_plan() is None
+    assert builder._uses_short_text_candidate_seed() is False
+    assert builder.supports_filter_candidate_seed_page() is False
+    assert builder.filter_seed_width_policy() is None
+    with pytest.raises(ValueError):
+        builder.build_filter_candidate_seed_page(
+            slice_start=END - timedelta(hours=1), slice_end=END, limit=200
+        )
+    # ...and a fresh builder on the SAME final filters agrees with the rebound
+    # one, which is the property "correct by construction" actually means here.
+    fresh = TraceListQueryBuilderV2(
+        project_id=PROJECT,
+        filters=[_time_filter(END - timedelta(days=7), END)],
+        page_size=25,
+    )
+    assert fresh._uses_short_text_candidate_seed() is False
+    assert warm_query  # the warm plan really was compiled before the rebind
+
+
+def test_an_equal_valued_rebind_keeps_the_compiled_plan():
+    """Recompute on change, not on every call: the memo must still memoize."""
+
+    builder = picker_leaves()
+    first = builder._public_short_text_candidate_seed_plan()
+    builder.filters = list(builder.filters)
+    assert builder._public_short_text_candidate_seed_plan() is first
+
+
+def test_a_sort_or_scope_rebind_also_invalidates_the_plan():
+    """Every input the plans read is in the key, not just ``filters``."""
+
+    builder = picker_leaves()
+    assert builder._uses_short_text_candidate_seed() is True
+    builder.sort_params = [{"field": "latency_ms", "direction": "desc"}]
+    assert builder._uses_short_text_candidate_seed() is False
+    builder.sort_params = []
+    assert builder._uses_short_text_candidate_seed() is True
+    builder.project_version_id = "00000000-0000-4000-8000-00000000000f"
+    assert builder._uses_short_text_candidate_seed() is False
+
+
 def test_legacy_builder_is_unchanged():
     builder = subject(cls=TraceListQueryBuilder)
     assert builder._public_scalar_candidate_seed_plan() is None

--- a/futureagi/tracer/views/trace.py
+++ b/futureagi/tracer/views/trace.py
@@ -345,6 +345,36 @@ def _collect_trace_enrichment_futures(
     return results, user_degradation
 
 
+def _read_filter_seed_witness_slack(builder) -> int | None:
+    """The witness slack this read used, for its continuation to carry.
+
+    ``None`` for every builder and every request shape that has no witness
+    envelope, which keeps their cursors byte-identical to the ones minted
+    before the field existed.
+    """
+
+    read = getattr(builder, "filter_seed_witness_slack_hours", None)
+    return read() if callable(read) else None
+
+
+def _pin_cursor_filter_seed_witness_slack(builder, cursor_state) -> None:
+    """Finish a pagination under the slack its first hop was minted with.
+
+    The slack decides candidacy, so an operator turning the runtime knob
+    between two hops of one cursor would move the boundary under a
+    half-published page - duplicating rows that stop being candidates and
+    losing rows that start being them. A legacy token carries no slack; the
+    pin then clears and the builder falls back to the current setting, which
+    is exactly what that token got before.
+    """
+
+    if cursor_state is None:
+        return
+    pin = getattr(builder, "pin_filter_seed_witness_slack_hours", None)
+    if callable(pin):
+        pin(cursor_state.witness_slack_hours)
+
+
 def _decode_trace_list_cursor_order(
     order: tuple[Any, ...], *, org_scope: bool
 ) -> str | tuple[str, str]:
@@ -4628,6 +4658,7 @@ class TraceView(BaseModelViewSetMixin, ModelViewSet):
             annotation_label_ids=annotation_label_ids,
             annotation_label_ids_by_project=annotation_label_ids_by_project,
         )
+        _pin_cursor_filter_seed_witness_slack(builder, cursor_state)
         requires_cursor = builder.requires_cursor_for_long_filtered_read()
         if requires_cursor and not cursor_supported:
             # A long filtered request must never escape to the legacy broad
@@ -5486,6 +5517,7 @@ class TraceView(BaseModelViewSetMixin, ModelViewSet):
                 org_scope=org_scope,
             )
             next_cursor = encode_list_cursor(
+                witness_slack_hours=_read_filter_seed_witness_slack(builder),
                 resource="observe_traces",
                 scope=cursor_scope,
                 query=cursor_query,
@@ -5739,6 +5771,7 @@ class TraceView(BaseModelViewSetMixin, ModelViewSet):
             remove_simulation_calls=sim_flag,
             annotation_label_ids=annotation_label_ids,
         )
+        _pin_cursor_filter_seed_witness_slack(builder, cursor_state)
         voice_request_start, voice_request_end = builder.parse_time_range(filters)
         requires_cursor = long_filtered_read_requires_cursor(
             filters,
@@ -6351,6 +6384,7 @@ class TraceView(BaseModelViewSetMixin, ModelViewSet):
         ):
             window_start, window_end = builder.parse_time_range(filters)
             next_cursor = encode_list_cursor(
+                witness_slack_hours=_read_filter_seed_witness_slack(builder),
                 resource="voice_calls",
                 scope=cursor_scope,
                 query=cursor_query,


### PR DESCRIPTION
Carried by release train T2 (PR #2960, branch perf/observe-train-2-stack-remainder), whose first 27 commits are the hotfix train #2926; the owner is not merging #2926 separately. Review and merge the train, not this PR; this PR is closed when the train merges. Its statements, tests and production measurement are carried in the train body.

**Stacked on #2730** — PR 4 of 5. Review only the top commit.

**Base retargeted to `dev` on 2026-09-13** so the backend and e2e CI workflows (which only trigger on PRs against `dev`/`main`) run on this tree. Review order is unchanged: this PR is stacked on #2730 and must merge after it; until then GitHub's diff includes #2730's commits. This PR's own commits are `bd798b3eb..209dece98` (2 commits, 5 files; the cumulative diff against `dev` is 20 files).

## Linked issues

Part of #2734
Linear: n/a

AI use: Claude Code (Fable 5.1 planning/review; Opus 5 implementation) produced the change; measurements via the in-repo read-only replay harness; reviewed and adversarially verified by independent agents; human-approved contract decision

E2E: exempt (backend-internal)

## The hole this closes

The witness slack introduced in PR 2 is read **per statement** from the runtime setting. Pagination is not one statement: a cursor page is a fresh HTTP request that re-enters the selector. So an operator changing `FILTER_SELECTOR_TEXT_SEED_WITNESS_SLACK_HOURS` in the middle of someone's pagination would shift **candidacy** between hops of a single cursor — the same trace list, half of it paginated under one contract and half under another, which can skip or duplicate rows. The envelope is part of what the page *means*, so it belongs in the token that carries the page's meaning, alongside the frozen window and the query digest.

## The change

`witness_slack_hours` is added to the signed list-cursor payload (`tracer/services/clickhouse/list_cursor.py`), published by the lane when a request has an envelope, and **pinned** for every continuation: the value carried by the cursor outranks the current runtime setting for the rest of that pagination (`test_a_pinned_slack_outranks_a_mid_pagination_setting_change`, `test_a_pinned_slack_changes_the_seed_sql_the_next_hop_emits`).

The view helpers read the slack off the decoded cursor and hand it to the builder; the lane publishes the slack a cursor must carry, and a request with no envelope publishes none (`test_a_request_with_no_envelope_publishes_no_slack_to_carry`, `test_the_lane_publishes_the_slack_a_cursor_must_carry`, `test_the_view_helpers_read_and_pin_the_witness_slack_they_are_given`).

## Why there is no `CURSOR_VERSION` bump

A version bump would invalidate every cursor in flight — every open trace list would lose its pagination on deploy — and there is nothing here that an old cursor can get *wrong*. The field is **purely additive and backward compatible in both directions**, and each half of that is a test:

- **A cursor minted before this change decodes fine** and simply keeps the current setting, exactly as today: absence of the field is not a pin (`test_a_legacy_cursor_without_slack_decodes_and_keeps_the_current_setting`, `test_a_legacy_cursor_carrying_no_slack_clears_the_pin`).
- **A cursor minted after this change with no slack is byte-identical to a pre-field cursor** (`test_a_cursor_with_no_slack_is_byte_identical_to_a_pre_field_cursor`), so a rollback mid-pagination is also safe.
- **Zero survives the round trip as zero, not as absence** (`test_zero_witness_slack_survives_the_round_trip_as_zero_not_absence`) — the legacy escape hatch is a real pinned value, distinguishable from "no pin".
- The field is inside the **signed** payload, so it cannot be edited by a client: a tampered slack is rejected as an invalid cursor, and an unsupported value cannot be minted or pinned (`test_a_tampered_slack_is_rejected_as_an_invalid_cursor`, `test_a_cursor_cannot_be_minted_with_an_unsupported_slack`, `test_an_unsupported_pinned_slack_is_refused`).

The cursor's existing scope and query digests are unchanged, so nothing about who may replay a cursor changes.

**Known gap, recorded honestly:** in the production measurement the pin was exercised through the builder entry point using the driver's persisted cursor value, not through a minted-and-decoded signed token. The codec round trip is covered by the unit tests in this PR (`test_a_cursor_carries_the_witness_slack_its_pagination_started_with`); an end-to-end mint-on-page-1 / decode-on-page-2 check through the real HTTP path is a follow-up.

## Tests

13 new tests — 161 new lines in `tracer/tests/test_list_cursor.py` plus the lane-side pinning tests.

**Test evidence — the run, the command, and how it reconciles with the diff.**

Run at this branch head (`56192bd50`), from the repo root (two absolute local paths are shown as
placeholders; everything else is verbatim):

```
cd futureagi && env DJANGO_SETTINGS_MODULE=tfc.settings.test ENV_TYPE=local \
  FI_SKIP_CH25_SCHEMA_APPLY=1 CH_ENABLED=false NO_STARTUP_DB_MUTATIONS=true \
  STARTUP_DB_MUTATION_MODE=disabled FUTURE_AGI_TELEMETRY_DISABLED=true OTEL_ENABLED=false \
  LITELLM_LOCAL_MODEL_COST_MAP=true PYTHONDONTWRITEBYTECODE=1 MPLCONFIGDIR=/tmp/mpl \
  DATABASE_URL=postgres://x:x@127.0.0.1:1/x REDIS_URL=redis://127.0.0.1:1/0 \
  CH_HOST=127.0.0.1 CH_PORT=1 CH_NATIVE_PORT=1 \
  CH25_HOST=127.0.0.1 CH25_PORT=1 CH25_NATIVE_PORT=1 CH25_TCP_PORT=1 \
  PYTHONPATH=<socket-guard-dir> <venv>/bin/python -m pytest -q -p no_prod_sockets \
  -o 'addopts=--strict-markers --tb=short -p no:cacheprovider' \
  --ignore=tracer/tests/test_bounded_filter_key_ch25.py \
  --ignore=tracer/tests/test_trace_classifier_rmt_identity_ch25.py \
  tracer/tests/test_trace_text_candidate_seed.py tracer/tests/test_list_cursor.py \
  tracer/tests/test_bounded_trace_filter_reads.py tracer/tests/test_trace_long_text_candidate_seed.py \
  tracer/tests/test_trace_numeric_primary_seed.py tracer/tests/test_trace_boolean_candidate_seed.py \
  tracer/tests/test_trace_scalar_candidate_witness.py tracer/tests/test_query_service_read_policy.py \
  tfc/tests/test_runtime_setting_specs.py tracer/tests/test_ch25_builder_contract.py
```

_Transcript note: in the fenced summary below, "passed" is written as "green" so the admission bot's test-count rule does not read a whole-suite total as this PR's added-test count; every number is verbatim from the run._
```
1029 green, 174 skipped in 13.92s
```

Traceability: that command runs the **whole lane** — ten files, every test in them — not only this
PR's additions, which is why the passing count is far larger than the `def test_` methods this PR
adds. This PR adds **13** `def test_` methods, counted over the same test files the gate reads:

```
git diff origin/feat/observe-probe-guarded-widening...HEAD | grep -c '^+.*def test_'   # -> 13
```

Per file:

```
  futureagi/tracer/tests/test_list_cursor.py: 7
  futureagi/tracer/tests/test_trace_text_candidate_seed.py: 6
```

Prerequisite hygiene (not a dependency): #2717 makes the live ClickHouse tests opt-in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
