### PR TITLE
fix(ci): pull MinIO from quay.io; Docker Hub no longer serves minio/minio

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -947,7 +947,7 @@ services:
     restart: unless-stopped
 
   minio:
-    image: minio/minio:RELEASE.2025-02-07T23-21-09Z
+    image: quay.io/minio/minio:RELEASE.2025-02-07T23-21-09Z
     command: server /data --console-address ":9001"
     environment:
       MINIO_ROOT_USER: ${MINIO_ROOT_USER:-futureagi}
@@ -1068,7 +1068,7 @@ services:
     restart: unless-stopped
 
   peerdb-minio:
-    image: minio/minio:latest
+    image: quay.io/minio/minio:latest
     profiles: ["peerdb", "full"]
     environment:
       MINIO_ROOT_USER: _peerdb_minioadmin

--- a/futureagi/docker-compose.peerdb.yml
+++ b/futureagi/docker-compose.peerdb.yml
@@ -138,7 +138,7 @@ services:
 
   # PeerDB MinIO (staging area for CH ingestion)
   peerdb-minio:
-    image: minio/minio:latest
+    image: quay.io/minio/minio:latest
     restart: unless-stopped
     volumes:
       - peerdb-minio-data:/data

--- a/futureagi/docker-compose.sdk-test.yml
+++ b/futureagi/docker-compose.sdk-test.yml
@@ -55,7 +55,7 @@ services:
       retries: 5
 
   test-minio:
-    image: minio/minio:latest
+    image: quay.io/minio/minio:latest
     container_name: sdk-test-minio
     environment:
       MINIO_ROOT_USER: minioadmin

--- a/futureagi/docker-compose.test.yml
+++ b/futureagi/docker-compose.test.yml
@@ -70,7 +70,7 @@ services:
       retries: 5
 
   test-minio:
-    image: minio/minio:RELEASE.2025-09-07T16-13-09Z
+    image: quay.io/minio/minio:RELEASE.2025-09-07T16-13-09Z
     environment:
       MINIO_ROOT_USER: minioadmin
       MINIO_ROOT_PASSWORD: minioadmin

--- a/futureagi/docker-compose.yml
+++ b/futureagi/docker-compose.yml
@@ -422,7 +422,7 @@ services:
   # ===========================================
 
   minio:
-    image: minio/minio:RELEASE.2025-02-07T23-21-09Z
+    image: quay.io/minio/minio:RELEASE.2025-02-07T23-21-09Z
     container_name: minio
     environment:
       MINIO_ROOT_USER: ${MINIO_ROOT_USER}
@@ -867,7 +867,7 @@ services:
     entrypoint: ["bash", "/setup.sh"]
 
   peerdb-minio:
-    image: minio/minio:latest
+    image: quay.io/minio/minio:latest
     container_name: peerdb-minio
     restart: unless-stopped
     volumes:


### PR DESCRIPTION
## Summary

Docker Hub no longer serves `minio/minio` (the repository returns 404), so every compose stack that starts MinIO — the backend test stack, the e2e stack, peerdb, the SDK test stack, and the dev stack — fails at `docker compose up` with `pull access denied`. All pytest shards and the e2e job have been red on every branch since. This points the same pinned tags at `quay.io/minio/minio`, where MinIO publishes them.

## Linked issues

Linear:

## AI use

AI use: Claude Code diagnosed the failure from the CI logs and made the registry swap; the maintainer reviewed.

## Type of change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📖 Documentation only
- [ ] 🧹 Chore / refactor (no user-visible change)
- [ ] 🚀 Performance improvement
- [ ] 🧪 Test-only change

## E2E coverage

E2E: exempt (tooling)

---

## 1) What changes were done

**A. MinIO image registry**

- `minio/minio:<tag>` → `quay.io/minio/minio:<tag>` in `docker-compose.yml`, `futureagi/docker-compose.yml`, `futureagi/docker-compose.test.yml`, `futureagi/docker-compose.peerdb.yml`, `futureagi/docker-compose.sdk-test.yml`. Tags unchanged; all three pinned tags verified present on quay.io.

---

## 2) Why the changes were done

- **Technical:** the Docker Hub repository is gone; quay.io is MinIO's registry and carries the identical tags. No version change.

---

## 3) Tests written + scenarios each covers

No test files. Verification: each pinned tag resolves on quay.io (`RELEASE.2025-02-07T23-21-09Z`, `RELEASE.2025-09-07T16-13-09Z`, `latest`); the touched compose files still parse. CI on this PR is the real test: the shards and e2e that fail on `dev` today should pass here.

---

## 4) How to run / test

```bash
cd futureagi && bin/test up   # pulls quay.io/minio/minio now
```

---

## 6) Edge cases & considerations

- The `.claude/worktrees/**` copies of these files are stale local duplicates, not tracked sources; untouched.
- Pull-through mirrors or air-gapped setups that only allow Docker Hub will need quay.io allowed.

---

## 8) Architectural / important decisions

- Kept the exact same tags rather than bumping MinIO, so this PR changes only the registry.

---

## Checklist

- [x] My code follows the [style guide](../CONTRIBUTING.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works
- [ ] `bin/test` passes locally (backend)
- [ ] `yarn test:run` passes locally (frontend)
- [ ] `yarn contracts:check` passes if API surface changed
- [ ] I've updated the documentation where relevant
- [x] No hardcoded secrets, URLs, or PII
- [x] I've signed the [CLA](../CONTRIBUTING.md#contributor-license-agreement-cla)
- [x] PR title follows Conventional Commits
- [ ] Linear issue is linked and updated with status

🤖 Generated with [Claude Code](https://claude.com/claude-code)
