### PR TITLE
fix(agentic_eval): return numeric result from calculate_rouge (RougeScore)

### DIFF
--- a/futureagi/agentic_eval/core_evals/fi_evals/function/functions.py
+++ b/futureagi/agentic_eval/core_evals/fi_evals/function/functions.py
@@ -177,10 +177,14 @@ def calculate_rouge(reference, hypothesis):
     scorer = rouge_scorer.RougeScorer(['rouge1', 'rouge2', 'rougeL'], use_stemmer=True)
     scores = scorer.score(reference, hypothesis)
 
-    # Parse rouge1 score and store as string
+    # `result` must be the numeric fmeasure like every other evaluator: the
+    # framework does `not eval_response["result"]` to decide failure and
+    # `float(result_value)` to record the metric. A formatted string is always
+    # truthy, so a string result could never be flagged as a failure (even
+    # ROUGE 0.0), and the `:.3f` rounding silently dropped precision. The
+    # human-readable breakdown stays in `reason`.
     rouge1_score = f"ROUGE-1: P={scores['rouge1'].precision:.3f}, R={scores['rouge1'].recall:.3f}, F={scores['rouge1'].fmeasure:.3f}"
-    score = f'{scores["rouge1"].fmeasure:.3f}'
-    return {"result": score, "reason": f"ROUGE score: {rouge1_score}"}
+    return {"result": scores["rouge1"].fmeasure, "reason": f"ROUGE score: {rouge1_score}"}
 
 def _pil_to_uint8_tensor(img, size: int = 299):
     """

--- a/futureagi/ee/tests/agentic_eval/tests/test_rouge_eval.py
+++ b/futureagi/ee/tests/agentic_eval/tests/test_rouge_eval.py
@@ -1,0 +1,38 @@
+"""Regression tests for calculate_rouge (RougeScore).
+
+`result` must be the numeric ROUGE-1 fmeasure, like every other evaluator.
+The framework decides failure with `not eval_response["result"]` and records
+the metric with `float(result_value)` (function_evaluator.py). A formatted
+string result is always truthy, so a string-returning RougeScore could never
+be flagged as a failure — even at ROUGE 0.0.
+"""
+
+
+def _calculate_rouge():
+    from agentic_eval.core_evals.fi_evals.function.functions import calculate_rouge
+
+    return calculate_rouge
+
+
+def test_rouge_result_is_numeric():
+    calculate_rouge = _calculate_rouge()
+    out = calculate_rouge("the cat sat on the mat", "the cat sat on the mat")
+    assert isinstance(out["result"], float)
+    assert out["result"] == 1.0
+
+
+def test_rouge_zero_score_is_falsy_so_failure_can_fire():
+    calculate_rouge = _calculate_rouge()
+    out = calculate_rouge("completely different", "xyz qrs tuv")
+    assert isinstance(out["result"], float)
+    assert out["result"] == 0.0
+    # The whole point: `not result` must be True for a zero score so the
+    # framework's is_failure() can flag it. A "0.000" string would be truthy.
+    assert not out["result"]
+
+
+def test_rouge_partial_score_is_float_and_bounded():
+    calculate_rouge = _calculate_rouge()
+    out = calculate_rouge("the cat sat on the mat", "the cat is on a mat")
+    assert isinstance(out["result"], float)
+    assert 0.0 < out["result"] < 1.0


### PR DESCRIPTION
## Summary

`calculate_rouge` (`RougeScore`) returned `result` as a formatted string (`f'{fmeasure:.3f}'`), the only one of the 44 evaluators in `functions.py` that doesn't return a numeric `result`. `FunctionEvaluator` decides failure with `not eval_response["result"]` (`function_evaluator.py:76`) and records the metric with `float(result_value)` (`:110`). A non-empty string is always truthy, so a RougeScore could never be flagged as a failure, even at ROUGE 0.0, while every numeric evaluator returning 0.0 is correctly failed. The `:.3f` also dropped precision before the `float()` cast, and rouge2/rougeL were discarded.

This returns the numeric ROUGE-1 fmeasure and keeps the human-readable P/R/F breakdown in `reason`.

## Linked issues

Closes #2738

## AI use

AI use: Claude Code wrote the fix and the regression tests from my direction; I reviewed the diff.

## Type of change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📖 Documentation only
- [ ] 🧹 Chore / refactor (no user-visible change)
- [ ] 🚀 Performance improvement
- [ ] 🧪 Test-only change

## E2E coverage

E2E: exempt (backend-internal)

---

## 1) What changes were done

```diff
-    score = f'{scores["rouge1"].fmeasure:.3f}'
-    return {"result": score, "reason": f"ROUGE score: {rouge1_score}"}
+    return {"result": scores["rouge1"].fmeasure, "reason": f"ROUGE score: {rouge1_score}"}
```

Behavior-preserving for the recorded metric value (which was already `float("0.500")`); it fixes pass/fail semantics and precision. There is a single implementation in this repo (the SDK copy tracked by #1890 is out of scope here).

## 2) Tests

Adds `futureagi/ee/tests/agentic_eval/tests/test_rouge_eval.py`:

- `result` is a `float` (1.0 on identical text).
- a zero score (disjoint text) is `0.0` and falsy, so `is_failure()` can fire.
- partial overlap is a float strictly in `(0, 1)`.

Checked directly against `rouge_score`, with the same `RougeScorer(['rouge1', 'rouge2', 'rougeL'], use_stemmer=True)` call the function makes: identical text gives `1.0`, disjoint text gives `0.0` (falsy; the old formatted `'0.000'` string is truthy), and partial overlap gives `0.667`.

Run with the project's own pytest config (`futureagi/pytest.ini`, `tfc.settings.test`) on the locked dependencies (`uv sync --frozen --all-extras`, Python 3.11), on macOS without the Docker services (there is no Docker on that machine, so not through `bin/test up`; this test does not need the ClickHouse sidecar). The runs were executed by Claude Code from my direction:

```
$ cd futureagi && uv run pytest --import-mode=importlib ee/tests/agentic_eval/tests/test_rouge_eval.py
ee/tests/agentic_eval/tests/test_rouge_eval.py::test_rouge_result_is_numeric PASSED
ee/tests/agentic_eval/tests/test_rouge_eval.py::test_rouge_zero_score_is_falsy_so_failure_can_fire PASSED
ee/tests/agentic_eval/tests/test_rouge_eval.py::test_rouge_partial_score_is_float_and_bounded PASSED
3 passed
```

With the fix reverted (`functions.py` from the parent commit) and the tests kept, all three fail on the bug itself:

```
E   where False = isinstance('1.000', float)
E   where False = isinstance('0.000', float)
E   where False = isinstance('0.667', float)
3 failed
```

`agentic_eval` is listed in `norecursedirs` in `futureagi/pytest.ini`, so a plain recursive run does not collect this directory (or its sibling tests). Run it by explicit path as above.

