### PR TITLE
fix: wire addFilter into DatasetFilterCard's add-filter button

### DIFF
--- a/frontend/src/sections/model/datasets/DatasetFilter/DatasetFilterCard.jsx
+++ b/frontend/src/sections/model/datasets/DatasetFilter/DatasetFilterCard.jsx
@@ -1,8 +1,9 @@
 import { Box, Button, Card } from "@mui/material";
 import React from "react";
+import PropTypes from "prop-types";
 import Iconify from "src/components/iconify";
 
-const DatasetFilterCard = () => {
+const DatasetFilterCard = ({ addFilter }) => {
   return (
     <Card sx={{ padding: 2, border: "none", display: "flex" }}>
       <Box sx={{ flex: 1 }} />
@@ -10,7 +11,7 @@ const DatasetFilterCard = () => {
         <Button
           variant="contained"
           color="primary"
-          onClick={() => {}}
+          onClick={() => addFilter()}
           startIcon={<Iconify icon="ic:round-plus" />}
           sx={{
             "& .MuiButton-startIcon": {
@@ -21,6 +22,10 @@ const DatasetFilterCard = () => {
       </Box>
     </Card>
   );
+};
+
+DatasetFilterCard.propTypes = {
+  addFilter: PropTypes.func.isRequired,
 };
 
 export default DatasetFilterCard;

--- a/frontend/src/sections/model/datasets/DatasetFilter/__tests__/DatasetFilterCard.test.jsx
+++ b/frontend/src/sections/model/datasets/DatasetFilter/__tests__/DatasetFilterCard.test.jsx
@@ -1,0 +1,14 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, userEvent } from "src/utils/test-utils";
+import DatasetFilterCard from "../DatasetFilterCard";
+
+describe("DatasetFilterCard", () => {
+  it("calls addFilter when the add-filter button is clicked", async () => {
+    const addFilter = vi.fn();
+    render(<DatasetFilterCard addFilter={addFilter} />);
+
+    await userEvent.click(screen.getByRole("button"));
+
+    expect(addFilter).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## Summary

`DatasetFilterCard`'s "Add Filter" button had an empty `onClick={() => {}}`, so clicking it did nothing. This wires a required `addFilter` prop into the click handler, matching the working pattern already used by the sibling `DatasetFilter.jsx`. The component isn't mounted on any live route yet, so this has no visible effect on the running app today — it just makes the component usable when something does mount it.

## Linked issues

Closes #1499
Linear:

## AI use

AI use: Claude Code drafted the fix and the test; I reviewed, ran, and finalized both.

## Type of change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## E2E coverage

E2E: exempt (not-in-stack) — `DatasetFilterCard` is not imported by any route or container component (verified with `grep -rn "DatasetFilterCard" frontend/src`, which returns only the component's own file and its test). Nothing in the running app exercises this path yet.

---

## 1) What changes were done

**A. `DatasetFilterCard.jsx`**

- Added a required `addFilter` prop (PropTypes-validated).
- The "Add Filter" button's `onClick` now calls `addFilter()` instead of a no-op.
- Appearance is unchanged.

## 2) Why the changes were done

- **Product/UX:** once this component is mounted somewhere, the button needs to actually do something.
- **Technical:** matches the existing, working pattern in `DatasetFilter.jsx` (`onClick={() => addFilter()}`, `addFilter: PropTypes.func`), so the fix follows the convention already established next to it rather than inventing a new one.

## 3) Tests written + scenarios each covers

**`DatasetFilterCard.test.jsx`** — confirms the button wiring works

- `calls addFilter when the add-filter button is clicked` — renders the component with a mock `addFilter`, clicks the button, asserts the mock fired exactly once. Fails against the pre-fix `onClick={() => {}}`.

```
✓ src/sections/model/datasets/DatasetFilter/__tests__/DatasetFilterCard.test.jsx (1 test) 88ms

 Test Files  1 passed (1)
      Tests  1 passed (1)
```

Confirmed this test fails without the fix (`AssertionError: expected "spy" to be called 1 times, but got 0 times`) by stashing the source change and re-running.

## 4) How to run / test

```bash
cd frontend
yarn test:run src/sections/model/datasets/DatasetFilter/__tests__/DatasetFilterCard.test.jsx
```

## 5) Screenshots / recordings

Not applicable — component isn't mounted on a live page, see E2E line above.

## 6) Edge cases & considerations

- `addFilter` is required (PropTypes), so a future caller that forgets to pass it gets a dev-time PropTypes warning rather than a silent no-op.

## 8) Architectural / important decisions

- Followed `DatasetFilter.jsx`'s existing `addFilter` pattern rather than introducing a new prop name or wiring through `ComplexFilter` — the issue scopes this fix to `DatasetFilterCard` itself; a `ComplexFilter` migration is a separate, larger change per the issue's own note.

## Checklist

- [x] My code follows the style guide
- [x] I've added tests that prove my fix is effective
- [x] `yarn test:run` passes locally (frontend)
- [x] No hardcoded secrets, URLs, or PII
- [ ] I've signed the CLA
- [x] PR title follows Conventional Commits

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
