### PR TITLE
chore(ci): pull the test MinIO image from quay.io [agent]

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -947,7 +947,7 @@ services:
     restart: unless-stopped
 
   minio:
-    image: minio/minio:RELEASE.2025-02-07T23-21-09Z
+    image: quay.io/minio/minio:RELEASE.2025-02-07T23-21-09Z
     command: server /data --console-address ":9001"
     environment:
       MINIO_ROOT_USER: ${MINIO_ROOT_USER:-futureagi}
@@ -1068,7 +1068,7 @@ services:
     restart: unless-stopped
 
   peerdb-minio:
-    image: minio/minio:latest
+    image: quay.io/minio/minio:latest
     profiles: ["peerdb", "full"]
     environment:
       MINIO_ROOT_USER: _peerdb_minioadmin

--- a/futureagi/docker-compose.peerdb.yml
+++ b/futureagi/docker-compose.peerdb.yml
@@ -138,7 +138,7 @@ services:
 
   # PeerDB MinIO (staging area for CH ingestion)
   peerdb-minio:
-    image: minio/minio:latest
+    image: quay.io/minio/minio:latest
     restart: unless-stopped
     volumes:
       - peerdb-minio-data:/data

--- a/futureagi/docker-compose.sdk-test.yml
+++ b/futureagi/docker-compose.sdk-test.yml
@@ -55,7 +55,7 @@ services:
       retries: 5
 
   test-minio:
-    image: minio/minio:latest
+    image: quay.io/minio/minio:latest
     container_name: sdk-test-minio
     environment:
       MINIO_ROOT_USER: minioadmin

--- a/futureagi/docker-compose.test.yml
+++ b/futureagi/docker-compose.test.yml
@@ -70,7 +70,7 @@ services:
       retries: 5
 
   test-minio:
-    image: minio/minio:RELEASE.2025-09-07T16-13-09Z
+    image: quay.io/minio/minio:RELEASE.2025-09-07T16-13-09Z
     environment:
       MINIO_ROOT_USER: minioadmin
       MINIO_ROOT_PASSWORD: minioadmin

--- a/futureagi/docker-compose.yml
+++ b/futureagi/docker-compose.yml
@@ -422,7 +422,7 @@ services:
   # ===========================================
 
   minio:
-    image: minio/minio:RELEASE.2025-02-07T23-21-09Z
+    image: quay.io/minio/minio:RELEASE.2025-02-07T23-21-09Z
     container_name: minio
     environment:
       MINIO_ROOT_USER: ${MINIO_ROOT_USER}
@@ -867,7 +867,7 @@ services:
     entrypoint: ["bash", "/setup.sh"]
 
   peerdb-minio:
-    image: minio/minio:latest
+    image: quay.io/minio/minio:latest
     container_name: peerdb-minio
     restart: unless-stopped
     volumes:


### PR DESCRIPTION
## Linked issues

Linked issue: none — CI infrastructure unblock (no product change). Every open backend PR's shards are red since 2026-09-11 ~23:00 UTC at the "Gate on service health" step, before a single test runs.

AI use: Claude Code (Fable 5.1) diagnosed the failure from the CI logs of #2728 and #2746, verified the quay.io tag with `docker manifest inspect`, and made the one-line change; no tests were written or run (there is nothing to run offline).

E2E: exempt (tooling) — CI compose file only; `node e2e/scripts/e2e-coverage.mjs --base origin/dev` reports {"classification": "EXEMPT", "autoReason": "stack-shape", "verdict": "pass"}

---

## What is broken

`docker compose -f docker-compose.test.yml up --wait` fails in every `pytest shard N` job:

```
test-minio Error pull access denied for minio/minio, repository does not exist or may require 'docker login'
```

Seen on #2728 (run 34659584824, all 10 shards) and #2746 (run 34659415801). The last green `dev` run (34607655844) pulled the image earlier the same day, so this is a registry-side change, not a repo change.

## The fix

Every compose file that names the MinIO image now pulls it from quay.io with its **existing tag unchanged**:

| File | Tag |
|---|---|
| `futureagi/docker-compose.test.yml` (backend CI) | `RELEASE.2025-09-07T16-13-09Z` |
| `docker-compose.yml` (root; E2E CI boots `peerdb-minio` from it) | `RELEASE.2025-02-07T23-21-09Z`, `latest` |
| `futureagi/docker-compose.yml` | `RELEASE.2025-02-07T23-21-09Z`, `latest` |
| `futureagi/docker-compose.peerdb.yml`, `futureagi/docker-compose.sdk-test.yml` | `latest` |

All three tags verified with `docker manifest inspect quay.io/minio/minio:<tag>` (each succeeds; the Docker Hub reference is denied). The first commit changed only the backend test compose; E2E CI then failed identically on `peerdb-minio` (run 34659929764), so the second commit covers the rest. Developer and deployment environments that pull these files will pick up the registry change on their next pull — same image, same tag.

## Tests

None run: this changes CI service image references only. The proof is this PR's own jobs: at the first commit all 10 `pytest shard` jobs went green (they had failed on the pull on every PR); the second commit is for the `e2e` job. `def test_` delta: 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

