### PR TITLE
fix: hide chat-simulation interruption KPIs in Call Analytics

### DIFF
--- a/frontend/src/components/VoiceDetailDrawerV2/VoiceRightPanel.jsx
+++ b/frontend/src/components/VoiceDetailDrawerV2/VoiceRightPanel.jsx
@@ -12,7 +12,7 @@ import {
 import { normalizeEvalResult } from "src/sections/develop-detail/DataTab/common";
 import CustomTooltip from "src/components/tooltip/CustomTooltip";
 import CallAnalyticsView from "./CallAnalyticsView";
-import { isLiveKitProvider } from "src/sections/agents/constants";
+import { AGENT_TYPES, isLiveKitProvider } from "src/sections/agents/constants";
 import ScoresListSection from "src/components/ScoresListSection/ScoresListSection";
 import { buildVoiceCallScoreSource } from "src/components/voiceAnnotationSources";
 import EvalsTabView from "src/components/traceDetail/EvalsTabView";
@@ -151,6 +151,7 @@ const VoiceRightPanel = ({
 
   const analyticsProps = useMemo(() => {
     // API-provided per-call metrics (prefer over client-computed values)
+    const isChatSimulation = data?.simulation_call_type === AGENT_TYPES.CHAT;
     const apiMetrics = {
       turnCount: data?.turn_count,
       talkRatio: data?.talk_ratio,
@@ -158,8 +159,13 @@ const VoiceRightPanel = ({
       avgAgentLatencyMs: data?.avg_agent_latency_ms ?? data?.avg_agent_latency,
       userWpm: data?.user_wpm,
       botWpm: data?.bot_wpm,
-      userInterruptionCount: data?.user_interruption_count,
-      aiInterruptionCount: data?.ai_interruption_count,
+      // Interruptions only make sense for voice; chat has no audio to interrupt.
+      ...(isChatSimulation
+        ? {}
+        : {
+            userInterruptionCount: data?.user_interruption_count,
+            aiInterruptionCount: data?.ai_interruption_count,
+          }),
     };
 
     if (isSimulate) {

--- a/frontend/src/components/VoiceDetailDrawerV2/__tests__/VoiceRightPanel.interruptions.test.jsx
+++ b/frontend/src/components/VoiceDetailDrawerV2/__tests__/VoiceRightPanel.interruptions.test.jsx
@@ -1,0 +1,57 @@
+import React from "react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { describe, expect, it, vi } from "vitest";
+import { render, screen } from "src/utils/test-utils";
+import VoiceRightPanel from "../VoiceRightPanel";
+
+vi.mock("src/sections/falcon-ai/helpers/openFixWithFalcon", () => ({
+  openFixWithFalcon: vi.fn(),
+}));
+
+vi.mock("src/components/ScoresListSection/ScoresListSection", () => ({
+  default: () => <div>Annotations</div>,
+}));
+
+const renderWithQueryClient = (ui) => {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+
+  return render(
+    <QueryClientProvider client={queryClient}>{ui}</QueryClientProvider>,
+  );
+};
+
+const baseData = {
+  id: "call-1",
+  module: "simulate",
+  status: "completed",
+  provider: "vapi",
+  attributes: {},
+  observation_span: [],
+  transcript: [],
+  user_interruption_count: 0,
+  ai_interruption_count: 0,
+};
+
+describe("VoiceRightPanel interruption KPIs", () => {
+  it("hides User Int. / AI Int. for a chat (text) simulation", () => {
+    renderWithQueryClient(
+      <VoiceRightPanel data={{ ...baseData, simulation_call_type: "text" }} />,
+    );
+
+    expect(screen.queryByText("User Int.")).not.toBeInTheDocument();
+    expect(screen.queryByText("AI Int.")).not.toBeInTheDocument();
+  });
+
+  it("still shows User Int. / AI Int. for a voice simulation", () => {
+    renderWithQueryClient(
+      <VoiceRightPanel
+        data={{ ...baseData, simulation_call_type: "voice" }}
+      />,
+    );
+
+    expect(screen.getByText("User Int.")).toBeInTheDocument();
+    expect(screen.getByText("AI Int.")).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary

Chat (text) simulations showed "User Int." / "AI Int." KPI cells in the Call Analytics view, always reading 0 since audio interruptions can't happen in a text conversation. `VoiceRightPanel` now omits `userInterruptionCount`/`aiInterruptionCount` from `apiMetrics` when `data.simulation_call_type` is the chat type, so `CallAnalyticsView`'s existing "skip these cells when null" logic kicks in and the cells disappear for chat. Voice simulations are unaffected.

## Linked issues

Closes #1503
Linear:

## AI use

AI use: Claude Code drafted the fix and the tests; I reviewed, ran, and finalized both.

## Type of change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## E2E coverage

E2E: exempt (cosmetic) — this only changes which KPI cells render for a given simulation type; no new interactive behavior, route, or write path is introduced, and `CallAnalyticsView`'s rendering logic for a missing metric (lines 204-224) is unchanged. This is a judgment call since it is data-conditional — happy to add a flow instead if a maintainer prefers.

---

## 1) What changes were done

**A. `VoiceRightPanel.jsx` `analyticsProps` memo**

- Added an `isChatSimulation` check (`data?.simulation_call_type === AGENT_TYPES.CHAT`).
- `userInterruptionCount` / `aiInterruptionCount` are now omitted from `apiMetrics` entirely for chat simulations, instead of always being set (even to 0) regardless of simulation type.
- No change to `CallAnalyticsView.jsx` — its existing `if (userInterrupts != null || aiInterrupts != null)` guard already treats a missing value as "don't render this cell", so omitting the keys is sufficient.

## 2) Why the changes were done

- **Product/UX:** "User Int." / "AI Int." reading 0 on every chat simulation is pure noise — those metrics are meaningless without audio.
- **Technical:** matches the existing `AGENT_TYPES.CHAT` / `isVoice = simulationCallType !== AGENT_TYPES.CHAT` pattern already used in `content-panel.jsx`, rather than comparing against the raw string `"text"`.

## 3) Tests written + scenarios each covers

**`VoiceRightPanel.interruptions.test.jsx`** — confirms the KPI cells are gated correctly by simulation type

- `hides User Int. / AI Int. for a chat (text) simulation` — renders with `simulation_call_type: "text"` and non-null interruption counts, asserts neither cell renders.
- `still shows User Int. / AI Int. for a voice simulation` — same data but `simulation_call_type: "voice"`, asserts both cells still render, proving the fix is scoped to chat and doesn't regress voice.

```
✓ src/components/VoiceDetailDrawerV2/__tests__/VoiceRightPanel.interruptions.test.jsx (2 tests) 79ms

 Test Files  1 passed (1)
      Tests  2 passed (2)
```

Confirmed the first test fails without the fix (stashed the source change, re-ran — `expected document not to contain element, found <p>User Int.</p>`). Also ran the full existing `VoiceDetailDrawerV2` suite to check for regressions:

```
 Test Files  11 passed (11)
      Tests  41 passed (41)
```

## 4) How to run / test

```bash
cd frontend
yarn test:run src/components/VoiceDetailDrawerV2/__tests__/VoiceRightPanel.interruptions.test.jsx
yarn test:run src/components/VoiceDetailDrawerV2/
```

### UI steps (manual)

1. Open Simulate, then a test run whose simulation is chat/text-based.
2. Open that run's Call Analytics tab — confirm "User Int." / "AI Int." no longer appear.
3. Open a voice simulation's Call Analytics tab — confirm they still appear as before.

## 5) Screenshots / recordings

_Add before/after screenshots of the Call Analytics KPI strip here (chat vs. voice)._

## 6) Edge cases & considerations

- Per the issue's own note: once `userInterruptionCount`/`aiInterruptionCount` are omitted for chat, `KpiStrip`'s second fallback (`else if (totalInterrupts != null)`, which reads a client-computed `metrics.interruptionCount`) still fires and renders a single "Interrupts" cell reading 0. The issue explicitly scopes silencing that fallback as a separate follow-up, not required here.

## 8) Architectural / important decisions

- Used the existing `AGENT_TYPES.CHAT` constant and the `isVoice` comparison pattern already established in `content-panel.jsx`, rather than comparing against the raw `"text"` string, so this stays consistent with the rest of the codebase.

## Checklist

- [x] My code follows the style guide
- [x] I've added tests that prove my fix is effective
- [x] `yarn test:run` passes locally (frontend)
- [x] No hardcoded secrets, URLs, or PII
- [ ] I've signed the CLA
- [x] PR title follows Conventional Commits

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
