### PR TITLE
ci: fix invalid workflow file (empty ${{ }} in a comment)

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -52,7 +52,7 @@ jobs:
           RAW_VERSION: ${{ inputs.version }}
         run: |
           set -eu
-          # Read the caller input from env (never ${{ }}-inlined into this script)
+          # Read the caller input from env, never inlined into this script,
           # and match with a whole-string bash regex: a crafted version can then
           # neither inject shell here nor smuggle a newline into GITHUB_OUTPUT.
           v="$RAW_VERSION"


### PR DESCRIPTION
## Summary

`release-images.yml` was rejected by GitHub as invalid, so the `v1.38.1` tag push scheduled no run and the release has no images. The cause is one comment in `build-image.yml` containing a literal `${{ }}` — GitHub evaluates expressions everywhere in a workflow file, comments included, and an empty one is a parse error. Reworded the comment; `actionlint` is clean on both files.

## Linked issues

Closes #
Linear:

## AI use

AI use: Claude Code introduced the comment in #2740 and made this fix.

## Type of change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📖 Documentation only
- [ ] 🧹 Chore / refactor (no user-visible change)
- [ ] 🚀 Performance improvement
- [ ] 🧪 Test-only change

## E2E coverage

E2E: exempt (tooling)

---

## 1) What changes were done

**A. `build-image.yml`** — one comment line reworded to drop the `${{ }}` literal.

---

## 2) Why the changes were done

- **Technical:** the release pipeline cannot run at all until the file parses.

---

## 3) Tests written + scenarios each covers

No test files. `actionlint` on `release-images.yml` + `build-image.yml`: clean (it pinpointed `build-image.yml:53:66` before the fix).

---

## 4) How to run / test

After merge, re-fire the release: either re-push the `v1.38.1` tag on the fixed commit, or cut `1.38.2` via release-please.

---

## 8) Architectural / important decisions

- Targeted at `main` directly: tag releases read the workflow from `main`, and `v1.38.1` is a release with no images until this lands.

---

## Checklist

- [x] My code follows the [style guide](../CONTRIBUTING.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works
- [ ] `bin/test` passes locally (backend)
- [ ] `yarn test:run` passes locally (frontend)
- [ ] `yarn contracts:check` passes if API surface changed
- [ ] I've updated the documentation where relevant
- [x] No hardcoded secrets, URLs, or PII
- [x] I've signed the [CLA](../CONTRIBUTING.md#contributor-license-agreement-cla)
- [x] PR title follows Conventional Commits
- [ ] Linear issue is linked and updated with status