### PR TITLE
ci: pull the test MinIO image from quay.io [agent]

### DIFF
--- a/futureagi/docker-compose.test.yml
+++ b/futureagi/docker-compose.test.yml
@@ -70,7 +70,7 @@ services:
       retries: 5
 
   test-minio:
-    image: minio/minio:RELEASE.2025-09-07T16-13-09Z
+    image: quay.io/minio/minio:RELEASE.2025-09-07T16-13-09Z
     environment:
       MINIO_ROOT_USER: minioadmin
       MINIO_ROOT_PASSWORD: minioadmin


### PR DESCRIPTION
## Linked issues

Linked issue: none — CI infrastructure unblock (no product change). Every open backend PR's shards are red since 2026-09-11 ~23:00 UTC at the "Gate on service health" step, before a single test runs.

AI use: Claude Code (Fable 5.1) diagnosed the failure from the CI logs of #2728 and #2746, verified the quay.io tag with `docker manifest inspect`, and made the one-line change; no tests were written or run (there is nothing to run offline).

E2E: exempt (tooling) — CI compose file only; `node e2e/scripts/e2e-coverage.mjs --base origin/dev` reports {"classification": "EXEMPT", "autoReason": "stack-shape", "verdict": "pass"}

---

## What is broken

`docker compose -f docker-compose.test.yml up --wait` fails in every `pytest shard N` job:

```
test-minio Error pull access denied for minio/minio, repository does not exist or may require 'docker login'
```

Seen on #2728 (run 34659584824, all 10 shards) and #2746 (run 34659415801). The last green `dev` run (34607655844) pulled the image earlier the same day, so this is a registry-side change, not a repo change.

## The fix

`futureagi/docker-compose.test.yml`: `minio/minio:RELEASE.2025-09-07T16-13-09Z` → `quay.io/minio/minio:RELEASE.2025-09-07T16-13-09Z`. Same pinned tag; `docker manifest inspect quay.io/minio/minio:RELEASE.2025-09-07T16-13-09Z` succeeds where the Docker Hub reference is denied.

## Not changed (a separate decision)

`docker-compose.yml` (root and `futureagi/`), `docker-compose.peerdb.yml` and `docker-compose.sdk-test.yml` still reference `minio/minio` (`RELEASE.2025-02-07T23-21-09Z` and `latest`) and will fail the same way when next pulled. They affect developer and deployment environments, so they are left for the maintainers.

## Tests

None run: this changes a CI service image reference only. The proof is this PR's own `pytest shard` jobs reaching the test step. `def test_` delta: 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
