### PR TITLE
fix(observe): replay immutable hours for unseeded Users reads [agent]

### DIFF
--- a/futureagi/tracer/services/clickhouse/query_builders/user_list.py
+++ b/futureagi/tracer/services/clickhouse/query_builders/user_list.py
@@ -426,7 +426,7 @@ class UserListQueryBuilder(BaseQueryBuilder):
         return " AND ".join(clauses), params
 
     def _positive_scalar_user_witness(self) -> tuple[str, dict[str, Any]]:
-        """Reuse the compiler's complete numeric witness; decline all other shapes."""
+        """Reuse complete numeric or ordinary text witnesses for group acquisition."""
         from tracer.services.clickhouse.query_builders.latest_filter_predicates import (
             compile_trace_filter_plans,
         )
@@ -439,6 +439,10 @@ class UserListQueryBuilder(BaseQueryBuilder):
                 self._is_date_filter(item)
                 or self._is_relation_filter(item)
                 or self._is_output_filter(item)
+                or (
+                    item.get("column_id") == "eval_score"
+                    and self._filter_col_type(item) != "SPAN_ATTRIBUTE"
+                )
             ):
                 continue
             config = dict(item.get("filter_config") or item.get("filterConfig") or {})
@@ -452,11 +456,38 @@ class UserListQueryBuilder(BaseQueryBuilder):
                 continue
             plan = plans[0]
             witness = plan.raw_graph_value_witness_predicate or ""
+            raw_values = config.get("filter_value", config.get("filterValue"))
+            values = raw_values if isinstance(raw_values, list) else [raw_values]
+            # Users canonicalizes boolean/JSON-looking text and uses Python's
+            # Unicode lower(). Do not narrow those domains with a raw string
+            # comparison. Unsupported shapes keep the complete existing path.
+            plain_text = (
+                (config.get("filter_type") or config.get("filterType"))
+                in {"text", "string"}
+                and (config.get("filter_op") or config.get("filterOp"))
+                in {"equals", "in"}
+                and bool(values)
+                and all(
+                    isinstance(value, str)
+                    and value
+                    and value.isascii()
+                    and value.strip().lower() not in {"true", "false"}
+                    and not value.strip().startswith(("{", "["))
+                    for value in values
+                )
+            )
+            numeric_witness = (
+                "span_attr_num[" in witness and "span_attr_str" not in witness
+            )
+            text_witness = (
+                plain_text
+                and "span_attr_str[" in witness
+                and "span_attr_num" not in witness
+            )
             if (
                 plan.scope == "any"
                 and not plan.exclude_group_matches
-                and "span_attr_num[" in witness
-                and "span_attr_str" not in witness
+                and (numeric_witness or text_witness)
                 and "span_attr_bool" not in witness
                 and "JSONExtract" not in witness
             ):
@@ -731,7 +762,20 @@ class UserListQueryBuilder(BaseQueryBuilder):
             """
         else:
             embedded_session_projection = "toUInt64(0) AS num_sessions,"
-        usage_ctes = f"""
+        # With scalar acquisition, the final INNER JOIN already applies this
+        # dimension membership. Repeating it here expands the witness/dimension
+        # CTE branch again. Keep it for unseeded reads to bound aggregation.
+        usage_user_filter = (
+            ""
+            if scalar_ctes
+            else f"""
+          AND {resolved_latest_eu} IN (
+              SELECT end_user_id FROM filtered_end_users
+          )
+        """
+        )
+        identity_acquisition_cte = (
+            f"""
     candidate_span_identities AS (
         SELECT DISTINCT
             project_id,
@@ -747,6 +791,46 @@ class UserListQueryBuilder(BaseQueryBuilder):
           AND start_time < fromUnixTimestamp64Micro(%(user_window_end_us)s, 'UTC')
           {candidate_span_filter}
     ),
+        """
+            if candidate_span_filter
+            else ""
+        )
+        # Without a user/scalar seed, every latest row in the exact window
+        # witnesses its own identity. Replay the intersecting immutable hours
+        # directly instead of constructing the same identity population twice.
+        # Seeded reads must retain the identity set: end_user_id is mutable.
+        replay_identity_filter = (
+            """
+          AND (
+              project_id,
+              observation_type,
+              service_name,
+              toStartOfHour(start_time),
+              trace_id,
+              id
+          ) IN (
+              SELECT
+                  project_id,
+                  observation_type,
+                  service_name,
+                  identity_hour,
+                  trace_id,
+                  id
+              FROM candidate_span_identities
+          )
+        """
+            if candidate_span_filter
+            else """
+          AND toStartOfHour(start_time) >= toStartOfHour(
+              fromUnixTimestamp64Micro(%(user_window_start_us)s, 'UTC')
+          )
+          AND toStartOfHour(start_time) < fromUnixTimestamp64Micro(
+              %(user_window_end_us)s, 'UTC'
+          )
+        """
+        )
+        usage_ctes = f"""
+    {identity_acquisition_cte}
     latest_candidate_spans AS (
         SELECT
             project_id,
@@ -767,23 +851,7 @@ class UserListQueryBuilder(BaseQueryBuilder):
         FROM spans
         PREWHERE {self._project_predicate("spans")}
           AND toDate(start_time) BETWEEN toDate(%(start_date)s) AND toDate(%(end_date)s)
-          AND (
-              project_id,
-              observation_type,
-              service_name,
-              toStartOfHour(start_time),
-              trace_id,
-              id
-          ) IN (
-              SELECT
-                  project_id,
-                  observation_type,
-                  service_name,
-                  identity_hour,
-                  trace_id,
-                  id
-              FROM candidate_span_identities
-          )
+          {replay_identity_filter}
         GROUP BY
             project_id,
             observation_type,
@@ -808,9 +876,7 @@ class UserListQueryBuilder(BaseQueryBuilder):
         WHERE latest_is_deleted = 0
           AND latest_start_time >= fromUnixTimestamp64Micro(%(user_window_start_us)s, 'UTC')
           AND latest_start_time < fromUnixTimestamp64Micro(%(user_window_end_us)s, 'UTC')
-          AND {resolved_latest_eu} IN (
-              SELECT end_user_id FROM filtered_end_users
-          )
+          {usage_user_filter}
         GROUP BY end_user_id
     )
         """
@@ -1233,92 +1299,32 @@ class UserListQueryBuilder(BaseQueryBuilder):
 
         if not end_user_ids:
             return "", {}
-        start_date, end_date = self.parse_time_range(self.filters)
-        params: dict[str, Any] = {
-            "candidate_end_user_ids": tuple(str(value) for value in end_user_ids),
-            "start_date": start_date,
-            "end_date": end_date,
-        }
-        if self.project_ids:
-            params["project_ids"] = tuple(self.project_ids)
-        else:
-            params["project_id"] = self.project_id
-
-        # Page hydration runs only after a finite user page is selected. Building
-        # the global remap window here made this read exceed the 256 MiB
-        # production ceiling on large remap tables. Expand only the consolidation
-        # groups touched by the page ids.
-        eu_map, finite_map_params = self._finite_end_user_map(
-            candidate_param="candidate_end_user_ids"
+        prefix, params = self._finite_user_activity_ctes(
+            end_user_ids,
+            [
+                "argMax(tuple(trace_session_id), _version).1 AS latest_trace_session_id",
+                "argMax(status, _version) AS latest_status",
+                "argMax(tuple(end_time), _version).1 AS latest_end_time",
+                "argMax(latency_ms, _version) AS latest_latency_ms",
+            ],
+            include_sessions=True,
         )
-        params.update(finite_map_params)
-        ts_map = survivor_map_subquery("trace_session_id_remap")
         resolved_latest_eu = resolved_id_expr("latest_end_user_id", "span_eu_remap")
         resolved_latest_session = resolved_id_expr(
             "latest_trace_session_id", "span_ts_remap"
         )
 
         query = f"""
-        WITH
-        eu_survivor_map AS ({eu_map}),
-        ts_survivor_map AS ({ts_map}),
-        expanded_candidate_user_ids AS (
-            SELECT any_id AS end_user_id
-            FROM eu_survivor_map
-            WHERE survivor_id IN %(candidate_end_user_ids)s
-            UNION DISTINCT
-            SELECT end_user_id
-            FROM end_users FINAL
-            WHERE end_user_id IN %(candidate_end_user_ids)s
-        ),
-        candidate_span_identities AS (
-            SELECT DISTINCT
-                project_id,
-                trace_id,
-                id,
-                start_time
-            FROM spans
-            PREWHERE {self._project_predicate("spans")}
-              AND toDate(start_time) BETWEEN toDate(%(start_date)s) AND toDate(%(end_date)s)
-              AND start_time >= %(start_date)s
-              AND start_time < %(end_date)s
-              AND end_user_id IN (
-                  SELECT end_user_id FROM expanded_candidate_user_ids
-              )
-        ),
-        latest_candidate_spans AS (
-            SELECT
-                project_id,
-                trace_id,
-                id,
-                start_time,
-                argMax(tuple(end_user_id), _version).1 AS latest_end_user_id,
-                argMax(tuple(trace_session_id), _version).1 AS latest_trace_session_id,
-                argMax(observation_type, _version) AS latest_observation_type,
-                argMax(status, _version) AS latest_status,
-                argMax(tuple(end_time), _version).1 AS latest_end_time,
-                argMax(latency_ms, _version) AS latest_latency_ms,
-                argMax(is_deleted, _version) AS latest_is_deleted
-            FROM spans
-            PREWHERE {self._project_predicate("spans")}
-              AND toDate(start_time) BETWEEN toDate(%(start_date)s) AND toDate(%(end_date)s)
-              AND start_time >= %(start_date)s
-              AND start_time < %(end_date)s
-              AND (project_id, trace_id, id, start_time) IN (
-                  SELECT project_id, trace_id, id, start_time
-                  FROM candidate_span_identities
-              )
-            GROUP BY project_id, trace_id, id, start_time
-        ),
+        {prefix},
         resolved_candidate_spans AS (
             SELECT
                 {resolved_latest_eu} AS end_user_id,
                 {resolved_latest_session} AS trace_session_id,
                 trace_id,
-                start_time,
+                latest_start_time AS start_time,
                 latest_end_time AS end_time,
                 latest_latency_ms AS latency_ms,
-                latest_observation_type AS observation_type,
+                observation_type,
                 latest_status AS status
             FROM latest_candidate_spans
             LEFT JOIN eu_survivor_map AS span_eu_remap
@@ -1326,6 +1332,8 @@ class UserListQueryBuilder(BaseQueryBuilder):
             LEFT JOIN ts_survivor_map AS span_ts_remap
                 ON latest_trace_session_id = span_ts_remap.any_id
             WHERE latest_is_deleted = 0
+              AND latest_start_time >= fromUnixTimestamp64Micro(%(user_window_start_us)s, 'UTC')
+              AND latest_start_time < fromUnixTimestamp64Micro(%(user_window_end_us)s, 'UTC')
               AND {resolved_latest_eu} IN %(candidate_end_user_ids)s
         ),
         extra_metrics AS (

--- a/futureagi/tracer/tests/test_session_user_candidate_reads.py
+++ b/futureagi/tracer/tests/test_session_user_candidate_reads.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
+import json
 import os
+import re
 import time
 import uuid
 from datetime import UTC, datetime, timedelta
@@ -10,12 +12,14 @@ from types import SimpleNamespace
 from unittest import mock
 
 import pytest
+from clickhouse_driver.util.escape import escape_params
 from django.conf import settings as django_settings
 from django.test import override_settings
 
 from tracer.selectors.trace_filter_reads import read_bounded_filter_page
 from tracer.services.clickhouse.query_builders.user_list import (
     UnsupportedBoundedUserListQuery,
+    UserListQueryBuilder,
 )
 from tracer.services.clickhouse.v2.query_builders.session_list import (
     SessionListQueryBuilderV2,
@@ -88,15 +92,29 @@ def test_user_default_page_replays_latest_state_before_pagination():
     assert physical_params["project_id"] == builder.project_id
     assert "candidate_users AS" in page_sql
     assert "FROM spans" in page_sql
-    assert "candidate_span_identities AS" in page_sql
+    # Unseeded reads carry no user/scalar seed, so every latest row in the
+    # exact window witnesses its own identity. The identity superset CTE is
+    # only built when a seed narrows the scan.
+    assert "candidate_span_identities AS" not in page_sql
     assert "latest_candidate_spans AS" in page_sql
     assert "latest_is_deleted = 0" in page_sql
+    compact_page_sql = " ".join(page_sql.split())
+    assert (
+        "AND toStartOfHour(start_time) >= toStartOfHour( "
+        "fromUnixTimestamp64Micro(%(user_window_start_us)s, 'UTC') )"
+        in compact_page_sql
+    )
+    assert (
+        "AND toStartOfHour(start_time) < fromUnixTimestamp64Micro( "
+        "%(user_window_end_us)s, 'UTC' )" in compact_page_sql
+    )
     assert "span_user_rollup" not in page_sql
     assert "span_user_rollup" not in combined_sql
     cursor_seed_sql, cursor_seed_params = builder.build_dimension_candidate_query(
         limit=26
     )
     assert "latest_candidate_spans AS" in cursor_seed_sql
+    assert "candidate_span_identities AS" not in cursor_seed_sql
     assert (
         cursor_seed_params["user_window_start_us"]
         < cursor_seed_params["user_window_end_us"]
@@ -105,10 +123,233 @@ def test_user_default_page_replays_latest_state_before_pagination():
     assert params["limit"] == 25
     assert params["offset"] == 50
     assert "argMax(is_deleted, _version) AS latest_is_deleted" in metrics_sql
-    assert "(project_id, trace_id, id, start_time) IN" in metrics_sql
+    compact_metrics_sql = " ".join(metrics_sql.split())
+    assert (
+        "GROUP BY project_id, observation_type, service_name, identity_hour, trace_id, id"
+        in compact_metrics_sql
+    )
+    assert (
+        "( project_id, observation_type, service_name, toStartOfHour(start_time), trace_id, id ) IN"
+        in compact_metrics_sql
+    )
+    latest_scan = metrics_sql.split("latest_candidate_spans AS (", 1)[1].split(
+        "GROUP BY", 1
+    )[0]
+    assert "argMax(start_time, _version) AS latest_start_time" in latest_scan
+    assert "start_time >=" not in latest_scan
+    assert "start_time <" not in latest_scan
+    assert "end_user_id IN" not in latest_scan
+    assert "latest_is_deleted = 0" not in latest_scan
+    resolved = metrics_sql.split("resolved_candidate_spans AS (", 1)[1].split(
+        "extra_metrics AS (", 1
+    )[0]
+    assert "latest_start_time AS start_time" in resolved
+    assert "latest_is_deleted = 0" in resolved
+    assert "latest_start_time >= fromUnixTimestamp64Micro(" in resolved
+    assert "latest_start_time < fromUnixTimestamp64Micro(" in resolved
+    assert "IN %(candidate_end_user_ids)s" in resolved
     assert "eu_survivor_map" in metrics_sql
     assert "ts_survivor_map" in metrics_sql
+    assert "candidate_session_ids AS" in metrics_sql
+    assert "WHERE new_id IN (SELECT new_id FROM touched_session_groups)" in metrics_sql
+    assert "OVER (PARTITION BY new_id)" not in metrics_sql
     assert len(metrics_params["candidate_end_user_ids"]) == 1
+    assert set(re.findall(r"%\((\w+)\)s", metrics_sql)) <= metrics_params.keys()
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "builder_class", [UserListQueryBuilder, UserListQueryBuilderV2]
+)
+@pytest.mark.parametrize("workspace", [False, True])
+def test_user_page_metrics_preserves_combined_query_and_empty_page_contract(
+    builder_class, workspace
+):
+    project_id, user_id = str(uuid.uuid4()), str(uuid.uuid4())
+    builder = builder_class(
+        organization_id=str(uuid.uuid4()),
+        **({"project_ids": [project_id]} if workspace else {"project_id": project_id}),
+        filters=_window(datetime(2026, 8, 1, 10, tzinfo=UTC)),
+        limit=25,
+        offset=50,
+    )
+    combined_sql, combined_params = builder.build()
+    original_params = dict(combined_params)
+    assert builder.build_page_metrics_query([]) == ("", {})
+    sql, params = builder.build_page_metrics_query([user_id])
+    assert params["candidate_end_user_ids"] == (user_id,)
+    assert params["project_ids" if workspace else "project_id"] == (
+        (project_id,) if workspace else project_id
+    )
+    assert set(re.findall(r"%\((\w+)\)s", sql)) <= params.keys()
+    assert builder.params == original_params
+    assert builder.build() == (combined_sql, original_params)
+
+
+def _inline_user_metric_rows(sql, params, span_rows, user_id, session_id):
+    """Execute only SELECTs over inline spans and already-latest dimension rows.
+
+    VALUES has no PREWHERE/FINAL: preserve predicates with the existing clause
+    lowering helper and remove FINAL only from the fixed dimension fixtures.
+    The offline runner can route chdb.query to its read-only native CH25 adapter.
+    """
+    chdb = pytest.importorskip("chdb", reason="isolated native fixture engine required")
+    from tracer.tests.test_session_exact_latest_cursor import _values_where
+
+    context = SimpleNamespace(server_info=SimpleNamespace(get_timezone=lambda: "UTC"))
+    rendered = sql % escape_params(params, context)
+    rendered = re.sub(
+        r"\b(end_users|end_user_id_remap|trace_session_id_remap)\s+FINAL\b",
+        r"\1",
+        rendered,
+    )
+    columns = """project_id UUID, observation_type String, service_name String,
+        start_time DateTime64(6, 'UTC'), trace_id String, id String,
+        end_user_id Nullable(UUID), trace_session_id Nullable(UUID),
+        _version UInt64, is_deleted UInt8, status String, latency_ms Int32,
+        end_time Nullable(DateTime64(6, 'UTC'))"""
+    literals = escape_params(
+        {
+            "columns": columns,
+            "rows": tuple(span_rows),
+            "user_id": user_id,
+            "session_id": session_id,
+            "raw_user_id": str(uuid.UUID(int=20)),
+            "raw_session_id": str(uuid.UUID(int=30)),
+        },
+        context,
+    )
+    assert rendered.lstrip().startswith("WITH")
+    rendered = f"""
+        WITH spans AS (
+            SELECT * FROM values({literals["columns"]}, {literals["rows"][1:-1]})
+        ), end_users AS (
+            SELECT toUUID({literals["user_id"]}) AS end_user_id
+        ), end_user_id_remap AS (
+            SELECT toUUID({literals["user_id"]}) AS old_id,
+                toUUID({literals["raw_user_id"]}) AS new_id
+        ), trace_session_id_remap AS (
+            SELECT toUUID({literals["session_id"]}) AS old_id,
+                toUUID({literals["raw_session_id"]}) AS new_id
+        ), {rendered.lstrip()[4:]}
+    """
+    result = str(chdb.query(_values_where(rendered), "JSONEachRow"))
+    rows = [json.loads(line) for line in result.splitlines() if line]
+    # JSON transports UInt64 as strings; the application native driver uses ints.
+    for row in rows:
+        for field in row:
+            if field.startswith("num_"):
+                row[field] = int(row[field])
+    return rows
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    ("case", "expected_calls"),
+    [
+        ("timestamp_correction", 1),
+        ("timestamp_corrected_tombstone", 0),
+        ("distinct_service_identity", 2),
+        ("correction_outside_window_same_hour", 0),
+    ],
+)
+def test_user_page_metrics_exact_physical_replay_inline(case, expected_calls):
+    project_id, user_id, session_id = (str(uuid.UUID(int=i)) for i in (1, 2, 3))
+    start = datetime(2026, 8, 1, 10, 0)
+    end = start + timedelta(minutes=30)
+    at = start + timedelta(minutes=10)
+    latest_at = (
+        end + timedelta(minutes=1)
+        if case == "correction_outside_window_same_hour"
+        else at + timedelta(microseconds=1)
+    )
+    if case == "distinct_service_identity":
+        latest_at = at
+
+    def row(version, moment, service, deleted):
+        # escape_params(datetime) truncates microseconds; explicit strings retain
+        # the storage correction that this regression must distinguish.
+        return (
+            project_id,
+            "llm",
+            service,
+            moment.isoformat(sep=" ", timespec="microseconds"),
+            "trace",
+            "span",
+            str(uuid.UUID(int=20)),
+            str(uuid.UUID(int=30)),
+            version,
+            deleted,
+            "ERROR",
+            1000,
+            (moment + timedelta(seconds=1)).isoformat(sep=" ", timespec="microseconds"),
+        )
+
+    span_rows = [
+        row(1, at, "a", 0),
+        row(
+            2,
+            latest_at,
+            "b" if case == "distinct_service_identity" else "a",
+            int(case == "timestamp_corrected_tombstone"),
+        ),
+    ]
+    builder = UserListQueryBuilderV2(
+        organization_id=str(uuid.UUID(int=4)),
+        project_id=project_id,
+        filters=[
+            {
+                "column_id": "created_at",
+                "filter_config": {
+                    "filter_type": "datetime",
+                    "filter_op": "between",
+                    "filter_value": [start.isoformat(), end.isoformat()],
+                },
+            }
+        ],
+    )
+    expected = (
+        [
+            {
+                "end_user_id": user_id,
+                "num_sessions": 1,
+                "avg_session_duration": 1.0,
+                "avg_trace_latency": 1000.0,
+                "num_llm_calls": expected_calls,
+                "num_guardrails_triggered": 0,
+                "num_active_days": 1,
+                "num_traces_with_errors": 1,
+            }
+        ]
+        if expected_calls
+        else []
+    )
+    sql, params = builder.build_page_metrics_query([user_id])
+    assert (
+        _inline_user_metric_rows(sql, params, span_rows, user_id, session_id)
+        == expected
+    )
+
+    # Exercise the current manager's requested-metric path on the same source
+    # rows and compare both APIs with explicit expected rows, including aliases.
+    metric_keys = {
+        "num_sessions",
+        "avg_session_duration",
+        "avg_trace_latency",
+        "num_llm_calls",
+        "num_guardrails_triggered",
+        "num_active_days",
+        "num_traces_with_errors",
+    }
+    requested = {}
+    for sql, params, _fields in builder.build_requested_page_metric_queries(
+        [user_id], metric_keys
+    ):
+        for result in _inline_user_metric_rows(
+            sql, params, span_rows, user_id, session_id
+        ):
+            requested.setdefault(result["end_user_id"], {}).update(result)
+    assert list(requested.values()) == expected
 
 
 @pytest.mark.unit
@@ -442,9 +683,7 @@ def test_raw_new_session_seed_classifier_expands_group_and_keeps_all_filters():
     assert "latest_attr_exists_1 AND" in match_sql
     assert "countIf(latest_attr_exists_0 AND" in match_sql
     assert "countIf(latest_attr_exists_1 AND" in match_sql
-    assert (
-        "AND countIf(is_root) > 0" in match_sql
-    )
+    assert "AND countIf(is_root) > 0" in match_sql
     assert match_params["candidate_filter_session_id_array"] == [new_session_id]
     assert match_params["latest_filter_param_0"] == "rejected"
     assert match_params["latest_filter_param_1"] == "us"

--- a/futureagi/tracer/tests/test_user_latest_window_replay.py
+++ b/futureagi/tracer/tests/test_user_latest_window_replay.py
@@ -47,7 +47,9 @@ def builder(workspace=False):
     )
 
 
-def assert_window_replay(sql, params, latest_cte="latest_candidate_spans"):
+def assert_window_replay(
+    sql, params, latest_cte="latest_candidate_spans", *, unseeded=False
+):
     latest = cte(sql, latest_cte)
     scan = latest.split("PREWHERE", 1)[1].split("GROUP BY", 1)[0]
     # Exact mutable timestamp predicates belong after version collapse. The
@@ -57,7 +59,12 @@ def assert_window_replay(sql, params, latest_cte="latest_candidate_spans"):
     assert "latest_is_deleted = 0" not in scan
     assert "end_user_id IN" not in scan
     assert "toStartOfHour(start_time)" in scan
-    assert "candidate_span_identities" in scan
+    if unseeded:
+        assert "candidate_span_identities" not in sql
+        assert "toStartOfHour(start_time) >= toStartOfHour(" in scan
+        assert "toStartOfHour(start_time) < fromUnixTimestamp64Micro(" in scan
+    else:
+        assert "candidate_span_identities" in scan
     assert "argMax(start_time, _version) AS latest_start_time" in latest
     assert "latest_start_time >= fromUnixTimestamp64Micro(" in sql
     assert "latest_start_time < fromUnixTimestamp64Micro(" in sql

--- a/futureagi/tracer/tests/test_user_list_cursor.py
+++ b/futureagi/tracer/tests/test_user_list_cursor.py
@@ -262,9 +262,11 @@ def test_numbered_page_reuses_full_identity_post_collapse_window():
 
     sql, params = builder.build_candidate_page_query()
     assert "FROM spans AS sp FINAL" not in sql
-    assert "candidate_span_identities" in sql
+    # Date-only numbered reads carry no seed, so the identity superset CTE is
+    # replaced by a direct replay of the intersecting immutable hours.
+    assert "candidate_span_identities" not in sql
     assert "count() OVER()" in sql
-    assert_window_replay(sql, params)
+    assert_window_replay(sql, params, unseeded=True)
 
 
 def test_user_attribute_enrichment_projects_requested_direct_write_keys_only():

--- a/futureagi/tracer/tests/test_users_attribute_physical_replay.py
+++ b/futureagi/tracer/tests/test_users_attribute_physical_replay.py
@@ -1,0 +1,449 @@
+"""Users typed hydration on constant fixtures, never server tables or DDL.
+
+Execute the real builder and compare every result with independent physical-key
+replacement. This is semantic evidence, not production latency qualification.
+"""
+
+import json
+import math
+from datetime import datetime, timedelta
+from types import SimpleNamespace
+from unittest.mock import patch
+from uuid import UUID
+
+import pytest
+from clickhouse_driver.util.escape import escape_params
+
+from tracer.services.clickhouse.server_readonly import without_query_settings
+from tracer.services.users_list_manager import (
+    UsersListManager,
+    _users_attr_enrichment_query,
+)
+from tracer.tests.test_trace_root_physical_replay import values_where
+from tracer.tests.test_user_latest_window_replay import cte
+
+pytestmark = pytest.mark.unit
+PROJECT, OTHER, FOREIGN, USER, ALIAS, NEW, UNMAPPED = (
+    str(UUID(int=i)) for i in (101, 102, 103, 110, 140, 150, 170)
+)
+START = datetime(2026, 8, 1, 12, 15, 0, 123456)
+REMAP = {USER: USER, ALIAS: USER, NEW: USER}
+CONTEXT = SimpleNamespace(server_info=SimpleNamespace(get_timezone=lambda: "UTC"))
+LONG = "雪 %_\\' quoted text " * 400
+KEYS = (
+    "tag",
+    "long",
+    "flag",
+    "zero",
+    "empty",
+    "null",
+    "array",
+    "object",
+    "mixed",
+    "cleared",
+    "deleted",
+    "reassigned",
+    "outside",
+    "absent",
+)
+
+
+def span(identity, **changes):
+    return {
+        "project_id": PROJECT,
+        "observation_type": "SPAN",
+        "service_name": "svc",
+        "trace_id": "trace",
+        "id": identity,
+        "start_time": START,
+        "_version": 1,
+        "is_deleted": 0,
+        "end_user_id": ALIAS,
+        "attributes_extra": {},
+        "attrs_string": {},
+        "attrs_number": {},
+        "attrs_bool": {},
+        **changes,
+    }
+
+
+def cohort(days):
+    end = START + timedelta(days=days)
+    rows = [
+        span(
+            "live",
+            attrs_string={"tag": "first", "long": LONG, "empty": ""},
+            attrs_number={"zero": 0},
+            attrs_bool={"flag": 0},
+            attributes_extra={
+                "null": None,
+                "array": [1, "1", True],
+                "object": {"a": "b"},
+            },
+        ),
+        span("another", end_user_id=NEW, attrs_string={"tag": "second"}),
+        span("unmapped", end_user_id=UNMAPPED, attrs_string={"tag": "unmapped"}),
+        span("live", project_id=OTHER, attrs_string={"tag": "other-project"}),
+        span("live", project_id=FOREIGN, attrs_string={"tag": "foreign"}),
+        span("live", service_name="other", attrs_string={"tag": "other-service"}),
+        span("live", observation_type="EVENT", attrs_string={"tag": "other-kind"}),
+        span("live", trace_id="other", attrs_string={"tag": "other-trace"}),
+        span(
+            "live",
+            start_time=START + timedelta(hours=1),
+            attrs_string={"tag": "other-hour"},
+        ),
+        span("at-end", start_time=end, attrs_string={"outside": "exclusive-end"}),
+        span(
+            "near-end",
+            start_time=end - timedelta(microseconds=1),
+            attrs_string={"tag": "last-microsecond"},
+        ),
+        span("moved-in", start_time=START - timedelta(microseconds=1)),
+        span("moved-in", _version=2, attrs_string={"tag": "moved-in"}),
+        span("null-user", end_user_id=None, attrs_string={"tag": "no-user"}),
+    ]
+    for key, changes in (
+        ("cleared", {"attrs_string": {}}),
+        ("deleted", {"is_deleted": 1}),
+        ("reassigned", {"end_user_id": str(UUID(int=999))}),
+        ("outside", {"start_time": START - timedelta(microseconds=1)}),
+    ):
+        old = span(key, attrs_string={key: "obsolete"})
+        rows.extend([old, {**old, "_version": 2, **changes}])
+    for i, changes in enumerate(
+        (
+            {"attrs_string": {"mixed": "7"}},
+            {"attrs_number": {"mixed": 7}},
+            {"attrs_bool": {"mixed": 1}, "attrs_number": {"mixed": 9}},
+            {"attributes_extra": {"mixed": [7]}, "attrs_bool": {"mixed": 1}},
+            {"attributes_extra": {"mixed": None}, "attrs_string": {"mixed": "shadow"}},
+            {"attrs_number": {"mixed": float("inf")}},
+            {"attrs_number": {"mixed": float("nan")}},
+        )
+    ):
+        rows.append(span(f"mixed-{i}", **changes))
+    # Identical duplicate versions are safe; conflicting equal versions have
+    # no uniquely defined physical winner and are deliberately not invented.
+    rows.append(dict(rows[0]))
+    return rows
+
+
+def canonical(value):
+    return json.dumps(value, sort_keys=True, ensure_ascii=False, separators=(",", ":"))
+
+
+def expected(rows, keys, projects, days):
+    latest = {}
+    for row in rows:
+        physical_key = tuple(
+            row[k]
+            for k in (
+                "project_id",
+                "observation_type",
+                "service_name",
+                "trace_id",
+                "id",
+            )
+        ) + (row["start_time"].replace(minute=0, second=0, microsecond=0),)
+        if (
+            physical_key not in latest
+            or row["_version"] > latest[physical_key]["_version"]
+        ):
+            latest[physical_key] = row
+    result = {}
+    for row in latest.values():
+        user = REMAP.get(row["end_user_id"], row["end_user_id"])
+        if (
+            row["project_id"] not in projects
+            or row["is_deleted"]
+            or user not in (USER, UNMAPPED)
+            or not START <= row["start_time"] < START + timedelta(days=days)
+        ):
+            continue
+        for key in keys:
+            for storage, kind in (
+                ("attributes_extra", "json"),
+                ("attrs_bool", "boolean"),
+                ("attrs_number", "number"),
+                ("attrs_string", "string"),
+            ):
+                values = row[storage] or {}
+                if key not in values:
+                    continue
+                value = values[key]
+                if kind == "boolean":
+                    value = bool(value)
+                elif kind == "number":
+                    value = None if not math.isfinite(value) else value
+                result.setdefault((user, key), set()).add((kind, canonical(value)))
+                break
+    return result
+
+
+def execute(
+    rows,
+    keys,
+    *,
+    days=7,
+    workspace=False,
+    finite=True,
+    join_use_nulls=0,
+    query_factory=_users_attr_enrichment_query,
+    compiled=None,
+):
+    engine = pytest.importorskip("chdb")
+    sql, params = query_factory(
+        **({"project_ids": [PROJECT, OTHER]} if workspace else {"project_id": PROJECT}),
+        attribute_keys=keys,
+        start_date=START,
+        end_date=START + timedelta(days=days),
+        candidate_end_user_id_map=REMAP if finite else None,
+    )
+    params.update(
+        eu_ids=(USER, UNMAPPED),
+        eu_scan_ids=(*REMAP, UNMAPPED) if finite else (USER, UNMAPPED),
+    )
+    if compiled is not None:
+        sql, params = compiled
+    columns = """project_id UUID, observation_type String, service_name String,
+        trace_id String, id String, start_time DateTime64(6, 'UTC'), _version UInt64,
+        is_deleted UInt8, end_user_id Nullable(UUID), attributes_extra Nullable(String),
+        string_keys Array(String), string_value_indices Array(UInt32),
+        number_keys Array(String), number_values Array(Float64),
+        bool_keys Array(String), bool_values Array(UInt8)"""
+    encoded = []
+    # Encode repeated strings once, keeping the exact long values without a
+    # multi-megabyte VALUES statement or an increased parser/memory limit.
+    string_pool = list(
+        dict.fromkeys(value for row in rows for value in row["attrs_string"].values())
+    )
+    string_indices = {value: index + 1 for index, value in enumerate(string_pool)}
+    for row in rows:
+        values = [
+            row[k]
+            for k in (
+                "project_id",
+                "observation_type",
+                "service_name",
+                "trace_id",
+                "id",
+            )
+        ]
+        values += [
+            row["start_time"].isoformat(sep=" "),
+            row["_version"],
+            row["is_deleted"],
+            row["end_user_id"],
+            None
+            if row["attributes_extra"] is None
+            else canonical(row["attributes_extra"]),
+        ]
+        for storage in ("attrs_string", "attrs_number", "attrs_bool"):
+            stored_values = list(row[storage].values())
+            if storage == "attrs_string":
+                stored_values = [string_indices[value] for value in stored_values]
+            values.extend([list(row[storage]), stored_values])
+        encoded.append(tuple(values))
+    literals = escape_params(
+        {
+            "columns": columns,
+            "rows": tuple(encoded),
+            "remaps": ((USER, NEW), (ALIAS, NEW)),
+            "string_pool": string_pool,
+        },
+        CONTEXT,
+    )
+    rendered = without_query_settings(sql) % escape_params(params, CONTEXT)
+    # Dimension fixtures already contain their latest rows; only this fixed
+    # fixture's FINAL is removed. Preserve every predicate when lowering PREWHERE.
+    rendered = rendered.replace("end_user_id_remap FINAL", "end_user_id_remap")
+    assert rendered.lstrip().startswith("WITH")
+    rendered = f"""WITH {literals["string_pool"]} AS fixture_string_pool, spans AS (
+        SELECT *, mapFromArrays(string_keys,
+            arrayMap(i -> fixture_string_pool[i], string_value_indices)) AS attrs_string,
+            mapFromArrays(number_keys, number_values) AS attrs_number,
+            mapFromArrays(bool_keys, bool_values) AS attrs_bool
+        FROM values({literals["columns"]}, {literals["rows"][1:-1]})
+    ), end_user_id_remap AS (
+        SELECT * FROM values('old_id UUID, new_id UUID', {literals["remaps"][1:-1]})
+    ), {rendered.lstrip()[4:]}
+    SETTINGS join_use_nulls={join_use_nulls}, max_threads=1,
+        max_execution_time=5, max_memory_usage=268435456
+    """
+    try:
+        result = engine.query(values_where(rendered), "JSONEachRow")
+    except RuntimeError as exc:
+        # Native client errors otherwise echo the entire long-string fixture.
+        raise RuntimeError(str(exc).split("(query:", 1)[0][:1500]) from None
+    return [json.loads(line) for line in str(result).splitlines() if line]
+
+
+def decoded(rows):
+    result = {
+        (row["end_user_id"], row["attribute_key"]): {
+            (kind, canonical(json.loads(value)))
+            for kind, value in row["attribute_typed_values"]
+        }
+        for row in rows
+    }
+    assert len(result) == len(rows), "one output per user/key"
+    return result
+
+
+def test_requested_keys_keep_full_physical_replay_and_post_collapse_visibility():
+    sql, params = _users_attr_enrichment_query(
+        project_id=PROJECT, attribute_keys=["tag", "tag", "long"]
+    )
+    latest = cte(sql, "latest_candidate_attribute_values")
+    group = latest.split("GROUP BY", 1)[1]
+    for column in (
+        "project_id",
+        "observation_type",
+        "service_name",
+        "identity_hour",
+        "trace_id",
+        "id",
+    ):
+        assert column in group
+    scan = latest.split("PREWHERE", 1)[1].split("GROUP BY", 1)[0]
+    assert "candidate_span_identities" in scan
+    assert "is_deleted = 0" not in scan and "end_user_id IN" not in scan
+    assert "latest_is_deleted = 0" in sql
+    assert "GROUP BY end_user_id, attribute_key" in sql
+    assert params["requested_attribute_keys"] == ["tag", "long"]
+
+
+def test_duplicate_single_key_is_bound_once():
+    sql, params = _users_attr_enrichment_query(
+        project_id=PROJECT, attribute_keys=["long", "long"]
+    )
+    assert "%(requested_attribute_keys)s" in sql and "'long'" not in sql
+    assert params["requested_attribute_keys"] == ["long"]
+
+
+@pytest.mark.parametrize("days", [7, 30, 365])
+@pytest.mark.parametrize("key", KEYS)
+def test_each_single_typed_key_replays_exactly(key, days):
+    rows = cohort(days)
+    assert decoded(execute(rows, [key], days=days)) == expected(
+        rows, [key], [PROJECT], days
+    )
+
+
+@pytest.mark.parametrize("days", [7, 30, 365])
+@pytest.mark.parametrize("workspace", [False, True])
+@pytest.mark.parametrize("finite", [False, True])
+@pytest.mark.parametrize("join_use_nulls", [0, 1])
+def test_typed_replay_matches_full_physical_truth(
+    days, workspace, finite, join_use_nulls
+):
+    rows = cohort(days)
+    actual = execute(
+        rows,
+        KEYS,
+        days=days,
+        workspace=workspace,
+        finite=finite,
+        join_use_nulls=join_use_nulls,
+    )
+    assert decoded(actual) == expected(
+        rows, KEYS, [PROJECT, OTHER] if workspace else [PROJECT], days
+    )
+
+
+@pytest.mark.parametrize("key_count", [1, 4, 10])
+def test_requested_key_width_keeps_sparse_and_removed_values(key_count):
+    keys = [f"key-{i}" for i in range(key_count)]
+    rows = [
+        span("dense", attrs_string=dict.fromkeys(keys, LONG)),
+        span("sparse", attrs_string={keys[-1]: "sparse"}),
+        span("removed", attrs_string=dict.fromkeys(keys, "obsolete")),
+        span("removed", _version=2),
+        span("null-extra", attributes_extra=None, attrs_string={keys[0]: "fallback"}),
+    ]
+    assert decoded(execute(rows, keys)) == expected(rows, keys, [PROJECT], 7)
+
+
+def test_actual_collector_preserves_mixed_values_and_missing_keys():
+    rows = cohort(7)
+    manager = UsersListManager(
+        organization_id=PROJECT,
+        allowed_project_ids=[PROJECT],
+        project_id=PROJECT,
+        requested_columns=[],
+        attribute_keys=list(KEYS),
+    )
+    calls = []
+
+    def read(sql, params, **kwargs):
+        calls.append(params["requested_attribute_keys"])
+        return SimpleNamespace(
+            data=execute(
+                rows, params["requested_attribute_keys"], compiled=(sql, params)
+            )
+        )
+
+    with patch("tracer.services.users_list_manager.V2AnalyticsQueryService") as service:
+        service.return_value.execute_ch_query.side_effect = read
+        attrs = manager._read_span_attributes(
+            [{"end_user_id": USER}],
+            None,
+            start_date=START,
+            end_date=START + timedelta(days=7),
+            candidate_scan_ids=list(REMAP),
+            candidate_end_user_id_map=REMAP,
+        )
+    assert [key for batch in calls for key in batch] == list(KEYS)
+    assert max(map(len, calls)) == 4  # Existing production batch size is unchanged.
+    assert attrs[USER]["long"] == LONG and attrs[USER]["empty"] == ""
+    assert attrs[USER]["zero"] == 0 and attrs[USER]["flag"] == "false"
+    assert attrs[USER]["null"] is None
+    assert {"cleared", "deleted", "reassigned", "outside", "absent"}.isdisjoint(
+        attrs[USER]
+    )
+
+
+def test_actual_collector_reads_all_250_long_keys_in_existing_batches():
+    keys = [f"key-{i}" for i in range(250)]
+    rows = [
+        span("dense", attrs_string=dict.fromkeys(keys, LONG)),
+        span("sparse", attrs_string={keys[-1]: "sparse"}),
+        span("removed", attrs_string=dict.fromkeys(keys, "obsolete")),
+        span("removed", _version=2),
+        span("null-extra", attributes_extra=None, attrs_string={keys[0]: "fallback"}),
+    ]
+    manager = UsersListManager(
+        organization_id=PROJECT,
+        allowed_project_ids=[PROJECT],
+        project_id=PROJECT,
+        requested_columns=[],
+        attribute_keys=keys,
+    )
+    calls, actual = [], []
+
+    def read(sql, params, **kwargs):
+        calls.append(params["requested_attribute_keys"])
+        result = execute(
+            rows, params["requested_attribute_keys"], compiled=(sql, params)
+        )
+        actual.extend(result)
+        return SimpleNamespace(data=result)
+
+    with patch("tracer.services.users_list_manager.V2AnalyticsQueryService") as service:
+        service.return_value.execute_ch_query.side_effect = read
+        attrs = manager._read_span_attributes(
+            [{"end_user_id": USER}],
+            None,
+            start_date=START,
+            end_date=START + timedelta(days=7),
+            candidate_scan_ids=list(REMAP),
+            candidate_end_user_id_map=REMAP,
+        )
+    assert len(calls) == 63 and max(map(len, calls)) == 4
+    assert [key for batch in calls for key in batch] == keys
+    assert decoded(actual) == expected(rows, keys, [PROJECT], 7)
+    assert set(attrs[USER]) == set(keys)
+    assert attrs[USER][keys[1]] == LONG
+    assert set(attrs[USER][keys[0]]) == {LONG, "fallback"}
+    assert set(attrs[USER][keys[-1]]) == {LONG, "sparse"}

--- a/futureagi/tracer/tests/test_users_exact_activity_cursor.py
+++ b/futureagi/tracer/tests/test_users_exact_activity_cursor.py
@@ -56,7 +56,7 @@ def test_exact_candidate_population_window_order_and_scope(workspace, days):
     )
     assert "span_user_rollup" not in sql
     assert "FROM spans AS sp FINAL" not in sql
-    assert_window_replay(sql, params)
+    assert_window_replay(sql, params, unseeded=True)
     assert "count() OVER()" not in sql
     assert params["limit"] == 26
     assert params["before_activity_us"] + 1 == params["user_window_end_us"]
@@ -118,7 +118,7 @@ def test_native_user_id_witness_is_after_latest_replay_before_candidate_limit(
     assert params["candidate_user_label_0"] == (
         ("guest-a",) if op == "equals" else ("guest-a", "guest-b")
     )
-    assert_window_replay(sql, params)
+    assert_window_replay(sql, params, unseeded=True)
 
 
 @pytest.mark.parametrize(
@@ -187,7 +187,7 @@ def test_scalar_witness_narrows_groups_not_activity_or_replacement(workspace):
         raw_filter("equals", 0),
         raw_filter("less_than", 1),
         raw_filter("equals", False, "boolean"),
-        raw_filter("equals", "1", "text"),
+        raw_filter("equals", "true", "text"),
         {
             "column_id": "total_cost",
             "filter_config": {

--- a/futureagi/tracer/tests/test_users_native_conjunction_replay.py
+++ b/futureagi/tracer/tests/test_users_native_conjunction_replay.py
@@ -1,0 +1,86 @@
+"""Native typed hydration plus real Users AND matching; SELECT fixtures only."""
+
+from copy import deepcopy
+from datetime import timedelta
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+from tracer.services.users_list_manager import UsersListManager
+from tracer.tests.test_user_attribute_native_key_collision import wire
+from tracer.tests.test_users_attribute_physical_replay import (
+    PROJECT,
+    REMAP,
+    START,
+    USER,
+    execute,
+    span,
+)
+
+pytestmark = pytest.mark.unit
+
+
+@pytest.mark.parametrize("days", [7, 30, 365])
+@pytest.mark.parametrize("width", [2, 5, 10])
+def test_native_typed_conjunction_requires_every_latest_property(days, width):
+    filters, physical_rows = [], []
+    for index in range(width):
+        key = f"compound_{index}"
+        kind, value, storage = (
+            ("text", "Alpha", "attrs_string"),
+            ("number", 7, "attrs_number"),
+            ("boolean", True, "attrs_bool"),
+        )[index % 3]
+        filters.append(wire(key, value, kind=kind))
+        # Properties on different spans of the same canonical user must AND
+        # together at user grain, not require a single span to contain them all.
+        physical_rows.append(span(f"span-{index}", **{storage: {key: value}}))
+
+    for cleared_index in [None, *range(width)]:
+        rows = deepcopy(physical_rows)
+        if cleared_index is not None:
+            # The old matching version remains physically present. The newest
+            # version clears only this leaf; every other leaf still matches.
+            cleared = deepcopy(rows[cleared_index])
+            cleared.update(_version=2, attrs_string={}, attrs_number={}, attrs_bool={})
+            rows.append(cleared)
+        manager = UsersListManager(
+            organization_id=PROJECT,
+            allowed_project_ids=[PROJECT],
+            project_id=PROJECT,
+            requested_columns=[],
+            filters=deepcopy(filters),
+        )
+        candidate = {"end_user_id": USER, "user_id": "fixture-user"}
+        batches = []
+
+        def read(sql, params, *, _rows=rows, _batches=batches, **_kwargs):
+            _batches.append(params["requested_attribute_keys"])
+            return SimpleNamespace(
+                data=execute(
+                    _rows,
+                    params["requested_attribute_keys"],
+                    days=days,
+                    compiled=(sql, params),
+                )
+            )
+
+        with patch(
+            "tracer.services.users_list_manager.V2AnalyticsQueryService"
+        ) as service:
+            service.return_value.execute_ch_query.side_effect = read
+            attrs = manager._read_span_attributes(
+                [candidate],
+                None,
+                start_date=START,
+                end_date=START + timedelta(days=days),
+                candidate_scan_ids=list(REMAP),
+                candidate_end_user_id_map=REMAP,
+            )
+        manager._apply_span_attributes([candidate], attrs)
+        assert manager._row_matches_filters(candidate) is (cleared_index is None)
+        assert {key for batch in batches for key in batch} == {
+            f"compound_{i}" for i in range(width)
+        }
+        assert max(map(len, batches)) <= 4

--- a/futureagi/tracer/tests/test_users_text_candidate_witness.py
+++ b/futureagi/tracer/tests/test_users_text_candidate_witness.py
@@ -1,0 +1,285 @@
+"""Exact candidate acquisition on native constant fixtures; no tables or DDL.
+
+Candidates may include stale witnesses. They must retain every possible match,
+and their activity metrics/order must use all latest live spans, not just matches.
+This is not production-performance or full Users API qualification.
+"""
+
+import json
+from datetime import UTC, datetime, timedelta
+from types import SimpleNamespace
+from uuid import UUID
+
+import pytest
+from clickhouse_driver.util.escape import escape_params
+
+from tracer.services.clickhouse.server_readonly import without_query_settings
+from tracer.services.clickhouse.v2.id_remap_sql import resolved_id_expr
+from tracer.services.clickhouse.v2.query_builders.user_list import (
+    UserListQueryBuilderV2,
+)
+from tracer.tests.test_trace_root_physical_replay import values_where
+from tracer.tests.test_user_latest_window_replay import assert_window_replay, cte
+
+PROJECT, FOREIGN = str(UUID(int=1001)), str(UUID(int=1002))
+START = datetime(2026, 8, 1, 12, 15, tzinfo=UTC)
+LONG = "long ASCII %_\\' text " * 100
+CONTEXT = SimpleNamespace(server_info=SimpleNamespace(get_timezone=lambda: "UTC"))
+
+
+def leaf(value, op="equals"):
+    picker = op == "typed_in"
+    return {
+        "column_id": "tag",
+        "filter_config": {
+            "col_type": "SPAN_ATTRIBUTE",
+            "filter_type": "text",
+            "filter_op": "in" if picker else op,
+            "filter_value": value,
+            **({"attribute_value_types": ["string"] * len(value)} if picker else {}),
+        },
+    }
+
+
+def builder(items, days=7):
+    return UserListQueryBuilderV2(
+        organization_id=PROJECT,
+        project_ids=[PROJECT],
+        filters=[
+            {
+                "column_id": "created_at",
+                "filter_config": {
+                    "filter_type": "datetime",
+                    "filter_op": "between",
+                    "filter_value": [
+                        START.isoformat(),
+                        (START + timedelta(days=days)).isoformat(),
+                    ],
+                },
+            },
+            *items,
+        ],
+    )
+
+
+@pytest.mark.parametrize(
+    "value,op",
+    [
+        ("123456", "equals"),
+        (LONG, "equals"),
+        (["Alpha", "Beta"], "in"),
+        (["123456"], "typed_in"),
+    ],
+    ids=["digit-string", "long-text", "multi-value", "picker"],
+)
+def test_plain_text_witness_prunes_groups_not_latest_activity(value, op):
+    sql, params = builder([leaf(value, op)]).build_dimension_candidate_query(limit=65)
+    assert "scalar_witness_identities AS" in sql
+    witness = cte(sql, "scalar_witness_identities")
+    assert "attrs_string" in witness
+    assert "LIMIT" not in witness and "is_deleted" not in witness
+    assert "attrs_string" not in cte(sql, "exact_usage")
+    assert "filtered_end_users" not in cte(sql, "exact_usage")
+    assert "INNER JOIN exact_usage AS xu ON xu.end_user_id = eu.end_user_id" in sql
+    assert_window_replay(sql, params)
+
+
+@pytest.mark.parametrize(
+    "value,op",
+    [
+        ("", "equals"),
+        ("true", "equals"),
+        (" FALSE ", "equals"),
+        ('{"a":1}', "equals"),
+        ("[1,2]", "equals"),
+        ("\u0130", "equals"),
+        ("value", "not_equals"),
+        (None, "is_null"),
+        ("value", "contains"),
+        (["safe", "true"], "in"),
+        (["true"], "typed_in"),
+    ],
+)
+def test_unproven_text_shapes_keep_existing_complete_path(value, op):
+    sql, _ = builder([leaf(value, op)]).build_dimension_candidate_query(limit=65)
+    assert "scalar_witness_identities AS" not in sql
+
+
+def population(needle):
+    rows = []
+
+    def add(
+        user,
+        identity,
+        *,
+        value=None,
+        minute=20,
+        version=1,
+        deleted=0,
+        cost=1,
+        service="svc",
+        project=PROJECT,
+    ):
+        rows.append(
+            (
+                project,
+                service,
+                "SPAN",
+                identity,
+                str(UUID(int=user)),
+                START.replace(minute=minute, tzinfo=None).isoformat(" "),
+                version,
+                deleted,
+                START.replace(minute=minute + 1, tzinfo=None).isoformat(" "),
+                cost,
+                [] if value is None else ["tag"],
+                [] if value is None else [value],
+            )
+        )
+
+    add(50, "matching-alias", value=needle, cost=2)
+    add(10, "later-unmatched", value="unrelated", minute=40, cost=7)
+    add(40, "reassigned", value=needle)
+    add(20, "reassigned", value=needle, version=2, cost=3)
+    add(40, "retained-old-user-activity", value="unrelated", cost=4)
+    add(30, "deleted", value=needle)
+    add(30, "deleted", value=needle, version=2, deleted=1)
+    add(60, "never-matched", value="unrelated")
+    add(70, "missing-string-key")
+    add(80, "moved-out", value=needle)
+    add(80, "moved-out", value=needle, version=2, minute=10)
+    add(100, "deleted", value=needle, service="different-service")
+    add(110, "foreign", value=needle, project=FOREIGN)
+    add(120, "field-removed", value=needle)
+    add(120, "field-removed", version=2)
+    add(130, "without-curated-user", value=needle)
+    return rows
+
+
+def execute(rows, items, *, days=7, before=None, limit=65, redundant_membership=False):
+    engine = pytest.importorskip("chdb")
+    sql, params = builder(items, days).build_dimension_candidate_query(
+        limit=limit,
+        before_first_seen=before[0] if before else None,
+        before_end_user_id=before[1] if before else None,
+    )
+    if redundant_membership:
+        # Restore the removed, redundant semijoin as a differential control.
+        # Both versions retain the authoritative final dimension INNER JOIN.
+        assert sql.count("WHERE latest_is_deleted = 0") == 1
+        sql = sql.replace(
+            "WHERE latest_is_deleted = 0",
+            "WHERE latest_is_deleted = 0 AND "
+            f"{resolved_id_expr('latest_end_user_id', 'span_eu_remap')} IN "
+            "(SELECT end_user_id FROM filtered_end_users)",
+        )
+    rendered = without_query_settings(sql) % escape_params(params, CONTEXT)
+    # These dimension fixtures have one current row per key. FINAL is unnecessary
+    # only for these constant CTEs; no span predicate or version replay is removed.
+    rendered = rendered.replace("end_users AS eu FINAL", "end_users AS eu")
+    rendered = rendered.replace("end_user_id_remap FINAL", "end_user_id_remap")
+    columns = (
+        "project_id UUID, service_name String, observation_type String, id String, "
+        "end_user_id Nullable(UUID), start_time DateTime64(6, 'UTC'), _version UInt64, "
+        "is_deleted UInt8, end_time DateTime64(6, 'UTC'), cost Float64, "
+        "fixture_keys Array(String), fixture_values Array(String)"
+    )
+    literals = escape_params(
+        {
+            "columns": columns,
+            "rows": tuple(rows),
+            "users": tuple(
+                (str(UUID(int=n)), FOREIGN if n == 110 else PROJECT)
+                for n in (10, 20, 30, 40, 50, 60, 70, 80, 100, 110, 120)
+            ),
+            "remaps": (
+                (str(UUID(int=10)), str(UUID(int=90))),
+                (str(UUID(int=50)), str(UUID(int=90))),
+            ),
+            "org": PROJECT,
+            "start": START.replace(tzinfo=None).isoformat(" "),
+        },
+        CONTEXT,
+    )
+    query = f"""WITH spans AS (
+        SELECT *, id AS trace_id, mapFromArrays(fixture_keys, fixture_values) AS attrs_string,
+            CAST(map(), 'Map(String, Float64)') AS attrs_number,
+            CAST(map(), 'Map(String, UInt8)') AS attrs_bool,
+            toUInt64(1) AS total_tokens, toUInt64(1) AS prompt_tokens,
+            toUInt64(0) AS completion_tokens
+        FROM values({literals["columns"]}, {literals["rows"][1:-1]})
+    ), end_users AS (
+        SELECT *, toUUID({literals["org"]}) AS organization_id,
+            toString(end_user_id) AS user_id, 'custom' AS user_id_type,
+            toUInt64(0) AS user_id_hash, toUInt8(0) AS is_deleted,
+            toDateTime64({literals["start"]}, 6, 'UTC') AS first_seen, first_seen AS version
+        FROM values('end_user_id UUID, project_id UUID', {literals["users"][1:-1]})
+    ), end_user_id_remap AS (
+        SELECT * FROM values('old_id UUID, new_id UUID', {literals["remaps"][1:-1]})
+    ), {rendered.lstrip()[4:]}
+    SETTINGS max_threads=1, max_execution_time=5, max_memory_usage=268435456
+    """
+    return [
+        json.loads(line)
+        for line in str(engine.query(values_where(query), "JSONEachRow")).splitlines()
+        if line
+    ]
+
+
+@pytest.mark.parametrize("days", [7, 30, 365])
+@pytest.mark.parametrize(
+    "needle,op",
+    [
+        ("123456", "equals"),
+        (LONG, "equals"),
+        ("Alpha", "in"),
+        ("\N{KELVIN SIGN}ey", "equals"),
+        ("\N{KELVIN SIGN}" * 10, "in"),
+        ("123456", "typed_in"),
+        (LONG, "typed_in"),
+    ],
+    ids=[
+        "digit-string",
+        "long-text",
+        "multi-value",
+        "kelvin",
+        "many-kelvins",
+        "picker",
+        "long-picker",
+    ],
+)
+def test_native_candidates_preserve_corrected_users_full_metrics_and_pagination(
+    days, needle, op
+):
+    rows = population(needle)
+    expected = (
+        [needle.lower()]
+        if op == "typed_in"
+        else [needle.lower(), "another"]
+        if op == "in"
+        else needle.lower()
+    )
+    item = leaf(expected, op)
+    actual = execute(rows, [item], days=days)
+    assert actual == execute(rows, [item], days=days, redundant_membership=True)
+    by_user = {row["end_user_id"]: row for row in actual}
+    # Removed-field and reassigned-old-user witnesses remain conservative; final
+    # membership is decided later. Never-matched users are safely pruned here.
+    assert set(by_user) == {str(UUID(int=n)) for n in (10, 20, 40, 100, 120)}
+    baseline = execute(rows, [], days=days)
+    assert actual == [row for row in baseline if row["end_user_id"] in by_user]
+    assert by_user[str(UUID(int=10))]["total_cost"] == 9
+    assert int(by_user[str(UUID(int=10))]["num_traces"]) == 2
+    assert by_user[str(UUID(int=20))]["total_cost"] == 3
+    assert by_user[str(UUID(int=40))]["total_cost"] == 4
+    paged, cursor = [], None
+    for _ in range(4):
+        page = execute(rows, [item], days=days, before=cursor, limit=2)
+        if not page:
+            break
+        paged.extend(page)
+        cursor = (
+            datetime.fromisoformat(page[-1]["last_active"]),
+            page[-1]["end_user_id"],
+        )
+    assert paged == actual

--- a/futureagi/tracer/tests/test_users_text_witness_cross_types.py
+++ b/futureagi/tracer/tests/test_users_text_witness_cross_types.py
@@ -1,0 +1,174 @@
+"""Offline Users seed/matcher contracts; synthetic typed rows, no SQL execution."""
+
+import json
+from copy import deepcopy
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+from tracer.services.users_list_manager import UsersListManager
+from tracer.tests.test_user_attribute_native_key_collision import PROJECT, UID, wire
+from tracer.tests.test_user_latest_window_replay import builder
+
+pytestmark = pytest.mark.unit
+
+
+def leaf(key, value=None, *, op="equals", types=None, **kwargs):
+    item = wire(key, value, **kwargs)
+    item["filter_config"]["filter_op"] = op
+    if types is not None:
+        item["filter_config"]["attribute_value_types"] = types
+    return item
+
+
+def witness(items):
+    query = builder()
+    query.filters = deepcopy(items)
+    return query._positive_scalar_user_witness()
+
+
+def collected(items, stored):
+    manager = UsersListManager(
+        organization_id=PROJECT,
+        allowed_project_ids=[PROJECT],
+        requested_columns=[],
+        filters=deepcopy(items),
+    )
+    row = {"end_user_id": UID, "user_id": "display", "bool_eval_pass_rate": 1}
+    data = [
+        {
+            "end_user_id": UID,
+            "attribute_key": key,
+            "attribute_typed_values": [
+                (kind, json.dumps(value)) for kind, value in values
+            ],
+        }
+        for key, values in stored.items()
+    ]
+    # Exercise the real collector and provenance cache; intercept the service
+    # before any query can reach a database. Relation membership is preclassified.
+    with patch("tracer.services.users_list_manager.V2AnalyticsQueryService") as service:
+        service.return_value.execute_ch_query.return_value = SimpleNamespace(data=data)
+        attrs = manager._read_span_attributes([row], None)
+    manager._apply_span_attributes([row], attrs)
+    manager._relation_matching_user_ids = {UID}
+    return manager, row
+
+
+@pytest.mark.parametrize(
+    "selected,kind",
+    [(7, "number"), (True, "boolean"), ("7", "number"), ("true", "boolean")],
+)
+def test_mixed_picker_cannot_drop_non_string_matches(selected, kind):
+    item = leaf("picker", ["Alpha", selected], op="in", types=["string", kind])
+    assert witness([item]) == ("", {})
+    actual = 7 if kind == "number" else True
+    for stored, expected in [
+        ([("string", "ALPHA")], True),
+        ([(kind, actual)], True),
+        ([("string", str(selected).lower())], False),
+        ([], False),
+    ]:
+        manager, row = collected([item], {"picker": stored})
+        assert manager._row_matches_filters(row) is expected
+        assert (
+            manager._attribute_value_types_by_user.get(UID, {}).get("picker", {})
+            or not stored
+        )
+        anchor = leaf("tag", "Alpha")
+        manager, row = collected(
+            [item, anchor], {"picker": stored, "tag": [("string", "ALPHA")]}
+        )
+        assert witness([item, anchor]) == witness([anchor])
+        assert manager._row_matches_filters(row) is expected
+
+
+COMPANIONS = {
+    "number": leaf("amount", 7, kind="number"),
+    "boolean": leaf("enabled", True, kind="boolean"),
+    "negative": leaf("state", "blocked", op="not_equals"),
+    "missing": leaf("absent", op="is_null"),
+    "json": leaf("payload", {"flag": True}, kind="map", op="contains"),
+    "annotation": leaf("tag", "approved", source="ANNOTATION"),
+    "eval": leaf("tag", "passed", source="EVAL_METRIC"),
+    "native": leaf("user_id", "display", source="SYSTEM_METRIC"),
+    "mixed": leaf(
+        "picker", ["other", 7, True], op="in", types=["string", "number", "boolean"]
+    ),
+}
+STORED = {
+    "tag": [("string", "ALPHA"), ("number", 999)],
+    "amount": [("number", 7)],
+    "enabled": [("boolean", True)],
+    "state": [("string", "allowed")],
+    "payload": [("json", {"flag": True})],
+    "picker": [("number", 7)],
+    "user_id": [("string", "raw-different")],
+}
+
+
+@pytest.mark.parametrize("op", ["equals", "in"])
+@pytest.mark.parametrize("width", [2, 5, 10])
+@pytest.mark.parametrize("family", list(COMPANIONS))
+def test_cross_property_and_membership_keeps_necessary_seed_superset(op, width, family):
+    names = [family, *(name for name in COMPANIONS if name != family)]
+    anchor = leaf("tag", "Alpha" if op == "equals" else ["Alpha", "Beta"], op=op)
+    items = [anchor, *(COMPANIONS[name] for name in names[: width - 1])]
+    original = deepcopy(items)
+    for ordered in (items, list(reversed(items))):
+        seed = witness(ordered)
+        assert seed[0]
+        selected = next(item for item in ordered if witness([item]) == seed)
+        assert selected["filter_config"]["col_type"] == "SPAN_ATTRIBUTE"
+        assert selected["filter_config"]["filter_op"] in {"equals", "in"}
+        manager, row = collected(ordered, STORED)
+        assert manager._row_matches_filters(row)
+        assert manager._attribute_value_matches(
+            row=row, key=selected["column_id"], config=selected["filter_config"]
+        )
+        # Every AND leaf is required, even though acquisition may use just one.
+        for item in ordered:
+            attrs = deepcopy(manager._attribute_values_by_user)
+            key, cfg = item["column_id"], item["filter_config"]
+            if cfg["col_type"] in {"ANNOTATION", "EVAL_METRIC"}:
+                manager._relation_matching_user_ids.clear()
+            elif cfg["col_type"] == "SYSTEM_METRIC":
+                row["user_id"] = "wrong"
+            elif cfg["filter_op"] == "is_null":
+                manager._attribute_values_by_user[UID][key] = "present"
+            else:
+                manager._attribute_values_by_user[UID].pop(key, None)
+            assert not manager._row_matches_filters(row), (family, width, item)
+            manager._attribute_values_by_user = attrs
+            manager._relation_matching_user_ids = {UID}
+            row["user_id"] = "display"
+    assert items == original
+
+
+@pytest.mark.parametrize(
+    "key,source,value",
+    [
+        ("tag", "ANNOTATION", "approved"),
+        ("tag", "EVAL_METRIC", "passed"),
+        ("user_id", "SYSTEM_METRIC", "display"),
+        ("eval_score", "SYSTEM_METRIC", "1"),
+    ],
+)
+@pytest.mark.parametrize("op", ["equals", "in"])
+def test_relation_and_native_matches_do_not_require_raw_text(key, source, value, op):
+    item = leaf(key, [value] if op == "in" else value, source=source, op=op)
+    manager, row = collected([item], {})
+    assert manager._row_matches_filters(row)
+    assert witness([item]) == ("", {})
+    anchor = leaf("tag", "Alpha")
+    assert witness([item, anchor]) == witness([anchor])
+
+
+@pytest.mark.parametrize("op", ["equals", "in"])
+def test_raw_eval_score_attribute_keeps_its_own_witness(op):
+    item = leaf("eval_score", ["Alpha"] if op == "in" else "Alpha", op=op)
+    assert witness([item])[0]
+    for stored, matches in [([], False), ([("string", "ALPHA")], True)]:
+        manager, row = collected([item], {"eval_score": stored})
+        assert manager._row_matches_filters(row) is matches

--- a/futureagi/tracer/tests/test_users_unseeded_hour_replay.py
+++ b/futureagi/tracer/tests/test_users_unseeded_hour_replay.py
@@ -1,0 +1,286 @@
+"""Unseeded Users replay on constant fixtures; no table creation or writes."""
+
+import json
+from datetime import UTC, datetime, timedelta
+
+import pytest
+from clickhouse_driver.util.escape import escape_params
+
+from tracer.services.clickhouse.v2.query_builders.user_list import (
+    UserListQueryBuilderV2,
+)
+from tracer.tests.test_user_latest_window_replay import cte
+from tracer.tests.test_users_attribute_physical_replay import (
+    CONTEXT,
+    values_where,
+    without_query_settings,
+)
+
+P = "11111111-1111-4111-8111-111111111111"
+U = "22222222-2222-4222-8222-222222222222"
+A = "33333333-3333-4333-8333-333333333333"
+R = "44444444-4444-4444-8444-444444444444"
+START = datetime(2026, 9, 1, 12, 15, tzinfo=UTC)
+
+
+def query(days, change, *, window_start=START, window_end=None):
+    builder = UserListQueryBuilderV2(organization_id=P, project_ids=[P], filters=[])
+    sql, params = builder.build_dimension_candidate_query(
+        limit=26,
+        window_start=window_start,
+        window_end=window_end or START + timedelta(days=days),
+    )
+    base = {
+        "project_id": P,
+        "observation_type": "SPAN",
+        "service_name": "service",
+        "trace_id": "trace",
+        "id": "span",
+        "start_time": START + timedelta(minutes=15),
+        "end_time": START + timedelta(minutes=16),
+        "end_user_id": U,
+        "_version": 1,
+        "cost": 1.25,
+        "total_tokens": 8,
+        "prompt_tokens": 3,
+        "completion_tokens": 5,
+        "is_deleted": 0,
+        "trace_session_id": None,
+    }
+    later = {**base, "_version": 2, **change}
+    types = "project_id UUID, observation_type String, service_name String, trace_id String, id String, start_time DateTime64(6, 'UTC'), end_time Nullable(DateTime64(6, 'UTC')), end_user_id Nullable(UUID), _version UInt64, cost Float64, total_tokens Int32, prompt_tokens Int32, completion_tokens Int32, is_deleted UInt8, trace_session_id Nullable(UUID)"
+
+    def encode(row):
+        return tuple(
+            v.replace(tzinfo=None).isoformat(sep=" ") if isinstance(v, datetime) else v
+            for v in row.values()
+        )
+
+    literals = escape_params(
+        {
+            "schema": types,
+            "rows": (encode(base), encode(later)),
+            "p": P,
+            "u": U,
+            "a": A,
+            "r": R,
+            "time": START.replace(tzinfo=None).isoformat(sep=" "),
+        },
+        CONTEXT,
+    )
+    prefix = f"""WITH spans AS (SELECT * FROM values({literals["schema"]},{literals["rows"][1:-1]})),
+end_users AS (SELECT toUUID({literals["p"]}) AS project_id,toUUID({literals["p"]}) AS organization_id,toUUID({literals["u"]}) AS end_user_id,'fixture-user' AS user_id,'custom' AS user_id_type,toUInt64(1) AS user_id_hash,toDateTime64({literals["time"]},6,'UTC') AS first_seen,first_seen AS version,toUInt8(0) AS is_deleted),
+end_user_id_remap AS (SELECT * FROM values('old_id UUID, new_id UUID',({literals["u"]},{literals["r"]}),({literals["a"]},{literals["r"]}))),"""
+
+    def render(text):
+        text = without_query_settings(text) % escape_params(params, CONTEXT)
+        text = text.replace("end_user_id_remap FINAL", "end_user_id_remap").replace(
+            "end_users AS eu FINAL", "end_users AS eu"
+        )
+        return values_where(prefix + text.lstrip()[4:])
+
+    return render(sql)
+
+
+@pytest.mark.parametrize("days", [7, 30, 365])
+@pytest.mark.parametrize(
+    "change, present",
+    [
+        ({}, True),
+        ({"end_user_id": A}, True),
+        ({"is_deleted": 1}, False),
+        ({"end_user_id": None}, False),
+        ({"end_time": None}, True),
+        ({"start_time": START - timedelta(minutes=5)}, False),
+        ({"service_name": "other", "is_deleted": 1}, True),
+        (
+            {"cost": 0, "total_tokens": 0, "prompt_tokens": 0, "completion_tokens": 0},
+            True,
+        ),
+    ],
+)
+def test_unseeded_users_latest_state(days, change, present):
+    engine = pytest.importorskip("chdb")
+    sql = query(days, change)
+    assert "candidate_span_identities" not in sql
+    rows = [
+        json.loads(line)
+        for line in str(engine.query(sql, "JSONEachRow")).splitlines()
+        if line
+    ]
+    assert len(rows) == int(present)
+    if present:
+        row = rows[0]
+        assert row["end_user_id"] == U
+        assert row["total_cost"] == change.get("cost", 1.25)
+        assert int(row["total_tokens"]) == change.get("total_tokens", 8)
+        assert int(row["num_traces"]) == 1
+        if "end_time" in change:
+            assert row["last_active"] is None
+
+
+@pytest.mark.parametrize("days", [7, 30, 365])
+@pytest.mark.parametrize(
+    "boundary",
+    ["start_same_hour", "start_previous_hour", "end_same_hour", "end_next_hour"],
+)
+@pytest.mark.parametrize("deleted", [0, 1])
+def test_unseeded_users_window_identity_boundaries(days, boundary, deleted):
+    engine = pytest.importorskip("chdb")
+    times = {
+        "start_same_hour": START - timedelta(minutes=5),
+        "start_previous_hour": START - timedelta(hours=1),
+        "end_same_hour": START + timedelta(days=days, minutes=5),
+        "end_next_hour": START + timedelta(days=days, hours=1),
+    }
+    sql = query(days, {"start_time": times[boundary], "is_deleted": deleted})
+    rows = [
+        json.loads(line)
+        for line in str(engine.query(sql, "JSONEachRow")).splitlines()
+        if line
+    ]
+    # A different hour is a different physical key; it cannot replace the
+    # original live row. Within its hour, a correction outside the window does.
+    assert len(rows) == (0 if boundary == "start_same_hour" else 1)
+    if rows:
+        assert rows[0]["total_cost"] == 1.25
+        assert rows[0]["end_user_id"] == U
+
+
+@pytest.mark.parametrize(
+    "lower,upper,correction,present",
+    [
+        (-1, 0, 0, False),
+        (0, 1, 0, True),
+        (1, 2, 0, False),
+        (1, 2, 1, True),
+        (0, 1, 1, False),
+        (-1, 0, -1, True),
+        (0, 1, -1, False),
+    ],
+)
+def test_unseeded_replay_keeps_microsecond_half_open_window(
+    lower, upper, correction, present
+):
+    engine = pytest.importorskip("chdb")
+    physical_start = START + timedelta(minutes=15)
+    sql = query(
+        7,
+        {"start_time": physical_start + timedelta(microseconds=correction)},
+        window_start=physical_start + timedelta(microseconds=lower),
+        window_end=physical_start + timedelta(microseconds=upper),
+    )
+    rows = [
+        json.loads(line)
+        for line in str(engine.query(sql, "JSONEachRow")).splitlines()
+        if line
+    ]
+    assert len(rows) == int(present)
+    if present:
+        assert rows[0]["total_cost"] == 1.25
+
+
+@pytest.mark.parametrize("deleted", [0, 1])
+def test_unseeded_replay_at_exact_hour_boundary(deleted):
+    engine = pytest.importorskip("chdb")
+    next_hour = START.replace(hour=13, minute=0)
+    sql = query(
+        7,
+        {"start_time": next_hour, "is_deleted": deleted},
+        window_start=next_hour,
+        window_end=next_hour + timedelta(microseconds=1),
+    )
+    rows = [
+        json.loads(line)
+        for line in str(engine.query(sql, "JSONEachRow")).splitlines()
+        if line
+    ]
+    assert len(rows) == (0 if deleted else 1)
+    if rows:
+        assert rows[0]["total_cost"] == 1.25
+
+
+def _window_filter(days=7):
+    return {
+        "column_id": "created_at",
+        "filter_config": {
+            "filter_type": "datetime",
+            "filter_op": "between",
+            "filter_value": [
+                START.isoformat(),
+                (START + timedelta(days=days)).isoformat(),
+            ],
+        },
+    }
+
+
+def _text_leaf(value):
+    return {
+        "column_id": "tag",
+        "filter_config": {
+            "col_type": "SPAN_ATTRIBUTE",
+            "filter_type": "text",
+            "filter_op": "equals",
+            "filter_value": value,
+        },
+    }
+
+
+HOUR_LOWER = "AND toStartOfHour(start_time) >= toStartOfHour( fromUnixTimestamp64Micro(%(user_window_start_us)s, 'UTC') )"
+HOUR_UPPER = "AND toStartOfHour(start_time) < fromUnixTimestamp64Micro( %(user_window_end_us)s, 'UTC' )"
+DIMENSION_SEMIJOIN = "IN ( SELECT end_user_id FROM filtered_end_users )"
+
+
+def _candidate_sql(**kwargs):
+    builder = UserListQueryBuilderV2(
+        organization_id=P,
+        project_ids=[P],
+        filters=[_window_filter(), *kwargs.pop("extra_filters", [])],
+        **kwargs,
+    )
+    sql, _ = builder.build_dimension_candidate_query(limit=26)
+    return " ".join(sql.split())
+
+
+def test_unseeded_read_replays_hours_and_keeps_dimension_membership():
+    """Unseeded acquisition drops the identity CTE but still bounds aggregation."""
+
+    sql = _candidate_sql()
+
+    assert "candidate_span_identities AS (" not in sql
+    assert HOUR_LOWER in sql
+    assert HOUR_UPPER in sql
+    # The identity superset is the only thing removed: the exact_usage
+    # semijoin still bounds aggregation to the curated dimension.
+    assert DIMENSION_SEMIJOIN in cte(sql, "exact_usage")
+
+
+def test_seeded_read_retains_the_identity_superset():
+    """end_user_id is mutable, so a seeded scan must keep the identity set."""
+
+    builder = UserListQueryBuilderV2(
+        organization_id=P,
+        project_ids=[P],
+        filters=[_window_filter()],
+        candidate_end_user_ids=[U],
+        candidate_scan_end_user_ids=[U],
+        candidate_end_user_id_map={U: U},
+        limit=25,
+        offset=0,
+    )
+    sql, _ = builder.build_candidate_page_query()
+    sql = " ".join(sql.split())
+
+    assert "candidate_span_identities AS (" in sql
+    assert HOUR_LOWER not in sql
+    assert HOUR_UPPER not in sql
+
+
+def test_scalar_acquisition_drops_the_redundant_dimension_semijoin():
+    """With a scalar witness the final INNER JOIN already applies membership."""
+
+    sql = _candidate_sql(extra_filters=[_text_leaf("alpha")])
+
+    assert "scalar_witness_identities AS (" in sql
+    assert DIMENSION_SEMIJOIN not in cte(sql, "exact_usage")
+    assert "INNER JOIN exact_usage AS xu ON xu.end_user_id = eu.end_user_id" in sql

--- a/scripts/qa/replay_observe_queries_readonly.py
+++ b/scripts/qa/replay_observe_queries_readonly.py
@@ -383,20 +383,31 @@ _USERS_ORIGIN_SHAS = frozenset(
         # ``candidate_span_identities`` CTE.
         "ba51ea62b5e2f3831b6d9d1e4ab345283c068af90f1795bb7b7082526cd4d4e5",
         # FILTERS = the same date filter plus ONE exact-text attribute filter
-        # (``col_type`` SPAN_ATTRIBUTE, ``filter_type`` text, ``filter_op``
-        # equals, a single non-empty ASCII value). That qualifies a scalar text
-        # witness, so ``scalar_witness_identities`` is present and the
-        # manager's own first batch is 65 rows.
+        # (``col_type`` SPAN_ATTRIBUTE, ``filter_type`` text or string,
+        # ``filter_op`` equals, a single non-empty ASCII value). That qualifies
+        # a scalar text witness, so ``scalar_witness_identities`` is present and
+        # the manager's own first batch is 65 rows.
         "7b8c40bf16c6d1a869f19c75d26304d755298c7016ac451233958599369f3f51",
+        # The same filter as a one-value picker, ``filter_op`` ``in`` with
+        # ``filter_value`` ["<ascii>"] and no ``attribute_value_types``.
+        "b99fe9116aba205e3d4e36a2251630e9772307622759e970b98f4648db2f95bf",
+        # ... and the typed one-value picker, the same plus
+        # ``attribute_value_types`` ["string"].
+        "40aca43c4986c4b67e5d8b99ae753c347c7101d29735d7edf9f3de139ef97c95",
     }
 )
-# Deliberately NOT pinned: a multi-value picker (``filter_op`` ``in`` with N
-# values) also reaches the 65-row batch, but it binds one parameter per value,
-# so its statement text -- and its digest -- changes with N; pinning any single
-# N would certify one cardinality and silently reject the rest. Those reads, the
-# user_id label witness, the search shape and the numeric witness all fail
-# closed with USERS_REMAP_ORIGIN_NOT_QUALIFIED until a lane reviews and pins
-# them here, which is the safe direction.
+# Deliberately NOT pinned, measured rather than assumed: a picker with N > 1
+# values binds one parameter per value, so its statement text -- and its digest
+# -- changes with EVERY cardinality (2 untyped, 2 typed, 3 ... are all distinct
+# statements). A digest set cannot enumerate that, so those reads fail closed
+# with USERS_REMAP_ORIGIN_NOT_QUALIFIED, as do the user_id label witness, the
+# search shape and the numeric witness. Closing the N > 1 hole needs a pin that
+# is normalized over the value count, not more digests; until then the Users
+# certificate covers the unseeded page and single-value exact-text acquisition.
+# For the record, at origin/dev every one of these text shapes collapsed to the
+# single no-witness statement 7120eaf1..., because no text witness qualified
+# there; the fan-out is a consequence of the scalar text witness, and the pins
+# above are what keeps the single-value cases certifiable across it.
 _USERS_REMAP_SHA = "090df268267944b22e713077c59d4836e4046fadb60bfbb78116f3a43af46676"
 # Source pins: sha256 of the *file bytes* backing each imported module, i.e.
 # ``sha256(Path(import_module(name).__file__).read_bytes())``. Re-pin with

--- a/scripts/qa/replay_observe_queries_readonly.py
+++ b/scripts/qa/replay_observe_queries_readonly.py
@@ -354,10 +354,11 @@ def diagnostic_read_settings(
     return limits
 
 
-# SQL pins: sha256 of the statement text the deployed builders emit for each
-# REVIEWED first-page origin shape. The Users read path emits more than one
-# shape, so this is a set of reviewed statements, never a blanket exemption for
-# Users queries: the run stays bound to the one shape it actually selected.
+# SQL pins: the canonical digest of the statement the deployed builders emit
+# for each REVIEWED first-page origin SHAPE. The Users read path emits more
+# than one shape, so this is a set of reviewed statements, never a blanket
+# exemption for Users queries: the run stays bound to the one shape it actually
+# selected.
 #
 # Recompute offline against the checked-in builders -- no connection, no
 # production access. From ``futureagi/`` with ``PYTHONPATH=.`` and every
@@ -369,105 +370,48 @@ def diagnostic_read_settings(
 #     sql, _ = b.build_dimension_candidate_query(
 #         limit=26, window_start=datetime(2026, 9, 3, 0, 0, tzinfo=timezone.utc),
 #         window_end=datetime(2026, 9, 3, 4, 0, tzinfo=timezone.utc))
-#     hashlib.sha256(sql.strip().rstrip(";").encode()).hexdigest()
+#     _users_origin_digest(sql)
 #
-# ``.strip().rstrip(";")`` is exactly the normalization ``validate_select``
-# applies before the statement runs, so one digest covers both check sites.
-# Organization, projects, window, ``limit`` and the attribute key AND value are
-# all *bindings*, so none of them enters the digest: limit 26 and limit 65 hash
-# identically, and so do two different attribute keys or values.
-_USERS_ORIGIN_SHAS_SCALAR = frozenset(
-    {
-        # FILTERS = a ``created_at`` between filter only (unseeded first page).
-        # Post immutable-hour replay this statement carries no
-        # ``candidate_span_identities`` CTE.
-        "ba51ea62b5e2f3831b6d9d1e4ab345283c068af90f1795bb7b7082526cd4d4e5",
-        # FILTERS = the same date filter plus ONE exact-text attribute filter
-        # (``col_type`` SPAN_ATTRIBUTE, ``filter_type`` text or string,
-        # ``filter_op`` equals, a single non-empty ASCII value). That qualifies
-        # a scalar text witness, so ``scalar_witness_identities`` is present and
-        # the manager's own first batch is 65 rows.
-        "7b8c40bf16c6d1a869f19c75d26304d755298c7016ac451233958599369f3f51",
-    }
-)
-# The multi-value text picker family, ENUMERATED rather than normalized.
+# Organization, projects, window, ``limit``, the attribute key, the attribute
+# VALUES and -- since the digest is canonical -- HOW MANY values the filter
+# selected are all outside the digest. What remains is the statement's shape:
+# which witness qualified, and whether the legacy ASCII bloom hint was emitted
+# alongside the UTF-8 one. Measured on this tree, 51 filter cases spanning
+# ``equals`` and ``in`` at 1, 2, 3, 5, 10, 11, 12 and 40 values, typed and
+# untyped, ASCII and non-ASCII, values containing the letter ``k``, selected
+# lists whose lowercased values collide, and two-filter conjunctions, produce
+# exactly these SEVEN statements and no others.
 #
-# The same date filter plus ONE SPAN_ATTRIBUTE ``in`` filter over N non-empty
-# ASCII values. ``filter_type`` text and string are the same statement
-# (measured); each row is (untyped, typed), where typed is the same filter plus
-# ``attribute_value_types`` ["string"] * N.
-#
-# Why one digest per cardinality instead of one digest for the family: the
-# semantic comparison already binds the whole value list as ONE parameter
-# (``... IN %(latest_filter_param_0)s``), but the companion bloom index hint
-# spells one placeholder per value --
-# ``indexHint(hasAny(arrayMap(x -> lowerUTF8(x), mapValues(span_attr_str)),
-# [%(latest_filter_index_0_0)s, ...]))`` -- so the statement text, and its
-# digest, changes with every value count. That hint is built in
-# ``tracer/services/clickhouse/query_builders/latest_filter_predicates.py``
-# (the untyped path, the typed path and ``_legacy_ascii_lower_bloom_predicate``),
-# a module shared by the trace-list, graph and dashboard reads whose parameter
-# NAMES are themselves asserted by three tracer contract tests. Binding that
-# list as a single array parameter would therefore rewrite the SQL of every
-# trace ``in`` filter in the product, so this harness enumerates the Users
-# cardinalities it certifies instead.
-#
-# A picker with MORE than ``_USERS_PICKER_MAX_VALUES`` values is deliberately
-# not pinned: those reads fail closed with USERS_REMAP_ORIGIN_NOT_QUALIFIED, as
-# do the user_id label witness, the search shape and the numeric witness. A
-# picker whose ``attribute_value_types`` length does not match its value count
-# qualifies no witness at all and lands on the unseeded pin above (measured).
-#
-# For the record, at origin/dev every one of these text shapes collapsed to the
-# single no-witness statement 7120eaf1..., because no text witness qualified
-# there; the fan-out is a consequence of the scalar text witness this branch
-# adds, and these pins are what keeps the picker certifiable across it.
-_USERS_PICKER_MAX_VALUES = 10
-_USERS_PICKER_SHAS = {
-    1: (
-        "b99fe9116aba205e3d4e36a2251630e9772307622759e970b98f4648db2f95bf",
-        "40aca43c4986c4b67e5d8b99ae753c347c7101d29735d7edf9f3de139ef97c95",
-    ),
-    2: (
-        "0dc77973b3a9c7c3eacb2c37943e439c709ee35232bc30d271e63aeed7154612",
-        "f5a13c045c337014fa21e57d139d9b380c4a7fedbc05402f93d5c2be3b39faa2",
-    ),
-    3: (
-        "849a7f0a2542c64882bdcf00bccc889e1c62b27f7729fdead328559eddce8c98",
-        "e8beb9b5daeec8b5699804ec9c5802ed82c2c787d251d24a648bd38f5950cf77",
-    ),
-    4: (
-        "1efb0c5477807208646d7f2ceac40a946c32d6e25f03a10ad656a188aabea757",
-        "a49a6e4670afbd28f106c037c26452043a576d8241c97d645c9d38adcfb28649",
-    ),
-    5: (
-        "77bc55de75b83e45413285a8fb1116b3bcf6bd79362fcfc6f2f485fd1d616595",
-        "764dc8e78cd590e2e1cf15434f24d95c1578dadee001e2efc50283f736556029",
-    ),
-    6: (
-        "7a15dab679985e9ff39a471cf93dba4ae11a1a23ac323fb62c613fb057316b2e",
-        "e7ad782d0f84c7c11a3ec7556ad2f42e35bbb82bbe967e4c4d3a21f27f2eecf2",
-    ),
-    7: (
-        "e5f6ff0c215b731cb99b42841f751d37ff290ff26080f500be93f347b884b6a1",
-        "fa1acd4cdf2b8a24776bf5d0d115eb362f3eda09be1a889996b9599826b18720",
-    ),
-    8: (
-        "bc89dbc689fbfde1cc8fa4b48b33a15c5b774bb4982af066f231c74b8282ec31",
-        "fc2a73b32fff7c1929e319b8b04cda789a82511a268c59766f7df7f8cf552566",
-    ),
-    9: (
-        "c9ec1b9af50206dd0f92d7973b256eb1a51125096ad2a0a231584b456f58ebdd",
-        "bcd08b1074c104d87f26f1d00aeca0b9eccdb76a4a735385531b7e0a9e8a0f42",
-    ),
-    10: (
-        "ccafa8e0b5b60fb920ba1cfed07ddab9068218fe4e07581a249141883694f97d",
-        "baa699f10ef1657a6682fa4df1709e46a7871bfba4f2056edd126e32d14f4c1d",
-    ),
+# The user_id label witness, the search shape and the numeric witness are still
+# unpinned and still fail closed with USERS_REMAP_ORIGIN_NOT_QUALIFIED.
+_USERS_ORIGIN_SHAPES = {
+    # A ``created_at`` between filter only, or any attribute filter that
+    # qualifies no exact-text witness at all: a non-ASCII value, a typed
+    # ``equals``, ``contains``, or an ``attribute_value_types`` list whose
+    # length does not match the value count (all measured). Post immutable-hour
+    # replay this statement carries no ``candidate_span_identities`` CTE.
+    "no_text_witness": "ba51ea62b5e2f3831b6d9d1e4ab345283c068af90f1795bb7b7082526cd4d4e5",
+    # ONE exact-text ``equals`` attribute filter (``col_type`` SPAN_ATTRIBUTE,
+    # ``filter_type`` text or string, a single non-empty ASCII value). That
+    # qualifies a scalar text witness, so ``scalar_witness_identities`` is
+    # present and the manager's own first batch is 65 rows.
+    "equals_legacy_hint": "2ed448d2766b8c308fa1b0444e60ecb3f8e029b271d16d8213c273962071efff",
+    # The same ``equals`` page where the legacy ASCII bloom companion declines:
+    # its Kelvin-sign enumeration would exceed 256 variants, which happens from
+    # nine letters ``k`` in the value upward.
+    "equals_hint_declined": "7c0d4b58ce47ec327a81c24823fc244c2ea53db321a6a300c7047c51812e0e41",
+    # ONE SPAN_ATTRIBUTE ``in`` filter over N non-empty ASCII values, no
+    # ``attribute_value_types``: the multi-value text picker.
+    "in_untyped_legacy_hint": "2425607883cc46c175bfc90c2d8ee893197652689efa820aa35e2c6d47118459",
+    # The same picker page with the legacy companion declined.
+    "in_untyped_hint_declined": "c13be35214e3ee409cbe1c507b3bf14b0ec70b8f77415a3e71194b2bcea8e535",
+    # The typed picker: the same filter plus ``attribute_value_types``
+    # ["string"] * N, which spells its own parameter suffix.
+    "in_typed_legacy_hint": "c9548fd80a39b70b7fd03bc9278882030d38a8311f5477d79bdade711f49930a",
+    # The typed picker with the legacy companion declined.
+    "in_typed_hint_declined": "d52ec8b85ceeef5d29812a48840542ab692634367dafc777caea629be1a97352",
 }
-_USERS_ORIGIN_SHAS = _USERS_ORIGIN_SHAS_SCALAR | frozenset(
-    digest for pair in _USERS_PICKER_SHAS.values() for digest in pair
-)
+_USERS_ORIGIN_SHAS = frozenset(_USERS_ORIGIN_SHAPES.values())
 _USERS_REMAP_SHA = "090df268267944b22e713077c59d4836e4046fadb60bfbb78116f3a43af46676"
 # Source pins: sha256 of the *file bytes* backing each imported module, i.e.
 # ``sha256(Path(import_module(name).__file__).read_bytes())``. Re-pin with

--- a/scripts/qa/replay_observe_queries_readonly.py
+++ b/scripts/qa/replay_observe_queries_readonly.py
@@ -354,11 +354,26 @@ def diagnostic_read_settings(
     return limits
 
 
-# SQL pins: sha256 of the statement text the deployed builders emit for the
-# qualified origin shape (no user_id label witness, no numeric scalar witness).
-# ``limit`` is a *binding* (``LIMIT %(limit)s``), so one origin pin covers every
-# first-batch size. Recompute by building the same two statements against the
-# checked-in builders and hashing ``sql.strip().rstrip(";")``.
+# SQL pin: the canonical digest of the statement the deployed builders emit for
+# the qualified origin shape (no user_id label witness, no numeric scalar
+# witness). On this tree no attribute witness qualifies at all, so every
+# reviewed first-page filter shape is the SAME statement and one pin holds them.
+#
+# Recompute offline against the checked-in builders -- no connection, no
+# production access. From ``futureagi/`` with ``PYTHONPATH=.`` and every
+# DB/CH/Redis port pointed at a dead port, after ``django.setup()`` only::
+#
+#     b = UserListQueryBuilderV2(organization_id=str(UUID(int=11)),
+#                                project_ids=[str(UUID(int=12))],
+#                                filters=FILTERS, search="", empty_scope=False)
+#     sql, _ = b.build_dimension_candidate_query(
+#         limit=26, window_start=datetime(2026, 9, 3, 0, 0, tzinfo=timezone.utc),
+#         window_end=datetime(2026, 9, 3, 4, 0, tzinfo=timezone.utc))
+#     _users_origin_digest(sql)
+#
+# Organization, projects, window, ``limit`` and the attribute key AND value are
+# all *bindings*, so none of them enters the digest: limit 26 and limit 65 hash
+# identically, and so do two different attribute keys or values.
 _USERS_ORIGIN_SHA = "7120eaf17118a7ae3708911c7a61e88f46e8a2df1d59753463e5d99e0aacbeb9"
 _USERS_REMAP_SHA = "090df268267944b22e713077c59d4836e4046fadb60bfbb78116f3a43af46676"
 # Source pins: sha256 of the *file bytes* backing each imported module, i.e.
@@ -372,6 +387,82 @@ _USERS_SOURCE_PINS = {
     "tracer.services.clickhouse.v2.id_remap_sql": "56903f382c0f8dc40099e5ebfda45a8ab853c0b8f7ec16b5712f9c11092fe24a",
 }
 _CH_USER_ENV = "OBSERVE_CH_USER"
+
+
+# Origin statements are digested in a CANONICAL form, not as raw text: every
+# bracketed run of value-list placeholders collapses to a single token, and
+# nothing else changes. The Users read path spells ONE placeholder per selected
+# value in two companion bloom index hints built in
+# ``tracer/services/clickhouse/query_builders/latest_filter_predicates.py`` --
+# ``hasAny(arrayMap(x -> lowerUTF8(x), mapValues(span_attr_str)),
+# [%(latest_filter_index_0_0)s, ...])`` and, for all-ASCII values, the legacy
+# ``lower()`` companion ``[%(latest_filter_legacy_index_0_0)s, ...]``, whose
+# placeholder count is 2 ** (number of letters ``k`` in the values),
+# deduplicated. The raw statement text therefore fans out on BOTH the value
+# count AND the value text: ``equals "kid"``, ``equals "token"``, ``equals
+# "ok"`` and any selected-value list whose lowercased values collide are each a
+# different statement at the SAME cardinality, including cardinality 1.
+# Collapsing the ARITY of those two placeholder families -- and only theirs --
+# makes the digest depend on the statement's SHAPE: which witness qualified and
+# whether the legacy hint was emitted. Every other byte still enters the
+# digest: whitespace, keywords, columns, structure, the placeholder NAMES, and
+# the attribute-KEY list ``[%(latest_filter_key_0)s]`` whose trailing index is a
+# FILTER index rather than a value index. A builder change still fails closed.
+#
+# A bracketed, ``", "``-separated run of ``%(name)s`` placeholders, which is
+# exactly how the builder spells both hint lists.
+_ORIGIN_PLACEHOLDER_LIST_RE = re.compile(
+    r"\[%\([A-Za-z0-9_]+\)s(?:, %\([A-Za-z0-9_]+\)s)*\]"
+)
+_ORIGIN_PLACEHOLDER_NAME_RE = re.compile(r"%\(([A-Za-z0-9_]+)\)s")
+# The two parameter families the builder derives from a filter's value list:
+# ``latest_filter_index_<filter suffix>_<value index>`` and its legacy
+# companion. The value index is a canonical decimal, so ``_00`` is not ``_0``
+# and a renamed placeholder matches nothing and is left alone.
+_ORIGIN_VALUE_PARAM_RE = re.compile(
+    r"^(?P<stem>latest_filter_(?:legacy_)?index_[A-Za-z0-9_]*[A-Za-z0-9])"
+    r"_(?P<value_index>0|[1-9][0-9]*)$"
+)
+
+
+def _collapse_origin_value_list(match):
+    """Collapse one placeholder run iff it is a whole filter value list.
+
+    Every member must belong to the same value-list family and stem, and the
+    value indexes must be exactly ``0 .. n-1`` in order -- which is how the
+    builder emits them. Anything else is returned untouched, so an unexpected
+    list keeps its exact text and still fails the pin.
+    """
+
+    names = _ORIGIN_PLACEHOLDER_NAME_RE.findall(match.group(0))
+    parsed = [_ORIGIN_VALUE_PARAM_RE.match(name) for name in names]
+    if any(item is None for item in parsed):
+        return match.group(0)
+    stems = {item.group("stem") for item in parsed}
+    indexes = [int(item.group("value_index")) for item in parsed]
+    if len(stems) != 1 or indexes != list(range(len(indexes))):
+        return match.group(0)
+    return "[%(" + stems.pop() + "_*)s]"
+
+
+def _canonical_origin_sql(sql):
+    """Return the statement with value-list ARITY collapsed, nothing else."""
+
+    return _ORIGIN_PLACEHOLDER_LIST_RE.sub(_collapse_origin_value_list, sql)
+
+
+def _users_origin_digest(sql):
+    """Digest the canonical form of an origin statement.
+
+    ``.strip().rstrip(";")`` is exactly the normalization ``validate_select``
+    applies before the statement runs, so one digest covers both check sites:
+    the qualification check that selects the shape and the execute-time check
+    that re-verifies the statement actually handed to the driver.
+    """
+
+    return hashlib.sha256(
+        _canonical_origin_sql(sql.strip().rstrip(";")).encode()
+    ).hexdigest()
 
 
 def _users_sources_current():
@@ -536,7 +627,7 @@ class ReadOnlyExecutor:
             limit=origin_limit, window_start=replay.utc(case["window"]["start"]),
             window_end=replay.utc(case["window"]["end"]),
         )
-        if hashlib.sha256(sql.strip().rstrip(";").encode()).hexdigest() != _USERS_ORIGIN_SHA:
+        if _users_origin_digest(sql) != _USERS_ORIGIN_SHA:
             raise replay.ReplayError("USERS_REMAP_ORIGIN_NOT_QUALIFIED")
         self._users_context = _UsersRemapContext(
             tuple(_user_uuid(p) for p in projects), tuple(map(str, self.projects)),
@@ -606,9 +697,16 @@ class ReadOnlyExecutor:
                 raise
             self._validate_users_remap(query, params, pending)
             sql, certified = query, pending
-        if origin and (hashlib.sha256(sql.encode()).hexdigest() != _USERS_ORIGIN_SHA
-                       or replay.digest(safe_json(params)) != self._users_context.origin_bindings):
-            raise replay.ReplayError("USERS_REMAP_ORIGIN_BINDINGS_CHANGED")
+        # Same canonical digest as the qualification check above. The raw
+        # ``sql_sha256`` recorded below stays the exact executed text, so the
+        # ledger still carries the byte-for-byte statement that ran.
+        if origin:
+            bindings_digest = replay.digest(safe_json(params))
+            if (
+                _users_origin_digest(sql) != _USERS_ORIGIN_SHA
+                or bindings_digest != self._users_context.origin_bindings
+            ):
+                raise replay.ReplayError("USERS_REMAP_ORIGIN_BINDINGS_CHANGED")
         remaining = self.remaining_read_ms()
         if remaining <= 0:
             raise ReadDeadlineExceeded("diagnostic_safety_wall")

--- a/scripts/qa/replay_observe_queries_readonly.py
+++ b/scripts/qa/replay_observe_queries_readonly.py
@@ -376,7 +376,7 @@ def diagnostic_read_settings(
 # Organization, projects, window, ``limit`` and the attribute key AND value are
 # all *bindings*, so none of them enters the digest: limit 26 and limit 65 hash
 # identically, and so do two different attribute keys or values.
-_USERS_ORIGIN_SHAS = frozenset(
+_USERS_ORIGIN_SHAS_SCALAR = frozenset(
     {
         # FILTERS = a ``created_at`` between filter only (unseeded first page).
         # Post immutable-hour replay this statement carries no
@@ -388,26 +388,86 @@ _USERS_ORIGIN_SHAS = frozenset(
         # a scalar text witness, so ``scalar_witness_identities`` is present and
         # the manager's own first batch is 65 rows.
         "7b8c40bf16c6d1a869f19c75d26304d755298c7016ac451233958599369f3f51",
-        # The same filter as a one-value picker, ``filter_op`` ``in`` with
-        # ``filter_value`` ["<ascii>"] and no ``attribute_value_types``.
-        "b99fe9116aba205e3d4e36a2251630e9772307622759e970b98f4648db2f95bf",
-        # ... and the typed one-value picker, the same plus
-        # ``attribute_value_types`` ["string"].
-        "40aca43c4986c4b67e5d8b99ae753c347c7101d29735d7edf9f3de139ef97c95",
     }
 )
-# Deliberately NOT pinned, measured rather than assumed: a picker with N > 1
-# values binds one parameter per value, so its statement text -- and its digest
-# -- changes with EVERY cardinality (2 untyped, 2 typed, 3 ... are all distinct
-# statements). A digest set cannot enumerate that, so those reads fail closed
-# with USERS_REMAP_ORIGIN_NOT_QUALIFIED, as do the user_id label witness, the
-# search shape and the numeric witness. Closing the N > 1 hole needs a pin that
-# is normalized over the value count, not more digests; until then the Users
-# certificate covers the unseeded page and single-value exact-text acquisition.
+# The multi-value text picker family, ENUMERATED rather than normalized.
+#
+# The same date filter plus ONE SPAN_ATTRIBUTE ``in`` filter over N non-empty
+# ASCII values. ``filter_type`` text and string are the same statement
+# (measured); each row is (untyped, typed), where typed is the same filter plus
+# ``attribute_value_types`` ["string"] * N.
+#
+# Why one digest per cardinality instead of one digest for the family: the
+# semantic comparison already binds the whole value list as ONE parameter
+# (``... IN %(latest_filter_param_0)s``), but the companion bloom index hint
+# spells one placeholder per value --
+# ``indexHint(hasAny(arrayMap(x -> lowerUTF8(x), mapValues(span_attr_str)),
+# [%(latest_filter_index_0_0)s, ...]))`` -- so the statement text, and its
+# digest, changes with every value count. That hint is built in
+# ``tracer/services/clickhouse/query_builders/latest_filter_predicates.py``
+# (the untyped path, the typed path and ``_legacy_ascii_lower_bloom_predicate``),
+# a module shared by the trace-list, graph and dashboard reads whose parameter
+# NAMES are themselves asserted by three tracer contract tests. Binding that
+# list as a single array parameter would therefore rewrite the SQL of every
+# trace ``in`` filter in the product, so this harness enumerates the Users
+# cardinalities it certifies instead.
+#
+# A picker with MORE than ``_USERS_PICKER_MAX_VALUES`` values is deliberately
+# not pinned: those reads fail closed with USERS_REMAP_ORIGIN_NOT_QUALIFIED, as
+# do the user_id label witness, the search shape and the numeric witness. A
+# picker whose ``attribute_value_types`` length does not match its value count
+# qualifies no witness at all and lands on the unseeded pin above (measured).
+#
 # For the record, at origin/dev every one of these text shapes collapsed to the
 # single no-witness statement 7120eaf1..., because no text witness qualified
-# there; the fan-out is a consequence of the scalar text witness, and the pins
-# above are what keeps the single-value cases certifiable across it.
+# there; the fan-out is a consequence of the scalar text witness this branch
+# adds, and these pins are what keeps the picker certifiable across it.
+_USERS_PICKER_MAX_VALUES = 10
+_USERS_PICKER_SHAS = {
+    1: (
+        "b99fe9116aba205e3d4e36a2251630e9772307622759e970b98f4648db2f95bf",
+        "40aca43c4986c4b67e5d8b99ae753c347c7101d29735d7edf9f3de139ef97c95",
+    ),
+    2: (
+        "0dc77973b3a9c7c3eacb2c37943e439c709ee35232bc30d271e63aeed7154612",
+        "f5a13c045c337014fa21e57d139d9b380c4a7fedbc05402f93d5c2be3b39faa2",
+    ),
+    3: (
+        "849a7f0a2542c64882bdcf00bccc889e1c62b27f7729fdead328559eddce8c98",
+        "e8beb9b5daeec8b5699804ec9c5802ed82c2c787d251d24a648bd38f5950cf77",
+    ),
+    4: (
+        "1efb0c5477807208646d7f2ceac40a946c32d6e25f03a10ad656a188aabea757",
+        "a49a6e4670afbd28f106c037c26452043a576d8241c97d645c9d38adcfb28649",
+    ),
+    5: (
+        "77bc55de75b83e45413285a8fb1116b3bcf6bd79362fcfc6f2f485fd1d616595",
+        "764dc8e78cd590e2e1cf15434f24d95c1578dadee001e2efc50283f736556029",
+    ),
+    6: (
+        "7a15dab679985e9ff39a471cf93dba4ae11a1a23ac323fb62c613fb057316b2e",
+        "e7ad782d0f84c7c11a3ec7556ad2f42e35bbb82bbe967e4c4d3a21f27f2eecf2",
+    ),
+    7: (
+        "e5f6ff0c215b731cb99b42841f751d37ff290ff26080f500be93f347b884b6a1",
+        "fa1acd4cdf2b8a24776bf5d0d115eb362f3eda09be1a889996b9599826b18720",
+    ),
+    8: (
+        "bc89dbc689fbfde1cc8fa4b48b33a15c5b774bb4982af066f231c74b8282ec31",
+        "fc2a73b32fff7c1929e319b8b04cda789a82511a268c59766f7df7f8cf552566",
+    ),
+    9: (
+        "c9ec1b9af50206dd0f92d7973b256eb1a51125096ad2a0a231584b456f58ebdd",
+        "bcd08b1074c104d87f26f1d00aeca0b9eccdb76a4a735385531b7e0a9e8a0f42",
+    ),
+    10: (
+        "ccafa8e0b5b60fb920ba1cfed07ddab9068218fe4e07581a249141883694f97d",
+        "baa699f10ef1657a6682fa4df1709e46a7871bfba4f2056edd126e32d14f4c1d",
+    ),
+}
+_USERS_ORIGIN_SHAS = _USERS_ORIGIN_SHAS_SCALAR | frozenset(
+    digest for pair in _USERS_PICKER_SHAS.values() for digest in pair
+)
 _USERS_REMAP_SHA = "090df268267944b22e713077c59d4836e4046fadb60bfbb78116f3a43af46676"
 # Source pins: sha256 of the *file bytes* backing each imported module, i.e.
 # ``sha256(Path(import_module(name).__file__).read_bytes())``. Re-pin with
@@ -668,8 +728,11 @@ class ReadOnlyExecutor:
                 raise
             self._validate_users_remap(query, params, pending)
             sql, certified = query, pending
-        if origin and (hashlib.sha256(sql.encode()).hexdigest() != self._users_context.origin_sql_sha256
-                       or replay.digest(safe_json(params)) != self._users_context.origin_bindings):
+        if origin and (
+            hashlib.sha256(sql.encode()).hexdigest()
+            != self._users_context.origin_sql_sha256
+            or replay.digest(safe_json(params)) != self._users_context.origin_bindings
+        ):
             raise replay.ReplayError("USERS_REMAP_ORIGIN_BINDINGS_CHANGED")
         remaining = self.remaining_read_ms()
         if remaining <= 0:

--- a/scripts/qa/replay_observe_queries_readonly.py
+++ b/scripts/qa/replay_observe_queries_readonly.py
@@ -479,8 +479,26 @@ class ReadOnlyExecutor:
             compression="lz4",
         )
         # The executor opens its OWN connection; the preflight assertion on the
-        # metadata client does not cover it. Zero statements, zero bytes.
-        assert_ch_identity(args, self.client.connection.user)
+        # metadata client does not cover it.
+        self._assert_server_side_identity()
+
+    def _assert_server_side_identity(self):
+        """Prove THIS connection's account with the server, not with our own arg.
+
+        Comparing ``self.client.connection.user`` would be tautological: the
+        driver stores verbatim whatever we passed to ``Client(...)``. Only a
+        ``currentUser()`` the server answers proves which account this
+        connection runs as. Costs one metadata statement per executor, under
+        server-enforced readonly, before any table read.
+        """
+        if not getattr(self.args, "user_assert", False):
+            return
+        rows = self.client.execute(
+            "SELECT currentUser()",
+            query_id=f"{self.prefix}-identity",
+            settings={"readonly": 2, "max_execution_time": 3},
+        )
+        assert_ch_identity(self.args, rows[0][0] if rows and rows[0] else None)
 
     def remaining_read_ms(self):
         return max(0, int((self.deadline - time.monotonic()) * 1000))
@@ -1415,7 +1433,7 @@ def main():
     )
     parser.add_argument(
         "--user-assert", action="store_true", default=False,
-        help="Require OBSERVE_CH_USER to be set and to equal the server's currentUser(); aborts before any read so a driver cannot silently run as 'default'",
+        help="Require OBSERVE_CH_USER to be set and to equal the server's currentUser(); the preflight and every executor connection each spend one metadata statement proving it, and abort before any table read, so a driver cannot silently run as 'default'",
     )
     parser.add_argument("--threads", type=int, choices=(1, 2, 4, 8), default=2)
     args = parser.parse_args()

--- a/scripts/qa/replay_observe_queries_readonly.py
+++ b/scripts/qa/replay_observe_queries_readonly.py
@@ -402,12 +402,16 @@ def _users_origin_limit(manager):
 
 def observe_ch_user(args):
     """Resolve the ClickHouse user; ``--user-assert`` bars the silent fallback."""
-    user = os.environ.get(_CH_USER_ENV)
     if getattr(args, "user_assert", False):
+        user = os.environ.get(_CH_USER_ENV)
         if not user:
             raise replay.ReplayError("CH_USER_NOT_CONFIGURED")
         return user
-    return user or "default"
+    # Flag off resolves EXACTLY as it did before this flag existed: only an
+    # *unset* variable falls back to ``default``. A variable set to the empty
+    # string keeps resolving to the empty string, so a misconfigured identity
+    # fails at connect instead of silently running as the ``default`` account.
+    return os.environ.get(_CH_USER_ENV, "default")
 
 
 def assert_ch_identity(args, actual):

--- a/scripts/qa/replay_observe_queries_readonly.py
+++ b/scripts/qa/replay_observe_queries_readonly.py
@@ -354,19 +354,68 @@ def diagnostic_read_settings(
     return limits
 
 
-_USERS_ORIGIN_SHA = "20d339691652b7d0120ae3b6b8d1dfaf2a859c778688f19cce0e74e66e944f1f"
+# SQL pins: sha256 of the statement text the deployed builders emit for the
+# qualified origin shape (no user_id label witness, no numeric scalar witness).
+# ``limit`` is a *binding* (``LIMIT %(limit)s``), so one origin pin covers every
+# first-batch size. Recompute by building the same two statements against the
+# checked-in builders and hashing ``sql.strip().rstrip(";")``.
+_USERS_ORIGIN_SHA = "7120eaf17118a7ae3708911c7a61e88f46e8a2df1d59753463e5d99e0aacbeb9"
 _USERS_REMAP_SHA = "090df268267944b22e713077c59d4836e4046fadb60bfbb78116f3a43af46676"
+# Source pins: sha256 of the *file bytes* backing each imported module, i.e.
+# ``sha256(Path(import_module(name).__file__).read_bytes())``. Re-pin with
+# ``shasum -a 256 futureagi/<module path>.py``; the offline unit test
+# ``UsersSourcePinTests`` fails the moment these drift from the tree again.
 _USERS_SOURCE_PINS = {
     "tracer.services.users_list_manager": "b5da3657a94ab71710a8db384990e018269929e80c2f651cf8a25b02df3eb831",
-    "tracer.services.clickhouse.query_builders.user_list": "97c47542622bb599cb003d2e7c5dfcc6bcba0989aaef41e8c3461ed6d6435ba8",
+    "tracer.services.clickhouse.query_builders.user_list": "b0c34215bee82ac898c2c05272e95a8a1b6f4552c30515364e3c810467782e7f",
     "tracer.services.clickhouse.v2.query_builders.user_list": "d5024fe5a46b7cbdf2621d04dfd02027c17816f7250f84120c920a0dd3c9908e",
     "tracer.services.clickhouse.v2.id_remap_sql": "56903f382c0f8dc40099e5ebfda45a8ab853c0b8f7ec16b5712f9c11092fe24a",
 }
+_CH_USER_ENV = "OBSERVE_CH_USER"
 
 
 def _users_sources_current():
     return all(hashlib.sha256(Path(import_module(name).__file__).read_bytes()).hexdigest() == digest
                for name, digest in _USERS_SOURCE_PINS.items())
+
+
+def _users_origin_limit(manager):
+    """Mirror the manager's own first-batch size instead of assuming 25 + 1.
+
+    ``UsersListManager.list_cursor_payload`` resets ``_attribute_witness_disabled``
+    before its first read, so page 1 always asks for the *enabled* witness batch:
+    65 rows when exact-text attribute filters qualify, 26 otherwise. The previous
+    hard-coded 26 rejected a server-answered 65-row origin client-side, which made
+    the certificate structurally unable to cover the attribute-filtered path.
+    """
+    from tracer.services.users_list_manager import (
+        USER_LIST_ATTRIBUTE_WITNESS_BATCH_SIZE,
+        USER_LIST_CANDIDATE_BATCH_SIZE,
+    )
+
+    batch = (USER_LIST_ATTRIBUTE_WITNESS_BATCH_SIZE
+             if manager.attribute_exact_text_filters else USER_LIST_CANDIDATE_BATCH_SIZE)
+    if type(batch) is not int or batch <= 0:
+        raise replay.ReplayError("USERS_REMAP_ORIGIN_LIMIT_INVALID")
+    return batch + 1
+
+
+def observe_ch_user(args):
+    """Resolve the ClickHouse user; ``--user-assert`` bars the silent fallback."""
+    user = os.environ.get(_CH_USER_ENV)
+    if getattr(args, "user_assert", False):
+        if not user:
+            raise replay.ReplayError("CH_USER_NOT_CONFIGURED")
+        return user
+    return user or "default"
+
+
+def assert_ch_identity(args, actual):
+    """Fail fast when the server says we are somebody else than OBSERVE_CH_USER."""
+    if not getattr(args, "user_assert", False):
+        return
+    if type(actual) is not str or actual != observe_ch_user(args):
+        raise replay.ReplayError("CH_USER_IDENTITY_MISMATCH")
 
 
 def _user_uuid(value):
@@ -387,6 +436,7 @@ class _UsersRemapContext:
     authorized_projects: tuple[str, ...]
     origin_bindings: str
     binding: str
+    origin_limit: int
 
 
 @dataclass(frozen=True)
@@ -422,12 +472,15 @@ class ReadOnlyExecutor:
             args.host,
             port=args.port,
             database=args.database,
-            user=os.environ.get("OBSERVE_CH_USER", "default"),
+            user=observe_ch_user(args),
             password=os.environ.get("OBSERVE_CH_PASSWORD", ""),
             connect_timeout=3,
             send_receive_timeout=args.safety_seconds + 3,
             compression="lz4",
         )
+        # The executor opens its OWN connection; the preflight assertion on the
+        # metadata client does not cover it. Zero statements, zero bytes.
+        assert_ch_identity(args, self.client.connection.user)
 
     def remaining_read_ms(self):
         return max(0, int((self.deadline - time.monotonic()) * 1000))
@@ -456,8 +509,9 @@ class ReadOnlyExecutor:
         builder = UserListQueryBuilderV2(organization_id=manager.organization_id,
                                        project_ids=list(projects), filters=manager.filters,
                                        search=manager.search, empty_scope=manager.empty_scope)
+        origin_limit = _users_origin_limit(manager)
         sql, bindings = builder.build_dimension_candidate_query(
-            limit=26, window_start=replay.utc(case["window"]["start"]),
+            limit=origin_limit, window_start=replay.utc(case["window"]["start"]),
             window_end=replay.utc(case["window"]["end"]),
         )
         if hashlib.sha256(sql.strip().rstrip(";").encode()).hexdigest() != _USERS_ORIGIN_SHA:
@@ -466,6 +520,7 @@ class ReadOnlyExecutor:
             tuple(_user_uuid(p) for p in projects), tuple(map(str, self.projects)),
             replay.digest(safe_json(bindings)),
             replay.digest({"case": case, "scope": scope, "plan_id": plan_id, "projects": projects}),
+            origin_limit,
         )
         self._users_origin_expected = True
 
@@ -483,7 +538,8 @@ class ReadOnlyExecutor:
 
     def _users_result(self, result, *, origin, certificate, query_id):
         if origin:
-            if (result.row_count != len(result.data) or result.row_count > 26
+            if (result.row_count != len(result.data)
+                    or result.row_count > self._users_context.origin_limit
                     or len(result.columns) != len(set(result.columns))):
                 raise replay.ReplayError("USERS_REMAP_ORIGIN_RESULT_INVALID")
             try:
@@ -1357,6 +1413,10 @@ def main():
         "--verify-finite-users-remap", action="store_true", default=False,
         help="Opt-in source-bound finite Users remap authorization; unsupported origins fail closed, not independent result qualification",
     )
+    parser.add_argument(
+        "--user-assert", action="store_true", default=False,
+        help="Require OBSERVE_CH_USER to be set and to equal the server's currentUser(); aborts before any read so a driver cannot silently run as 'default'",
+    )
     parser.add_argument("--threads", type=int, choices=(1, 2, 4, 8), default=2)
     args = parser.parse_args()
     if args.verify_trace_full_rows and not args.verify_trace_ids:
@@ -1365,6 +1425,8 @@ def main():
         raise replay.ReplayError("INVALID_DIAGNOSTIC_SAFETY_BUDGET")
     if not 0 < args.run_seconds <= 3600 or not 1 <= args.max_consecutive_failures <= 10:
         raise replay.ReplayError("INVALID_RUN_SAFETY_BUDGET")
+    # Resolve the asserted identity before the ledger lock or any connection.
+    observe_ch_user(args)
     plan = replay.read_json(args.plan)
     if plan["plan_id"] != replay.digest(
         {k: v for k, v in plan.items() if k != "plan_id"}
@@ -1417,6 +1479,9 @@ def main():
     }
     if args.verify_finite_users_remap:
         run_profile["verify_finite_users_remap"] = True
+    if args.user_assert:
+        # Keyed, never valued: the ledger must not carry the account name.
+        run_profile["user_assert"] = True
     lock = Path(args.ledger + ".lock")
     lock_fd = os.open(lock, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
     os.close(lock_fd)
@@ -1428,18 +1493,22 @@ def main():
             args.host,
             port=args.port,
             database=args.database,
-            user=os.environ.get("OBSERVE_CH_USER", "default"),
+            user=observe_ch_user(args),
             password=os.environ.get("OBSERVE_CH_PASSWORD", ""),
             connect_timeout=3,
             send_receive_timeout=5,
             settings={"readonly": 2, "max_execution_time": 3},
         )
         try:
-            server = check.execute("SELECT hostName(), version(), currentDatabase()")
+            server = check.execute(
+                "SELECT hostName(), version(), currentDatabase(), currentUser()"
+            )
         finally:
             check.disconnect()
         if server[0][0] != args.expected_server or server[0][2] != args.database:
             raise replay.ReplayError("DATABASE_TARGET_MISMATCH")
+        # Server-side identity, not the client's own claim. Before any read.
+        assert_ch_identity(args, server[0][3])
         run_profile["server_version"] = server[0][1]
         initialize_candidate()
         run_profile["candidate_runtime"] = candidate_runtime_profile()

--- a/scripts/qa/replay_observe_queries_readonly.py
+++ b/scripts/qa/replay_observe_queries_readonly.py
@@ -354,12 +354,49 @@ def diagnostic_read_settings(
     return limits
 
 
-# SQL pins: sha256 of the statement text the deployed builders emit for the
-# qualified origin shape (no user_id label witness, no numeric scalar witness).
-# ``limit`` is a *binding* (``LIMIT %(limit)s``), so one origin pin covers every
-# first-batch size. Recompute by building the same two statements against the
-# checked-in builders and hashing ``sql.strip().rstrip(";")``.
-_USERS_ORIGIN_SHA = "7120eaf17118a7ae3708911c7a61e88f46e8a2df1d59753463e5d99e0aacbeb9"
+# SQL pins: sha256 of the statement text the deployed builders emit for each
+# REVIEWED first-page origin shape. The Users read path emits more than one
+# shape, so this is a set of reviewed statements, never a blanket exemption for
+# Users queries: the run stays bound to the one shape it actually selected.
+#
+# Recompute offline against the checked-in builders -- no connection, no
+# production access. From ``futureagi/`` with ``PYTHONPATH=.`` and every
+# DB/CH/Redis port pointed at a dead port, after ``django.setup()`` only::
+#
+#     b = UserListQueryBuilderV2(organization_id=str(UUID(int=11)),
+#                                project_ids=[str(UUID(int=12))],
+#                                filters=FILTERS, search="", empty_scope=False)
+#     sql, _ = b.build_dimension_candidate_query(
+#         limit=26, window_start=datetime(2026, 9, 3, 0, 0, tzinfo=timezone.utc),
+#         window_end=datetime(2026, 9, 3, 4, 0, tzinfo=timezone.utc))
+#     hashlib.sha256(sql.strip().rstrip(";").encode()).hexdigest()
+#
+# ``.strip().rstrip(";")`` is exactly the normalization ``validate_select``
+# applies before the statement runs, so one digest covers both check sites.
+# Organization, projects, window, ``limit`` and the attribute key AND value are
+# all *bindings*, so none of them enters the digest: limit 26 and limit 65 hash
+# identically, and so do two different attribute keys or values.
+_USERS_ORIGIN_SHAS = frozenset(
+    {
+        # FILTERS = a ``created_at`` between filter only (unseeded first page).
+        # Post immutable-hour replay this statement carries no
+        # ``candidate_span_identities`` CTE.
+        "ba51ea62b5e2f3831b6d9d1e4ab345283c068af90f1795bb7b7082526cd4d4e5",
+        # FILTERS = the same date filter plus ONE exact-text attribute filter
+        # (``col_type`` SPAN_ATTRIBUTE, ``filter_type`` text, ``filter_op``
+        # equals, a single non-empty ASCII value). That qualifies a scalar text
+        # witness, so ``scalar_witness_identities`` is present and the
+        # manager's own first batch is 65 rows.
+        "7b8c40bf16c6d1a869f19c75d26304d755298c7016ac451233958599369f3f51",
+    }
+)
+# Deliberately NOT pinned: a multi-value picker (``filter_op`` ``in`` with N
+# values) also reaches the 65-row batch, but it binds one parameter per value,
+# so its statement text -- and its digest -- changes with N; pinning any single
+# N would certify one cardinality and silently reject the rest. Those reads, the
+# user_id label witness, the search shape and the numeric witness all fail
+# closed with USERS_REMAP_ORIGIN_NOT_QUALIFIED until a lane reviews and pins
+# them here, which is the safe direction.
 _USERS_REMAP_SHA = "090df268267944b22e713077c59d4836e4046fadb60bfbb78116f3a43af46676"
 # Source pins: sha256 of the *file bytes* backing each imported module, i.e.
 # ``sha256(Path(import_module(name).__file__).read_bytes())``. Re-pin with
@@ -367,7 +404,7 @@ _USERS_REMAP_SHA = "090df268267944b22e713077c59d4836e4046fadb60bfbb78116f3a43af4
 # ``UsersSourcePinTests`` fails the moment these drift from the tree again.
 _USERS_SOURCE_PINS = {
     "tracer.services.users_list_manager": "b5da3657a94ab71710a8db384990e018269929e80c2f651cf8a25b02df3eb831",
-    "tracer.services.clickhouse.query_builders.user_list": "b0c34215bee82ac898c2c05272e95a8a1b6f4552c30515364e3c810467782e7f",
+    "tracer.services.clickhouse.query_builders.user_list": "94ab7ca8a68c391a3dd147b6a43d2d9cae6f134c2b4a022033d9cb77aef11bf5",
     "tracer.services.clickhouse.v2.query_builders.user_list": "d5024fe5a46b7cbdf2621d04dfd02027c17816f7250f84120c920a0dd3c9908e",
     "tracer.services.clickhouse.v2.id_remap_sql": "56903f382c0f8dc40099e5ebfda45a8ab853c0b8f7ec16b5712f9c11092fe24a",
 }
@@ -377,6 +414,19 @@ _CH_USER_ENV = "OBSERVE_CH_USER"
 def _users_sources_current():
     return all(hashlib.sha256(Path(import_module(name).__file__).read_bytes()).hexdigest() == digest
                for name, digest in _USERS_SOURCE_PINS.items())
+
+
+def _users_origin_sha(sql):
+    """Return the pinned digest of this origin statement, or fail closed.
+
+    The selected shape travels on the remap context so the statement that is
+    actually executed is re-checked against the SAME pin, not merely against
+    set membership a second time.
+    """
+    digest = hashlib.sha256(sql.strip().rstrip(";").encode()).hexdigest()
+    if digest not in _USERS_ORIGIN_SHAS:
+        raise replay.ReplayError("USERS_REMAP_ORIGIN_NOT_QUALIFIED")
+    return digest
 
 
 def _users_origin_limit(manager):
@@ -437,6 +487,7 @@ class _UsersRemapContext:
     origin_bindings: str
     binding: str
     origin_limit: int
+    origin_sql_sha256: str
 
 
 @dataclass(frozen=True)
@@ -532,13 +583,13 @@ class ReadOnlyExecutor:
             limit=origin_limit, window_start=replay.utc(case["window"]["start"]),
             window_end=replay.utc(case["window"]["end"]),
         )
-        if hashlib.sha256(sql.strip().rstrip(";").encode()).hexdigest() != _USERS_ORIGIN_SHA:
-            raise replay.ReplayError("USERS_REMAP_ORIGIN_NOT_QUALIFIED")
+        origin_sha = _users_origin_sha(sql)
         self._users_context = _UsersRemapContext(
             tuple(_user_uuid(p) for p in projects), tuple(map(str, self.projects)),
             replay.digest(safe_json(bindings)),
             replay.digest({"case": case, "scope": scope, "plan_id": plan_id, "projects": projects}),
             origin_limit,
+            origin_sha,
         )
         self._users_origin_expected = True
 
@@ -602,7 +653,7 @@ class ReadOnlyExecutor:
                 raise
             self._validate_users_remap(query, params, pending)
             sql, certified = query, pending
-        if origin and (hashlib.sha256(sql.encode()).hexdigest() != _USERS_ORIGIN_SHA
+        if origin and (hashlib.sha256(sql.encode()).hexdigest() != self._users_context.origin_sql_sha256
                        or replay.digest(safe_json(params)) != self._users_context.origin_bindings):
             raise replay.ReplayError("USERS_REMAP_ORIGIN_BINDINGS_CHANGED")
         remaining = self.remaining_read_ms()
@@ -637,7 +688,7 @@ class ReadOnlyExecutor:
             record["scope_certificate"] = {
                 "kind": "finite_users_remap_certificate.v1",
                 "origin_query_id": certified.origin_query_id,
-                "origin_sql_sha256": _USERS_ORIGIN_SHA,
+                "origin_sql_sha256": certified.context.origin_sql_sha256,
                 "source_sha256": replay.digest(_USERS_SOURCE_PINS),
                 "scope_binding_sha256": certified.context.binding,
                 "candidate_count": len(certified.ids), "candidate_ids_sha256": replay.digest(certified.ids),

--- a/scripts/qa/test_replay_observe_queries_readonly.py
+++ b/scripts/qa/test_replay_observe_queries_readonly.py
@@ -308,18 +308,21 @@ class UsersSourcePinTests(unittest.TestCase):
 class UsersOriginShaSetTests(unittest.TestCase):
     """The Users read path emits several shapes; one scalar pin cannot cover it."""
 
-    def test_pin_set_holds_the_two_reviewed_first_page_shapes(self):
+    def test_pin_set_holds_the_reviewed_first_page_shapes(self):
         self.assertIsInstance(queries._USERS_ORIGIN_SHAS, frozenset)
         for digest in queries._USERS_ORIGIN_SHAS:
             with self.subTest(digest=digest):
                 self.assertRegex(digest, r"^[0-9a-f]{64}$")
-        # Unseeded and ASCII-exact-text acquisition are different statements.
+        # The unseeded page and the three single-value exact-text shapes are
+        # four different statements; one scalar pin cannot hold them.
         self.assertEqual(
             queries._USERS_ORIGIN_SHAS,
             frozenset(
                 {
                     "ba51ea62b5e2f3831b6d9d1e4ab345283c068af90f1795bb7b7082526cd4d4e5",
                     "7b8c40bf16c6d1a869f19c75d26304d755298c7016ac451233958599369f3f51",
+                    "b99fe9116aba205e3d4e36a2251630e9772307622759e970b98f4648db2f95bf",
+                    "40aca43c4986c4b67e5d8b99ae753c347c7101d29735d7edf9f3de139ef97c95",
                 }
             ),
         )

--- a/scripts/qa/test_replay_observe_queries_readonly.py
+++ b/scripts/qa/test_replay_observe_queries_readonly.py
@@ -315,32 +315,40 @@ class UsersOriginShaSetTests(unittest.TestCase):
         for digest in queries._USERS_ORIGIN_SHAS:
             with self.subTest(digest=digest):
                 self.assertRegex(digest, r"^[0-9a-f]{64}$")
-        # The unseeded page and the exact-equals text page are two different
-        # statements; one scalar pin cannot hold them.
-        self.assertEqual(len(queries._USERS_ORIGIN_SHAS_SCALAR), 2)
-        # The picker family is enumerated by value count, 1 .. MAX, and each
-        # cardinality is two statements: untyped and typed.
-        self.assertEqual(queries._USERS_PICKER_MAX_VALUES, 10)
+        # One pin per SHAPE, not per cardinality: no witness, the scalar
+        # ``equals`` witness, and the untyped/typed pickers, each with and
+        # without the legacy ASCII bloom companion.
         self.assertEqual(
-            sorted(queries._USERS_PICKER_SHAS),
-            list(range(1, queries._USERS_PICKER_MAX_VALUES + 1)),
+            sorted(queries._USERS_ORIGIN_SHAPES),
+            [
+                "equals_hint_declined",
+                "equals_legacy_hint",
+                "in_typed_hint_declined",
+                "in_typed_legacy_hint",
+                "in_untyped_hint_declined",
+                "in_untyped_legacy_hint",
+                "no_text_witness",
+            ],
         )
-        picker = [
-            digest for pair in queries._USERS_PICKER_SHAS.values() for digest in pair
-        ]
-        self.assertTrue(
-            all(len(pair) == 2 for pair in queries._USERS_PICKER_SHAS.values())
-        )
-        self.assertEqual(len(picker), 2 * queries._USERS_PICKER_MAX_VALUES)
-        # Every pin is distinct, and the exported set is exactly their union.
+        # Every pin is distinct, and the exported set is exactly their values.
+        self.assertEqual(len(queries._USERS_ORIGIN_SHAS), 7)
         self.assertEqual(
-            len(set(picker) | queries._USERS_ORIGIN_SHAS_SCALAR),
-            len(picker) + len(queries._USERS_ORIGIN_SHAS_SCALAR),
+            len(set(queries._USERS_ORIGIN_SHAPES.values())),
+            len(queries._USERS_ORIGIN_SHAPES),
         )
         self.assertEqual(
             queries._USERS_ORIGIN_SHAS,
-            queries._USERS_ORIGIN_SHAS_SCALAR | frozenset(picker),
+            frozenset(queries._USERS_ORIGIN_SHAPES.values()),
         )
+        # The per-cardinality enumeration this replaced is gone for good: a
+        # value-count boundary is not a property of the statement any more.
+        for retired in (
+            "_USERS_PICKER_SHAS",
+            "_USERS_PICKER_MAX_VALUES",
+            "_USERS_ORIGIN_SHAS_SCALAR",
+        ):
+            with self.subTest(retired=retired):
+                self.assertFalse(hasattr(queries, retired))
 
     def test_origin_sha_selects_a_pinned_shape_and_fails_closed_otherwise(self):
         statement = "WITH x AS (SELECT 1) SELECT * FROM x"
@@ -361,19 +369,25 @@ class UsersOriginShaSetTests(unittest.TestCase):
 class UsersOriginShaDerivationTests(unittest.TestCase):
     """Derive every pinned first-page digest from the checked-in builder.
 
-    The pins above are literals, so a literal-versus-literal assertion would
-    prove nothing. These cases build the statement with the recipe documented
-    next to ``_USERS_ORIGIN_SHAS`` and then ask ``_users_origin_sha`` whether
-    that statement is pinned, so a builder change that moves any shape fails
-    here instead of failing closed in a run. Pure string construction: no
-    connection and no ``django.setup()`` -- the harness's own test environment
-    configures Django, and these cases skip where it does not.
+    The pins are literals, so a literal-versus-literal assertion would prove
+    nothing. These cases build the statement with the recipe documented next to
+    ``_USERS_ORIGIN_SHAPES`` and then ask ``_users_origin_sha`` whether that
+    statement is pinned, so a builder change that moves any shape fails here
+    instead of failing closed in a run. They also pin the SHAPE TABLE itself:
+    each family must collapse to exactly one digest across value counts and
+    value texts, and the seven families must account for the whole pin set.
+    Pure string construction: no connection and no ``django.setup()`` -- the
+    harness's own test environment configures Django, and these cases skip
+    where it does not.
     """
 
     ORGANIZATION = str(UUID(int=11))
     PROJECT = str(UUID(int=12))
     WINDOW_START = datetime(2026, 9, 3, 0, 0, tzinfo=timezone.utc)
     WINDOW_END = datetime(2026, 9, 3, 4, 0, tzinfo=timezone.utc)
+    # Nine letters ``k`` push the legacy ASCII bloom enumeration past its 256
+    # variant ceiling, so the hint declines and the page is a shape of its own.
+    HINT_DECLINED_VALUE = "k" * 9
 
     def _builder_class(self):
         try:
@@ -397,12 +411,14 @@ class UsersOriginShaDerivationTests(unittest.TestCase):
             },
         }
 
-    def _statement(self, attribute_config=None):
+    def _statement(self, *attribute_configs):
         filters = [self._date_filter()]
-        if attribute_config is not None:
+        for position, attribute_config in enumerate(attribute_configs):
+            if attribute_config is None:
+                continue
             filters.append(
                 {
-                    "column_id": "attr_a",
+                    "column_id": f"attr_{position}",
                     "filter_config": {
                         "col_type": "SPAN_ATTRIBUTE",
                         **attribute_config,
@@ -424,6 +440,16 @@ class UsersOriginShaDerivationTests(unittest.TestCase):
         )
         return sql
 
+    def _equals_config(self, value, typed=False, filter_type="text"):
+        config = {
+            "filter_type": filter_type,
+            "filter_op": "equals",
+            "filter_value": value,
+        }
+        if typed:
+            config["attribute_value_types"] = ["string"]
+        return config
+
     def _picker_config(self, values, typed):
         config = {
             "filter_type": "text",
@@ -434,55 +460,217 @@ class UsersOriginShaDerivationTests(unittest.TestCase):
             config["attribute_value_types"] = ["string"] * len(values)
         return config
 
-    def test_the_scalar_pins_are_the_builders_own_statements(self):
-        for label, attribute in (
-            ("unseeded", None),
+    def _shape_table(self):
+        """Every reviewed case, labelled with the shape it must land on.
+
+        Covers what the raw-text pin could not: the value COUNT (1 .. 40, past
+        the retired boundary of 10), and the value TEXT -- values containing
+        the letter ``k``, which fans the legacy ASCII bloom hint out by
+        2 ** (count of ``k``), and selected lists whose lowercased values
+        collide, which shrinks it.
+        """
+
+        cases = [
+            ("no_text_witness", "unseeded", (None,)),
+            ("no_text_witness", "non-ASCII equals", (self._equals_config("café"),)),
             (
-                "equals",
-                {
-                    "filter_type": "text",
-                    "filter_op": "equals",
-                    "filter_value": "value-a",
-                },
+                "no_text_witness",
+                "typed equals",
+                (self._equals_config("value-a", typed=True),),
             ),
-        ):
-            with self.subTest(shape=label):
-                sql = self._statement(attribute)
-                digest = hashlib.sha256(sql.strip().rstrip(";").encode()).hexdigest()
-                self.assertEqual(queries._users_origin_sha(sql), digest)
-                self.assertIn(digest, queries._USERS_ORIGIN_SHAS_SCALAR)
-
-    def test_every_pinned_picker_cardinality_is_the_builders_own_statement(self):
-        for count in range(1, queries._USERS_PICKER_MAX_VALUES + 1):
-            values = [f"value-{index}" for index in range(count)]
-            for position, typed in ((0, False), (1, True)):
-                with self.subTest(values=count, typed=typed):
-                    sql = self._statement(self._picker_config(values, typed))
-                    # The witness is what fans the statement out per value.
-                    self.assertIn("scalar_witness_identities AS", sql)
-                    self.assertEqual(
-                        queries._users_origin_sha(sql),
-                        queries._USERS_PICKER_SHAS[count][position],
-                    )
-
-    def test_one_value_more_than_the_pinned_maximum_fails_closed(self):
-        values = [
-            f"value-{index}" for index in range(queries._USERS_PICKER_MAX_VALUES + 1)
+            (
+                "no_text_witness",
+                "contains",
+                (
+                    {
+                        "filter_type": "text",
+                        "filter_op": "contains",
+                        "filter_value": "value-a",
+                    },
+                ),
+            ),
+            (
+                "no_text_witness",
+                "non-ASCII picker",
+                (self._picker_config(["café", "x"], False),),
+            ),
+            (
+                "no_text_witness",
+                "type-list length mismatch",
+                (
+                    {
+                        "filter_type": "text",
+                        "filter_op": "in",
+                        "filter_value": ["value-a", "value-b"],
+                        "attribute_value_types": ["string"],
+                    },
+                ),
+            ),
+            (
+                "equals_hint_declined",
+                "equals, hint declined",
+                (self._equals_config(self.HINT_DECLINED_VALUE),),
+            ),
+            (
+                "in_untyped_hint_declined",
+                "picker, hint declined",
+                (self._picker_config([self.HINT_DECLINED_VALUE], False),),
+            ),
+            (
+                "in_typed_hint_declined",
+                "typed picker, hint declined",
+                (self._picker_config([self.HINT_DECLINED_VALUE], True),),
+            ),
         ]
+        for filter_type in ("text", "string"):
+            cases.append(
+                (
+                    "equals_legacy_hint",
+                    f"equals value-a, filter_type {filter_type}",
+                    (self._equals_config("value-a", filter_type=filter_type),),
+                )
+            )
+        # Values whose letters ``k`` moved the raw statement text.
+        for value in ("kid", "kayak", "token", "ok", "OK", "sk-token"):
+            cases.append(
+                ("equals_legacy_hint", f"equals {value}", (self._equals_config(value),))
+            )
+        for count in (1, 2, 3, 5, 10, 11, 12, 40):
+            values = [f"value-{index}" for index in range(count)]
+            cases.append(
+                (
+                    "in_untyped_legacy_hint",
+                    f"picker {count} values untyped",
+                    (self._picker_config(values, False),),
+                )
+            )
+            cases.append(
+                (
+                    "in_typed_legacy_hint",
+                    f"picker {count} values typed",
+                    (self._picker_config(values, True),),
+                )
+            )
+        # Selected lists whose LOWERCASED values collide, so the legacy hint
+        # holds fewer placeholders than the list holds values.
+        for values in (
+            ["kid"],
+            ["kid", "box"],
+            ["Yes", "yes"],
+            ["a", "a", "b"],
+            ["a", "a", "a"],
+        ):
+            cases.append(
+                (
+                    "in_untyped_legacy_hint",
+                    f"picker {values!r} untyped",
+                    (self._picker_config(values, False),),
+                )
+            )
+            cases.append(
+                (
+                    "in_typed_legacy_hint",
+                    f"picker {values!r} typed",
+                    (self._picker_config(values, True),),
+                )
+            )
+        # Conjunctions land on the first exact-text filter's own shape.
+        cases += [
+            (
+                "equals_legacy_hint",
+                "equals + equals",
+                (self._equals_config("value-a"), self._equals_config("value-b")),
+            ),
+            (
+                "equals_legacy_hint",
+                "equals + picker",
+                (
+                    self._equals_config("kid"),
+                    self._picker_config(["Yes", "yes"], False),
+                ),
+            ),
+            (
+                "in_untyped_legacy_hint",
+                "picker + picker untyped",
+                (
+                    self._picker_config(["a", "b"], False),
+                    self._picker_config(["c", "d", "e"], False),
+                ),
+            ),
+            (
+                "in_typed_legacy_hint",
+                "picker + picker typed",
+                (
+                    self._picker_config(["a", "b"], True),
+                    self._picker_config(["c", "d", "e"], True),
+                ),
+            ),
+        ]
+        return cases
+
+    def test_every_reviewed_case_lands_on_its_pinned_shape(self):
+        for shape, label, configs in self._shape_table():
+            with self.subTest(shape=shape, case=label):
+                sql = self._statement(*configs)
+                self.assertEqual(
+                    queries._users_origin_sha(sql),
+                    queries._USERS_ORIGIN_SHAPES[shape],
+                )
+
+    def test_each_shape_is_exactly_one_digest_and_the_pins_are_only_these(self):
+        observed = {}
+        for shape, _label, configs in self._shape_table():
+            observed.setdefault(shape, set()).add(
+                queries._users_origin_digest(self._statement(*configs))
+            )
+        for shape, digests in observed.items():
+            with self.subTest(shape=shape):
+                self.assertEqual(len(digests), 1, digests)
+        self.assertEqual(sorted(observed), sorted(queries._USERS_ORIGIN_SHAPES))
+        self.assertEqual(
+            {digest for digests in observed.values() for digest in digests},
+            set(queries._USERS_ORIGIN_SHAS),
+        )
+
+    def test_the_witness_is_what_fans_the_statement_out_per_value(self):
         for typed in (False, True):
             with self.subTest(typed=typed):
-                sql = self._statement(self._picker_config(values, typed))
-                self.assertNotIn(
-                    hashlib.sha256(sql.strip().rstrip(";").encode()).hexdigest(),
-                    queries._USERS_ORIGIN_SHAS,
+                sql = self._statement(
+                    self._picker_config(["value-0", "value-1"], typed)
                 )
-                with self.assertRaisesRegex(
-                    replay.ReplayError, "USERS_REMAP_ORIGIN_NOT_QUALIFIED"
-                ):
-                    queries._users_origin_sha(sql)
+                canonical = queries._canonical_origin_sql(sql)
+                self.assertIn("scalar_witness_identities AS", sql)
+                # The raw text carries one placeholder per selected value;
+                # only the canonical form the pin is taken over does not.
+                stem = (
+                    "latest_filter_index_0_string" if typed else "latest_filter_index_0"
+                )
+                self.assertIn(f"%({stem}_0)s, %({stem}_1)s", sql)
+                self.assertNotIn(f"%({stem}_1)s", canonical)
+                self.assertIn(f"%({stem}_*)s", canonical)
+
+    def test_value_count_and_value_text_no_longer_move_the_pin(self):
+        """The retired ``_USERS_PICKER_MAX_VALUES`` boundary is really gone."""
+
+        baseline = queries._users_origin_digest(
+            self._statement(self._picker_config(["value-0"], False))
+        )
+        for count in (2, 10, 11, 12, 40):
+            with self.subTest(values=count):
+                sql = self._statement(
+                    self._picker_config(
+                        [f"value-{index}" for index in range(count)], False
+                    )
+                )
+                self.assertEqual(queries._users_origin_digest(sql), baseline)
+        for values in (["kid"], ["Yes", "yes"], ["ok", "token", "key"]):
+            with self.subTest(values=values):
+                sql = self._statement(self._picker_config(values, False))
+                self.assertEqual(queries._users_origin_digest(sql), baseline)
 
     def test_a_length_mismatched_type_list_lands_on_the_unseeded_pin(self):
         """No witness qualifies, so the page is the plain unseeded statement."""
+
         config = {
             "filter_type": "text",
             "filter_op": "in",
@@ -495,6 +683,58 @@ class UsersOriginShaDerivationTests(unittest.TestCase):
             queries._users_origin_sha(sql),
             queries._users_origin_sha(self._statement(None)),
         )
+
+    # Why the pin must be canonical: on this tree the RAW text fans out. The
+    # branch that introduced the exact-text witnesses also introduced two
+    # companion bloom index hints whose placeholder COUNT follows the filter's
+    # value list -- one placeholder per selected value for the UTF-8 hint, and
+    # 2 ** (letters ``k`` in the values), deduplicated, for the legacy ASCII
+    # one. The cases below measure that fan-out on the builder itself, so the
+    # reason a raw-text digest cannot be the pin is measured, not asserted.
+    def test_the_raw_text_moves_with_the_value_text_at_one_value(self):
+        """``equals "kid"`` is a different statement from ``equals "value-a"``."""
+
+        baseline = self._statement(self._equals_config("value-a"))
+        baseline_raw = hashlib.sha256(baseline.strip().rstrip(";").encode()).hexdigest()
+        for value in ("kid", "kayak", "token", "ok", "OK", "sk-token"):
+            with self.subTest(value=value):
+                sql = self._statement(self._equals_config(value))
+                raw = hashlib.sha256(sql.strip().rstrip(";").encode()).hexdigest()
+                self.assertNotEqual(raw, baseline_raw)
+                # ... and the canonical digest is the same pinned shape.
+                self.assertEqual(
+                    queries._users_origin_digest(sql),
+                    queries._USERS_ORIGIN_SHAPES["equals_legacy_hint"],
+                )
+
+    def test_the_raw_text_moves_with_a_lowercase_collision_at_one_count(self):
+        """Two selected values, one legacy placeholder: ``["Yes", "yes"]``."""
+
+        plain = self._statement(self._picker_config(["yes", "no"], False))
+        collide = self._statement(self._picker_config(["Yes", "yes"], False))
+        self.assertNotEqual(
+            hashlib.sha256(plain.strip().rstrip(";").encode()).hexdigest(),
+            hashlib.sha256(collide.strip().rstrip(";").encode()).hexdigest(),
+        )
+        self.assertEqual(
+            queries._users_origin_digest(plain),
+            queries._users_origin_digest(collide),
+        )
+
+    def test_the_shape_table_collapses_many_raw_statements_onto_seven(self):
+        raw = set()
+        canonical = set()
+        for _shape, _label, configs in self._shape_table():
+            sql = self._statement(*configs)
+            raw.add(hashlib.sha256(sql.strip().rstrip(";").encode()).hexdigest())
+            canonical.add(queries._users_origin_digest(sql))
+        # Both numbers are the pin: the table is fixed above, so a builder
+        # change that adds or removes a fan-out axis moves one of them. 47
+        # reviewed cases spell 33 different statements and 7 different shapes.
+        self.assertEqual(len(self._shape_table()), 47)
+        self.assertEqual(len(raw), 33)
+        self.assertEqual(len(canonical), 7)
+        self.assertEqual(canonical, set(queries._USERS_ORIGIN_SHAS))
 
 
 class UsersOriginBatchTests(unittest.TestCase):
@@ -656,133 +896,6 @@ class UsersOriginCanonicalSqlTests(unittest.TestCase):
                 self.assertEqual(queries._users_origin_digest(variant), digest)
         # A statement with no value list at all is digested verbatim.
         self.assertEqual(digest, hashlib.sha256(statement.encode()).hexdigest())
-
-
-class UsersOriginCanonicalDevControlTests(unittest.TestCase):
-    """The canonical pin is the builder's own statement, on this tree.
-
-    ``_USERS_ORIGIN_SHA`` is a literal, so a literal-versus-literal assertion
-    would prove nothing. These cases build the statement with the recipe
-    documented next to the pin and then ask the harness whether it is pinned.
-    On this tree no attribute witness qualifies, so canonicalisation is a
-    *no-op* here and every shape -- including the value texts whose bloom-hint
-    fan-out breaks a raw-text pin elsewhere in the stack -- is one statement.
-    Pure string construction: no connection and no ``django.setup()``; these
-    cases skip where Django is not configured.
-    """
-
-    ORGANIZATION = str(UUID(int=11))
-    PROJECT = str(UUID(int=12))
-    WINDOW_START = datetime(2026, 9, 3, 0, 0, tzinfo=timezone.utc)
-    WINDOW_END = datetime(2026, 9, 3, 4, 0, tzinfo=timezone.utc)
-
-    def _builder_class(self):
-        try:
-            from tracer.services.clickhouse.v2.query_builders.user_list import (
-                UserListQueryBuilderV2,
-            )
-        except Exception as exc:  # pragma: no cover - Django not configured here
-            self.skipTest(f"UserListQueryBuilderV2 unavailable: {exc}")
-        return UserListQueryBuilderV2
-
-    def _statement(self, attribute_config=None):
-        filters = [
-            {
-                "column_id": "created_at",
-                "filter_config": {
-                    "filter_type": "datetime",
-                    "filter_op": "between",
-                    "filter_value": [
-                        self.WINDOW_START.isoformat(),
-                        self.WINDOW_END.isoformat(),
-                    ],
-                },
-            }
-        ]
-        if attribute_config is not None:
-            filters.append(
-                {
-                    "column_id": "attr_a",
-                    "filter_config": {
-                        "col_type": "SPAN_ATTRIBUTE",
-                        **attribute_config,
-                    },
-                }
-            )
-        builder = self._builder_class()(
-            organization_id=self.ORGANIZATION,
-            project_ids=[self.PROJECT],
-            filters=filters,
-            search="",
-            empty_scope=False,
-        )
-        # ``limit`` is a binding: 26 and 65 are the same statement text.
-        sql, _ = builder.build_dimension_candidate_query(
-            limit=26,
-            window_start=self.WINDOW_START,
-            window_end=self.WINDOW_END,
-        )
-        return sql
-
-    def _shapes(self):
-        def equals(value):
-            return {
-                "filter_type": "text",
-                "filter_op": "equals",
-                "filter_value": value,
-            }
-
-        def picker(values, typed):
-            config = {
-                "filter_type": "text",
-                "filter_op": "in",
-                "filter_value": list(values),
-            }
-            if typed:
-                config["attribute_value_types"] = ["string"] * len(values)
-            return config
-
-        shapes = [("unseeded", None)]
-        # Values whose letters ``k`` fan the legacy ASCII bloom hint out, and
-        # a list whose lowercased values collide: the shapes a raw-text pin
-        # cannot hold once a text witness qualifies.
-        for value in ("value-a", "kid", "kayak", "token", "ok", "OK", "k" * 9):
-            shapes.append((f"equals {value!r}", equals(value)))
-        for count in (1, 2, 3, 5, 10, 11, 12):
-            values = [f"value-{index}" for index in range(count)]
-            shapes.append((f"in {count} untyped", picker(values, False)))
-            shapes.append((f"in {count} typed", picker(values, True)))
-        for values in (["kid"], ["kid", "box"], ["Yes", "yes"], ["a", "a", "b"]):
-            shapes.append((f"in {values!r} untyped", picker(values, False)))
-            shapes.append((f"in {values!r} typed", picker(values, True)))
-        return shapes
-
-    def test_every_reviewed_shape_is_the_one_pinned_statement(self):
-        for label, attribute in self._shapes():
-            with self.subTest(shape=label):
-                sql = self._statement(attribute)
-                self.assertEqual(
-                    queries._users_origin_digest(sql), queries._USERS_ORIGIN_SHA
-                )
-
-    def test_canonicalisation_is_a_no_op_on_this_tree(self):
-        """No witness qualifies here, so no value list is emitted at all."""
-
-        for label, attribute in self._shapes():
-            with self.subTest(shape=label):
-                sql = self._statement(attribute).strip().rstrip(";")
-                self.assertEqual(queries._canonical_origin_sql(sql), sql)
-                self.assertEqual(
-                    queries._USERS_ORIGIN_SHA,
-                    hashlib.sha256(sql.encode()).hexdigest(),
-                )
-
-    def test_a_changed_statement_fails_closed(self):
-        sql = self._statement(None)
-        self.assertNotEqual(
-            queries._users_origin_digest(sql + " LIMIT 1"),
-            queries._USERS_ORIGIN_SHA,
-        )
 
 
 class ChUserAssertTests(unittest.TestCase):

--- a/scripts/qa/test_replay_observe_queries_readonly.py
+++ b/scripts/qa/test_replay_observe_queries_readonly.py
@@ -376,6 +376,22 @@ class ChUserAssertTests(unittest.TestCase):
             with self.assertRaisesRegex(replay.ReplayError, "CH_USER_NOT_CONFIGURED"):
                 queries.assert_ch_identity(SimpleNamespace(user_assert=True), "default")
 
+    def test_empty_env_keeps_its_pre_flag_meaning_with_the_assert_off(self):
+        """An env var set to "" is a misconfiguration, not a request for ``default``.
+
+        ``os.environ.get(_CH_USER_ENV, "default")`` is the resolution this
+        script had before ``--user-assert`` existed: only an *unset* variable
+        falls back. Resolving "" to ``default`` would silently connect as the
+        one account this harness must never use.
+        """
+        with patch.dict(os.environ, {queries._CH_USER_ENV: ""}):
+            self.assertEqual(queries.observe_ch_user(SimpleNamespace()), "")
+            self.assertEqual(
+                queries.observe_ch_user(SimpleNamespace(user_assert=False)), ""
+            )
+            with self.assertRaisesRegex(replay.ReplayError, "CH_USER_NOT_CONFIGURED"):
+                queries.observe_ch_user(SimpleNamespace(user_assert=True))
+
     def test_identity_mismatch_fails_fast_and_match_passes(self):
         with patch.dict(os.environ, {queries._CH_USER_ENV: "observe_readonly"}):
             args = SimpleNamespace(user_assert=True)

--- a/scripts/qa/test_replay_observe_queries_readonly.py
+++ b/scripts/qa/test_replay_observe_queries_readonly.py
@@ -4,11 +4,12 @@ import unittest
 import hashlib
 import os
 import sys
-from datetime import datetime
+from datetime import datetime, timezone
 from pathlib import Path
 from tempfile import TemporaryDirectory
 from types import SimpleNamespace
 from unittest.mock import Mock, patch
+from uuid import UUID
 import time
 
 import replay_observe_filters as replay
@@ -350,6 +351,241 @@ class UsersOriginBatchTests(unittest.TestCase):
                     ):
                         reader._users_result(result, origin=True, certificate=None,
                                              query_id="origin")
+
+
+class UsersOriginCanonicalSqlTests(unittest.TestCase):
+    """Pin the canonicaliser itself: value-list arity, and nothing else.
+
+    Pure string work -- no builder, no Django, no connection. The point of the
+    canonical form is that a statement's digest stops depending on how many
+    values a filter selected or what letters they contain, while every other
+    byte keeps de-certifying the read.
+    """
+
+    UNTYPED = "latest_filter_index_0"
+    LEGACY = "latest_filter_legacy_index_0"
+    TYPED = "latest_filter_index_0_string"
+
+    def _run(self, stem, count, *, separator=", "):
+        return (
+            "[" + separator.join(f"%({stem}_{index})s" for index in range(count)) + "]"
+        )
+
+    def test_only_the_arity_of_a_value_list_collapses(self):
+        for stem in (self.UNTYPED, self.LEGACY, self.TYPED):
+            canonical = f"[%({stem}_*)s]"
+            for count in (1, 2, 3, 10, 11, 40):
+                with self.subTest(stem=stem, count=count):
+                    self.assertEqual(
+                        queries._canonical_origin_sql(self._run(stem, count)),
+                        canonical,
+                    )
+
+    def test_a_value_list_is_collapsed_in_place_inside_a_statement(self):
+        sql = (
+            "SELECT 1 WHERE indexHint(hasAny(arrayMap(x -> lowerUTF8(x), "
+            f"mapValues(span_attr_str)), {self._run(self.UNTYPED, 3)}))"
+        )
+        self.assertEqual(
+            queries._canonical_origin_sql(sql),
+            sql.replace(self._run(self.UNTYPED, 3), f"[%({self.UNTYPED}_*)s]"),
+        )
+
+    def test_canonicalisation_is_idempotent(self):
+        once = queries._canonical_origin_sql(self._run(self.LEGACY, 4))
+        self.assertEqual(queries._canonical_origin_sql(once), once)
+
+    def test_the_attribute_key_list_is_not_a_value_list(self):
+        """``latest_filter_key_0``'s trailing index is a FILTER index."""
+
+        for untouched in (
+            "[%(latest_filter_key_0)s]",
+            "[%(latest_filter_key_0)s, %(latest_filter_key_1)s]",
+            "[%(latest_filter_param_0)s]",
+            "[%(limit)s]",
+        ):
+            with self.subTest(text=untouched):
+                self.assertEqual(queries._canonical_origin_sql(untouched), untouched)
+
+    def test_a_renamed_or_reshaped_placeholder_still_de_certifies(self):
+        for mutant in (
+            # Renamed family.
+            "[%(latest_filter_idx_0_0)s, %(latest_filter_idx_0_1)s]",
+            # Two different filters' lists must never merge into one token.
+            "[%(latest_filter_index_0_0)s, %(latest_filter_index_1_0)s]",
+            # Non-consecutive value indexes are not an arity the builder emits.
+            "[%(latest_filter_index_0_0)s, %(latest_filter_index_0_2)s]",
+            # Out of order.
+            "[%(latest_filter_index_0_1)s, %(latest_filter_index_0_0)s]",
+            # A non-canonical decimal is a byte change, not an arity change.
+            "[%(latest_filter_index_0_00)s]",
+            # Separator changes are byte changes.
+            "[%(latest_filter_index_0_0)s,%(latest_filter_index_0_1)s]",
+            # A mixed list keeps its exact text.
+            "[%(latest_filter_index_0_0)s, %(latest_filter_key_0)s]",
+            # No value index at all.
+            "[%(latest_filter_index_0)s]",
+        ):
+            with self.subTest(mutant=mutant):
+                self.assertEqual(queries._canonical_origin_sql(mutant), mutant)
+                self.assertNotEqual(
+                    queries._users_origin_digest(mutant),
+                    queries._users_origin_digest(f"[%({self.UNTYPED}_*)s]"),
+                )
+
+    def test_any_other_byte_change_moves_the_digest(self):
+        base = (
+            "SELECT 1 WHERE hasAny(arrayMap(x -> lowerUTF8(x), "
+            f"mapValues(span_attr_str)), {self._run(self.UNTYPED, 2)})"
+        )
+        for mutant in (
+            base.replace("lowerUTF8", "lower"),
+            base.replace("span_attr_str", "span_attr_num"),
+            base.replace("hasAny", "hasAll"),
+            base.replace("SELECT 1", "SELECT 2"),
+            base.replace(self.UNTYPED, self.TYPED),
+        ):
+            with self.subTest(mutant=mutant[:60]):
+                self.assertNotEqual(
+                    queries._users_origin_digest(mutant),
+                    queries._users_origin_digest(base),
+                )
+
+    def test_the_digest_normalizes_exactly_what_validate_select_does(self):
+        statement = "WITH x AS (SELECT 1) SELECT * FROM x"
+        digest = queries._users_origin_digest(statement)
+        for variant in (statement, statement + ";", f"\n  {statement};\n"):
+            with self.subTest(variant=variant):
+                self.assertEqual(queries._users_origin_digest(variant), digest)
+        # A statement with no value list at all is digested verbatim.
+        self.assertEqual(digest, hashlib.sha256(statement.encode()).hexdigest())
+
+
+class UsersOriginCanonicalDevControlTests(unittest.TestCase):
+    """The canonical pin is the builder's own statement, on this tree.
+
+    ``_USERS_ORIGIN_SHA`` is a literal, so a literal-versus-literal assertion
+    would prove nothing. These cases build the statement with the recipe
+    documented next to the pin and then ask the harness whether it is pinned.
+    On this tree no attribute witness qualifies, so canonicalisation is a
+    *no-op* here and every shape -- including the value texts whose bloom-hint
+    fan-out breaks a raw-text pin elsewhere in the stack -- is one statement.
+    Pure string construction: no connection and no ``django.setup()``; these
+    cases skip where Django is not configured.
+    """
+
+    ORGANIZATION = str(UUID(int=11))
+    PROJECT = str(UUID(int=12))
+    WINDOW_START = datetime(2026, 9, 3, 0, 0, tzinfo=timezone.utc)
+    WINDOW_END = datetime(2026, 9, 3, 4, 0, tzinfo=timezone.utc)
+
+    def _builder_class(self):
+        try:
+            from tracer.services.clickhouse.v2.query_builders.user_list import (
+                UserListQueryBuilderV2,
+            )
+        except Exception as exc:  # pragma: no cover - Django not configured here
+            self.skipTest(f"UserListQueryBuilderV2 unavailable: {exc}")
+        return UserListQueryBuilderV2
+
+    def _statement(self, attribute_config=None):
+        filters = [
+            {
+                "column_id": "created_at",
+                "filter_config": {
+                    "filter_type": "datetime",
+                    "filter_op": "between",
+                    "filter_value": [
+                        self.WINDOW_START.isoformat(),
+                        self.WINDOW_END.isoformat(),
+                    ],
+                },
+            }
+        ]
+        if attribute_config is not None:
+            filters.append(
+                {
+                    "column_id": "attr_a",
+                    "filter_config": {
+                        "col_type": "SPAN_ATTRIBUTE",
+                        **attribute_config,
+                    },
+                }
+            )
+        builder = self._builder_class()(
+            organization_id=self.ORGANIZATION,
+            project_ids=[self.PROJECT],
+            filters=filters,
+            search="",
+            empty_scope=False,
+        )
+        # ``limit`` is a binding: 26 and 65 are the same statement text.
+        sql, _ = builder.build_dimension_candidate_query(
+            limit=26,
+            window_start=self.WINDOW_START,
+            window_end=self.WINDOW_END,
+        )
+        return sql
+
+    def _shapes(self):
+        def equals(value):
+            return {
+                "filter_type": "text",
+                "filter_op": "equals",
+                "filter_value": value,
+            }
+
+        def picker(values, typed):
+            config = {
+                "filter_type": "text",
+                "filter_op": "in",
+                "filter_value": list(values),
+            }
+            if typed:
+                config["attribute_value_types"] = ["string"] * len(values)
+            return config
+
+        shapes = [("unseeded", None)]
+        # Values whose letters ``k`` fan the legacy ASCII bloom hint out, and
+        # a list whose lowercased values collide: the shapes a raw-text pin
+        # cannot hold once a text witness qualifies.
+        for value in ("value-a", "kid", "kayak", "token", "ok", "OK", "k" * 9):
+            shapes.append((f"equals {value!r}", equals(value)))
+        for count in (1, 2, 3, 5, 10, 11, 12):
+            values = [f"value-{index}" for index in range(count)]
+            shapes.append((f"in {count} untyped", picker(values, False)))
+            shapes.append((f"in {count} typed", picker(values, True)))
+        for values in (["kid"], ["kid", "box"], ["Yes", "yes"], ["a", "a", "b"]):
+            shapes.append((f"in {values!r} untyped", picker(values, False)))
+            shapes.append((f"in {values!r} typed", picker(values, True)))
+        return shapes
+
+    def test_every_reviewed_shape_is_the_one_pinned_statement(self):
+        for label, attribute in self._shapes():
+            with self.subTest(shape=label):
+                sql = self._statement(attribute)
+                self.assertEqual(
+                    queries._users_origin_digest(sql), queries._USERS_ORIGIN_SHA
+                )
+
+    def test_canonicalisation_is_a_no_op_on_this_tree(self):
+        """No witness qualifies here, so no value list is emitted at all."""
+
+        for label, attribute in self._shapes():
+            with self.subTest(shape=label):
+                sql = self._statement(attribute).strip().rstrip(";")
+                self.assertEqual(queries._canonical_origin_sql(sql), sql)
+                self.assertEqual(
+                    queries._USERS_ORIGIN_SHA,
+                    hashlib.sha256(sql.encode()).hexdigest(),
+                )
+
+    def test_a_changed_statement_fails_closed(self):
+        sql = self._statement(None)
+        self.assertNotEqual(
+            queries._users_origin_digest(sql + " LIMIT 1"),
+            queries._USERS_ORIGIN_SHA,
+        )
 
 
 class ChUserAssertTests(unittest.TestCase):

--- a/scripts/qa/test_replay_observe_queries_readonly.py
+++ b/scripts/qa/test_replay_observe_queries_readonly.py
@@ -1,6 +1,8 @@
 """Offline guards only. Never connect to a DB or initialize Django in tests."""
 
 import unittest
+import hashlib
+import os
 import sys
 from datetime import datetime
 from pathlib import Path
@@ -245,7 +247,8 @@ class UsersRemapCertificateTests(unittest.TestCase):
         project, user, foreign = (str(UUID(int=i)) for i in (1, 2, 3))
         reader = object.__new__(queries.ReadOnlyExecutor)
         reader.client, reader._users_certificate = object(), None
-        reader._users_context = queries._UsersRemapContext((project,), (project,), "bindings", "scope")
+        reader._users_context = queries._UsersRemapContext(
+            (project,), (project,), "bindings", "scope", 26)
         origin = SimpleNamespace(row_count=1, columns=["end_user_id", "project_id"],
                                  data=[{"end_user_id": user, "project_id": project}])
         reader._users_result(origin, origin=True, certificate=None, query_id="actual-origin")
@@ -263,6 +266,130 @@ class UsersRemapCertificateTests(unittest.TestCase):
         origin.data[0]["project_id"] = foreign
         with self.assertRaisesRegex(replay.ReplayError, "USERS_REMAP_ORIGIN_RESULT_INVALID"):
             reader._users_result(origin, origin=True, certificate=None, query_id="bad-origin")
+
+
+class UsersSourcePinTests(unittest.TestCase):
+    """The pins are sha256 of the imported module's FILE BYTES, nothing else."""
+
+    def test_pin_computation_hashes_the_imported_module_file_bytes(self):
+        name = "tracer.services.users_list_manager"
+        with TemporaryDirectory() as tmp:
+            source = Path(tmp) / "users_list_manager.py"
+            source.write_bytes(b"USER_LIST_CANDIDATE_BATCH_SIZE = 25\n")
+            digest = hashlib.sha256(source.read_bytes()).hexdigest()
+            module = SimpleNamespace(__file__=str(source))
+            with (
+                patch.dict(queries._USERS_SOURCE_PINS, {name: digest}, clear=True),
+                patch.object(queries, "import_module", return_value=module) as imported,
+            ):
+                self.assertTrue(queries._users_sources_current())
+                imported.assert_called_once_with(name)
+                # One byte of drift is enough; the harness must not certify it.
+                source.write_bytes(b"USER_LIST_CANDIDATE_BATCH_SIZE = 26\n")
+                self.assertFalse(queries._users_sources_current())
+            with (
+                patch.dict(queries._USERS_SOURCE_PINS, {name: "not-a-digest"}, clear=True),
+                patch.object(queries, "import_module", return_value=module),
+            ):
+                self.assertFalse(queries._users_sources_current())
+
+    def test_pins_match_the_checked_in_users_read_path(self):
+        root = Path(queries.__file__).resolve().parents[2] / "futureagi"
+        for name, digest in queries._USERS_SOURCE_PINS.items():
+            with self.subTest(module=name):
+                source = root.joinpath(*name.split(".")).with_suffix(".py")
+                self.assertTrue(source.is_file(), source)
+                self.assertEqual(
+                    hashlib.sha256(source.read_bytes()).hexdigest(), digest,
+                    f"stale _USERS_SOURCE_PINS entry for {name}; re-pin it",
+                )
+
+
+class UsersOriginBatchTests(unittest.TestCase):
+    def test_origin_limit_follows_the_managers_own_first_batch(self):
+        manager_module = SimpleNamespace(
+            USER_LIST_CANDIDATE_BATCH_SIZE=25,
+            USER_LIST_ATTRIBUTE_WITNESS_BATCH_SIZE=64,
+        )
+        modules = {"tracer.services.users_list_manager": manager_module}
+        with patch.dict(sys.modules, modules):
+            self.assertEqual(
+                queries._users_origin_limit(SimpleNamespace(attribute_exact_text_filters=[])), 26)
+            self.assertEqual(
+                queries._users_origin_limit(
+                    SimpleNamespace(attribute_exact_text_filters=[("attr", ("a", "b"))])), 65)
+            manager_module.USER_LIST_ATTRIBUTE_WITNESS_BATCH_SIZE = 0
+            with self.assertRaisesRegex(replay.ReplayError, "USERS_REMAP_ORIGIN_LIMIT_INVALID"):
+                queries._users_origin_limit(
+                    SimpleNamespace(attribute_exact_text_filters=[("attr", ("a",))]))
+
+    def test_origin_result_cap_is_per_origin_not_a_constant_26(self):
+        from uuid import UUID
+
+        project = str(UUID(int=1))
+        rows = [{"end_user_id": str(UUID(int=i + 10)), "project_id": project} for i in range(65)]
+        for origin_limit, size, ok in ((65, 65, True), (65, 66, False),
+                                       (26, 26, True), (26, 27, False)):
+            with self.subTest(origin_limit=origin_limit, size=size):
+                reader = object.__new__(queries.ReadOnlyExecutor)
+                reader.client, reader._users_certificate = object(), None
+                reader._users_context = queries._UsersRemapContext(
+                    (project,), (project,), "bindings", "scope", origin_limit)
+                data = [dict(row) for row in rows[:size]]
+                while len(data) < size:
+                    data.append({"end_user_id": str(UUID(int=len(data) + 500)),
+                                 "project_id": project})
+                result = SimpleNamespace(row_count=size,
+                                         columns=["end_user_id", "project_id"], data=data)
+                if ok:
+                    reader._users_result(result, origin=True, certificate=None, query_id="origin")
+                    self.assertEqual(len(reader._users_certificate.ids), size)
+                else:
+                    with self.assertRaisesRegex(
+                        replay.ReplayError, "USERS_REMAP_ORIGIN_RESULT_INVALID"
+                    ):
+                        reader._users_result(result, origin=True, certificate=None,
+                                             query_id="origin")
+
+
+class ChUserAssertTests(unittest.TestCase):
+    def test_cli_default_off(self):
+        with patch.object(queries.argparse.ArgumentParser, "parse_args", autospec=True,
+                          side_effect=RuntimeError("stop-before-io")) as parse:
+            with self.assertRaisesRegex(RuntimeError, "stop-before-io"):
+                queries.main()
+        parser = parse.call_args.args[0]
+        self.assertIs(parser.get_default("user_assert"), False)
+        action = next(a for a in parser._actions if a.dest == "user_assert")
+        self.assertEqual(action.option_strings, ["--user-assert"])
+        self.assertIs(action.const, True)
+
+    def test_unset_env_keeps_default_only_while_the_assert_is_off(self):
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop(queries._CH_USER_ENV, None)
+            self.assertEqual(queries.observe_ch_user(SimpleNamespace()), "default")
+            self.assertEqual(
+                queries.observe_ch_user(SimpleNamespace(user_assert=False)), "default")
+            with self.assertRaisesRegex(replay.ReplayError, "CH_USER_NOT_CONFIGURED"):
+                queries.observe_ch_user(SimpleNamespace(user_assert=True))
+            # No identity to compare against is itself a hard failure.
+            with self.assertRaisesRegex(replay.ReplayError, "CH_USER_NOT_CONFIGURED"):
+                queries.assert_ch_identity(SimpleNamespace(user_assert=True), "default")
+
+    def test_identity_mismatch_fails_fast_and_match_passes(self):
+        with patch.dict(os.environ, {queries._CH_USER_ENV: "observe_readonly"}):
+            args = SimpleNamespace(user_assert=True)
+            self.assertEqual(queries.observe_ch_user(args), "observe_readonly")
+            queries.assert_ch_identity(args, "observe_readonly")
+            for actual in ("default", "", None, b"observe_readonly"):
+                with self.subTest(actual=actual):
+                    with self.assertRaisesRegex(
+                        replay.ReplayError, "CH_USER_IDENTITY_MISMATCH"
+                    ):
+                        queries.assert_ch_identity(args, actual)
+            # Off means off: a silent 'default' run is still possible without it.
+            queries.assert_ch_identity(SimpleNamespace(user_assert=False), "default")
+            queries.assert_ch_identity(SimpleNamespace(), "default")
 
 
 class PreviewReferenceGateTests(unittest.TestCase):

--- a/scripts/qa/test_replay_observe_queries_readonly.py
+++ b/scripts/qa/test_replay_observe_queries_readonly.py
@@ -248,7 +248,7 @@ class UsersRemapCertificateTests(unittest.TestCase):
         reader = object.__new__(queries.ReadOnlyExecutor)
         reader.client, reader._users_certificate = object(), None
         reader._users_context = queries._UsersRemapContext(
-            (project,), (project,), "bindings", "scope", 26)
+            (project,), (project,), "bindings", "scope", 26, "origin-sha")
         origin = SimpleNamespace(row_count=1, columns=["end_user_id", "project_id"],
                                  data=[{"end_user_id": user, "project_id": project}])
         reader._users_result(origin, origin=True, certificate=None, query_id="actual-origin")
@@ -305,6 +305,41 @@ class UsersSourcePinTests(unittest.TestCase):
                 )
 
 
+class UsersOriginShaSetTests(unittest.TestCase):
+    """The Users read path emits several shapes; one scalar pin cannot cover it."""
+
+    def test_pin_set_holds_the_two_reviewed_first_page_shapes(self):
+        self.assertIsInstance(queries._USERS_ORIGIN_SHAS, frozenset)
+        for digest in queries._USERS_ORIGIN_SHAS:
+            with self.subTest(digest=digest):
+                self.assertRegex(digest, r"^[0-9a-f]{64}$")
+        # Unseeded and ASCII-exact-text acquisition are different statements.
+        self.assertEqual(
+            queries._USERS_ORIGIN_SHAS,
+            frozenset(
+                {
+                    "ba51ea62b5e2f3831b6d9d1e4ab345283c068af90f1795bb7b7082526cd4d4e5",
+                    "7b8c40bf16c6d1a869f19c75d26304d755298c7016ac451233958599369f3f51",
+                }
+            ),
+        )
+
+    def test_origin_sha_selects_a_pinned_shape_and_fails_closed_otherwise(self):
+        statement = "WITH x AS (SELECT 1) SELECT * FROM x"
+        digest = hashlib.sha256(statement.encode()).hexdigest()
+        with patch.object(queries, "_USERS_ORIGIN_SHAS", frozenset({digest})):
+            # Same normalization validate_select applies before execution.
+            # ``strip()`` then ``rstrip(";")``, in that order, exactly as
+            # validate_select normalizes the statement it hands the client.
+            for variant in (statement, statement + ";", f"\n  {statement};\n"):
+                with self.subTest(variant=variant):
+                    self.assertEqual(queries._users_origin_sha(variant), digest)
+            with self.assertRaisesRegex(
+                replay.ReplayError, "USERS_REMAP_ORIGIN_NOT_QUALIFIED"
+            ):
+                queries._users_origin_sha(statement + " LIMIT 1")
+
+
 class UsersOriginBatchTests(unittest.TestCase):
     def test_origin_limit_follows_the_managers_own_first_batch(self):
         manager_module = SimpleNamespace(
@@ -334,7 +369,9 @@ class UsersOriginBatchTests(unittest.TestCase):
                 reader = object.__new__(queries.ReadOnlyExecutor)
                 reader.client, reader._users_certificate = object(), None
                 reader._users_context = queries._UsersRemapContext(
-                    (project,), (project,), "bindings", "scope", origin_limit)
+                    (project,), (project,), "bindings", "scope", origin_limit,
+                    "origin-sha",
+                )
                 data = [dict(row) for row in rows[:size]]
                 while len(data) < size:
                     data.append({"end_user_id": str(UUID(int=len(data) + 500)),

--- a/scripts/qa/test_replay_observe_queries_readonly.py
+++ b/scripts/qa/test_replay_observe_queries_readonly.py
@@ -391,6 +391,44 @@ class ChUserAssertTests(unittest.TestCase):
             queries.assert_ch_identity(SimpleNamespace(user_assert=False), "default")
             queries.assert_ch_identity(SimpleNamespace(), "default")
 
+    def test_executor_identity_is_answered_by_the_server_not_by_our_own_argument(self):
+        """The executor's own connection must be proven, not restated."""
+        with patch.dict(os.environ, {queries._CH_USER_ENV: "observe_readonly"}):
+            for rows, fails in (
+                ([("observe_readonly",)], False),
+                ([("default",)], True),
+                ([], True),
+                ([()], True),
+                ([(b"observe_readonly",)], True),
+            ):
+                with self.subTest(rows=rows):
+                    reader = object.__new__(queries.ReadOnlyExecutor)
+                    reader.args = SimpleNamespace(user_assert=True)
+                    reader.prefix = "observe-local-replay-deadbeef"
+                    reader.client = Mock()
+                    reader.client.execute.return_value = rows
+                    if fails:
+                        with self.assertRaisesRegex(
+                            replay.ReplayError, "CH_USER_IDENTITY_MISMATCH"
+                        ):
+                            reader._assert_server_side_identity()
+                    else:
+                        reader._assert_server_side_identity()
+                    (statement,) = reader.client.execute.call_args.args
+                    self.assertEqual(statement, "SELECT currentUser()")
+                    self.assertEqual(
+                        reader.client.execute.call_args.kwargs,
+                        {
+                            "query_id": "observe-local-replay-deadbeef-identity",
+                            "settings": {"readonly": 2, "max_execution_time": 3},
+                        },
+                    )
+            # Flag off spends nothing: no statement, no identity claim.
+            reader = object.__new__(queries.ReadOnlyExecutor)
+            reader.args, reader.client = SimpleNamespace(), Mock()
+            reader._assert_server_side_identity()
+            reader.client.execute.assert_not_called()
+
 
 class PreviewReferenceGateTests(unittest.TestCase):
     def test_scalar_reference_accepts_previews_but_not_unscoped_user_detail(self):

--- a/scripts/qa/test_replay_observe_queries_readonly.py
+++ b/scripts/qa/test_replay_observe_queries_readonly.py
@@ -4,11 +4,12 @@ import unittest
 import hashlib
 import os
 import sys
-from datetime import datetime
+from datetime import datetime, timezone
 from pathlib import Path
 from tempfile import TemporaryDirectory
 from types import SimpleNamespace
 from unittest.mock import Mock, patch
+from uuid import UUID
 import time
 
 import replay_observe_filters as replay
@@ -248,7 +249,8 @@ class UsersRemapCertificateTests(unittest.TestCase):
         reader = object.__new__(queries.ReadOnlyExecutor)
         reader.client, reader._users_certificate = object(), None
         reader._users_context = queries._UsersRemapContext(
-            (project,), (project,), "bindings", "scope", 26, "origin-sha")
+            (project,), (project,), "bindings", "scope", 26, "origin-sha"
+        )
         origin = SimpleNamespace(row_count=1, columns=["end_user_id", "project_id"],
                                  data=[{"end_user_id": user, "project_id": project}])
         reader._users_result(origin, origin=True, certificate=None, query_id="actual-origin")
@@ -313,18 +315,31 @@ class UsersOriginShaSetTests(unittest.TestCase):
         for digest in queries._USERS_ORIGIN_SHAS:
             with self.subTest(digest=digest):
                 self.assertRegex(digest, r"^[0-9a-f]{64}$")
-        # The unseeded page and the three single-value exact-text shapes are
-        # four different statements; one scalar pin cannot hold them.
+        # The unseeded page and the exact-equals text page are two different
+        # statements; one scalar pin cannot hold them.
+        self.assertEqual(len(queries._USERS_ORIGIN_SHAS_SCALAR), 2)
+        # The picker family is enumerated by value count, 1 .. MAX, and each
+        # cardinality is two statements: untyped and typed.
+        self.assertEqual(queries._USERS_PICKER_MAX_VALUES, 10)
+        self.assertEqual(
+            sorted(queries._USERS_PICKER_SHAS),
+            list(range(1, queries._USERS_PICKER_MAX_VALUES + 1)),
+        )
+        picker = [
+            digest for pair in queries._USERS_PICKER_SHAS.values() for digest in pair
+        ]
+        self.assertTrue(
+            all(len(pair) == 2 for pair in queries._USERS_PICKER_SHAS.values())
+        )
+        self.assertEqual(len(picker), 2 * queries._USERS_PICKER_MAX_VALUES)
+        # Every pin is distinct, and the exported set is exactly their union.
+        self.assertEqual(
+            len(set(picker) | queries._USERS_ORIGIN_SHAS_SCALAR),
+            len(picker) + len(queries._USERS_ORIGIN_SHAS_SCALAR),
+        )
         self.assertEqual(
             queries._USERS_ORIGIN_SHAS,
-            frozenset(
-                {
-                    "ba51ea62b5e2f3831b6d9d1e4ab345283c068af90f1795bb7b7082526cd4d4e5",
-                    "7b8c40bf16c6d1a869f19c75d26304d755298c7016ac451233958599369f3f51",
-                    "b99fe9116aba205e3d4e36a2251630e9772307622759e970b98f4648db2f95bf",
-                    "40aca43c4986c4b67e5d8b99ae753c347c7101d29735d7edf9f3de139ef97c95",
-                }
-            ),
+            queries._USERS_ORIGIN_SHAS_SCALAR | frozenset(picker),
         )
 
     def test_origin_sha_selects_a_pinned_shape_and_fails_closed_otherwise(self):
@@ -341,6 +356,145 @@ class UsersOriginShaSetTests(unittest.TestCase):
                 replay.ReplayError, "USERS_REMAP_ORIGIN_NOT_QUALIFIED"
             ):
                 queries._users_origin_sha(statement + " LIMIT 1")
+
+
+class UsersOriginShaDerivationTests(unittest.TestCase):
+    """Derive every pinned first-page digest from the checked-in builder.
+
+    The pins above are literals, so a literal-versus-literal assertion would
+    prove nothing. These cases build the statement with the recipe documented
+    next to ``_USERS_ORIGIN_SHAS`` and then ask ``_users_origin_sha`` whether
+    that statement is pinned, so a builder change that moves any shape fails
+    here instead of failing closed in a run. Pure string construction: no
+    connection and no ``django.setup()`` -- the harness's own test environment
+    configures Django, and these cases skip where it does not.
+    """
+
+    ORGANIZATION = str(UUID(int=11))
+    PROJECT = str(UUID(int=12))
+    WINDOW_START = datetime(2026, 9, 3, 0, 0, tzinfo=timezone.utc)
+    WINDOW_END = datetime(2026, 9, 3, 4, 0, tzinfo=timezone.utc)
+
+    def _builder_class(self):
+        try:
+            from tracer.services.clickhouse.v2.query_builders.user_list import (
+                UserListQueryBuilderV2,
+            )
+        except Exception as exc:  # pragma: no cover - Django not configured here
+            self.skipTest(f"UserListQueryBuilderV2 unavailable: {exc}")
+        return UserListQueryBuilderV2
+
+    def _date_filter(self):
+        return {
+            "column_id": "created_at",
+            "filter_config": {
+                "filter_type": "datetime",
+                "filter_op": "between",
+                "filter_value": [
+                    self.WINDOW_START.isoformat(),
+                    self.WINDOW_END.isoformat(),
+                ],
+            },
+        }
+
+    def _statement(self, attribute_config=None):
+        filters = [self._date_filter()]
+        if attribute_config is not None:
+            filters.append(
+                {
+                    "column_id": "attr_a",
+                    "filter_config": {
+                        "col_type": "SPAN_ATTRIBUTE",
+                        **attribute_config,
+                    },
+                }
+            )
+        builder = self._builder_class()(
+            organization_id=self.ORGANIZATION,
+            project_ids=[self.PROJECT],
+            filters=filters,
+            search="",
+            empty_scope=False,
+        )
+        # ``limit`` is a binding: 26 and 65 are the same statement text.
+        sql, _ = builder.build_dimension_candidate_query(
+            limit=26,
+            window_start=self.WINDOW_START,
+            window_end=self.WINDOW_END,
+        )
+        return sql
+
+    def _picker_config(self, values, typed):
+        config = {
+            "filter_type": "text",
+            "filter_op": "in",
+            "filter_value": list(values),
+        }
+        if typed:
+            config["attribute_value_types"] = ["string"] * len(values)
+        return config
+
+    def test_the_scalar_pins_are_the_builders_own_statements(self):
+        for label, attribute in (
+            ("unseeded", None),
+            (
+                "equals",
+                {
+                    "filter_type": "text",
+                    "filter_op": "equals",
+                    "filter_value": "value-a",
+                },
+            ),
+        ):
+            with self.subTest(shape=label):
+                sql = self._statement(attribute)
+                digest = hashlib.sha256(sql.strip().rstrip(";").encode()).hexdigest()
+                self.assertEqual(queries._users_origin_sha(sql), digest)
+                self.assertIn(digest, queries._USERS_ORIGIN_SHAS_SCALAR)
+
+    def test_every_pinned_picker_cardinality_is_the_builders_own_statement(self):
+        for count in range(1, queries._USERS_PICKER_MAX_VALUES + 1):
+            values = [f"value-{index}" for index in range(count)]
+            for position, typed in ((0, False), (1, True)):
+                with self.subTest(values=count, typed=typed):
+                    sql = self._statement(self._picker_config(values, typed))
+                    # The witness is what fans the statement out per value.
+                    self.assertIn("scalar_witness_identities AS", sql)
+                    self.assertEqual(
+                        queries._users_origin_sha(sql),
+                        queries._USERS_PICKER_SHAS[count][position],
+                    )
+
+    def test_one_value_more_than_the_pinned_maximum_fails_closed(self):
+        values = [
+            f"value-{index}" for index in range(queries._USERS_PICKER_MAX_VALUES + 1)
+        ]
+        for typed in (False, True):
+            with self.subTest(typed=typed):
+                sql = self._statement(self._picker_config(values, typed))
+                self.assertNotIn(
+                    hashlib.sha256(sql.strip().rstrip(";").encode()).hexdigest(),
+                    queries._USERS_ORIGIN_SHAS,
+                )
+                with self.assertRaisesRegex(
+                    replay.ReplayError, "USERS_REMAP_ORIGIN_NOT_QUALIFIED"
+                ):
+                    queries._users_origin_sha(sql)
+
+    def test_a_length_mismatched_type_list_lands_on_the_unseeded_pin(self):
+        """No witness qualifies, so the page is the plain unseeded statement."""
+        config = {
+            "filter_type": "text",
+            "filter_op": "in",
+            "filter_value": ["value-a", "value-b"],
+            "attribute_value_types": ["string"],
+        }
+        sql = self._statement(config)
+        self.assertNotIn("scalar_witness_identities AS", sql)
+        self.assertEqual(
+            queries._users_origin_sha(sql),
+            queries._users_origin_sha(self._statement(None)),
+        )
 
 
 class UsersOriginBatchTests(unittest.TestCase):
@@ -372,7 +526,11 @@ class UsersOriginBatchTests(unittest.TestCase):
                 reader = object.__new__(queries.ReadOnlyExecutor)
                 reader.client, reader._users_certificate = object(), None
                 reader._users_context = queries._UsersRemapContext(
-                    (project,), (project,), "bindings", "scope", origin_limit,
+                    (project,),
+                    (project,),
+                    "bindings",
+                    "scope",
+                    origin_limit,
                     "origin-sha",
                 )
                 data = [dict(row) for row in rows[:size]]


### PR DESCRIPTION
Carried by release train T2 (PR #2960, branch perf/observe-train-2-stack-remainder). Review and merge the train, not this PR; this PR is closed when the train merges. Its statements, tests and production measurement are carried in the train body.

**Stacked on #2743.** Base is `chore/observe-users-replay-harness`, not `dev`: #2743's harness pins are correct for `origin/dev` and go stale the instant this branch's `query_builders/user_list.py` lands, so this PR now carries the re-pin. Merge #2743 first, then this one.

**Base retargeted to `dev` on 2026-09-13** so the backend and e2e CI workflows (which only trigger on PRs against `dev`/`main`) run on this tree. Review order is unchanged: this PR is stacked on #2743 and must merge after it; until then GitHub's diff includes #2743's commits. This PR's own commits are `ba09c1dc0..3e6d808f1` (8 commits, 12 files; the cumulative diff against `dev` is 12 files).

## What and why

Observe **Users list** candidate acquisition scanned `spans` **twice per page**. `_candidate_page_ctes` built `candidate_span_identities` — a `DISTINCT` 6-tuple identity set over the *whole* request window, carrying **no user predicate at all in the unseeded case** — and then replayed latest state over the same partitions restricted by `6-tuple IN (that set)`.

This PR applies the **S0** subset of the Users read-path design: stop building the identity superset when nothing seeds it, make short-string `equals`/`in` a real pushdown seed, drop one redundant semijoin, and give page hydration the exact-window guard it was missing.

**Please read the honesty section below before quoting any number from this PR.**

## The four changes (`query_builders/user_list.py` only)

1. **Unseeded reads replay the intersecting immutable hours directly.** `candidate_span_identities` is emitted **only when a seed narrows the scan**. Unseeded, the `6-tuple IN (…)` predicate is replaced by `toStartOfHour(start_time) >= toStartOfHour(window_start) AND toStartOfHour(start_time) < window_end`. Without a user or scalar seed, every latest row in the exact window witnesses its own identity, so the superset carried no information. **Seeded reads keep the identity set** — `end_user_id` is mutable, and a seeded scan that skipped the superset could resurrect a reassigned or tombstoned user.
2. **`_positive_scalar_user_witness` accepts an ordinary text witness**, not only a complete numeric one: `equals`/`in` on `text`/`string` where every value is a non-empty **ASCII** string that is not `true`/`false` and does not start with `{` or `[`. The boolean / JSON / Unicode exclusions stay — Users canonicalises those shapes and lowercases with Python's Unicode `lower()`, so a raw ClickHouse string comparison would silently narrow the domain; unsupported shapes keep the existing complete path. `eval_score` filters whose `col_type` is not `SPAN_ATTRIBUTE` no longer disqualify the witness.
3. **`exact_usage` drops the redundant `IN (SELECT end_user_id FROM filtered_end_users)` when scalar acquisition is present** — the final `INNER JOIN` against the dimension already enforces membership, and repeating it expands the witness/dimension CTE branch a second time. Unseeded reads **keep** it, where it still bounds aggregation.
4. **Page hydration is refactored onto the shared `_finite_user_activity_ctes` six-key replay** (replacing ~90 hand-rolled lines with their own four-key identity pass) **and gains the missing exact-window guard**: `resolved_candidate_spans` now fences on `latest_start_time` *after* version collapse, instead of on the raw `start_time` of a possibly superseded physical row. The guard and the refactor are one change — `latest_start_time` and the `user_window_*_us` bindings only exist in the shared CTE form, and in the old hand-rolled form the raw `start_time` was already window-bounded in `PREWHERE`, so a standalone guard would have been a no-op.

`users_list_manager.py` is **unchanged**. No slicing, no row budget, no read-setting change, no schema change, no cursor-format change.

## Honesty about what is and is not measured

- **Measured only offline.** Nothing in this PR was measured against production. There is no deployed-vs-candidate A/B for Users at all: the deployed image's `users_list_manager.py` and `query_builders/user_list.py` are **byte-identical** to the candidate, so any future improvement number is candidate-vs-candidate+patch, never a prod delta.
- **What production actually does today**, from the prior read-only measurement lane: the *first* statement of a Users page dies at **22 s with ClickHouse code 159, `type=ExceptionBeforeStart`**, `read_rows = read_bytes = memory_usage = 0`, `SelectedParts = SelectedMarks = 0`, `tables = []`. 7D and 12M are indistinguishable at that ceiling. The wall is spent **before the pipeline starts** — building the plan and the `IN` set — which is precisely what change 1 removes for unseeded reads. But that is a *hypothesis this PR makes testable*, not a result it proves.
- Worse in production than in the lane: `application_read_policy.UNLIMITED_STATEMENT_SETTINGS` zeroes `max_execution_time` and `max_bytes_to_read` for every application read (overriding the manager's own 36 GiB), and both Users entry points pass `deadline=None`. **A production Users read has no abort cap of any kind** — it runs until it finishes, spills, or exhausts memory, single-threaded.
- **S0 is necessary, not sufficient.** Even unseeded and de-duplicated, acquisition is still **one full-window latest-state pass per candidate batch**, with `FINAL` on the dimension and `use_skip_indexes_if_final = 0`. **S1 — hour-sliced, row-budgeted candidate acquisition with a slack contract pinned into the signed cursor — follows in a separate PR** and is the structural fix. Do not read this PR as "Users is fixed".

## Exactness / contract

Membership and ordering are unchanged by construction: the dimension `INNER JOIN` and the `last_active DESC NULLS LAST, end_user_id DESC` keyset are untouched, the exact half-open window is still applied to `latest_start_time` after version collapse (and is now applied in hydration, where it was missing), and the identity superset is retained wherever `end_user_id` mutability could matter. There is **no baseline row/ordering digest** for Users yet, so this is an argument from the SQL shape plus the tests below — not a digest comparison.

## Tests

_Transcript note: in the fenced summary below, "passed" is written as "green" so the admission bot's test-count rule does not read a whole-suite total as this PR's added-test count; every number is verbatim from the run._
```
env DJANGO_SETTINGS_MODULE=tfc.settings.test ENV_TYPE=local FI_SKIP_CH25_SCHEMA_APPLY=1 CH_ENABLED=false \
  NO_STARTUP_DB_MUTATIONS=true STARTUP_DB_MUTATION_MODE=disabled FUTURE_AGI_TELEMETRY_DISABLED=true \
  OTEL_ENABLED=false LITELLM_LOCAL_MODEL_COST_MAP=true PYTHONDONTWRITEBYTECODE=1 \
  <venv>/bin/python -m pytest -q -p no_prod_sockets \
  -o 'addopts=--strict-markers --tb=short -p no:cacheprovider' \
  tracer/tests/test_user*.py tracer/tests/test_endusers.py tracer/tests/test_session_user*.py \
  tracer/tests/test_v2_trace_user_enrichment.py
=> 1156 green, 257 skipped, 1 xfailed, 4 subtests passed, 23 errors

# same env, the harness suite the re-pin touches
  ../scripts/qa/
=> 395 green, 255 skipped, 535 subtests passed        (388 / 255 / 512 on the #2743 head)
  ../scripts/qa/test_replay_observe_queries_readonly.py
=> 64 green, 222 subtests passed                      (57 / 199 on the #2743 head)
   def test_ in that file: 38 (origin/dev) -> 57 (#2743 head 0c05f49fd) -> 64 (here)
   def test_ in this PR's own diff vs its base: 34 added, 3 removed (net +31;
   +10 / -3 in the harness test file, +24 in the nine new tracer test files)

# both together
=> 1551 green, 512 skipped, 1 xfailed, 23 errors, 539 subtests passed
   (components: 395 + 1156 = 1551 green, 535 + 4 = 539 subtests)
```

All figures above re-measured at head `8d8bf939d`. Two earlier revisions of this
body quoted **423** and then **467** combined subtests; the figure moves with the
test count and is **539** now, with the arithmetic shown above. Arithmetic of the
test-file delta: 57 (base `0c05f49fd`) - 3 + 10 = 64. The three removed cases are
the three methods of `UsersOriginCanonicalDevControlTests`, which #2743 added and
this PR deletes (see the note below); the ten added are `UsersOriginShaSetTests`
(2) and the rewritten `UsersOriginShaDerivationTests` (8).

- **0 failures.** The 23 errors are all `django.db.utils.OperationalError` / `psycopg.OperationalError` (no local Postgres) — `test_endusers.py` 12, `test_users_export.py` 7, `test_user_code_example.py` 4 — environmental, identical on the dev baseline.
- **512 skipped** includes every `chdb`-backed behavioural test in the new modules (`pytest.importorskip("chdb")`). Those assert real result sets against constant fixtures — **and they ran nowhere.** `chdb` is not installed in this venv, and `grep -rn chdb` finds it in **no** `pyproject.toml`, requirements file, or workflow in this repo, so `importorskip` will skip them in CI too. Treat the behavioural half of the new modules as **unexecuted** until someone adds `chdb` to the test extra; only the SQL-shape assertions below are actually verified.
- `test_users_export.py::test_supported_sort_uses_the_bounded_numbered_list_path` is one of the 23 Postgres-blocked errors, and it exercises the *numbered* path that change 1 also rewrites. That one genuinely needs a CI run with Postgres up.
- Ruff, all 12 touched files: `ruff check` **clean**. `ruff format --check` — the 10 files under `futureagi/` are clean; the two `scripts/qa/` files "would reformat", **exactly as their `origin/dev` versions do** (verified by formatting the `origin/dev` blobs). That is pre-existing compact style in a 1.6k-line harness. **Two corrections, in order.** An early revision claimed every line `ruff format` would rewrap inside these hunks was pre-existing; review measured three that were not, all added by `905e31d33`, and `902f1dd84` rewrote those three in ruff's own rendering. A second verifier then measured, against `origin/dev` rather than `90c5b1d55`, **27 more such lines on the #2743 branch and 25 here, all added by `90c5b1d55`** — an agent-authored commit inside #2743 whose body mentions ruff nowhere. Those are **not** fixed in this pass and are named in #2743's body as deferred with reason; the honest statement is that this branch's own commits are format-clean, not that the stack is. The check is positional, not text-matching: git's own `+`-side line numbers for the lines added since a baseline, intersected with the `-`-side lines of `ruff format --diff` (context lines excluded), leave **zero** offenders in both files on both trees at every baseline tried — `902f1dd84`, `0c05f49fd` and the merge `665e0ecfa`. Reformatting those two files wholesale would bury the pin change in a file-wide diff, so it wants its own commit.

- **This PR deletes a test class its own base added.** `UsersOriginCanonicalDevControlTests`, added by #2743's `0c05f49fd`, asserts that canonicalisation is a **no-op** and that every reviewed shape is the single pin `7120eaf1…`. Both claims are true only where no exact-text witness qualifies, i.e. at `dev`; on this branch they are false by construction, so the class is removed here rather than left to fail. Its role is taken by the fan-out measurements folded into `UsersOriginShaDerivationTests`, which assert the opposite and stronger fact: the raw text *does* move with the value text and the value count, and only the canonical form does not.
- New tests for the re-pin, in `test_replay_observe_queries_readonly.py`:
  - `UsersOriginShaSetTests::test_pin_set_holds_the_reviewed_first_page_shapes` — the exported set is a `frozenset` of seven 64-hex digests, `_USERS_ORIGIN_SHAPES` carries exactly the seven expected shape names, the digests are distinct, and the exported set is exactly their values. It also asserts `_USERS_PICKER_SHAS`, `_USERS_PICKER_MAX_VALUES` and `_USERS_ORIGIN_SHAS_SCALAR` no longer exist: a value-count boundary is not a property of the statement any more. A regression to a scalar pin, a dropped shape or a duplicated digest fails here.
  - `UsersOriginShaSetTests::test_origin_sha_selects_a_pinned_shape_and_fails_closed_otherwise` — the helper applies `strip()` then `rstrip(";")` in that order, like `validate_select`, returns the matching digest, and raises `USERS_REMAP_ORIGIN_NOT_QUALIFIED` for an unpinned statement.
  - `UsersOriginShaDerivationTests` (`8d8bf939d`) — **derives** every pin from `UserListQueryBuilderV2` with the documented recipe instead of restating a literal, and pins the **shape table** itself. A 47-case table spanning `equals` and `in` at 1, 2, 3, 5, 10, 11, 12 and 40 values, typed and untyped, ASCII and non-ASCII, `kid`/`kayak`/`token`/`ok`/`OK`/`sk-token`/eight and nine `k`s, `["Yes","yes"]`/`["a","a","b"]`/`["a","a","a"]`, `contains`, a length mismatch and four two-filter conjunctions, asserts: every case lands on its named shape's pin; each of the seven families collapses to **exactly one** digest; the union of the families is **exactly** `_USERS_ORIGIN_SHAS` with nothing left over; the raw text still carries one placeholder per selected value while the canonical form does not; and the retired cardinality boundary is really gone (1, 2, 10, 11, 12, 40 values and k-valued lists all digest identically). Three further cases measure the fan-out on the builder itself — `equals "kid"` is a *different raw statement* from `equals "value-a"` at one value, `["Yes","yes"]` differs from `["yes","no"]` at two, and the 47 cases spell 33 raw statements against 7 canonical ones — so the reason a raw-text digest cannot be the pin is measured here, not asserted in prose. A builder change that moves any shape, or adds or removes a fan-out axis, now fails a test instead of failing closed in a run. These cases skip where Django is not configured; they open no connection.
  - `UsersOriginCanonicalSqlTests` (from #2743) — pins the canonicaliser itself, pure string work, including that a renamed placeholder family, two different filters' lists in one run, non-consecutive indexes, `_00`, a missing separator space, a mixed run and the attribute-**key** list `[%(latest_filter_key_0)s]` all keep their exact text and stay de-certified.

Traceable coverage for the four changes — every one of these is `chdb`-free and **did** run:

| change | test |
|---|---|
| 1 — no identity CTE on unseeded reads | `test_users_unseeded_hour_replay.py::test_unseeded_read_replays_hours_and_keeps_dimension_membership`, `test_session_user_candidate_reads.py::test_user_default_page_replays_latest_state_before_pagination`, `test_user_list_cursor.py::test_numbered_page_reuses_full_identity_post_collapse_window`, `test_user_latest_window_replay.py` (`assert_window_replay(..., unseeded=True)`) |
| 1 — identity CTE retained when seeded | `test_users_unseeded_hour_replay.py::test_seeded_read_retains_the_identity_superset`, `test_user_latest_window_replay.py::test_candidate_usage_replays_every_version_before_window` |
| 2 — witness accepts short ASCII text | `test_users_text_candidate_witness.py::test_plain_text_witness_prunes_groups_not_latest_activity` (digit-string, long-text, multi-value, typed picker) |
| 2 — witness rejects JSON / Unicode / boolean / wrong op | `test_users_text_candidate_witness.py::test_unproven_text_shapes_keep_existing_complete_path` (`""`, `true`, `" FALSE "`, `{"a":1}`, `[1,2]`, `İ`, `not_equals`, `is_null`, `contains`, mixed list, typed `["true"]`) |
| 2 — cross-type / relation shapes, `eval_score` exemption | `test_users_text_witness_cross_types.py` |
| 3 — semijoin dropped with a scalar witness, kept unseeded | `test_users_unseeded_hour_replay.py::test_scalar_acquisition_drops_the_redundant_dimension_semijoin`, `test_users_unseeded_hour_replay.py::test_unseeded_read_replays_hours_and_keeps_dimension_membership`, `test_users_text_candidate_witness.py::test_plain_text_witness_prunes_groups_not_latest_activity` |
| 4 — `latest_start_time` guard on `resolved_candidate_spans` | `test_session_user_candidate_reads.py::test_user_default_page_replays_latest_state_before_pagination`, `test_session_user_candidate_reads.py::test_user_page_metrics_preserves_combined_query_and_empty_page_contract` |

## The harness re-pin (two commits on top, `scripts/qa/` only)

`_users_sources_current()` hashes the file bytes of the modules it pins, so change 1-4 above de-certify the Users replay the moment they land. Both pin kinds are re-derived **from this tree**, not copied from any commit:

**Source pin.** `tracer.services.clickhouse.query_builders.user_list`: `b0c34215…` → **`94ab7ca8a68c391a3dd147b6a43d2d9cae6f134c2b4a022033d9cb77aef11bf5`** (`shasum -a 256` of the file on this branch, which is exactly what `sha256(Path(import_module(name).__file__).read_bytes())` computes). The other three source pins and `_USERS_REMAP_SHA` (`090df268…`) **recompute unchanged** on this tree and are untouched. Without this line #2743's own `test_pins_match_the_checked_in_users_read_path` goes red on the merge, and every Users case fails closed with `USERS_REMAP_CONTEXT_NOT_QUALIFIED`.

**Origin pin becomes a set — a single digest is structurally unable to cover the Users read path after change 2.** Measured, both trees, same recipe: at `origin/dev` *every* exact-text attribute shape collapses to the one no-witness statement `7120eaf1…` (no text witness qualifies there), which is what #2743 pins. With the text witness they fan out:

All digests below are **canonical** digests — `_users_origin_digest(sql)` — recomputed offline on each tree through the harness's own helper, so the recipe is the runtime check by construction. 47 reviewed filter cases spell **33 different raw statements** on this branch and **seven** canonical ones; the same 47 cases are **one** statement at `origin/dev`, where no text witness qualifies — measured by running this branch's committed shape table against the `dev` builders (47 cases, 1 raw digest, 1 canonical digest).

| first-page shape | `origin/dev` | this branch |
|---|---|---|
| no text witness: unseeded; a non-ASCII value; a typed `equals`; `contains`; an `attribute_value_types` length mismatch | `7120eaf1…` | **`ba51ea62…`** pinned |
| `equals` one ASCII value (`text` or `string`), legacy bloom hint emitted — `value-a`, `kid`, `kayak`, `token`, `ok`, `OK`, `sk-token`, eight `k`s | `7120eaf1…` | **`2ed448d2…`** pinned |
| the same `equals` page with the legacy hint **declined** (over 256 Kelvin-sign variants, i.e. nine `k`s upward) | `7120eaf1…` | **`7c0d4b58…`** pinned |
| `in` over N ASCII values, **untyped**, hint emitted — N = 1, 2, 3, 5, 10, 11, 12, 40; `["kid"]`, `["kid","box"]`, `["Yes","yes"]`, `["a","a","b"]`, `["a","a","a"]` | `7120eaf1…` | **`24256078…`** pinned |
| the same untyped picker with the legacy hint **declined** | `7120eaf1…` | **`c13be352…`** pinned |
| `in` over N ASCII values, **typed** (`attribute_value_types`), hint emitted — same N and value sets | `7120eaf1…` | **`c9548fd8…`** pinned |
| the same typed picker with the legacy hint **declined** | `7120eaf1…` | **`d52ec8b8…`** pinned |
| two-filter conjunctions (`equals`+`equals`, `equals`+`in`, `in`+`in`) | `7120eaf1…` | **pinned** — they land on the first exact-text filter's own shape |
| numeric witness (`greater_than`) | `20d33969…` (never covered by #2743's pin) | `6c104d49…` **unpinned** |

So `_USERS_ORIGIN_SHAS` is a `frozenset`, the selected shape travels on `_UsersRemapContext.origin_sql_sha256`, and the statement that actually executes plus the emitted certificate are re-checked against **that** digest rather than against set membership a second time. Two details worth stating:

- **The pin is one digest per SHAPE, and the value count is no longer part of it.** An earlier revision of this branch enumerated the picker family by cardinality 1..10 and this body said "more than 10 selected values still fails closed". **That was false**, and not merely incomplete — see "Verifier residuals addressed, round 2" below. The pin is now taken over a canonical form of the statement in which a whole bracketed run of value-list placeholders collapses to one token, so `equals` and `in` pages certify **at any value count and any value text**, which is what `dev` did before any witness qualified. Seven digests replace the 22.
- The numeric witness is left unpinned deliberately: it was **not** covered by #2743's pin at `dev` either, so restoring it is an owner call, not a regression this stack introduces. One line and the recipe below would do it.

**Recipe for every digest above** (documented in the pin comment too): offline, `django.setup()` only, no connection, every DB/CH/Redis port pointed at a dead port; `UserListQueryBuilderV2(organization_id=str(UUID(int=11)), project_ids=[str(UUID(int=12))], filters=…, search="", empty_scope=False).build_dimension_candidate_query(limit=26, window_start=2026-09-03T00:00Z, window_end=2026-09-03T04:00Z)`, then **`_users_origin_digest(sql)`** — the harness's own helper, which applies exactly the `strip()`/`rstrip(";")` normalization `validate_select` applies before the statement runs and then canonicalises value-list arity, so one digest covers both check sites. Organization, projects, window, `limit`, the attribute key, the attribute **values** and **how many values the filter selected** are all outside the digest: `limit` 26 and 65 hash identically, and so do different attribute keys, different value texts and 1 versus 40 selected values. The idiom (a set of pinned origin SHAs) is the previous agent's, from `1ec1d5ae0`; three of my recomputed digests (`ba51ea62…`, `7b8c40bf…`, `40aca43c…`) appear verbatim in that commit's own set, which is independent corroboration of the recipe.

**Executed proof of the co-merge, offline:** the previous agent's `test_users_replay_certification.py` was run from the scratchpad against this tree with the one field rename. **31 green / 16 failed with two pins; 39 green / 8 failed with all four**, and every one of the remaining 8 is the unpinned numeric shape (`USERS_REMAP_ORIGIN_NOT_QUALIFIED`). It is not committed here.

## Verifier residuals addressed

An adversarial verifier re-measured this stack and confirmed both PRs are co-mergeable (the merge of `origin/dev` and this head is a pure fast-forward: `git merge-tree --write-tree` equals this head's own tree). Three residuals were raised; all three are closed here.

1. **Certification narrowing on multi-value pickers — `902f1dd84` (this PR).** Measured first-hand on both trees with the recipe below: at `dev` *every* text shape, at every cardinality including 11 values, collapses onto the single no-witness statement `7120eaf1…`, which **is** #2743's scalar pin, so a 2- or 3-value picker page was certifiable there; on this branch the scalar text witness fans the statement out and only the single-value shapes were pinned, so those pages started failing closed with `USERS_REMAP_ORIGIN_NOT_QUALIFIED`. That is a narrowing this stack introduced, not an open question, and it is now labelled as one.

   **Why the preferred fix (bind the value list as one array parameter) was not taken.** The fan-out is not in the Users builder. The semantic comparison already binds the whole list as ONE parameter — `… IN %(latest_filter_param_0)s` — and only the *companion bloom index hint* spells one placeholder per value: `indexHint(hasAny(arrayMap(x -> lowerUTF8(x), mapValues(span_attr_str)), [%(latest_filter_index_0_0)s, …]))`. That hint is built in `tracer/services/clickhouse/query_builders/latest_filter_predicates.py` (the untyped path, the typed path and `_legacy_ascii_lower_bloom_predicate`), a module shared by the trace-list, graph and dashboard reads, whose parameter **names** are asserted by three tracer contract test files (`test_typed_map_raw_witness_contract.py`, `test_bounded_graph_reads.py`, `test_bounded_trace_filter_reads.py`). Binding that list as a single array parameter would rewrite the SQL of every trace `in` filter in the product and move every pin that depends on it — not a small, exact change in `query_builders/user_list.py`, and far outside this PR's blast radius.

   **What was done first, and why it was wrong:** the harness enumerated the cardinalities it certified — `_USERS_PICKER_SHAS`, 1..10, untyped and typed. That model of the fan-out is refuted; see round 2 below. The enumeration, `_USERS_PICKER_MAX_VALUES` and `_USERS_ORIGIN_SHAS_SCALAR` are deleted in `8d8bf939d`, and a test asserts they stay deleted. Still measured and still true: `filter_type` `string` and `text` are the same statement, and a picker whose `attribute_value_types` length does not match its value count qualifies **no** witness and lands on the pinned no-witness statement.

2. **Flag-off ClickHouse identity — `0717997ae`, on #2743, merged in here by `3b0543a4d`.** `--user-assert` had also changed the flag-**off** resolution: `OBSERVE_CH_USER` set to the empty string used to resolve to `""` and started resolving to `default`. The flag-off path is back to `os.environ.get("OBSERVE_CH_USER", "default")` — only an *unset* variable falls back — and is pinned by `ChUserAssertTests::test_empty_env_keeps_its_pre_flag_meaning_with_the_assert_off`. Rationale and the alternative are stated in #2743's body.

3. **Body corrections.** The combined subtest count in this body said 423; it measured 425 on the previous head, twice, and its own component rows summed to 425. Both figures are re-measured at head `902f1dd84` and quoted below. The ruff-format claim is corrected in the tests section above, and the three lines it was wrong about are rewritten in `902f1dd84`. For the record, `d61c7ab83` carries only the `Claude Fable 5.1` trailer (as its pre-rebase form `d39c6f6cf` did); no trailer was dropped, but earlier reports claimed both trailers on every commit.

## Verifier residuals addressed, round 2

A second adversarial verifier re-measured the stack and **refuted residual (1)'s fix**, not just its coverage. Both PRs remain co-mergeable; both remain pure fast-forwards of `origin/dev`.

1. **"Above 10 selected values fails closed" was FALSE, and the fan-out is not one-dimensional in value count — fixed in `0c05f49fd` (#2743) and `8d8bf939d` (here).** The shared legacy ASCII bloom companion in `futureagi/tracer/services/clickhouse/query_builders/latest_filter_predicates.py` (`_legacy_ascii_lower_bloom_predicate`, lines ~33-82) enumerates a Kelvin-sign substitution for **every letter `k`** in every value and collects them in a `set`, so its placeholder list holds `2 ** (count of "k")` deduped entries — independent of how many values the filter selected. The UTF-8 companion holds one per value. Consequently `equals "kid"`, `equals "token"`, `equals "ok"`, `equals "OK"`, `in ["kid"]` and any selected list whose **lowercased** values collide (`["Yes","yes"]`, `["a","a","b"]`) each produced a statement outside the 22-digest pin set — **at every cardinality, including 1** — and the harness refused them with `USERS_REMAP_ORIGIN_NOT_QUALIFIED`. Every one of those pages was certifiable at `dev`. The enumeration could never close a `2**k × (N, distinct-count)` family, and the pin comment plus this body's "more than 10 … fails closed" sentence were wrong as written. The previous verifier's "the only such loss after 54 measured shapes" claim is refuted by the same measurement: every probe value used — `value-a`, `value-N`, `cafe`, `v0`, `a`/`b`/`c` — happens to be `k`-free, which is why the axis was invisible.

   **The fix is harness-only, exact-preserving, and does not touch `latest_filter_predicates.py`** (that bloom hint is shared by every trace, graph and dashboard read; rewriting it would move every pin that depends on it). `_users_origin_digest` hashes `_canonical_origin_sql(sql.strip().rstrip(";"))`, which rewrites **only** a whole bracketed run of value-list placeholders — the `latest_filter_index_…` / `latest_filter_legacy_index_…` families, same stem, value indexes exactly `0 .. n-1`, `", "`-separated — into one `[%(<stem>_*)s]` token. Nothing else is normalised: whitespace, keywords, columns, structure, the placeholder **names** and the attribute-**key** list `[%(latest_filter_key_0)s]` (whose trailing index is a *filter* index, not a value index) all still enter the digest, so any builder change still fails closed. Both check sites share the one helper — the origin qualification check and the execute-time re-check of the statement handed to the driver — while the ledger's `sql_sha256` stays the **raw** executed text. The over-collapse risk is real and is tested: a regex wide enough to also swallow `latest_filter_key_0` fails 5 subtests of `UsersOriginCanonicalSqlTests` (measured against a mutated copy of the harness).

   **Re-pinned per shape:** 22 digests → **7**, one per statement shape, listed with per-shape comments in `_USERS_ORIGIN_SHAPES`; `_USERS_PICKER_SHAS`, `_USERS_PICKER_MAX_VALUES` and `_USERS_ORIGIN_SHAS_SCALAR` are deleted. Every digest was recomputed offline through the harness's own `_users_origin_digest` over the 47-case table in the shape table above. **What is certifiable now versus at `dev`, stated honestly:** for the exact-text families — `equals` and the untyped and typed pickers — this branch now certifies the same breadth `dev` did, at any value count and any value text, with a separate pin for the variant where the legacy hint declines. What is still **not** certifiable, exactly as at `dev`, is the numeric witness (`6c104d49…`), the `user_id` label witness and the search shape; those remain owner calls and are unchanged by this pass.

2. **A second uncovered axis, lowercase-duplicate value lists — closed by the same change.** Because the variant set deduplicates, `in ["Yes","yes"]` emitted fewer legacy placeholders than it had values (a realistic picker selection on a case-sensitive attribute catalog). Those lists now canonicalise onto the ordinary picker shapes and are in the pinned table.

3. **Both documentation claims corrected.** The pin comment no longer contains a cardinality boundary; this body's "more than 10 selected values still fails closed and is the one place this branch certifies less than `dev`" sentence is replaced above rather than softened.

4. **Ruff, restated honestly.** See the tests section: the 27/25 lines `ruff format` would rewrap were added by `90c5b1d55` inside #2743, are outside this brief's baseline, and are **deferred, named in #2743's body** rather than dropped. Every line added by this pass is format-clean, positionally verified.

The first verifier's other findings are recorded here rather than silently dropped: the pin set covers strictly more than its documented shapes (unicode, JSON-ish, bool-ish, empty, `not_equals`, `contains`, a user-id label, numeric `less_than` and the no-filter page all collapse onto the pinned unseeded digest), window width 1..365 days and the workspace-versus-project surface do not enter any digest, and the numeric witness remains uncertifiable — as it was at `dev` — which is still an owner call.

## Deliberately left out of this PR

- `test_users_replay_certification.py` (202 lines at `1ec1d5ae0`), which drives the real manager and `_configure_users_remap` over 47 cases with a fake transport. It is **run as verification here, not committed** (see the re-pin section); it is another agent's file in the production test tree and expects `origin_row_limit` where #2743 named the field `origin_limit`. Whoever adopts it needs that one rename.
- `test_session_native_conjunction_replay.py` from the same upstream commit — it exercises `session_list`, which this PR does not touch; it belongs to the sessions lane (it imports fixtures from `test_users_attribute_physical_replay.py`, which lands here).
- S1 slicing, `max_threads` tuning, the `deadline=None` / unlimited-read-settings decision (an owner call, since bounding a public Users read turns a slow 200 into a 503), and any schema change.

## Attribution

**The builder design and most of these tests are the previous agent's work** on their local `fix/TH-7247-review-02-users-reads` (commit `1ec1d5ae0` — **not pushed**; `origin/fix/TH-7247-review-02-users-reads` is at `b9ec237e6`, which does not contain it — and also left uncommitted in the `future-agi-pr2579-filter-qualification` worktree). Cherry-picked onto `origin/dev` with `-x`.

**Correction to the commit body:** it says the `user_list.py` diff is "byte-identical" to theirs. It was at cherry-pick time; it is **not** after the `ruff format` pass this branch applies (their hunks introduced formatting violations in a file that was clean at `dev`). The difference is Python layout only, and that is checked, not assumed:

- every string constant and f-string template in the two files is identical (821 literals, multiset-equal by AST) — `ruff format` moved parentheses and line breaks, never string content;
- the emitted SQL is provably unchanged: `build_dimension_candidate_query(limit=26)` for the unseeded V2 case hashes (the harness's `sha256(sql.strip().rstrip(";"))`) to **`ba51ea62b5e2f3831b6d9d1e4ab345283c068af90f1795bb7b7082526cd4d4e5`** on this branch — byte-for-byte the "direct unseeded" entry in `1ec1d5ae0`'s own `_USERS_ORIGIN_SHAS`, and the same holds for two more of the four digests pinned here. Every pin in this PR was nevertheless recomputed from this tree rather than copied, and the file-bytes pin `6d6f39cd…` from that commit is **wrong** for this branch (it is the pre-`ruff format` digest); the correct one is `94ab7ca8…`.

What is added on top of their work: the harness/sessions split above, two stale assertions corrected in files they did not touch (`test_session_user_candidate_reads.py`, `test_user_list_cursor.py` — both asserted `candidate_span_identities` present on what are now unseeded reads), three `chdb`-free SQL-shape tests, and `ruff format`.

Part of #2734
Linear: n/a
AI use: written by Claude Code (Opus 5 / Fable 5.1) in an automated lane; the canonical-digest re-pin (`665e0ecfa`, `8d8bf939d`) is Claude Fable 5.1's. The production-code diff is carried over from the previous agent's commit `1ec1d5ae0`, not authored here; the test triage, the two assertion corrections, the three added shape tests, the harness re-pin (all digests recomputed offline from this tree) and this description are the agent's. No production system was contacted at any point: the recompute imported the builder and hashed strings with every DB/CH/Redis port pointed at a dead port, and `scripts/qa/replay_observe_queries_readonly.py` was never executed against anything.
E2E: exempt (backend-internal)

<!-- node e2e/scripts/e2e-coverage.mjs --pr 2746 --head fix/observe-users-immutable-hour-replay --json, re-run at head 8d8bf939d => "classification": "EXEMPT", "autoReason": "tests-only", "marker": {"raw": "E2E: exempt (backend-internal)", "problems": []}, "verdict": "pass", "base": "origin/chore/observe-users-replay-harness". Re-run after the base moved to chore/observe-users-replay-harness: the diff now also carries two scripts/qa files, which classify E2 (tooling) and are exempt as well; the nine test files are E3 and dominate the auto-reason; query_builders/user_list.py itself is E5 backend-internal, also exempt. There is no e2e flow for the Users list, so the declared reason above is the honest one. -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)