### PR TITLE
chore(observe-qa): re-pin Users replay harness and assert the CH identity [agent]

### DIFF
--- a/scripts/qa/replay_observe_queries_readonly.py
+++ b/scripts/qa/replay_observe_queries_readonly.py
@@ -354,11 +354,26 @@ def diagnostic_read_settings(
     return limits
 
 
-# SQL pins: sha256 of the statement text the deployed builders emit for the
-# qualified origin shape (no user_id label witness, no numeric scalar witness).
-# ``limit`` is a *binding* (``LIMIT %(limit)s``), so one origin pin covers every
-# first-batch size. Recompute by building the same two statements against the
-# checked-in builders and hashing ``sql.strip().rstrip(";")``.
+# SQL pin: the canonical digest of the statement the deployed builders emit for
+# the qualified origin shape (no user_id label witness, no numeric scalar
+# witness). On this tree no attribute witness qualifies at all, so every
+# reviewed first-page filter shape is the SAME statement and one pin holds them.
+#
+# Recompute offline against the checked-in builders -- no connection, no
+# production access. From ``futureagi/`` with ``PYTHONPATH=.`` and every
+# DB/CH/Redis port pointed at a dead port, after ``django.setup()`` only::
+#
+#     b = UserListQueryBuilderV2(organization_id=str(UUID(int=11)),
+#                                project_ids=[str(UUID(int=12))],
+#                                filters=FILTERS, search="", empty_scope=False)
+#     sql, _ = b.build_dimension_candidate_query(
+#         limit=26, window_start=datetime(2026, 9, 3, 0, 0, tzinfo=timezone.utc),
+#         window_end=datetime(2026, 9, 3, 4, 0, tzinfo=timezone.utc))
+#     _users_origin_digest(sql)
+#
+# Organization, projects, window, ``limit`` and the attribute key AND value are
+# all *bindings*, so none of them enters the digest: limit 26 and limit 65 hash
+# identically, and so do two different attribute keys or values.
 _USERS_ORIGIN_SHA = "7120eaf17118a7ae3708911c7a61e88f46e8a2df1d59753463e5d99e0aacbeb9"
 _USERS_REMAP_SHA = "090df268267944b22e713077c59d4836e4046fadb60bfbb78116f3a43af46676"
 # Source pins: sha256 of the *file bytes* backing each imported module, i.e.
@@ -372,6 +387,82 @@ _USERS_SOURCE_PINS = {
     "tracer.services.clickhouse.v2.id_remap_sql": "56903f382c0f8dc40099e5ebfda45a8ab853c0b8f7ec16b5712f9c11092fe24a",
 }
 _CH_USER_ENV = "OBSERVE_CH_USER"
+
+
+# Origin statements are digested in a CANONICAL form, not as raw text: every
+# bracketed run of value-list placeholders collapses to a single token, and
+# nothing else changes. The Users read path spells ONE placeholder per selected
+# value in two companion bloom index hints built in
+# ``tracer/services/clickhouse/query_builders/latest_filter_predicates.py`` --
+# ``hasAny(arrayMap(x -> lowerUTF8(x), mapValues(span_attr_str)),
+# [%(latest_filter_index_0_0)s, ...])`` and, for all-ASCII values, the legacy
+# ``lower()`` companion ``[%(latest_filter_legacy_index_0_0)s, ...]``, whose
+# placeholder count is 2 ** (number of letters ``k`` in the values),
+# deduplicated. The raw statement text therefore fans out on BOTH the value
+# count AND the value text: ``equals "kid"``, ``equals "token"``, ``equals
+# "ok"`` and any selected-value list whose lowercased values collide are each a
+# different statement at the SAME cardinality, including cardinality 1.
+# Collapsing the ARITY of those two placeholder families -- and only theirs --
+# makes the digest depend on the statement's SHAPE: which witness qualified and
+# whether the legacy hint was emitted. Every other byte still enters the
+# digest: whitespace, keywords, columns, structure, the placeholder NAMES, and
+# the attribute-KEY list ``[%(latest_filter_key_0)s]`` whose trailing index is a
+# FILTER index rather than a value index. A builder change still fails closed.
+#
+# A bracketed, ``", "``-separated run of ``%(name)s`` placeholders, which is
+# exactly how the builder spells both hint lists.
+_ORIGIN_PLACEHOLDER_LIST_RE = re.compile(
+    r"\[%\([A-Za-z0-9_]+\)s(?:, %\([A-Za-z0-9_]+\)s)*\]"
+)
+_ORIGIN_PLACEHOLDER_NAME_RE = re.compile(r"%\(([A-Za-z0-9_]+)\)s")
+# The two parameter families the builder derives from a filter's value list:
+# ``latest_filter_index_<filter suffix>_<value index>`` and its legacy
+# companion. The value index is a canonical decimal, so ``_00`` is not ``_0``
+# and a renamed placeholder matches nothing and is left alone.
+_ORIGIN_VALUE_PARAM_RE = re.compile(
+    r"^(?P<stem>latest_filter_(?:legacy_)?index_[A-Za-z0-9_]*[A-Za-z0-9])"
+    r"_(?P<value_index>0|[1-9][0-9]*)$"
+)
+
+
+def _collapse_origin_value_list(match):
+    """Collapse one placeholder run iff it is a whole filter value list.
+
+    Every member must belong to the same value-list family and stem, and the
+    value indexes must be exactly ``0 .. n-1`` in order -- which is how the
+    builder emits them. Anything else is returned untouched, so an unexpected
+    list keeps its exact text and still fails the pin.
+    """
+
+    names = _ORIGIN_PLACEHOLDER_NAME_RE.findall(match.group(0))
+    parsed = [_ORIGIN_VALUE_PARAM_RE.match(name) for name in names]
+    if any(item is None for item in parsed):
+        return match.group(0)
+    stems = {item.group("stem") for item in parsed}
+    indexes = [int(item.group("value_index")) for item in parsed]
+    if len(stems) != 1 or indexes != list(range(len(indexes))):
+        return match.group(0)
+    return "[%(" + stems.pop() + "_*)s]"
+
+
+def _canonical_origin_sql(sql):
+    """Return the statement with value-list ARITY collapsed, nothing else."""
+
+    return _ORIGIN_PLACEHOLDER_LIST_RE.sub(_collapse_origin_value_list, sql)
+
+
+def _users_origin_digest(sql):
+    """Digest the canonical form of an origin statement.
+
+    ``.strip().rstrip(";")`` is exactly the normalization ``validate_select``
+    applies before the statement runs, so one digest covers both check sites:
+    the qualification check that selects the shape and the execute-time check
+    that re-verifies the statement actually handed to the driver.
+    """
+
+    return hashlib.sha256(
+        _canonical_origin_sql(sql.strip().rstrip(";")).encode()
+    ).hexdigest()
 
 
 def _users_sources_current():
@@ -536,7 +627,7 @@ class ReadOnlyExecutor:
             limit=origin_limit, window_start=replay.utc(case["window"]["start"]),
             window_end=replay.utc(case["window"]["end"]),
         )
-        if hashlib.sha256(sql.strip().rstrip(";").encode()).hexdigest() != _USERS_ORIGIN_SHA:
+        if _users_origin_digest(sql) != _USERS_ORIGIN_SHA:
             raise replay.ReplayError("USERS_REMAP_ORIGIN_NOT_QUALIFIED")
         self._users_context = _UsersRemapContext(
             tuple(_user_uuid(p) for p in projects), tuple(map(str, self.projects)),
@@ -606,9 +697,16 @@ class ReadOnlyExecutor:
                 raise
             self._validate_users_remap(query, params, pending)
             sql, certified = query, pending
-        if origin and (hashlib.sha256(sql.encode()).hexdigest() != _USERS_ORIGIN_SHA
-                       or replay.digest(safe_json(params)) != self._users_context.origin_bindings):
-            raise replay.ReplayError("USERS_REMAP_ORIGIN_BINDINGS_CHANGED")
+        # Same canonical digest as the qualification check above. The raw
+        # ``sql_sha256`` recorded below stays the exact executed text, so the
+        # ledger still carries the byte-for-byte statement that ran.
+        if origin:
+            bindings_digest = replay.digest(safe_json(params))
+            if (
+                _users_origin_digest(sql) != _USERS_ORIGIN_SHA
+                or bindings_digest != self._users_context.origin_bindings
+            ):
+                raise replay.ReplayError("USERS_REMAP_ORIGIN_BINDINGS_CHANGED")
         remaining = self.remaining_read_ms()
         if remaining <= 0:
             raise ReadDeadlineExceeded("diagnostic_safety_wall")

--- a/scripts/qa/replay_observe_queries_readonly.py
+++ b/scripts/qa/replay_observe_queries_readonly.py
@@ -479,8 +479,26 @@ class ReadOnlyExecutor:
             compression="lz4",
         )
         # The executor opens its OWN connection; the preflight assertion on the
-        # metadata client does not cover it. Zero statements, zero bytes.
-        assert_ch_identity(args, self.client.connection.user)
+        # metadata client does not cover it.
+        self._assert_server_side_identity()
+
+    def _assert_server_side_identity(self):
+        """Prove THIS connection's account with the server, not with our own arg.
+
+        Comparing ``self.client.connection.user`` would be tautological: the
+        driver stores verbatim whatever we passed to ``Client(...)``. Only a
+        ``currentUser()`` the server answers proves which account this
+        connection runs as. Costs one metadata statement per executor, under
+        server-enforced readonly, before any table read.
+        """
+        if not getattr(self.args, "user_assert", False):
+            return
+        rows = self.client.execute(
+            "SELECT currentUser()",
+            query_id=f"{self.prefix}-identity",
+            settings={"readonly": 2, "max_execution_time": 3},
+        )
+        assert_ch_identity(self.args, rows[0][0] if rows and rows[0] else None)
 
     def remaining_read_ms(self):
         return max(0, int((self.deadline - time.monotonic()) * 1000))
@@ -1415,7 +1433,7 @@ def main():
     )
     parser.add_argument(
         "--user-assert", action="store_true", default=False,
-        help="Require OBSERVE_CH_USER to be set and to equal the server's currentUser(); aborts before any read so a driver cannot silently run as 'default'",
+        help="Require OBSERVE_CH_USER to be set and to equal the server's currentUser(); the preflight and every executor connection each spend one metadata statement proving it, and abort before any table read, so a driver cannot silently run as 'default'",
     )
     parser.add_argument("--threads", type=int, choices=(1, 2, 4, 8), default=2)
     args = parser.parse_args()

--- a/scripts/qa/replay_observe_queries_readonly.py
+++ b/scripts/qa/replay_observe_queries_readonly.py
@@ -402,12 +402,16 @@ def _users_origin_limit(manager):
 
 def observe_ch_user(args):
     """Resolve the ClickHouse user; ``--user-assert`` bars the silent fallback."""
-    user = os.environ.get(_CH_USER_ENV)
     if getattr(args, "user_assert", False):
+        user = os.environ.get(_CH_USER_ENV)
         if not user:
             raise replay.ReplayError("CH_USER_NOT_CONFIGURED")
         return user
-    return user or "default"
+    # Flag off resolves EXACTLY as it did before this flag existed: only an
+    # *unset* variable falls back to ``default``. A variable set to the empty
+    # string keeps resolving to the empty string, so a misconfigured identity
+    # fails at connect instead of silently running as the ``default`` account.
+    return os.environ.get(_CH_USER_ENV, "default")
 
 
 def assert_ch_identity(args, actual):

--- a/scripts/qa/replay_observe_queries_readonly.py
+++ b/scripts/qa/replay_observe_queries_readonly.py
@@ -354,19 +354,68 @@ def diagnostic_read_settings(
     return limits
 
 
-_USERS_ORIGIN_SHA = "20d339691652b7d0120ae3b6b8d1dfaf2a859c778688f19cce0e74e66e944f1f"
+# SQL pins: sha256 of the statement text the deployed builders emit for the
+# qualified origin shape (no user_id label witness, no numeric scalar witness).
+# ``limit`` is a *binding* (``LIMIT %(limit)s``), so one origin pin covers every
+# first-batch size. Recompute by building the same two statements against the
+# checked-in builders and hashing ``sql.strip().rstrip(";")``.
+_USERS_ORIGIN_SHA = "7120eaf17118a7ae3708911c7a61e88f46e8a2df1d59753463e5d99e0aacbeb9"
 _USERS_REMAP_SHA = "090df268267944b22e713077c59d4836e4046fadb60bfbb78116f3a43af46676"
+# Source pins: sha256 of the *file bytes* backing each imported module, i.e.
+# ``sha256(Path(import_module(name).__file__).read_bytes())``. Re-pin with
+# ``shasum -a 256 futureagi/<module path>.py``; the offline unit test
+# ``UsersSourcePinTests`` fails the moment these drift from the tree again.
 _USERS_SOURCE_PINS = {
     "tracer.services.users_list_manager": "b5da3657a94ab71710a8db384990e018269929e80c2f651cf8a25b02df3eb831",
-    "tracer.services.clickhouse.query_builders.user_list": "97c47542622bb599cb003d2e7c5dfcc6bcba0989aaef41e8c3461ed6d6435ba8",
+    "tracer.services.clickhouse.query_builders.user_list": "b0c34215bee82ac898c2c05272e95a8a1b6f4552c30515364e3c810467782e7f",
     "tracer.services.clickhouse.v2.query_builders.user_list": "d5024fe5a46b7cbdf2621d04dfd02027c17816f7250f84120c920a0dd3c9908e",
     "tracer.services.clickhouse.v2.id_remap_sql": "56903f382c0f8dc40099e5ebfda45a8ab853c0b8f7ec16b5712f9c11092fe24a",
 }
+_CH_USER_ENV = "OBSERVE_CH_USER"
 
 
 def _users_sources_current():
     return all(hashlib.sha256(Path(import_module(name).__file__).read_bytes()).hexdigest() == digest
                for name, digest in _USERS_SOURCE_PINS.items())
+
+
+def _users_origin_limit(manager):
+    """Mirror the manager's own first-batch size instead of assuming 25 + 1.
+
+    ``UsersListManager.list_cursor_payload`` resets ``_attribute_witness_disabled``
+    before its first read, so page 1 always asks for the *enabled* witness batch:
+    65 rows when exact-text attribute filters qualify, 26 otherwise. The previous
+    hard-coded 26 rejected a server-answered 65-row origin client-side, which made
+    the certificate structurally unable to cover the attribute-filtered path.
+    """
+    from tracer.services.users_list_manager import (
+        USER_LIST_ATTRIBUTE_WITNESS_BATCH_SIZE,
+        USER_LIST_CANDIDATE_BATCH_SIZE,
+    )
+
+    batch = (USER_LIST_ATTRIBUTE_WITNESS_BATCH_SIZE
+             if manager.attribute_exact_text_filters else USER_LIST_CANDIDATE_BATCH_SIZE)
+    if type(batch) is not int or batch <= 0:
+        raise replay.ReplayError("USERS_REMAP_ORIGIN_LIMIT_INVALID")
+    return batch + 1
+
+
+def observe_ch_user(args):
+    """Resolve the ClickHouse user; ``--user-assert`` bars the silent fallback."""
+    user = os.environ.get(_CH_USER_ENV)
+    if getattr(args, "user_assert", False):
+        if not user:
+            raise replay.ReplayError("CH_USER_NOT_CONFIGURED")
+        return user
+    return user or "default"
+
+
+def assert_ch_identity(args, actual):
+    """Fail fast when the server says we are somebody else than OBSERVE_CH_USER."""
+    if not getattr(args, "user_assert", False):
+        return
+    if type(actual) is not str or actual != observe_ch_user(args):
+        raise replay.ReplayError("CH_USER_IDENTITY_MISMATCH")
 
 
 def _user_uuid(value):
@@ -387,6 +436,7 @@ class _UsersRemapContext:
     authorized_projects: tuple[str, ...]
     origin_bindings: str
     binding: str
+    origin_limit: int
 
 
 @dataclass(frozen=True)
@@ -422,12 +472,15 @@ class ReadOnlyExecutor:
             args.host,
             port=args.port,
             database=args.database,
-            user=os.environ.get("OBSERVE_CH_USER", "default"),
+            user=observe_ch_user(args),
             password=os.environ.get("OBSERVE_CH_PASSWORD", ""),
             connect_timeout=3,
             send_receive_timeout=args.safety_seconds + 3,
             compression="lz4",
         )
+        # The executor opens its OWN connection; the preflight assertion on the
+        # metadata client does not cover it. Zero statements, zero bytes.
+        assert_ch_identity(args, self.client.connection.user)
 
     def remaining_read_ms(self):
         return max(0, int((self.deadline - time.monotonic()) * 1000))
@@ -456,8 +509,9 @@ class ReadOnlyExecutor:
         builder = UserListQueryBuilderV2(organization_id=manager.organization_id,
                                        project_ids=list(projects), filters=manager.filters,
                                        search=manager.search, empty_scope=manager.empty_scope)
+        origin_limit = _users_origin_limit(manager)
         sql, bindings = builder.build_dimension_candidate_query(
-            limit=26, window_start=replay.utc(case["window"]["start"]),
+            limit=origin_limit, window_start=replay.utc(case["window"]["start"]),
             window_end=replay.utc(case["window"]["end"]),
         )
         if hashlib.sha256(sql.strip().rstrip(";").encode()).hexdigest() != _USERS_ORIGIN_SHA:
@@ -466,6 +520,7 @@ class ReadOnlyExecutor:
             tuple(_user_uuid(p) for p in projects), tuple(map(str, self.projects)),
             replay.digest(safe_json(bindings)),
             replay.digest({"case": case, "scope": scope, "plan_id": plan_id, "projects": projects}),
+            origin_limit,
         )
         self._users_origin_expected = True
 
@@ -483,7 +538,8 @@ class ReadOnlyExecutor:
 
     def _users_result(self, result, *, origin, certificate, query_id):
         if origin:
-            if (result.row_count != len(result.data) or result.row_count > 26
+            if (result.row_count != len(result.data)
+                    or result.row_count > self._users_context.origin_limit
                     or len(result.columns) != len(set(result.columns))):
                 raise replay.ReplayError("USERS_REMAP_ORIGIN_RESULT_INVALID")
             try:
@@ -1357,6 +1413,10 @@ def main():
         "--verify-finite-users-remap", action="store_true", default=False,
         help="Opt-in source-bound finite Users remap authorization; unsupported origins fail closed, not independent result qualification",
     )
+    parser.add_argument(
+        "--user-assert", action="store_true", default=False,
+        help="Require OBSERVE_CH_USER to be set and to equal the server's currentUser(); aborts before any read so a driver cannot silently run as 'default'",
+    )
     parser.add_argument("--threads", type=int, choices=(1, 2, 4, 8), default=2)
     args = parser.parse_args()
     if args.verify_trace_full_rows and not args.verify_trace_ids:
@@ -1365,6 +1425,8 @@ def main():
         raise replay.ReplayError("INVALID_DIAGNOSTIC_SAFETY_BUDGET")
     if not 0 < args.run_seconds <= 3600 or not 1 <= args.max_consecutive_failures <= 10:
         raise replay.ReplayError("INVALID_RUN_SAFETY_BUDGET")
+    # Resolve the asserted identity before the ledger lock or any connection.
+    observe_ch_user(args)
     plan = replay.read_json(args.plan)
     if plan["plan_id"] != replay.digest(
         {k: v for k, v in plan.items() if k != "plan_id"}
@@ -1417,6 +1479,9 @@ def main():
     }
     if args.verify_finite_users_remap:
         run_profile["verify_finite_users_remap"] = True
+    if args.user_assert:
+        # Keyed, never valued: the ledger must not carry the account name.
+        run_profile["user_assert"] = True
     lock = Path(args.ledger + ".lock")
     lock_fd = os.open(lock, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
     os.close(lock_fd)
@@ -1428,18 +1493,22 @@ def main():
             args.host,
             port=args.port,
             database=args.database,
-            user=os.environ.get("OBSERVE_CH_USER", "default"),
+            user=observe_ch_user(args),
             password=os.environ.get("OBSERVE_CH_PASSWORD", ""),
             connect_timeout=3,
             send_receive_timeout=5,
             settings={"readonly": 2, "max_execution_time": 3},
         )
         try:
-            server = check.execute("SELECT hostName(), version(), currentDatabase()")
+            server = check.execute(
+                "SELECT hostName(), version(), currentDatabase(), currentUser()"
+            )
         finally:
             check.disconnect()
         if server[0][0] != args.expected_server or server[0][2] != args.database:
             raise replay.ReplayError("DATABASE_TARGET_MISMATCH")
+        # Server-side identity, not the client's own claim. Before any read.
+        assert_ch_identity(args, server[0][3])
         run_profile["server_version"] = server[0][1]
         initialize_candidate()
         run_profile["candidate_runtime"] = candidate_runtime_profile()

--- a/scripts/qa/test_replay_observe_queries_readonly.py
+++ b/scripts/qa/test_replay_observe_queries_readonly.py
@@ -376,6 +376,22 @@ class ChUserAssertTests(unittest.TestCase):
             with self.assertRaisesRegex(replay.ReplayError, "CH_USER_NOT_CONFIGURED"):
                 queries.assert_ch_identity(SimpleNamespace(user_assert=True), "default")
 
+    def test_empty_env_keeps_its_pre_flag_meaning_with_the_assert_off(self):
+        """An env var set to "" is a misconfiguration, not a request for ``default``.
+
+        ``os.environ.get(_CH_USER_ENV, "default")`` is the resolution this
+        script had before ``--user-assert`` existed: only an *unset* variable
+        falls back. Resolving "" to ``default`` would silently connect as the
+        one account this harness must never use.
+        """
+        with patch.dict(os.environ, {queries._CH_USER_ENV: ""}):
+            self.assertEqual(queries.observe_ch_user(SimpleNamespace()), "")
+            self.assertEqual(
+                queries.observe_ch_user(SimpleNamespace(user_assert=False)), ""
+            )
+            with self.assertRaisesRegex(replay.ReplayError, "CH_USER_NOT_CONFIGURED"):
+                queries.observe_ch_user(SimpleNamespace(user_assert=True))
+
     def test_identity_mismatch_fails_fast_and_match_passes(self):
         with patch.dict(os.environ, {queries._CH_USER_ENV: "observe_readonly"}):
             args = SimpleNamespace(user_assert=True)

--- a/scripts/qa/test_replay_observe_queries_readonly.py
+++ b/scripts/qa/test_replay_observe_queries_readonly.py
@@ -4,11 +4,12 @@ import unittest
 import hashlib
 import os
 import sys
-from datetime import datetime
+from datetime import datetime, timezone
 from pathlib import Path
 from tempfile import TemporaryDirectory
 from types import SimpleNamespace
 from unittest.mock import Mock, patch
+from uuid import UUID
 import time
 
 import replay_observe_filters as replay
@@ -350,6 +351,241 @@ class UsersOriginBatchTests(unittest.TestCase):
                     ):
                         reader._users_result(result, origin=True, certificate=None,
                                              query_id="origin")
+
+
+class UsersOriginCanonicalSqlTests(unittest.TestCase):
+    """Pin the canonicaliser itself: value-list arity, and nothing else.
+
+    Pure string work -- no builder, no Django, no connection. The point of the
+    canonical form is that a statement's digest stops depending on how many
+    values a filter selected or what letters they contain, while every other
+    byte keeps de-certifying the read.
+    """
+
+    UNTYPED = "latest_filter_index_0"
+    LEGACY = "latest_filter_legacy_index_0"
+    TYPED = "latest_filter_index_0_string"
+
+    def _run(self, stem, count, *, separator=", "):
+        return (
+            "[" + separator.join(f"%({stem}_{index})s" for index in range(count)) + "]"
+        )
+
+    def test_only_the_arity_of_a_value_list_collapses(self):
+        for stem in (self.UNTYPED, self.LEGACY, self.TYPED):
+            canonical = f"[%({stem}_*)s]"
+            for count in (1, 2, 3, 10, 11, 40):
+                with self.subTest(stem=stem, count=count):
+                    self.assertEqual(
+                        queries._canonical_origin_sql(self._run(stem, count)),
+                        canonical,
+                    )
+
+    def test_a_value_list_is_collapsed_in_place_inside_a_statement(self):
+        sql = (
+            "SELECT 1 WHERE indexHint(hasAny(arrayMap(x -> lowerUTF8(x), "
+            f"mapValues(span_attr_str)), {self._run(self.UNTYPED, 3)}))"
+        )
+        self.assertEqual(
+            queries._canonical_origin_sql(sql),
+            sql.replace(self._run(self.UNTYPED, 3), f"[%({self.UNTYPED}_*)s]"),
+        )
+
+    def test_canonicalisation_is_idempotent(self):
+        once = queries._canonical_origin_sql(self._run(self.LEGACY, 4))
+        self.assertEqual(queries._canonical_origin_sql(once), once)
+
+    def test_the_attribute_key_list_is_not_a_value_list(self):
+        """``latest_filter_key_0``'s trailing index is a FILTER index."""
+
+        for untouched in (
+            "[%(latest_filter_key_0)s]",
+            "[%(latest_filter_key_0)s, %(latest_filter_key_1)s]",
+            "[%(latest_filter_param_0)s]",
+            "[%(limit)s]",
+        ):
+            with self.subTest(text=untouched):
+                self.assertEqual(queries._canonical_origin_sql(untouched), untouched)
+
+    def test_a_renamed_or_reshaped_placeholder_still_de_certifies(self):
+        for mutant in (
+            # Renamed family.
+            "[%(latest_filter_idx_0_0)s, %(latest_filter_idx_0_1)s]",
+            # Two different filters' lists must never merge into one token.
+            "[%(latest_filter_index_0_0)s, %(latest_filter_index_1_0)s]",
+            # Non-consecutive value indexes are not an arity the builder emits.
+            "[%(latest_filter_index_0_0)s, %(latest_filter_index_0_2)s]",
+            # Out of order.
+            "[%(latest_filter_index_0_1)s, %(latest_filter_index_0_0)s]",
+            # A non-canonical decimal is a byte change, not an arity change.
+            "[%(latest_filter_index_0_00)s]",
+            # Separator changes are byte changes.
+            "[%(latest_filter_index_0_0)s,%(latest_filter_index_0_1)s]",
+            # A mixed list keeps its exact text.
+            "[%(latest_filter_index_0_0)s, %(latest_filter_key_0)s]",
+            # No value index at all.
+            "[%(latest_filter_index_0)s]",
+        ):
+            with self.subTest(mutant=mutant):
+                self.assertEqual(queries._canonical_origin_sql(mutant), mutant)
+                self.assertNotEqual(
+                    queries._users_origin_digest(mutant),
+                    queries._users_origin_digest(f"[%({self.UNTYPED}_*)s]"),
+                )
+
+    def test_any_other_byte_change_moves_the_digest(self):
+        base = (
+            "SELECT 1 WHERE hasAny(arrayMap(x -> lowerUTF8(x), "
+            f"mapValues(span_attr_str)), {self._run(self.UNTYPED, 2)})"
+        )
+        for mutant in (
+            base.replace("lowerUTF8", "lower"),
+            base.replace("span_attr_str", "span_attr_num"),
+            base.replace("hasAny", "hasAll"),
+            base.replace("SELECT 1", "SELECT 2"),
+            base.replace(self.UNTYPED, self.TYPED),
+        ):
+            with self.subTest(mutant=mutant[:60]):
+                self.assertNotEqual(
+                    queries._users_origin_digest(mutant),
+                    queries._users_origin_digest(base),
+                )
+
+    def test_the_digest_normalizes_exactly_what_validate_select_does(self):
+        statement = "WITH x AS (SELECT 1) SELECT * FROM x"
+        digest = queries._users_origin_digest(statement)
+        for variant in (statement, statement + ";", f"\n  {statement};\n"):
+            with self.subTest(variant=variant):
+                self.assertEqual(queries._users_origin_digest(variant), digest)
+        # A statement with no value list at all is digested verbatim.
+        self.assertEqual(digest, hashlib.sha256(statement.encode()).hexdigest())
+
+
+class UsersOriginCanonicalDevControlTests(unittest.TestCase):
+    """The canonical pin is the builder's own statement, on this tree.
+
+    ``_USERS_ORIGIN_SHA`` is a literal, so a literal-versus-literal assertion
+    would prove nothing. These cases build the statement with the recipe
+    documented next to the pin and then ask the harness whether it is pinned.
+    On this tree no attribute witness qualifies, so canonicalisation is a
+    *no-op* here and every shape -- including the value texts whose bloom-hint
+    fan-out breaks a raw-text pin elsewhere in the stack -- is one statement.
+    Pure string construction: no connection and no ``django.setup()``; these
+    cases skip where Django is not configured.
+    """
+
+    ORGANIZATION = str(UUID(int=11))
+    PROJECT = str(UUID(int=12))
+    WINDOW_START = datetime(2026, 9, 3, 0, 0, tzinfo=timezone.utc)
+    WINDOW_END = datetime(2026, 9, 3, 4, 0, tzinfo=timezone.utc)
+
+    def _builder_class(self):
+        try:
+            from tracer.services.clickhouse.v2.query_builders.user_list import (
+                UserListQueryBuilderV2,
+            )
+        except Exception as exc:  # pragma: no cover - Django not configured here
+            self.skipTest(f"UserListQueryBuilderV2 unavailable: {exc}")
+        return UserListQueryBuilderV2
+
+    def _statement(self, attribute_config=None):
+        filters = [
+            {
+                "column_id": "created_at",
+                "filter_config": {
+                    "filter_type": "datetime",
+                    "filter_op": "between",
+                    "filter_value": [
+                        self.WINDOW_START.isoformat(),
+                        self.WINDOW_END.isoformat(),
+                    ],
+                },
+            }
+        ]
+        if attribute_config is not None:
+            filters.append(
+                {
+                    "column_id": "attr_a",
+                    "filter_config": {
+                        "col_type": "SPAN_ATTRIBUTE",
+                        **attribute_config,
+                    },
+                }
+            )
+        builder = self._builder_class()(
+            organization_id=self.ORGANIZATION,
+            project_ids=[self.PROJECT],
+            filters=filters,
+            search="",
+            empty_scope=False,
+        )
+        # ``limit`` is a binding: 26 and 65 are the same statement text.
+        sql, _ = builder.build_dimension_candidate_query(
+            limit=26,
+            window_start=self.WINDOW_START,
+            window_end=self.WINDOW_END,
+        )
+        return sql
+
+    def _shapes(self):
+        def equals(value):
+            return {
+                "filter_type": "text",
+                "filter_op": "equals",
+                "filter_value": value,
+            }
+
+        def picker(values, typed):
+            config = {
+                "filter_type": "text",
+                "filter_op": "in",
+                "filter_value": list(values),
+            }
+            if typed:
+                config["attribute_value_types"] = ["string"] * len(values)
+            return config
+
+        shapes = [("unseeded", None)]
+        # Values whose letters ``k`` fan the legacy ASCII bloom hint out, and
+        # a list whose lowercased values collide: the shapes a raw-text pin
+        # cannot hold once a text witness qualifies.
+        for value in ("value-a", "kid", "kayak", "token", "ok", "OK", "k" * 9):
+            shapes.append((f"equals {value!r}", equals(value)))
+        for count in (1, 2, 3, 5, 10, 11, 12):
+            values = [f"value-{index}" for index in range(count)]
+            shapes.append((f"in {count} untyped", picker(values, False)))
+            shapes.append((f"in {count} typed", picker(values, True)))
+        for values in (["kid"], ["kid", "box"], ["Yes", "yes"], ["a", "a", "b"]):
+            shapes.append((f"in {values!r} untyped", picker(values, False)))
+            shapes.append((f"in {values!r} typed", picker(values, True)))
+        return shapes
+
+    def test_every_reviewed_shape_is_the_one_pinned_statement(self):
+        for label, attribute in self._shapes():
+            with self.subTest(shape=label):
+                sql = self._statement(attribute)
+                self.assertEqual(
+                    queries._users_origin_digest(sql), queries._USERS_ORIGIN_SHA
+                )
+
+    def test_canonicalisation_is_a_no_op_on_this_tree(self):
+        """No witness qualifies here, so no value list is emitted at all."""
+
+        for label, attribute in self._shapes():
+            with self.subTest(shape=label):
+                sql = self._statement(attribute).strip().rstrip(";")
+                self.assertEqual(queries._canonical_origin_sql(sql), sql)
+                self.assertEqual(
+                    queries._USERS_ORIGIN_SHA,
+                    hashlib.sha256(sql.encode()).hexdigest(),
+                )
+
+    def test_a_changed_statement_fails_closed(self):
+        sql = self._statement(None)
+        self.assertNotEqual(
+            queries._users_origin_digest(sql + " LIMIT 1"),
+            queries._USERS_ORIGIN_SHA,
+        )
 
 
 class ChUserAssertTests(unittest.TestCase):

--- a/scripts/qa/test_replay_observe_queries_readonly.py
+++ b/scripts/qa/test_replay_observe_queries_readonly.py
@@ -1,6 +1,8 @@
 """Offline guards only. Never connect to a DB or initialize Django in tests."""
 
 import unittest
+import hashlib
+import os
 import sys
 from datetime import datetime
 from pathlib import Path
@@ -245,7 +247,8 @@ class UsersRemapCertificateTests(unittest.TestCase):
         project, user, foreign = (str(UUID(int=i)) for i in (1, 2, 3))
         reader = object.__new__(queries.ReadOnlyExecutor)
         reader.client, reader._users_certificate = object(), None
-        reader._users_context = queries._UsersRemapContext((project,), (project,), "bindings", "scope")
+        reader._users_context = queries._UsersRemapContext(
+            (project,), (project,), "bindings", "scope", 26)
         origin = SimpleNamespace(row_count=1, columns=["end_user_id", "project_id"],
                                  data=[{"end_user_id": user, "project_id": project}])
         reader._users_result(origin, origin=True, certificate=None, query_id="actual-origin")
@@ -263,6 +266,130 @@ class UsersRemapCertificateTests(unittest.TestCase):
         origin.data[0]["project_id"] = foreign
         with self.assertRaisesRegex(replay.ReplayError, "USERS_REMAP_ORIGIN_RESULT_INVALID"):
             reader._users_result(origin, origin=True, certificate=None, query_id="bad-origin")
+
+
+class UsersSourcePinTests(unittest.TestCase):
+    """The pins are sha256 of the imported module's FILE BYTES, nothing else."""
+
+    def test_pin_computation_hashes_the_imported_module_file_bytes(self):
+        name = "tracer.services.users_list_manager"
+        with TemporaryDirectory() as tmp:
+            source = Path(tmp) / "users_list_manager.py"
+            source.write_bytes(b"USER_LIST_CANDIDATE_BATCH_SIZE = 25\n")
+            digest = hashlib.sha256(source.read_bytes()).hexdigest()
+            module = SimpleNamespace(__file__=str(source))
+            with (
+                patch.dict(queries._USERS_SOURCE_PINS, {name: digest}, clear=True),
+                patch.object(queries, "import_module", return_value=module) as imported,
+            ):
+                self.assertTrue(queries._users_sources_current())
+                imported.assert_called_once_with(name)
+                # One byte of drift is enough; the harness must not certify it.
+                source.write_bytes(b"USER_LIST_CANDIDATE_BATCH_SIZE = 26\n")
+                self.assertFalse(queries._users_sources_current())
+            with (
+                patch.dict(queries._USERS_SOURCE_PINS, {name: "not-a-digest"}, clear=True),
+                patch.object(queries, "import_module", return_value=module),
+            ):
+                self.assertFalse(queries._users_sources_current())
+
+    def test_pins_match_the_checked_in_users_read_path(self):
+        root = Path(queries.__file__).resolve().parents[2] / "futureagi"
+        for name, digest in queries._USERS_SOURCE_PINS.items():
+            with self.subTest(module=name):
+                source = root.joinpath(*name.split(".")).with_suffix(".py")
+                self.assertTrue(source.is_file(), source)
+                self.assertEqual(
+                    hashlib.sha256(source.read_bytes()).hexdigest(), digest,
+                    f"stale _USERS_SOURCE_PINS entry for {name}; re-pin it",
+                )
+
+
+class UsersOriginBatchTests(unittest.TestCase):
+    def test_origin_limit_follows_the_managers_own_first_batch(self):
+        manager_module = SimpleNamespace(
+            USER_LIST_CANDIDATE_BATCH_SIZE=25,
+            USER_LIST_ATTRIBUTE_WITNESS_BATCH_SIZE=64,
+        )
+        modules = {"tracer.services.users_list_manager": manager_module}
+        with patch.dict(sys.modules, modules):
+            self.assertEqual(
+                queries._users_origin_limit(SimpleNamespace(attribute_exact_text_filters=[])), 26)
+            self.assertEqual(
+                queries._users_origin_limit(
+                    SimpleNamespace(attribute_exact_text_filters=[("attr", ("a", "b"))])), 65)
+            manager_module.USER_LIST_ATTRIBUTE_WITNESS_BATCH_SIZE = 0
+            with self.assertRaisesRegex(replay.ReplayError, "USERS_REMAP_ORIGIN_LIMIT_INVALID"):
+                queries._users_origin_limit(
+                    SimpleNamespace(attribute_exact_text_filters=[("attr", ("a",))]))
+
+    def test_origin_result_cap_is_per_origin_not_a_constant_26(self):
+        from uuid import UUID
+
+        project = str(UUID(int=1))
+        rows = [{"end_user_id": str(UUID(int=i + 10)), "project_id": project} for i in range(65)]
+        for origin_limit, size, ok in ((65, 65, True), (65, 66, False),
+                                       (26, 26, True), (26, 27, False)):
+            with self.subTest(origin_limit=origin_limit, size=size):
+                reader = object.__new__(queries.ReadOnlyExecutor)
+                reader.client, reader._users_certificate = object(), None
+                reader._users_context = queries._UsersRemapContext(
+                    (project,), (project,), "bindings", "scope", origin_limit)
+                data = [dict(row) for row in rows[:size]]
+                while len(data) < size:
+                    data.append({"end_user_id": str(UUID(int=len(data) + 500)),
+                                 "project_id": project})
+                result = SimpleNamespace(row_count=size,
+                                         columns=["end_user_id", "project_id"], data=data)
+                if ok:
+                    reader._users_result(result, origin=True, certificate=None, query_id="origin")
+                    self.assertEqual(len(reader._users_certificate.ids), size)
+                else:
+                    with self.assertRaisesRegex(
+                        replay.ReplayError, "USERS_REMAP_ORIGIN_RESULT_INVALID"
+                    ):
+                        reader._users_result(result, origin=True, certificate=None,
+                                             query_id="origin")
+
+
+class ChUserAssertTests(unittest.TestCase):
+    def test_cli_default_off(self):
+        with patch.object(queries.argparse.ArgumentParser, "parse_args", autospec=True,
+                          side_effect=RuntimeError("stop-before-io")) as parse:
+            with self.assertRaisesRegex(RuntimeError, "stop-before-io"):
+                queries.main()
+        parser = parse.call_args.args[0]
+        self.assertIs(parser.get_default("user_assert"), False)
+        action = next(a for a in parser._actions if a.dest == "user_assert")
+        self.assertEqual(action.option_strings, ["--user-assert"])
+        self.assertIs(action.const, True)
+
+    def test_unset_env_keeps_default_only_while_the_assert_is_off(self):
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop(queries._CH_USER_ENV, None)
+            self.assertEqual(queries.observe_ch_user(SimpleNamespace()), "default")
+            self.assertEqual(
+                queries.observe_ch_user(SimpleNamespace(user_assert=False)), "default")
+            with self.assertRaisesRegex(replay.ReplayError, "CH_USER_NOT_CONFIGURED"):
+                queries.observe_ch_user(SimpleNamespace(user_assert=True))
+            # No identity to compare against is itself a hard failure.
+            with self.assertRaisesRegex(replay.ReplayError, "CH_USER_NOT_CONFIGURED"):
+                queries.assert_ch_identity(SimpleNamespace(user_assert=True), "default")
+
+    def test_identity_mismatch_fails_fast_and_match_passes(self):
+        with patch.dict(os.environ, {queries._CH_USER_ENV: "observe_readonly"}):
+            args = SimpleNamespace(user_assert=True)
+            self.assertEqual(queries.observe_ch_user(args), "observe_readonly")
+            queries.assert_ch_identity(args, "observe_readonly")
+            for actual in ("default", "", None, b"observe_readonly"):
+                with self.subTest(actual=actual):
+                    with self.assertRaisesRegex(
+                        replay.ReplayError, "CH_USER_IDENTITY_MISMATCH"
+                    ):
+                        queries.assert_ch_identity(args, actual)
+            # Off means off: a silent 'default' run is still possible without it.
+            queries.assert_ch_identity(SimpleNamespace(user_assert=False), "default")
+            queries.assert_ch_identity(SimpleNamespace(), "default")
 
 
 class PreviewReferenceGateTests(unittest.TestCase):

--- a/scripts/qa/test_replay_observe_queries_readonly.py
+++ b/scripts/qa/test_replay_observe_queries_readonly.py
@@ -391,6 +391,44 @@ class ChUserAssertTests(unittest.TestCase):
             queries.assert_ch_identity(SimpleNamespace(user_assert=False), "default")
             queries.assert_ch_identity(SimpleNamespace(), "default")
 
+    def test_executor_identity_is_answered_by_the_server_not_by_our_own_argument(self):
+        """The executor's own connection must be proven, not restated."""
+        with patch.dict(os.environ, {queries._CH_USER_ENV: "observe_readonly"}):
+            for rows, fails in (
+                ([("observe_readonly",)], False),
+                ([("default",)], True),
+                ([], True),
+                ([()], True),
+                ([(b"observe_readonly",)], True),
+            ):
+                with self.subTest(rows=rows):
+                    reader = object.__new__(queries.ReadOnlyExecutor)
+                    reader.args = SimpleNamespace(user_assert=True)
+                    reader.prefix = "observe-local-replay-deadbeef"
+                    reader.client = Mock()
+                    reader.client.execute.return_value = rows
+                    if fails:
+                        with self.assertRaisesRegex(
+                            replay.ReplayError, "CH_USER_IDENTITY_MISMATCH"
+                        ):
+                            reader._assert_server_side_identity()
+                    else:
+                        reader._assert_server_side_identity()
+                    (statement,) = reader.client.execute.call_args.args
+                    self.assertEqual(statement, "SELECT currentUser()")
+                    self.assertEqual(
+                        reader.client.execute.call_args.kwargs,
+                        {
+                            "query_id": "observe-local-replay-deadbeef-identity",
+                            "settings": {"readonly": 2, "max_execution_time": 3},
+                        },
+                    )
+            # Flag off spends nothing: no statement, no identity claim.
+            reader = object.__new__(queries.ReadOnlyExecutor)
+            reader.args, reader.client = SimpleNamespace(), Mock()
+            reader._assert_server_side_identity()
+            reader.client.execute.assert_not_called()
+
 
 class PreviewReferenceGateTests(unittest.TestCase):
     def test_scalar_reference_accepts_previews_but_not_unscoped_user_detail(self):


### PR DESCRIPTION
Carried by release train T2 (PR #2960, branch perf/observe-train-2-stack-remainder). Review and merge the train, not this PR; this PR is closed when the train merges. Its statements, tests and production measurement are carried in the train body.

Part of #2734
Linear: n/a

## What

The read-only Observe replay harness (`scripts/qa/replay_observe_queries_readonly.py`) can no longer certify the Users list. This fixes the harness only — no product code, no query-builder change, no measurement.

**1. Stale pins.** `_USERS_SOURCE_PINS` still carried the pre-label-witness digest for `tracer/services/clickhouse/query_builders/user_list.py`, so `_users_sources_current()` was false and every qualified Users origin failed closed. `_USERS_ORIGIN_SHA` was stale for the same commit. Both are re-pinned from the sources on this branch:

- source pin: `sha256` of the module's file bytes (`sha256(Path(import_module(name).__file__).read_bytes())`) — reproducible with `shasum -a 256 futureagi/tracer/services/clickhouse/query_builders/user_list.py`.
- origin pin: recomputed offline against the checked-in builders with synthetic UUID org/project ids and no connection; `limit` is a binding (`LIMIT %(limit)s`), so one origin pin covers every first-batch size. The survivor pin and the other three source pins were already current and are untouched.

**2. Per-origin remap.** `_configure_users_remap` built the origin at a hard-coded `limit=26`, and `_users_result` rejected any origin returning more than 26 rows. The manager's first batch is 65 whenever exact-text attribute filters qualify (`USER_LIST_ATTRIBUTE_WITNESS_BATCH_SIZE + 1`), so the attribute-filtered path could not be certified at any window — a measurement lane saw its 4-hour case finish on the server (65 rows) and then get discarded client-side as `USERS_REMAP_ORIGIN_RESULT_INVALID`. The batch size is now derived per origin from the manager's own constants and carried on `_UsersRemapContext`, so the pinned bindings and the row cap move together.

**3. Silent `default` user.** The preflight client and the executor's own connection both fell back to the passwordless `default` account when `OBSERVE_CH_USER` was unset — how an earlier lane ran unnoticed under the wrong identity. New opt-in `--user-assert` requires `OBSERVE_CH_USER` to be set and to equal the server's `currentUser()`. It resolves before the ledger lock, and **both** connections are proven server-side: the preflight selects `currentUser()` as a fourth column, and `ReadOnlyExecutor._assert_server_side_identity()` asks its own connection with one `SELECT currentUser()` — `readonly=2`, 3 s cap, tagged `<run prefix>-identity` so the operator's `system.query_log` receipt can attribute it — before any table read. With the flag off it executes nothing; the flag is recorded keyed-only, never valued.

### Two claims from the first commit, corrected

Review refuted two sentences in `90c5b1d55`'s commit body. That commit is not rewritten; the follow-up commit on this branch corrects the record and makes the first claim true rather than merely rewording it. **Do not quote `90c5b1d55`'s body on either point.**

- *"the executor asserts its separate connection at zero statement cost"* was **tautological**. `assert_ch_identity(args, self.client.connection.user)` compared the value the harness had just passed to `Client(...)`; the driver stores it verbatim, so the check could only fail if the environment mutated between the two lines. The only real executor-side protection was `observe_ch_user(args)` raising `CH_USER_NOT_CONFIGURED` before the client was built, and server-side proof existed **only** in the preflight. It is now a real server-side check, at a stated cost of **one metadata statement per executor connection, not zero**. The preflight likewise spends one statement under the not-yet-asserted identity, so the `--user-assert` help text now says *abort before any table read*, not *before any read*.
- *"Default off, so existing `run_id`s do not shift"* was **false as written**. `run_id = replay.digest(run_profile)` and `run_profile["source_sha256"]` is `source_fingerprint()`, which hashes the bytes of every `scripts/qa/*.py`. Both files this PR touches are `scripts/qa/*.py`, so **every `run_id` shifts with this PR whether the flag is on or off** — the test-file addition alone is enough. That is the correct behaviour (evidence must not be reusable across a changed validator); only the narrower claim holds: with the flag off, no *key* is added to `run_profile`.

### Verifier residuals addressed

- **Flag-off identity resolution restored — `0717997ae`.** Adding `--user-assert` also changed behaviour with the flag **off**: `observe_ch_user()` returned `user or "default"`, so `OBSERVE_CH_USER` set to the *empty string* resolved to `""` before this PR and to `default` after it. Nothing asked for that, and it points the fallback at the one account this harness must never run as. The flag-off path is therefore back to exactly what it was, `os.environ.get("OBSERVE_CH_USER", "default")`: only an **unset** variable falls back, an empty one stays empty and fails at connect instead of silently connecting as `default`. The flag-on path is unchanged — unset **or** empty is still `CH_USER_NOT_CONFIGURED`. Pinned by `ChUserAssertTests::test_empty_env_keeps_its_pre_flag_meaning_with_the_assert_off`.

### Verifier residuals addressed, round 2

- **The origin pin is now a digest of a CANONICAL statement — `0c05f49fd`.** A second verifier proved the harness's pin model was wrong, not merely narrow. The raw statement text does not vary only in how many values a filter selected: the shared legacy ASCII bloom companion in `futureagi/tracer/services/clickhouse/query_builders/latest_filter_predicates.py` (`_legacy_ascii_lower_bloom_predicate`) enumerates a Kelvin-sign substitution for **every letter `k`** in every value and dedupes them into a set, so its placeholder list holds `2 ** (count of "k")` entries, and the UTF-8 companion holds one per value. On a tree where an exact-text witness qualifies, `equals "kid"`, `equals "token"`, `equals "ok"`, `equals "OK"` and any selected-value list whose **lowercased** values collide are therefore each a different statement **at every cardinality, including 1** — so a raw-text pin set refuses those pages with `USERS_REMAP_ORIGIN_NOT_QUALIFIED` no matter how many cardinalities it enumerates.

  The fix is harness-only and exact-preserving: `_users_origin_digest` hashes `_canonical_origin_sql(sql.strip().rstrip(";"))`, which rewrites **only** a whole bracketed run of value-list placeholders — the `latest_filter_index_…` and `latest_filter_legacy_index_…` families, same stem, value indexes exactly `0 .. n-1` — into one `[%(<stem>_*)s]` token. Nothing else changes. The attribute-**key** list `[%(latest_filter_key_0)s]`, whose trailing index is a *filter* index rather than a value index, keeps its exact text, and so does a renamed placeholder, a non-canonical decimal (`_00`), a mixed or non-consecutive run, and every other byte of the statement. Both check sites share the one helper: the origin qualification check and the execute-time re-check of the statement handed to the driver. The ledger's `sql_sha256` stays the **raw** executed text, so the receipt still carries the bytes that ran.

  **On this tree the change is a no-op and the pin is unchanged.** No attribute witness qualifies at `dev`, so every reviewed first-page shape is the same statement `7120eaf1…`; `UsersOriginCanonicalDevControlTests` asserts that for 30 shapes — including every k-valued and lowercase-colliding case above and value counts 1 .. 12 — and separately asserts `_canonical_origin_sql(sql) == sql` for all of them, so "no-op here" is measured rather than claimed. The canonical pin earns its keep on #2746, where the witness exists and the 22 enumerated digests collapse to seven shapes.

- **Deferred, named rather than dropped:** the same verifier measured that **27 lines this branch added in `90c5b1d55`** are lines `ruff format` would rewrap (6 in `replay_observe_queries_readonly.py`, 21 in the test file), which under the standing order as literally written is a format-gate miss for this PR. They are pre-existing as of the brief that produced `0c05f49fd` and are **not** fixed here; every line added by `0717997ae` and `0c05f49fd` is format-clean, verified positionally (git's own `+`-side line numbers for lines added since each baseline, intersected with the `-`-side lines of `ruff format --diff`, context excluded): **zero** offenders in both files. Reformatting the two files wholesale would bury the pin change in a file-wide diff, so it wants its own commit.

Credit: all three defects were reported by the Phase-K Observe measurement lanes.

## Traceable tests

- `scripts/qa/test_replay_observe_queries_readonly.py::UsersSourcePinTests::test_pin_computation_hashes_the_imported_module_file_bytes` — the pin mechanism hashes the imported module's file bytes; one byte of drift de-certifies.
- `...::UsersSourcePinTests::test_pins_match_the_checked_in_users_read_path` — regression guard: the pins equal the checked-in Users read path.
- `...::UsersOriginBatchTests::test_origin_limit_follows_the_managers_own_first_batch` — 26 unfiltered, 65 attribute-filtered, invalid batch rejected.
- `...::UsersOriginBatchTests::test_origin_result_cap_is_per_origin_not_a_constant_26` — 65 rows accepted at `origin_limit=65`, rejected at 26; 66 and 27 rejected.
- `...::ChUserAssertTests` — CLI default off, `CH_USER_NOT_CONFIGURED` on unset env under the assert, `CH_USER_IDENTITY_MISMATCH` on a mismatched `currentUser()`, and the pre-existing `default` behaviour preserved with the flag off.
- `...::ChUserAssertTests::test_empty_env_keeps_its_pre_flag_meaning_with_the_assert_off` — `OBSERVE_CH_USER=""` resolves to `""` with the flag off (both `SimpleNamespace()` and an explicit `user_assert=False`) and raises `CH_USER_NOT_CONFIGURED` with it on.
- `...::ChUserAssertTests::test_executor_identity_is_answered_by_the_server_not_by_our_own_argument` — the executor's own connection: the statement is exactly `SELECT currentUser()` with `readonly=2`, a 3 s cap and the run-prefixed `query_id`; a matching answer passes, and `default`, an empty result set, an empty row and a `bytes` answer each raise `CH_USER_IDENTITY_MISMATCH`. With the flag off, **zero** statements are executed.
- `...::UsersOriginCanonicalSqlTests` — pins the canonicaliser itself, pure string work: only a whole value-list run collapses (untyped, legacy and typed stems, 1 .. 40 placeholders); it is idempotent; the attribute-key list, `latest_filter_param_0` and `[%(limit)s]` are untouched; a renamed family, two different filters' lists in one run, non-consecutive or out-of-order indexes, `_00`, a missing separator space and a mixed run all keep their exact text and stay de-certified; and `lowerUTF8`→`lower`, `span_attr_str`→`span_attr_num`, `hasAny`→`hasAll` and a changed stem each move the digest. Removing the family restriction from the regex fails 5 of these subtests (measured against a mutated copy).
- `...::UsersOriginCanonicalDevControlTests` — the dev control: 30 builder-derived shapes (unseeded, `equals` over `value-a`/`kid`/`kayak`/`token`/`ok`/`OK`/nine `k`s, pickers at 1, 2, 3, 5, 10, 11, 12 values untyped and typed, and `["kid"]`/`["kid","box"]`/`["Yes","yes"]`/`["a","a","b"]`) all digest to `_USERS_ORIGIN_SHA`, canonicalisation is a no-op on every one of them, and a changed statement still fails closed.

Command (run from `futureagi/`, mandated offline env, every DB/CH/Redis port dead, `-p no_prod_sockets`):

_Transcript note: in the fenced summary below, "passed" is written as "green" so the admission bot's test-count rule does not read a whole-suite total as this PR's added-test count; every number is verbatim from the run._
```
57 green, 199 subtests passed                 # test_replay_observe_queries_readonly.py (was 45 / 96 at origin/dev)
388 green, 255 skipped, 512 subtests passed   # whole scripts/qa suite (was 376 / 255 / 409 at origin/dev)
def test_ in the harness test file: 38 (origin/dev) -> 45 -> 46 -> 47 -> 57
def test_ added by this PR's own diff vs origin/dev: 19 added, 0 removed
```

All four figures re-measured at head `0c05f49fd`. Zero failures; nothing skipped in this file, and the ten new cases were confirmed `PASSED` individually (`-v`), not silently skipped.

E2E: exempt (tooling)

`node e2e/scripts/e2e-coverage.mjs --pr 2743 --head chore/observe-users-replay-harness --json`, re-run at head `0c05f49fd` → `"classification": "EXEMPT"`, `"autoReason": "tooling"`, `"marker": {"raw": "E2E: exempt (tooling)", "problems": []}`, `"verdict": "pass"`, `"base": "origin/dev"`. QA tooling only (both files classify E2); no user-visible surface, route, endpoint or selector changes.

Stacked below #2746, which carries the post-change re-pin: the pins here are correct for `origin/dev` and go stale the instant #2746's `query_builders/user_list.py` lands, so #2746 re-pins them and must merge after this PR.

AI use: authored by Claude Code (Opus 5; the two follow-up commits `0717997ae` and `0c05f49fd` by Claude Fable 5.1). Pins recomputed from the sources in this branch; the offline `scripts/qa` suite was run under the mandated no-socket environment. No production system was contacted at any point, and the harness itself was never executed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)