### PR TITLE
fix: stop Share dialog's Done button from implying it saves anything

### DIFF
--- a/frontend/src/components/Share/Share.jsx
+++ b/frontend/src/components/Share/Share.jsx
@@ -79,6 +79,15 @@ const Share = ({ open, title = "Share as link", body, onClose }) => {
           {body}
         </Typography>
 
+        <Typography
+          mb={2}
+          variant="caption"
+          color="text.secondary"
+          fontWeight={typographyTheme.fontWeightRegular}
+        >
+          Note: This creates a direct link without access control.
+        </Typography>
+
         <Box display="flex" alignItems="center" gap={theme.spacing(1)} mt={2}>
           <Box flex={8}>
             <TextField
@@ -152,9 +161,9 @@ const Share = ({ open, title = "Share as link", body, onClose }) => {
             Cancel
           </Button>
           <Button
-            aria-label="finish-share-project"
-            variant="contained"
-            color="primary"
+            aria-label="close-share-project"
+            variant="outlined"
+            color="inherit"
             onClick={onClose}
             sx={{
               flex: 1,
@@ -162,7 +171,7 @@ const Share = ({ open, title = "Share as link", body, onClose }) => {
               fontSize: "13px",
             }}
           >
-            Done
+            Close
           </Button>
         </Box>
       </DialogActions>

--- a/frontend/src/components/Share/__tests__/Share.test.jsx
+++ b/frontend/src/components/Share/__tests__/Share.test.jsx
@@ -1,0 +1,43 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, userEvent } from "src/utils/test-utils";
+import Share from "../Share";
+
+describe("Share", () => {
+  it("does not present the confirmation button as a primary save action", () => {
+    const onClose = vi.fn();
+    render(
+      <Share
+        open
+        body="Anyone with the link will be able to view the data."
+        onClose={onClose}
+      />,
+    );
+
+    const confirmButton = screen.getByLabelText("close-share-project");
+    expect(confirmButton).toHaveTextContent("Close");
+    expect(confirmButton).not.toHaveClass("MuiButton-contained");
+    expect(confirmButton).toHaveClass("MuiButton-outlined");
+    expect(
+      screen.queryByLabelText("finish-share-project"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("tells the user the link has no access control", () => {
+    render(<Share open body="Share this link." onClose={vi.fn()} />);
+
+    expect(
+      screen.getByText(
+        "Note: This creates a direct link without access control.",
+      ),
+    ).toBeInTheDocument();
+  });
+
+  it("still just closes the dialog when the confirmation button is clicked", async () => {
+    const onClose = vi.fn();
+    render(<Share open body="Share this link." onClose={onClose} />);
+
+    await userEvent.click(screen.getByLabelText("close-share-project"));
+
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## Summary

The Share dialog's confirmation button read "Done" and was styled as the primary save action, even though its `onClick` only ever called `onClose` — no sharing or access-control configuration has ever been saved by this component. This makes the button honestly reflect that: renamed to "Close", restyled as a secondary action, and added a static note clarifying the link has no access control. Backend-integrated access control stays out of scope, per the issue.

## Linked issues

Closes #1501
Linear:

## AI use

AI use: Claude Code drafted the fix and the tests; I reviewed, ran, and finalized both.

## Type of change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## E2E coverage

E2E: exempt (cosmetic) — label, style, and aria-label only; the button's behavior (`onClick={onClose}`) is unchanged, it already closed the dialog and still does. No new save/persistence path is introduced. `git grep -rn "finish-share-project"` confirms no other file depended on the old aria-label.

---

## 1) What changes were done

**A. `Share.jsx` confirmation button**

- Text changed from "Done" to "Close".
- `variant` changed from `contained` to `outlined`, `color` from `primary` to `inherit`, so it no longer reads as a primary save action.
- `aria-label` changed from `finish-share-project` to `close-share-project`.
- Added a static `Typography` line under the dialog body: "Note: This creates a direct link without access control."

Unaffected: the Cancel button, the URL copy behavior, and the component's prop API (`open`, `title`, `body`, `onClose`).

## 2) Why the changes were done

- **Product/UX:** the dialog's own body text tells the user "Anyone with the link will be able to view the data," then shows a primary "Done" button next to it — that reads as "save/confirm sharing," which never happens. This was actively misleading.
- **Technical:** this is the minimal, scoped fix described by the issue; integrating `Share.jsx` with the real access-control persistence that `ShareDialog.jsx` already has is explicitly out of scope here.

## 3) Tests written + scenarios each covers

**`Share.test.jsx`** — confirms the button no longer looks or is labeled like a save action, and that the access-control note is shown

- `does not present the confirmation button as a primary save action` — asserts the button reads "Close", carries the `outlined` class (not `contained`), and the old `finish-share-project` label is gone.
- `tells the user the link has no access control` — asserts the new note text renders.
- `still just closes the dialog when the confirmation button is clicked` — asserts `onClose` still fires once on click, so existing behavior is unaffected.

```
✓ src/components/Share/__tests__/Share.test.jsx (3 tests) 153ms

 Test Files  1 passed (1)
      Tests  3 passed (3)
```

Confirmed all 3 fail without the fix (stashed the source change, re-ran — `close-share-project` label not found, tests throw `TestingLibraryElementError`).

## 4) How to run / test

```bash
cd frontend
yarn test:run src/components/Share/__tests__/Share.test.jsx
```

### UI steps (manual)

1. Start the stack, log in, open a project detail view or a dataset row, and trigger the share dialog.
2. Confirm the button now reads "Close", is not visually primary, and a note about no access control appears under the dialog body text.

## 5) Screenshots / recordings

_Add before/after screenshots of the dialog here._

## 6) Edge cases & considerations

- `ShareDialog.jsx` (the separate component with real backend-integrated access control) is untouched — this fix only touches `Share.jsx`.

## 8) Architectural / important decisions

- Did not merge this into or redirect it toward `ShareDialog.jsx` — the issue scopes the fix to `Share.jsx` only; consolidating the two is a larger, separate change.

## Checklist

- [x] My code follows the style guide
- [x] I've added tests that prove my fix is effective
- [x] `yarn test:run` passes locally (frontend)
- [x] No hardcoded secrets, URLs, or PII
- [ ] I've signed the CLA
- [x] PR title follows Conventional Commits

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
